### PR TITLE
test(determinism): enforce cross-target position identity per-mesh (split the manifest hash)

### DIFF
--- a/docs/architecture/mesh-determinism.md
+++ b/docs/architecture/mesh-determinism.md
@@ -11,7 +11,14 @@ Running `process_geometry` over the synthetic fixture in
 `ifc_lite_processing::determinism` produces, bit-for-bit:
 
 - Per mesh, in emit order: `express_id`, `geometry_class`, position f32 bits,
-  normal f32 bits, triangle indices, and the per-element f64 `origin`.
+  normal f32 bits, triangle indices, and the per-element f64 `origin`. These are
+  hashed into THREE separate per-mesh fields so the cross-target guard can hold
+  each to a different standard: `positions_hash` (positions) and
+  `indices_origin_hash` (identity + topology + placement) are byte-identical on
+  every target for every mesh, with no exemption; `normals_hash` is the only
+  surface allowed the documented trig gap, and only for the curved mesh. This is
+  what makes the "positions are byte-identical cross-target, even for the round
+  column" claim below a test-enforced invariant rather than prose.
   Emit order itself is part of the contract: entity jobs are processed in file
   scan order and rayon's ordered collect preserves it, so the mesh list is
   identical regardless of thread count (verified with `RAYON_NUM_THREADS=1`).
@@ -77,8 +84,11 @@ near-zero normal components (true value ~0, e.g. sin at the angle pi) keep
 the full residue: measured -7.0e-17 native vs -2.1e-17 wasm32 on the fixture
 column. Closing this requires deterministic trig (e.g. the pure-Rust `libm`
 crate) in the profile tessellation path -- a separate work item. Until then
-the round column's mesh hash is the ONLY divergence between the two pinned
-manifests.
+the round column's `normals_hash` is the ONLY divergence between the two pinned
+manifests: its `positions_hash` and `indices_origin_hash` match native ==
+wasm32 (empirically confirmed and asserted per-field by the guard), so a future
+change that diverged the curved mesh's POSITIONS across targets would fail the
+guard instead of hiding inside a combined per-mesh hash.
 
 ## What was fixed to get here
 

--- a/rust/processing/src/determinism.rs
+++ b/rust/processing/src/determinism.rs
@@ -6,9 +6,13 @@
 //! kernel's predicate sign manifest (`ifc_lite_geometry::kernel::manifest`).
 //!
 //! Runs the full `process_geometry` pipeline over a small synthetic fixture
-//! and FNV-1a-hashes the emitted wire bytes: per-mesh
-//! (express id, geometry class, position/normal f32 bits, indices, origin f64
-//! bits) in emit order, plus the sorted `flat_voids`, `flat_material_colors`
+//! and FNV-1a-hashes the emitted wire bytes: per-mesh, in emit order, as three
+//! separate hashes - `positions_hash` (position f32 bits), `normals_hash`
+//! (normal f32 bits), and `indices_origin_hash` (express id, geometry class,
+//! indices, origin f64 bits) - so the cross-target guard can assert positions
+//! and topology byte-identical on every target while exempting only the curved
+//! mesh's normals for the libm trig gap. Plus the sorted `flat_voids`,
+//! `flat_material_colors`
 //! and `flat_styles_rgba8` wire arrays. The resulting [`MeshManifest`] is
 //! pinned in `rust/processing/tests/manifests/mesh_determinism.json`
 //! (asserted on x86_64 AND arm64) and in its wasm32 pair (identical except
@@ -174,9 +178,18 @@ pub struct MeshManifestEntry {
     pub geometry_class: u8,
     pub vertex_count: usize,
     pub triangle_count: usize,
-    /// FNV-1a over (express_id, geometry_class, position f32 bits, normal f32
-    /// bits, indices, origin f64 bits), all little-endian.
-    pub hash: String,
+    /// FNV-1a over the position f32 bits (little-endian). Split out from the
+    /// normals so the cross-target guard can assert it byte-identical for EVERY
+    /// mesh, including the curved-profile one: the circle-tessellation libm
+    /// sin/cos gap lands in the near-zero radial-normal components, not here.
+    pub positions_hash: String,
+    /// FNV-1a over the normal f32 bits. The ONLY per-mesh surface allowed to
+    /// differ across targets, and only for the curved-profile mesh (see the
+    /// wasm leg's trig-gap guard).
+    pub normals_hash: String,
+    /// FNV-1a over (express_id, geometry_class, indices u32, origin f64 bits) -
+    /// identity, topology and placement, byte-identical across all targets.
+    pub indices_origin_hash: String,
 }
 
 /// The pinned mesh-output determinism fingerprint.
@@ -298,16 +311,24 @@ pub fn compute_mesh_manifest() -> MeshManifest {
     let mut vertex_count = 0usize;
     let mut triangle_count = 0usize;
     for mesh in &result.meshes {
-        let mut h = FNV_OFFSET_BASIS;
-        fnv1a_bytes(&mut h, &mesh.express_id.to_le_bytes());
-        fnv1a_bytes(&mut h, &[mesh.geometry_class]);
-        fnv1a_f32_bits(&mut h, &mesh.positions);
-        fnv1a_f32_bits(&mut h, &mesh.normals);
-        fnv1a_u32s(&mut h, &mesh.indices);
+        // Positions alone: the surface asserted byte-identical on EVERY target.
+        let mut hp = FNV_OFFSET_BASIS;
+        fnv1a_f32_bits(&mut hp, &mesh.positions);
+        // Normals alone: the only per-mesh surface with a documented trig gap.
+        let mut hn = FNV_OFFSET_BASIS;
+        fnv1a_f32_bits(&mut hn, &mesh.normals);
+        // Identity + topology + placement: all cross-target byte-identical.
+        let mut hio = FNV_OFFSET_BASIS;
+        fnv1a_bytes(&mut hio, &mesh.express_id.to_le_bytes());
+        fnv1a_bytes(&mut hio, &[mesh.geometry_class]);
+        fnv1a_u32s(&mut hio, &mesh.indices);
         for c in mesh.origin {
-            fnv1a_bytes(&mut h, &c.to_bits().to_le_bytes());
+            fnv1a_bytes(&mut hio, &c.to_bits().to_le_bytes());
         }
-        fnv1a_bytes(&mut top, &h.to_le_bytes());
+        // Fold all three into the top-level fingerprint in a fixed order.
+        fnv1a_bytes(&mut top, &hp.to_le_bytes());
+        fnv1a_bytes(&mut top, &hn.to_le_bytes());
+        fnv1a_bytes(&mut top, &hio.to_le_bytes());
         vertex_count += mesh.positions.len() / 3;
         triangle_count += mesh.indices.len() / 3;
         meshes.push(MeshManifestEntry {
@@ -315,7 +336,9 @@ pub fn compute_mesh_manifest() -> MeshManifest {
             geometry_class: mesh.geometry_class,
             vertex_count: mesh.positions.len() / 3,
             triangle_count: mesh.indices.len() / 3,
-            hash: hex(h),
+            positions_hash: hex(hp),
+            normals_hash: hex(hn),
+            indices_origin_hash: hex(hio),
         });
     }
 
@@ -420,22 +443,45 @@ pub fn diff_report(expected: &MeshManifest, actual: &MeshManifest) -> Option<Str
             expected.style_entry_count, actual.style_entry_count
         ));
     }
+    let fmt = |m: &MeshManifestEntry| {
+        format!(
+            "#{} class {} v{} t{} pos={} nrm={} io={}",
+            m.express_id,
+            m.geometry_class,
+            m.vertex_count,
+            m.triangle_count,
+            m.positions_hash,
+            m.normals_hash,
+            m.indices_origin_hash,
+        )
+    };
     let common = expected.meshes.len().min(actual.meshes.len());
     for i in 0..common {
         let (e, a) = (&expected.meshes[i], &actual.meshes[i]);
         if e != a {
+            let mut which = Vec::new();
+            if e.positions_hash != a.positions_hash {
+                which.push("positions");
+            }
+            if e.normals_hash != a.normals_hash {
+                which.push("normals");
+            }
+            if e.indices_origin_hash != a.indices_origin_hash {
+                which.push("indices/origin");
+            }
             lines.push(format!(
-                "mesh[{i}]: expected #{} class {} v{} t{} {} got #{} class {} v{} t{} {}",
-                e.express_id, e.geometry_class, e.vertex_count, e.triangle_count, e.hash,
-                a.express_id, a.geometry_class, a.vertex_count, a.triangle_count, a.hash
+                "mesh[{i}]: differs in [{}]: expected {} got {}",
+                which.join("+"),
+                fmt(e),
+                fmt(a)
             ));
         }
     }
     for (i, e) in expected.meshes.iter().enumerate().skip(common) {
-        lines.push(format!("mesh[{i}]: expected #{} {} got NOTHING", e.express_id, e.hash));
+        lines.push(format!("mesh[{i}]: expected {} got NOTHING", fmt(e)));
     }
     for (i, a) in actual.meshes.iter().enumerate().skip(common) {
-        lines.push(format!("mesh[{i}]: expected NOTHING got #{} {}", a.express_id, a.hash));
+        lines.push(format!("mesh[{i}]: expected NOTHING got {}", fmt(a)));
     }
     Some(lines.join("\n"))
 }

--- a/rust/processing/src/determinism.rs
+++ b/rust/processing/src/determinism.rs
@@ -460,6 +460,18 @@ pub fn diff_report(expected: &MeshManifest, actual: &MeshManifest) -> Option<Str
         let (e, a) = (&expected.meshes[i], &actual.meshes[i]);
         if e != a {
             let mut which = Vec::new();
+            if e.express_id != a.express_id {
+                which.push("express_id");
+            }
+            if e.geometry_class != a.geometry_class {
+                which.push("geometry_class");
+            }
+            if e.vertex_count != a.vertex_count {
+                which.push("vertex_count");
+            }
+            if e.triangle_count != a.triangle_count {
+                which.push("triangle_count");
+            }
             if e.positions_hash != a.positions_hash {
                 which.push("positions");
             }

--- a/rust/processing/tests/manifests/mesh_determinism.json
+++ b/rust/processing/tests/manifests/mesh_determinism.json
@@ -1,5 +1,5 @@
 {
-  "hash": "0xd5f9fd32f588a4d3",
+  "hash": "0x041aeeae89017e49",
   "mesh_count": 6,
   "vertex_count": 372,
   "triangle_count": 232,
@@ -15,42 +15,54 @@
       "geometry_class": 0,
       "vertex_count": 48,
       "triangle_count": 32,
-      "hash": "0xfd748a2c97b330a6"
+      "positions_hash": "0xf7644f11ac208315",
+      "normals_hash": "0xa88e5063a279b7a5",
+      "indices_origin_hash": "0x9b0470dcf50dd0f6"
     },
     {
       "express_id": 200,
       "geometry_class": 0,
       "vertex_count": 24,
       "triangle_count": 12,
-      "hash": "0xfadd393c11f0f80a"
+      "positions_hash": "0x8714e603df509575",
+      "normals_hash": "0xf0285567a570a265",
+      "indices_origin_hash": "0xa480bfc9608ffc1a"
     },
     {
       "express_id": 400,
       "geometry_class": 0,
       "vertex_count": 12,
       "triangle_count": 4,
-      "hash": "0xbd390dfe930a4a1a"
+      "positions_hash": "0x0b1739ede9d48645",
+      "normals_hash": "0xfa3830252911fdfb",
+      "indices_origin_hash": "0xefa67a238c3c3ad4"
     },
     {
       "express_id": 500,
       "geometry_class": 0,
       "vertex_count": 216,
       "triangle_count": 140,
-      "hash": "0xfbf6e673c68d70f7"
+      "positions_hash": "0xe42a379a27d5cf05",
+      "normals_hash": "0x7bce397307fbbe75",
+      "indices_origin_hash": "0x99bb177d5bce4417"
     },
     {
       "express_id": 600,
       "geometry_class": 0,
       "vertex_count": 48,
       "triangle_count": 32,
-      "hash": "0x165b2db7e78b6424"
+      "positions_hash": "0x3c3dcacbe0e4a9e5",
+      "normals_hash": "0xa88e5063a279b7a5",
+      "indices_origin_hash": "0x2bd37de922a65ae4"
     },
     {
       "express_id": 700,
       "geometry_class": 0,
       "vertex_count": 24,
       "triangle_count": 12,
-      "hash": "0x0cbf2b2be41ac691"
+      "positions_hash": "0xc42face08bbfc5c5",
+      "normals_hash": "0xf0285567a570a265",
+      "indices_origin_hash": "0x891c764aab66dbb1"
     }
   ]
 }

--- a/rust/processing/tests/manifests/mesh_determinism.wasm32.json
+++ b/rust/processing/tests/manifests/mesh_determinism.wasm32.json
@@ -1,68 +1,68 @@
 {
-          "hash": "0xf2c197ba3c2986d1",
-          "mesh_count": 6,
-          "vertex_count": 372,
-          "triangle_count": 232,
-          "voids_hash": "0xe20db54c093020fd",
-          "void_host_count": 2,
-          "material_colors_hash": "0x2c8ff21c7f9f5da3",
-          "material_element_count": 2,
-          "styles_hash": "0xe0a323d7dfcfaf31",
-          "style_entry_count": 5,
-          "meshes": [
-            {
-              "express_id": 100,
-              "geometry_class": 0,
-              "vertex_count": 48,
-              "triangle_count": 32,
-              "positions_hash": "0xf7644f11ac208315",
-              "normals_hash": "0xa88e5063a279b7a5",
-              "indices_origin_hash": "0x9b0470dcf50dd0f6"
-            },
-            {
-              "express_id": 200,
-              "geometry_class": 0,
-              "vertex_count": 24,
-              "triangle_count": 12,
-              "positions_hash": "0x8714e603df509575",
-              "normals_hash": "0xf0285567a570a265",
-              "indices_origin_hash": "0xa480bfc9608ffc1a"
-            },
-            {
-              "express_id": 400,
-              "geometry_class": 0,
-              "vertex_count": 12,
-              "triangle_count": 4,
-              "positions_hash": "0x0b1739ede9d48645",
-              "normals_hash": "0xfa3830252911fdfb",
-              "indices_origin_hash": "0xefa67a238c3c3ad4"
-            },
-            {
-              "express_id": 500,
-              "geometry_class": 0,
-              "vertex_count": 216,
-              "triangle_count": 140,
-              "positions_hash": "0xe42a379a27d5cf05",
-              "normals_hash": "0xc51d78373842c015",
-              "indices_origin_hash": "0x99bb177d5bce4417"
-            },
-            {
-              "express_id": 600,
-              "geometry_class": 0,
-              "vertex_count": 48,
-              "triangle_count": 32,
-              "positions_hash": "0x3c3dcacbe0e4a9e5",
-              "normals_hash": "0xa88e5063a279b7a5",
-              "indices_origin_hash": "0x2bd37de922a65ae4"
-            },
-            {
-              "express_id": 700,
-              "geometry_class": 0,
-              "vertex_count": 24,
-              "triangle_count": 12,
-              "positions_hash": "0xc42face08bbfc5c5",
-              "normals_hash": "0xf0285567a570a265",
-              "indices_origin_hash": "0x891c764aab66dbb1"
-            }
-          ]
-        }
+  "hash": "0xf2c197ba3c2986d1",
+  "mesh_count": 6,
+  "vertex_count": 372,
+  "triangle_count": 232,
+  "voids_hash": "0xe20db54c093020fd",
+  "void_host_count": 2,
+  "material_colors_hash": "0x2c8ff21c7f9f5da3",
+  "material_element_count": 2,
+  "styles_hash": "0xe0a323d7dfcfaf31",
+  "style_entry_count": 5,
+  "meshes": [
+    {
+      "express_id": 100,
+      "geometry_class": 0,
+      "vertex_count": 48,
+      "triangle_count": 32,
+      "positions_hash": "0xf7644f11ac208315",
+      "normals_hash": "0xa88e5063a279b7a5",
+      "indices_origin_hash": "0x9b0470dcf50dd0f6"
+    },
+    {
+      "express_id": 200,
+      "geometry_class": 0,
+      "vertex_count": 24,
+      "triangle_count": 12,
+      "positions_hash": "0x8714e603df509575",
+      "normals_hash": "0xf0285567a570a265",
+      "indices_origin_hash": "0xa480bfc9608ffc1a"
+    },
+    {
+      "express_id": 400,
+      "geometry_class": 0,
+      "vertex_count": 12,
+      "triangle_count": 4,
+      "positions_hash": "0x0b1739ede9d48645",
+      "normals_hash": "0xfa3830252911fdfb",
+      "indices_origin_hash": "0xefa67a238c3c3ad4"
+    },
+    {
+      "express_id": 500,
+      "geometry_class": 0,
+      "vertex_count": 216,
+      "triangle_count": 140,
+      "positions_hash": "0xe42a379a27d5cf05",
+      "normals_hash": "0xc51d78373842c015",
+      "indices_origin_hash": "0x99bb177d5bce4417"
+    },
+    {
+      "express_id": 600,
+      "geometry_class": 0,
+      "vertex_count": 48,
+      "triangle_count": 32,
+      "positions_hash": "0x3c3dcacbe0e4a9e5",
+      "normals_hash": "0xa88e5063a279b7a5",
+      "indices_origin_hash": "0x2bd37de922a65ae4"
+    },
+    {
+      "express_id": 700,
+      "geometry_class": 0,
+      "vertex_count": 24,
+      "triangle_count": 12,
+      "positions_hash": "0xc42face08bbfc5c5",
+      "normals_hash": "0xf0285567a570a265",
+      "indices_origin_hash": "0x891c764aab66dbb1"
+    }
+  ]
+}

--- a/rust/processing/tests/manifests/mesh_determinism.wasm32.json
+++ b/rust/processing/tests/manifests/mesh_determinism.wasm32.json
@@ -1,56 +1,68 @@
 {
-  "hash": "0x67a57cad9b16ed91",
-  "mesh_count": 6,
-  "vertex_count": 372,
-  "triangle_count": 232,
-  "voids_hash": "0xe20db54c093020fd",
-  "void_host_count": 2,
-  "material_colors_hash": "0x2c8ff21c7f9f5da3",
-  "material_element_count": 2,
-  "styles_hash": "0xe0a323d7dfcfaf31",
-  "style_entry_count": 5,
-  "meshes": [
-    {
-      "express_id": 100,
-      "geometry_class": 0,
-      "vertex_count": 48,
-      "triangle_count": 32,
-      "hash": "0xfd748a2c97b330a6"
-    },
-    {
-      "express_id": 200,
-      "geometry_class": 0,
-      "vertex_count": 24,
-      "triangle_count": 12,
-      "hash": "0xfadd393c11f0f80a"
-    },
-    {
-      "express_id": 400,
-      "geometry_class": 0,
-      "vertex_count": 12,
-      "triangle_count": 4,
-      "hash": "0xbd390dfe930a4a1a"
-    },
-    {
-      "express_id": 500,
-      "geometry_class": 0,
-      "vertex_count": 216,
-      "triangle_count": 140,
-      "hash": "0x795858dfb218cf27"
-    },
-    {
-      "express_id": 600,
-      "geometry_class": 0,
-      "vertex_count": 48,
-      "triangle_count": 32,
-      "hash": "0x165b2db7e78b6424"
-    },
-    {
-      "express_id": 700,
-      "geometry_class": 0,
-      "vertex_count": 24,
-      "triangle_count": 12,
-      "hash": "0x0cbf2b2be41ac691"
-    }
-  ]
-}
+          "hash": "0xf2c197ba3c2986d1",
+          "mesh_count": 6,
+          "vertex_count": 372,
+          "triangle_count": 232,
+          "voids_hash": "0xe20db54c093020fd",
+          "void_host_count": 2,
+          "material_colors_hash": "0x2c8ff21c7f9f5da3",
+          "material_element_count": 2,
+          "styles_hash": "0xe0a323d7dfcfaf31",
+          "style_entry_count": 5,
+          "meshes": [
+            {
+              "express_id": 100,
+              "geometry_class": 0,
+              "vertex_count": 48,
+              "triangle_count": 32,
+              "positions_hash": "0xf7644f11ac208315",
+              "normals_hash": "0xa88e5063a279b7a5",
+              "indices_origin_hash": "0x9b0470dcf50dd0f6"
+            },
+            {
+              "express_id": 200,
+              "geometry_class": 0,
+              "vertex_count": 24,
+              "triangle_count": 12,
+              "positions_hash": "0x8714e603df509575",
+              "normals_hash": "0xf0285567a570a265",
+              "indices_origin_hash": "0xa480bfc9608ffc1a"
+            },
+            {
+              "express_id": 400,
+              "geometry_class": 0,
+              "vertex_count": 12,
+              "triangle_count": 4,
+              "positions_hash": "0x0b1739ede9d48645",
+              "normals_hash": "0xfa3830252911fdfb",
+              "indices_origin_hash": "0xefa67a238c3c3ad4"
+            },
+            {
+              "express_id": 500,
+              "geometry_class": 0,
+              "vertex_count": 216,
+              "triangle_count": 140,
+              "positions_hash": "0xe42a379a27d5cf05",
+              "normals_hash": "0xc51d78373842c015",
+              "indices_origin_hash": "0x99bb177d5bce4417"
+            },
+            {
+              "express_id": 600,
+              "geometry_class": 0,
+              "vertex_count": 48,
+              "triangle_count": 32,
+              "positions_hash": "0x3c3dcacbe0e4a9e5",
+              "normals_hash": "0xa88e5063a279b7a5",
+              "indices_origin_hash": "0x2bd37de922a65ae4"
+            },
+            {
+              "express_id": 700,
+              "geometry_class": 0,
+              "vertex_count": 24,
+              "triangle_count": 12,
+              "positions_hash": "0xc42face08bbfc5c5",
+              "normals_hash": "0xf0285567a570a265",
+              "indices_origin_hash": "0x891c764aab66dbb1"
+            }
+          ]
+        }

--- a/rust/processing/tests/mesh_determinism.rs
+++ b/rust/processing/tests/mesh_determinism.rs
@@ -118,14 +118,33 @@ fn wasm_manifest_differs_only_in_the_trig_gap() {
         assert_eq!(n.geometry_class, w.geometry_class, "manifest drift: geometry_class");
         assert_eq!(n.vertex_count, w.vertex_count, "manifest drift: per-mesh vertex_count");
         assert_eq!(n.triangle_count, w.triangle_count, "manifest drift: per-mesh triangle_count");
+        // Positions AND identity/topology/origin are byte-identical on EVERY
+        // mesh cross-target - including the curved column. This is the invariant
+        // the hash split exists to enforce: the trig gap lives in the near-zero
+        // radial-normal components, not in the (snapped) positions, so a future
+        // change that diverged the curved mesh's positions across targets would
+        // now fail here instead of hiding inside a combined per-mesh hash.
+        assert_eq!(
+            n.positions_hash, w.positions_hash,
+            "manifest drift: mesh #{} POSITIONS differ between native and wasm32 \
+             (positions must be byte-identical cross-target, curved mesh included)",
+            n.express_id
+        );
+        assert_eq!(
+            n.indices_origin_hash, w.indices_origin_hash,
+            "manifest drift: mesh #{} indices/origin differ between native and wasm32",
+            n.express_id
+        );
+        // Normals are the ONLY per-mesh surface allowed to differ, and only for
+        // the curved-profile mesh whose radial normals carry the libm trig gap.
         if n.express_id == TRIG_GAP_EXPRESS_ID {
-            if n.hash != w.hash {
+            if n.normals_hash != w.normals_hash {
                 gap_meshes += 1;
             }
         } else {
             assert_eq!(
-                n.hash, w.hash,
-                "manifest drift: mesh #{} bytes differ between native and wasm32 \
+                n.normals_hash, w.normals_hash,
+                "manifest drift: mesh #{} normals differ between native and wasm32 \
                  outside the documented trig gap",
                 n.express_id
             );


### PR DESCRIPTION
## What and why

The mesh-output determinism manifest (#1492) folded each mesh's positions + normals + indices + origin into **one** per-mesh hash, and the native/wasm32 trig-gap guard (`wasm_manifest_differs_only_in_the_trig_gap`) exempted the round column's **entire** hash. So the contract's claim that the curved mesh's *positions* are byte-identical cross-target, with only its normals carrying the libm sin/cos ULP gap, was asserted in prose (`mesh-determinism.md`, the `TRIG_GAP_EXPRESS_ID` comment) but **not enforced** - a change that diverged that mesh's positions across targets would still pass.

## The fix

- Split `MeshManifestEntry` into `positions_hash` + `normals_hash` + `indices_origin_hash`.
- The guard now asserts `positions_hash` **and** `indices_origin_hash` byte-identical for **every** mesh including the round column, and exempts only `normals_hash` (and only for the curved mesh). `diff_report` names which sub-hash diverged.
- Re-pinned **both** manifests (native + wasm32) on real targets, per the house rule.

## Empirical result (the point of the change)

Regenerating on both targets confirms the invariant directly: across native and wasm32 the 6 fixture meshes agree on positions and indices/origin **everywhere**; the only divergence is the round column's **normals** - exactly the documented trig gap, now held to that scope per-field.

```
#100/#200/#400/#600/#700: positions SAME, normals SAME, indices_origin SAME
#500 (round column):       positions SAME, normals DIFFER, indices_origin SAME
```

## How it was verified

`cargo test -p ifc-lite-processing --test mesh_determinism` (3 tests) green, and the wasm32 leg `wasm-pack test --node rust/wasm-bindings --test mesh_determinism` green (the manifests were regenerated from these exact runs). `cargo clippy -p ifc-lite-processing --all-targets` clean. Contract doc updated.

## Notes

- Determinism-manifest / test-utility change only; no wasm-bindgen surface change, so `pkg/ifc-lite.d.ts` is untouched and no npm changeset is needed (the `ifc_lite_processing` crate bump is handled by release-crates versioning). The kernel predicate manifests are untouched.