### PR TITLE
fix(server): keep memory admission active without a cgroup limit

### DIFF
--- a/apps/server/OPERATIONS.md
+++ b/apps/server/OPERATIONS.md
@@ -32,7 +32,11 @@ your corpus. Concretely for a single-replica box:
   memory gate is active out of the box on both. Only when neither is readable
   (non-Linux, or `/proc` unavailable) does it fall back to `0` (gate off), which
   the server logs a startup `WARN` about. Set it explicitly to override, or to
-  `0` to opt out deliberately,
+  `0` to opt out deliberately. Caveat: the physical-RAM fallback reads
+  `/proc/meminfo` `MemTotal`, which is HOST-wide. In a container run with **no**
+  cgroup memory limit, that budget reflects the whole host, not the pod's usable
+  RAM, so set `IFC_MEM_BUDGET_MB` explicitly (or give the container a memory
+  limit) in that case,
 - keep `IFC_MAX_CONCURRENT_PARSES` at the core count,
 - lower `MAX_FILE_SIZE_MB` below 500 unless the box has multiple GB of
   headroom per concurrent slot,

--- a/apps/server/OPERATIONS.md
+++ b/apps/server/OPERATIONS.md
@@ -11,7 +11,7 @@ replica.
 | Variable | Default | Meaning |
 |---|---|---|
 | `IFC_MAX_CONCURRENT_PARSES` | `WORKER_THREADS` (= cores) | Parse jobs running at once (CPU gate) |
-| `IFC_MEM_BUDGET_MB` | 70% of the cgroup memory limit, else 0 | Total admitted upload bytes at once; `0` disables the byte gate |
+| `IFC_MEM_BUDGET_MB` | 70% of the tightest readable ceiling (cgroup, else physical RAM), else 0 | Total admitted upload bytes at once; `0` is an explicit opt-out that disables the byte gate |
 | `IFC_ADMISSION_QUEUE_DEPTH` | `2 * WORKER_THREADS` | Requests allowed to wait for a slot before immediate 503 |
 | `IFC_ADMISSION_QUEUE_TIMEOUT_SECS` | `5` | Longest a queued request waits before 503 |
 | `IFC_MEM_SHED_PCT` | `85` | RSS percentage of the budget above which new work is shed |
@@ -27,8 +27,12 @@ Budget roughly `file_size x (1x upload buffer + 3-6x decode/mesh working set)`
 for geometry-heavy models; the multiplier is workload-dependent, re-measure on
 your corpus. Concretely for a single-replica box:
 
-- set `IFC_MEM_BUDGET_MB` to about 70% of instance RAM (the cgroup default
-  does this for you inside containers),
+- `IFC_MEM_BUDGET_MB` defaults to 70% of the tightest readable memory ceiling:
+  the cgroup limit inside containers, or physical RAM on a bare VM, so the
+  memory gate is active out of the box on both. Only when neither is readable
+  (non-Linux, or `/proc` unavailable) does it fall back to `0` (gate off), which
+  the server logs a startup `WARN` about. Set it explicitly to override, or to
+  `0` to opt out deliberately,
 - keep `IFC_MAX_CONCURRENT_PARSES` at the core count,
 - lower `MAX_FILE_SIZE_MB` below 500 unless the box has multiple GB of
   headroom per concurrent slot,

--- a/apps/server/src/admission.rs
+++ b/apps/server/src/admission.rs
@@ -291,29 +291,6 @@ pub fn resident_bytes_now() -> u64 {
     }
 }
 
-/// Container memory limit from cgroups (v2 then v1), if readable. Seeds the
-/// default memory budget so it self-tunes to the instance size.
-pub fn cgroup_memory_limit_bytes() -> Option<u64> {
-    for path in [
-        "/sys/fs/cgroup/memory.max",
-        "/sys/fs/cgroup/memory/memory.limit_in_bytes",
-    ] {
-        if let Ok(raw) = std::fs::read_to_string(path) {
-            let raw = raw.trim();
-            if raw == "max" {
-                return None;
-            }
-            if let Ok(v) = raw.parse::<u64>() {
-                // cgroup v1 reports a huge sentinel when unlimited.
-                if v > 0 && v < (1 << 60) {
-                    return Some(v);
-                }
-            }
-        }
-    }
-    None
-}
-
 /// Background sampler: refreshes the shared RSS gauge every 500 ms so the
 /// admission breaker reads a cheap atomic, never the filesystem, per request.
 pub fn spawn_rss_sampler(admission: Arc<Admission>) {

--- a/apps/server/src/config.rs
+++ b/apps/server/src/config.rs
@@ -122,17 +122,17 @@ impl Config {
                 .and_then(|v| v.parse().ok())
                 .unwrap_or(worker_threads)
                 .max(1),
-            mem_budget_mb: std::env::var("IFC_MEM_BUDGET_MB")
-                .ok()
-                .and_then(|v| v.parse().ok())
-                .unwrap_or_else(|| {
-                    // Self-tune to the container: 70% of the cgroup limit,
-                    // leaving headroom for the allocator and the OS. 0 when
-                    // no limit is readable (memory gate disabled).
-                    crate::admission::cgroup_memory_limit_bytes()
-                        .map(|b| (b / (1024 * 1024) * 70 / 100) as usize)
-                        .unwrap_or(0)
-                }),
+            // Self-tune to the tightest readable memory ceiling (cgroup, else
+            // physical RAM), 70% of it; an explicit IFC_MEM_BUDGET_MB wins and
+            // `=0` is an opt-out. Only 0 when no ceiling is readable, which
+            // main() warns about (memory admission then falls back to OFF).
+            mem_budget_mb: crate::mem_policy::resolve_mem_budget_mb(
+                std::env::var("IFC_MEM_BUDGET_MB")
+                    .ok()
+                    .and_then(|v| v.parse().ok()),
+                crate::mem_policy::cgroup_memory_limit_bytes(),
+                crate::mem_policy::total_physical_memory_bytes(),
+            ),
             admission_queue_depth: std::env::var("IFC_ADMISSION_QUEUE_DEPTH")
                 .ok()
                 .and_then(|v| v.parse().ok())

--- a/apps/server/src/main.rs
+++ b/apps/server/src/main.rs
@@ -220,13 +220,26 @@ async fn main() {
     }));
     admission::spawn_rss_sampler(Arc::clone(&admission));
     if config.mem_budget_mb == 0 {
-        // No readable memory ceiling (non-Linux dev, /proc unavailable, or an
-        // explicit IFC_MEM_BUDGET_MB=0): the byte gate and RSS breaker are off,
-        // so concurrent large uploads can OOM this replica.
-        tracing::warn!(
-            max_concurrent_parses = config.max_concurrent_parses,
-            "Memory admission is OFF (no readable memory ceiling): concurrent large uploads can OOM this replica. Set IFC_MEM_BUDGET_MB, or run under a cgroup memory limit. (IFC_MEM_BUDGET_MB=0 is an explicit opt-out.)"
-        );
+        // Budget 0 = memory gate off. Two distinct causes; log them differently:
+        //  - explicit `IFC_MEM_BUDGET_MB=0`: the operator opted out deliberately
+        //    (info, not a warning);
+        //  - no readable ceiling (non-Linux dev, /proc unavailable): a silent
+        //    degradation that risks OOM, so warn.
+        let opted_out = std::env::var("IFC_MEM_BUDGET_MB")
+            .ok()
+            .and_then(|v| v.parse::<usize>().ok())
+            == Some(0);
+        if opted_out {
+            tracing::info!(
+                max_concurrent_parses = config.max_concurrent_parses,
+                "Memory admission disabled via IFC_MEM_BUDGET_MB=0 (opt-out); only the CPU concurrency gate applies."
+            );
+        } else {
+            tracing::warn!(
+                max_concurrent_parses = config.max_concurrent_parses,
+                "Memory admission is OFF (no readable memory ceiling: non-Linux host or /proc unavailable): concurrent large uploads can OOM this replica. Set IFC_MEM_BUDGET_MB, or run under a cgroup memory limit."
+            );
+        }
     } else {
         tracing::info!(
             max_concurrent_parses = config.max_concurrent_parses,

--- a/apps/server/src/main.rs
+++ b/apps/server/src/main.rs
@@ -38,6 +38,7 @@ use tower_http::{
 
 mod admission;
 mod config;
+mod mem_policy;
 mod error;
 mod middleware;
 mod routes;
@@ -218,14 +219,24 @@ async fn main() {
         shed_pct: config.mem_shed_pct,
     }));
     admission::spawn_rss_sampler(Arc::clone(&admission));
-    tracing::info!(
-        max_concurrent_parses = config.max_concurrent_parses,
-        mem_budget_mb = config.mem_budget_mb,
-        queue_depth = config.admission_queue_depth,
-        queue_timeout_secs = config.admission_queue_timeout_secs,
-        shed_pct = config.mem_shed_pct,
-        "Admission control active (mem budget 0 = byte gate disabled)"
-    );
+    if config.mem_budget_mb == 0 {
+        // No readable memory ceiling (non-Linux dev, /proc unavailable, or an
+        // explicit IFC_MEM_BUDGET_MB=0): the byte gate and RSS breaker are off,
+        // so concurrent large uploads can OOM this replica.
+        tracing::warn!(
+            max_concurrent_parses = config.max_concurrent_parses,
+            "Memory admission is OFF (no readable memory ceiling): concurrent large uploads can OOM this replica. Set IFC_MEM_BUDGET_MB, or run under a cgroup memory limit. (IFC_MEM_BUDGET_MB=0 is an explicit opt-out.)"
+        );
+    } else {
+        tracing::info!(
+            max_concurrent_parses = config.max_concurrent_parses,
+            mem_budget_mb = config.mem_budget_mb,
+            queue_depth = config.admission_queue_depth,
+            queue_timeout_secs = config.admission_queue_timeout_secs,
+            shed_pct = config.mem_shed_pct,
+            "Admission control active (byte budget + RSS breaker)"
+        );
+    }
 
     let state = AppState {
         cache,

--- a/apps/server/src/mem_policy.rs
+++ b/apps/server/src/mem_policy.rs
@@ -34,44 +34,72 @@ pub fn cgroup_memory_limit_bytes() -> Option<u64> {
         "/sys/fs/cgroup/memory/memory.limit_in_bytes",
     ] {
         if let Ok(raw) = std::fs::read_to_string(path) {
-            let raw = raw.trim();
-            if raw == "max" {
-                return None;
-            }
-            if let Ok(v) = raw.parse::<u64>() {
-                // cgroup v1 reports a huge sentinel when unlimited.
-                if v > 0 && v < (1 << 60) {
-                    return Some(v);
-                }
+            match parse_cgroup_limit(&raw) {
+                CgroupLimit::Unlimited => return None,
+                CgroupLimit::Bytes(v) => return Some(v),
+                CgroupLimit::Invalid => {} // unreadable value: try the next path
             }
         }
     }
     None
 }
 
+/// Parsed outcome of one cgroup memory-limit file. `Unlimited` (`max`, or a
+/// v1 huge sentinel) stops the search - the ceiling is genuinely uncapped, so we
+/// must NOT fall back to another file. `Invalid` lets the caller try the next.
+#[derive(Debug, PartialEq, Eq)]
+enum CgroupLimit {
+    Unlimited,
+    Bytes(u64),
+    Invalid,
+}
+
+fn parse_cgroup_limit(raw: &str) -> CgroupLimit {
+    let raw = raw.trim();
+    if raw == "max" {
+        return CgroupLimit::Unlimited;
+    }
+    match raw.parse::<u64>() {
+        // cgroup v1 reports a huge sentinel (~i64::MAX) when unlimited.
+        Ok(v) if v >= (1 << 60) => CgroupLimit::Unlimited,
+        Ok(v) if v > 0 => CgroupLimit::Bytes(v),
+        _ => CgroupLimit::Invalid,
+    }
+}
+
 /// Total physical RAM in bytes from `/proc/meminfo` `MemTotal`, if readable.
 ///
 /// `None` on non-Linux and on any parse failure (never panics). This is the
 /// fallback ceiling when no cgroup limit is set, so a bare Linux VM still gets
-/// a bounded memory gate instead of an unbounded one.
+/// a bounded memory gate instead of an unbounded one. NOTE: `MemTotal` is
+/// HOST-wide - in a container with no cgroup limit this over-states the
+/// container-usable RAM (see OPERATIONS.md).
 pub fn total_physical_memory_bytes() -> Option<u64> {
     #[cfg(target_os = "linux")]
     {
-        let meminfo = std::fs::read_to_string("/proc/meminfo").ok()?;
-        // `MemTotal:      16305200 kB`
-        let kb = meminfo
-            .lines()
-            .find_map(|line| line.strip_prefix("MemTotal:"))?
-            .split_whitespace()
-            .next()?
-            .parse::<u64>()
-            .ok()?;
-        Some(kb * 1024)
+        Some(parse_meminfo_memtotal_kb(&std::fs::read_to_string("/proc/meminfo").ok()?)? * 1024)
     }
     #[cfg(not(target_os = "linux"))]
     {
         None
     }
+}
+
+/// Extract `MemTotal` (in kB) from `/proc/meminfo` content, or `None`. Pure so
+/// the parse - the only place a wrong line/unit would size every bare-VM budget
+/// wrong - is unit-tested without a live `/proc`.
+// Only called from the Linux branch of `total_physical_memory_bytes`; the unit
+// test exercises it on every target, but the non-Linux *binary* never calls it.
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+fn parse_meminfo_memtotal_kb(meminfo: &str) -> Option<u64> {
+    // `MemTotal:      16305200 kB` - must match MemTotal, not MemFree/MemAvailable.
+    meminfo
+        .lines()
+        .find_map(|line| line.strip_prefix("MemTotal:"))?
+        .split_whitespace()
+        .next()?
+        .parse::<u64>()
+        .ok()
 }
 
 /// Resolve the admission memory budget (MB) from the three inputs, in one place
@@ -105,6 +133,30 @@ mod tests {
     use super::*;
 
     const GB: u64 = 1024 * 1024 * 1024;
+
+    #[test]
+    fn parse_cgroup_limit_handles_max_sentinel_and_values() {
+        assert_eq!(parse_cgroup_limit("max\n"), CgroupLimit::Unlimited);
+        // cgroup v1 unlimited sentinel (~i64::MAX, >= 1<<60).
+        assert_eq!(parse_cgroup_limit("9223372036854771712\n"), CgroupLimit::Unlimited);
+        assert_eq!(parse_cgroup_limit("  2147483648  "), CgroupLimit::Bytes(2_147_483_648));
+        assert_eq!(parse_cgroup_limit("0"), CgroupLimit::Invalid);
+        assert_eq!(parse_cgroup_limit("garbage"), CgroupLimit::Invalid);
+        assert_eq!(parse_cgroup_limit(""), CgroupLimit::Invalid);
+    }
+
+    #[test]
+    fn parse_meminfo_picks_memtotal_in_kb_only() {
+        let meminfo = "MemTotal:       16305200 kB\n\
+                       MemFree:         1234567 kB\n\
+                       MemAvailable:    9876543 kB\n";
+        assert_eq!(parse_meminfo_memtotal_kb(meminfo), Some(16_305_200));
+        // Must NOT match MemFree/MemAvailable, and tolerate missing/garbage.
+        assert_eq!(parse_meminfo_memtotal_kb("MemFree: 100 kB\n"), None);
+        assert_eq!(parse_meminfo_memtotal_kb("MemTotal: notanumber kB"), None);
+        assert_eq!(parse_meminfo_memtotal_kb(""), None);
+    }
+
 
     #[test]
     fn explicit_budget_wins_over_ceilings() {

--- a/apps/server/src/mem_policy.rs
+++ b/apps/server/src/mem_policy.rs
@@ -1,0 +1,154 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Memory-budget policy: the readers and the resolver that decide the
+//! admission byte budget at startup.
+//!
+//! The byte-weighted admission semaphore (see [`crate::admission`]) is the
+//! load-bearing bound against OOM from concurrent large uploads, but it only
+//! engages when the budget is non-zero. Previously the budget was derived from
+//! the cgroup limit alone, so a bare VM / non-containerized deployment (no
+//! readable cgroup ceiling) resolved to `0` and silently degraded to a bare
+//! CPU-concurrency count - the exact failure the admission work set out to
+//! fix. This module adds a physical-RAM fallback so the memory gate stays
+//! active without a cgroup, and keeps the three ceilings + the 70% math in one
+//! place the resolver tests exercise.
+//!
+//! No `sysinfo`/libc dependency: the readers parse `/proc` directly, matching
+//! [`crate::admission::resident_bytes_now`]; the release matrix includes a musl
+//! target where a heavy cross-platform crate is a known build risk.
+
+/// Fraction of the tightest readable memory ceiling to admit, leaving headroom
+/// for the allocator, the OS page cache, and non-parse allocations.
+const BUDGET_PCT_OF_CEILING: u64 = 70;
+
+/// Container memory limit from cgroups (v2 then v1), if readable.
+///
+/// `None` when unlimited or unreadable (non-Linux, or a bare host outside a
+/// cgroup). Moved here from `admission` so all memory-ceiling readers live
+/// beside the resolver.
+pub fn cgroup_memory_limit_bytes() -> Option<u64> {
+    for path in [
+        "/sys/fs/cgroup/memory.max",
+        "/sys/fs/cgroup/memory/memory.limit_in_bytes",
+    ] {
+        if let Ok(raw) = std::fs::read_to_string(path) {
+            let raw = raw.trim();
+            if raw == "max" {
+                return None;
+            }
+            if let Ok(v) = raw.parse::<u64>() {
+                // cgroup v1 reports a huge sentinel when unlimited.
+                if v > 0 && v < (1 << 60) {
+                    return Some(v);
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Total physical RAM in bytes from `/proc/meminfo` `MemTotal`, if readable.
+///
+/// `None` on non-Linux and on any parse failure (never panics). This is the
+/// fallback ceiling when no cgroup limit is set, so a bare Linux VM still gets
+/// a bounded memory gate instead of an unbounded one.
+pub fn total_physical_memory_bytes() -> Option<u64> {
+    #[cfg(target_os = "linux")]
+    {
+        let meminfo = std::fs::read_to_string("/proc/meminfo").ok()?;
+        // `MemTotal:      16305200 kB`
+        let kb = meminfo
+            .lines()
+            .find_map(|line| line.strip_prefix("MemTotal:"))?
+            .split_whitespace()
+            .next()?
+            .parse::<u64>()
+            .ok()?;
+        Some(kb * 1024)
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        None
+    }
+}
+
+/// Resolve the admission memory budget (MB) from the three inputs, in one place
+/// the tests exercise so it can never silently regress to 0-when-a-ceiling-is-
+/// readable.
+///
+/// Precedence:
+/// 1. An explicit `IFC_MEM_BUDGET_MB` wins outright. `Some(0)` is honored as a
+///    deliberate opt-out (memory gate off) - it is NOT treated as "unset".
+/// 2. Otherwise, 70% of the tightest readable ceiling: `min(cgroup, physical)`.
+///    Using the tighter of the two keeps a small cgroup from being overridden
+///    by a large host, and lets physical RAM bound a bare VM with no cgroup.
+/// 3. Otherwise `0` (gate off) - only when neither ceiling is readable
+///    (non-Linux dev, or `/proc` unavailable), which the caller logs loudly.
+pub fn resolve_mem_budget_mb(
+    explicit_mb: Option<usize>,
+    cgroup_bytes: Option<u64>,
+    physical_bytes: Option<u64>,
+) -> usize {
+    if let Some(mb) = explicit_mb {
+        return mb;
+    }
+    match [cgroup_bytes, physical_bytes].into_iter().flatten().min() {
+        Some(ceiling) => (ceiling / (1024 * 1024) * BUDGET_PCT_OF_CEILING / 100) as usize,
+        None => 0,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const GB: u64 = 1024 * 1024 * 1024;
+
+    #[test]
+    fn explicit_budget_wins_over_ceilings() {
+        assert_eq!(
+            resolve_mem_budget_mb(Some(4096), Some(10 * GB), Some(32 * GB)),
+            4096
+        );
+    }
+
+    #[test]
+    fn explicit_zero_is_honored_as_opt_out() {
+        // Some(0) is a deliberate "turn the gate off", not "unset" - it must
+        // NOT fall through to a ceiling-derived budget.
+        assert_eq!(resolve_mem_budget_mb(Some(0), Some(10 * GB), Some(32 * GB)), 0);
+    }
+
+    #[test]
+    fn uses_tightest_readable_ceiling() {
+        // 70% of the tighter (cgroup) ceiling, not the host.
+        assert_eq!(
+            resolve_mem_budget_mb(None, Some(10 * GB), Some(32 * GB)),
+            10 * 1024 * 70 / 100,
+        );
+    }
+
+    #[test]
+    fn physical_ram_bounds_a_bare_vm_with_no_cgroup() {
+        // The load-bearing fix: no cgroup, but readable physical RAM -> a
+        // NON-ZERO budget, so the memory gate stays active on a bare VM.
+        let mb = resolve_mem_budget_mb(None, None, Some(16 * GB));
+        assert_eq!(mb, 16 * 1024 * 70 / 100);
+        assert!(mb > 0);
+    }
+
+    #[test]
+    fn no_readable_ceiling_disables_the_gate() {
+        assert_eq!(resolve_mem_budget_mb(None, None, None), 0);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn physical_memory_is_readable_on_linux() {
+        // On any Linux host (incl. CI) /proc/meminfo yields a positive total.
+        let total = total_physical_memory_bytes();
+        assert!(total.is_some_and(|b| b > 0));
+    }
+}


### PR DESCRIPTION
## What and why

The byte-weighted admission semaphore (#1505) is the load-bearing bound against OOM from concurrent large uploads, but it only engages when the budget is non-zero. The budget was derived from the cgroup limit **alone** (`config.rs`), so a bare VM / non-containerized deployment with no readable cgroup ceiling resolved to `0` and silently degraded to a bare CPU-concurrency count, which does **not** bound resident memory. That is the exact "4 concurrent large files OOM the box" failure the admission work set out to fix.

## The fix

- Add a **physical-RAM fallback**: the budget self-tunes to 70% of the tightest readable ceiling, `min(cgroup, /proc/meminfo MemTotal)`. So the memory gate is active out of the box on a bare Linux VM too, not just in containers.
- An explicit `IFC_MEM_BUDGET_MB` still wins, and `=0` remains a deliberate opt-out (honored, not treated as "unset").
- Only when **neither** ceiling is readable (non-Linux dev, `/proc` unavailable) does it fall back to `0`, and `main()` now logs a startup `WARN` so the OFF state is not silent. The `ifc_server_mem_budget_bytes=0` gauge already reflects it for scrapers.
- The cgroup reader, the new physical-RAM reader, and the resolver (the 70% math) move into a new `mem_policy` module so the precedence lives in **one place the tests exercise**. Side benefit: `admission.rs` drops 413 -> 390, back under the ~400-line rule.
- No `sysinfo`/libc dependency: `/proc` is parsed directly, matching `resident_bytes_now` (the release matrix includes a musl target where a heavy cross-platform crate is a known build risk).

## How it was verified

`cargo test -p ifc-lite-server` green (38 tests). New `mem_policy` resolver tests cover: explicit-wins, explicit-`0` opt-out, tightest-ceiling selection, the **bare-VM physical-RAM fallback yields a non-zero budget**, and no-ceiling-off. `cargo clippy -p ifc-lite-server --all-targets` clean.

## Notes

- Kept scope tight: no change to the `/ready` or `/health` response shapes (the metrics gauge already exposes the OFF state). Deliberately did not add a readiness field to avoid touching a probe contract.
- No changeset: `apps/server` is not under published `packages/*`. Shipping the fix in `@ifc-lite/server-bin` is a release-bump decision (non-blocking).