### PR TITLE
docs: add repo scaffolding for outside integrators

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,12 @@
+# Code owners for ifc-lite.
+# A review from an owner is requested automatically on matching paths.
+# See https://docs.github.com/articles/about-code-owners
+
+# Default owner for everything in the repo.
+*                       @louistrue
+
+# Geometry kernel and processing pipeline are correctness-critical
+# (determinism manifests, exact CSG). Keep an explicit owner.
+/rust/                  @louistrue
+/apps/server/           @louistrue
+/.github/               @louistrue

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,61 @@
+name: Bug report
+description: A defect in the viewer, kernel, CLI, server, or a package.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the report. A minimal reproduction (a small IFC file plus the
+        exact command or steps) is worth far more than a description.
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: Package version, CLI `ifc-lite --version`, or the commit SHA.
+      placeholder: "e.g. @ifc-lite/viewer 0.13.0, or commit abc1234"
+    validations:
+      required: true
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Which surface
+      options:
+        - Viewer (browser)
+        - Geometry / CSG kernel
+        - CLI
+        - Server
+        - A published @ifc-lite/* package
+        - MCP
+        - Other / not sure
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Reproduction
+      description: Steps or the exact command. Attach or link a minimal IFC if geometry is involved.
+      placeholder: |
+        1. ifc-lite export model.ifc --format glb --out out.glb
+        2. ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected vs actual
+    validations:
+      required: true
+  - type: textarea
+    id: env
+    attributes:
+      label: Environment
+      description: OS, browser + GPU (for viewer), Node version (for CLI/server).
+    validations:
+      required: false
+  - type: checkboxes
+    id: privacy
+    attributes:
+      label: Privacy
+      options:
+        - label: My attached files and text contain no confidential or client-identifying data.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
 blank_issues_enabled: true
 contact_links:
-  - name: Security vulnerability
+  - name: Security vulnerability (private advisory)
     url: https://github.com/LTplus-AG/ifc-lite/security/advisories/new
     about: Report a vulnerability privately. Do not open a public issue for it.
+  - name: Security vulnerability (email)
+    url: mailto:louis@lt.plus
+    about: Email fallback for security reports (mirrors SECURITY.md), in case private advisories are unavailable.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/LTplus-AG/ifc-lite/security/advisories/new
+    about: Report a vulnerability privately. Do not open a public issue for it.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,23 @@
+name: Feature request
+description: Propose a capability or an improvement.
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: The problem
+      description: What are you trying to do that is hard or impossible today?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+<!-- Keep this focused: one change per PR. Delete sections that do not apply. -->
+
+## What and why
+
+<!-- The change and the problem it solves. Link the issue if there is one. -->
+
+## How it was verified
+
+<!-- Commands run and what you observed. Not "should work". -->
+
+- [ ] `cargo test --workspace` (Rust) and/or `pnpm test` (TS) pass locally
+- [ ] Geometry/WASM change: ran `scripts/build-wasm.sh` then `pnpm test:wasm-contract`
+
+## Checklist
+
+- [ ] A test asserts the new behavior through a fixture or a stated invariant
+- [ ] Published `packages/*` touched: added a changeset (`pnpm changeset`) and, if
+      the export surface changed, ran `pnpm api-surface:update`
+- [ ] Geometry-output change: re-pinned **both** `mesh_determinism.json` and
+      `mesh_determinism.wasm32.json` (or: no geometry output changed)
+- [ ] House rules: no `as any` / `@ts-ignore`, no silent `catch {}`, no module
+      pushed past ~400 non-generated lines, no repo-wide `cargo fmt`
+- [ ] No client or project identifiers in code, tests, commit messages, or this PR

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,71 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at louis@lt.plus.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+
+[homepage]: https://www.contributor-covenant.org

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -62,10 +62,59 @@ All complaints will be reviewed and investigated promptly and fairly.
 All community leaders are obligated to respect the privacy and security of the
 reporter of any incident.
 
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
 ## Attribution
 
 This Code of Conduct is adapted from the [Contributor Covenant][homepage],
 version 2.1, available at
 https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).
 
 [homepage]: https://www.contributor-covenant.org

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,66 @@
+# Contributing to ifc-lite
+
+Thanks for your interest. ifc-lite is a client-side IFC/BIM toolkit: a WebGPU
+viewer, a pure-Rust exact geometry kernel compiled to WASM and native, and a set
+of published `@ifc-lite/*` packages plus a CLI, MCP server, and HTTP server.
+
+`AGENTS.md` is the source of truth for architecture, invariants, and the review
+conventions ("house rules"). Read it before a non-trivial change. This file is
+the short version for getting set up and opening a PR.
+
+## Setup
+
+```bash
+pnpm install
+pnpm fixtures        # fetch test models (tests skip cleanly when absent)
+pnpm dev             # run the viewer
+```
+
+Rust lives under `rust/` and `apps/server`; the TS packages under `packages/`
+and `apps/`. The WASM bundle is rebuilt with `scripts/build-wasm.sh` (needs the
+pinned nightly + `wasm-pack`); the committed `pkg/ifc-lite.d.ts` type surface is
+what lets `pnpm typecheck` run without the Rust toolchain.
+
+## Test
+
+```bash
+pnpm test                  # TS (turbo)
+cargo test --workspace     # Rust (use test, not check: check skips #[cfg(test)])
+pnpm test:wasm-contract    # the real wasm boundary (build-wasm.sh first, or it skips)
+```
+
+A change ships with a test that asserts real behavior through a fixture or a
+stated invariant. Regression tests cite the issue or PR number.
+
+## House rules (self-policed, not linted)
+
+- No `as any` / `@ts-ignore`; fix the types or add a `.d.ts`.
+- No silent `catch {}`; log or rethrow.
+- Split modules over ~400 non-generated lines.
+- Package-specific deps go in the consuming package, never the root.
+- Never run a repo-wide `cargo fmt`; format only the lines you touch.
+- Never break the cross-platform determinism manifests. A legitimate
+  geometry-output change re-pins both `mesh_determinism.json` and
+  `mesh_determinism.wasm32.json` (see `docs/architecture/mesh-determinism.md`).
+
+## Published packages
+
+A change to any published `packages/*` needs a changeset:
+
+```bash
+pnpm changeset               # describe the change; pick the bump level
+pnpm api-surface:update      # if you added/removed/renamed an export
+```
+
+Never hand-edit versions or `CHANGELOG.md`.
+
+## Pull requests
+
+- Branch from `main`; one focused change per PR.
+- Fill in the PR template. Green CI plus one approval plus resolved
+  conversations are required to merge (squash only).
+- Keep client and project identifiers out of code, tests, commit messages, and
+  PR text.
+
+By contributing you agree your contributions are licensed under the repository
+license and that you follow the [Code of Conduct](./CODE_OF_CONDUCT.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,25 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please report security issues privately, not through public issues or pull
+requests.
+
+- Preferred: open a private advisory at
+  https://github.com/LTplus-AG/ifc-lite/security/advisories/new
+- Or email louis@lt.plus
+
+Include a description, the affected surface (viewer, kernel, CLI, server, or a
+package), and a minimal reproduction if you have one. We aim to acknowledge a
+report within a few business days.
+
+ifc-lite runs untrusted IFC input through a parser and a geometry kernel, so
+parser and kernel crashes, out-of-bounds reads, and unbounded memory or time on
+crafted input are in scope. Please do not include confidential or
+client-identifying model data in a report; a minimal synthetic reproduction is
+strongly preferred.
+
+## Supported versions
+
+Security fixes target the latest released version on the default branch. Older
+versions are not maintained.


### PR DESCRIPTION
## What and why

Adds the standard community-health files that were flagged missing in the maturity review (Tier 4.11): `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md`, `.github/CODEOWNERS`, a PR template, and bug/feature issue templates. These are the visible "set up for outside integrators" signals the repo lacked.

Tailored to the repo, not generic boilerplate:
- `CONTRIBUTING.md` points at the real `pnpm`/`cargo` dev, test, and changeset commands and the house rules, and defers depth to `AGENTS.md`.
- `SECURITY.md` scopes parser/kernel crashes on untrusted IFC input and asks for synthetic repros (no confidential model data), routing reports to a private advisory.
- Templates carry the determinism-manifest and no-client-identifiers reminders that match the house rules.

## How it was verified

Docs/config only, no code. Issue-template YAML follows the GitHub form schema; `CODEOWNERS` uses `@louistrue` as the default owner.

## Notes

- No CI cost added and no "presence-guard" test: these are static docs, not a code feature, so a test asserting they exist would be redundant clutter.
- No changeset: nothing under published `packages/*` changed.