### PR TITLE
test(hygiene): ratchet the ~400-line module-size rule into a CI gate

### DIFF
--- a/rust/processing/tests/module_size_allowlist.txt
+++ b/rust/processing/tests/module_size_allowlist.txt
@@ -5,7 +5,8 @@
 # these grows PAST its budget, or if a NEW file crosses 400 without an entry.
 # The rule: shrink or split. When you split a file below 400, delete its row
 # (the total must trend DOWN). Only ADD a row with a written justification.
-# Generated/ and tests/examples/benches/fuzz are exempt (see the test).
+# Regenerated against the branch's merge base; refresh on rebase if a listed
+# file drifts on main. Generated/ and tests/examples/benches/fuzz are exempt.
      413 apps/server/src/admission.rs
      420 apps/server/src/routes/parse/parquet_stream.rs
      756 apps/server/src/services/parquet_data_model.rs
@@ -19,7 +20,7 @@
      463 rust/core/src/parser/tokenizer.rs
      550 rust/core/src/schema_gen.rs
      990 rust/core/src/units.rs
-    3816 rust/export/src/gltf.rs
+    3863 rust/export/src/gltf.rs
      655 rust/export/src/model.rs
      611 rust/export/src/step.rs
     1233 rust/geometry/src/alignment.rs
@@ -34,11 +35,11 @@
      408 rust/geometry/src/geom_hash.rs
      641 rust/geometry/src/kernel/arrangement/classify.rs
      566 rust/geometry/src/kernel/fixed.rs
-     799 rust/geometry/src/kernel/mesh_bridge.rs
+     846 rust/geometry/src/kernel/mesh_bridge.rs
      700 rust/geometry/src/kernel/predicates.rs
     1383 rust/geometry/src/kernel/retriangulate.rs
      468 rust/geometry/src/kernel/tritri.rs
-    1574 rust/geometry/src/mesh.rs
+    1529 rust/geometry/src/mesh.rs
      920 rust/geometry/src/processors/boolean/mod.rs
      486 rust/geometry/src/processors/brep/faceted.rs
      402 rust/geometry/src/processors/csg_primitive.rs
@@ -64,8 +65,9 @@
      730 rust/geometry/src/router/voids/probe.rs
     1002 rust/geometry/src/router/voids/synthesis.rs
     1472 rust/geometry/src/space_dcel/mod.rs
+     525 rust/geometry/src/transform.rs
      782 rust/geometry/src/triangulation.rs
-     626 rust/geometry/src/void_analysis.rs
+     715 rust/geometry/src/void_analysis.rs
      745 rust/geometry/src/void_index.rs
      441 rust/processing/src/determinism.rs
      877 rust/processing/src/element.rs

--- a/rust/processing/tests/module_size_allowlist.txt
+++ b/rust/processing/tests/module_size_allowlist.txt
@@ -1,0 +1,88 @@
+# Module-size ratchet allowlist (see module_size_ratchet.rs).
+# Non-generated, non-test Rust source files currently over the ~400-line
+# house rule (AGENTS.md). Each line is '<budget> <path>'; the budget is the
+# line count at the time it was recorded. The ratchet test fails if any of
+# these grows PAST its budget, or if a NEW file crosses 400 without an entry.
+# The rule: shrink or split. When you split a file below 400, delete its row
+# (the total must trend DOWN). Only ADD a row with a written justification.
+# Generated/ and tests/examples/benches/fuzz are exempt (see the test).
+     413 apps/server/src/admission.rs
+     420 apps/server/src/routes/parse/parquet_stream.rs
+     756 apps/server/src/services/parquet_data_model.rs
+     581 apps/server/src/services/parquet_optimized.rs
+     584 apps/server/src/services/parquet.rs
+     497 rust/clash/src/tests.rs
+    1193 rust/core/src/decoder.rs
+     429 rust/core/src/fast_parse.rs
+     793 rust/core/src/georef.rs
+     445 rust/core/src/model_bounds.rs
+     601 rust/core/src/parser/scanner.rs
+     463 rust/core/src/parser/tokenizer.rs
+     550 rust/core/src/schema_gen.rs
+     990 rust/core/src/units.rs
+    3816 rust/export/src/gltf.rs
+     655 rust/export/src/model.rs
+     611 rust/export/src/step.rs
+    1233 rust/geometry/src/alignment.rs
+     568 rust/geometry/src/bool2d.rs
+    1875 rust/geometry/src/cdt.rs
+     535 rust/geometry/src/congruence/engine.rs
+     895 rust/geometry/src/csg/consolidate.rs
+    1061 rust/geometry/src/csg/mod.rs
+     436 rust/geometry/src/csg/normals.rs
+    1036 rust/geometry/src/extrusion.rs
+     759 rust/geometry/src/facet_weld.rs
+     408 rust/geometry/src/geom_hash.rs
+     417 rust/geometry/src/instancing/tests.rs
+     641 rust/geometry/src/kernel/arrangement/classify.rs
+     566 rust/geometry/src/kernel/fixed.rs
+     799 rust/geometry/src/kernel/mesh_bridge.rs
+     700 rust/geometry/src/kernel/predicates.rs
+    1383 rust/geometry/src/kernel/retriangulate.rs
+     468 rust/geometry/src/kernel/tritri.rs
+    1574 rust/geometry/src/mesh.rs
+     920 rust/geometry/src/processors/boolean/mod.rs
+     486 rust/geometry/src/processors/brep/faceted.rs
+     402 rust/geometry/src/processors/csg_primitive.rs
+     608 rust/geometry/src/processors/sectioned.rs
+     944 rust/geometry/src/processors/tests.rs
+     758 rust/geometry/src/profile_extractor.rs
+     431 rust/geometry/src/profile.rs
+     598 rust/geometry/src/profiles/curves_2d.rs
+     709 rust/geometry/src/profiles/curves_3d.rs
+     898 rust/geometry/src/profiles/mod.rs
+     596 rust/geometry/src/profiles/shapes.rs
+     706 rust/geometry/src/profiles/simplify.rs
+     703 rust/geometry/src/profiles/tests.rs
+     781 rust/geometry/src/rect_fast.rs
+     461 rust/geometry/src/router/clipping.rs
+     710 rust/geometry/src/router/diagnostics.rs
+     659 rust/geometry/src/router/layers.rs
+     572 rust/geometry/src/router/mod.rs
+    1072 rust/geometry/src/router/processing.rs
+     446 rust/geometry/src/router/rtc_offset.rs
+     908 rust/geometry/src/router/tests.rs
+     497 rust/geometry/src/router/voids_2d.rs
+     618 rust/geometry/src/router/voids/aabb_clip.rs
+     871 rust/geometry/src/router/voids/geom.rs
+    1963 rust/geometry/src/router/voids/mod.rs
+     730 rust/geometry/src/router/voids/probe.rs
+     574 rust/geometry/src/router/voids/reveal_tests.rs
+    1002 rust/geometry/src/router/voids/synthesis.rs
+    1472 rust/geometry/src/space_dcel/mod.rs
+     760 rust/geometry/src/space_dcel/tests.rs
+     782 rust/geometry/src/triangulation.rs
+     626 rust/geometry/src/void_analysis.rs
+     745 rust/geometry/src/void_index.rs
+     441 rust/processing/src/determinism.rs
+     877 rust/processing/src/element.rs
+     468 rust/processing/src/georeferencing.rs
+     772 rust/processing/src/prepass.rs
+    1674 rust/processing/src/processor/mod.rs
+     440 rust/processing/src/symbolic/items.rs
+     767 rust/wasm-bindings/src/api/gpu_meshes/batch.rs
+     727 rust/wasm-bindings/src/api/gpu_meshes/prepass.rs
+     436 rust/wasm-bindings/src/api/grid_lines.rs
+     879 rust/wasm-bindings/src/api/mod.rs
+     692 rust/wasm-bindings/src/zero_copy/mesh.rs
+     743 rust/wasm-bindings/src/zero_copy/symbolic.rs

--- a/rust/processing/tests/module_size_allowlist.txt
+++ b/rust/processing/tests/module_size_allowlist.txt
@@ -6,8 +6,6 @@
 # The rule: shrink or split. When you split a file below 400, delete its row
 # (the total must trend DOWN). Only ADD a row with a written justification.
 # Regenerated against the branch's merge base; refresh on rebase if a listed
-# file drifts on main. Generated/ and tests/examples/benches/fuzz are exempt.
-     413 apps/server/src/admission.rs
      420 apps/server/src/routes/parse/parquet_stream.rs
      756 apps/server/src/services/parquet_data_model.rs
      581 apps/server/src/services/parquet_optimized.rs
@@ -20,7 +18,7 @@
      463 rust/core/src/parser/tokenizer.rs
      550 rust/core/src/schema_gen.rs
      990 rust/core/src/units.rs
-    3863 rust/export/src/gltf.rs
+    3943 rust/export/src/gltf.rs
      655 rust/export/src/model.rs
      611 rust/export/src/step.rs
     1233 rust/geometry/src/alignment.rs
@@ -62,14 +60,14 @@
      618 rust/geometry/src/router/voids/aabb_clip.rs
      871 rust/geometry/src/router/voids/geom.rs
     1963 rust/geometry/src/router/voids/mod.rs
-     730 rust/geometry/src/router/voids/probe.rs
+     621 rust/geometry/src/router/voids/probe.rs
     1002 rust/geometry/src/router/voids/synthesis.rs
     1472 rust/geometry/src/space_dcel/mod.rs
      525 rust/geometry/src/transform.rs
      782 rust/geometry/src/triangulation.rs
      715 rust/geometry/src/void_analysis.rs
      745 rust/geometry/src/void_index.rs
-     441 rust/processing/src/determinism.rs
+     499 rust/processing/src/determinism.rs
      877 rust/processing/src/element.rs
      468 rust/processing/src/georeferencing.rs
      772 rust/processing/src/prepass.rs

--- a/rust/processing/tests/module_size_allowlist.txt
+++ b/rust/processing/tests/module_size_allowlist.txt
@@ -11,7 +11,6 @@
      756 apps/server/src/services/parquet_data_model.rs
      581 apps/server/src/services/parquet_optimized.rs
      584 apps/server/src/services/parquet.rs
-     497 rust/clash/src/tests.rs
     1193 rust/core/src/decoder.rs
      429 rust/core/src/fast_parse.rs
      793 rust/core/src/georef.rs
@@ -33,7 +32,6 @@
     1036 rust/geometry/src/extrusion.rs
      759 rust/geometry/src/facet_weld.rs
      408 rust/geometry/src/geom_hash.rs
-     417 rust/geometry/src/instancing/tests.rs
      641 rust/geometry/src/kernel/arrangement/classify.rs
      566 rust/geometry/src/kernel/fixed.rs
      799 rust/geometry/src/kernel/mesh_bridge.rs
@@ -45,7 +43,6 @@
      486 rust/geometry/src/processors/brep/faceted.rs
      402 rust/geometry/src/processors/csg_primitive.rs
      608 rust/geometry/src/processors/sectioned.rs
-     944 rust/geometry/src/processors/tests.rs
      758 rust/geometry/src/profile_extractor.rs
      431 rust/geometry/src/profile.rs
      598 rust/geometry/src/profiles/curves_2d.rs
@@ -53,7 +50,6 @@
      898 rust/geometry/src/profiles/mod.rs
      596 rust/geometry/src/profiles/shapes.rs
      706 rust/geometry/src/profiles/simplify.rs
-     703 rust/geometry/src/profiles/tests.rs
      781 rust/geometry/src/rect_fast.rs
      461 rust/geometry/src/router/clipping.rs
      710 rust/geometry/src/router/diagnostics.rs
@@ -61,16 +57,13 @@
      572 rust/geometry/src/router/mod.rs
     1072 rust/geometry/src/router/processing.rs
      446 rust/geometry/src/router/rtc_offset.rs
-     908 rust/geometry/src/router/tests.rs
      497 rust/geometry/src/router/voids_2d.rs
      618 rust/geometry/src/router/voids/aabb_clip.rs
      871 rust/geometry/src/router/voids/geom.rs
     1963 rust/geometry/src/router/voids/mod.rs
      730 rust/geometry/src/router/voids/probe.rs
-     574 rust/geometry/src/router/voids/reveal_tests.rs
     1002 rust/geometry/src/router/voids/synthesis.rs
     1472 rust/geometry/src/space_dcel/mod.rs
-     760 rust/geometry/src/space_dcel/tests.rs
      782 rust/geometry/src/triangulation.rs
      626 rust/geometry/src/void_analysis.rs
      745 rust/geometry/src/void_index.rs

--- a/rust/processing/tests/module_size_ratchet.rs
+++ b/rust/processing/tests/module_size_ratchet.rs
@@ -101,6 +101,31 @@ fn line_count(path: &std::path::Path) -> usize {
         .unwrap_or(0)
 }
 
+/// Pure ratchet decision: given `(relpath, line_count)` for every non-exempt
+/// file and the allowlist, return `(new_offenders, grew)`. Extracted from the
+/// tree walk so the FIRING path (a new god file, or an allowlisted file over
+/// budget) is unit-testable with synthetic inputs, not only the all-clean tree.
+fn evaluate(
+    files: &[(String, usize)],
+    allowlist: &std::collections::HashMap<String, usize>,
+) -> (Vec<String>, Vec<String>) {
+    let mut new_offenders = Vec::new(); // over LIMIT, not allowlisted
+    let mut grew = Vec::new(); // allowlisted, over budget
+    for (rel, lines) in files {
+        match allowlist.get(rel) {
+            Some(&budget) if *lines > budget => {
+                grew.push(format!("  {rel}: {lines} lines, budget {budget}"));
+            }
+            Some(_) => {}
+            None if *lines > LIMIT => new_offenders.push(format!("  {rel}: {lines} lines")),
+            None => {}
+        }
+    }
+    new_offenders.sort();
+    grew.sort();
+    (new_offenders, grew)
+}
+
 #[test]
 fn no_module_grows_past_its_ratchet_budget() {
     let Some(root) = repo_root() else {
@@ -109,44 +134,27 @@ fn no_module_grows_past_its_ratchet_budget() {
     };
     let allowlist = parse_allowlist();
 
-    let mut files = Vec::new();
+    let mut paths = Vec::new();
     for top in ["rust", "apps"] {
-        collect_rs_files(&root.join(top), &mut files);
+        collect_rs_files(&root.join(top), &mut paths);
     }
-
-    let mut new_offenders = Vec::new(); // over LIMIT, not allowlisted
-    let mut grew = Vec::new(); // allowlisted, over budget
-    // relpath -> current line count, for every non-exempt file, so the stale-row
-    // advisory below can tell "gone/exempt" from "shrank below the limit".
-    let mut seen = std::collections::HashMap::new();
-
-    for path in &files {
-        let rel = path
-            .strip_prefix(&root)
-            .unwrap_or(path)
-            .to_string_lossy()
-            .replace('\\', "/");
-        if is_exempt(&rel) {
-            continue;
-        }
-        let lines = line_count(path);
-        seen.insert(rel.clone(), lines);
-        match allowlist.get(&rel) {
-            Some(&budget) => {
-                if lines > budget {
-                    grew.push(format!("  {rel}: {lines} lines, budget {budget}"));
-                }
-            }
-            None if lines > LIMIT => {
-                new_offenders.push(format!("  {rel}: {lines} lines"));
-            }
-            None => {}
-        }
-    }
+    // (relpath, line_count) for every non-exempt file.
+    let files: Vec<(String, usize)> = paths
+        .iter()
+        .map(|p| {
+            (
+                p.strip_prefix(&root).unwrap_or(p).to_string_lossy().replace('\\', "/"),
+                line_count(p),
+            )
+        })
+        .filter(|(rel, _)| !is_exempt(rel))
+        .collect();
 
     // Advisory only (never fails the build, to avoid merge-order coupling): an
     // allowlisted file that dropped to <= LIMIT or vanished should have its row
     // removed so the list keeps trending down.
+    let seen: std::collections::HashMap<&String, usize> =
+        files.iter().map(|(r, n)| (r, *n)).collect();
     for rel in allowlist.keys() {
         match seen.get(rel) {
             None => eprintln!(
@@ -159,9 +167,9 @@ fn no_module_grows_past_its_ratchet_budget() {
         }
     }
 
+    let (new_offenders, grew) = evaluate(&files, &allowlist);
     let mut msg = String::new();
     if !new_offenders.is_empty() {
-        new_offenders.sort();
         msg.push_str(&format!(
             "New non-generated .rs file(s) over {LIMIT} lines with no allowlist row.\n\
              Split them (AGENTS.md rule), or - only with a written justification - \
@@ -170,7 +178,6 @@ fn no_module_grows_past_its_ratchet_budget() {
         ));
     }
     if !grew.is_empty() {
-        grew.sort();
         msg.push_str(&format!(
             "Allowlisted file(s) grew PAST their recorded budget. Shrink or split \
              instead of raising the budget:\n{}\n",
@@ -178,6 +185,35 @@ fn no_module_grows_past_its_ratchet_budget() {
         ));
     }
     assert!(msg.is_empty(), "\n{msg}");
+}
+
+#[test]
+fn evaluate_fires_on_new_god_file_and_over_budget() {
+    let mut allowlist = std::collections::HashMap::new();
+    allowlist.insert("rust/a/big.rs".to_string(), 500usize);
+    allowlist.insert("rust/a/grown.rs".to_string(), 600usize);
+    let files = vec![
+        ("rust/a/small.rs".to_string(), 399),   // under the limit - clean
+        ("rust/a/at_limit.rs".to_string(), 400), // exactly 400 is NOT > 400 - clean
+        ("rust/a/new_god.rs".to_string(), 401), // new offender: >400, not allowlisted
+        ("rust/a/big.rs".to_string(), 500),     // allowlisted, at budget - clean
+        ("rust/a/grown.rs".to_string(), 601),   // allowlisted, over budget - FIRES
+    ];
+    let (new_offenders, grew) = evaluate(&files, &allowlist);
+    assert_eq!(new_offenders, vec!["  rust/a/new_god.rs: 401 lines"]);
+    assert_eq!(grew, vec!["  rust/a/grown.rs: 601 lines, budget 600"]);
+}
+
+#[test]
+fn evaluate_is_clean_when_within_budget() {
+    let mut allowlist = std::collections::HashMap::new();
+    allowlist.insert("rust/a/big.rs".to_string(), 500usize);
+    let files = vec![
+        ("rust/a/small.rs".to_string(), 12),
+        ("rust/a/big.rs".to_string(), 480), // shrank below budget - fine
+    ];
+    let (new_offenders, grew) = evaluate(&files, &allowlist);
+    assert!(new_offenders.is_empty() && grew.is_empty());
 }
 
 #[test]

--- a/rust/processing/tests/module_size_ratchet.rs
+++ b/rust/processing/tests/module_size_ratchet.rs
@@ -60,11 +60,18 @@ fn collect_rs_files(dir: &std::path::Path, out: &mut Vec<std::path::PathBuf>) {
 
 /// Generated code and test/support files are not subject to the split rule.
 fn is_exempt(rel: &str) -> bool {
+    let base = rel.rsplit('/').next().unwrap_or(rel);
     rel.contains("/generated/")
         || rel.contains("/tests/")
         || rel.contains("/examples/")
         || rel.contains("/benches/")
         || rel.contains("/fuzz/")
+        // `#[cfg(test)]` module files embedded in src/ are test code, not
+        // production modules subject to the split rule (e.g. src/tests.rs,
+        // foo_tests.rs, foo_test.rs).
+        || base == "tests.rs"
+        || base.ends_with("_tests.rs")
+        || base.ends_with("_test.rs")
 }
 
 /// Parse the committed allowlist into (relpath -> budget). Skips comment/blank
@@ -109,7 +116,9 @@ fn no_module_grows_past_its_ratchet_budget() {
 
     let mut new_offenders = Vec::new(); // over LIMIT, not allowlisted
     let mut grew = Vec::new(); // allowlisted, over budget
-    let mut seen = std::collections::HashSet::new();
+    // relpath -> current line count, for every non-exempt file, so the stale-row
+    // advisory below can tell "gone/exempt" from "shrank below the limit".
+    let mut seen = std::collections::HashMap::new();
 
     for path in &files {
         let rel = path
@@ -121,7 +130,7 @@ fn no_module_grows_past_its_ratchet_budget() {
             continue;
         }
         let lines = line_count(path);
-        seen.insert(rel.clone());
+        seen.insert(rel.clone(), lines);
         match allowlist.get(&rel) {
             Some(&budget) => {
                 if lines > budget {
@@ -139,8 +148,14 @@ fn no_module_grows_past_its_ratchet_budget() {
     // allowlisted file that dropped to <= LIMIT or vanished should have its row
     // removed so the list keeps trending down.
     for rel in allowlist.keys() {
-        if !seen.contains(rel) {
-            eprintln!("note: allowlist row for {rel} is now <= {LIMIT} lines (or gone); remove the row");
+        match seen.get(rel) {
+            None => eprintln!(
+                "note: allowlist row {rel:?} no longer matches a tracked file (gone or now exempt); remove it"
+            ),
+            Some(&lines) if lines <= LIMIT => eprintln!(
+                "note: {rel} is now {lines} <= {LIMIT} lines; remove its allowlist row (the total should trend down)"
+            ),
+            Some(_) => {}
         }
     }
 

--- a/rust/processing/tests/module_size_ratchet.rs
+++ b/rust/processing/tests/module_size_ratchet.rs
@@ -1,0 +1,182 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Module-size ratchet: makes the AGENTS.md "split modules over ~400
+//! non-generated lines" rule an actual CI gate instead of an unenforced review
+//! convention (it had zero executable enforcement, so the tree accumulated 80+
+//! files over the bar).
+//!
+//! The gate has two teeth:
+//!  1. A NEW non-generated, non-test `.rs` file that crosses 400 lines and is
+//!     not in `module_size_allowlist.txt` fails the build. This is the
+//!     load-bearing guarantee: no new god files.
+//!  2. An allowlisted file that GROWS past its recorded budget fails. Existing
+//!     debt is frozen; a big file can only stay flat or shrink.
+//!
+//! Shrinking a file below 400 lets you delete its allowlist row (the total
+//! trends down). Adding a row is allowed only with a written justification in
+//! the PR. Generated code and test/example/bench/fuzz files are exempt.
+//!
+//! This runs in the required `rust-tests` lane (`cargo test --workspace`), so a
+//! violation blocks merge. Cross-crate file walking mirrors `styling_parity`.
+
+const LIMIT: usize = 400;
+const ALLOWLIST: &str = include_str!("module_size_allowlist.txt");
+
+/// Repo root = first ancestor holding both `rust/` and `apps/`. `None` in a
+/// packaged/standalone context (the test then skips, like `styling_parity`).
+fn repo_root() -> Option<std::path::PathBuf> {
+    let mut dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).to_path_buf();
+    loop {
+        if dir.join("rust").is_dir() && dir.join("apps").is_dir() {
+            return Some(dir);
+        }
+        if !dir.pop() {
+            return None;
+        }
+    }
+}
+
+fn collect_rs_files(dir: &std::path::Path, out: &mut Vec<std::path::PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            let skip = matches!(
+                path.file_name().and_then(|n| n.to_str()),
+                Some("target" | "node_modules" | ".git" | "dist" | "build")
+            );
+            if !skip {
+                collect_rs_files(&path, out);
+            }
+        } else if path.extension().and_then(|e| e.to_str()) == Some("rs") {
+            out.push(path);
+        }
+    }
+}
+
+/// Generated code and test/support files are not subject to the split rule.
+fn is_exempt(rel: &str) -> bool {
+    rel.contains("/generated/")
+        || rel.contains("/tests/")
+        || rel.contains("/examples/")
+        || rel.contains("/benches/")
+        || rel.contains("/fuzz/")
+}
+
+/// Parse the committed allowlist into (relpath -> budget). Skips comment/blank
+/// lines. A malformed data line is a hard error (the file is a contract).
+fn parse_allowlist() -> std::collections::HashMap<String, usize> {
+    let mut map = std::collections::HashMap::new();
+    for line in ALLOWLIST.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let (budget, path) = line
+            .split_once(char::is_whitespace)
+            .unwrap_or_else(|| panic!("module_size_allowlist.txt: malformed line: {line:?}"));
+        let budget: usize = budget
+            .trim()
+            .parse()
+            .unwrap_or_else(|_| panic!("module_size_allowlist.txt: bad budget in: {line:?}"));
+        map.insert(path.trim().to_string(), budget);
+    }
+    map
+}
+
+fn line_count(path: &std::path::Path) -> usize {
+    std::fs::read_to_string(path)
+        .map(|s| s.lines().count())
+        .unwrap_or(0)
+}
+
+#[test]
+fn no_module_grows_past_its_ratchet_budget() {
+    let Some(root) = repo_root() else {
+        eprintln!("repo root not found (packaged context) - skipping module-size ratchet");
+        return;
+    };
+    let allowlist = parse_allowlist();
+
+    let mut files = Vec::new();
+    for top in ["rust", "apps"] {
+        collect_rs_files(&root.join(top), &mut files);
+    }
+
+    let mut new_offenders = Vec::new(); // over LIMIT, not allowlisted
+    let mut grew = Vec::new(); // allowlisted, over budget
+    let mut seen = std::collections::HashSet::new();
+
+    for path in &files {
+        let rel = path
+            .strip_prefix(&root)
+            .unwrap_or(path)
+            .to_string_lossy()
+            .replace('\\', "/");
+        if is_exempt(&rel) {
+            continue;
+        }
+        let lines = line_count(path);
+        seen.insert(rel.clone());
+        match allowlist.get(&rel) {
+            Some(&budget) => {
+                if lines > budget {
+                    grew.push(format!("  {rel}: {lines} lines, budget {budget}"));
+                }
+            }
+            None if lines > LIMIT => {
+                new_offenders.push(format!("  {rel}: {lines} lines"));
+            }
+            None => {}
+        }
+    }
+
+    // Advisory only (never fails the build, to avoid merge-order coupling): an
+    // allowlisted file that dropped to <= LIMIT or vanished should have its row
+    // removed so the list keeps trending down.
+    for rel in allowlist.keys() {
+        if !seen.contains(rel) {
+            eprintln!("note: allowlist row for {rel} is now <= {LIMIT} lines (or gone); remove the row");
+        }
+    }
+
+    let mut msg = String::new();
+    if !new_offenders.is_empty() {
+        new_offenders.sort();
+        msg.push_str(&format!(
+            "New non-generated .rs file(s) over {LIMIT} lines with no allowlist row.\n\
+             Split them (AGENTS.md rule), or - only with a written justification - \
+             add a row to rust/processing/tests/module_size_allowlist.txt:\n{}\n",
+            new_offenders.join("\n")
+        ));
+    }
+    if !grew.is_empty() {
+        grew.sort();
+        msg.push_str(&format!(
+            "Allowlisted file(s) grew PAST their recorded budget. Shrink or split \
+             instead of raising the budget:\n{}\n",
+            grew.join("\n")
+        ));
+    }
+    assert!(msg.is_empty(), "\n{msg}");
+}
+
+#[test]
+fn allowlist_is_well_formed_and_over_limit() {
+    // The allowlist should only carry genuine debt: every budget must exceed
+    // LIMIT (a <= LIMIT budget means the row is stale and should be deleted).
+    let stale: Vec<_> = parse_allowlist()
+        .into_iter()
+        .filter(|(_, budget)| *budget <= LIMIT)
+        .map(|(rel, budget)| format!("  {rel}: budget {budget} <= {LIMIT}"))
+        .collect();
+    assert!(
+        stale.is_empty(),
+        "allowlist rows at or under the {LIMIT}-line limit (delete them):\n{}",
+        stale.join("\n")
+    );
+}


### PR DESCRIPTION
## What and why

AGENTS.md says *split modules over ~400 non-generated lines*, but the rule had **zero executable enforcement** (no workflow, no test), so the tree drifted to **80** non-generated source files over the bar (~31k excess lines). This adds the missing gate.

## The ratchet

A test in the required `rust-tests` lane (`cargo test --workspace`) with two teeth:

1. A **new** non-generated, non-test `.rs` file that crosses 400 lines and is not in `module_size_allowlist.txt` fails the build. This is the load-bearing guarantee: **no new god files**.
2. An **allowlisted** file that grows past its recorded budget fails. Existing debt is frozen; a big file can only stay flat or shrink.

The allowlist is seeded at the current line counts, so this is **green on landing** and imposes no reformat. Splitting a file below 400 lets you delete its row (a soft note flags stale rows so the list trends down); adding a row requires a written justification. Generated/ and test/example/bench/fuzz files are exempt. Walk pattern mirrors `styling_parity`; skips cleanly in a packaged context.

## How it was verified

`cargo test -p ifc-lite-processing --test module_size_ratchet` green as seeded. Fault-injection: tightening `gltf.rs`'s budget below its real size fires the `grew past budget` failure (restored -> green). `cargo clippy` clean.

## Notes / choices

- **Per-file budgets** (rigorous: catches a single file ballooning) over a single total-excess number (looser). If you prefer less day-to-day friction, the alternative is a one-number total-excess ratchet; say the word and I'll swap it.
- The `admission.rs` row (413) reflects `main`; PR #1547 shrinks it to 390, which still passes (<= budget) and can drop its row when both land.
- This is the systemic PR1 of the god-files item; the actual byte-exact splits (`gltf.rs` -> `gltf/`, `voids/mod.rs`) are follow-ups that ratchet their rows down.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated checks to keep source files within size limits.
  * New safeguards flag unusually large new files and prevent existing files from growing beyond their approved budgets.
  * Improved reporting to highlight outdated size exceptions that can be cleaned up.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->