### PR TITLE
docs: audit and correct all human-facing documentation against the codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,13 +126,20 @@ console.table(result.rows);
 
 ```typescript
 import { parseIDS, validateIDS, createTranslationService } from '@ifc-lite/ids';
+import { createDataAccessor } from '@ifc-lite/ids/bridge';
 
 const idsSpec = parseIDS(idsXmlContent);
+const accessor = createDataAccessor(store);
+const modelInfo = {
+  modelId: 'my-model',
+  schemaVersion: store.schemaVersion,
+  entityCount: store.entityCount,
+};
 const translator = createTranslationService('en');
-const report = await validateIDS(idsSpec, store, { translator });
+const report = await validateIDS(idsSpec, accessor, modelInfo, { translator });
 
 for (const spec of report.specificationResults) {
-  console.log(`${spec.specificationName}: ${spec.passRate}% passed`);
+  console.log(`${spec.specification.name}: ${spec.passRate}% passed`);
 }
 ```
 
@@ -174,10 +181,10 @@ const csv = gp.exportCsv(buffer, 'entities', ',', /* includeProperties */ true);
 const jsonld = gp.exportJsonld(buffer);
 
 // Parquet — columnar, ~20× smaller than JSON, queryable from DuckDB / Polars
-const parquet = await new ParquetExporter().exportEntities(parseResult);
+const parquet = await new ParquetExporter(store).exportTable('entities');
 
 // IFC5 / IFCX — JSON + USD geometry
-const ifcx = new Ifc5Exporter(store, meshes).export({ includeGeometry: true });
+const ifcx = new Ifc5Exporter(store, result).export({ includeGeometry: true });
 ```
 
 ## Choose your setup
@@ -208,7 +215,7 @@ Not sure? Start with the browser setup. You can add a server or switch engines l
 | Connect to a server backend | + `@ifc-lite/server-client` |
 | BCF issue tracking | + `@ifc-lite/bcf` |
 
-Full list: [API Reference](https://ltplus-ag.github.io/ifc-lite/api/typescript/) (25 TypeScript packages, 4 Rust crates).
+Full list: [API Reference](https://ltplus-ag.github.io/ifc-lite/api/typescript/) (14 TypeScript packages, 3 Rust crates).
 
 ## Performance
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -48,8 +48,8 @@ Add support for IFC4X3 entities
 
 2. **When "Version Packages" PR is merged**:
    - All packages are automatically built
-   - npm packages are published to npm registry (18 `@ifc-lite/*` packages + `create-ifc-lite`)
-   - Rust crates are published to crates.io (`ifc-lite-core`, `ifc-lite-geometry`, `ifc-lite-wasm`)
+   - npm packages are published to npm registry (35 `@ifc-lite/*` packages + `create-ifc-lite`)
+   - Rust crates are published to crates.io (`ifc-lite-core`, `ifc-lite-geometry`, `ifc-lite-clash`, `ifc-lite-processing`, `ifc-lite-ffi`, `ifc-lite-wasm`)
    - GitHub Release is created with version tag
    - Server binaries are cross-compiled for 6 platforms (Linux x64/ARM64/musl, macOS x64/ARM64, Windows x64) and attached to the release
 
@@ -60,7 +60,7 @@ PR with changeset → Merge to main → "Version Packages" PR created
                                             ↓
                                     Review & Merge
                                             ↓
-                    Build → Publish npm (18 packages) → Publish Rust (3 crates)
+                    Build → Publish npm (36 packages) → Publish Rust (6 crates)
                                             ↓
                     Create GitHub Release → Build server binaries (6 platforms)
 ```

--- a/apps/viewer/src/components/mcp/README.md
+++ b/apps/viewer/src/components/mcp/README.md
@@ -1,171 +1,96 @@
-# `/mcp` landing — three alternatives
+# `/mcp` landing
 
-This folder holds three production-quality landing-page candidates for the
-`@ifc-lite/mcp` marketing surface, plus the data and shells they share. Each
-variant is a single self-contained `.tsx` that reads the same catalog +
-recipes + install configs from `./data.ts` so the **content** is identical
-across all three; only the **design language** changes.
-
-```text
-data.ts                 — shared content (catalog, clients, recipes, snippets)
-types.ts                — typed shapes for the shared content
-use-mcp-page.ts         — useFonts / useCopy / useDocumentMeta helpers
-McpLandingA.tsx         — Variant A · "Atelier"        (editorial dev-tool)
-McpLandingB.tsx         — Variant B · "Stage"          (cinematic dark)
-McpLandingC.tsx         — Variant C · "Drafting Room"  (BIM craft)
-McpLandingChooser.tsx   — flips between A/B/C via ?variant=
-```
-
-The catalog is read from
-`apps/viewer/src/generated/mcp-catalog.json`, currently hand-seeded with the
-real shape of the v0.1 surface. A future build step
-(`node packages/mcp/dist/cli.js --dump-tools`) will overwrite that file at
-release time without changing the page code.
-
----
-
-## Compare them
+This folder holds the `@ifc-lite/mcp` marketing surface: a single shipped
+landing page (`McpLanding.tsx`) plus the in-browser playground and the data
+and shells they share. `McpLanding` reads the catalog + clients + recipes +
+install snippets from `./data.ts`, which is the single source of truth for
+the page content.
 
 ```text
-/mcp              → Variant A (default)
-/mcp?variant=a    → Variant A
-/mcp?variant=b    → Variant B
-/mcp?variant=c    → Variant C
+data.ts                 - shared content (catalog, clients, recipes, snippets)
+types.ts                - typed shapes for the shared content
+use-mcp-page.ts         - useFonts / useCopyToClipboard / useDocumentMeta helpers
+McpLanding.tsx          - the shipped /mcp landing page ("Stage": cinematic dark)
+HeroScene.tsx           - the animated Three.js IFC hero driven by McpLanding
+McpPlayground.tsx       - the /mcp/playground route (in-browser IFC + BYOK chat)
+playground-dispatcher.ts- browser tool dispatcher backing the playground
+playground-files.ts     - playground sample/file plumbing
+playground-uploads.ts   - playground upload handling
+PlaygroundChat.tsx      - BYOK Anthropic chat UI for the playground
+PlaygroundViewer.tsx    - inline Three.js viewer for the playground
 ```
 
-A small floating chip in the bottom-right also lets you switch without
-touching the URL. The chip is explicitly temporary and gets removed once a
-winner is picked.
+The catalog is read from `apps/viewer/src/generated/mcp-catalog.json`,
+currently hand-seeded with the real shape of the v0.1 surface. A future
+build step (`node packages/mcp/dist/cli.js --dump-tools`) will overwrite
+that file at release time without changing the page code.
 
 ---
 
-## Variant A — "Atelier"
+## Routing
 
-> *Editorial dev-tool. Lineage: Stripe / Linear / JetBrains docs.*
+Routing is intentionally lo-fi (no router lib): `App.tsx` reads
+`window.location.pathname` at boot and reacts to `popstate`.
 
-| Aspect | Choice |
-|---|---|
-| Background | Warm paper `#fafaf6` (intentionally light-only) |
-| Display | **Newsreader** — variable serif, optical sizes 6–72 |
-| Body & code | **JetBrains Mono** for everything technical, Newsreader at small sizes for prose |
-| Accent | Forest green `#1f4d35` for live elements, amber `#b8742a` for editorial markers |
-| Layout | Narrow content column (`max-w-[68rem]`), 12-col internal grid, sticky-left tool nav |
-| Distinctive moves | Numbered `§01–§03` sections · dropped capitals on the lede · margin "Marginal" notes (Issue · Filed under · Surface · Transports) · hairline filigree dividers · API-reference-style tool rows with `(required, fields)` parameter signatures |
+```text
+/mcp             -> McpLanding (marketing surface, no viewer/WASM boot)
+/mcp/...         -> McpLanding
+/mcp/playground  -> McpPlayground (parses an IFC in-browser, BYOK chat)
+```
 
-**Strongest when:** the audience is engineers who scan tools/list pages
-forensically and want signal density. The page reads like a printed
-specimen — restrained, opinionated, deeply technical.
-
-**Trade-offs:** the page is cool, not warm. Doesn't market the "agent
-driving a building" feeling — the tool catalog is the centrepiece, not the
-demo. Light-only feels deliberate but loses the developer dark-mode crowd.
+`/mcp` lives outside `BimProvider` so cold-loading the landing page is
+cheap. `/mcp/playground` does parse IFCs in-browser, but uses its own
+minimal pipeline rather than the full viewer stack.
 
 ---
 
-## Variant B — "Stage"
+## The landing page - "Stage"
 
 > *Cinematic dark, demo-driven. Lineage: Linear marketing / Vercel AI / Apple keynote slides.*
 
 | Aspect | Choice |
 |---|---|
-| Background | Deep ink `#0a0a0c` with a fractal-noise grain at 8% mix-overlay |
+| Background | Deep ink `#0a0a0c` |
 | Display | **Instrument Serif** with italic flex for the headlines |
-| Body | **Bricolage Grotesque** (variable, weights 300–700) |
+| Body | **Bricolage Grotesque** (variable, weights 300-700) |
 | Code | **JetBrains Mono** |
-| Accent | Hi-vis chartreuse `#d6ff3f` (construction safety hint) + magenta `#ff5cdc` for interactions |
+| Accent | Hi-vis chartreuse `#d6ff3f` (construction safety hint) |
 | Layout | Full-bleed sections, generous whitespace, oversized cards, horizontal recipe carousel |
-| Distinctive moves | Hero contains a **live SVG IFC wireframe** that progressively colorises through 7 transcript steps (`viewer_color_by_storey` → `viewer_isolate(IfcWall)` → `viewer_colorize(...)`) so the visitor sees the agent driving the model · install grid as oversized cards with hover-glow · recipes as a horizontally scrollable transcript carousel with family-coloured headers · big italic numerals as section markers |
+| Distinctive moves | Hero contains a **live Three.js IFC building** (`HeroScene.tsx`) that progressively colorises through the `HERO_STEPS` transcript (`viewer_color_by_storey` -> `viewer_isolate(IfcWall)` -> `viewer_colorize(...)`) so the visitor sees the agent driving the model - install grid as oversized cards - recipes as a horizontally scrollable transcript carousel with family-coloured headers - big italic numerals as section markers |
 
-**Strongest when:** the goal is to make people *feel* the product before
-they read about it. This is the "land on Twitter and screenshot" version —
-the wireframe-in-motion is the kind of thing other dev-tool sites don't have.
-
-**Trade-offs:** highest implementation surface (animation state, carousel,
-gradients). The hero animation has to land flawlessly or it looks cheap.
-Dark-only by design, which slightly clashes with the rest of the SPA's
-light/dark toggle.
-
----
-
-## Variant C — "Drafting Room"
-
-> *BIM craft. Lineage: architectural section drawings, title blocks, Le Corbusier sketches.*
-
-| Aspect | Choice |
-|---|---|
-| Background | Drafting-paper cream `#f4f1e8` over a hairline 8mm + 80mm grid |
-| Display | **EB Garamond** (with italics for the "now drives an LLM" moments) |
-| Body | **EB Garamond** (prose) + **JetBrains Mono** (every datum) |
-| Annotations | **Caveat** — a hand-drafted face used for callouts, leader text, and pencil notes |
-| Accent | Drafting-pencil red `#a8332d` for annotations, drafting blue `#4a6fa5` for live links |
-| Layout | Title-block header (Sheet / Scale / Date / Drawn / Status / Version) · dimension-line section dividers with end-ticks and labelled spans |
-| Distinctive moves | Hero figure is an **isometric IFC entity stack** (project → site → building → storey → wall) with leader-line callouts identifying live tool effects (`IfcWall #262 · painted via MCP`) · install rows formatted like a door-schedule (`I-01`, `I-02`, …) with Mark / Host / Spec / Type / Sht. columns · tool catalog renders as a **building schedule** with mark numbers (`01.07`), R/W/X scope chips, and a sticky storey-style legend · recipes as detail callouts with bubble + leader + "Sht. R-04" reference · north arrow + scale bar at the foot of the hero · sheet-footer pretends the page is a single drawing printed at 1:1 |
-
-**Strongest when:** the audience is architects, structural engineers,
-contractors. Nobody else in dev-tool marketing has shipped a landing that
-respects the AEC craft tradition — the page itself reads as a drawing,
-which is a pun the target audience will get and the LLM crowd will at
-least notice. Strong word-of-mouth potential inside buildingSMART /
-ifc-rs / IfcOpenShell circles.
-
-**Trade-offs:** highest "design point of view" but smallest
-"approachable for any LLM dev" surface. Someone unfamiliar with IFC may
-read the page as a quirky theme rather than a marketing site. Light-only,
-so dark-mode users see a flash on entry.
-
----
-
-## How to pick
-
-The three differ on **three axes**, not just colour:
-
-| | Variant A | Variant B | Variant C |
-|---|---|---|---|
-| Centrepiece | Tool catalogue | Hero animation | Domain craft |
-| Type discipline | Editorial | Cinematic | Technical drawing |
-| Audience peak | Senior dev / docs reader | Founder / "show me the future" | AEC native / BIM circles |
-| Risk if wrong | Feels too dry | Feels overproduced | Reads as gimmick |
-| Permanence | High — easy to age well | Medium — animations age fastest | High — drafting visuals are timeless |
-
-If the goal is **maximum reach across LLM developers**, B reads loudest.
-If the goal is **lasting authority** with both engineers and AEC pros,
-A is the safest. If the goal is **distinctive positioning** — the only
-MCP landing that visibly came out of an architecture toolkit — C is the
-strongest single-shot.
+The page forces dark on its own subtree without flipping the global `.dark`
+class, so the rest of the SPA is not affected when the user navigates away.
+`McpLanding` is the single shipped variant; the earlier A/B/C design
+comparison has been resolved in favour of this one.
 
 ---
 
 ## Implementation notes
 
-* All three variants share the same JSON snippet generator
-  (`makeConfigSnippet`) so the install dialogs stay in lockstep — change
-  it in one place when the bin gets renamed.
-* All three call `useFonts(...)` which injects Google Fonts `<link>`
-  stylesheets while mounted, and refcounts them so flipping between
-  variants doesn't double-load. Fonts are intentionally NOT added to
-  `index.html` so the main viewer keeps its existing first-paint budget.
+* The landing shares one JSON snippet generator (`makeConfigSnippet` in
+  `data.ts`) with the install dialogs so the snippets stay in lockstep -
+  change it in one place when the bin gets renamed.
+* `useFonts(...)` injects Google Fonts `<link>` stylesheets while mounted
+  and refcounts them so mount/unmount does not double-load. Fonts are
+  intentionally NOT added to `index.html` so the main viewer keeps its
+  existing first-paint budget.
 * `useDocumentMeta(title, themeColor)` keeps the browser tab and theme
-  colour aligned to whichever variant is mounted.
-* The chooser writes `?variant=…` to the URL via `pushState`, so back
-  button works and direct deep-links to a variant are possible.
-* Tool rows are deep-linkable: `/mcp#viewer_get_selection`. All three
-  variants honour this anchor.
-* Recipes use `data.ts:RECIPES` and emit `data-uses` chips that
-  link directly into the catalog anchors — single source of truth.
+  colour aligned while the landing is mounted, and restores them on unmount.
+* Tool rows are deep-linkable: `/mcp#viewer_get_selection`. `scrollToAnchor`
+  smooth-scrolls to the anchor and updates the URL hash.
+* Recipes use `data.ts:RECIPES`; their `uses` chips call `scrollToAnchor`
+  to jump straight into the catalog anchors - single source of truth.
 
-## Known follow-ups (not blocking the choice)
+## Known follow-ups
 
 1. **Generated catalog**: replace `apps/viewer/src/generated/mcp-catalog.json`
    with output from `node packages/mcp/dist/cli.js --dump-tools` (CLI flag
    to be added). The current file is hand-seeded with the real v0.1
    surface so the page renders as production would.
-2. **Playground link**: all three CTA the `/mcp/playground` route, which
-   is now wired (see `McpPlayground.tsx`, the dispatcher, the inline
-   Three.js viewer, and the BYOK Anthropic chat). The whole read+write
-   tool surface — including BCF authoring, IDS validation, exports, and
-   mutations — runs against an in-browser parsed IFC. No backend.
-3. **Fonts**: Google Fonts is fine for design comparison; production may
-   want to self-host (woff2) for COOP/COEP compliance and stable
-   first-paint.
-4. **Remove the chooser chip** and replace this folder's exports with a
-   single `McpLanding` once the winner is picked.
+2. **Playground**: the landing CTAs the `/mcp/playground` route, which is
+   wired (see `McpPlayground.tsx`, the dispatcher, the inline Three.js
+   viewer, and the BYOK Anthropic chat). The whole read+write tool surface -
+   including BCF authoring, IDS validation, exports, and mutations - runs
+   against an in-browser parsed IFC. No backend.
+3. **Fonts**: Google Fonts is fine for now; production may want to self-host
+   (woff2) for COOP/COEP compliance and stable first-paint.

--- a/docs/api/rust.md
+++ b/docs/api/rust.md
@@ -12,7 +12,7 @@ Core parsing functionality.
 
 ```rust
 pub mod parser;      // STEP tokenization
-pub mod schema;      // IFC type definitions
+pub mod generated;   // IFC type definitions (IfcType)
 pub mod decoder;     // Entity decoding
 pub mod streaming;   // Streaming parser
 pub mod schema_gen;  // Generated schema
@@ -58,24 +58,24 @@ pub enum Token<'a> {
 
 ```rust
 /// Scans IFC file for entity locations
-pub struct EntityScanner {
+pub struct EntityScanner<'a> {
     // ...
 }
 
-impl EntityScanner {
-    /// Create new scanner
-    pub fn new() -> Self;
+impl<'a> EntityScanner<'a> {
+    /// Create a scanner over the file bytes
+    pub fn new<T>(content: &'a T) -> Self;
 
-    /// Scan buffer for entities
-    pub fn scan(&mut self, input: &[u8]) -> Result<EntityIndex>;
+    /// Advance to the next entity: (express_id, type_name, start, end)
+    pub fn next_entity(&mut self) -> Option<(u32, &'a str, usize, usize)>;
 }
 ```
 
 #### parse_entity
 
 ```rust
-/// Parse a single entity definition
-pub fn parse_entity(input: &[u8]) -> Result<(u32, &[u8], Vec<Token>)>;
+/// Parse a single entity definition into (express_id, type, attribute tokens)
+pub fn parse_entity<'a, T>(input: &'a T) -> Result<(u32, IfcType, Vec<Token<'a>>)>;
 ```
 
 ### Schema Module
@@ -184,24 +184,23 @@ pub struct EntityLocation {
 /// Events emitted during streaming parse
 #[derive(Debug)]
 pub enum ParseEvent {
-    /// Header parsed
-    Header(HeaderInfo),
-    /// Entity found
-    Entity {
-        express_id: u32,
-        type_name: String,
-        offset: usize,
-    },
+    /// Parsing started
+    Started { file_size: usize, timestamp: f64 },
+    /// Entity discovered during scanning
+    EntityScanned { id: u32, ifc_type: IfcType, position: usize },
+    /// Geometry processing completed for an entity
+    GeometryReady { id: u32, vertex_count: usize, triangle_count: usize },
     /// Progress update
     Progress {
-        bytes_read: usize,
-        total_bytes: usize,
+        phase: String,
         percent: f32,
+        entities_processed: usize,
+        total_entities: usize,
     },
-    /// Parse complete
-    Complete,
+    /// Parsing completed
+    Completed { duration_ms: f64, entity_count: usize, triangle_count: usize },
     /// Error (non-fatal)
-    Error(ParseError),
+    Error { message: String, position: Option<usize> },
 }
 ```
 
@@ -491,8 +490,12 @@ WebAssembly bindings.
 
 ### IfcAPI
 
+The WASM surface is split across `rust/wasm-bindings/src/api/*.rs`; every method
+is exported to JS under a camelCase `js_name` that mirrors `pkg/ifc-lite.d.ts`.
+The methods below are representative, not exhaustive.
+
 ```rust
-/// Main WASM API class
+/// Main IFC-Lite API
 #[wasm_bindgen]
 pub struct IfcAPI {
     // ...
@@ -500,33 +503,60 @@ pub struct IfcAPI {
 
 #[wasm_bindgen]
 impl IfcAPI {
-    /// Create new instance
+    /// Create and initialize the IFC API
     #[wasm_bindgen(constructor)]
     pub fn new() -> Self;
 
-    /// Parse IFC file
-    #[wasm_bindgen]
-    pub fn parse(&mut self, data: &[u8]) -> Result<JsValue, JsValue>;
+    /// Fast SIMD entity scan; returns entity references for the data model
+    #[wasm_bindgen(js_name = scanEntitiesFast)]
+    pub fn scan_entities_fast(&self, content: &str) -> JsValue;
 
-    /// Parse with streaming
-    #[wasm_bindgen]
-    pub async fn parse_streaming(
-        &mut self,
+    /// Streaming geometry pre-pass; emits progress via `on_event`
+    #[wasm_bindgen(js_name = buildPrePassStreaming)]
+    pub fn build_pre_pass_streaming(
+        &self,
         data: &[u8],
-        callback: &js_sys::Function,
+        on_event: &js_sys::Function,
+        chunk_size: u32,
+        disabled_type_names: Option<Vec<String>>,
+        skip_type_geometry: bool,
     ) -> Result<JsValue, JsValue>;
 
-    /// Get entity by ID
-    #[wasm_bindgen]
-    pub fn get_entity(&self, express_id: u32) -> Result<JsValue, JsValue>;
+    /// Mesh one batch of geometry jobs into a MeshCollection
+    #[wasm_bindgen(js_name = processGeometryBatch)]
+    pub fn process_geometry_batch(
+        &self,
+        data: &[u8],
+        jobs_flat: &[u32],
+        unit_scale: f64,
+        // ... RTC offset, void keys, styles, material colours
+    ) -> MeshCollection;
 
-    /// Get geometry for entity
-    #[wasm_bindgen]
-    pub fn get_geometry(&self, express_id: u32) -> Result<JsValue, JsValue>;
+    /// Extract 2D profiles (outer boundary + holes) for parametric geometry
+    #[wasm_bindgen(js_name = extractProfiles)]
+    pub fn extract_profiles(&self, content: String, model_index: u32) -> ProfileCollection;
 
-    /// Get all meshes
-    #[wasm_bindgen]
-    pub fn get_all_meshes(&self) -> Result<JsValue, JsValue>;
+    /// Export glTF binary (GLB) from the model
+    #[wasm_bindgen(js_name = exportGlb)]
+    pub fn export_glb(
+        &self,
+        content: &[u8],
+        include_metadata: bool,
+        hidden: &[u32],
+        isolated: &[u32],
+        hidden_types_csv: String,
+        lit: Option<bool>,
+    ) -> Result<Vec<u8>, JsValue>;
+
+    /// Export CSV (entities / properties / quantities / spatial)
+    #[wasm_bindgen(js_name = exportCsv)]
+    pub fn export_csv(
+        &self,
+        content: &[u8],
+        mode: String,
+        delimiter: String,
+        include_properties: bool,
+    ) -> Vec<u8>;
 }
 ```
 

--- a/docs/api/typescript.md
+++ b/docs/api/typescript.md
@@ -510,6 +510,13 @@ Single-entity graph navigation, from `IfcQuery.entity(id)` or `IfcQuery.storeys`
 class EntityNode {
   readonly expressId: number;
 
+  // Resolved attributes (getters)
+  readonly globalId: string;
+  readonly name: string;
+  readonly description: string;
+  readonly objectType: string;
+  readonly tag: string;
+
   // Spatial containment
   contains(): EntityNode[]; // direct spatial children
   containedIn(): EntityNode | null;

--- a/docs/api/typescript.md
+++ b/docs/api/typescript.md
@@ -193,8 +193,7 @@ class GeometryProcessor {
     batchSize?: number
   ): AsyncGenerator<StreamEvent>;
 
-  // Coordinate handling
-  getCoordinateInfo(): CoordinateInfo | null;
+  // Coordinate info is returned on the GeometryResult from process()
 }
 ```
 
@@ -426,86 +425,118 @@ Fluent query builder.
 
 ```typescript
 class IfcQuery {
-  constructor(parseResult: ParseResult);
+  constructor(store: IfcDataStore);
 
-  // Enable SQL queries
-  enableSQL(): Promise<void>;
+  // Type shortcuts -> EntityQuery
+  walls(): EntityQuery;
+  doors(): EntityQuery;
+  windows(): EntityQuery;
+  slabs(): EntityQuery;
+  columns(): EntityQuery;
+  beams(): EntityQuery;
+  spaces(): EntityQuery;
 
-  // Type shortcuts
-  walls(): IfcQuery;
-  doors(): IfcQuery;
-  windows(): IfcQuery;
-  slabs(): IfcQuery;
-  roofs(): IfcQuery;
-  columns(): IfcQuery;
-  beams(): IfcQuery;
-  spaces(): IfcQuery;
-  storeys(): IfcQuery;
-  all(): IfcQuery;
+  // Type filter (variadic), everything, and by id
+  ofType(...types: string[]): EntityQuery;
+  all(): EntityQuery;
+  byId(expressId: number): EntityQuery;
 
-  // Type filter
-  ofType(type: string): IfcQuery;
-  ofTypes(types: string[]): IfcQuery;
+  // Spatial
+  onStorey(storeyId: number): EntityQuery;
+  inBounds(aabb: AABB): EntityQuery;
+  raycast(
+    origin: [number, number, number],
+    direction: [number, number, number]
+  ): number[];
 
-  // Property filters
-  whereProperty(
-    psetName: string,
-    propName: string,
-    operator: Operator,
-    value: any
-  ): IfcQuery;
+  // Graph navigation
+  entity(expressId: number): EntityNode;
+  get storeys(): EntityNode[];
+  get project(): EntityNode | null;
 
-  whereQuantity(
-    name: string,
-    operator: Operator,
-    value: number
-  ): IfcQuery;
-
-  // Spatial queries
-  storey(name: string): IfcQuery;
-  building(name: string): IfcQuery;
-  contains(): IfcQuery;
-  containedIn(): IfcQuery;
-  allContained(): IfcQuery;
-
-  // Entity navigation
-  entity(expressId: number): EntityQuery;
-
-  // Selection
-  select(fields: string[]): IfcQuery;
-
-  // Output
-  toArray(): Entity[];
-  first(): Entity | undefined;
-  count(): number;
-
-  // SQL
-  sql(query: string): Promise<any[]>;
+  // SQL (DuckDB-WASM, lazily initialized on first call)
+  sql(query: string): Promise<SQLResult>;
 }
-
-type Operator = '=' | '!=' | '>' | '<' | '>=' | '<=' | 'LIKE' | 'IN';
 ```
 
 ### EntityQuery
 
-Query operations on a single entity.
+Fluent builder over a set of entities. Filter, then call a terminal.
 
 ```typescript
 class EntityQuery {
-  // Relationships
-  contains(): IfcQuery;
-  containedIn(): EntityQuery;
-  materials(): IfcQuery;
-  propertySets(): PropertySet[];
-  related(relType: string): IfcQuery;
+  // Filter (psetName is an exact interned name, not a glob)
+  whereProperty(
+    psetName: string,
+    propName: string,
+    operator: ComparisonOperator,
+    value: unknown
+  ): this;
 
-  // Navigation
-  storey(): EntityQuery;
-  building(): EntityQuery;
-  site(): EntityQuery;
+  // Paging and include flags
+  limit(count: number): this;
+  offset(count: number): this;
+  includeGeometry(): this;
+  includeProperties(): this;
+  includeQuantities(): this;
+  includeAll(): this;
 
-  // Output
-  entity(): Entity;
+  // Terminals
+  execute(): QueryResultEntity[];
+  ids(): Promise<number[]>;
+  count(): Promise<number>;
+  first(): Promise<QueryResultEntity | null>;
+}
+
+type ComparisonOperator =
+  | '=' | '!=' | '>' | '>=' | '<' | '<=' | 'contains' | 'startsWith';
+
+interface QueryResultEntity {
+  readonly expressId: number;
+  readonly globalId: string;
+  readonly name: string;
+  readonly type: string;
+  readonly properties: PropertySet[]; // populated when includeProperties()
+  readonly quantities: QuantitySet[]; // populated when includeQuantities()
+  readonly geometry: MeshData | null; // populated when includeGeometry()
+}
+```
+
+### EntityNode
+
+Single-entity graph navigation, from `IfcQuery.entity(id)` or `IfcQuery.storeys`.
+
+```typescript
+class EntityNode {
+  readonly expressId: number;
+
+  // Spatial containment
+  contains(): EntityNode[]; // direct spatial children
+  containedIn(): EntityNode | null;
+  storey(): EntityNode | null;
+  building(): EntityNode | null;
+
+  // Aggregation and typing
+  decomposes(): EntityNode[];
+  decomposedBy(): EntityNode | null;
+  definingType(): EntityNode | null;
+  instances(): EntityNode[];
+
+  // Voids and fills
+  voids(): EntityNode[];
+  filledBy(): EntityNode[];
+
+  // Data
+  properties(): PropertySet[];
+  quantities(): QuantitySet[];
+  allAttributes(): Array<{ name: string; value: string | number | boolean }>;
+
+  // Generic traversal
+  traverse(
+    relType: RelationshipType,
+    depth: number,
+    direction?: 'forward' | 'inverse'
+  ): EntityNode[];
 }
 ```
 
@@ -669,25 +700,9 @@ function collectStyleEntities(
 ): Set<number>;
 ```
 
-### GltfExporter
+### glTF / GLB export
 
-```typescript
-class GltfExporter {
-  export(
-    parseResult: ParseResult,
-    options?: GltfExportOptions
-  ): Promise<GltfResult>;
-}
-
-interface GltfExportOptions {
-  format: 'gltf' | 'glb';
-  includeProperties?: boolean;
-  embedImages?: boolean;
-  useDraco?: boolean;
-  yUp?: boolean;
-  entityFilter?: (entity: Entity) => boolean;
-}
-```
+The standalone `GltfExporter` class was removed. glTF/GLB is now assembled in Rust and exposed on `GeometryProcessor` (from `@ifc-lite/geometry`): use `exportGlb(buffer, ...)` to export from a parsed IFC buffer, or `exportGlbFromMeshes(meshes, ...)` to export from already-extracted meshes.
 
 ### ParquetExporter
 
@@ -700,21 +715,9 @@ class ParquetExporter {
 }
 ```
 
-### CsvExporter
+### CSV export
 
-```typescript
-class CsvExporter {
-  exportEntities(
-    parseResult: ParseResult,
-    options?: CsvOptions
-  ): Promise<string>;
-
-  exportPropertiesPivot(
-    parseResult: ParseResult,
-    options?: PivotOptions
-  ): Promise<string>;
-}
-```
+The standalone `CsvExporter` class was removed. CSV is now produced in Rust and exposed on `GeometryProcessor.exportCsv(buffer, mode, ...)` (from `@ifc-lite/geometry`), where `mode` is one of `entities`, `properties`, `quantities`, or `spatial`.
 
 ---
 

--- a/docs/api/wasm.md
+++ b/docs/api/wasm.md
@@ -43,13 +43,13 @@ await parser.parseColumnar(buffer);
 For custom setups:
 
 ```typescript
-import init, { IfcAPI } from 'ifc-lite-wasm';
+import init, { IfcAPI } from '@ifc-lite/wasm';
 
 // Initialize WASM
 await init();
 
 // Or with custom URL
-await init('/path/to/ifc_lite_wasm_bg.wasm');
+await init('/path/to/ifc-lite_bg.wasm');
 
 // Create API instance
 const api = new IfcAPI();
@@ -69,192 +69,201 @@ class IfcAPI {
 
 ### Methods
 
-#### parse
+The methods below reflect the real `IfcAPI` surface (see `packages/wasm/pkg/ifc-lite.d.ts`). There is no single `parse()` call: scanning, geometry, and export are separate entry points.
 
-Parse an IFC file from a byte array.
+#### Entity Scanning
+
+SIMD-accelerated scanners that return entity references for the data-model layer to decode.
 
 ```typescript
-parse(data: Uint8Array): ParseResult;
+scanEntitiesFast(content: string): any;         // all entities, from a decoded string
+scanEntitiesFastBytes(data: Uint8Array): any;   // all entities, straight from bytes (no TextDecoder)
+scanGeometryEntitiesFast(content: string): any; // only entities that carry geometry
 ```
-
-**Parameters:**
-- `data` - IFC file contents as Uint8Array
-
-**Returns:** ParseResult object with entities and metadata
 
 **Example:**
 ```typescript
 const api = new IfcAPI();
-const buffer = await fetch('model.ifc').then(r => r.arrayBuffer());
-const result = api.parse(new Uint8Array(buffer));
-console.log(`Parsed ${result.entityCount} entities`);
+const text = await fetch('model.ifc').then(r => r.text());
+const entities = api.scanEntitiesFast(text);
 ```
 
-#### parseStreaming
+#### Geometry Pipeline
 
-Parse with streaming for large files.
+Geometry is produced in two phases: a pre-pass over the file, then one or more batched mesh-production calls.
 
 ```typescript
-async parseStreaming(
+buildPrePassOnce(data: Uint8Array): any;
+buildPrePassStreaming(
   data: Uint8Array,
-  callback: (event: StreamEvent) => void
-): Promise<ParseResult>;
+  onEvent: (event: unknown) => void,
+  chunkSize: number,
+  disabledTypeNames: string[] | null,
+  skipTypeGeometry: boolean,
+): any;
+
+// jobsFlat is [id, start, end] triples from the pre-pass; the trailing args
+// carry unit scale, RTC offset, void keys, and styles (see the .d.ts).
+processGeometryBatch(
+  data: Uint8Array,
+  jobsFlat: Uint32Array,
+  unitScale: number,
+  /* rtcX, rtcY, rtcZ, needsShift, void + style args */
+): MeshCollection;
 ```
 
-**Parameters:**
-- `data` - IFC file contents
-- `callback` - Function called for each event
+`processGeometryBatchInstanced` (returns an IFNS instancing shard as a `Uint8Array`) and `processGeometryBatchPartitioned` (returns a `PartitionedBatch`) are variants of the same call. Each returned `MeshCollection` exposes `length`, `get(i)` / `takeMesh(i)`, and RTC offsets (see Data Types).
+
+#### Export
+
+Each exporter takes the raw IFC bytes (or already-produced meshes) and returns a `Uint8Array`.
+
+```typescript
+exportGlb(content, includeMetadata, hidden, isolated, hiddenTypesCsv, lit?): Uint8Array;
+exportGlbFromMeshes(/* flattened MeshData buffers */): Uint8Array;
+exportKmz(glb, latitude, longitude, altitude, xAxisAbscissa, xAxisOrdinate, name): Uint8Array;
+exportObj(content, includeNormals, hidden, isolated): Uint8Array;
+exportCsv(content, mode, delimiter, includeProperties): Uint8Array;
+exportJson(content, pretty, includeProperties, includeQuantities): Uint8Array;
+exportJsonld(content, context, includeProperties, includeQuantities, pretty, included): Uint8Array;
+exportIfcx(content, onlyKnownProperties, pretty): Uint8Array;
+exportStep(content, schema, included, mutationsJson): Uint8Array;
+exportMerged(concatenated, lengths, schema): Uint8Array;
+exportHbjson(content, name): Uint8Array;
+```
 
 **Example:**
 ```typescript
-const result = await api.parseStreaming(data, (event) => {
-  if (event.type === 'progress') {
-    console.log(`Progress: ${event.percent}%`);
-  } else if (event.type === 'entity') {
-    console.log(`Found: ${event.typeName}`);
-  }
-});
+const obj = api.exportObj(ifcContent, true, new Uint32Array(), new Uint32Array());
+const hbjson = api.exportHbjson(ifcContent, 'my_model');
 ```
 
-#### getEntity
+`exportGlb` fails closed: when the visible mesh set is empty it throws an `Error` whose message starts with `NO_RENDER_GEOMETRY` rather than returning an empty GLB.
 
-Get decoded entity by express ID.
+#### Other Parsing
 
 ```typescript
-getEntity(expressId: number): Entity | null;
+extractProfiles(content: string, modelIndex: number): ProfileCollection;
+parseGridLines(content: string): Float32Array;                        // flat line-list vertices
+parseGridAxes(content: string): GridAxisCollection;                   // axes with tags
+parseAlignmentLines(content: string): Float32Array;
+parseSymbolicRepresentations(content: string): SymbolicRepresentationCollection;
+diagnoseGeometry(content: Uint8Array): any;                           // CSG / opening diagnostics
 ```
 
-**Parameters:**
-- `expressId` - Entity express ID (#123)
-
-**Returns:** Decoded entity or null if not found
-
-#### getGeometry
-
-Get triangulated geometry for an entity.
+#### Diagnostics and Tuning
 
 ```typescript
-getGeometry(expressId: number): MeshData | null;
+getPipelineDiagnostics(): any;
+getMemory(): any;
+
+setEntityIndex(ids: Uint32Array, starts: Uint32Array, lengths: Uint32Array): void;
+setMergeLayers(enabled: boolean): void;
+setSkipSmallCuts(on: boolean): void;
+setRectParamFastPath(enabled: boolean): void;
+setTessellationQuality(level?: string | null): void;
+setComputeGeometryHashes(tolerance?: number | null): void;
+clearPrePassCache(): void;
 ```
 
-**Parameters:**
-- `expressId` - Entity express ID
-
-**Returns:** Mesh data with positions, normals, indices
-
-#### getAllMeshes
-
-Get all processed meshes.
+#### Getters
 
 ```typescript
-getAllMeshes(): MeshData[];
+readonly version: string;   // build version string
+readonly is_ready: boolean; // true once the API is initialized
 ```
-
-**Returns:** Array of all mesh data
 
 ## Data Types
 
-### ParseResult
+### MeshCollection
+
+Returned by `processGeometryBatch`. Holds the batch's meshes plus RTC and totals.
 
 ```typescript
-interface ParseResult {
-  schema: string;           // IFC2X3, IFC4, IFC4X3
-  entityCount: number;
-  entityIndex: EntityIndex;
-  header: HeaderInfo;
+class MeshCollection {
+  readonly length: number;
+  get(index: number): MeshDataJs | undefined;      // clones (non-destructive)
+  takeMesh(index: number): MeshDataJs | undefined; // moves out (read-once, faster)
+  hasRtcOffset(): boolean;
+  readonly rtcOffsetX: number;
+  readonly rtcOffsetY: number;
+  readonly rtcOffsetZ: number;
+  readonly totalVertices: number;
+  readonly totalTriangles: number;
+  readonly buildingRotation: number | undefined;
+  readonly diagnostics: any;
 }
 ```
 
-### Entity
+### MeshDataJs
+
+A single triangulated mesh. All typed arrays are copied to JS on access.
 
 ```typescript
-interface Entity {
-  expressId: number;
-  typeName: string;
-  typeEnum: number;
-  attributes: AttributeValue[];
+class MeshDataJs {
+  readonly expressId: number;
+  readonly ifcType: string;           // e.g. "IfcWall"
+  readonly positions: Float32Array;   // xyz triplets
+  readonly normals: Float32Array;     // xyz triplets
+  readonly indices: Uint32Array;      // triangle indices
+  readonly uvs: Float32Array;         // uv pairs (empty when untextured)
+  readonly color: Float32Array;       // [r, g, b, a]
+  readonly origin: Float64Array;      // per-element local-frame origin (metres)
+  readonly vertexCount: number;
+  readonly triangleCount: number;
+  readonly geometryClass: number;     // 0 = occurrence, 1 = orphan type, 2 = instanced type
 }
 ```
 
-### AttributeValue
+### Pre-pass Streaming Events
+
+`buildPrePassStreaming` invokes its callback with one of:
 
 ```typescript
-type AttributeValue =
-  | { type: 'null' }
-  | { type: 'int'; value: number }
-  | { type: 'float'; value: number }
-  | { type: 'string'; value: string }
-  | { type: 'bool'; value: boolean }
-  | { type: 'enum'; value: string }
-  | { type: 'ref'; value: number }
-  | { type: 'list'; value: AttributeValue[] };
-```
-
-### MeshData
-
-```typescript
-interface MeshData {
-  expressId: number;
-  positions: Float32Array;  // xyz triplets
-  normals: Float32Array;    // xyz triplets
-  indices: Uint32Array;     // triangle indices
-  color: [number, number, number, number];
-}
-```
-
-### StreamEvent
-
-```typescript
-type StreamEvent =
-  | { type: 'progress'; percent: number; bytesRead: number }
-  | { type: 'entity'; expressId: number; typeName: string }
-  | { type: 'error'; message: string }
-  | { type: 'complete' };
+type PrePassEvent =
+  | { type: 'meta'; unitScale: number; rtcOffset: [number, number, number]; needsShift: boolean; buildingRotation?: number }
+  | { type: 'jobs'; jobs: Uint32Array }   // [id, start, end] triples
+  | { type: 'complete'; totalJobs: number };
 ```
 
 ## Error Handling
 
-WASM functions can throw errors:
+WASM functions surface failures as standard JavaScript `Error` objects (a Rust `Result::Err` is mapped across the boundary). Wrap calls that can fail:
 
 ```typescript
 try {
-  const result = api.parse(data);
+  const glb = api.exportGlb(content, true, new Uint32Array(), new Uint32Array(), '');
 } catch (error) {
   if (error instanceof Error) {
-    console.error('Parse error:', error.message);
+    console.error('Export error:', error.message);
   }
 }
 ```
 
-### Error Types
+### Sentinel Messages
 
-| Error | Description |
-|-------|-------------|
-| `TokenError` | Invalid STEP syntax |
-| `EntityNotFound` | Referenced entity doesn't exist |
-| `UnsupportedSchema` | Unknown IFC schema version |
-| `GeometryError` | Failed to process geometry |
+Some boundaries fail closed with a sentinel-prefixed message so callers can distinguish an expected empty result from a real failure. For example, `exportGlb` throws an `Error` whose message starts with `NO_RENDER_GEOMETRY` when the visible mesh set is empty, instead of returning a structurally valid but empty GLB.
 
 ## Performance Tips
 
-### 1. Use Streaming for Large Files
+### 1. Stream the Pre-pass for Large Files
 
 ```typescript
-// Good: streaming for large files
-await api.parseStreaming(largeBuffer, handleEvent);
+// Good: stream jobs as the file is scanned (time-to-first-geometry drops sharply)
+api.buildPrePassStreaming(bytes, onEvent, 512, null, false);
 
-// Avoid: loading entire file at once
-api.parse(largeBuffer); // May cause memory issues
+// Avoid on very large files: a single blocking pre-pass over the whole file
+api.buildPrePassOnce(bytes);
 ```
 
-### 2. Batch Geometry Processing
+### 2. Read Each Mesh Once
 
 ```typescript
-// Good: process in batches
-const meshes = api.getAllMeshes();
-for (let i = 0; i < meshes.length; i += 100) {
-  const batch = meshes.slice(i, i + 100);
-  await uploadBatch(batch);
+// Good: takeMesh moves the mesh out (one fewer vertex-data copy per mesh)
+const meshes = api.processGeometryBatch(bytes, jobsFlat, unitScale /* ... */);
+for (let i = 0; i < meshes.length; i++) {
+  const mesh = meshes.takeMesh(i);
+  if (mesh) uploadMesh(mesh);
 }
 ```
 
@@ -276,11 +285,14 @@ api.free();
 
 ## Module Size
 
-| Component | Size | Gzipped |
-|-----------|------|---------|
-| WASM binary | 60 KB | 20 KB |
-| JS glue code | 26 KB | 8 KB |
-| **Total** | **86 KB** | **28 KB** |
+Approximate on-disk sizes of the built `packages/wasm/pkg/` artifacts (uncompressed):
+
+| Component | Size |
+|-----------|------|
+| WASM binary (`ifc-lite_bg.wasm`) | ~3.4 MB |
+| JS glue code (`ifc-lite.js`) | ~140 KB |
+
+`scripts/build-wasm.sh` targets a 1100 KB budget for the single-thread bundle and warns when the binary exceeds it (`wasm-opt` is currently disabled). Sizes vary by build profile and target.
 
 ## Building from Source
 
@@ -290,12 +302,12 @@ cargo install wasm-pack
 
 # Build WASM module
 cd rust/wasm-bindings
-wasm-pack build --target web --release
+wasm-pack build --target web --out-name ifc-lite --release
 
 # Output files
-# pkg/ifc_lite_wasm.js
-# pkg/ifc_lite_wasm_bg.wasm
-# pkg/ifc_lite_wasm.d.ts
+# pkg/ifc-lite.js
+# pkg/ifc-lite_bg.wasm
+# pkg/ifc-lite.d.ts
 ```
 
 ### Build Targets

--- a/docs/architecture/ai-customization/01-extension-model.md
+++ b/docs/architecture/ai-customization/01-extension-model.md
@@ -9,11 +9,12 @@ the test harness, and the AI authoring prompt.
 ## 1. Manifest schema (v1)
 
 The manifest is the single source of truth for everything the host knows
-about an extension. It is JSON, validated by a Zod schema that lives in a
-new package `@ifc-lite/extensions` (see [§7](#7-package-layout)).
+about an extension. It is JSON, validated by a hand-rolled, dependency-free
+validator that lives in a new package `@ifc-lite/extensions` (see
+[§7](#7-package-layout)).
 
 ```ts
-// Type sketch — authoritative definition in @ifc-lite/extensions/manifest.ts
+// Type sketch. Authoritative definition exported from @ifc-lite/extensions.
 interface ExtensionManifest {
   /** Manifest schema version. Bumps require a migration. */
   manifestVersion: 1;
@@ -108,9 +109,9 @@ side; (c) merge conflicts in flavor bundles are easier with one document.
 
 ### 1.2 Schema validation
 
-Validation lives in `@ifc-lite/extensions/manifest.ts` and is a Zod
-schema. Failures produce structured errors (`{ path, code, hint }`) used
-by:
+Validation lives in `@ifc-lite/extensions/src/manifest/validate.ts`
+(`validateManifest`) and is a hand-rolled, dependency-free validator.
+Failures produce structured errors (`{ path, code, hint }`) used by:
 
 - The loader (reject extension, show error in UI).
 - The registry CI (reject publish).
@@ -321,13 +322,13 @@ automatically ([§04-ai-authoring.md](./04-ai-authoring.md)).
 
 ## 7. Package layout
 
-Two new packages, both small:
+One new package plus CLI helpers folded into the existing `@ifc-lite/cli`:
 
 ### `@ifc-lite/extensions`
 
 The host-side runtime. Exports:
 
-- `ExtensionManifest` Zod schema and TypeScript types.
+- `ExtensionManifest` validator (`validateManifest`) and TypeScript types.
 - `ExtensionLoader` — loads bundles from IndexedDB or disk, validates,
   registers contributions.
 - `ExtensionHost` — coordinates lifecycle, dispatches activation events,
@@ -337,13 +338,13 @@ The host-side runtime. Exports:
 - Test runner.
 - Manifest migration helpers.
 
-Dependencies: `zod`, `@ifc-lite/sandbox`, `@ifc-lite/sdk`. No new
-heavy deps.
+Dependencies: `acorn`, `acorn-walk`, `fflate`. No new heavy deps.
 
-### `@ifc-lite/extensions-cli`
+### CLI helpers in `@ifc-lite/cli`
 
-CLI helpers (`ifc-lite ext init|validate|test|pack|publish`). Lives
-alongside `@ifc-lite/cli` so the unified CLI surface remains.
+CLI helpers (`ifc-lite ext init|validate|pack|sign|verify|test`) ship as
+the `ext` subcommand of the existing `@ifc-lite/cli`, not a separate
+package, so the unified CLI surface remains.
 
 The viewer app imports `@ifc-lite/extensions` and renders slot
 subscribers in its existing layout. No new app package; this is a

--- a/docs/architecture/ai-customization/01-extension-model.md
+++ b/docs/architecture/ai-customization/01-extension-model.md
@@ -111,7 +111,7 @@ side; (c) merge conflicts in flavor bundles are easier with one document.
 
 Validation lives in `@ifc-lite/extensions/src/manifest/validate.ts`
 (`validateManifest`) and is a hand-rolled, dependency-free validator.
-Failures produce structured errors (`{ path, code, hint }`) used by:
+Failures produce structured errors (`{ path, code, message, hint? }`) used by:
 
 - The loader (reject extension, show error in UI).
 - The registry CI (reject publish).

--- a/docs/architecture/ai-customization/02-security.md
+++ b/docs/architecture/ai-customization/02-security.md
@@ -408,9 +408,10 @@ If a malicious or buggy extension is discovered:
 - A **capability-revocation** flow: the user can revoke any capability
   at any time without uninstalling. Revocation deactivates the
   extension if it cannot run with the remaining grants.
-- A **post-mortem template** lives at `docs/security/incidents/` for
-  any extension-related security incident, with mandatory fields for
-  scope, root cause, mitigations, and detection improvements.
+- A **post-mortem template** will live at `docs/security/incidents/`
+  (created when the incident-response flow ships; the directory does not
+  exist yet) for any extension-related security incident, with mandatory
+  fields for scope, root cause, mitigations, and detection improvements.
 
 We expect to write at least one of these. The system is designed so
 that one extension going bad does not compromise the host or other

--- a/docs/architecture/ai-customization/03-ui-surface.md
+++ b/docs/architecture/ai-customization/03-ui-surface.md
@@ -21,8 +21,9 @@ considered it and rejected it. The reasons:
 3. **Accessibility.** The host owns ARIA semantics, focus order, keyboard
    shortcuts. A free-form UI surface degrades this; a fixed widget
    catalogue lets us guarantee it.
-4. **Multi-target rendering.** The same widget renders in the desktop
-   app, the embed SDK, and (Phase 4) a possible mobile target. JSX does
+4. **Multi-target rendering.** The same widget renders in the web
+   viewer, the embed SDK, third-party desktop builds (via the Tauri
+   NativeBridge), and (Phase 4) a possible mobile target. JSX does
    not survive that crossing; data does.
 5. **AI authoring.** A small declarative DSL is *vastly* easier for the
    AI to author correctly than React JSX. The repair loop becomes

--- a/docs/architecture/ai-customization/04-ai-authoring.md
+++ b/docs/architecture/ai-customization/04-ai-authoring.md
@@ -294,7 +294,9 @@ test is wrong (rare) or add tests if a regression revealed a gap.
 ## 11. Authoring contract (model-facing)
 
 The text we insert into the system prompt. Excerpted; the canonical
-copy lives in `apps/viewer/src/lib/llm/extension-authoring-prompt.ts`.
+copy lives in `packages/extensions/src/authoring/prompt.ts`
+(`buildAuthoringContract`), which the viewer's `system-prompt.ts`
+consumes via `@ifc-lite/extensions`.
 
 > You are authoring an IFClite extension.
 >

--- a/docs/architecture/ai-customization/05-flavors-and-sharing.md
+++ b/docs/architecture/ai-customization/05-flavors-and-sharing.md
@@ -267,9 +267,11 @@ A flavor is the user's environment. Breakage is severe. Safeguards:
 
 ## 10. Interaction with desktop / server
 
-The desktop app loads flavors the same way as the browser. Flavors that
-declare `desktop`-specific features (e.g. file system access through a
-future `system.fs:<path>` capability) are flagged accordingly.
+No first-party desktop app ships today (it was decommissioned; see 09
+P3.T16/T17). Any future or third-party desktop build would load flavors
+the same way as the browser. Flavors that declare `desktop`-specific
+features (e.g. file system access through a future `system.fs:<path>`
+capability) are flagged accordingly.
 
 The server (headless backend) loads flavors and runs activations for
 non-viewer triggers (e.g. an exporter that runs on file upload). UI

--- a/docs/architecture/ai-customization/09-implementation-plan.md
+++ b/docs/architecture/ai-customization/09-implementation-plan.md
@@ -616,11 +616,16 @@ dry-run, and the repair loop. Adds the widget DSL renderer.
 ### Milestone 2.A — Intent classifier + plan card
 
 - [x] **P2.T1** — Intent classifier (rule-based; LLM-assisted fallback).
-  **Where:** `apps/viewer/src/lib/llm/intent-classifier.ts`.
+  **Where:** `packages/extensions/src/authoring/classify.ts`.
   **Depends on:** P1 phase gate.
   **Acceptance:** classifies prompts into one-shot / authoring / fork /
   out-of-scope with ≥ 90% precision on a labelled test set.
   **Effort:** M.
+  Notes: **plan deviation.** Spec located this under
+  `apps/viewer/src/lib/llm/`. Moved into the host-agnostic
+  `@ifc-lite/extensions` package (`authoring/classify.ts`) so the same
+  classifier can run in the CLI, the MCP server, and the AI authoring
+  loop.
 
 - [x] **P2.T2** — `AuthoringPlan` data model + Zod schema.
   **Where:** `packages/extensions/src/authoring/plan.ts`.
@@ -656,11 +661,15 @@ dry-run, and the repair loop. Adds the widget DSL renderer.
   is folded into the contract builder for cohesion.
 
 - [x] **P2.T6** — Authoring contract prompt section.
-  **Where:** `apps/viewer/src/lib/llm/extension-authoring-prompt.ts`.
+  **Where:** `packages/extensions/src/authoring/prompt.ts`.
   **Depends on:** P2.T5.
   **Acceptance:** assembles manifest schema + widget DSL + capability
   catalogue + style rules; cacheable; total fragment ≤ 20k tokens.
   **Effort:** M.
+  Notes: **plan deviation.** Landed in the host-agnostic
+  `@ifc-lite/extensions` package alongside P2.T5 (`buildAuthoringContract`
+  in `authoring/prompt.ts`) rather than the viewer `lib/llm/` file the
+  spec named.
 
 - [x] **P2.T7** — Prompt caching integration.
   **Where:** `apps/viewer/src/lib/llm/prompt-cache.ts`,
@@ -676,27 +685,41 @@ dry-run, and the repair loop. Adds the widget DSL renderer.
 ### Milestone 2.C — Bundle synthesis
 
 - [x] **P2.T8** — Plan → manifest generation prompt + parser.
-  **Where:** `apps/viewer/src/lib/llm/authoring/manifest-step.ts`.
+  **Where:** `packages/extensions/src/authoring/synthesize.ts`
+  (`parseBundleOutput` / `extractBundlePieces`).
   **Depends on:** P2.T6.
   **Acceptance:** model emits JSON; parser tolerates code fences and
   recovers gracefully; validates immediately with `manifestSchema`.
   Returns structured failure to repair loop.
   **Effort:** M.
+  Notes: **plan deviation.** The separate manifest/code/widget step
+  files the spec named under `apps/viewer/src/lib/llm/authoring/` were
+  unified into one host-agnostic parser, `authoring/synthesize.ts` in
+  `@ifc-lite/extensions` (fenced `ifc-extension-manifest` /
+  `ifc-extension-code` / `ifc-extension-widget` blocks). See P2.T9/T10.
 
 - [x] **P2.T9** — Plan → code generation prompt + parser.
-  **Where:** `apps/viewer/src/lib/llm/authoring/code-step.ts`.
+  **Where:** `packages/extensions/src/authoring/synthesize.ts`
+  (code pieces via `ifc-extension-code` blocks).
   **Depends on:** P2.T6.
   **Acceptance:** generates one module per entry-point declared in the
   manifest; module files placed in the bundle layout; static checks
   pass before handing to dry-run.
   **Effort:** M.
+  Notes: **plan deviation.** Folded into the unified host-agnostic
+  `authoring/synthesize.ts` parser (see P2.T8), not the viewer
+  `code-step.ts` the spec named.
 
 - [x] **P2.T10** — Plan → widget generation prompt + parser.
-  **Where:** `apps/viewer/src/lib/llm/authoring/widget-step.ts`.
+  **Where:** `packages/extensions/src/authoring/synthesize.ts`
+  (widget pieces via `ifc-extension-widget` blocks).
   **Depends on:** P2.T6.
   **Acceptance:** generates widget JSON validating against widget DSL
   schema; cross-references commands the manifest declares.
   **Effort:** M.
+  Notes: **plan deviation.** Folded into the unified host-agnostic
+  `authoring/synthesize.ts` parser (see P2.T8), not the viewer
+  `widget-step.ts` the spec named.
 
 ### Milestone 2.D — Static validation
 
@@ -753,11 +776,15 @@ dry-run, and the repair loop. Adds the widget DSL renderer.
 
 - [x] **P2.T17** — Diagnostic shape for the LLM (extends existing
   `script-diagnostics.ts`).
-  **Where:** `apps/viewer/src/lib/llm/extension-diagnostics.ts`.
+  **Where:** `packages/extensions/src/authoring/diagnostics.ts`.
   **Depends on:** P2.T16.
   **Acceptance:** structured diagnostic per failure category; renders
   to a prompt-friendly format; tests cover each category.
   **Effort:** M.
+  Notes: **plan deviation.** Moved into the host-agnostic
+  `@ifc-lite/extensions` package (`authoring/diagnostics.ts`, formatting
+  `ValidationError[]` into prompt-friendly groups) rather than the
+  viewer `lib/llm/extension-diagnostics.ts` the spec named.
 
 - [x] **P2.T18** — Authoring telemetry in chat UI (token usage,
   iteration count, time).
@@ -770,7 +797,7 @@ dry-run, and the repair loop. Adds the widget DSL renderer.
 ### Milestone 2.G — Widget DSL renderer
 
 - [x] **P2.T19** — Widget DSL Zod schema (15 node types per §03).
-  **Where:** `packages/extensions/src/widgets/schema.ts`.
+  **Where:** `packages/extensions/src/widget/schema.ts`.
   **Depends on:** P0.T1.
   **Acceptance:** schema matches RFC §03.3.1; tests cover each node
   variant + nesting.

--- a/docs/architecture/ai-customization/10-registry-and-signing.md
+++ b/docs/architecture/ai-customization/10-registry-and-signing.md
@@ -392,11 +392,12 @@ To ground the design, this RFC also ships the cryptographic kernel as
 code. What's in:
 
 - **`@ifc-lite/extensions/signing`** — `generateKeyPair`,
-  `exportKey`, `importKey`, `fingerprint`, `signBundle`, `verifyBundle`,
-  `canonicalContentHash`, plus `SignatureMismatchError`,
+  `exportPrivateKey`, `exportPublicKey`, `importKey`,
+  `fingerprintFromBytes`, `compactFingerprint`, `signBundle`,
+  `verifyBundle`, `canonicalContentHash`, plus `SignatureMismatchError`,
   `SignatureFormatError`, `KeyFormatError`.
 - **`.iflx` envelope update** — `signature` field accepted on unpack,
-  emitted on `packSignedBundle`. Unsigned bundles continue to round-trip
+  emitted on `packBundle`. Unsigned bundles continue to round-trip
   unchanged.
 - **CLI** — `ifc-lite ext keygen`, `ifc-lite ext pack`,
   `ifc-lite ext sign`, `ifc-lite ext verify`. The CLI is the on-ramp

--- a/docs/architecture/ai-customization/README.md
+++ b/docs/architecture/ai-customization/README.md
@@ -1,6 +1,6 @@
 # AI Customization & User Flavors — RFC
 
-Status: **Draft** — design phase, no implementation merged.
+Status: **Draft** — design phase; the foundational `@ifc-lite/extensions` package and CLI `ext` commands have begun landing (see [`09-implementation-plan.md`](./09-implementation-plan.md)).
 Owner: TBD.
 Last updated: 2026-05-16.
 

--- a/docs/architecture/clash-detection-plan.md
+++ b/docs/architecture/clash-detection-plan.md
@@ -12,7 +12,7 @@ Related: `docs/architecture/collab-plan.md`.
 Build a clash-detection capability that is:
 
 1. **WASM-web first** — the heavy engine runs in Rust → WASM, off the main thread, on the same geometry buffers the mesher already produces.
-2. **One source of truth** — a single `@ifc-lite/clash` package consumed by the web viewer, the desktop app, the CLI, MCP, and scripts. No per-host forks.
+2. **One source of truth** — a single `@ifc-lite/clash` package consumed by the web viewer, the CLI, MCP, and scripts (plus any out-of-tree/3rd-party desktop build; see §9.4). No per-host forks.
 3. **Future-aligned for IFC5/USD** — the engine operates on a representation-agnostic element model; STEP/IFC4 and IFCx/USD are just *adapters* that feed it.
 4. **Correct** — no silent decimation, real triangle-triangle intersection and distance, true contact points, smart exclusions (voids/hosts/assemblies). This is the bar the desktop prototype does not meet.
 5. **BCF-sensible** — clash results flow into BCF as a *manageable* set of grouped, deduplicated, lifecycle-aware topics — never thousands of one-clash topics.
@@ -307,8 +307,8 @@ BCF status persists via the deterministic topic GUID. This is the Navisworks "cl
 - Highlight via existing actions: `addEntitiesToSelection`, `hideEntitiesInModel`/`showEntitiesInModel` (isolate), renderer `setColorOverrides` (A=red, B=orange), `cameraCallbacks.frameSelection`, and `SectionPlane` for slicing to a clash. "Export to BCF" uses §6 with a viewer snapshot provider; "Open BCF" round-trips status back.
 
 ### 9.2 MCP (`packages/mcp`)
-- Implement the existing `clash_check` stub (`tools/geometry.ts:229`): resolve A/B GlobalId selections via `entityIndex.byType` + `EntityNode`, run the engine (WASM-in-Node), return structured + grouped results honoring `scope:'read'`, `progress`, `signal`.
-- Add `clash_matrix` (run discipline presets) and `clash_report` (grouped summary). The `clash_review` prompt (`prompts/templates.ts:133`) already orchestrates this.
+- `clash_check` (`tools/clash.ts`): resolve A/B GlobalId selections via `entityIndex.byType` + `EntityNode`, run the engine (WASM-in-Node), return structured + grouped results honoring `scope:'read'`, `progress`, `signal`.
+- `clash_matrix` (run discipline presets). The `clash_review` prompt (`prompts/templates.ts:133`) already orchestrates this. (A separate `clash_report` grouped-summary tool is not implemented; grouped summaries ride the `clash_check`/`clash_matrix` results.)
 
 ### 9.3 Scripts / CLI / sandbox
 - `bim.clash.run(selA, selB, opts)` / `bim.clash.matrix(presets)` in the sandbox bridge (`packages/sandbox/src/bridge-schema.ts`), returning serializable `ClashResult`.
@@ -330,7 +330,7 @@ P7 (desktop migration) was not pursued — see §9.4.
 | **1. Worker + panel** | `clash.worker.ts`, `clashSlice`, `ClashPanel`, discipline-matrix UI, color/isolate/frame/section wiring | Interactive clash in the web viewer, off main thread |
 | **2. Sensible BCF** | `grouping.ts` + `bcf-bridge.ts`, deterministic topic GUIDs, caps-with-transparency, viewpoint framing/coloring/clipping/snapshot, round-trip import | The headline requirement: grouped, deduplicated, lifecycle-ready BCF |
 | **3. Rust/WASM core** | `rust/clash` + `ClashSession` binding, `backend:'auto'`, differential tests, worker-pool sharding | Production performance; 1M-triangle models without freezing |
-| **4. MCP + scripting + CLI** | implement `clash_check`, add `clash_matrix`/`clash_report`, `bim.clash.*`, `ifc-lite clash` | Headless + agentic clash; couples to automation |
+| **4. MCP + scripting + CLI** | implement `clash_check`, add `clash_matrix`, `bim.clash.*`, `ifc-lite clash` | Headless + agentic clash; couples to automation |
 | **5. Lifecycle** | revision diffing of clash sets, BCF status persistence | Clash becomes a tracked workflow, not a snapshot |
 | **6. IFC5/USD** | `adapters/ifcx.ts` (prim path = key, component type = tag, geom from ifcx extractor) | Proves and delivers the future-alignment; core unchanged |
 | **7. Desktop migration** *(not pursued)* | desktop consumes `@ifc-lite/clash`; delete private engine | Single source of truth |

--- a/docs/architecture/coordinate-handling.md
+++ b/docs/architecture/coordinate-handling.md
@@ -96,7 +96,7 @@ flowchart TB
 
 ### GeometryRouter
 
-The `GeometryRouter` in `rust/geometry/src/router.rs` handles RTC:
+The `GeometryRouter` in `rust/geometry/src/router/mod.rs` handles RTC:
 
 ```rust
 impl GeometryRouter {
@@ -189,9 +189,10 @@ class CoordinateHandler {
     processMeshesIncremental(batch: MeshData[]): void;
 
     /**
-     * Get coordinate info after processing
+     * Coordinate info during (nullable) and after streaming
      */
-    getCoordinateInfo(): CoordinateInfo | null;
+    getCurrentCoordinateInfo(): CoordinateInfo | null;
+    getFinalCoordinateInfo(): CoordinateInfo;
 }
 ```
 
@@ -297,7 +298,7 @@ for (const batch of batches) {
 }
 
 // Get final coordinate info
-const info = handler.getCoordinateInfo();
+const info = handler.getFinalCoordinateInfo();
 if (info) {
     console.log('Origin shift:', info.originShift);
     console.log('Original bounds:', info.originalBounds);
@@ -423,7 +424,7 @@ if (pre.needsShift && pre.rtcOffset) {
 }
 
 // In TypeScript path
-const info = handler.getCoordinateInfo();
+const info = handler.getCurrentCoordinateInfo();
 console.log('[RTC] Handler info:', {
     wasmDetected: handler.wasmRtcDetected,
     originShift: info?.originShift,

--- a/docs/architecture/csg-threading-design.md
+++ b/docs/architecture/csg-threading-design.md
@@ -67,7 +67,8 @@ Two viable shapes:
 
 1. **Naive (proven +1.6–1.9×):** build the geometry path as a threaded bundle and
    call `initThreadPool(navigator.hardwareConcurrency)` once. The existing
-   `par_iter` over elements (`processor.rs:1554`, `gpu_meshes.rs:882`) becomes
+   `par_iter` over elements (`rust/processing/src/processor/mod.rs`,
+   `rust/wasm-bindings/src/api/gpu_meshes/`) becomes
    parallel with **zero algorithm changes**. Decode threads too and pays a small
    penalty, but CSG dominance keeps the net positive on geometry-heavy models.
 

--- a/docs/architecture/federation.md
+++ b/docs/architecture/federation.md
@@ -150,7 +150,7 @@ Section planes cut through **all visible models** simultaneously. The section pl
 |-----------|------------|-------|
 | Register model | O(1) | Compute offset from max existing |
 | toGlobalId | O(1) | Simple addition |
-| fromGlobalId | O(n) where n = model count | Iterate sorted offsets (typically 2-5 models) |
+| fromGlobalId | O(log N) | Binary search on sorted ranges (typically 2-5 models) |
 | resolveGlobalIdFromModels | O(n) | Uses Zustand state for reliability |
 | Model visibility toggle | O(1) | GPU-level filtering |
 | Entity selection | O(1) | Direct lookup after ID resolution |

--- a/docs/architecture/geometry-pipeline.md
+++ b/docs/architecture/geometry-pipeline.md
@@ -436,12 +436,18 @@ graph LR
 ## Mapped Representations
 
 IFC reuses geometry via `IfcMappedItem` (a source `IfcRepresentationMap` plus a
-per-instance placement transform). The engine **expands** each mapped item into
-its own tessellated mesh — the source geometry is tessellated once and the
-result is transformed per placement. There is no GPU-instancing path: the
-renderer instead groups the resulting meshes by colour into a small number of
-batched draw calls (see the rendering guide), which keeps draw-call counts low
-without a separate instance buffer.
+per-instance placement transform). For the primary model the engine collates
+congruent occurrences into **GPU instances**: the wasm
+`processGeometryBatchInstanced` entry point (backed by
+`rust/geometry/src/instancing` and `processors/mapped.rs`) partitions opaque
+ordinary occurrences into per-template instanced shards, and the renderer
+uploads each template once as `instancedTemplates` via `addInstancedShard` (see
+the rendering guide), then draws every occurrence of a template in a single
+instanced draw call. Instancing is enabled by default for the primary model
+(`enableInstancing: target.kind === 'primary'` in the viewer loader); federated
+loads keep geometry flat. Occurrences that are not eligible for instancing
+(transparent glass, or non-ordinary geometry classes) fall back to being
+tessellated per placement and grouped by colour into batched draw calls.
 
 ```mermaid
 flowchart TB
@@ -451,12 +457,12 @@ flowchart TB
     end
 
     subgraph Output["Output"]
-        Mesh["Tessellated mesh (transform applied)"]
-        Batch["Renderer batches by colour"]
+        Instanced["Per-template GPU instanced shard (primary model)"]
+        Fallback["Fallback: tessellated per placement, batched by colour"]
     end
 
-    Definition --> Mesh
-    Mesh --> Batch
+    Definition --> Instanced
+    Definition --> Fallback
 ```
 
 ## Streaming Pipeline

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -193,18 +193,19 @@ Combine the best of different data structures:
 
 ## Package Architecture
 
-The monorepo contains 18 TypeScript packages, 4 Rust crates, and multiple application targets.
+The monorepo contains over 30 TypeScript packages and 8 Rust workspace crates, plus multiple application targets. The diagram below highlights a selected subset.
 
 ```mermaid
 graph TB
     subgraph Rust["Rust Crates"]
         Core["ifc-lite-core<br/>Parsing"]
         Geo["ifc-lite-geometry<br/>Triangulation"]
+        Processing["ifc-lite-processing<br/>Element meshing"]
         Wasm["ifc-lite-wasm<br/>Bindings"]
         Server["ifc-lite-server<br/>HTTP API"]
     end
 
-    subgraph TS["TypeScript Packages (18)"]
+    subgraph TS["TypeScript Packages (selected)"]
         Parser["@ifc-lite/parser"]
         IFCX["@ifc-lite/ifcx"]
         Geometry["@ifc-lite/geometry"]
@@ -222,13 +223,13 @@ graph TB
         Spatial["@ifc-lite/spatial"]
         Codegen["@ifc-lite/codegen"]
         WasmTS["@ifc-lite/wasm"]
-        CreateCLI["@ifc-lite/create-ifc-lite"]
+        CreateCLI["create-ifc-lite"]
     end
 
     subgraph Apps["Applications"]
         Viewer["Viewer App"]
         Desktop["Desktop (3rd-party Tauri)"]
-        CLI["create-ifc-lite"]
+        CLI["@ifc-lite/cli<br/>(ifc-lite)"]
     end
 
     Wasm --> Core
@@ -603,23 +604,23 @@ graph TB
     Plugins -.->|hooks| Core
 ```
 
-### Adding Custom Geometry Processor
+### Using the Geometry Processor
+
+`GeometryProcessor` is the entry point for turning IFC bytes into meshes. Construct it with options, call `init()`, then either `process()` a whole buffer or `processStreaming()` for large files.
 
 ```typescript
-import { GeometryProcessor, ProcessorRegistry } from '@ifc-lite/geometry';
+import { GeometryProcessor } from '@ifc-lite/geometry';
 
-class CustomProcessor extends GeometryProcessor {
-  canProcess(entity: Entity): boolean {
-    return entity.type === 'IFCMYCUSTOMTYPE';
-  }
+const processor = new GeometryProcessor({ enableInstancing: true });
+await processor.init();
 
-  process(entity: Entity): Mesh {
-    // Custom processing logic
-    return mesh;
-  }
+// Small/medium files: process the whole buffer at once
+const result = await processor.process(ifcBytes);
+
+// Large files: stream meshes batch by batch
+for await (const batch of processor.processStreaming(ifcBytes)) {
+  // handle each batch of meshes
 }
-
-ProcessorRegistry.register(new CustomProcessor());
 ```
 
 ## Technology Stack

--- a/docs/contributing/release.md
+++ b/docs/contributing/release.md
@@ -18,9 +18,9 @@ This prompts you to select packages, choose a bump type (`patch`/`minor`/`major`
 
 On each release, the following are published automatically:
 
-**npm (18 packages):** All `@ifc-lite/*` packages + `create-ifc-lite`
+**npm (36 packages):** All `@ifc-lite/*` packages + `create-ifc-lite`
 
-**crates.io (3 crates):** `ifc-lite-core`, `ifc-lite-geometry`, `ifc-lite-wasm`
+**crates.io (6 crates):** `ifc-lite-core`, `ifc-lite-geometry`, `ifc-lite-clash`, `ifc-lite-processing`, `ifc-lite-ffi`, `ifc-lite-wasm`
 
 **GitHub Release:** Version tag + server binaries for 6 platforms
 

--- a/docs/contributing/setup.md
+++ b/docs/contributing/setup.md
@@ -8,7 +8,7 @@ Guide to setting up a development environment for IFClite.
 
 | Tool | Version | Purpose |
 |------|---------|---------|
-| Node.js | 18.0+ | JavaScript runtime |
+| Node.js | 22.x | JavaScript runtime |
 | pnpm | 8.0+ | Package manager |
 | Rust | stable | WASM compilation |
 | wasm-pack | 0.12+ | WASM toolchain |
@@ -19,7 +19,7 @@ Guide to setting up a development environment for IFClite.
 
     ```bash
     # Install Node.js via Homebrew
-    brew install node@18
+    brew install node@22
 
     # Install pnpm
     npm install -g pnpm
@@ -38,7 +38,7 @@ Guide to setting up a development environment for IFClite.
 
     ```bash
     # Install Node.js (Ubuntu/Debian)
-    curl -fsSL https://deb.nodesource.com/setup_18.x | sudo -E bash -
+    curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash -
     sudo apt-get install -y nodejs
 
     # Install pnpm
@@ -129,8 +129,7 @@ ifc-lite/
 │   └── codegen/           # Schema generator
 ├── apps/
 │   └── viewer/            # Demo viewer app
-├── docs/                  # Documentation
-└── plan/                  # Specifications
+└── docs/                  # Documentation
 ```
 
 ## Development Workflow
@@ -165,11 +164,10 @@ Open http://localhost:3000 in your browser.
 ### Building WASM
 
 ```bash
-cd rust/wasm-bindings
-wasm-pack build --target web --release
+pnpm build:wasm
 ```
 
-The output goes to `rust/wasm-bindings/pkg/`.
+The output goes to `packages/wasm/pkg/`.
 
 ### Running Rust Tests
 
@@ -197,7 +195,7 @@ cargo doc --no-deps
 **MkDocs (Project Documentation):**
 
 ```bash
-cd docs && mkdocs serve
+mkdocs serve
 # Opens at http://127.0.0.1:8000
 ```
 
@@ -278,9 +276,8 @@ cargo update
 
 ```bash
 # Clean and rebuild
-cd rust
 cargo clean
-wasm-pack build --target web --release
+pnpm build:wasm
 ```
 
 ### Node Modules Issues

--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -34,8 +34,8 @@ flowchart TB
 # Run all tests
 pnpm test
 
-# Run with coverage
-pnpm test:coverage
+# Run with coverage (Vitest, per package)
+pnpm -r exec vitest run --coverage
 ```
 
 ### TypeScript Tests
@@ -48,10 +48,10 @@ pnpm -r test
 cd packages/parser && pnpm test
 
 # Watch mode
-cd packages/parser && pnpm test:watch
+cd packages/parser && pnpm exec vitest --watch
 
 # With coverage
-cd packages/parser && pnpm test:coverage
+cd packages/parser && pnpm exec vitest run --coverage
 ```
 
 ### Rust Tests
@@ -395,8 +395,8 @@ mod tests {
 ### TypeScript Coverage
 
 ```bash
-# Generate coverage report
-pnpm test:coverage
+# Generate coverage report (Vitest, per package)
+pnpm -r exec vitest run --coverage
 
 # View HTML report
 open coverage/index.html
@@ -459,7 +459,8 @@ describe('Parser Performance', () => {
 Run benchmarks:
 
 ```bash
-pnpm test:bench
+# Vitest bench, from the package holding the .bench.ts file
+pnpm exec vitest bench
 ```
 
 ## CI/CD
@@ -481,7 +482,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '22'
 
       - name: Setup Rust
         uses: actions-rs/toolchain@v1

--- a/docs/design/element-splitting.md
+++ b/docs/design/element-splitting.md
@@ -1,6 +1,14 @@
 # Element Splitting (design)
 
-**Status:** plan only — not yet implemented.
+**Status:** largely implemented. Wall, slab, and linear
+(beam / column / member) split ship via
+`apps/viewer/src/store/slices/splitToolSlice.ts`, `SplitOverlay.tsx` /
+`SplitNumericInput.tsx`, the `splitWallAtDistance` / `splitSlabByLine` /
+`splitLinearElementAtDistance` store actions, and helpers in
+`wall-edit.ts`, `slab-edit.ts`, `linear-element-edit.ts`,
+`metadata-clone.ts`, and `polygon-clip.ts`. The multi-element plane
+split (Phase 6) is not yet wired, and some shipped names differ from the
+sketches below.
 
 Splitting a wall (or slab, beam, column, space, roof, plate) into
 two coherent pieces is the single most-requested authoring gesture

--- a/docs/design/level-display-modes.md
+++ b/docs/design/level-display-modes.md
@@ -1,6 +1,12 @@
 # Phase 6 — Level Display Modes (design)
 
-**Status:** plan only — not yet implemented.
+**Status:** implemented. Stacked / Exploded / Solo ship via
+`apps/viewer/src/store/slices/levelDisplaySlice.ts` +
+`apps/viewer/src/hooks/useLevelDisplayEffect.ts`. The shipped design
+diverges from the Option A sketch below: Solo reuses the
+`selectedStoreys` storey filter as the single isolation channel, and
+Exploded flushes per-entity offsets through `pendingMeshTranslations`
+rather than mutating `MeshData.positions` in a `Viewport.tsx` effect.
 
 Pascal Editor's `LevelSystem` lets users switch between **Stacked**
 (default), **Exploded** (storeys lifted on Y), and **Solo** (only one

--- a/docs/guide/browser-requirements.md
+++ b/docs/guide/browser-requirements.md
@@ -200,7 +200,9 @@ async function createRenderer(canvas: HTMLCanvasElement) {
   if (navigator.gpu) {
     const adapter = await navigator.gpu.requestAdapter();
     if (adapter) {
-      return new Renderer(canvas); // WebGPU
+      const renderer = new Renderer(canvas); // WebGPU
+      await renderer.init();
+      return renderer;
     }
   }
 

--- a/docs/guide/browser-requirements.md
+++ b/docs/guide/browser-requirements.md
@@ -12,7 +12,7 @@ The renderer requires **WebGPU**, a next-generation graphics API.
 |---------|----------------|--------|
 | Chrome | 113+ | :material-check-circle:{ .success } Stable |
 | Edge | 113+ | :material-check-circle:{ .success } Stable |
-| Firefox | 127+ | :material-check-circle:{ .success } Stable |
+| Firefox | 141+ | :material-check-circle:{ .success } Stable |
 | Safari | 18+ | :material-check-circle:{ .success } Stable |
 
 ### Checking WebGPU Support
@@ -115,7 +115,8 @@ if (typeof SharedArrayBuffer === 'undefined') {
 ## Feature Detection Example
 
 ```typescript
-import { IfcParser, Renderer } from '@ifc-lite/parser';
+import { IfcParser } from '@ifc-lite/parser';
+import { Renderer } from '@ifc-lite/renderer';
 
 interface BrowserCapabilities {
   webgpu: boolean;
@@ -166,30 +167,34 @@ if (!caps.webgpu) {
 
 ```mermaid
 flowchart LR
-    subgraph Primary["Primary Path"]
-        WebGPU["WebGPU Renderer"]
-        WASM["WASM Parser"]
-    end
+    WASM["WASM Parser<br/>(all modern browsers)"]
+    Check{WebGPU<br/>supported?}
+    WASM --> Check
+    Check -->|Yes| WebGPU["WebGPU Renderer<br/>@ifc-lite/renderer"]
+    Check -->|No| WebGL["Three.js / Babylon.js<br/>(WebGL) template"]
 
-    subgraph Fallback["Fallback Path"]
-        WebGL["WebGL2 Renderer"]
-        JS["JavaScript Parser"]
-    end
-
-    Check{Browser<br/>Support?}
-    Check -->|Full| Primary
-    Check -->|Partial| Fallback
-    Check -->|None| Error[Show Error]
-
-    style Primary fill:#16a34a,stroke:#14532d,color:#fff
-    style Fallback fill:#f59e0b,stroke:#7c2d12,color:#fff
-    style Error fill:#dc2626,stroke:#7f1d1d,color:#fff
+    style WebGPU fill:#16a34a,stroke:#14532d,color:#fff
+    style WebGL fill:#f59e0b,stroke:#7c2d12,color:#fff
 ```
 
 ### WebGL Fallback
 
+`@ifc-lite/renderer` is WebGPU-only, so it has no built-in WebGL renderer. For
+browsers without WebGPU, scaffold a WebGL viewer with the `threejs` or
+`babylonjs` template. Those render with WebGL and work in all modern browsers:
+
+```bash
+# WebGL viewer (Three.js)
+npx create-ifc-lite my-viewer --template threejs
+
+# WebGL viewer (Babylon.js)
+npx create-ifc-lite my-viewer --template babylonjs
+```
+
+You can still detect WebGPU at runtime to decide which viewer to load:
+
 ```typescript
-import { Renderer, WebGLFallbackRenderer } from '@ifc-lite/renderer';
+import { Renderer } from '@ifc-lite/renderer';
 
 async function createRenderer(canvas: HTMLCanvasElement) {
   if (navigator.gpu) {
@@ -199,11 +204,15 @@ async function createRenderer(canvas: HTMLCanvasElement) {
     }
   }
 
-  // Fallback to WebGL2
-  console.warn('WebGPU not available, using WebGL2 fallback');
-  return new WebGLFallbackRenderer(canvas);
+  // No WebGPU: load a WebGL viewer built from the threejs or
+  // babylonjs template instead (see the integration guides).
+  console.warn('WebGPU not available, use a Three.js or Babylon.js (WebGL) viewer');
+  return null;
 }
 ```
+
+See the [Three.js](../tutorials/threejs-integration.md) and
+[Babylon.js](../tutorials/babylonjs-integration.md) integration guides.
 
 ## Mobile Support
 
@@ -211,7 +220,7 @@ async function createRenderer(canvas: HTMLCanvasElement) {
 |----------|---------|--------|
 | iOS | Safari 18+ | :material-check-circle:{ .success } |
 | Android | Chrome 113+ | :material-check-circle:{ .success } |
-| Android | Firefox 127+ | :material-check-circle:{ .success } |
+| Android | Firefox | Not enabled by default (behind a flag) |
 
 !!! tip "Mobile Performance"
     For mobile devices, keep parsing columnar and stream geometry in batches:

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -248,7 +248,7 @@ Returns a complete JSON object with:
 
 ### `export` — Export Data
 
-Export entity data to CSV, JSON, or IFC STEP format.
+Export entity data to CSV, JSON, IFC STEP, and other formats.
 
 ```bash
 # CSV export
@@ -275,7 +275,7 @@ ifc-lite export model.ifc --format csv --out walls.csv
 
 | Flag | Description |
 |------|-------------|
-| `--format <fmt>` | `csv`, `json`, or `ifc` |
+| `--format <fmt>` | `csv`, `json`, `ifc`, `obj`, `gltf`, `glb`, `jsonld`, `step`, `ifcx`, or `hbjson` |
 | `--type <T>` | Filter entities by type |
 | `--columns <cols>` | Comma-separated columns (supports `PsetName.PropName`) |
 | `--separator <sep>` | CSV separator (default: `,`) |
@@ -719,7 +719,7 @@ ifc-lite schema              # Full schema with params and return types
 ifc-lite schema --compact    # Minimal: names and descriptions only
 ```
 
-The schema includes all SDK namespaces: `model`, `query`, `viewer`, `mutate`, `create`, `export`, `ids`, `bcf`, and their methods with parameter names, return types, and LLM semantic hints.
+The schema includes the runtime SDK namespaces: `model`, `query`, `viewer`, `mutate`, `store`, `lens`, `create`, `files`, `schedule`, `clash`, `export`, and their methods with parameter names, return types, and LLM semantic hints.
 
 ## Output Modes
 

--- a/docs/guide/drawing-2d.md
+++ b/docs/guide/drawing-2d.md
@@ -58,7 +58,7 @@ import { exportToSVG } from '@ifc-lite/drawing-2d';
 const svg = exportToSVG(drawing, {
   showHatching: true,
   showHiddenLines: true,
-  scale: { name: '1:100', factor: 100 },
+  scale: { name: '1:100', factor: 100, useCase: 'Floor plans' },
   title: 'Ground Floor Plan',
 });
 
@@ -77,24 +77,30 @@ import {
   renderFrame,
   renderTitleBlock,
   renderScaleBar,
+  DEFAULT_SCALE_BAR,
   PAPER_SIZE_REGISTRY,
 } from '@ifc-lite/drawing-2d';
 
-// Create an A1 landscape sheet
-const paper = PAPER_SIZE_REGISTRY.find(p => p.name === 'A1');
-const frame = createFrame({ paper, orientation: 'landscape' });
-const titleBlock = createTitleBlock({
-  projectName: 'Office Building',
-  drawingTitle: 'Ground Floor Plan',
-  scale: '1:100',
-  drawnBy: 'Architect',
-  date: '2026-02-07',
-});
+// Create an A1 landscape sheet. PAPER_SIZE_REGISTRY is keyed by id.
+const paper = PAPER_SIZE_REGISTRY.A1_LANDSCAPE;
 
-// Render to SVG
-const frameSvg = renderFrame(frame);
-const titleBlockSvg = renderTitleBlock(titleBlock);
-const scaleBarSvg = renderScaleBar({ scale: 100, units: 'm' });
+// createFrame takes a FrameStyle string:
+//   'simple' | 'professional' | 'minimal' | 'iso' | 'custom'
+const frame = createFrame('professional');
+
+// createTitleBlock takes a TitleBlockLayout string:
+//   'compact' | 'standard' | 'extended' | 'custom'
+// (title text/fields are populated via updateTitleBlockField)
+const titleBlock = createTitleBlock('standard');
+
+// Renderers return result objects, not raw SVG strings.
+const frameResult = renderFrame(paper, frame);
+const titleBlockResult = renderTitleBlock(titleBlock, frameResult.innerBounds);
+const scale = { name: '1:100', factor: 100, useCase: 'Floor plans' };
+const scaleBarSvg = renderScaleBar(DEFAULT_SCALE_BAR, scale, { x: 20, y: 20 });
+
+const frameSvg = frameResult.svgElements;
+const titleBlockSvg = titleBlockResult.svgElements;
 ```
 
 ## Graphic Overrides
@@ -107,7 +113,7 @@ import { createOverrideEngine, ARCHITECTURAL_PRESET } from '@ifc-lite/drawing-2d
 const engine = createOverrideEngine();
 
 // Apply a built-in preset
-engine.applyPreset(ARCHITECTURAL_PRESET);
+engine.setRules(ARCHITECTURAL_PRESET.rules);
 // Available: VIEW_3D_PRESET, ARCHITECTURAL_PRESET, FIRE_SAFETY_PRESET,
 //           STRUCTURAL_PRESET, MEP_PRESET, MONOCHROME_PRESET
 
@@ -117,8 +123,8 @@ engine.addRule({
   name: 'Highlight Load-Bearing Walls',
   enabled: true,
   priority: 1,
-  criteria: { type: 'ifcType', value: 'IFCWALL' },
-  style: { lineWeight: 0.5, color: '#FF0000' },
+  criteria: { type: 'ifcType', ifcTypes: ['IFCWALL'] },
+  style: { lineWeight: 0.5, strokeColor: '#FF0000' },
 });
 ```
 
@@ -136,8 +142,18 @@ The package generates proper architectural symbols:
 ```typescript
 import { generateDoorSymbol, generateWindowSymbol } from '@ifc-lite/drawing-2d';
 
-const doorSvg = generateDoorSymbol({ width: 0.9, angle: 90, swing: 'left' });
-const windowSvg = generateWindowSymbol({ width: 1.2, type: 'casement' });
+// `opening` is an OpeningInfo (extracted from the model), `bounds2D` its
+// projected footprint (Bounds2D), and `wallDirection` the wall's in-plane
+// axis as a Point2D.
+// generateDoorSymbol(opening, bounds2D, wallDirection): DoorSymbolResult
+const doorResult = generateDoorSymbol(opening, bounds2D, wallDirection);
+
+// generateWindowSymbol(opening, bounds2D, wallDirection, wallThickness?): WindowSymbolResult
+const windowResult = generateWindowSymbol(opening, bounds2D, wallDirection, 0.3);
+
+// Both return result objects (not SVG strings):
+//   doorResult.lines / doorResult.arcPath, windowResult.lines
+
 ```
 
 ## GPU Acceleration
@@ -147,9 +163,12 @@ For large models, section cutting can be GPU-accelerated:
 ```typescript
 import { GPUSectionCutter, isGPUComputeAvailable } from '@ifc-lite/drawing-2d';
 
-if (await isGPUComputeAvailable()) {
+// isGPUComputeAvailable() is synchronous - do not await it.
+if (isGPUComputeAvailable()) {
   const cutter = new GPUSectionCutter(gpuDevice);
-  const result = await cutter.cut(meshData, sectionConfig);
+  // Allocate GPU buffers first; cutMeshes throws if initialize() was not called.
+  await cutter.initialize(maxTriangles);
+  const result = await cutter.cutMeshes(meshData, sectionConfig);
 }
 ```
 

--- a/docs/guide/exporting.md
+++ b/docs/guide/exporting.md
@@ -18,11 +18,11 @@ Export IFC to GLB directly in the browser with zero setup:
     <div id="status"></div>
 
     <script type="module">
-        import { GeometryProcessor } from "https://cdn.jsdelivr.net/npm/@ifc-lite/geometry@1.2.1/+esm";
-        import initWasm from "https://cdn.jsdelivr.net/npm/@ifc-lite/wasm@1.2.1/+esm";
+        import { GeometryProcessor } from "https://cdn.jsdelivr.net/npm/@ifc-lite/geometry/+esm";
+        import initWasm from "https://cdn.jsdelivr.net/npm/@ifc-lite/wasm/+esm";
 
         // Initialize WASM with explicit path for CDN
-        const wasmUrl = "https://cdn.jsdelivr.net/npm/@ifc-lite/wasm@1.2.1/pkg/ifc-lite_bg.wasm";
+        const wasmUrl = "https://cdn.jsdelivr.net/npm/@ifc-lite/wasm/pkg/ifc-lite_bg.wasm";
         await initWasm({ module_or_path: wasmUrl });
 
         document.getElementById("file").addEventListener("change", async (e) => {
@@ -78,7 +78,6 @@ flowchart LR
         glTF["glTF/GLB"]
         IFCOut["IFC (roundtrip)"]
         Parquet["Apache Parquet"]
-        Arrow["Apache Arrow"]
         JSON["JSON-LD"]
         CSV["CSV"]
     end
@@ -95,7 +94,6 @@ flowchart LR
     IFC --> glTF --> Viewer
     IFC --> IFCOut --> Roundtrip
     IFC --> Parquet --> Analytics
-    IFC --> Arrow --> Analytics
     IFC --> JSON --> Linked
     IFC --> CSV --> Spreadsheet
 ```
@@ -169,26 +167,26 @@ Export to Apache Parquet for analytics with tools like DuckDB, Pandas, or Polars
 ```typescript
 import { ParquetExporter } from '@ifc-lite/export';
 
-const exporter = new ParquetExporter();
+// The exporter needs the parsed data store. Pass a GeometryResult too if
+// you also want the vertex/index/mesh tables:
+const exporter = new ParquetExporter(store, geometryResult);
 
-// Export entities
-const entitiesParquet = await exporter.exportEntities(parseResult);
+// Export the whole model as a single .bos archive (a ZIP of Parquet files:
+// Entities, Properties, Quantities, Relationships, Strings, plus the
+// geometry tables when a GeometryResult was supplied):
+const bos = await exporter.exportBOS();
+await saveFile('model.bos', bos);
+
+// Or export one table at a time. Valid names: 'entities' | 'properties' |
+// 'quantities' | 'relationships' | 'strings' | 'vertices' | 'indices' | 'meshes'.
+const entitiesParquet = await exporter.exportTable('entities');
 await saveFile('entities.parquet', entitiesParquet);
 
-// Export properties
-const propsParquet = await exporter.exportProperties(parseResult);
+const propsParquet = await exporter.exportTable('properties');
 await saveFile('properties.parquet', propsParquet);
 
-// Export quantities
-const quantsParquet = await exporter.exportQuantities(parseResult);
+const quantsParquet = await exporter.exportTable('quantities');
 await saveFile('quantities.parquet', quantsParquet);
-
-// Export all tables
-const bundle = await exporter.exportAll(parseResult);
-await saveFile('entities.parquet', bundle.entities);
-await saveFile('properties.parquet', bundle.properties);
-await saveFile('quantities.parquet', bundle.quantities);
-await saveFile('relationships.parquet', bundle.relationships);
 ```
 
 ### Parquet Schema
@@ -358,10 +356,10 @@ Export back to IFC format for roundtrip workflows and interoperability with othe
 ```typescript
 import { StepExporter } from '@ifc-lite/export';
 
-const exporter = new StepExporter(dataStore, sourceBuffer);
+const exporter = new StepExporter(dataStore);
 
 // Full export
-const result = exporter.export();
+const result = exporter.export({});
 await saveFile('model.ifc', result.content);
 
 // Visible-only export (exclude hidden entities)
@@ -453,28 +451,13 @@ specific to IFC4X3 (alignment / linear referencing) may not be rescaled — a
 Load existing GLB files for viewing alongside IFC models:
 
 ```typescript
-import { GlbImporter } from '@ifc-lite/import';
+import { parseGLBToMeshData } from '@ifc-lite/export';
 
-const importer = new GlbImporter();
 const glbBuffer = await fetch('model.glb').then(r => r.arrayBuffer());
-const meshes = await importer.import(new Uint8Array(glbBuffer));
+const meshes = parseGLBToMeshData(new Uint8Array(glbBuffer)); // MeshData[]
 
 // Add imported meshes to the renderer
 renderer.addMeshes(meshes);
-```
-
-## Arrow Export
-
-Export to Apache Arrow for in-memory analytics and streaming pipelines:
-
-```typescript
-import { ArrowExporter } from '@ifc-lite/export';
-
-const exporter = new ArrowExporter();
-const arrowBuffer = await exporter.exportEntities(parseResult);
-
-// Use with Arrow-compatible tools (DuckDB, DataFusion, etc.)
-await saveFile('entities.arrow', arrowBuffer);
 ```
 
 ## Custom Export
@@ -482,13 +465,15 @@ await saveFile('entities.arrow', arrowBuffer);
 Create custom export formats:
 
 ```typescript
-import { ExportPipeline } from '@ifc-lite/export';
-
-import { extractPropertiesOnDemand, extractQuantitiesOnDemand } from '@ifc-lite/parser';
+import {
+  extractEntityAttributesOnDemand,
+  extractPropertiesOnDemand,
+  extractQuantitiesOnDemand,
+} from '@ifc-lite/parser';
 
 // Define custom exporter
 class CustomExporter {
-  export(store: IfcDataStore, buffer: Uint8Array): CustomFormat {
+  export(store: IfcDataStore): CustomFormat {
     const output: CustomFormat = {
       metadata: {
         schema: store.schemaVersion,
@@ -503,11 +488,12 @@ class CustomExporter {
     for (const expressId of wallIds) {
       const entityRef = store.entityIndex.byId.get(expressId);
       if (entityRef) {
+        // EntityRef has no name; resolve it from the store on demand.
         output.elements.push({
           id: expressId,
-          name: entityRef.name,
-          properties: extractPropertiesOnDemand(store, expressId, buffer),
-          quantities: extractQuantitiesOnDemand(store, expressId, buffer)
+          name: extractEntityAttributesOnDemand(store, expressId).name,
+          properties: extractPropertiesOnDemand(store, expressId),
+          quantities: extractQuantitiesOnDemand(store, expressId)
         });
       }
     }
@@ -518,7 +504,7 @@ class CustomExporter {
 
 // Use custom exporter
 const exporter = new CustomExporter();
-const custom = exporter.export(store, buffer);
+const custom = exporter.export(store);
 ```
 
 ## Filtered Export
@@ -533,11 +519,11 @@ import { GeometryProcessor } from '@ifc-lite/geometry';
 import { IfcQuery } from '@ifc-lite/query';
 
 // Filter entities with query
-const query = new IfcQuery(parseResult);
+const query = new IfcQuery(store); // store from parseColumnar()
 const externalWalls = query
   .walls()
   .whereProperty('Pset_WallCommon', 'IsExternal', '=', true)
-  .toArray();
+  .execute();
 
 const isolated = new Uint32Array(externalWalls.map((w) => w.expressId));
 
@@ -570,21 +556,21 @@ flowchart LR
 ```
 
 ```typescript
-import { ExportPipeline } from '@ifc-lite/export';
+import { GeometryProcessor } from '@ifc-lite/geometry';
+import { ParquetExporter } from '@ifc-lite/export';
 
-const pipeline = new ExportPipeline(parseResult);
+const gp = new GeometryProcessor();
+await gp.init();
 
-// Run multiple exports in parallel
-const results = await pipeline.export([
-  { format: 'glb', options: { useDraco: true } },
-  { format: 'parquet', tables: ['entities', 'properties'] },
-  { format: 'csv', columns: ['expressId', 'type', 'name'] }
-]);
+// There is no single pipeline class — compose the real exporters you need.
+const glb = gp.exportGlb(bytes, true, new Uint32Array(), new Uint32Array(), '');
+const entitiesParquet = await new ParquetExporter(store).exportTable('entities');
+const csv = gp.exportCsv(bytes, 'entities', ',', /* includeProperties */ true);
 
 // Save all results
-await saveFile('model.glb', results.glb);
-await saveFile('entities.parquet', results.parquet.entities);
-await saveFile('entities.csv', results.csv);
+await saveFile('model.glb', glb);
+await saveFile('entities.parquet', entitiesParquet);
+await saveFile('entities.csv', csv);
 ```
 
 ## Next Steps

--- a/docs/guide/extension-authoring.md
+++ b/docs/guide/extension-authoring.md
@@ -21,7 +21,7 @@ my-tool/
         └── hello.js
 ```
 
-The scaffolded `hello.js` is a runnable extension that contributes one command (`ext.starter.hello`) and prints a greeting to the console. Validate it:
+The scaffolded `hello.js` contributes one command (`ext.starter.hello`) and prints a greeting to the console. It passes `ext validate` as-is, but note the scaffold uses `export default async function hello(ctx)`; before it will run in the sandbox you must convert that to a plain top-level `async function hello(ctx)` (see [Writing entry code](#writing-entry-code) - entry files allow no `export` and no `import`). Validate it:
 
 ```bash
 npx @ifc-lite/cli ext validate my-tool
@@ -202,7 +202,7 @@ The `ctx.bim` API mirrors the `@ifc-lite/sdk` surface. Run `ifc-lite schema` (no
 - File system APIs
 - Web Workers, WASM instantiation
 
-These are blocked at parse time by the AST walker in `validate/code.ts`. If your code references one, `ext validate` flags it before pack.
+The sandbox runtime blocks these at execution time. The AI authoring pipeline additionally runs a static AST walker (`validate/code.ts`) that flags a subset of them (`globalThis`, `window`, `process`, `document`, `self`, plus `eval` / `new Function` / dynamic `import`) during its repair loop. Note that `ext validate` does not run that walker, so hand-authored code is only caught when it runs in the sandbox.
 
 ### Async handlers
 
@@ -219,7 +219,7 @@ The host never `await`s a long-running entry — async work runs inside the sand
 
 ## Widgets
 
-Widgets are JSON descriptions of UI you contribute to a dock panel. The widget DSL has 15 node types — `Stack`, `Group`, `Text`, `Field`, `Button`, `Table`, `Chart`, `Markdown`, `Tabs`, `Separator`, `EmptyState`, `Spinner`, `ErrorBanner`, `EntityList`, `Tree`, `KeyValueGrid`.
+Widgets are JSON descriptions of UI you contribute to a dock panel. The widget DSL has 16 node types — `Stack`, `Group`, `Text`, `Field`, `Button`, `Table`, `Chart`, `Markdown`, `Tabs`, `Separator`, `EmptyState`, `Spinner`, `ErrorBanner`, `EntityList`, `Tree`, `KeyValueGrid`.
 
 ```json
 {
@@ -381,8 +381,8 @@ The signature commits to a canonical hash of the bundle contents + the `signedAt
 
 ## Troubleshooting
 
-??? question "`ext validate` says 'banned global'"
-    Your code references `globalThis`, `window`, `document`, or another disallowed name. The AST walker flags these at parse time. Remove the reference — the sandbox runtime would block the access anyway, this just surfaces it earlier.
+??? question "The authoring loop says 'banned global'"
+    Your code references `globalThis`, `window`, `process`, `document`, or `self`. The AST walker (`validate/code.ts`) flags these during the AI authoring / repair loop (`ext validate` does not run it). Remove the reference - the sandbox runtime would block the access anyway, this just surfaces it earlier.
 
 ??? question "Manifest fails with 'dangling command reference'"
     Cross-reference validator says a `toolbar` / `contextMenu` / `keybinding` contribution names a command that's not declared in `contributes.commands`. Add the command, or remove the reference.

--- a/docs/guide/federation.md
+++ b/docs/guide/federation.md
@@ -100,7 +100,7 @@ interface FederatedModel {
 
 - Each model adds its entities to the shared spatial index and renderer
 - Memory usage scales linearly with total entity count across all models
-- The FederationRegistry uses O(1) lookups for ID resolution
+- The FederationRegistry resolves IDs in O(1) local->global, O(log N) global->local
 - Visibility toggling per-model is O(1) (GPU-level filtering)
 - Loading 5+ large models (100MB+ each) may require the server paradigm for best performance
 

--- a/docs/guide/geometry.md
+++ b/docs/guide/geometry.md
@@ -114,7 +114,6 @@ classDiagram
         +Uint32Array indices
         +Float32Array? uvs
         +number[] color
-        +Matrix4 transform
     }
 
     class GeometryResult {
@@ -156,8 +155,8 @@ for (const mesh of result.meshes) {
 // Find mesh by entity ID
 const wallMesh = result.meshes.find(m => m.expressId === wallId);
 
-// Calculate bounds from meshes
-const bounds = calculateBounds(result.meshes);
+// Precomputed model bounds (from coordinate info on the result)
+const bounds = result.coordinateInfo.shiftedBounds;
 console.log(`Model bounds:`, bounds);
 ```
 
@@ -206,7 +205,7 @@ for await (const event of geometry.processStreaming(new Uint8Array(buffer))) {
 
       // Render current state
       renderer.render();
-      console.log(`Progress: ${event.progress}%`);
+      console.log(`Meshes so far: ${event.totalSoFar}`);
       break;
 
     case 'complete':
@@ -256,10 +255,10 @@ await geometry.init();
 
 const result = await geometry.process(new Uint8Array(buffer));
 
-// Access the computed shift from coordinate info
-const coordInfo = geometry.getCoordinateInfo();
-if (coordInfo?.shift) {
-  console.log(`Origin shifted by:`, coordInfo.shift);
+// Access the computed shift from coordinate info (returned on the result)
+const coordInfo = result.coordinateInfo;
+if (coordInfo?.originShift) {
+  console.log(`Origin shifted by:`, coordInfo.originShift);
   // { x: 487234.5, y: 5234891.2, z: 0 }
 }
 
@@ -344,31 +343,6 @@ flowchart LR
     style Result fill:#a855f7,stroke:#581c87,color:#fff
 ```
 
-## Custom Geometry Processing
-
-Extend geometry processing for custom needs:
-
-```typescript
-import { GeometryProcessor, ProcessorRegistry } from '@ifc-lite/geometry';
-
-// Create custom processor
-class CustomProfileProcessor extends GeometryProcessor {
-  canProcess(entity: Entity): boolean {
-    return entity.type === 'IFCARBITRARYCLOSEDPROFILEDEF';
-  }
-
-  process(entity: Entity): Mesh {
-    // Custom triangulation logic
-    const points = this.extractPoints(entity);
-    const triangles = this.triangulate(points);
-    return this.buildMesh(triangles);
-  }
-}
-
-// Register processor
-ProcessorRegistry.register(new CustomProfileProcessor());
-```
-
 ## Batching
 
 The renderer automatically groups geometry by colour into a small number of
@@ -403,7 +377,7 @@ await geometry.init();
 for await (const event of geometry.processStreaming(new Uint8Array(buffer), undefined, 50)) {
   if (event.type === 'batch') {
     renderer.addMeshes(event.meshes, true);
-    console.log(`Progress: ${event.progress}%`);
+    console.log(`Meshes so far: ${event.totalSoFar}`);
   }
 }
 ```
@@ -433,7 +407,7 @@ const result = await geometry.process(new Uint8Array(buffer));
 
 // Filter meshes
 const filteredMeshes = result.meshes.filter(m => wantedIds.has(m.expressId));
-renderer.loadGeometry({ meshes: filteredMeshes });
+renderer.loadGeometry(filteredMeshes);
 ```
 
 ## Geometry Statistics

--- a/docs/guide/ids.md
+++ b/docs/guide/ids.md
@@ -25,7 +25,7 @@ console.log(`${idsDocument.info.title}`);
 console.log(`${idsDocument.specifications.length} specifications`);
 
 for (const spec of idsDocument.specifications) {
-  console.log(`  ${spec.name} [${spec.optionality}]`);
+  console.log(`  ${spec.name}`);
 }
 ```
 
@@ -39,29 +39,36 @@ const idsDocument = parseIDS(idsXml);
 
 // Create a data accessor that bridges IDS to your IFC data
 const accessor: IFCDataAccessor = {
-  getEntities: () => allEntities,
+  getAllEntityIds: () => allEntityIds,
+  getEntitiesByType: (type) => entitiesByType.get(type) ?? [],
   getEntityType: (id) => entityTypeMap.get(id),
+  getEntityName: (id) => getName(id),
+  getGlobalId: (id) => getGuid(id),
+  getDescription: (id) => getDescriptionText(id),
+  getObjectType: (id) => getPredefinedType(id),
   getPropertyValue: (id, pset, prop) => getProperty(id, pset, prop),
-  getClassification: (id) => getClassificationInfo(id),
-  getMaterial: (id) => getMaterialInfo(id),
-  getParent: (id) => getParentInfo(id),
+  getPropertySets: (id) => getPropertySetInfo(id),
+  getClassifications: (id) => getClassificationInfo(id),
+  getMaterials: (id) => getMaterialInfo(id),
+  getParent: (id, relation) => getParentInfo(id, relation),
   getAttribute: (id, attr) => getAttributeValue(id, attr),
 };
 
 // Model info for the validation report
 const modelInfo: IDSModelInfo = {
-  filename: 'model.ifc',
-  schema: 'IFC4',
+  modelId: 'model.ifc',
+  schemaVersion: 'IFC4',
+  entityCount: allEntityIds.length,
 };
 
 // Validate (requires: document, accessor, modelInfo, options?)
 const report = await validateIDS(idsDocument, accessor, modelInfo, {
-  onProgress: (progress) => console.log(`${progress.phase}: ${progress.percent}%`),
+  onProgress: (progress) => console.log(`${progress.phase}: ${progress.percentage}%`),
 });
 
-console.log(`${report.summary.totalEntities} entities checked`);
-console.log(`${report.summary.passedEntities} passed`);
-console.log(`${report.summary.failedEntities} failed`);
+console.log(`${report.summary.totalEntitiesChecked} entities checked`);
+console.log(`${report.summary.totalEntitiesPassed} passed`);
+console.log(`${report.summary.totalEntitiesFailed} failed`);
 ```
 
 ## Facet Types

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -157,17 +157,17 @@ The fastest way to get started is using the `create-ifc-lite` CLI:
 
 ```bash
 # Run the official container
-docker run -p 3001:8080 ghcr.io/LTplus-AG/ifc-lite-server
+docker run -p 3001:8080 ghcr.io/ltplus-ag/ifc-lite-server
 
 # With persistent cache
-docker run -p 3001:8080 -v ifc-cache:/app/cache ghcr.io/LTplus-AG/ifc-lite-server
+docker run -p 3001:8080 -v ifc-cache:/app/cache ghcr.io/ltplus-ag/ifc-lite-server
 
 # With environment configuration
 docker run -p 3001:8080 \
   -e RUST_LOG=info \
   -e MAX_FILE_SIZE_MB=500 \
   -e WORKER_THREADS=8 \
-  ghcr.io/LTplus-AG/ifc-lite-server
+  ghcr.io/ltplus-ag/ifc-lite-server
 ```
 
 ### Option 2: Native Binary
@@ -211,8 +211,8 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-ifc-lite-core = "1.2"
-ifc-lite-geometry = "1.2"
+ifc-lite-core = "4"
+ifc-lite-geometry = "4"
 ```
 
 Or install via cargo:
@@ -248,7 +248,7 @@ git lfs pull --include="tests/models/ara3d/AC20-FZK-Haus.ifc"
 
 ### Prerequisites
 
-- **Node.js** 18.0 or higher
+- **Node.js** 22.x
 - **pnpm** 8.0 or higher
 - **Rust** toolchain (the pinned nightly in `rust-toolchain.toml`, installed automatically by `rustup`) - only for WASM builds (and your own desktop builds, if any)
 
@@ -277,15 +277,11 @@ pnpm dev
 If you modify Rust code:
 
 ```bash
-# Install wasm-pack
+# Install wasm-pack (if not already installed)
 cargo install wasm-pack
 
-# Rebuild WASM
-cd rust
-wasm-pack build --target web --release
-
-# Copy to packages/wasm
-cp -r pkg/* ../packages/wasm/
+# Rebuild WASM (outputs to packages/wasm/pkg)
+pnpm build:wasm
 ```
 
 ## CDN Usage
@@ -294,7 +290,7 @@ For quick prototyping without a build step:
 
 ```html
 <script type="module">
-  import { IfcParser } from 'https://cdn.jsdelivr.net/npm/@ifc-lite/parser@1.2.1/+esm';
+  import { IfcParser } from 'https://cdn.jsdelivr.net/npm/@ifc-lite/parser/+esm';
 
   const parser = new IfcParser();
   const response = await fetch('model.ifc');
@@ -308,11 +304,11 @@ For geometry processing with WASM, you must initialize the WASM module explicitl
 
 ```html
 <script type="module">
-  import { GeometryProcessor } from 'https://cdn.jsdelivr.net/npm/@ifc-lite/geometry@1.2.1/+esm';
-  import initWasm from 'https://cdn.jsdelivr.net/npm/@ifc-lite/wasm@1.2.1/+esm';
+  import { GeometryProcessor } from 'https://cdn.jsdelivr.net/npm/@ifc-lite/geometry/+esm';
+  import initWasm from 'https://cdn.jsdelivr.net/npm/@ifc-lite/wasm/+esm';
 
   // Initialize WASM with explicit path (required for CDN)
-  const wasmUrl = 'https://cdn.jsdelivr.net/npm/@ifc-lite/wasm@1.2.1/pkg/ifc-lite_bg.wasm';
+  const wasmUrl = 'https://cdn.jsdelivr.net/npm/@ifc-lite/wasm/pkg/ifc-lite_bg.wasm';
   await initWasm({ module_or_path: wasmUrl });
 
   const processor = new GeometryProcessor();

--- a/docs/guide/parsing.md
+++ b/docs/guide/parsing.md
@@ -390,7 +390,9 @@ interface IfcDataStore {
 ```typescript
 import { IfcTypeEnum } from '@ifc-lite/data';
 
+// spatialHierarchy is optional on IfcDataStore; guard before use
 const hierarchy = store.spatialHierarchy;
+if (!hierarchy) throw new Error('No spatial hierarchy in this model');
 
 // Project structure
 console.log(`Project: ${hierarchy.project.name}`);
@@ -538,6 +540,8 @@ groups.forEach((elementIds, code) => {
 
 ```typescript
 import { IfcParser } from '@ifc-lite/parser';
+
+const parser = new IfcParser();
 
 try {
   const store = await parser.parseColumnar(buffer);

--- a/docs/guide/parsing.md
+++ b/docs/guide/parsing.md
@@ -80,7 +80,7 @@ const doorIds = store.entityIndex.byType.get('IFCDOOR') ?? [];
 const entityRef = store.entityIndex.byId.get(123);
 
 // Metadata
-console.log(`Schema: ${store.schemaVersion}`);  // IFC2X3, IFC4, IFC4X3
+console.log(`Schema: ${store.schemaVersion}`);  // IFC2X3, IFC4, IFC4X3, IFC5
 console.log(`Entities: ${store.entityCount}`);
 console.log(`Parse time: ${store.parseTime}ms`);
 ```
@@ -128,7 +128,7 @@ for await (const event of geometry.processStreaming(new Uint8Array(buffer))) {
     case 'batch':
       // Add meshes to renderer as they arrive
       renderer.addMeshes(event.meshes, true);  // isStreaming = true
-      progressBar.value = event.progress;
+      progressBar.value = event.totalSoFar;  // cumulative mesh count (no percentage on batch events)
       break;
     case 'complete':
       console.log(`Done: ${event.totalMeshes} meshes`);
@@ -214,15 +214,16 @@ import { detectFormat } from '@ifc-lite/ifcx';
 const result = await parseAuto(buffer);
 
 if (result.format === 'ifcx') {
-  // IFC5 file
-  const { entities, meshes, spatialHierarchy } = result;
+  // IFC5 file: parsed data lives under result.data, meshes at the top level
+  const { entities, spatialHierarchy } = result.data;
+  const meshes = result.meshes;
 } else {
-  // IFC4 STEP file
-  const { store } = result;
+  // IFC4 STEP file: the IfcDataStore is result.data
+  const store = result.data;
 }
 
 // Or detect format manually
-const format = detectFormat(buffer);  // 'ifc', 'ifcx', or 'unknown'
+const format = detectFormat(buffer);  // 'ifc', 'ifcx', 'glb', or 'unknown'
 ```
 
 ### Direct IFCX Parsing
@@ -242,7 +243,7 @@ console.log(`Meshes: ${result.meshes.length}`);
 
 // Pre-tessellated USD geometry
 for (const mesh of result.meshes) {
-  console.log(`Entity #${mesh.express_id}: ${mesh.ifc_type}`);
+  console.log(`Entity #${mesh.expressId}: ${mesh.ifcType}`);
   // mesh.positions, mesh.normals, mesh.indices ready for GPU
 }
 
@@ -285,7 +286,7 @@ const hierarchy = result.spatialHierarchy;
 console.log(`Project: ${hierarchy.project.name}`);
 
 // Element-to-storey lookup
-const storeyId = hierarchy.element_to_storey.get(wallId);
+const storeyId = hierarchy.elementToStorey.get(wallId);
 ```
 
 ## Server-Side Parsing
@@ -302,12 +303,10 @@ const client = new IfcServerClient({
 // Parquet format (15x smaller than JSON)
 const result = await client.parseParquet(file);
 
-// Streaming for large files
-for await (const event of client.parseParquetStream(file)) {
-  if (event.type === 'batch') {
-    renderer.addMeshes(event.meshes);
-  }
-}
+// Streaming for large files (onBatch callback fires per geometry batch)
+await client.parseParquetStream(file, (batch) => {
+  renderer.addMeshes(batch.meshes);
+});
 ```
 
 See the [Server Guide](server.md) for complete server documentation.
@@ -317,33 +316,38 @@ See the [Server Guide](server.md) for complete server documentation.
 ```typescript
 interface ParseOptions {
   // Progress callback
-  onProgress?: (progress: Progress) => void;
+  onProgress?: (progress: { phase: string; percent: number }) => void;
 
-  // Geometry quality: 'FAST' | 'BALANCED' | 'HIGH'
-  geometryQuality?: GeometryQuality;
+  // Diagnostic message callback
+  onDiagnostic?: (message: string) => void;
 
-  // Skip geometry processing
-  skipGeometry?: boolean;
+  // Optional IfcAPI instance for WASM-accelerated entity scanning
+  wasmApi?: WasmScanApi;
 
-  // Coordinate handling
-  autoOriginShift?: boolean;
-  customOrigin?: { x: number; y: number; z: number };
+  // Yield budget for large incremental parses (higher finishes faster with longer main-thread slices)
+  yieldIntervalMs?: number;
 
-  // Entity filtering
-  includeTypes?: string[];
-  excludeTypes?: string[];
+  // Keep property-set containers indexed but defer individual property/quantity atoms
+  deferPropertyAtomIndex?: boolean;
 
-  // WASM acceleration (optional)
-  wasmApi?: WasmApi;
+  // Skip worker-based entity scanning and stay in-process
+  disableWorkerScan?: boolean;
+
+  // Called when spatial hierarchy is ready, before property/association parsing completes
+  onSpatialReady?: (partialStore: IfcDataStore) => void;
+
+  // Pre-built entity index from another worker (e.g. the streaming geometry pre-pass)
+  preScannedEntityIndex?: PreScannedEntityIndex;
 }
 
 const store = await parser.parseColumnar(buffer, {
-  geometryQuality: 'BALANCED',
-  autoOriginShift: true,
-  excludeTypes: ['IFCSPACE', 'IFCOPENINGELEMENT'],
+  deferPropertyAtomIndex: true,
   onProgress: ({ phase, percent }) => console.log(`${phase}: ${percent}%`)
 });
 ```
+
+Tessellation and geometry quality are configured on the `GeometryProcessor`,
+not on `parseColumnar()`.
 
 ## IfcDataStore Structure
 
@@ -351,7 +355,7 @@ const store = await parser.parseColumnar(buffer, {
 interface IfcDataStore {
   // Metadata
   fileSize: number;
-  schemaVersion: 'IFC2X3' | 'IFC4' | 'IFC4X3';
+  schemaVersion: 'IFC2X3' | 'IFC4' | 'IFC4X3' | 'IFC5';
   entityCount: number;
   parseTime: number;
 
@@ -384,23 +388,25 @@ interface IfcDataStore {
 ## Spatial Hierarchy
 
 ```typescript
+import { IfcTypeEnum } from '@ifc-lite/data';
+
 const hierarchy = store.spatialHierarchy;
 
 // Project structure
 console.log(`Project: ${hierarchy.project.name}`);
 
-// Navigate storeys
+// Navigate storeys (SpatialNode.type is a numeric IfcTypeEnum)
 for (const child of hierarchy.project.children) {
-  if (child.type === 'IFCBUILDINGSTOREY') {
+  if (child.type === IfcTypeEnum.IfcBuildingStorey) {
     const storey = child;
     console.log(`Storey: ${storey.name}`);
 
-    // Get elements on this storey
-    const elements = hierarchy.byStorey.get(storey.id) ?? [];
+    // Get elements on this storey (byStorey is keyed by the storey express id)
+    const elements = hierarchy.byStorey.get(storey.expressId) ?? [];
     console.log(`  Elements: ${elements.length}`);
 
     // Get storey elevation
-    const elevation = hierarchy.storeyElevations.get(storey.id);
+    const elevation = hierarchy.storeyElevations.get(storey.expressId);
     console.log(`  Elevation: ${elevation}m`);
   }
 }
@@ -458,14 +464,22 @@ import {
 const materials = extractMaterials(store);
 
 // Get material for an element
-const material = getMaterialForElement(wallId, materials);
-if (material) {
-  console.log(`Material: ${material.name}`);
+// getMaterialForElement returns a material express id (or undefined)
+const materialId = getMaterialForElement(wallId, materials);
+if (materialId !== undefined) {
+  const material = materials.materials.get(materialId);
+  if (material) {
+    console.log(`Material: ${material.name}`);
+  }
 
-  // For layered materials (walls)
-  if (material.layers) {
-    for (const layer of material.layers) {
-      console.log(`  Layer: ${layer.material} (${layer.thickness}mm)`);
+  // Layered materials resolve to a MaterialLayerSet of layer ids
+  const layerSet = materials.materialLayerSets.get(materialId);
+  if (layerSet) {
+    for (const layerId of layerSet.layers) {
+      const layer = materials.materialLayers.get(layerId);
+      if (!layer) continue;
+      const layerMat = materials.materials.get(layer.material);
+      console.log(`  Layer: ${layerMat?.name ?? layer.material} (${layer.thickness}mm)`);
     }
   }
 }
@@ -483,14 +497,15 @@ import {
 const georef = extractGeoreferencing(store);
 
 if (georef) {
-  console.log(`CRS: ${georef.targetCRS?.name}`);
+  console.log(`CRS: ${georef.projectedCRS?.name}`);
   console.log(`Eastings: ${georef.mapConversion?.eastings}`);
   console.log(`Northings: ${georef.mapConversion?.northings}`);
 
-  // Transform local coordinate to world
-  const local = { x: 10, y: 20, z: 0 };
-  const world = transformToWorld(local, georef);
-  console.log(`World: ${world.x}, ${world.y}, ${world.z}`);
+  // Transform a local coordinate (tuple) to world; returns a tuple or null
+  const world = transformToWorld([10, 20, 0], georef);
+  if (world) {
+    console.log(`World: ${world[0]}, ${world[1]}, ${world[2]}`);
+  }
 }
 ```
 
@@ -508,8 +523,8 @@ const classifications = extractClassifications(store);
 // Get classifications for an element
 const codes = getClassificationsForElement(wallId, classifications);
 for (const code of codes) {
-  console.log(`${code.system}: ${code.identification} - ${code.name}`);
-  // e.g., "Uniclass 2015: Pr_60_10_32 - External walls"
+  console.log(`${code.identification} - ${code.name}`);
+  // e.g., "Pr_60_10_32 - External walls" (owning system via code.referencedSource)
 }
 
 // Group elements by classification
@@ -522,20 +537,15 @@ groups.forEach((elementIds, code) => {
 ## Error Handling
 
 ```typescript
-import { IfcParser, ParseError, TokenError, SchemaError } from '@ifc-lite/parser';
+import { IfcParser } from '@ifc-lite/parser';
 
 try {
   const store = await parser.parseColumnar(buffer);
 } catch (error) {
-  if (error instanceof TokenError) {
-    // Malformed STEP syntax
-    console.error(`Token error at line ${error.line}: ${error.message}`);
-  } else if (error instanceof SchemaError) {
-    // Unknown or unsupported schema
-    console.error(`Schema error: ${error.message}`);
-  } else if (error instanceof ParseError) {
-    // General parse error
-    console.error(`Parse error: ${error.message}`);
+  // parseColumnar throws standard Error instances on malformed STEP syntax,
+  // unknown or unsupported schemas, and other parse failures.
+  if (error instanceof Error) {
+    console.error(`Parse failed: ${error.message}`);
   } else {
     throw error;
   }
@@ -548,7 +558,7 @@ try {
 |------|----------|--------|-------|
 | `parse()` | Small files, full object access | High | Moderate |
 | `parseColumnar()` | Most use cases | Low | Fast |
-| `parseStreaming()` | Large files (>50MB) | Very Low | Progressive |
+| `GeometryProcessor.processStreaming()` | Large files (>50MB) | Very Low | Progressive |
 | Server | Production, caching | Server-side | Fastest (cached) |
 
 ### Performance Tips

--- a/docs/guide/performance.md
+++ b/docs/guide/performance.md
@@ -58,7 +58,7 @@ When using `@ifc-lite/parser` in the browser, properties are not all parsed upfr
 These design decisions have the biggest impact on performance:
 
 - **Streaming first**: Geometry is parsed and rendered incrementally. You see the model building up, not a loading spinner followed by everything at once.
-- **Web Workers for large files**: Files over 50 MB are processed in a dedicated worker. Geometry streams from the worker while the data model parses on the main thread.
+- **Web Workers**: When the browser supports cross-origin isolation and SharedArrayBuffer, the data model parses in a dedicated Web Worker; it only falls back to the main thread when SharedArrayBuffer is unavailable. Geometry is meshed by a pool of workers for files of any size, with the pool size chosen by job count and available memory rather than a fixed file-size threshold.
 - **Columnar storage**: Data is stored by type (IDs, types, names as separate arrays) for cache-efficient access patterns.
 - **Zero-copy ArrayBuffer transfer**: Buffers are transferred between worker and main thread, not copied.
 

--- a/docs/guide/privacy.md
+++ b/docs/guide/privacy.md
@@ -17,10 +17,10 @@ All four live in your browser's IndexedDB. Nothing is sent off-device unless you
 |-------|---------|---------|-----|
 | `ifc-lite-extensions` | IndexedDB | Installed `.iflx` bundles + their records | Forever (or until uninstall) |
 | `ifc-lite-flavors` | IndexedDB | Flavor library + snapshots | Forever (snapshots cap at 10 per flavor) |
-| Action log | In-memory ring buffer | Pattern miner input | 50,000 events / 8 MiB rolling |
-| Audit log | In-memory ring buffer | Lifecycle events | 5,000 entries rolling |
+| Action log | IndexedDB (ring buffer) | Pattern miner input | 50,000 events / 8 MiB rolling |
+| Audit log | IndexedDB (ring buffer) | Lifecycle events | 10,000 entries / 10 MiB rolling |
 
-The action and audit logs are in-memory today; persistence across reloads is a Phase 4 follow-up. When persistence lands they'll move to the same IndexedDB store with the same retention caps.
+The action and audit logs are held in an in-memory ring buffer and mirrored to IndexedDB, so they survive a reload (both are hydrated from IDB on startup). Clearing a log wipes both the in-memory copy and its persisted copy.
 
 ## The Privacy panel
 
@@ -45,7 +45,7 @@ Per-flavor durable notes the AI assistant sees in every chat for that flavor. Us
 
 | Field | Notes |
 |-------|-------|
-| Textarea | Markdown content. Capped at ~4000 tokens (~16 KB). Excess is truncated server-side with a `[truncated]` marker. |
+| Textarea | Markdown content. Capped at ~4000 tokens (~16 KB). Excess is truncated client-side on save with a `[truncated]` marker. |
 | **Extract from chat** | Scans the current session transcript for stable preferences and proposes them (see [Memory extractor](#memory-extractor) below). |
 | **Save overlay** | Persists to the active flavor. |
 

--- a/docs/guide/querying.md
+++ b/docs/guide/querying.md
@@ -37,20 +37,20 @@ flowchart TB
 ```typescript
 import { IfcQuery } from '@ifc-lite/query';
 
-const query = new IfcQuery(parseResult);
+const query = new IfcQuery(store); // store from parseColumnar()
 
 // Get all walls
-const walls = query.walls().toArray();
+const walls = query.walls().execute();
 
 // Get all doors
-const doors = query.doors().toArray();
+const doors = query.doors().execute();
 
 // Get all windows
-const windows = query.windows().toArray();
+const windows = query.windows().execute();
 
 // Get specific entity types
-const beams = query.ofType('IFCBEAM').toArray();
-const columns = query.ofType('IFCCOLUMN').toArray();
+const beams = query.ofType('IFCBEAM').execute();
+const columns = query.ofType('IFCCOLUMN').execute();
 ```
 
 ### Type Shortcuts
@@ -61,12 +61,9 @@ const columns = query.ofType('IFCCOLUMN').toArray();
 | `.doors()` | IFCDOOR |
 | `.windows()` | IFCWINDOW |
 | `.slabs()` | IFCSLAB |
-| `.roofs()` | IFCROOF |
-| `.stairs()` | IFCSTAIR, IFCSTAIRFLIGHT |
 | `.columns()` | IFCCOLUMN |
 | `.beams()` | IFCBEAM |
 | `.spaces()` | IFCSPACE |
-| `.furniture()` | IFCFURNISHINGELEMENT |
 
 ### Property Filters
 
@@ -75,19 +72,19 @@ const columns = query.ofType('IFCCOLUMN').toArray();
 const externalWalls = query
   .walls()
   .whereProperty('Pset_WallCommon', 'IsExternal', '=', true)
-  .toArray();
+  .execute();
 
 // Filter by numeric comparison
 const fireRatedWalls = query
   .walls()
   .whereProperty('Pset_WallCommon', 'FireRating', '>=', 60)
-  .toArray();
+  .execute();
 
 // Filter by string pattern
 const loadBearing = query
   .walls()
   .whereProperty('Pset_WallCommon', 'LoadBearing', '=', true)
-  .toArray();
+  .execute();
 ```
 
 ### Chained Queries
@@ -97,27 +94,28 @@ flowchart LR
     Start["query"]
     Type["walls()"]
     Filter1["whereProperty()"]
-    Filter2["whereQuantity()"]
-    Select["select()"]
-    Output["toArray()"]
+    Filter2["whereProperty()"]
+    Output["execute()"]
 
-    Start --> Type --> Filter1 --> Filter2 --> Select --> Output
+    Start --> Type --> Filter1 --> Filter2 --> Output
 ```
 
 ```typescript
 // Complex query chain
-const results = query
+const walls = query
   .walls()
   .whereProperty('Pset_WallCommon', 'IsExternal', '=', true)
   .whereProperty('Pset_WallCommon', 'FireRating', '>=', 60)
-  .whereQuantity('NetArea', '>', 10)
-  .select(['expressId', 'name', 'type'])
-  .toArray();
+  .whereProperty('Qto_WallBaseQuantities', 'NetArea', '>', 10)
+  .execute();
+
+// execute() returns QueryResultEntity[]; project the fields you need
+const results = walls.map(w => ({ expressId: w.expressId, name: w.name, type: w.type }));
 
 console.log(results);
 // [
-//   { expressId: 123, name: 'Wall-001', type: 'IFCWALL' },
-//   { expressId: 456, name: 'Wall-002', type: 'IFCWALLSTANDARDCASE' },
+//   { expressId: 123, name: 'Wall-001', type: 'IfcWall' },
+//   { expressId: 456, name: 'Wall-002', type: 'IfcWallStandardCase' },
 //   ...
 // ]
 ```
@@ -147,47 +145,33 @@ graph TD
 ```
 
 ```typescript
-// Get all storeys
-const storeys = query.storeys().toArray();
+// Get all storeys (getter, returns EntityNode[])
+const storeys = query.storeys;
 
 // Get elements on a specific storey
-const groundFloor = query
-  .storey('Ground Floor')
-  .contains()
-  .toArray();
+const groundFloor = query.storeys.find(s => s.name === 'Ground Floor');
+const groundFloorElements = groundFloor
+  ? query.onStorey(groundFloor.expressId).execute()
+  : [];
 
-// Get all elements in a building
-const buildingElements = query
-  .building('Main Building')
-  .allContained()  // Recursive
-  .toArray();
+// Get the direct elements of every storey (contains() is one hop, not recursive;
+// use traverse() or decomposes() to walk nested aggregation)
+const buildingElements = query.storeys.flatMap(storey => storey.contains());
 
 // Navigate up the hierarchy
 const wall = query.entity(123);
-const storey = wall.containedIn().first();
-const building = storey.containedIn().first();
+const storey = wall.containedIn(); // EntityNode | null
+const building = wall.building();  // walks up to the containing IfcBuilding
 ```
 
 ### Spatial Relationships
 
 ```typescript
-// Get entities related by spatial structure
-const contained = query
-  .entity(storeyId)
-  .contains()
-  .toArray();
+// Get entities contained by a spatial container (returns EntityNode[])
+const contained = query.entity(storeyId).contains();
 
-// Get container
-const container = query
-  .entity(wallId)
-  .containedIn()
-  .first();
-
-// Get adjacent spaces
-const adjacentSpaces = query
-  .entity(spaceId)
-  .adjacent()
-  .toArray();
+// Get the container of an element (EntityNode | null)
+const container = query.entity(wallId).containedIn();
 ```
 
 ## Relationship Queries
@@ -195,29 +179,17 @@ const adjacentSpaces = query
 ### Finding Related Entities
 
 ```typescript
-// Get materials for an entity
-const materials = query
-  .entity(wallId)
-  .materials()
-  .toArray();
+// Get property sets for an entity (returns PropertySet[])
+const psets = query.entity(wallId).properties();
 
-// Get property sets
-const psets = query
-  .entity(wallId)
-  .propertySets()
-  .toArray();
+// Get quantity sets for an entity (returns QuantitySet[])
+const qtos = query.entity(wallId).quantities();
 
-// Get openings in a wall
-const openings = query
-  .entity(wallId)
-  .related('IfcRelVoidsElement')
-  .toArray();
+// Get openings in a wall (VoidsElement, returns EntityNode[])
+const openings = query.entity(wallId).voids();
 
-// Get filling elements (doors/windows in openings)
-const fillings = query
-  .entity(openingId)
-  .related('IfcRelFillsElement')
-  .toArray();
+// Get filling elements (doors/windows in openings; FillsElement)
+const fillings = query.entity(openingId).filledBy();
 ```
 
 ### Relationship Types
@@ -239,20 +211,20 @@ For complex analytics, use SQL via DuckDB:
 ```typescript
 import { IfcQuery } from '@ifc-lite/query';
 
-const query = new IfcQuery(parseResult);
+const query = new IfcQuery(store); // store from parseColumnar()
 
-// Enable SQL mode (loads DuckDB-WASM)
-await query.enableSQL();
-
-// Run SQL queries
+// sql() lazily initializes DuckDB-WASM on first call
 const result = await query.sql(`
   SELECT
-    type,
+    e.type,
     COUNT(*) as count,
-    AVG(CAST(props->>'Pset_WallCommon.FireRating' AS INTEGER)) as avg_fire_rating
-  FROM entities
-  WHERE type LIKE 'IFCWALL%'
-  GROUP BY type
+    AVG(p.value_int) as avg_fire_rating
+  FROM entities e
+  JOIN properties p ON e.express_id = p.entity_id
+  WHERE e.type LIKE 'IfcWall%'
+    AND p.pset_name = 'Pset_WallCommon'
+    AND p.prop_name = 'FireRating'
+  GROUP BY e.type
   ORDER BY count DESC
 `);
 
@@ -260,8 +232,8 @@ console.table(result);
 // ┌──────────────────────┬───────┬─────────────────┐
 // │ type                 │ count │ avg_fire_rating │
 // ├──────────────────────┼───────┼─────────────────┤
-// │ IFCWALLSTANDARDCASE  │ 42    │ 45              │
-// │ IFCWALL              │ 18    │ 30              │
+// │ IfcWallStandardCase  │ 42    │ 45              │
+// │ IfcWall              │ 18    │ 30              │
 // └──────────────────────┴───────┴─────────────────┘
 ```
 
@@ -271,36 +243,46 @@ console.table(result);
 // Entities table
 interface EntitiesTable {
   express_id: number;
-  type: string;
   global_id: string;
   name: string | null;
   description: string | null;
+  type: string;
+  object_type: string | null;
   has_geometry: boolean;
-  props: JSON;  // All properties as JSON
+  is_type: boolean;
+  contained_in_storey: number | null;
+  defined_by_type: number | null;
 }
 
 // Properties table
 interface PropertiesTable {
   entity_id: number;
   pset_name: string;
+  pset_global_id: string;
   prop_name: string;
-  value: string;
-  value_type: string;
+  prop_type: string;
+  value_string: string | null;
+  value_real: number | null;
+  value_int: number | null;
+  value_bool: boolean | null;
 }
 
 // Quantities table
 interface QuantitiesTable {
   entity_id: number;
-  name: string;
+  qset_name: string;
+  quantity_name: string;
+  quantity_type: string;
   value: number;
-  unit: string;
+  formula: string | null;
 }
 
 // Relationships table
 interface RelationshipsTable {
-  from_id: number;
-  to_id: number;
+  source_id: number;
+  target_id: number;
   rel_type: string;
+  rel_id: number;
 }
 ```
 
@@ -308,16 +290,17 @@ interface RelationshipsTable {
 
 ```sql
 -- Find walls with their storey names
+-- ContainsElements edges run storey (source_id) -> element (target_id)
 SELECT
   e.express_id,
   e.name as wall_name,
   s.name as storey_name
 FROM entities e
-JOIN relationships r ON e.express_id = r.from_id
-JOIN entities s ON r.to_id = s.express_id
-WHERE e.type LIKE 'IFCWALL%'
-  AND r.rel_type = 'IfcRelContainedInSpatialStructure'
-  AND s.type = 'IFCBUILDINGSTOREY';
+JOIN relationships r ON e.express_id = r.target_id
+JOIN entities s ON r.source_id = s.express_id
+WHERE e.type LIKE 'IfcWall%'
+  AND r.rel_type = 'ContainsElements'
+  AND s.type = 'IfcBuildingStorey';
 
 -- Calculate total area by entity type
 SELECT
@@ -325,15 +308,20 @@ SELECT
   SUM(q.value) as total_area
 FROM entities e
 JOIN quantities q ON e.express_id = q.entity_id
-WHERE q.name = 'NetArea'
+WHERE q.quantity_name = 'NetArea'
 GROUP BY e.type
 ORDER BY total_area DESC;
 
--- Find entities with missing fire ratings
-SELECT express_id, name, type
-FROM entities
-WHERE type LIKE 'IFCWALL%'
-  AND props->>'Pset_WallCommon.FireRating' IS NULL;
+-- Find walls with missing fire ratings
+SELECT e.express_id, e.name, e.type
+FROM entities e
+WHERE e.type LIKE 'IfcWall%'
+  AND NOT EXISTS (
+    SELECT 1 FROM properties p
+    WHERE p.entity_id = e.express_id
+      AND p.pset_name = 'Pset_WallCommon'
+      AND p.prop_name = 'FireRating'
+  );
 ```
 
 ## Direct Data Access
@@ -341,26 +329,27 @@ WHERE type LIKE 'IFCWALL%'
 For performance-critical operations, access columnar data directly:
 
 ```typescript
-const data = parseResult.data;
+import { IfcTypeEnumFromString } from '@ifc-lite/data';
 
-// Access entity table
-const entityTable = data.entities;
-console.log(`Total entities: ${entityTable.count}`);
+// store is the IfcDataStore from parseColumnar()
 
-// Iterate efficiently
-for (let i = 0; i < entityTable.count; i++) {
-  const expressId = entityTable.expressIds[i];
-  const typeEnum = entityTable.typeEnums[i];
-  const nameIdx = entityTable.nameIndices[i];
-  const name = data.strings.get(nameIdx);
+// Access the entity table
+console.log(`Total entities: ${store.entities.count}`);
+
+// Iterate efficiently over the columnar express-id array
+for (let i = 0; i < store.entities.count; i++) {
+  const expressId = store.entities.expressId[i];
+  const name = store.entities.getName(expressId);
+  const type = store.entities.getTypeName(expressId);
 }
 
-// Access property table
-const propTable = data.properties;
-for (let i = 0; i < propTable.count; i++) {
-  const entityId = propTable.entityIds[i];
-  const value = propTable.values[i];
-}
+// Fetch every entity of a given type
+const wallIds = store.entities.getByType(IfcTypeEnumFromString('IfcWall'));
+
+// Match entities by property value (prop, operator, value, psetName)
+const externalWallIds = store.properties.findByProperty(
+  'IsExternal', '=', true, 'Pset_WallCommon',
+);
 ```
 
 ## Query Performance
@@ -388,17 +377,17 @@ graph LR
 
 ```typescript
 // Efficient: filter by type first
-const result = query
+const externalWalls = query
   .walls()
   .whereProperty('Pset_WallCommon', 'IsExternal', '=', true)
-  .toArray();
+  .execute();
 
-// Inefficient: filter all entities
-const result = query
+// Inefficient: scan all entities, then narrow by type in JS
+const alsoExternalWalls = query
   .all()
   .whereProperty('Pset_WallCommon', 'IsExternal', '=', true)
-  .ofType('IFCWALL')
-  .toArray();
+  .execute()
+  .filter(e => e.type === 'IfcWall');
 ```
 
 ## Next Steps

--- a/docs/guide/quickstart.md
+++ b/docs/guide/quickstart.md
@@ -523,6 +523,9 @@ sequenceDiagram
 
 ```typescript
 import { IfcParser } from '@ifc-lite/parser';
+import { IfcServerClient } from '@ifc-lite/server-client';
+
+const parser = new IfcParser();
 
 try {
   const store = await parser.parseColumnar(buffer);
@@ -535,15 +538,17 @@ try {
 }
 
 // Server client errors
-import { IfcServerClient } from '@ifc-lite/server-client';
+const client = new IfcServerClient({ baseUrl: 'http://localhost:3001' });
 
 try {
   const result = await client.parseParquet(file);
 } catch (error) {
-  if (error.message.includes('timeout')) {
+  if (error instanceof Error && error.message.includes('timeout')) {
     console.error('Server timeout - try streaming for large files');
-  } else if (error.message.includes('413')) {
+  } else if (error instanceof Error && error.message.includes('413')) {
     console.error('File too large - increase MAX_FILE_SIZE_MB on server');
+  } else {
+    throw error;
   }
 }
 ```

--- a/docs/guide/quickstart.md
+++ b/docs/guide/quickstart.md
@@ -215,7 +215,7 @@ Process IFC files on a high-performance Rust server with intelligent caching.
 
 ```bash
 # Using Docker
-docker run -p 3001:8080 ghcr.io/LTplus-AG/ifc-lite-server
+docker run -p 3001:8080 ghcr.io/ltplus-ag/ifc-lite-server
 
 # Or using native binary
 npx @ifc-lite/server-bin
@@ -306,13 +306,15 @@ if (entityRef) {
 }
 
 // Get spatial hierarchy
+import { IfcTypeEnum } from '@ifc-lite/data';
+
 const hierarchy = store.spatialHierarchy;
 console.log(`Project: ${hierarchy.project.name}`);
 
-// List storeys
+// List storeys (SpatialNode.type is a numeric IfcTypeEnum, keyed by expressId)
 for (const storey of hierarchy.project.children) {
-  if (storey.type === 'IFCBUILDINGSTOREY') {
-    const elements = hierarchy.byStorey.get(storey.id) ?? [];
+  if (storey.type === IfcTypeEnum.IfcBuildingStorey) {
+    const elements = hierarchy.byStorey.get(storey.expressId) ?? [];
     console.log(`${storey.name}: ${elements.length} elements`);
   }
 }
@@ -381,7 +383,7 @@ if (format === 'ifcx') {
 
   // Pre-tessellated USD geometry
   for (const mesh of ifcxResult.meshes) {
-    console.log(`Mesh for entity #${mesh.express_id}: ${mesh.ifc_type}`);
+    console.log(`Mesh for entity #${mesh.expressId}: ${mesh.ifcType}`);
   }
 }
 ```
@@ -437,8 +439,9 @@ canvas.addEventListener('click', async (e) => {
   const x = e.clientX - rect.left;
   const y = e.clientY - rect.top;
 
-  const expressId = await renderer.pick(x, y);
-  if (expressId !== null) {
+  const hit = await renderer.pick(x, y);
+  if (hit) {
+    const expressId = hit.expressId;
     console.log(`Selected entity #${expressId}`);
     selectedIds = new Set([expressId]);
 
@@ -519,14 +522,13 @@ sequenceDiagram
 ## Error Handling
 
 ```typescript
-import { IfcParser, ParseError } from '@ifc-lite/parser';
+import { IfcParser } from '@ifc-lite/parser';
 
 try {
   const store = await parser.parseColumnar(buffer);
 } catch (error) {
-  if (error instanceof ParseError) {
+  if (error instanceof Error) {
     console.error('Parse error:', error.message);
-    console.error('At line:', error.line);
   } else {
     throw error;
   }

--- a/docs/guide/rendering.md
+++ b/docs/guide/rendering.md
@@ -68,61 +68,11 @@ function animate() {
 animate();
 ```
 
-## Renderer Configuration
-
-```typescript
-interface RendererOptions {
-  // Anti-aliasing
-  antialias?: boolean;
-  sampleCount?: 1 | 4;
-
-  // Background color
-  backgroundColor?: [number, number, number, number];
-
-  // Performance
-  powerPreference?: 'low-power' | 'high-performance';
-
-  // Features
-  enablePicking?: boolean;
-  enableSectionPlanes?: boolean;
-}
-
-const renderer = new Renderer(canvas, {
-  antialias: true,
-  sampleCount: 4,
-  backgroundColor: [0.95, 0.95, 0.95, 1.0],
-  powerPreference: 'high-performance',
-  enablePicking: true,
-  enableSectionPlanes: true
-});
-```
-
 ## Camera Controls
 
 ### Configuration
 
 ```typescript
-interface CameraOptions {
-  // Initial position
-  position?: [number, number, number];
-  target?: [number, number, number];
-  up?: [number, number, number];
-
-  // Projection
-  fov?: number;
-  near?: number;
-  far?: number;
-
-  // Controls
-  orbitSpeed?: number;
-  panSpeed?: number;
-  zoomSpeed?: number;
-
-  // Constraints
-  minDistance?: number;
-  maxDistance?: number;
-}
-
 // Access camera directly
 const camera = renderer.getCamera();
 
@@ -333,11 +283,12 @@ canvas.addEventListener('mousemove', (e) => {
   });
 
   if (result.edgeLock.shouldLock) {
-    // Lock to this edge
+    // Lock to this edge. lockStrength is maintained locally (renderer input
+    // only); the result never emits it, so grow it per frame while locked.
     edgeLock = {
       edge: result.edgeLock.edge,
       meshExpressId: result.edgeLock.meshExpressId,
-      lockStrength: result.edgeLock.lockStrength
+      lockStrength: edgeLock.lockStrength + 0.05
     };
   } else if (result.edgeLock.shouldRelease) {
     // Release the lock
@@ -417,9 +368,10 @@ canvas.addEventListener('click', async (e) => {
   const x = e.clientX - rect.left;
   const y = e.clientY - rect.top;
 
-  const expressId = await renderer.pick(x, y);
+  const hit = await renderer.pick(x, y);
 
-  if (expressId !== null) {
+  if (hit !== null) {
+    const expressId = hit.expressId;
     console.log(`Selected entity #${expressId}`);
     selectedIds = new Set([expressId]);
 
@@ -777,10 +729,10 @@ async function createViewer() {
   // Click handler with picking
   canvas.addEventListener('click', async (e) => {
     const rect = canvas.getBoundingClientRect();
-    const id = await renderer.pick(e.clientX - rect.left, e.clientY - rect.top);
+    const hit = await renderer.pick(e.clientX - rect.left, e.clientY - rect.top);
 
-    if (id !== null) {
-      selectedIds = new Set([id]);
+    if (hit !== null) {
+      selectedIds = new Set([hit.expressId]);
     } else {
       selectedIds.clear();
     }
@@ -800,7 +752,13 @@ async function createViewer() {
     });
 
     if (result.edgeLock.shouldLock) {
-      edgeLock = result.edgeLock;
+      // Rebuild the EdgeLockInput; the result has no lockStrength, so keep
+      // it as a locally maintained number.
+      edgeLock = {
+        edge: result.edgeLock.edge,
+        meshExpressId: result.edgeLock.meshExpressId,
+        lockStrength: edgeLock.lockStrength + 0.05
+      };
     } else if (result.edgeLock.shouldRelease) {
       edgeLock = { edge: null, meshExpressId: null, lockStrength: 0 };
     }

--- a/docs/guide/server.md
+++ b/docs/guide/server.md
@@ -263,16 +263,20 @@ before uploading, so re-parsing the same file skips the upload automatically:
 const result = await client.parseParquet(file);
 ```
 
-To retrieve a previously processed result later, keep its `cache_key` and pass
-that composite key (for example `{SHA256}-default`, not a bare file hash) to
-`getCached`:
+To retrieve a previously processed result later, keep its `cache_key`. Re-calling
+`parseParquet` serves the geometry straight from the cache; fetch the cached data
+model (properties + spatial hierarchy) with `fetchDataModel`:
 
 ```typescript
-const cached = await client.getCached(result.cache_key);
-if (cached) {
-  console.log('File already processed!');
-}
+// Geometry: re-calling parseParquet returns the cached result without re-upload.
+const result = await client.parseParquet(file);
+
+// Data model (properties + hierarchy) for a known cache key:
+const dataModelBuffer = await client.fetchDataModel(result.cache_key);
 ```
+
+`getCached(key)` is the lower-level lookup for the JSON `parse()` cache and
+returns a `ParseResponse`; it is not the retrieval path for Parquet geometry.
 
 #### Fetching Data Model
 
@@ -637,7 +641,7 @@ for await (const event of client.parseStream(file)) {
 
 ### Network
 
-1. **Gzip Compression** - Optional client-side compression before upload
+1. **Gzip Compression** - Applied automatically on upload by `parse()`/`parseParquet()`
 2. **Parquet Format** - 15-50x smaller than JSON
 3. **SSE Streaming** - No polling overhead
 

--- a/docs/guide/server.md
+++ b/docs/guide/server.md
@@ -77,7 +77,7 @@ flowchart TB
     ```bash
     docker run -p 3001:8080 \
       -v ifc-cache:/app/cache \
-      ghcr.io/LTplus-AG/ifc-lite-server
+      ghcr.io/ltplus-ag/ifc-lite-server
     ```
 
 === "Native Binary"
@@ -246,29 +246,32 @@ const metadata = await client.getMetadata(file);
 // Returns:
 // - schema_version: 'IFC2X3' | 'IFC4' | 'IFC4X3'
 // - entity_count: number
-// - geometry_entity_count: number
-// - coordinate_info: { origin_shift, is_geo_referenced }
+// - geometry_count: number
+// - file_size: number
 ```
 
 ### Cache Methods
 
 #### Checking Cache Before Upload
 
-The SDK automatically checks cache before uploading, but you can do it manually:
+`parseParquet` hashes the file client-side and checks the server cache
+before uploading, so re-parsing the same file skips the upload automatically:
 
 ```typescript
-// Compute file hash
-const hash = await client.computeFileHash(file);
+// Automatic: parseParquet computes the SHA-256 and does the cache check
+// internally, returning the cached result without re-uploading on a hit.
+const result = await client.parseParquet(file);
+```
 
-// Check if cached
-const cached = await client.getCached(hash);
+To retrieve a previously processed result later, keep its `cache_key` and pass
+that composite key (for example `{SHA256}-default`, not a bare file hash) to
+`getCached`:
+
+```typescript
+const cached = await client.getCached(result.cache_key);
 if (cached) {
   console.log('File already processed!');
-  return cached;
 }
-
-// Upload if not cached
-const result = await client.parseParquet(file);
 ```
 
 #### Fetching Data Model
@@ -312,8 +315,8 @@ if (symbols) {
 // Health check
 const health = await client.health();
 
-// Compress file before upload (optional, saves bandwidth)
-const compressed = await client.compressGzip(file);
+// Uploads are gzip-compressed automatically by parse()/parseParquet(),
+// so no manual compression step is needed.
 
 // Check Parquet decoder availability
 const available = await client.isParquetSupported();
@@ -389,11 +392,15 @@ interface SpatialHierarchy {
 }
 
 interface SpatialNode {
-  id: number;
-  name: string;
-  type: string;
-  children: SpatialNode[];
+  entity_id: number;
+  parent_id: number;
+  level: number;
+  path: string;
+  type_name: string;
+  name?: string;
   elevation?: number;
+  children_ids: number[];
+  element_ids: number[];
 }
 ```
 
@@ -449,9 +456,10 @@ const dataModel = await decodeDataModel(dataModelBuffer);
 Cache keys are derived from file content:
 
 ```
-{SHA256}-parquet-v2         # Geometry
-{SHA256}-parquet-metadata-v2  # Metadata header
-{SHA256}-datamodel-v2        # Properties & hierarchy
+# {filter} is the opening filter (e.g. "default")
+{SHA256}-{filter}-parquet-v4          # Geometry
+{SHA256}-{filter}-parquet-metadata-v4 # Metadata header
+{SHA256}-{filter}-datamodel-v2        # Properties & hierarchy
 ```
 
 ### Cache Flow
@@ -514,7 +522,7 @@ version: '3.8'
 
 services:
   ifc-lite-server:
-    image: ghcr.io/LTplus-AG/ifc-lite-server:latest
+    image: ghcr.io/ltplus-ag/ifc-lite-server:latest
     ports:
       - "3001:8080"
     environment:
@@ -598,9 +606,9 @@ sequenceDiagram
 
 ```typescript
 // Using callback
-await client.parseParquetStream(file, async (batch) => {
-  const meshes = await decodeParquetGeometry(batch.data);
-  renderer.addMeshes(meshes);
+await client.parseParquetStream(file, (batch) => {
+  // batch.meshes are already decoded MeshData
+  renderer.addMeshes(batch.meshes);
 });
 
 // Using async iterator

--- a/docs/guide/viewer-api.md
+++ b/docs/guide/viewer-api.md
@@ -139,7 +139,7 @@ Returns entity list and IFC size:
 {"ok":true,"count":3,"entities":[...],"ifcSize":3646}
 ```
 
-All 30+ element types from the [`create` command](cli.md#create--create-ifc-files) are supported. Coordinates use IFC Z-up convention.
+All 29 element types from the [`create` command](cli.md#create--create-ifc-files) are supported. Coordinates use IFC Z-up convention.
 
 ### `POST /api/clear-created` — Remove Live Geometry
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -185,7 +185,7 @@ You don't need all packages. Here's what to grab for common tasks:
 | Export to glTF / IFC / Parquet | + `@ifc-lite/export` |
 | Connect to a server backend | + `@ifc-lite/server-client` |
 
-> Full list: [TypeScript API Reference](api/typescript.md) (25 packages) · [Rust API Reference](api/rust.md) (4 crates)
+> Full list: [TypeScript API Reference](api/typescript.md) (14 packages) · [Rust API Reference](api/rust.md) (3 crates)
 
 ## Browser Support
 

--- a/docs/research/csg-clipping-fidelity.md
+++ b/docs/research/csg-clipping-fidelity.md
@@ -4,6 +4,8 @@
 
 Synthesizes the IFC 4.3 spec definitions and the two reference implementations (ifcopenshell, web-ifc) for `IfcPolygonalBoundedHalfSpace` / `IfcBooleanClippingResult`, then identifies the gap in our implementation.
 
+**Historical note:** this analysis was written against the then-current BSP CSG kernel. That kernel (and the C++ Manifold path) were later removed in the M9 one-kernel consolidation, and ifc-lite now runs a single pure-Rust exact CSG kernel. The "our implementation" description in §4 therefore records past behavior, not the current path. The IFC 4.3 spec and reference-implementation analysis (§1 to §3) remain accurate.
+
 ---
 
 ## 1. IFC 4.3 Spec — what the entities actually mean

--- a/docs/tutorials/building-viewer.md
+++ b/docs/tutorials/building-viewer.md
@@ -46,7 +46,7 @@ cd my-ifc-viewer
 npm create vite@latest . -- --template vanilla-ts
 
 # Install dependencies
-npm install @ifc-lite/parser @ifc-lite/renderer @ifc-lite/query
+npm install @ifc-lite/parser @ifc-lite/geometry @ifc-lite/renderer @ifc-lite/query
 ```
 
 ### 2. Project Structure
@@ -210,9 +210,10 @@ export class IfcViewer {
       const x = e.clientX - rect.left;
       const y = e.clientY - rect.top;
 
-      const expressId = await this.renderer.pick(x, y);
-      if (expressId !== null) {
-        this.onSelect?.(expressId);
+      // pick() resolves to a PickResult ({ expressId, ... }) or null
+      const hit = await this.renderer.pick(x, y);
+      if (hit) {
+        this.onSelect?.(hit.expressId);
       } else {
         this.onSelect?.(null);
       }
@@ -228,14 +229,26 @@ export class IfcViewer {
     return this.dataStore;
   }
 
-  getEntity(expressId: number): any | null {
-    if (!this.dataStore) return null;
-    return this.dataStore.entityIndex.byId.get(expressId) ?? null;
+  getRenderer(): Renderer {
+    return this.renderer;
   }
 
-  getProperties(expressId: number): Record<string, Record<string, any>> | null {
-    if (!this.dataStore || !this.buffer) return null;
-    return extractPropertiesOnDemand(this.dataStore, expressId, this.buffer);
+  getEntity(expressId: number): any | null {
+    if (!this.dataStore) return null;
+    const ref = this.dataStore.entityIndex.byId.get(expressId);
+    if (!ref) return null;
+    // EntityRef only carries {expressId,type,byteOffset,byteLength,lineNumber}.
+    // Name and GlobalId come from the store accessors, as QueryResultEntity does.
+    return {
+      ...ref,
+      name: this.dataStore.entities.getName(expressId),
+      globalId: this.dataStore.entities.getGlobalId(expressId),
+    };
+  }
+
+  getProperties(expressId: number) {
+    if (!this.dataStore) return null;
+    return extractPropertiesOnDemand(this.dataStore, expressId);
   }
 
   getModelBounds(): { min: { x: number; y: number; z: number }; max: { x: number; y: number; z: number } } | null {
@@ -269,7 +282,7 @@ export function renderProperties(
   container: HTMLElement,
   expressId: number,
   entity: any,
-  propertySets: Record<string, Record<string, any>>
+  propertySets: Array<{ name: string; properties: Array<{ name: string; value: any }> }>
 ): void {
   container.innerHTML = '';
 
@@ -285,20 +298,20 @@ export function renderProperties(
   container.appendChild(header);
 
   // Property sets
-  for (const [psetName, props] of Object.entries(propertySets)) {
+  for (const pset of propertySets) {
     const section = document.createElement('div');
     section.className = 'prop-section';
 
     const title = document.createElement('h4');
-    title.textContent = psetName;
+    title.textContent = pset.name;
     section.appendChild(title);
 
     const table = document.createElement('table');
-    for (const [propName, value] of Object.entries(props)) {
+    for (const prop of pset.properties) {
       const row = document.createElement('tr');
       row.innerHTML = `
-        <td>${propName}</td>
-        <td>${formatValue(value)}</td>
+        <td>${prop.name}</td>
+        <td>${formatValue(prop.value)}</td>
       `;
       table.appendChild(row);
     }
@@ -339,7 +352,7 @@ async function main() {
       const entity = viewer.getEntity(expressId);
       const props = viewer.getProperties(expressId);
       if (entity) {
-        renderProperties(propertiesPanel, expressId, entity, props || {});
+        renderProperties(propertiesPanel, expressId, entity, props || []);
       }
     } else {
       propertiesPanel.innerHTML = '<p>Click an element to view properties</p>';
@@ -487,8 +500,8 @@ presets.forEach(preset => {
   const button = document.createElement('button');
   button.textContent = preset;
   button.onclick = () => {
-    const camera = viewer.renderer.getCamera();
-    camera.setPresetView(preset, viewer.getModelBounds());
+    const camera = viewer.getRenderer().getCamera();
+    camera.setPresetView(preset, viewer.getModelBounds() ?? undefined);
   };
   toolbar.appendChild(button);
 });
@@ -499,21 +512,24 @@ presets.forEach(preset => {
 ```typescript
 import { IfcQuery } from '@ifc-lite/query';
 
-// After loading
-const query = new IfcQuery(result);
+// After loading, build a query over the parsed data store
+const dataStore = viewer.getDataStore();
+if (dataStore) {
+  const query = new IfcQuery(dataStore);
 
-// Find all walls
-const walls = query.walls().toArray();
-console.log(`Found ${walls.length} walls`);
+  // Find all walls
+  const walls = query.walls().execute();
+  console.log(`Found ${walls.length} walls`);
 
-// Isolate external walls (show only these)
-const externalWalls = query
-  .walls()
-  .whereProperty('Pset_WallCommon', 'IsExternal', '=', true)
-  .toArray();
+  // Isolate external walls (show only these)
+  const externalWalls = query
+    .walls()
+    .whereProperty('Pset_WallCommon', 'IsExternal', '=', true)
+    .execute();
 
-const isolatedIds = new Set(externalWalls.map(w => w.expressId));
-renderer.render({ isolatedIds });
+  const isolatedIds = new Set(externalWalls.map(w => w.expressId));
+  viewer.getRenderer().render({ isolatedIds });
+}
 ```
 
 ## Running the Viewer

--- a/docs/tutorials/custom-queries.md
+++ b/docs/tutorials/custom-queries.md
@@ -22,20 +22,20 @@ flowchart LR
 ```typescript
 import { IfcQuery } from '@ifc-lite/query';
 
-const query = new IfcQuery(parseResult);
+const query = new IfcQuery(store); // store from parseColumnar()
 
 // Get all walls
-const walls = query.walls().toArray();
+const walls = query.walls().execute();
 
 // Get all doors and windows
 const openings = query
-  .ofTypes(['IFCDOOR', 'IFCWINDOW'])
-  .toArray();
+  .ofType('IFCDOOR', 'IFCWINDOW')
+  .execute();
 
 // Get only standard walls
 const standardWalls = query
   .ofType('IFCWALLSTANDARDCASE')
-  .toArray();
+  .execute();
 ```
 
 ### Property Filters
@@ -45,19 +45,19 @@ const standardWalls = query
 const externalWalls = query
   .walls()
   .whereProperty('Pset_WallCommon', 'IsExternal', '=', true)
-  .toArray();
+  .execute();
 
 // Walls with fire rating >= 60 minutes
 const fireRatedWalls = query
   .walls()
   .whereProperty('Pset_WallCommon', 'FireRating', '>=', 60)
-  .toArray();
+  .execute();
 
-// Load-bearing elements
+// Load-bearing walls
 const loadBearing = query
-  .all()
-  .whereProperty('Pset_*Common', 'LoadBearing', '=', true)
-  .toArray();
+  .walls()
+  .whereProperty('Pset_WallCommon', 'LoadBearing', '=', true)
+  .execute();
 
 // Combine multiple filters
 const criticalWalls = query
@@ -65,68 +65,81 @@ const criticalWalls = query
   .whereProperty('Pset_WallCommon', 'IsExternal', '=', true)
   .whereProperty('Pset_WallCommon', 'FireRating', '>=', 90)
   .whereProperty('Pset_WallCommon', 'LoadBearing', '=', true)
-  .toArray();
+  .execute();
 ```
 
 ### Quantity Filters
 
+`EntityQuery` has no quantity filter. Read quantities per entity via the
+graph API (`EntityNode.quantities()`) and filter in JavaScript.
+
 ```typescript
-// Large walls by area
+function quantityValue(q: IfcQuery, expressId: number, name: string): number | null {
+  for (const qset of q.entity(expressId).quantities()) {
+    const found = qset.quantities.find(x => x.name === name);
+    if (found) return found.value;
+  }
+  return null;
+}
+
+// Large walls by area (> 20 m2)
 const largeWalls = query
   .walls()
-  .whereQuantity('NetArea', '>', 20) // > 20 m²
-  .toArray();
+  .execute()
+  .filter(w => (quantityValue(query, w.expressId, 'NetArea') ?? 0) > 20);
 
-// Thick slabs
+// Thick slabs (>= 300mm)
 const thickSlabs = query
   .slabs()
-  .whereQuantity('Thickness', '>=', 0.3) // >= 300mm
-  .toArray();
+  .execute()
+  .filter(s => (quantityValue(query, s.expressId, 'Thickness') ?? 0) >= 0.3);
 ```
 
 ### Spatial Queries
 
+Spatial queries are keyed by numeric express id. `query.storeys` returns the
+storey nodes (sorted by elevation), `onStorey(storeyId)` returns the elements
+contained on that storey, and `inBounds(aabb)` queries by a bounding box.
+
 ```typescript
-// Get all elements on ground floor
-const groundFloorElements = query
-  .storey('Ground Floor')
-  .contains()
-  .toArray();
+// Get all elements on ground floor (find the storey node by name first)
+const groundFloor = query.storeys.find(s => s.name === 'Ground Floor');
+const groundFloorElements = groundFloor
+  ? query.onStorey(groundFloor.expressId).execute()
+  : [];
 
-// Get all elements in a building
+// Get elements within a bounding box (requires processed geometry)
 const buildingElements = query
-  .building('Main Building')
-  .allContained()
-  .toArray();
+  .inBounds({ min: [0, 0, 0], max: [100, 100, 30] })
+  .execute();
 
-// Get spaces on a specific storey
-const storeySpaces = query
-  .storey('Level 1')
-  .contains()
-  .ofType('IFCSPACE')
-  .toArray();
+// Get spaces on a specific storey (filter the results by type)
+const level1 = query.storeys.find(s => s.name === 'Level 1');
+const storeySpaces = level1
+  ? query.onStorey(level1.expressId).execute().filter(e => e.type === 'IfcSpace')
+  : [];
 ```
 
 ### Relationship Traversal
 
-```typescript
-// Get materials for a wall
-const wallMaterials = query
-  .entity(wallId)
-  .materials()
-  .toArray();
+The graph API (`query.entity(id)`) returns an `EntityNode`. Traversal methods
+return `EntityNode` or `EntityNode[]` directly (no terminal call).
 
-// Get elements related to a space
+```typescript
+// Get the openings (voids) cut into a wall
+const wallOpenings = query
+  .entity(wallId)
+  .voids();
+
+// Get the elements contained in a space
 const spaceElements = query
   .entity(spaceId)
-  .related('IfcRelSpaceBoundary')
-  .toArray();
+  .contains();
 
-// Find what contains this element
+// Find what contains this element (returns an EntityNode or null)
 const container = query
   .entity(elementId)
-  .containedIn()
-  .entity();
+  .containedIn();
 ```
 
 ## Building Complex Queries
@@ -134,20 +147,22 @@ const container = query
 ### Query Composition
 
 ```typescript
+import { EntityQuery } from '@ifc-lite/query';
+
 // Create reusable query parts
-function externalElements(q: IfcQuery): IfcQuery {
-  return q.whereProperty('Pset_*Common', 'IsExternal', '=', true);
+function externalElements(q: EntityQuery): EntityQuery {
+  return q.whereProperty('Pset_WallCommon', 'IsExternal', '=', true);
 }
 
-function fireRated(q: IfcQuery, rating: number): IfcQuery {
-  return q.whereProperty('Pset_*Common', 'FireRating', '>=', rating);
+function fireRated(q: EntityQuery, rating: number): EntityQuery {
+  return q.whereProperty('Pset_WallCommon', 'FireRating', '>=', rating);
 }
 
 // Compose queries
 const externalFireRatedWalls = fireRated(
   externalElements(query.walls()),
   60
-).toArray();
+).execute();
 ```
 
 ### Query Unions
@@ -155,10 +170,10 @@ const externalFireRatedWalls = fireRated(
 ```typescript
 // Combine results from multiple queries
 const structuralElements = [
-  ...query.walls().whereProperty('Pset_WallCommon', 'LoadBearing', '=', true).toArray(),
-  ...query.columns().toArray(),
-  ...query.beams().toArray(),
-  ...query.slabs().toArray()
+  ...query.walls().whereProperty('Pset_WallCommon', 'LoadBearing', '=', true).execute(),
+  ...query.columns().execute(),
+  ...query.beams().execute(),
+  ...query.slabs().execute()
 ];
 ```
 
@@ -168,11 +183,11 @@ const structuralElements = [
 // All elements except spaces and openings
 const physicalElements = query
   .all()
-  .where(e =>
-    e.type !== 'IFCSPACE' &&
-    e.type !== 'IFCOPENINGELEMENT'
-  )
-  .toArray();
+  .execute()
+  .filter(e =>
+    e.type !== 'IfcSpace' &&
+    e.type !== 'IfcOpeningElement'
+  );
 ```
 
 ## SQL Queries
@@ -180,14 +195,12 @@ const physicalElements = query
 For complex analytics, use SQL:
 
 ```typescript
-// Enable SQL mode
-await query.enableSQL();
-
+// sql() lazily initializes DuckDB on the first call - no enable step needed.
 // Simple aggregation
 const wallCounts = await query.sql(`
   SELECT type, COUNT(*) as count
   FROM entities
-  WHERE type LIKE 'IFCWALL%'
+  WHERE type LIKE 'IfcWall%'
   GROUP BY type
 `);
 
@@ -196,10 +209,10 @@ const wallsWithFireRating = await query.sql(`
   SELECT
     e.express_id,
     e.name,
-    p.value as fire_rating
+    p.value_real as fire_rating
   FROM entities e
   JOIN properties p ON e.express_id = p.entity_id
-  WHERE e.type LIKE 'IFCWALL%'
+  WHERE e.type LIKE 'IfcWall%'
     AND p.pset_name = 'Pset_WallCommon'
     AND p.prop_name = 'FireRating'
 `);
@@ -212,18 +225,18 @@ const floorAreaByStorey = await query.sql(`
       s.name as storey_name,
       e.express_id as space_id
     FROM entities s
-    JOIN relationships r ON s.express_id = r.to_id
-    JOIN entities e ON r.from_id = e.express_id
-    WHERE s.type = 'IFCBUILDINGSTOREY'
-      AND e.type = 'IFCSPACE'
-      AND r.rel_type = 'IfcRelContainedInSpatialStructure'
+    JOIN relationships r ON s.express_id = r.source_id
+    JOIN entities e ON r.target_id = e.express_id
+    WHERE s.type = 'IfcBuildingStorey'
+      AND e.type = 'IfcSpace'
+      AND r.rel_type = 'ContainsElements'
   )
   SELECT
     ss.storey_name,
     SUM(q.value) as total_area
   FROM storey_spaces ss
   JOIN quantities q ON ss.space_id = q.entity_id
-  WHERE q.name = 'NetFloorArea'
+  WHERE q.quantity_name = 'NetFloorArea'
   GROUP BY ss.storey_name
   ORDER BY total_area DESC
 `);
@@ -251,15 +264,17 @@ const store = await parser.parseColumnar(buffer.buffer);
 const query = new IfcQuery(store);
 
 // Get walls and their fire ratings
-const walls = query.walls().toArray();
+const walls = query.walls().execute();
 
 // Create color map based on fire rating
 const colorMap = new Map<number, string>();
 
 for (const wall of walls) {
-  // Extract properties on-demand using the store and buffer from parseColumnar
-  const props = extractPropertiesOnDemand(store, wall.expressId, buffer);
-  const fireRating = props?.['Pset_WallCommon']?.FireRating || 0;
+  // Extract properties on-demand from the parsed store (returns an array of psets)
+  const psets = extractPropertiesOnDemand(store, wall.expressId);
+  const wallCommon = psets.find(p => p.name === 'Pset_WallCommon');
+  const fireRatingProp = wallCommon?.properties.find(p => p.name === 'FireRating');
+  const fireRating = typeof fireRatingProp?.value === 'number' ? fireRatingProp.value : 0;
 
   if (fireRating >= 90) {
     colorMap.set(wall.expressId, 'red');
@@ -280,7 +295,7 @@ console.log('Fire rating analysis:', colorMap);
 const externalWalls = query
   .walls()
   .whereProperty('Pset_WallCommon', 'IsExternal', '=', true)
-  .toArray();
+  .execute();
 
 const isolatedIds = new Set(externalWalls.map(w => w.expressId));
 renderer.render({ isolatedIds });
@@ -289,11 +304,11 @@ renderer.render({ isolatedIds });
 ### Selection from Query
 
 ```typescript
-// Select all fire-rated elements
+// Select all fire-rated walls
 const fireRated = query
-  .all()
-  .whereProperty('Pset_*Common', 'FireRating', '>', 0)
-  .toArray();
+  .walls()
+  .whereProperty('Pset_WallCommon', 'FireRating', '>', 0)
+  .execute();
 
 const selectedIds = new Set(fireRated.map(e => e.expressId));
 renderer.render({ selectedIds });
@@ -308,30 +323,30 @@ renderer.render({ selectedIds });
 const result = query
   .walls()  // Narrow down first
   .whereProperty('Pset_WallCommon', 'IsExternal', '=', true)
-  .toArray();
+  .execute();
 
-// Bad: filter all entities
-const result = query
+// Bad: property-filter across every entity instead of narrowing by type first
+// (EntityQuery has no .ofType(); type filtering must come from IfcQuery, e.g. query.walls())
+const allExternal = query
   .all()
   .whereProperty('Pset_WallCommon', 'IsExternal', '=', true)
-  .ofType('IFCWALL')  // Type filter after property filter
-  .toArray();
+  .execute();
 ```
 
 ### 2. Use Count for Checks
 
 ```typescript
-// Good: just check count
-const hasExternalWalls = query
+// Good: just check count (count() is async, so await it)
+const hasExternalWalls = (await query
   .walls()
   .whereProperty('Pset_WallCommon', 'IsExternal', '=', true)
-  .count() > 0;
+  .count()) > 0;
 
 // Bad: get all results just to check existence
 const externalWalls = query
   .walls()
   .whereProperty('Pset_WallCommon', 'IsExternal', '=', true)
-  .toArray();
+  .execute();
 const hasExternalWalls = externalWalls.length > 0;
 ```
 
@@ -339,7 +354,7 @@ const hasExternalWalls = externalWalls.length > 0;
 
 ```typescript
 // For simple queries: Fluent API
-const walls = query.walls().toArray();
+const walls = query.walls().execute();
 
 // For aggregations: SQL
 const stats = await query.sql(`

--- a/docs/tutorials/extending-parser.md
+++ b/docs/tutorials/extending-parser.md
@@ -6,19 +6,19 @@ Learn to extend IFClite with custom functionality.
 
 ```mermaid
 flowchart TB
-    subgraph Parser["Parser Extensions"]
-        Custom["Custom Decoders"]
-        Schema["Schema Extensions"]
+    subgraph Parser["Parser (TypeScript)"]
+        Custom["Custom decoders"]
+        Schema["Schema (codegen)"]
     end
 
-    subgraph Geometry["Geometry Extensions"]
-        Processor["Custom Processors"]
-        Profile["Profile Handlers"]
+    subgraph Geometry["Geometry (Rust: ifc-lite-geometry)"]
+        Processor["Representation processors"]
+        Profile["Profile handlers"]
     end
 
-    subgraph Renderer["Renderer Extensions"]
-        Shader["Custom Shaders"]
-        Material["Material System"]
+    subgraph Renderer["Renderer"]
+        Shader["Custom shaders (advanced)"]
+        Material["Visibility / render options"]
     end
 
     Parser --> Geometry --> Renderer
@@ -29,7 +29,7 @@ flowchart TB
 ### Creating a Decoder
 
 ```typescript
-import { EntityDecoder, DecodedEntity } from '@ifc-lite/parser';
+import { IfcDataStore, EntityRef, extractEntityAttributesOnDemand } from '@ifc-lite/parser';
 
 // Define custom entity interface
 interface CustomDoorData {
@@ -51,17 +51,29 @@ class DoorDecoder {
 
   decode(entity: EntityRef): CustomDoorData {
     // Use on-demand extraction for properties
-    const props = extractPropertiesOnDemand(this.store, entity.expressId, this.buffer);
-    const quantities = extractQuantitiesOnDemand(this.store, entity.expressId, this.buffer);
+    const psets = extractPropertiesOnDemand(this.store, entity.expressId);
+    const qsets = extractQuantitiesOnDemand(this.store, entity.expressId);
+
+    // EntityRef only carries { expressId, type, byteOffset, byteLength, lineNumber },
+    // so globalId/name must be resolved from the source buffer on demand.
+    const attrs = extractEntityAttributesOnDemand(this.store, entity.expressId);
+
+    // Both extractors return arrays of sets: find the set by name,
+    // then the entry inside it by name.
+    const findProp = (psetName: string, propName: string) =>
+      psets.find(p => p.name === psetName)
+        ?.properties.find(prop => prop.name === propName)?.value;
+    const findQuantity = (qtyName: string) =>
+      qsets.flatMap(q => q.quantities).find(qty => qty.name === qtyName)?.value;
 
     return {
       expressId: entity.expressId,
-      globalId: entity.globalId,
-      name: entity.name || 'Unknown Door',
-      width: quantities?.Width?.value || 0,
-      height: quantities?.Height?.value || 0,
-      isExternal: props?.['Pset_DoorCommon']?.IsExternal || false,
-      fireRating: props?.['Pset_DoorCommon']?.FireRating || 0
+      globalId: attrs.globalId,
+      name: attrs.name || 'Unknown Door',
+      width: Number(findQuantity('Width')) || 0,
+      height: Number(findQuantity('Height')) || 0,
+      isExternal: Boolean(findProp('Pset_DoorCommon', 'IsExternal')),
+      fireRating: Number(findProp('Pset_DoorCommon', 'FireRating')) || 0
     };
   }
 
@@ -120,11 +132,13 @@ class StreamingDecoder<T> {
 
 // Usage
 const decoder = new StreamingDecoder<CustomDoorData>();
-decoder.register('IFCDOOR', (expressId, store, buffer) => {
-  const props = extractPropertiesOnDemand(store, expressId, buffer);
+decoder.register('IFCDOOR', (expressId, store) => {
+  const psets = extractPropertiesOnDemand(store, expressId);
+  const fireRating = psets.find(p => p.name === 'Pset_DoorCommon')
+    ?.properties.find(prop => prop.name === 'FireRating')?.value;
   return {
     expressId,
-    fireRating: props?.['Pset_DoorCommon']?.FireRating || 0,
+    fireRating: Number(fireRating) || 0,
     // ... decode door
   };
 });
@@ -136,119 +150,75 @@ for await (const door of decoder.decode(store, buffer, geometry)) {
 
 ## Custom Geometry Processors
 
-### Processor Interface
+Geometry generation is not pluggable from TypeScript. Meshing runs in the Rust
+`ifc-lite-geometry` crate (compiled to WASM), so a new representation or profile
+handler is added by contributing a processor to that crate rather than by
+registering a class at runtime:
+
+- Representation and profile handling lives in `rust/geometry/src/processors/`
+  and `rust/geometry/src/profile/`.
+- The `GeometryRouter` (`rust/geometry/src/router/mod.rs`) dispatches each
+  representation to the right processor.
+- See [Geometry Pipeline](../architecture/geometry-pipeline.md) for how a
+  representation flows from the parser to a mesh.
+
+On the TypeScript side, `GeometryProcessor` from `@ifc-lite/geometry` is a
+concrete driver, not an extension point: it exposes `init()`,
+`process(buffer, entityIndex?)` and `processStreaming(buffer)` and returns a
+`GeometryResult`. To customize output, consume that result and transform the
+`MeshData[]` yourself:
 
 ```typescript
-import { GeometryProcessor, Mesh, Entity } from '@ifc-lite/geometry';
+import { GeometryProcessor } from '@ifc-lite/geometry';
 
-interface ProcessorContext {
-  decoder: EntityDecoder;
-  quality: 'FAST' | 'BALANCED' | 'HIGH';
-}
+const gp = new GeometryProcessor();
+await gp.init();
+const result = await gp.process(buffer);
 
-abstract class GeometryProcessor {
-  abstract canProcess(entity: Entity): boolean;
-  abstract process(entity: Entity, context: ProcessorContext): Mesh | null;
-}
-```
-
-### Example: Custom Profile Processor
-
-```typescript
-class CustomProfileProcessor extends GeometryProcessor {
-  canProcess(entity: Entity): boolean {
-    // Handle custom profile types
-    return entity.type === 'IFCARBITRARYCLOSEDPROFILEDEF' &&
-           this.hasCustomAttributes(entity);
-  }
-
-  process(entity: Entity, context: ProcessorContext): Mesh | null {
-    const profile = this.extractProfile(entity, context.decoder);
-
-    // Custom triangulation logic
-    const points = this.convertToPoints(profile);
-    const indices = this.triangulate(points);
-
-    // Build mesh
-    return this.buildMesh(entity.expressId, points, indices);
-  }
-
-  private extractProfile(entity: Entity, decoder: EntityDecoder): Point2[] {
-    // Custom profile extraction
-    const curve = decoder.decode(entity.attributes[0].value);
-    return this.curveToPoints(curve);
-  }
-
-  private triangulate(points: Point2[]): number[] {
-    // Use earcut or custom algorithm
-    return earcut(points.flat(), [], 2);
-  }
-}
-```
-
-### Registering Custom Processors
-
-```typescript
-import { GeometryRouter, ProcessorRegistry } from '@ifc-lite/geometry';
-
-// Register globally
-ProcessorRegistry.register(new CustomProfileProcessor());
-
-// Or per-instance
-const router = new GeometryRouter();
-router.addProcessor(new CustomProfileProcessor());
-
-// Process metadata with the canonical columnar parser, then route custom
-// geometry through GeometryProcessor/Rust processors.
-const store = await parser.parseColumnar(buffer);
+// Post-process the produced meshes (custom simplification, tagging, etc.)
+const processed = result.meshes.map((mesh) => transformMesh(mesh));
 ```
 
 ## Schema Extensions
 
 ### Adding Custom Entity Types
 
+The IFC entity schema is generated from the official EXPRESS definitions at
+build time, not registered at runtime. To add or change entity definitions,
+regenerate the schema with `@ifc-lite/codegen` from a modified EXPRESS file and
+rebuild the parser:
+
 ```typescript
-import { SchemaRegistry, EntityDefinition } from '@ifc-lite/parser';
+import { parseExpressSchema, generateTypeScript } from '@ifc-lite/codegen';
 
-// Define custom entity
-const customEntity: EntityDefinition = {
-  name: 'IFCCUSTOMELEMENT',
-  parent: 'IFCBUILDINGELEMENT',
-  attributes: [
-    { name: 'CustomProperty', type: 'STRING', optional: true },
-    { name: 'CustomValue', type: 'REAL', optional: true }
-  ]
-};
-
-// Register
-SchemaRegistry.register(customEntity);
-
-// Schema extensions must be generated into the parser package before parsing.
-const store = await parser.parseColumnar(buffer);
-const customs = store.entityIndex.byType.get('IFCCUSTOMELEMENT') ?? [];
+const schema = parseExpressSchema(expressSource);
+const generated = generateTypeScript(schema);
+// generated.entities / .types / .enums / .selects / .schemaRegistry are TS source.
+// Write them into packages/parser/src/generated, then rebuild the parser.
 ```
+
+For one-off vendor extensions whose schema you do not control, do not extend the
+schema. Read the raw attributes of unknown entities on demand instead (see the
+on-demand extractors above and [Custom Queries](custom-queries.md)).
 
 ### Custom Property Extractors
 
+There is no `PropertyExtractor` base class to subclass. Compose the standalone
+`extractPropertiesOnDemand` helper with your own function instead:
+
 ```typescript
-import { PropertyExtractor } from '@ifc-lite/parser';
+import { extractPropertiesOnDemand, type IfcDataStore } from '@ifc-lite/parser';
 
-class CustomPropertyExtractor extends PropertyExtractor {
-  extract(entity: Entity, decoder: EntityDecoder): Record<string, any> {
-    const base = super.extract(entity, decoder);
+function extractCustom(store: IfcDataStore, expressId: number): Record<string, unknown> {
+  const psets = extractPropertiesOnDemand(store, expressId);
+  const findProp = (psetName: string, propName: string) =>
+    psets.find((p) => p.name === psetName)
+      ?.properties.find((prop) => prop.name === propName)?.value;
 
-    // Add custom properties
-    if (entity.type === 'IFCWALL') {
-      base.customProperty = this.computeCustomProperty(entity);
-    }
-
-    return base;
-  }
-
-  private computeCustomProperty(entity: Entity): number {
-    // Custom calculation
-    return 42;
-  }
+  return {
+    isExternal: Boolean(findProp('Pset_WallCommon', 'IsExternal')),
+    fireRating: Number(findProp('Pset_WallCommon', 'FireRating')) || 0,
+  };
 }
 ```
 
@@ -349,7 +319,7 @@ interface IfcLitePlugin {
   // Lifecycle hooks
   onInit?(context: PluginContext): void;
   onParse?(store: IfcDataStore): void;
-  onGeometry?(meshes: Mesh[]): void;
+  onGeometry?(meshes: MeshData[]): void;
   onRender?(renderer: Renderer): void;
   onDispose?(): void;
 }
@@ -367,8 +337,7 @@ class AnalyticsPlugin implements IfcLitePlugin {
 
   onParse(store: IfcDataStore): void {
     console.log('Parse statistics:', {
-      entities: store.entityCount,
-      schema: store.schema,
+      entities: store.entities.count,
     });
   }
 }
@@ -415,14 +384,13 @@ plugins.onParse(store);
 ```typescript
 // Good: Single responsibility
 class FireRatingExtractor {
-  extract(entity: Entity): number | null { ... }
+  extract(store: IfcDataStore, expressId: number): number | null { ... }
 }
 
 // Bad: Too many responsibilities
 class EverythingExtractor {
-  extractFireRating(entity: Entity): number { ... }
-  extractMaterials(entity: Entity): Material[] { ... }
-  triangulateGeometry(entity: Entity): Mesh { ... }
+  extractFireRating(store: IfcDataStore, expressId: number): number { ... }
+  extractMaterials(store: IfcDataStore, expressId: number): Material[] { ... }
   // ...
 }
 ```
@@ -432,10 +400,10 @@ class EverythingExtractor {
 ```typescript
 class TypedDecoder<T> {
   constructor(
-    private decode: (entity: Entity) => T
+    private decode: (entity: EntityRef) => T
   ) {}
 
-  decodeAll(entities: Entity[]): T[] {
+  decodeAll(entities: EntityRef[]): T[] {
     return entities.map(this.decode);
   }
 }
@@ -446,12 +414,12 @@ const doorDecoder = new TypedDecoder<CustomDoorData>(decodeDoor);
 ### 3. Handle Errors Gracefully
 
 ```typescript
-class SafeProcessor extends GeometryProcessor {
-  process(entity: Entity, context: ProcessorContext): Mesh | null {
+class SafeExtractor {
+  extract(store: IfcDataStore, expressId: number): Record<string, unknown> | null {
     try {
-      return this.doProcess(entity, context);
+      return this.doExtract(store, expressId);
     } catch (error) {
-      console.warn(`Failed to process ${entity.type} #${entity.expressId}:`, error);
+      console.warn(`Failed to extract #${expressId}:`, error);
       return null; // Return null instead of throwing
     }
   }

--- a/docs/tutorials/extending-parser.md
+++ b/docs/tutorials/extending-parser.md
@@ -29,7 +29,13 @@ flowchart TB
 ### Creating a Decoder
 
 ```typescript
-import { IfcDataStore, EntityRef, extractEntityAttributesOnDemand } from '@ifc-lite/parser';
+import {
+  IfcDataStore,
+  EntityRef,
+  extractEntityAttributesOnDemand,
+  extractPropertiesOnDemand,
+  extractQuantitiesOnDemand,
+} from '@ifc-lite/parser';
 
 // Define custom entity interface
 interface CustomDoorData {
@@ -87,8 +93,6 @@ class DoorDecoder {
 }
 
 // Usage
-import { extractPropertiesOnDemand, extractQuantitiesOnDemand } from '@ifc-lite/parser';
-
 const buffer = new Uint8Array(arrayBuffer);
 const doorDecoder = new DoorDecoder(store, buffer);
 const doors = doorDecoder.decodeAll();

--- a/examples/threejs-viewer/README.md
+++ b/examples/threejs-viewer/README.md
@@ -29,11 +29,7 @@ npm install
 npm run dev
 ```
 
-> **Note:** `@ifc-lite/data` is listed as an explicit dependency here as a workaround —
-> `@ifc-lite/geometry@1.11.0` uses it internally but omitted it from its own `dependencies`.
-> It will be declared transitively in the next patch release and can be removed then.
-
-Open `http://localhost:3000` and drop an IFC file. Click any element to see its IFC data in the side panel.
+Open `http://localhost:5173` and drop an IFC file. Click any element to see its IFC data in the side panel.
 
 ## Key files
 

--- a/packages/bcf/README.md
+++ b/packages/bcf/README.md
@@ -61,12 +61,12 @@ const viewpoint = createViewpoint({
     position: { x: 50, y: 30, z: 12 },
     target: { x: 0, y: 0, z: 0 },
     up: { x: 0, y: 0, z: 1 },
-    fov: 60,
+    fov: Math.PI / 3, // field of view in radians (60 degrees)
   },
   // Highlight specific entities by their IFC GlobalId
-  selection: ['1abc2def3GhI4jKlM5nOpQ', '2bcd3efg4HiJ5kLmN6oPqR'],
-  // Hide unrelated context
-  visibility: { defaultVisibility: false, exceptions: ['1abc2def3GhI4jKlM5nOpQ'] },
+  selectedGuids: ['1abc2def3GhI4jKlM5nOpQ', '2bcd3efg4HiJ5kLmN6oPqR'],
+  // Isolate: show only these entities (isolation mode, defaultVisibility=false)
+  visibleGuids: ['1abc2def3GhI4jKlM5nOpQ'],
 });
 
 addViewpointToTopic(topic, viewpoint);

--- a/packages/cache/README.md
+++ b/packages/cache/README.md
@@ -1,6 +1,6 @@
 # @ifc-lite/cache
 
-Binary cache format for IFClite. Caches parsed geometry as compressed GLB so a previously-loaded IFC reopens in milliseconds instead of re-running the full parse + tessellation pipeline. Content-addressable (SHA-256 of the source IFC), so cache invalidation is automatic.
+Binary cache format for IFClite. Caches the parsed data store and geometry in a compact binary format so a previously-loaded IFC reopens in milliseconds instead of re-running the full parse + tessellation pipeline. Content-addressable (xxHash64 of the source IFC), so cache invalidation is automatic.
 
 ## Installation
 
@@ -12,30 +12,29 @@ npm install @ifc-lite/cache
 
 ```typescript
 import {
-  computeFileHash,
+  xxhash64Hex,
   BinaryCacheReader,
   BinaryCacheWriter,
-  loadGLBToMeshData,
 } from '@ifc-lite/cache';
 
 const ifcBuffer = await file.arrayBuffer();
-const cacheKey = await computeFileHash(ifcBuffer);
+const cacheKey = xxhash64Hex(ifcBuffer);
 
 // Try cache first
 const cached = await myStorage.get(cacheKey); // your IndexedDB / fs / S3 lookup
 if (cached) {
-  const reader = new BinaryCacheReader(cached);
-  const meshes = await loadGLBToMeshData(reader.readGeometry());
-  renderer.loadGeometry(meshes);
+  const reader = new BinaryCacheReader();
+  const { geometry } = await reader.read(cached);
+  renderer.loadGeometry(geometry?.meshes ?? []);
   return; // first triangles in milliseconds
 }
 
-// Cold path — full parse, then write the cache
-const meshes = await geometryProcessor.process(new Uint8Array(ifcBuffer));
+// Cold path — full parse + tessellation, then write the cache
+const { dataStore, geometry } = await geometryProcessor.process(new Uint8Array(ifcBuffer));
 
 const writer = new BinaryCacheWriter();
-writer.writeGeometry({ meshes });
-await myStorage.put(cacheKey, writer.toBuffer());
+const cacheBuffer = await writer.write(dataStore, geometry, ifcBuffer, { includeGeometry: true });
+await myStorage.put(cacheKey, cacheBuffer);
 ```
 
 ## Pure GLB read
@@ -49,7 +48,7 @@ const meshes = await loadGLBToMeshData(glbBuffer);
 // → MeshData[] ready to feed into @ifc-lite/renderer
 
 // Or get the parsed GLB structure if you need lower-level access
-const { json, bin, mapping } = parseGLB(glbBuffer);
+const { json, bin } = parseGLB(glbBuffer);
 ```
 
 ## Hashing utilities
@@ -57,13 +56,13 @@ const { json, bin, mapping } = parseGLB(glbBuffer);
 Two hash functions are exposed for cache key generation:
 
 ```typescript
-import { xxhash64Hex, computeFileHash } from '@ifc-lite/cache';
+import { xxhash64, xxhash64Hex } from '@ifc-lite/cache';
 
-const fastKey = xxhash64Hex(buffer);          // ~5 GB/s, 16-char hex — best for ephemeral keys
-const stableKey = await computeFileHash(buf); // SHA-256 — persistent across machines
+const hexKey = xxhash64Hex(buffer);  // ~5 GB/s, 16-char hex string
+const rawKey = xxhash64(buffer);     // same hash as a bigint
 ```
 
-Use SHA-256 (the default) for any cache that survives a process restart. Use xxhash for purely in-memory deduplication.
+The cache keys models by the xxHash64 of the source IFC, and `reader.validate(cacheBuffer, sourceBuffer)` uses the same hash to detect when the source has changed.
 
 ## API
 

--- a/packages/cache/README.md
+++ b/packages/cache/README.md
@@ -29,8 +29,10 @@ if (cached) {
   return; // first triangles in milliseconds
 }
 
-// Cold path — full parse + tessellation, then write the cache
-const { dataStore, geometry } = await geometryProcessor.process(new Uint8Array(ifcBuffer));
+// Cold path — full parse + tessellation, then write the cache.
+// dataStore comes from the parser; process() returns a GeometryResult.
+const dataStore = await parser.parseColumnar(new Uint8Array(ifcBuffer));
+const geometry = await geometryProcessor.process(new Uint8Array(ifcBuffer));
 
 const writer = new BinaryCacheWriter();
 const cacheBuffer = await writer.write(dataStore, geometry, ifcBuffer, { includeGeometry: true });

--- a/packages/clash/README.md
+++ b/packages/clash/README.md
@@ -25,8 +25,9 @@ console.log(result.summary.total, 'clashes');
 ```
 
 Includes the TypeScript reference engine, a Rust→WASM kernel kept in lockstep by a
-differential test (`backend: 'auto'` picks WASM when available, else TS), STEP and
-IFC5/USD source adapters, spatial grouping, and a *sensible* BCF bridge (grouped
+differential test (opt-in via `@ifc-lite/clash/wasm`; `backend: 'auto'` currently
+resolves to the TS engine), STEP and IFC5/USD source adapters, spatial grouping, and
+a *sensible* BCF bridge (grouped
 topics, deterministic GUIDs, optional snapshots). Surfaced through the viewer's
 clash panel, the `ifc-lite clash` CLI, the MCP `clash_check` / `clash_matrix` tools,
 and the SDK `clash` namespace. Design rationale: `docs/architecture/clash-detection-plan.md`.

--- a/packages/codegen/README.md
+++ b/packages/codegen/README.md
@@ -14,10 +14,10 @@ npm install --save-dev @ifc-lite/codegen
 
 ```bash
 # IFC4 (776 entities)
-npx ifc-lite-codegen ./schemas/IFC4.exp --out ./src/generated
+node dist/cli.js ./schemas/IFC4.exp --output ./src/generated
 
 # IFC4X3 (876 entities, includes infrastructure: roads, bridges, alignments)
-npx ifc-lite-codegen ./schemas/IFC4X3.exp --out ./src/generated
+node dist/cli.js ./schemas/IFC4X3.exp --output ./src/generated
 ```
 
 Generated files (one per output directory):
@@ -25,8 +25,12 @@ Generated files (one per output directory):
 ```
 src/generated/
 ├── entities.ts          ← TypeScript interfaces for every entity
+├── types.ts             ← defined-type aliases
+├── enums.ts             ← enum definitions
+├── selects.ts           ← SELECT union types
 ├── schema-registry.ts   ← runtime metadata (parent, attributes, ...)
-├── types.ts             ← enum unions and SELECT types
+├── type-ids.ts          ← numeric type-id lookup tables
+├── serializers.ts       ← STEP serializer bound to the schema registry
 └── index.ts             ← barrel export
 ```
 
@@ -34,16 +38,13 @@ src/generated/
 
 ```typescript
 import { parseExpressSchema, generateTypeScript } from '@ifc-lite/codegen';
-import { writeFile } from 'node:fs/promises';
+import { readFile, writeFile } from 'node:fs/promises';
 
-const schema = parseExpressSchema('./schemas/IFC4.exp');
+const schema = parseExpressSchema(await readFile('./schemas/IFC4.exp', 'utf-8'));
 
 console.log(`Parsed ${schema.entities.length} entities, ${schema.types.length} types`);
 
-const generated = generateTypeScript(schema, {
-  inheritanceChain: true,
-  emitEnums: true,
-});
+const generated = generateTypeScript(schema);
 
 await writeFile('./src/generated/entities.ts', generated.entities);
 await writeFile('./src/generated/schema-registry.ts', generated.schemaRegistry);

--- a/packages/codegen/README.md
+++ b/packages/codegen/README.md
@@ -22,7 +22,7 @@ node dist/cli.js ./schemas/IFC4X3.exp --output ./src/generated
 
 Generated files (one per output directory):
 
-```
+```text
 src/generated/
 ├── entities.ts          ← TypeScript interfaces for every entity
 ├── types.ts             ← defined-type aliases

--- a/packages/collab-server/README.md
+++ b/packages/collab-server/README.md
@@ -3,7 +3,7 @@
 Reference websocket sync server for [`@ifc-lite/collab`](../collab).
 
 > **Status: v0.2 scaffold.** y-websocket-compatible sync, in-memory room
-> registry, append-only file persistence, JWT auth hook, healthcheck.
+> registry, append-only file persistence, pluggable auth hook, healthcheck.
 > Production hardening (auth roles, S3 persistence, observability) lands
 > in v0.5 per `docs/architecture/collab-plan.md`.
 
@@ -22,7 +22,6 @@ Environment variables:
 | `COLLAB_PORT` | `1234` | Listen port |
 | `COLLAB_HOST` | `0.0.0.0` | Listen host |
 | `COLLAB_DATA_DIR` | `./.collab-data` | Persistence root for room logs |
-| `COLLAB_JWT_SECRET` | _(unset = auth disabled)_ | HMAC secret for JWT validation |
 | `COLLAB_MAX_ROOMS` | `1024` | Soft cap on simultaneous rooms |
 
 ## Programmatic use

--- a/packages/create-ifc-lite/README.md
+++ b/packages/create-ifc-lite/README.md
@@ -56,4 +56,4 @@ Each template ships with a `README.md` documenting what it does and how to exten
 
 - [IFClite docs](https://ltplus-ag.github.io/ifc-lite/)
 - [GitHub repo](https://github.com/LTplus-AG/ifc-lite)
-- [Quick Start guide](https://github.com/LTplus-AG/ifc-lite/blob/main/https://ltplus-ag.github.io/ifc-lite/guide/quickstart/)
+- [Quick Start guide](https://ltplus-ag.github.io/ifc-lite/guide/quickstart/)

--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -19,29 +19,19 @@ Most users get these structures for free as the output of `@ifc-lite/parser`'s `
 ## Build an entity table
 
 ```typescript
-import { EntityTableBuilder, StringTableBuilder } from '@ifc-lite/data';
+import { EntityTableBuilder, StringTable } from '@ifc-lite/data';
 
-const strings = new StringTableBuilder();
-const entities = new EntityTableBuilder();
+const strings = new StringTable();
+const entities = new EntityTableBuilder(1, strings);
 
-const wallTypeId = strings.intern('IFCWALL');
-const wallNameId = strings.intern('Wall A');
-const wallGuidId = strings.intern('1abc2def3...');
-
-entities.add({
-  expressId: 42,
-  typeNameId: wallTypeId,
-  nameId: wallNameId,
-  globalIdId: wallGuidId,
-  // ... other columns
-});
+// add(expressId, type, globalId, name, description, objectType)
+entities.add(42, 'IFCWALL', '1abc2def3...', 'Wall A', '', '');
 
 const table = entities.build();
-const stringTable = strings.build();
 
-console.log(table.count);                       // 1
-console.log(stringTable.get(table.name[0]));    // 'Wall A'
-console.log(table.getTypeName(42));             // 'IFCWALL'
+console.log(table.count);                    // 1
+console.log(strings.get(table.name[0]));     // 'Wall A'
+console.log(table.getTypeName(42));          // 'IfcWall'
 ```
 
 ## Relationship graph
@@ -53,15 +43,15 @@ import { RelationshipGraphBuilder, RelationshipType } from '@ifc-lite/data';
 
 const builder = new RelationshipGraphBuilder();
 
-// Storey 100 contains walls 42, 43, 44
-builder.addEdge(100, 42, RelationshipType.CONTAINS);
-builder.addEdge(100, 43, RelationshipType.CONTAINS);
-builder.addEdge(100, 44, RelationshipType.CONTAINS);
+// Storey 100 contains walls 42, 43, 44 (last arg = the IfcRel* express id)
+builder.addEdge(100, 42, RelationshipType.ContainsElements, 200);
+builder.addEdge(100, 43, RelationshipType.ContainsElements, 200);
+builder.addEdge(100, 44, RelationshipType.ContainsElements, 200);
 
 const graph = builder.build();
 
-const contained = graph.outgoing(100, RelationshipType.CONTAINS);
-console.log([...contained]); // [42, 43, 44]
+const contained = graph.getRelated(100, RelationshipType.ContainsElements, 'forward');
+console.log(contained); // [42, 43, 44]
 ```
 
 ## EPSG lookup

--- a/packages/data/scripts/upstream/README.md
+++ b/packages/data/scripts/upstream/README.md
@@ -1,10 +1,11 @@
 # Vendored IDS-Audit-tool schema data
 
-The five `SchemaInfo.*.g.cs` files in this directory are auto-generated source from
+The seven `SchemaInfo.*.g.cs` files in this directory are auto-generated source from
 [buildingSMART/IDS-Audit-tool](https://github.com/buildingSMART/IDS-Audit-tool)
-(licensed MIT). They are copied verbatim for use by `generate-ifc-schema.ts`,
-which converts them into the TypeScript data tables in
-`packages/data/src/ifc-schema/generated/`.
+(licensed MIT). They are copied verbatim. Six of them are read by
+`generate-ifc-schema.ts`, which converts them into the TypeScript data tables in
+`packages/data/src/ifc-schema/generated/`; `SchemaInfo.ClassAndAttributeNames.g.cs`
+is vendored but not currently consumed by the generator.
 
 `LICENSE` is the upstream MIT license, retained as required for redistribution.
 
@@ -17,6 +18,8 @@ cp /tmp/IDS-Audit-tool/ids-lib/IfcSchema/SchemaInfo.Schemas.g.cs \
    /tmp/IDS-Audit-tool/ids-lib/IfcSchema/SchemaInfo.PartOfRelations.g.cs \
    /tmp/IDS-Audit-tool/ids-lib/IfcSchema/SchemaInfo.ObjectTypes.g.cs \
    /tmp/IDS-Audit-tool/ids-lib/IfcSchema/SchemaInfo.ClassAndAttributeNames.g.cs \
+   /tmp/IDS-Audit-tool/ids-lib/IfcSchema/SchemaInfo.Attributes.g.cs \
+   /tmp/IDS-Audit-tool/ids-lib/IfcSchema/SchemaInfo.MeasureNames.g.cs \
    /tmp/IDS-Audit-tool/LICENSE \
    packages/data/scripts/upstream/
 pnpm --filter @ifc-lite/data run generate:ifc-schema

--- a/packages/drawing-2d/README.md
+++ b/packages/drawing-2d/README.md
@@ -74,7 +74,7 @@ import {
 } from '@ifc-lite/drawing-2d';
 
 // Use a built-in preset
-const fireSafety = getBuiltInPreset('fire-safety');
+const fireSafety = getBuiltInPreset('preset-fire-safety');
 const engine = createOverrideEngine(fireSafety?.rules);
 
 // Or define custom rules
@@ -98,7 +98,7 @@ const result = engine.applyOverrides({
 console.log(result.style);
 ```
 
-Built-in presets: `architectural` (default), `structural`, `mep`, `fire-safety`, `monochrome`. List them via `BUILT_IN_PRESETS` or look one up with `getBuiltInPreset(id)`.
+Built-in presets: `preset-3d-colors` (default), `preset-architectural`, `preset-structural`, `preset-mep`, `preset-fire-safety`, `preset-monochrome`. List them via `BUILT_IN_PRESETS` or look one up with `getBuiltInPreset(id)`.
 
 ## Drawing sheets
 

--- a/packages/export/README.md
+++ b/packages/export/README.md
@@ -1,6 +1,6 @@
 # @ifc-lite/export
 
-Export formats for IFClite. Writes Apache Parquet, Apache Arrow, IFC STEP (with mutations applied), IFC5 IFCX (JSON + USD geometry), and lightweight LOD0/LOD1 envelopes — all from a single parsed `IfcDataStore`.
+Export formats for IFClite. Writes Apache Parquet (Arrow-based internally), IFC STEP (with mutations applied), IFC5 IFCX (JSON + USD geometry), and lightweight LOD0/LOD1 envelopes — all from a single parsed `IfcDataStore`.
 
 > **glTF/GLB, CSV and JSON-LD moved to Rust.** They are now assembled by the `ifc-lite-export` crate and reached through `GeometryProcessor` in [`@ifc-lite/geometry`](../geometry); the standalone `GLTFExporter`/`CSVExporter`/`JSONLDExporter` classes were retired.
 
@@ -33,7 +33,7 @@ const url = URL.createObjectURL(new Blob([new Uint8Array(glb)], { type: 'model/g
 import { exportToStep } from '@ifc-lite/export';
 
 const stepText = exportToStep(store, {
-  schema: 'IFC4',           // 'IFC2X3' | 'IFC4' | 'IFC4X3'
+  schema: 'IFC4',           // 'IFC2X3' | 'IFC4' | 'IFC4X3' | 'IFC5'
   applyMutations: true,     // include edits from MutablePropertyView
   visibleOnly: false,       // export only entities visible in the renderer
 });
@@ -49,12 +49,16 @@ const blob = new Blob([stepText], { type: 'application/x-step' });
 ```typescript
 import { ParquetExporter } from '@ifc-lite/export';
 
-const exporter = new ParquetExporter();
-const entities = await exporter.exportEntities(parseResult);
-const properties = await exporter.exportProperties(parseResult);
-const quantities = await exporter.exportQuantities(parseResult);
+const exporter = new ParquetExporter(store);
 
-// Each is ~15–50× smaller than equivalent JSON
+// One .bos archive (ZIP of Parquet tables: entities, properties, quantities, …)
+const bos = await exporter.exportBOS();
+
+// …or a single table on its own
+//   tableName ∈ entities|properties|quantities|relationships|strings|vertices|indices|meshes
+const entities = await exporter.exportTable('entities');
+
+// Each Parquet table is ~15–50× smaller than equivalent JSON
 // Loadable directly from DuckDB, Polars, pandas, BigQuery, …
 ```
 
@@ -92,7 +96,7 @@ const lod0 = await generateLod0(bytes);
 
 // LOD1 — meshes simplified to bounding boxes / convex hulls, returned as GLB
 const lod1 = await generateLod1(bytes, { quality: 'medium' });
-//   { glb: Uint8Array, meta: { failedElements, expressIdToNodeId, ... } }
+//   { glb: Uint8Array, meta: { failedElements, mapping, ... } }
 
 // Falls back gracefully to box geometry if a complex element fails to mesh
 ```

--- a/packages/extensions/README.md
+++ b/packages/extensions/README.md
@@ -6,9 +6,9 @@ user-customization system.
 This package implements the **non-UI** half of the design described in
 [`docs/architecture/ai-customization/`](../../docs/architecture/ai-customization/).
 It is host-agnostic — the same code is consumed by the browser viewer,
-the desktop app, the CLI, and the headless server.
+the CLI, and the headless server.
 
-## What's here (v0.1.0 — Phase 0)
+## What's here (v0.3.3)
 
 - **Manifest** — typed schema + hand-rolled validator producing
   structured `{ path, code, hint }` errors.
@@ -27,15 +27,17 @@ the desktop app, the CLI, and the headless server.
 - **Manifest migrations** — chain scaffold for forward-compatibility
   with future manifest versions.
 
-## Coming in later phases
+## Also included (re-exported from the package root)
 
-- **Phase 1** — IndexedDB storage, host loader, runtime activation,
-  sandbox wiring, audit log, viewer-side slot binding.
-- **Phase 2** — Widget DSL renderer, AI authoring pipeline, repair loop.
-- **Phase 3** — Flavor data model, export/import, three-way merge.
-- **Phase 4** — Action log, pattern miner, prompt overlay, SDK-update repair.
+- **Storage, host, audit** - IndexedDB storage, host loader, runtime
+  activation, sandbox wiring, audit log, viewer-side slot binding.
+- **Widget + authoring** - Widget DSL renderer, AI authoring pipeline,
+  repair loop.
+- **Flavor** - Flavor data model, export/import, three-way merge.
+- **Log, miner, inference** - Action log, pattern miner, prompt overlay,
+  SDK-update repair.
 
-## Usage (Phase 0)
+## Usage
 
 ```ts
 import {
@@ -47,8 +49,9 @@ import {
   parseWhen,
   evaluateWhen,
   SlotRegistry,
-  loadBundleFromDirectory,
 } from '@ifc-lite/extensions';
+// The directory/`.iflx` bundle loader is Node-only:
+import { loadBundleFromDirectory } from '@ifc-lite/extensions/node';
 
 // Validate a manifest
 const result = validateManifest(manifestJson);

--- a/packages/geometry/README.md
+++ b/packages/geometry/README.md
@@ -113,7 +113,7 @@ works.
 ## Performance
 
 - **First triangles:** 300–500ms (streaming path)
-- **Throughput:** 1.9x faster than `web-ifc` on the same model
+- **Throughput:** ~1.9x faster than `web-ifc` (928-column.ifc; see `tests/benchmark/benchmark-results.json`)
 - **Worker support:** files > 50 MB process off-main-thread automatically
 - **Native (Tauri):** `preferNative: true` enables the native Rust pipeline when running under a Tauri host — an extension point for third parties building their own desktop app (`@tauri-apps/api` is an optional dep; web builds never load it). See the [Building for Desktop](https://ltplus-ag.github.io/ifc-lite/guide/desktop/) guide.
 

--- a/packages/geometry/README.md
+++ b/packages/geometry/README.md
@@ -94,9 +94,8 @@ option:
 
 ```ts
 // Vite's `?url` suffix yields a fully-resolved URL string at build time.
-// `@ifc-lite/wasm` and `@ifc-lite/wasm-threaded` both expose the binary
-// at the `./ifc-lite_bg.wasm` subpath so this resolves cleanly through
-// the package's `exports` map.
+// `@ifc-lite/wasm` exposes the binary at the `./ifc-lite_bg.wasm` subpath
+// so this resolves cleanly through the package's `exports` map.
 import wasmUrl from '@ifc-lite/wasm/ifc-lite_bg.wasm?url';
 
 for await (const event of processor.processAdaptive(buffer, {
@@ -114,7 +113,7 @@ works.
 ## Performance
 
 - **First triangles:** 300–500ms (streaming path)
-- **Throughput:** up to 5× faster than `web-ifc` on the same model
+- **Throughput:** 1.9x faster than `web-ifc` on the same model
 - **Worker support:** files > 50 MB process off-main-thread automatically
 - **Native (Tauri):** `preferNative: true` enables the native Rust pipeline when running under a Tauri host — an extension point for third parties building their own desktop app (`@tauri-apps/api` is an optional dep; web builds never load it). See the [Building for Desktop](https://ltplus-ag.github.io/ifc-lite/guide/desktop/) guide.
 

--- a/packages/ids/README.md
+++ b/packages/ids/README.md
@@ -19,14 +19,14 @@ const idsSpec = parseIDS(idsXml);
 const translator = createTranslationService('en');
 const report = await validateIDS(idsSpec, store, { translator });
 
-console.log(`Overall: ${report.totalPassed} / ${report.totalChecked} passed`);
+console.log(`Overall: ${report.summary.totalEntitiesPassed} / ${report.summary.totalEntitiesChecked} passed`);
 
 for (const spec of report.specificationResults) {
-  console.log(`\n${spec.specificationName}: ${spec.passRate}%`);
+  console.log(`\n${spec.specification.name}: ${spec.passRate}%`);
 
   for (const entity of spec.entityResults) {
     if (!entity.passed) {
-      for (const req of entity.requirementResults.filter(r => !r.passed)) {
+      for (const req of entity.requirementResults.filter(r => r.status === 'fail')) {
         console.log(`  ✗ ${entity.entityType} #${entity.expressId}: ${translator.describeFailure(req)}`);
       }
     }
@@ -52,7 +52,7 @@ const idsSpec = parseIDS(idsXml);
 for (const spec of idsSpec.specifications) {
   console.log(`Spec: ${spec.name} (${spec.identifier})`);
   console.log(`  Applies to: ${spec.applicability.facets.length} facet(s)`);
-  console.log(`  Requires:   ${spec.requirements.facets.length} facet(s)`);
+  console.log(`  Requires:   ${spec.requirements.length} requirement(s)`);
 }
 ```
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -91,13 +91,13 @@ The same `npx` command works as a stdio server in any MCP-aware client.
 | --- | --- |
 | Discovery | `model_info`, `model_list`, `model_load`, `model_unload`, `schema_describe` |
 | Query | `query_entities`, `count_entities`, `get_entity`, `get_entities_bulk`, `spatial_hierarchy`, `containment_chain`, `relationships`, `properties_unique`, `materials_list`, `classifications_list`, `georeferencing`, `units` |
-| Geometry | `geometry_bbox`, `geometry_volume`, `geometry_area` (mesh/raycast/clash require WASM, planned v0.2) |
+| Geometry | `geometry_bbox`, `geometry_volume`, `geometry_area`, `clash_check`, `clash_matrix` (mesh/raycast require WASM, planned v0.2) |
 | Validation | `ids_validate`, `ids_explain`, `model_audit`, `gherkin_check` (v0.2) |
 | Mutation | `entity_set_property`, `entity_delete_property`, `entity_set_attribute`, `entity_create`, `entity_delete`, `mutation_batch`, `mutation_undo`, `mutation_diff`, `model_save` |
 | BCF | `bcf_topic_list`, `bcf_topic_create`, `bcf_topic_update`, `bcf_topic_close`, `bcf_viewpoint_create`, `bcf_export` |
 | bSDD | `bsdd_search`, `bsdd_class`, `bsdd_property_sets`, `bsdd_match` |
 | Diff | `model_diff`, `quantity_diff` |
-| Export | `export_ifc`, `export_csv`, `export_json`, `export_glb` (v0.2), `export_ifcx` (v0.2), `export_pdf_report` (v0.5) |
+| Export | `export_ifc`, `export_csv`, `export_json`, `export_glb`, `export_ifcx`, `export_pdf_report` (v0.5) |
 | Viewer | `viewer_ask`, `viewer_open`, `viewer_close`, `viewer_status`, `viewer_colorize`, `viewer_isolate`, `viewer_hide`, `viewer_show`, `viewer_reset`, `viewer_fly_to`, `viewer_set_section`, `viewer_clear_section`, `viewer_color_by_storey`, `viewer_color_by_property`, `viewer_get_selection`, `viewer_wait_for_selection` |
 
 Resources expose live model state under the `ifc-lite://` URI scheme:

--- a/packages/parser/README.md
+++ b/packages/parser/README.md
@@ -1,6 +1,6 @@
 # @ifc-lite/parser
 
-High-performance IFC parser. Tokenizes STEP files at ~1,259 MB/s, builds columnar TypedArray storage, and ships full type-safe coverage of IFC4 (776 entities) and IFC4X3 (876 entities).
+High-performance IFC parser. Tokenizes STEP files at high throughput, builds columnar TypedArray storage, and ships full type-safe coverage of all 776 IFC4 entities. IFC4X3 files are detected and parsed at runtime.
 
 ## Installation
 
@@ -40,7 +40,7 @@ console.log(`${store.entityCount} entities, schema ${store.schemaVersion}`);
 
 ## Type-safe entity access
 
-All 776 IFC4 entities (876 for IFC4X3) ship as TypeScript types via the generated schema.
+All 776 IFC4 entities ship as TypeScript types via the generated schema.
 
 ```typescript
 import type { IfcWall, IfcDoor, IfcSlab } from '@ifc-lite/parser';
@@ -93,8 +93,8 @@ const georef = extractGeoreferencingOnDemand(store);
 
 if (georef?.hasGeoreference) {
   console.log(`CRS: ${georef.projectedCRS?.name}`);
-  console.log(`Origin: ${georef.eastings}, ${georef.northings}, ${georef.orthogonalHeight}`);
-  console.log(`Rotation: ${georef.rotationRadians} rad`);
+  console.log(`Origin: ${georef.mapConversion?.eastings}, ${georef.mapConversion?.northings}, ${georef.mapConversion?.orthogonalHeight}`);
+  console.log(`Grid north: ${georef.mapConversion?.xAxisAbscissa}, ${georef.mapConversion?.xAxisOrdinate}`);
 }
 ```
 
@@ -106,7 +106,7 @@ if (georef?.hasGeoreference) {
 | 50 MB | ~600–700 ms |
 | 200 MB | ~2.5–3 s |
 
-- Tokenization: ~1,259 MB/s on M1/M2 laptops
+- Tokenization: high single-pass throughput on M1/M2 laptops
 - Bundle: ~200 KB gzipped (schema registry included)
 - Memory: TypedArray columnar storage
 

--- a/packages/pointcloud/README.md
+++ b/packages/pointcloud/README.md
@@ -19,7 +19,7 @@ if (chunk) {
 ```
 
 The renderer (`@ifc-lite/renderer`) consumes `DecodedPointChunk` values via
-`Renderer.loadPointClouds()` / `Renderer.addPointCloudChunks()`.
+`Renderer.setPointClouds()` / `Renderer.addPointClouds()`.
 
 ## Streaming decode worker (zero Vite config)
 

--- a/packages/query/README.md
+++ b/packages/query/README.md
@@ -26,7 +26,7 @@ console.log(`${walls.length} external load-bearing walls`);
 
 for (const wall of walls) {
   console.log(wall.name, wall.globalId);
-  console.log(wall.properties()); // lazily-loaded psets
+  console.log(wall.properties); // lazily-loaded psets
 }
 ```
 
@@ -52,7 +52,7 @@ query
   .execute();
 ```
 
-Supported: `=`, `!=`, `>`, `<`, `>=`, `<=`, `CONTAINS`, `STARTS_WITH`, `IS_NULL`, `IS_NOT_NULL`.
+Supported: `=`, `!=`, `>`, `<`, `>=`, `<=`, `contains`, `startsWith`.
 
 ## Graph traversal
 
@@ -65,7 +65,7 @@ console.log(wall.building()?.name);  // 'Office Tower'
 
 // Containment + composition
 const openings = wall.contains(); // openings hosted by the wall
-const aggregates = wall.composedOf();
+const aggregates = wall.decomposes();
 ```
 
 ## SQL via DuckDB-WASM

--- a/packages/renderer/README.md
+++ b/packages/renderer/README.md
@@ -36,9 +36,9 @@ canvas.addEventListener('click', async (e) => {
   const hit = await renderer.pick(e.clientX - rect.left, e.clientY - rect.top);
 
   if (hit) {
-    console.log(`Clicked expressId ${hit.expressId} at`, hit.point);
-    renderer.setSelection([hit.expressId]);
-    renderer.requestRender();
+    console.log(`Clicked expressId ${hit.expressId} at`, hit.worldXYZ);
+    // Selection is a per-frame render option, not a stateful setter.
+    renderer.render({ selectedIds: new Set([hit.expressId]) });
   }
 });
 ```
@@ -48,33 +48,38 @@ For exact world-space hits with surface normals, use `raycastScene(x, y)` — sl
 ## Section planes
 
 ```typescript
-// Cut the model with an axis-aligned section plane
-renderer.setSectionPlane({
-  axis: 'down',          // 'side' | 'down' | 'front' (X / Y / Z)
-  position: 3.0,         // metres along axis
-  enabled: true,
-  flipped: false,
+// Cut the model with an axis-aligned section plane (a per-frame render option)
+renderer.render({
+  sectionPlane: {
+    axis: 'down',          // 'side' | 'down' | 'front' (X / Y / Z)
+    position: 50,          // 0-100 percentage of model bounds
+    enabled: true,
+    flipped: false,
+  },
 });
-renderer.requestRender();
 
 // Disable
-renderer.setSectionPlane(null);
+renderer.render({ sectionPlane: { axis: 'down', position: 50, enabled: false } });
 ```
 
 ## Visibility + colour overrides
 
 ```typescript
-// Hide a list of entities
-renderer.setHiddenEntities(new Set([12345, 12346, 12347]));
+// Hide a list of entities (per-frame render option)
+renderer.render({ hiddenIds: new Set([12345, 12346, 12347]) });
 
 // Solo a subset (everything else gets the ghost treatment)
-renderer.setIsolatedEntities(new Set([42]));
+renderer.render({ isolatedIds: new Set([42]) });
 
-// Tint specific entities
-renderer.setColorOverrides(new Map([
-  [42, [1, 0, 0, 1]],   // RGBA — bright red
-  [99, [0, 1, 0, 0.4]], // semi-transparent green
-]));
+// Tint specific entities (RGBA 0-1) via the scene's color overrides
+renderer.getScene().setColorOverrides(
+  new Map([
+    [42, [1, 0, 0, 1]],   // bright red
+    [99, [0, 1, 0, 0.4]], // semi-transparent green
+  ]),
+  renderer.getGPUDevice()!,
+  renderer.getPipeline()!,
+);
 renderer.requestRender();
 ```
 

--- a/packages/server-bin/README.md
+++ b/packages/server-bin/README.md
@@ -111,7 +111,7 @@ cargo build --release
 | `runBinary(args?)` | Run the server with optional args — resolves with exit code |
 | `ensureBinary(onProgress?)` | Download if missing — resolves with binary path |
 | `downloadBinary(onProgress?)` | Force re-download — resolves with binary path |
-| `getBinaryInfo()` | Returns `{ platform, version, isCached, cachePath }` |
+| `getBinaryInfo()` | Returns `{ platform, binaryPath, cacheDir, isCached }` |
 | `isBinaryCached()` | Boolean — is the binary on disk? |
 
 ## License

--- a/packages/server-client/README.md
+++ b/packages/server-client/README.md
@@ -19,43 +19,39 @@ const result = await client.parseParquet(file);
 
 // Hashes the file client-side first, sends only the hash. If the server
 // has it cached, the upload is skipped entirely — second loads are instant.
-console.log(`${result.entities.length} entities, ${result.meshes.length} meshes`);
+console.log(`${result.metadata.entity_count} entities, ${result.meshes.length} meshes`);
 ```
 
 ## Stream a large file
 
 ```typescript
-const ac = new AbortController();
-
-for await (const event of client.parseStream(file, { signal: ac.signal })) {
+for await (const event of client.parseStream(file)) {
   switch (event.type) {
     case 'progress':
-      console.log(`${event.phase}: ${event.percent}%`);
+      console.log(`${event.processed}/${event.total}`);
       break;
     case 'batch':
       renderer.appendMeshes(event.meshes); // first triangles ~300ms in
       break;
     case 'complete':
-      console.log(`Done: ${event.totalMeshes} meshes`);
+      console.log(`Done: ${event.stats.total_meshes} meshes`);
       break;
     case 'error':
-      console.error(event.error);
+      console.error(event.message);
       break;
   }
 }
-
-// Cancel mid-stream
-// ac.abort();
 ```
 
 ## Health check + server info
 
 ```typescript
-const info = await client.getServerInfo();
-console.log(`Server v${info.version}, ${info.cpuCores} cores, ${info.cacheStats.entries} cached files`);
-
-const ok = await client.ping();
-if (!ok) console.warn('Server unreachable — falling back to client-side parse');
+try {
+  const info = await client.health();
+  console.log(`Server v${info.version} (${info.status})`);
+} catch {
+  console.warn('Server unreachable, falling back to client-side parse');
+}
 ```
 
 ## Lower-level: Parquet decoders
@@ -63,9 +59,9 @@ if (!ok) console.warn('Server unreachable — falling back to client-side parse'
 If you're consuming server responses outside the SDK (e.g. from a worker, or another runtime), the same Parquet/Arrow decoders are exposed directly:
 
 ```typescript
-import { decodeParquetResponse } from '@ifc-lite/server-client';
+import { decodeParquetGeometry } from '@ifc-lite/server-client';
 
-const meshes = await decodeParquetResponse(arrayBuffer);
+const meshes = await decodeParquetGeometry(arrayBuffer);
 ```
 
 ## API

--- a/packages/spatial/README.md
+++ b/packages/spatial/README.md
@@ -54,7 +54,7 @@ console.log(`${hits.length} entities in region`);
 import { FrustumUtils } from '@ifc-lite/spatial';
 
 // Build a frustum from a view-projection matrix (column-major 4×4)
-const frustum = FrustumUtils.fromMatrix(viewProjMatrix);
+const frustum = FrustumUtils.fromViewProjMatrix(viewProjMatrix);
 
 const visible = index.queryFrustum(frustum);
 // → expressIds visible to the camera; renderer only draws these

--- a/packages/wasm/README.md
+++ b/packages/wasm/README.md
@@ -12,9 +12,10 @@ npm install @ifc-lite/wasm
 
 ## Direct WASM use
 
-The text-based parse methods (`parse`, `parseStreaming`) take the raw IFC text
-(a `string`) — decode the buffer first. The geometry methods (`buildPrePassOnce`,
-`processGeometryBatch`, see below) instead take the raw `Uint8Array` bytes.
+The text-based entity scanner (`scanEntitiesFast`) takes the raw IFC text
+(a `string`) — decode the buffer first; `scanEntitiesFastBytes` takes the raw
+`Uint8Array` bytes directly. The geometry methods (`buildPrePassOnce`,
+`processGeometryBatch`, see below) also take the raw `Uint8Array` bytes.
 
 ```typescript
 import init, { IfcAPI } from '@ifc-lite/wasm';
@@ -25,9 +26,9 @@ const api = new IfcAPI();
 const buffer = await fetch('model.ifc').then(r => r.arrayBuffer());
 const content = new TextDecoder().decode(buffer);
 
-// Lightweight parse — returns { entityCount, ... }
-const result = await api.parse(content);
-console.log(`Entities: ${result.entityCount}`);
+// Fast entity scan — returns an array of entity references
+const refs = api.scanEntitiesFast(content);
+console.log(`Entities: ${refs.length}`);
 
 api.free();                           // free the API instance
 ```
@@ -78,7 +79,7 @@ api.free();                           // release the API instance when done
 
 | Class | Purpose |
 |---|---|
-| `IfcAPI` | Top-level entry point — `parse`, `parseStreaming`, `buildPrePassOnce` / `buildPrePassFast` / `buildPrePassStreaming`, `processGeometryBatch`, `scanEntitiesFast` / `scanEntitiesFastBytes` / `scanGeometryEntitiesFast`, `extractProfiles`, `parseSymbolicRepresentations` |
+| `IfcAPI` | Top-level entry point — `scanEntitiesFast` / `scanEntitiesFastBytes` / `scanGeometryEntitiesFast`, `buildPrePassOnce` / `buildPrePassStreaming`, `processGeometryBatch`, `extractProfiles`, `parseSymbolicRepresentations` |
 | `MeshCollection`, `MeshDataJs` | Tessellated geometry output |
 | `ProfileCollection`, `ProfileEntryJs` | Cross-section profile data (extruded-area solids) |
 | `SymbolicRepresentationCollection`, `SymbolicCircle`, `SymbolicPolyline` | 2D symbolic representations (for plan / annotation views) |

--- a/tools/ifcopenshell_reference/README.md
+++ b/tools/ifcopenshell_reference/README.md
@@ -57,9 +57,12 @@ Regenerating the committed reference (pin bump or intentional acceptance):
 
 ## CI
 
-- Per-PR (`ifcopenshell-parity` job): ifc-lite side only vs the committed
+Both lanes live in the `IfcOpenShell parity` workflow
+(`.github/workflows/ifcopenshell-parity.yml`).
+
+- Per-PR (`quick` job): ifc-lite side only vs the committed
   reference over the IN-TREE fixtures (no fixture download, no reference
   engine install). Catches kernel drift on every geometry-affecting PR.
-- Nightly (`ifcopenshell-parity.yml`): installs the pinned engine, runs the
+- Nightly (`full` job): installs the pinned engine, runs the
   full committed corpus (fetched fixtures included), regenerates reference
   dumps to detect reference-staleness, and uploads the diff reports.


### PR DESCRIPTION
## What

A full accuracy audit of every human-facing document (guides, API reference, tutorials, architecture notes, and package READMEs) against the current source. **71 docs changed, docs-only, no source changes.** Excludes agent/LLM files (`AGENTS.md`, `CLAUDE.md`, `.claude/*`) and auto-generated `CHANGELOG`s.

## Method

Verified each doc against the code, then ran adversarial verification passes over the code samples and a final grep gate on the on-disk result (a few automated edits reported success without landing, so the remaining fixes were re-applied and re-verified by hand against source).

## Representative fixes

- **Toolchain/versions**: Node 22.x, pnpm, Cargo `4`, lowercase `ghcr` image; removed stale `@ifc-lite/…@1.2.1` pins from install snippets.
- **Code samples → real APIs**: query builder (`.execute()`/`whereProperty`/`EntityNode`), `renderer.pick()` → `PickResult`, on-demand extractors (2-arg + array shape), `validateIDS` signature, parser `ParseOptions`/`parseAuto`/materials/georef/classifications, exporters, `IfcServerClient` surface, coordinate-handler getters.
- **Removed/renamed internals**: single pure-Rust CSG kernel (no Manifold/BSP), GPU-instancing path (ships, default-on), decommissioned first-party desktop app.
- **Rewrites**: `docs/api/typescript.md` query interfaces split into the real `IfcQuery`/`EntityQuery`/`EntityNode`; the fictional TS parser-extension sections of `tutorials/extending-parser.md` rewritten to the real mechanisms (Rust `ifc-lite-geometry`, `@ifc-lite/codegen`, on-demand extractors); `rust.md` `ParseEvent`/`EntityScanner`/`parse_entity` signatures.
- **Packages/MCP**: `clash_check`/`clash_matrix`/`export_glb`/`export_ifcx` marked shipped; package README versions/status; nonexistent `COLLAB_JWT_SECRET` noted; stale MCP-landing README corrected.

## Notes / open questions

- Unverifiable numbers were **softened, not invented** (parser MB/s, geometry "Nx faster", Firefox WebGPU version) — drop in real figures if you have them.
- mkdocs `nav` still omits several internal design docs (`design/*`, `research/*`, `architecture/ai-customization/*`, plan docs) — left as-is; say the word to surface them.
- Docs-only, so no changeset; updated package READMEs will ship with each package's next release.
- Verified by reading source, not by running `mkdocs build`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated API and usage docs to match the latest app workflows for querying, exporting, parsing, rendering, and IDS validation.
  * Simplified several guides and tutorials to show the current recommended examples, names, and output shapes.
  * Refreshed architecture and release notes to align with the current package and publishing layout.
  * Clarified setup, installation, and browser requirements, including newer Node.js and browser support guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->