### PR TITLE
ci(parity): fault-injection proof the ifcopenshell-parity quick lane reds on divergence (prep required-check promotion)

### DIFF
--- a/.github/workflows/ifcopenshell-parity.yml
+++ b/.github/workflows/ifcopenshell-parity.yml
@@ -10,6 +10,18 @@
 #   (not on the "Build + WASM + Rust + Node" needs-list) so branch
 #   protection and CI cost are unchanged; promote later if it proves stable.
 #
+#   Promotion plan (F4): the harness's red path is now fault-injection
+#   tested (tools/ifcopenshell_reference/test_harness.py::
+#   EndToEndFaultInjection, run by the "Unit tests" step below) - it
+#   perturbs an in-memory copy of a REAL committed reference dump and
+#   asserts `compare.py` exits non-zero on bbox/volume divergence and on a
+#   dropped element, plus a positive control that an unperturbed copy stays
+#   green. That is the evidence bar for "required"; the flip itself is a
+#   branch-protection ruleset edit only the repo owner can make (Settings ->
+#   Rules -> Rulesets -> add `parity (in-tree fixtures, committed
+#   reference)` to the required-checks list). Not done here - a workflow
+#   file cannot self-promote its own check.
+#
 # - nightly (`full` job): installs the PINNED engine, runs the whole
 #   committed corpus (fetched fixtures included), regenerates the reference
 #   dumps to detect reference-staleness, and uploads diff reports. Modeled on

--- a/tools/ifcopenshell_reference/README.md
+++ b/tools/ifcopenshell_reference/README.md
@@ -11,7 +11,11 @@ re-runnable differential against a pinned reference engine.
 - `canonical.py` - every stat both sides report (bbox, tri/vertex counts,
   signed volume, watertightness), computed from plain vertex/face arrays so
   the comparison measures geometry, never stat-computation differences.
-  Known-answer unit tests in `test_harness.py` (stdlib unittest).
+  Known-answer unit tests in `test_harness.py` (stdlib unittest), including
+  an `EndToEndFaultInjection` suite that perturbs an in-memory copy of a
+  real committed reference dump and asserts `compare.py` actually exits
+  non-zero - proof the "quick" CI lane's red path has teeth, not just that
+  `classify()` is correct in isolation.
 - `dump_reference.py` - canonical per-element JSON from the PINNED
   IfcOpenShell (world coords + welded, matching the provenance of the old
   baked constants). Engine failures become first-class `skip:<reason>` rows.

--- a/tools/ifcopenshell_reference/test_harness.py
+++ b/tools/ifcopenshell_reference/test_harness.py
@@ -172,7 +172,9 @@ class EndToEndFaultInjection(unittest.TestCase):
         old_argv = sys.argv
         sys.argv = argv
         try:
-            with contextlib.redirect_stdout(io.StringIO()):
+            with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(
+                io.StringIO()
+            ):
                 rc = compare.main()
         finally:
             sys.argv = old_argv
@@ -198,23 +200,47 @@ class EndToEndFaultInjection(unittest.TestCase):
         self.assertNotEqual(
             rc, 0, "compare.py must exit non-zero when bbox diverges beyond the 1mm gate"
         )
-        failure = next(f for f in report["failures"] if f["express_id"] == eid)
+        failure = next(
+            (f for f in report["failures"] if f["express_id"] == eid), None
+        )
+        self.assertIsNotNone(
+            failure, f"element {eid} must appear in report failures on a bbox divergence"
+        )
         self.assertIn("bbox", failure["failing"])
 
     def test_volume_divergence_reds(self):
         doc = copy.deepcopy(self.doc)
-        eid = doc["elements"][0]["express_id"]
-        # +50% >> the 1% VOLUME_REL_TOL gate, still inside the bbox volume so
-        # it stays a *usable* volume comparison rather than tripping the
-        # mixed-winding advisory path.
-        doc["elements"][0]["volume"] = round(doc["elements"][0]["volume"] * 1.5, 6)
+        elem = doc["elements"][0]
+        eid = elem["express_id"]
+        # +50% >> the 1% VOLUME_REL_TOL gate. The perturbed volume must stay
+        # INSIDE the bbox volume (see compare.usable_volume): a value above it
+        # is a mixed-winding artifact that downgrades to the advisory path,
+        # so the gate would exit 0 and this test would fail confusingly
+        # rather than proving the volume gate reds. Lock that precondition in
+        # so a future reference regeneration with a more voluminous shape
+        # fails loudly here instead of silently defanging the test.
+        perturbed = round(elem["volume"] * 1.5, 6)
+        ext = [elem["bbox"]["max"][i] - elem["bbox"]["min"][i] for i in range(3)]
+        bbox_vol = ext[0] * ext[1] * ext[2]
+        self.assertTrue(
+            elem.get("closed") and perturbed <= bbox_vol * 1.001,
+            f"perturbed volume {perturbed} must stay a *usable* (closed, "
+            f"<= bbox volume {bbox_vol}) comparison for this test to exercise "
+            "the volume gate rather than the mixed-winding advisory path",
+        )
+        elem["volume"] = perturbed
         lite = self._write_lite(doc)
         report_path = Path(self.tmpdir.name) / "volume.report.json"
         rc, report = self._run_compare(lite, report_path)
         self.assertNotEqual(
             rc, 0, "compare.py must exit non-zero when volume diverges beyond the 1% gate"
         )
-        failure = next(f for f in report["failures"] if f["express_id"] == eid)
+        failure = next(
+            (f for f in report["failures"] if f["express_id"] == eid), None
+        )
+        self.assertIsNotNone(
+            failure, f"element {eid} must appear in report failures on a volume divergence"
+        )
         self.assertIn("volume", failure["failing"])
 
     def test_dropped_element_reds_as_reference_only(self):

--- a/tools/ifcopenshell_reference/test_harness.py
+++ b/tools/ifcopenshell_reference/test_harness.py
@@ -7,7 +7,16 @@
 Run: python -m unittest test_harness  (stdlib only, no engine required)
 """
 
+from __future__ import annotations
+
+import contextlib
+import copy
+import io
+import json
+import sys
+import tempfile
 import unittest
+from pathlib import Path
 
 import canonical
 import compare
@@ -100,6 +109,125 @@ class ComparatorClassification(unittest.TestCase):
         skipped = canonical.skip_record(1, "IfcWall", "x")
         self.assertEqual(compare.classify(skipped, self.ok())[0], "IFCLITE_ONLY")
         self.assertEqual(compare.classify(skipped, skipped)[0], "BOTH_SKIP")
+
+
+class EndToEndFaultInjection(unittest.TestCase):
+    """Proves the RED path end to end, not just the classify() helper.
+
+    ``ComparatorClassification`` above exercises ``classify()`` in isolation
+    against hand-built dicts - it proves the classification RULES are
+    correct, but not that the CLI entry point CI actually runs
+    (``compare.py --reference ... --ifclite ...``, exit code, the
+    committed-reference file, the shipped allowlist.json) fires red on a
+    real divergence. A gate that is only proven correct in a unit and never
+    proven to fire in its own binary is not evidence the "quick" job in
+    ifcopenshell-parity.yml is fit to be promoted to a required check.
+
+    This suite loads an ACTUAL committed reference dump (never mutated on
+    disk), perturbs an in-memory copy the way a genuine kernel regression
+    would, feeds the perturbed copy through ``compare.main()`` exactly as
+    the workflow invokes it (same argv shape, same allowlist.json), and
+    asserts the process reports failure. A positive control (unperturbed
+    copy stays green) rules out "always red"; the shipped allowlist.json is
+    used unmodified so an allowlisted fixture couldn't silently mask a
+    fault-injection failure.
+    """
+
+    FIXTURE = "bath_csg_solid"
+    HERE = Path(__file__).resolve().parent
+
+    def setUp(self):
+        self.ref_path = self.HERE / "reference" / f"{self.FIXTURE}.reference.json"
+        self.allowlist_path = self.HERE / "allowlist.json"
+        self.doc = json.loads(self.ref_path.read_text())
+        # Fixture must stay outside allowlist.json, or a perturbation could
+        # be silently absorbed instead of failing the gate.
+        allow = json.loads(self.allowlist_path.read_text())
+        self.assertNotIn(
+            self.doc["fixture"],
+            allow,
+            f"{self.FIXTURE} must stay unlisted in allowlist.json for this "
+            "fault-injection suite to prove anything",
+        )
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmpdir.cleanup)
+
+    def _write_lite(self, doc: dict) -> Path:
+        path = Path(self.tmpdir.name) / "perturbed.ifclite.json"
+        path.write_text(json.dumps(doc))
+        return path
+
+    def _run_compare(self, lite_path: Path, report_path: Path | None = None) -> tuple[int, dict | None]:
+        argv = [
+            "compare.py",
+            "--reference",
+            str(self.ref_path),
+            "--ifclite",
+            str(lite_path),
+            "--allowlist",
+            str(self.allowlist_path),
+        ]
+        if report_path is not None:
+            argv += ["--report", str(report_path)]
+        old_argv = sys.argv
+        sys.argv = argv
+        try:
+            with contextlib.redirect_stdout(io.StringIO()):
+                rc = compare.main()
+        finally:
+            sys.argv = old_argv
+        report = json.loads(report_path.read_text()) if report_path else None
+        return rc, report
+
+    def test_unperturbed_copy_is_green(self):
+        # Positive control: an untouched copy of the reference must exit 0,
+        # so the two failing tests below prove the gate reacts to the
+        # perturbation, not that it is unconditionally red.
+        lite = self._write_lite(copy.deepcopy(self.doc))
+        rc, _ = self._run_compare(lite)
+        self.assertEqual(rc, 0)
+
+    def test_bbox_divergence_reds(self):
+        doc = copy.deepcopy(self.doc)
+        eid = doc["elements"][0]["express_id"]
+        # 50 mm >> the 1 mm BBOX_TOL_M gate.
+        doc["elements"][0]["bbox"]["max"][0] += 0.05
+        lite = self._write_lite(doc)
+        report_path = Path(self.tmpdir.name) / "bbox.report.json"
+        rc, report = self._run_compare(lite, report_path)
+        self.assertNotEqual(
+            rc, 0, "compare.py must exit non-zero when bbox diverges beyond the 1mm gate"
+        )
+        failure = next(f for f in report["failures"] if f["express_id"] == eid)
+        self.assertIn("bbox", failure["failing"])
+
+    def test_volume_divergence_reds(self):
+        doc = copy.deepcopy(self.doc)
+        eid = doc["elements"][0]["express_id"]
+        # +50% >> the 1% VOLUME_REL_TOL gate, still inside the bbox volume so
+        # it stays a *usable* volume comparison rather than tripping the
+        # mixed-winding advisory path.
+        doc["elements"][0]["volume"] = round(doc["elements"][0]["volume"] * 1.5, 6)
+        lite = self._write_lite(doc)
+        report_path = Path(self.tmpdir.name) / "volume.report.json"
+        rc, report = self._run_compare(lite, report_path)
+        self.assertNotEqual(
+            rc, 0, "compare.py must exit non-zero when volume diverges beyond the 1% gate"
+        )
+        failure = next(f for f in report["failures"] if f["express_id"] == eid)
+        self.assertIn("volume", failure["failing"])
+
+    def test_dropped_element_reds_as_reference_only(self):
+        # Simulates the kernel silently failing to produce geometry for an
+        # element the reference engine handled - REFERENCE_ONLY, which
+        # compare.py treats as a failure (docstring: "-> fails").
+        doc = copy.deepcopy(self.doc)
+        doc["elements"] = []
+        lite = self._write_lite(doc)
+        rc, _ = self._run_compare(lite)
+        self.assertNotEqual(
+            rc, 0, "a dropped element (REFERENCE_ONLY) must fail the gate"
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

The `quick` job in `.github/workflows/ifcopenshell-parity.yml` is intentionally non-required today ("promote later if it proves stable"). Promoting a check to required is a trust decision, so this PR adds the missing evidence: proof the gate actually goes red when geometry diverges from the committed reference, not just that its classification rules are correct in isolation.

**What's new**: `EndToEndFaultInjection` in `tools/ifcopenshell_reference/test_harness.py` (stdlib `unittest`, no engine/wheel required — same as the existing suite the `quick` job already runs via `python -m unittest test_harness -v`):

- `test_unperturbed_copy_is_green` — positive control: an untouched copy of a real committed reference dump (`reference/bath_csg_solid.reference.json`) passes through `compare.main()` (same CLI entry point, same shipped `allowlist.json`) and exits 0. Proves the two red tests below are catching the perturbation, not "always red."
- `test_bbox_divergence_reds` — perturbs one element's bbox by 5cm (>> the 1mm `BBOX_TOL_M` gate) and asserts `compare.main()` exits non-zero with `"bbox"` in the reported `failing` list.
- `test_volume_divergence_reds` — perturbs volume by +50% (>> the 1% `VOLUME_REL_TOL` gate, staying inside the bbox volume so it doesn't trip the mixed-winding advisory path) and asserts the same.
- `test_dropped_element_reds_as_reference_only` — empties the element list (simulating the kernel silently failing to produce geometry for an element the reference handled) and asserts `REFERENCE_ONLY` fails the gate.

This is stronger than the existing `ComparatorClassification` tests, which only exercise `classify()` against hand-built dicts. `EndToEndFaultInjection` drives the real `compare.py` CLI against a real committed reference file (never mutated on disk — only an in-memory `copy.deepcopy()` is perturbed and written to a tempdir) and the real `allowlist.json`, matching exactly how the `quick` job invokes it. `setUp()` also asserts `bath_csg_solid.ifc` stays absent from `allowlist.json`, so a future allowlist entry can't silently defang this suite without failing loudly.

Also updates the workflow header comment to document the promotion plan, and a short README.md note.

## What still needs a human

**The required-check ruleset flip is NOT in this PR and cannot be done by an agent.** It's a branch-protection edit only the repo owner can make: Settings → Rules → Rulesets → add `parity (in-tree fixtures, committed reference)` to the required-checks list (alongside Build + WASM + Rust + Node). This PR only produces the evidence that flip is safe.

## Testing

Ran locally (system Python 3.9, no IfcOpenShell/ifclite_geom wheel installed — this suite is deliberately stdlib-only so it doesn't need either):

```
$ python3 -m unittest test_harness -v
...
test_bbox_divergence_reds (test_harness.EndToEndFaultInjection) ... ok
test_dropped_element_reds_as_reference_only (test_harness.EndToEndFaultInjection) ... ok
test_unperturbed_copy_is_green (test_harness.EndToEndFaultInjection) ... ok
test_volume_divergence_reds (test_harness.EndToEndFaultInjection) ... ok
----------------------------------------------------------------------
Ran 15 tests in 0.004s

OK
```

Verified `git status` shows no diff under `tools/ifcopenshell_reference/reference/` after the run — the committed reference corpus is never touched, only in-memory copies. CI's own `quick` job will additionally run this on Python 3.12 with the real `ifclite_geom` wheel installed, exercising the exact environment the promotion decision is about.

## Test plan

- [x] `python3 -m unittest test_harness -v` passes locally (15/15, including the 4 new fault-injection tests)
- [x] Committed reference JSON under `tools/ifcopenshell_reference/reference/` unmodified by the test run
- [ ] CI `quick` job on this PR (path-gated: touches `tools/ifcopenshell_reference/**`) — will run the same suite on Python 3.12 with the real wheel