### PR TITLE
fix(viewer): world-context TOP/BOTTOM read north-up, not the IfcSite axes (#1532)

### DIFF
--- a/apps/viewer/src/components/viewer/Viewport.tsx
+++ b/apps/viewer/src/components/viewer/Viewport.tsx
@@ -11,6 +11,7 @@ import { Renderer, type VisualEnhancementOptions, type LightingEnvironment } fro
 import type { MeshData, CoordinateInfo, PointCloudAsset } from '@ifc-lite/geometry';
 import { useViewerStore, resolveEntityRef, type MeasurePoint, type SnapVisualization } from '@/store';
 import { LIGHTING_PRESETS } from '@/lib/lighting-presets';
+import { presetViewRotation } from '@/lib/preset-view-orientation';
 import { sunLightingForAltitude } from '@/lib/geo/solar-direction';
 import {
   useSelectionState,
@@ -719,8 +720,17 @@ export function Viewport({
       // Register camera callbacks for ViewCube and other controls
       setCameraCallbacks({
         setPresetView: (view) => {
-          // Pass actual geometry bounds to avoid distance drift
-          const rotation = coordinateInfoRef.current?.buildingRotation;
+          // Pass actual geometry bounds to avoid distance drift. When the Cesium
+          // world-context basemap is actually rendering, TOP/BOTTOM read as a map
+          // (north up) instead of the building's IfcSite axes; elsewhere they stay
+          // building-aligned (#1532). cesiumAvailable gates out a stale
+          // cesiumEnabled after georef disappears (no basemap = no north-up).
+          const { cesiumEnabled, cesiumAvailable } = useViewerStore.getState();
+          const rotation = presetViewRotation(
+            view,
+            coordinateInfoRef.current?.buildingRotation,
+            cesiumEnabled && cesiumAvailable,
+          );
           camera.setPresetView(view, geometryBoundsRef.current, rotation);
           // Initial render - animation loop will continue rendering during animation
           renderCurrent();

--- a/apps/viewer/src/components/viewer/useKeyboardControls.ts
+++ b/apps/viewer/src/components/viewer/useKeyboardControls.ts
@@ -10,8 +10,9 @@
 import { useEffect, type MutableRefObject } from 'react';
 import type { Renderer } from '@ifc-lite/renderer';
 import type { MeshData, CoordinateInfo } from '@ifc-lite/geometry';
-import type { SectionPlane } from '@/store';
+import { useViewerStore, type SectionPlane } from '@/store';
 import { goHomeFromStore } from '@/store/homeView';
+import { presetViewRotation } from '@/lib/preset-view-orientation';
 import { getEntityBounds } from '../../utils/viewportUtils.js';
 
 export interface UseKeyboardControlsParams {
@@ -99,7 +100,16 @@ export function useKeyboardControls(params: UseKeyboardControlsParams): void {
 
       // Preset views - set view and re-render
       const setViewAndRender = (view: 'top' | 'bottom' | 'front' | 'back' | 'left' | 'right') => {
-        const rotation = coordinateInfoRef.current?.buildingRotation;
+        // Match the viewcube: when the Cesium world-context basemap is rendering,
+        // TOP/BOTTOM read north-up rather than following the building's IfcSite
+        // axes (#1532). cesiumAvailable guards a stale cesiumEnabled after georef
+        // disappears.
+        const { cesiumEnabled, cesiumAvailable } = useViewerStore.getState();
+        const rotation = presetViewRotation(
+          view,
+          coordinateInfoRef.current?.buildingRotation,
+          cesiumEnabled && cesiumAvailable,
+        );
         camera.setPresetView(view, geometryBoundsRef.current, rotation);
         renderScene();
         updateCameraRotationRealtime(camera.getRotation());

--- a/apps/viewer/src/lib/preset-view-orientation.test.ts
+++ b/apps/viewer/src/lib/preset-view-orientation.test.ts
@@ -1,0 +1,36 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+
+import { presetViewRotation } from './preset-view-orientation.js';
+
+describe('presetViewRotation (#1532)', () => {
+  const BR = Math.PI; // ~180deg IfcSite placement rotation (the reported case)
+
+  it('drops building rotation for TOP/BOTTOM when the world-context basemap is active (north-up)', () => {
+    assert.strictEqual(presetViewRotation('top', BR, true), 0);
+    assert.strictEqual(presetViewRotation('bottom', BR, true), 0);
+  });
+
+  it('keeps building rotation for TOP/BOTTOM when the basemap is off (plan stays building-aligned)', () => {
+    assert.strictEqual(presetViewRotation('top', BR, false), BR);
+    assert.strictEqual(presetViewRotation('bottom', BR, false), BR);
+  });
+
+  it('always keeps building rotation for side views (they face the building front)', () => {
+    for (const v of ['front', 'back', 'left', 'right'] as const) {
+      assert.strictEqual(presetViewRotation(v, BR, true), BR);
+      assert.strictEqual(presetViewRotation(v, BR, false), BR);
+    }
+  });
+
+  it('passes undefined building rotation through unchanged, but still forces 0 for world-context top/bottom', () => {
+    assert.strictEqual(presetViewRotation('front', undefined, false), undefined);
+    assert.strictEqual(presetViewRotation('top', undefined, false), undefined);
+    assert.strictEqual(presetViewRotation('top', undefined, true), 0);
+    assert.strictEqual(presetViewRotation('bottom', undefined, true), 0);
+  });
+});

--- a/apps/viewer/src/lib/preset-view-orientation.ts
+++ b/apps/viewer/src/lib/preset-view-orientation.ts
@@ -1,0 +1,33 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+export type PresetView = 'top' | 'bottom' | 'front' | 'back' | 'left' | 'right';
+
+/**
+ * Y-axis rotation to hand `Camera.setPresetView` for a preset view.
+ *
+ * By default the presets align to the building's local axes via the IfcSite
+ * placement rotation (`buildingRotation`): a site rotated relative to the grid
+ * still shows "straight", the floor-plan / drawing convention. But the Cesium
+ * world-context basemap is a map, where TOP/BOTTOM are expected to read
+ * north-up. So when the basemap is active we drop `buildingRotation` for the
+ * TOP/BOTTOM presets (rotation 0 = geographic north at the top of the screen),
+ * while the side views still face the building's front. See issue #1532: a
+ * model whose IfcSite is placed rotated ~180 degrees otherwise puts north at
+ * the bottom of the world-context top view.
+ *
+ * `worldContextActive` should reflect a basemap that is actually rendering
+ * (`cesiumEnabled && cesiumAvailable`), not just the toggle, so a stale
+ * `cesiumEnabled` after georeferencing disappears does not force north-up.
+ */
+export function presetViewRotation(
+  view: PresetView,
+  buildingRotation: number | undefined,
+  worldContextActive: boolean,
+): number | undefined {
+  if (worldContextActive && (view === 'top' || view === 'bottom')) {
+    return 0;
+  }
+  return buildingRotation;
+}


### PR DESCRIPTION
## Summary

Fixes #1532: in the Cesium "3D world context", the TOP view showed geographic **north pointing down** for georeferenced models.

## Root cause

The default TOP/BOTTOM presets orient the camera to the building's local axes via `buildingRotation` (the IfcSite placement's Z-rotation, `atan2(siteX.y, siteX.x)`) -- the floor-plan / drawing convention. The reported model's IfcSite is placed rotated ~180 degrees relative to the RD grid, so on the north-aligned basemap the plan view followed the building and put north at the bottom. Georeferencing itself is fine (footprint placement uses `IfcMapConversion`, independent of the site rotation), which is why placement looked correct but north was down.

Verified against the real Cesium camera math (`Camera.updateMembers` orthonormalization) headlessly: `buildingRotation=0` gives screen-up = North; `buildingRotation=180deg` gives screen-up = South.

An intuitive-looking alternative -- that the bridge feeds a degenerate world-Y "up" for the straight-down view -- was tested and **ruled out**: Cesium re-orthonormalizes `up` against the view direction, so raw world-Y already resolves to North.

## Fix

When the world-context basemap is active, drop `buildingRotation` for TOP/BOTTOM so they read north-up like a map. Side views still face the building's front, and with the basemap off everything stays building-aligned (plain-viewer plan views unchanged). Applied at both preset entry points (the viewcube/command wrapper and the `1`/`2` keyboard keys) via a shared, tested pure helper `presetViewRotation`.

## Behavior

- Cesium on + TOP/BOTTOM -> geographic north up.
- Cesium off, or side views -> unchanged (building-aligned).
- Minor: toggling the basemap on while already in TOP needs a re-click to re-orient (the rotation is chosen at preset time).

## Tests

- New unit test for `presetViewRotation` (basemap on/off x top/bottom/side x defined/undefined rotation).
- Viewer typecheck clean.

## Out of scope (noted for follow-up)

`buildModelMatrix` (the GLB placement) does not apply the meridian-convergence gamma that the camera bridge does, so the 3D footprint can sit up to ~gamma off true north on the basemap (sub-degree for RD, larger for oblique projections like Krovak). Separate from this 180-degree issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)