### PR TITLE
fix(viewer): place the Cesium 3D model with the same convergence-corrected rotation as the camera (#1408 follow-up)

### DIFF
--- a/apps/viewer/src/components/viewer/CesiumOverlay.tsx
+++ b/apps/viewer/src/components/viewer/CesiumOverlay.tsx
@@ -29,7 +29,6 @@ import {
   computeCesiumPlacement,
   shouldPreferOrthometricTerrain,
 } from '@/lib/geo/cesium-placement';
-import { getEffectiveHorizontalScale, resolveMapUnitToMetreScale } from '@/lib/geo/geo-scale';
 import { egm96Undulation } from '@/lib/geo/egm96-undulation';
 import { buildMergedGLB } from '@/lib/geo/cesium-glb';
 import { applySolarScene, SunPathDome } from '@/lib/geo/cesium-sun';
@@ -61,19 +60,10 @@ function loadCesium() {
 function buildModelMatrix(
   Cesium: typeof import('cesium'),
   bridge: CesiumBridge,
-  mapConversion: MapConversion | undefined,
-  projectedCRS: ProjectedCRS | undefined,
   coordinateInfo: CoordinateInfo | undefined,
-  lengthUnitScale: number,
 ) {
   // GLB vertices are in viewer-space metres (geometry engine converts during
-  // extraction). IfcMapConversion.Scale is defined per IFC spec relative to
-  // the project length unit, so applying it raw to metre-converted geometry
-  // double-scales the model — see issue #595. Use the effective scale.
-  const mapUnitScale = resolveMapUnitToMetreScale(projectedCRS?.mapUnitScale, lengthUnitScale);
-  const hScale = getEffectiveHorizontalScale(mapConversion?.scale, mapUnitScale, lengthUnitScale);
-  const absc = mapConversion?.xAxisAbscissa ?? 1.0;
-  const ordi = mapConversion?.xAxisOrdinate ?? 0.0;
+  // extraction; the effective map scale is already folded into the rotation).
   const bounds = coordinateInfo?.originalBounds;
   // Viewer bounds are already in metres (geometry engine converts from IFC native unit)
   const mvx = bounds ? (bounds.min.x + bounds.max.x) / 2 : 0;
@@ -87,16 +77,20 @@ function buildModelMatrix(
     bridge.modelOrigin.longitude, bridge.modelOrigin.latitude, bridge.modelOrigin.height,
   );
   const enuToEcef = Cesium.Transforms.eastNorthUpToFixedFrame(origin);
-  // No lengthUnitScale here — viewer-space GLB vertices are already in metres.
-  const sa = hScale * absc, so = hScale * ordi;
-  const tx = -(sa * mvx + so * mvz);
-  const ty = -(so * mvx - sa * mvz);
+  // No lengthUnitScale here: viewer-space GLB vertices are already in metres.
+  // Reuse the bridge's convergence-corrected viewer-to-ENU rotation so the
+  // model geometry and the camera frame agree on north; a grid-only rotation
+  // here would leave the model rotated by the meridian convergence off the
+  // true-north basemap (up to ~8 deg for Krovak). See #1408.
+  const rot = bridge.viewerRotation;
+  const tx = -(rot.eastFromVx * mvx + rot.eastFromVz * mvz);
+  const ty = -(rot.northFromVx * mvx + rot.northFromVz * mvz);
   const tz = -mvy;
   const ifcToEnu = new Cesium.Matrix4(
-    sa, 0,  so, tx,
-    so, 0, -sa, ty,
-    0,  1,  0,  tz,
-    0,  0,  0,  1,
+    rot.eastFromVx,  0, rot.eastFromVz,  tx,
+    rot.northFromVx, 0, rot.northFromVz, ty,
+    0,               1, 0,               tz,
+    0,               0, 0,               1,
   );
   return Cesium.Matrix4.multiply(enuToEcef, ifcToEnu, new Cesium.Matrix4());
 }
@@ -544,7 +538,7 @@ export function CesiumOverlay({
         if (cancelled) return;
 
         // Build initial model matrix
-        const modelMatrix = buildModelMatrix(Cesium, bridge, mapConversion, projectedCRS, coordinateInfo, lengthUnitScale);
+        const modelMatrix = buildModelMatrix(Cesium, bridge, coordinateInfo);
 
         const blob = new Blob([glbBytes as BlobPart], { type: 'model/gltf-binary' });
         const glbUrl = URL.createObjectURL(blob);
@@ -618,7 +612,7 @@ export function CesiumOverlay({
     const Cesium = cesiumModule;
     if (!model || !bridge || !viewer || !Cesium) return;
 
-    const newMatrix = buildModelMatrix(Cesium, bridge, mapConversion, projectedCRS, coordinateInfo, lengthUnitScale);
+    const newMatrix = buildModelMatrix(Cesium, bridge, coordinateInfo);
     model.modelMatrix = newMatrix;
     viewer.scene.requestRender();
     // Depend on bridgeVersion so the matrix is rebuilt with the *new* bridge

--- a/apps/viewer/src/lib/geo/cesium-bridge.test.ts
+++ b/apps/viewer/src/lib/geo/cesium-bridge.test.ts
@@ -7,7 +7,7 @@ import assert from 'node:assert';
 
 import proj4 from 'proj4';
 
-import { computeGridConvergence } from './cesium-bridge.js';
+import { computeGridConvergence, viewerToEnuRotation } from './cesium-bridge.js';
 
 /**
  * Independent grid-convergence ground truth: reproject a grid-north step to
@@ -84,5 +84,63 @@ describe('computeGridConvergence (#1408)', () => {
   it('returns 0 for a geographic (longlat) CRS', () => {
     const longlat = '+proj=longlat +datum=WGS84 +no_defs';
     assert.strictEqual(computeGridConvergence(longlat, 14.5, 50, 14.5, 50), 0);
+  });
+});
+
+describe('viewerToEnuRotation — model/camera share one convergence-corrected rotation (#1408 follow-up)', () => {
+  const KROVAK =
+    '+proj=krovak +lat_0=49.5 +lon_0=24.83333333333333 '
+    + '+alpha=30.28813972222222 +k=0.9999 +x_0=0 +y_0=0 +ellps=bessel '
+    + '+towgs84=570.8,85.7,462.8,4.998,1.587,5.261,3.56 +units=m +no_defs';
+  const easting = -737624.9683493343;
+  const northing = -1050307.039993465;
+  const [lon, lat] = proj4(KROVAK, 'WGS84', [easting, northing]);
+  const gamma = computeGridConvergence(KROVAK, easting, northing, lon, lat);
+
+  // Bearing (rad, from true north, +east) at which a viewer→ENU rotation places
+  // the model's grid-north edge (viewer −Z). ENU = rot · (0,0,−1).
+  function gridNorthBearing(rot: ReturnType<typeof viewerToEnuRotation>): number {
+    return Math.atan2(-rot.eastFromVz, -rot.northFromVz);
+  }
+  // proj4 ground truth: bearing of a grid-north step on the true-north globe.
+  const truthBearing = -groundTruthConvergence(KROVAK, easting, northing);
+
+  it('with gamma, grid-north lands on the proj4 footprint bearing (model matches basemap + camera)', () => {
+    const rot = viewerToEnuRotation(1, 1, 0, gamma);
+    assert.ok(
+      Math.abs(gridNorthBearing(rot) - truthBearing) < 1e-9,
+      `bearing ${gridNorthBearing(rot)} must equal proj4 truth ${truthBearing}`,
+    );
+  });
+
+  it('a grid-only rotation (gamma=0, the pre-fix model matrix) is off by the full convergence', () => {
+    const rot0 = viewerToEnuRotation(1, 1, 0, 0);
+    // Points straight at true north (bearing 0) instead of −gamma...
+    assert.ok(Math.abs(gridNorthBearing(rot0)) < 1e-12, 'grid-only points at true north');
+    // ...i.e. ~7.7° off the correct basemap bearing for Krovak — the bug.
+    const offDeg = Math.abs(gridNorthBearing(rot0) - truthBearing) * 180 / Math.PI;
+    assert.ok(offDeg > 7 && offDeg < 8.5, `expected ~7.7° drift, got ${offDeg.toFixed(3)}°`);
+  });
+
+  it('carries the Helmert grid rotation + scale (reduces to the legacy sa/so at gamma=0)', () => {
+    const hScale = 2, absc = 0.5, ordi = Math.sqrt(3) / 2; // 60° rotated, ×2 scale
+    const r = viewerToEnuRotation(hScale, absc, ordi, 0);
+    assert.ok(Math.abs(r.eastFromVx - hScale * absc) < 1e-12);
+    assert.ok(Math.abs(r.eastFromVz - hScale * ordi) < 1e-12);
+    assert.ok(Math.abs(r.northFromVx - hScale * ordi) < 1e-12);
+    assert.ok(Math.abs(r.northFromVz - (-hScale * absc)) < 1e-12);
+  });
+
+  it('composes R(gamma) after Helmert with a non-trivial rotation AND non-zero gamma (cross terms)', () => {
+    const hScale = 1.3, absc = 0.6, ordi = 0.8, gamma = 0.135; // rotated + scaled + convergence
+    const r = viewerToEnuRotation(hScale, absc, ordi, gamma);
+    // Independent construction: apply the planar rotation R(gamma) to the
+    // grid-only (Helmert) coefficients. [e'; n'] = [[cg,-sg],[sg,cg]] [e; n].
+    const g = viewerToEnuRotation(hScale, absc, ordi, 0);
+    const cg = Math.cos(gamma), sg = Math.sin(gamma);
+    assert.ok(Math.abs(r.eastFromVx - (cg * g.eastFromVx - sg * g.northFromVx)) < 1e-12);
+    assert.ok(Math.abs(r.northFromVx - (sg * g.eastFromVx + cg * g.northFromVx)) < 1e-12);
+    assert.ok(Math.abs(r.eastFromVz - (cg * g.eastFromVz - sg * g.northFromVz)) < 1e-12);
+    assert.ok(Math.abs(r.northFromVz - (sg * g.eastFromVz + cg * g.northFromVz)) < 1e-12);
   });
 });

--- a/apps/viewer/src/lib/geo/cesium-bridge.ts
+++ b/apps/viewer/src/lib/geo/cesium-bridge.ts
@@ -47,6 +47,14 @@ export interface GeodesicPosition {
 export interface CesiumBridge {
   modelOrigin: GeodesicPosition;
   rotationAngle: number;
+  /**
+   * The convergence-corrected viewer-to-ENU rotation this bridge computed once
+   * at creation. Exposed so the model-placement matrix reuses the exact same
+   * rotation as the camera frame (a pure consumer) instead of re-deriving a
+   * grid-only one; they must not drift, else the 3D model sits rotated by the
+   * meridian convergence off the true-north basemap. See #1408.
+   */
+  viewerRotation: ViewerToEnuRotation;
 
   /**
    * Sync the Cesium camera using lookAtTransform with a viewer→ECEF matrix.
@@ -187,6 +195,46 @@ export function computeGridConvergence(
   return Math.atan2(-east, north);
 }
 
+/**
+ * In-plane coefficients of the viewer-to-ENU rotation. `vy` maps straight to
+ * ENU up, so only the East/North rows depend on (vx, vz).
+ */
+export interface ViewerToEnuRotation {
+  eastFromVx: number;
+  eastFromVz: number;
+  northFromVx: number;
+  northFromVz: number;
+}
+
+/**
+ * Build the viewer-to-ENU rotation: the Helmert grid alignment (IfcMapConversion
+ * XAxisAbscissa/Ordinate, scaled by hScale) composed with the meridian
+ * convergence R(gamma) that turns grid axes into the true-north ENU frame
+ * Cesium uses (east = R(gamma) applied to the Helmert grid vectors).
+ *
+ * SINGLE SOURCE OF TRUTH: both the camera frame (`createCesiumBridge`) and the
+ * model-placement matrix (`buildModelMatrix`, via `bridge.viewerRotation`)
+ * derive their viewer-to-ENU rotation from this one function, so the model and
+ * the camera can never disagree on which way is north on the basemap. See #1408.
+ */
+export function viewerToEnuRotation(
+  hScale: number,
+  absc: number,
+  ordi: number,
+  gamma: number,
+): ViewerToEnuRotation {
+  const cg = Math.cos(gamma);
+  const sg = Math.sin(gamma);
+  const ce = hScale * absc;
+  const co = hScale * ordi;
+  return {
+    eastFromVx: cg * ce - sg * co,
+    eastFromVz: cg * co + sg * ce,
+    northFromVx: sg * ce + cg * co,
+    northFromVz: sg * co - cg * ce,
+  };
+}
+
 export async function createCesiumBridge(
   mapConversion: MapConversion,
   projectedCRS: ProjectedCRS,
@@ -237,32 +285,21 @@ export async function createCesiumBridge(
   const originLon = origin.longitude;
   const originLat = origin.latitude;
 
-  // ── Build the viewer→ENU 3x3 rotation matrix ──
-  // This converts a DELTA vector from viewer space to ENU.
-  // Step 1: viewer Y-up → IFC Z-up: (vx, vy, vz) → (vx, -vz, vy)
-  // Step 2: Helmert rotation: (ifcX, ifcY) → GRID (east, north) with scale
-  //   eg = hScale * (absc * vx - ordi * (-vz)) = hScale * (absc*vx + ordi*vz)
-  //   ng = hScale * (ordi * vx + absc * (-vz)) = hScale * (ordi*vx - absc*vz)
-  // Step 3: grid → true ENU. IfcMapConversion aligns the model to GRID north,
-  //   but Cesium's eastNorthUpToFixedFrame() is a TRUE-north frame. Rotate the
-  //   grid axes by the meridian convergence gamma so grid north lands where the
-  //   basemap puts it (the 2D footprint already bakes this in via proj4). See
-  //   issue #1408. R(gamma): east = cg*eg - sg*ng, north = sg*eg + cg*ng.
-  //   up    = vy  (ifcZ = vy, vertical is viewer Y)
-  //
-  // Viewer-space deltas are already in metres (geometry engine converts during
-  // extraction), so no lengthUnitScale needed here.
+  // Build the viewer-to-ENU 3x3 rotation matrix (converts a delta vector from
+  // viewer space to ENU). Viewer Y-up maps to IFC Z-up ((vx,vy,vz) -> (vx,-vz,
+  // vy)), then the Helmert grid alignment, then the meridian convergence
+  // R(gamma) into true-north ENU; `viewerToEnuRotation` composes all three
+  // (up = vy). The model-placement matrix reuses the very same `rot` via
+  // `bridge.viewerRotation` so the two never drift. Viewer-space deltas are
+  // already metres, so no lengthUnitScale.
   const gamma = computeGridConvergence(projDef, origin.easting, origin.northing, originLon, originLat);
-  const cg = Math.cos(gamma);
-  const sg = Math.sin(gamma);
-  const ce = hScale * absc;
-  const co = hScale * ordi;
-  const m00 = cg * ce - sg * co;   // east  from vx
+  const rot = viewerToEnuRotation(hScale, absc, ordi, gamma);
+  const m00 = rot.eastFromVx;      // east  from vx
   const m01 = 0;                   // east  from vy
-  const m02 = cg * co + sg * ce;   // east  from vz
-  const m10 = sg * ce + cg * co;   // north from vx
+  const m02 = rot.eastFromVz;      // east  from vz
+  const m10 = rot.northFromVx;     // north from vx
   const m11 = 0;                   // north from vy
-  const m12 = sg * co - cg * ce;   // north from vz
+  const m12 = rot.northFromVz;     // north from vz
   const m20 = 0;                   // up    from vx
   const m21 = 1;                   // up    from vy (vertical = viewer Y, already metres)
   const m22 = 0;                   // up    from vz
@@ -432,6 +469,7 @@ export async function createCesiumBridge(
   return {
     modelOrigin,
     rotationAngle: rotAngle,
+    viewerRotation: rot,
     syncCamera,
     queryTerrainHeight,
     viewerToGeodetic,

--- a/apps/viewer/src/lib/geo/solar-direction.ts
+++ b/apps/viewer/src/lib/geo/solar-direction.ts
@@ -7,8 +7,8 @@
  * viewer's world space, and shape the sun's photometric properties from its
  * altitude (warm low sun, twilight fade, night).
  *
- * Frame math — must stay the inverse of the viewer→ENU matrix built in
- * `cesium-bridge.ts` (createCesiumBridge):
+ * Frame math: the inverse of the Helmert grid alignment (IfcMapConversion
+ * XAxisAbscissa/Ordinate):
  *
  *   east  = absc·vx + ordi·vz
  *   north = ordi·vx − absc·vz
@@ -22,6 +22,13 @@
  *   vz = ordi·e − absc·n
  *
  * Sanity check at no rotation (absc=1, ordi=0): east→+X, up→+Y, north→−Z.
+ *
+ * NOTE: this is the GRID-only inverse; it does NOT include the meridian
+ * convergence R(gamma) that `cesium-bridge.ts` (viewerToEnuRotation) folds into
+ * the camera and model placement. So on high-convergence CRSs the WebGPU-viewer
+ * sun azimuth is off true north by ~gamma. The Cesium sun (cesium-sun.ts) is
+ * unaffected: it drives the sun through true-ENU (eastNorthUpToFixedFrame).
+ * Threading gamma here is a tracked follow-up.
  */
 
 import type { Enu } from '@ifc-lite/solar';


### PR DESCRIPTION
## Summary

Follow-up to #1408: the Cesium 3D **model placement** was missing the meridian-convergence rotation the **camera frame** already applies, so on oblique projections the model sat rotated by the convergence off both the basemap and the camera.

## The bug

`createCesiumBridge` rotates the viewer->ENU axes by the grid convergence gamma so grid north lands on the true-north basemap (#1408). But `buildModelMatrix` built a **grid-only** rotation, so the 3D model geometry and the camera used different viewer->ENU rotations and drifted apart by gamma.

Verified headlessly with real `@cesium/engine` + proj4 (Krovak): the model placed grid-north at bearing **0.0 deg**, but the proj4 footprint truth and the camera both put it at **-7.75 deg** (a 7.75 deg drift). Sub-degree for RD / UTM-centre, up to ~8 deg for oblique projections like Krovak.

## Fix (DRY)

Extract the viewer->ENU rotation into one shared `viewerToEnuRotation()` helper and expose the computed rotation (`viewerRotation`) on the bridge. `createCesiumBridge` and `buildModelMatrix` now derive their rotation from the same single source and cannot drift; `buildModelMatrix` becomes a pure consumer (drops its own hScale/absc/ordi derivation).

## Tests

proj4 bearing tests: the shared rotation places grid-north on the footprint truth (0 drift with gamma; ~7.7 deg off without), plus an R(gamma)-after-Helmert composition test for the cross terms. Full geo suite green (68/68); viewer typecheck clean.

## Noted, deferred (separate follow-up)

`solar-direction.ts` (the WebGPU-viewer sun) has the same grid-only omission: its ENU->viewer mapping ignores convergence, so the WebGPU sun azimuth is off true north by ~gamma on high-convergence CRSs. This is pre-existing (since #1408) and in a separate render path (the Cesium sun uses true-ENU and is unaffected, and now consistent with this fix). I corrected its now-stale docstring here and will fix it (thread gamma) as its own verified change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)