### PR TITLE
test(hygiene): wave-3 nits (#1552 oracle, #1549 diff_report, #1551 set_entity_index, #1547 main())

### DIFF
--- a/apps/server/src/main.rs
+++ b/apps/server/src/main.rs
@@ -77,6 +77,38 @@ fn build_cors_layer(config: &Config) -> CorsLayer {
     }
 }
 
+/// Startup log level for the memory-admission "gate off" branch in `main`,
+/// derived purely from the re-parsed `IFC_MEM_BUDGET_MB` env var (#1547).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LogDecision {
+    /// `IFC_MEM_BUDGET_MB=0`: the operator opted out of the memory gate
+    /// deliberately. Not a warning-worthy condition.
+    Info,
+    /// The env var is unset or unparseable AND the memory gate still ended
+    /// up off, i.e. auto-detection found no readable ceiling (non-Linux
+    /// host or `/proc` unavailable) — a silent OOM-risk degradation.
+    Warn,
+    /// A positive budget was explicitly requested. `main`'s call site only
+    /// reaches `memory_admission_log_level` from inside the
+    /// `config.mem_budget_mb == 0` branch, where this variant can never
+    /// actually occur (an explicit positive `IFC_MEM_BUDGET_MB` resolves
+    /// `config.mem_budget_mb` to that same positive value, see
+    /// `mem_policy::resolve_mem_budget_mb`). Kept so the function is total
+    /// over its input and independently unit-testable.
+    Active,
+}
+
+/// Pure decision for [`LogDecision`] from the resolved `IFC_MEM_BUDGET_MB`
+/// env var: `None` (unset/unparseable), `Some(0)` (explicit opt-out), or
+/// `Some(n)` with `n > 0` (an explicit positive budget).
+fn memory_admission_log_level(budget_mb: Option<u64>) -> LogDecision {
+    match budget_mb {
+        Some(0) => LogDecision::Info,
+        Some(_) => LogDecision::Active,
+        None => LogDecision::Warn,
+    }
+}
+
 /// Application state shared across handlers.
 #[derive(Clone)]
 pub struct AppState {
@@ -220,25 +252,25 @@ async fn main() {
     }));
     admission::spawn_rss_sampler(Arc::clone(&admission));
     if config.mem_budget_mb == 0 {
-        // Budget 0 = memory gate off. Two distinct causes; log them differently:
-        //  - explicit `IFC_MEM_BUDGET_MB=0`: the operator opted out deliberately
-        //    (info, not a warning);
-        //  - no readable ceiling (non-Linux dev, /proc unavailable): a silent
-        //    degradation that risks OOM, so warn.
-        let opted_out = std::env::var("IFC_MEM_BUDGET_MB")
+        // Budget 0 = memory gate off. Two distinct causes, logged differently
+        // by `memory_admission_log_level` below (see its doc for the third,
+        // unreachable-here-but-testable case).
+        let budget_env = std::env::var("IFC_MEM_BUDGET_MB")
             .ok()
-            .and_then(|v| v.parse::<usize>().ok())
-            == Some(0);
-        if opted_out {
-            tracing::info!(
-                max_concurrent_parses = config.max_concurrent_parses,
-                "Memory admission disabled via IFC_MEM_BUDGET_MB=0 (opt-out); only the CPU concurrency gate applies."
-            );
-        } else {
-            tracing::warn!(
-                max_concurrent_parses = config.max_concurrent_parses,
-                "Memory admission is OFF (no readable memory ceiling: non-Linux host or /proc unavailable): concurrent large uploads can OOM this replica. Set IFC_MEM_BUDGET_MB, or run under a cgroup memory limit."
-            );
+            .and_then(|v| v.parse::<u64>().ok());
+        match memory_admission_log_level(budget_env) {
+            LogDecision::Info => {
+                tracing::info!(
+                    max_concurrent_parses = config.max_concurrent_parses,
+                    "Memory admission disabled via IFC_MEM_BUDGET_MB=0 (opt-out); only the CPU concurrency gate applies."
+                );
+            }
+            LogDecision::Warn | LogDecision::Active => {
+                tracing::warn!(
+                    max_concurrent_parses = config.max_concurrent_parses,
+                    "Memory admission is OFF (no readable memory ceiling: non-Linux host or /proc unavailable): concurrent large uploads can OOM this replica. Set IFC_MEM_BUDGET_MB, or run under a cgroup memory limit."
+                );
+            }
         }
     } else {
         tracing::info!(
@@ -265,4 +297,32 @@ async fn main() {
 
     let listener = tokio::net::TcpListener::bind(addr).await.unwrap();
     axum::serve(listener, app).await.unwrap();
+}
+
+#[cfg(test)]
+mod memory_admission_log_level_tests {
+    use super::{memory_admission_log_level, LogDecision};
+
+    /// #1547: unset/unparseable `IFC_MEM_BUDGET_MB` (auto-detection found no
+    /// readable memory ceiling) must warn, not silently stay quiet.
+    #[test]
+    fn unset_warns() {
+        assert_eq!(memory_admission_log_level(None), LogDecision::Warn);
+    }
+
+    /// `IFC_MEM_BUDGET_MB=0` is a deliberate opt-out, not a degradation.
+    #[test]
+    fn explicit_zero_is_opt_out_info() {
+        assert_eq!(memory_admission_log_level(Some(0)), LogDecision::Info);
+    }
+
+    /// A positive explicit budget is neither the info nor the warn "gate
+    /// off" case (main's `config.mem_budget_mb == 0` guard means this
+    /// variant is never actually reached at the call site, but the pure
+    /// function itself must be total and correct over its whole domain).
+    #[test]
+    fn positive_budget_is_active() {
+        assert_eq!(memory_admission_log_level(Some(1)), LogDecision::Active);
+        assert_eq!(memory_admission_log_level(Some(4096)), LogDecision::Active);
+    }
 }

--- a/rust/geometry/tests/rect_param_gate.rs
+++ b/rust/geometry/tests/rect_param_gate.rs
@@ -18,9 +18,8 @@
 //! kept, not discarded to the exact kernel). The global counter is drained
 //! immediately before the single process call, scoping the read to this host.
 
-use ifc_lite_core::{build_entity_index, DecodedEntity, EntityDecoder, EntityScanner, IfcType};
-use ifc_lite_geometry::{propagate_voids_to_parts, GeometryRouter, Mesh, RectParam};
-use nalgebra::Matrix3;
+use ifc_lite_core::{build_entity_index, EntityDecoder, EntityScanner};
+use ifc_lite_geometry::{propagate_voids_to_parts, GeometryRouter, Mesh};
 use rustc_hash::FxHashMap;
 
 /// Rotated (36.87 deg in plan, NON-axis-aligned so the world path defers and
@@ -135,63 +134,48 @@ fn watertight(mesh: &Mesh) -> (bool, usize, usize) {
     (!edges.is_empty() && bad == 0, edges.len(), bad)
 }
 
-/// Signed-permutation axis map of `m` (each row one entry ~ +/-1), or `None`.
-fn signed_perm(m: &Matrix3<f64>, tol: f64) -> Option<[usize; 3]> {
-    let mut out = [0usize; 3];
-    let mut used = [false; 3];
-    for i in 0..3 {
-        let (mut best, mut ba, mut second) = (0usize, 0.0, 0.0);
-        for j in 0..3 {
-            let a = m[(i, j)].abs();
-            if a > ba {
-                second = ba;
-                ba = a;
-                best = j;
-            } else if a > second {
-                second = a;
-            }
-        }
-        if ba < 1.0 - tol || second > tol || used[best] {
-            return None;
-        }
-        used[best] = true;
-        out[i] = best;
-    }
-    Some(out)
-}
+/// Analytic ground-truth cut volume, computed from the LITERAL dimensions
+/// baked into the `IFC` fixture above, independent of `parametric_rect_probe`
+/// (#1552). The prior version derived "truth" by calling the very same
+/// `router.parametric_rect_probe()` the code under test also uses, which is
+/// self-referential: a systematic frame/axis bug in `parametric_rect_probe`
+/// would corrupt both the "expected" and "actual" sides identically, so this
+/// oracle must never call it (or anything that reuses its internals).
+///
+/// Derivation from the fixture's raw STEP parametrics (re-verify by hand
+/// against the `IFC` string above if this ever needs to change):
+///   - Host wall (#100): `IFCRECTANGLEPROFILEDEF` #130 is 4.0 (length) x 0.3
+///     (thickness), extruded #140 depth 2.5 (height) -> box volume
+///     4.0 * 0.3 * 2.5.
+///   - Opening (#200): profile #227 is 1.0 (length) x 1.5 (height), extruded
+///     #231 depth 1.0 along the opening's local Z, which axis #213/#214 map
+///     to the WALL's thickness direction (Y). The opening's own placement
+///     #211 sits at wall-local y=-0.5 and the 1.0 extrusion reaches y=+0.5,
+///     i.e. it deliberately overshoots the wall's +/-0.15 half-thickness on
+///     both sides so the cut always goes fully through, clamped by the host
+///     to exactly the wall's 0.3 thickness. The opening is centred on the
+///     host in length (wall-local x=0) and height (wall-local z=1.25, the
+///     host's own z-centre), both well inside the host's extents, so neither
+///     of those two axes is clamped.
+///   - Clamped opening volume: 1.0 (length) * 1.5 (height) * 0.3 (thickness,
+///     clamped from the oversized 1.0 extrusion down to the host).
+///
+/// A rigid rotation of the whole assembly (the fixture's wall is rotated
+/// about Z in world space) does not change either volume, so this is exact
+/// regardless of that rotation.
+fn analytic_cut_volume() -> f64 {
+    const WALL_LENGTH: f64 = 4.0;
+    const WALL_THICKNESS: f64 = 0.3;
+    const WALL_HEIGHT: f64 = 2.5;
+    const OPENING_LENGTH: f64 = 1.0;
+    const OPENING_HEIGHT: f64 = 1.5;
+    // The opening's extrusion overshoots the host on both faces, so the
+    // clamped cut depth is the full host thickness, not the raw 1.0 extrusion.
+    let clamped_opening_depth = WALL_THICKNESS;
 
-/// Analytic ground-truth cut volume: host box minus the opening box clamped to
-/// the host. Exact for a box-minus-box; reads both frames from the parametrics.
-fn analytic_cut_volume(
-    router: &GeometryRouter,
-    host: &DecodedEntity,
-    opening_ids: &[u32],
-    decoder: &mut EntityDecoder,
-) -> Option<f64> {
-    let hp: RectParam = router.parametric_rect_probe(host, decoder)?;
-    let rt = hp.r.transpose();
-    let host_vol = 8.0 * hp.half[0] * hp.half[1] * hp.half[2];
-    let mut opening_vol = 0.0;
-    for &oid in opening_ids {
-        let opening = decoder.decode_by_id(oid).ok()?;
-        if opening.ifc_type != IfcType::IfcOpeningElement {
-            continue;
-        }
-        for b in router.parametric_rect_probe_all(&opening, decoder)? {
-            let map = signed_perm(&(rt * b.r), 1.0e-3)?;
-            let cf = rt * (b.center - hp.center);
-            let cf = [cf.x, cf.y, cf.z];
-            let half_f = [b.half[map[0]], b.half[map[1]], b.half[map[2]]];
-            let mut v = 1.0;
-            for i in 0..3 {
-                let lo = (cf[i] - half_f[i]).max(-hp.half[i]);
-                let hi = (cf[i] + half_f[i]).min(hp.half[i]);
-                v *= (hi - lo).max(0.0);
-            }
-            opening_vol += v;
-        }
-    }
-    Some((host_vol - opening_vol).abs())
+    let host_vol = WALL_LENGTH * WALL_THICKNESS * WALL_HEIGHT;
+    let opening_vol = OPENING_LENGTH * OPENING_HEIGHT * clamped_opening_depth;
+    (host_vol - opening_vol).abs()
 }
 
 #[test]
@@ -208,13 +192,27 @@ fn param_fast_path_fires_watertight_and_matches_analytic_on_the_shipped_default(
     );
 
     let host = decoder.decode_by_id(HOST_ID).expect("decode wall");
-    // Drain the global "emitted" counter immediately before the single process
-    // call so what we read back is this host's post-self-check emissions.
-    let _ = ifc_lite_geometry::rect_fast::take_param_fires();
+    // `PARAM_FIRES` (rect_fast.rs) is a process-global counter, so reading its
+    // absolute value would be unsafe under cargo test's default parallel test
+    // execution if this file ever grew a second `#[test]` sharing the process
+    // (each `tests/*.rs` integration file is its own binary/process today, so
+    // there is currently nothing else to race with here, but `serial_test` is
+    // not a workspace dev-dependency, so we don't reach for `#[serial]`).
+    // Snapshot-and-diff instead: `take_param_fires()` swaps the counter to 0
+    // and returns the prior value, so draining immediately before the call
+    // under test and reading again immediately after yields the DELTA
+    // attributable to this one call, robust to any future concurrent user.
+    let before_param_fires = ifc_lite_geometry::rect_fast::take_param_fires();
     let result = router
         .process_element_with_voids(&host, &mut decoder, &void_index)
         .expect("process wall with voids");
+    // `take_param_fires()` already resets the counter on read, so the value
+    // read here IS the delta accrued strictly between the two calls above.
     let emitted_param_cuts = ifc_lite_geometry::rect_fast::take_param_fires();
+    assert_eq!(
+        before_param_fires, 0,
+        "unexpected pre-existing PARAM_FIRES count before the call under test"
+    );
 
     // (a) The shipped default (param ON) must both ENGAGE and EMIT the analytic
     // cut on this rotated rectangular wall (exactly the case #1493 targets, which
@@ -253,12 +251,7 @@ fn param_fast_path_fires_watertight_and_matches_analytic_on_the_shipped_default(
     // truth (encoded as agreement, NOT kernel bit-equality, since memory records
     // the param path as MORE correct than the exact kernel on such hosts).
     let pv = mesh_volume(&result).abs();
-    let truth = analytic_cut_volume(&router, &host, &void_index[&HOST_ID], &mut decoder)
-        .expect(
-            "analytic ground truth requires the host + every opening to be an \
-             axis-aligned rectangular box (the committed fixture is); a None here \
-             means a fixture edit introduced a non-axis-aligned opening",
-        );
+    let truth = analytic_cut_volume();
     let rel = (pv - truth).abs() / truth.max(1.0e-9);
     assert!(
         rel < 0.02,

--- a/rust/processing/src/determinism_tests.rs
+++ b/rust/processing/src/determinism_tests.rs
@@ -1,0 +1,88 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Unit tests for `determinism::diff_report` (#1549). Split into its own
+//! `_tests.rs` sibling file (declared from `lib.rs`, not from inside
+//! `determinism.rs` itself) so it doesn't count against `determinism.rs`'s
+//! `module_size_ratchet` budget, which already sits exactly at its frozen
+//! limit.
+
+use crate::determinism::*;
+
+/// A minimal, internally-consistent manifest for `diff_report` unit tests.
+/// The exact hash strings are arbitrary placeholders (never real FNV-1a
+/// output) - only their equality/inequality across two manifests matters.
+fn manifest(hash: &str, voids_hash: &str, mesh_positions_hash: &str) -> MeshManifest {
+    MeshManifest {
+        hash: hash.to_string(),
+        mesh_count: 1,
+        vertex_count: 3,
+        triangle_count: 1,
+        voids_hash: voids_hash.to_string(),
+        void_host_count: 2,
+        material_colors_hash: "0xaaaa".to_string(),
+        material_element_count: 2,
+        styles_hash: "0xbbbb".to_string(),
+        style_entry_count: 2,
+        meshes: vec![MeshManifestEntry {
+            express_id: 100,
+            geometry_class: 0,
+            vertex_count: 3,
+            triangle_count: 1,
+            positions_hash: mesh_positions_hash.to_string(),
+            normals_hash: "0xcccc".to_string(),
+            indices_origin_hash: "0xdddd".to_string(),
+        }],
+    }
+}
+
+/// #1549: `diff_report` had zero unit coverage. Diverge exactly two known
+/// top-level fields (`hash`, `voids_hash`) and assert the report names
+/// BOTH by field name, and does not falsely name an unrelated field
+/// (`positions_hash`, which is unchanged here).
+#[test]
+fn diff_report_names_the_diverged_top_level_fields() {
+    let expected = manifest("0x1", "0xv1", "0xp1");
+    let actual = manifest("0x2", "0xv2", "0xp1");
+    let report = diff_report(&expected, &actual).expect("manifests differ, must report");
+    assert!(
+        report.contains("hash: expected 0x1 got 0x2"),
+        "must name the top-level hash field:\n{report}"
+    );
+    assert!(
+        report.contains("voids_hash: expected 0xv1 got 0xv2"),
+        "must name voids_hash:\n{report}"
+    );
+    assert!(
+        !report.contains("positions_hash"),
+        "positions_hash is unchanged and must not be reported:\n{report}"
+    );
+}
+
+/// A per-mesh divergence (only `positions_hash` on mesh index 0 differs)
+/// must be named both by mesh index and by the specific sub-field.
+#[test]
+fn diff_report_names_the_diverged_mesh_subfield() {
+    let expected = manifest("0x1", "0xv1", "0xp1");
+    let mut actual = expected.clone();
+    actual.meshes[0].positions_hash = "0xp2".to_string();
+    // The top-level `hash` also necessarily changes with any mesh delta
+    // in production, but this test only mutates the per-mesh field, so
+    // top-level `hash` stays equal here - isolating the per-mesh path.
+    let report = diff_report(&expected, &actual).expect("mesh entry differs, must report");
+    assert!(
+        report.contains("mesh[0]"),
+        "must identify which mesh index diverged:\n{report}"
+    );
+    assert!(
+        report.contains("positions"),
+        "must name the diverged mesh sub-field:\n{report}"
+    );
+}
+
+#[test]
+fn diff_report_is_none_when_manifests_match() {
+    let m = manifest("0x1", "0xv1", "0xp1");
+    assert!(diff_report(&m, &m).is_none());
+}

--- a/rust/processing/src/lib.rs
+++ b/rust/processing/src/lib.rs
@@ -8,6 +8,16 @@
 //! the HTTP server and the native FFI library.
 
 pub mod determinism;
+// `determinism::diff_report` unit tests (#1549) live in this sibling
+// `_tests.rs` file, declared from here rather than inside `determinism.rs`,
+// because that module already sits exactly at its frozen
+// `module_size_ratchet` budget (`tests/module_size_allowlist.txt`); adding
+// even a `mod` declaration there would fail the "no allowlisted file grows"
+// gate. `_tests.rs` is itself exempt from that ratchet (see
+// `module_size_ratchet.rs`'s `is_exempt`).
+#[cfg(test)]
+#[path = "determinism_tests.rs"]
+mod determinism_tests;
 pub mod element;
 pub mod geometry_export;
 mod georeferencing;

--- a/scripts/test-wasm-contract.mjs
+++ b/scripts/test-wasm-contract.mjs
@@ -605,6 +605,78 @@ test('getPipelineDiagnostics: undefined before load, accumulates across batches,
   }
 });
 
+// ===== setEntityIndex (production load-start reset path, #1551) =====
+// The `getPipelineDiagnostics` test above only exercises the buildPrePassOnce
+// reset. `setEntityIndex` is the OTHER load-start reset path: the geometry
+// PROCESS worker (packages/geometry/src/geometry.worker.ts) is a separate
+// wasm realm from the pre-pass worker, so it never calls buildPrePassOnce
+// itself — it receives an already-built entity index over SAB and installs
+// it via setEntityIndex before its first processGeometryBatch. Nothing
+// previously asserted that this path resets load-scoped state the same way.
+test('setEntityIndex resets pipeline diagnostics like a fresh load, and installs a working entity-index cache', () => {
+  const entityIdxApi = new IfcAPI();
+  const bytes = new TextEncoder().encode(columnContent);
+  try {
+    // First "load", via the normal buildPrePassOnce + processGeometryBatch
+    // path, to put this IfcAPI into a NON-fresh state (diagnostics
+    // populated) — the state setEntityIndex must reset on the next load.
+    const pre = entityIdxApi.buildPrePassOnce(bytes);
+    assert.ok(pre.totalJobs > 0, 'fixture must produce geometry jobs');
+    const runBatch = () => {
+      const c = entityIdxApi.processGeometryBatch(
+        bytes, pre.jobs, pre.unitScale,
+        pre.rtcOffset[0], pre.rtcOffset[1], pre.rtcOffset[2], pre.needsShift,
+        pre.voidKeys, pre.voidCounts, pre.voidValues, pre.styleIds, pre.styleColors,
+      );
+      try {
+        assert.ok(c.length > 0, 'first-load batch must produce meshes');
+      } finally {
+        c.free();
+      }
+    };
+    runBatch();
+    const before = entityIdxApi.getPipelineDiagnostics();
+    assert.ok(before && before.batches === 1, 'diagnostics must be populated before setEntityIndex');
+
+    // Build the (ids, starts, lengths) columns the worker realm would receive
+    // over SAB, the same way scanEntitiesFastBytes already exposes them.
+    const refs = entityIdxApi.scanEntitiesFastBytes(bytes);
+    assert.ok(Array.isArray(refs) && refs.length > 0, 'scan must find entities');
+    const ids = Uint32Array.from(refs.map((r) => r.expressId));
+    const starts = Uint32Array.from(refs.map((r) => r.byteOffset));
+    const lengths = Uint32Array.from(refs.map((r) => r.byteLength));
+
+    entityIdxApi.setEntityIndex(ids, starts, lengths);
+
+    // (a) setEntityIndex is a load-START reset, same contract as
+    // buildPrePassOnce (rust/wasm-bindings/src/api/mod.rs set_entity_index ->
+    // reset_pipeline_diagnostics): the PREVIOUS load's diagnostics must not
+    // leak into the next one on a reused IfcAPI.
+    assert.equal(entityIdxApi.getPipelineDiagnostics(), undefined,
+      'setEntityIndex must reset pipeline diagnostics like a fresh load');
+
+    // (b) Functional correctness of the installed cache: a subsequent
+    // processGeometryBatch must still produce valid meshes by reusing the
+    // Arc<EntityIndex> setEntityIndex populated, not a silently empty/corrupt
+    // one that would make every job fail to decode.
+    const collection = entityIdxApi.processGeometryBatch(
+      bytes, pre.jobs, pre.unitScale,
+      pre.rtcOffset[0], pre.rtcOffset[1], pre.rtcOffset[2], pre.needsShift,
+      pre.voidKeys, pre.voidCounts, pre.voidValues, pre.styleIds, pre.styleColors,
+    );
+    try {
+      assert.ok(collection.length > 0, 'batch after setEntityIndex must still produce meshes');
+    } finally {
+      collection.free();
+    }
+    const after = entityIdxApi.getPipelineDiagnostics();
+    assert.ok(after && after.batches === 1,
+      'the post-setEntityIndex batch must start a fresh accumulator at 1, not accumulate onto the prior load');
+  } finally {
+    entityIdxApi.clearPrePassCache();
+  }
+});
+
 // Summary
 console.log('\n' + '═'.repeat(50));
 console.log(`📊 Results: ${passed} passed, ${failed} failed`);


### PR DESCRIPTION
## What changed

- **#1552 (`rect_param_gate.rs`)**: `analytic_cut_volume()` no longer calls `router.parametric_rect_probe()` to derive its "expected" value. It now computes the expected cut volume directly from the literal box/opening dimensions baked into the fixture. Also made the process-global `PARAM_FIRES` counter read explicitly delta-based (drain-before / read-after) with a comment explaining why (no `serial_test` dep in the workspace; each `tests/*.rs` file is its own process today).
- **#1549 (`determinism.rs`)**: added unit tests for `diff_report()` — a top-level-field divergence, a per-mesh sub-field divergence, and the equal-manifests `None` case — asserting the report names the actual diverged field(s), not just that it's non-empty. Tests live in a new `determinism_tests.rs` sibling file (declared from `lib.rs`) rather than inline, because `determinism.rs` sits exactly at its frozen `module_size_ratchet` budget and any addition there would fail that gate.
- **#1551 (`scripts/test-wasm-contract.mjs`)**: added a test covering `setEntityIndex`'s load-start reset path (pipeline diagnostics reset + a working entity-index cache for the next `processGeometryBatch`), mirroring the existing `buildPrePassOnce` reset test but for the "geometry process worker" call path.
- **#1547 (`apps/server/src/main.rs`)**: extracted the inline info-vs-warn decision for the "memory admission gate is off" startup log into `memory_admission_log_level(Option<u64>) -> LogDecision`, a pure function, with unit tests for all three input cases (unset, explicit `0`, explicit positive). Pure refactor — behavior is unchanged.

## Why

Four independent hygiene gaps flagged after their originating PRs merged: a self-referential test oracle, an under-tested pure function, an untested wasm-bindings reset path, and inline branching logic with zero unit coverage.

## Testing

- `cargo test -p ifc-lite-geometry --test rect_param_gate` — 1 passed
- `cargo test -p ifc-lite-processing determinism` — 3 new unit tests passed (`determinism_tests::*`), plus the existing `mesh_determinism` integration suite green
- `cargo test -p ifc-lite-processing --test module_size_ratchet` — 4 passed (confirms the sibling-file split keeps `determinism.rs` at its frozen budget)
- `cargo test -p ifc-lite-server` — 43 passed (incl. 3 new `memory_admission_log_level_tests::*`)
- `node scripts/test-wasm-contract.mjs` (wasm pkg + fixtures staged locally) — 24 passed, incl. the new `setEntityIndex` test
- `cargo build --workspace --tests` and a full `cargo test --workspace --no-fail-fast` — no regressions introduced; the only failures are pre-existing environmental fixture gaps unrelated to this change (`rust/export`'s `duplex.ifc` and `rust/geometry`'s `advanced_model.ifc` fixtures aren't staged in this workspace run)

## Risks / things not verified

- No new crate dependency added (`serial_test` deliberately not introduced; see #1552 commit message for the delta-read rationale instead).
- Pure refactor for #1547: behavior is unchanged, confirmed by code inspection plus the new unit tests, not a runtime A/B (no easy way to flip `IFC_MEM_BUDGET_MB` at startup in a unit test).
- Did not attempt to fix the two pre-existing fixture-gap failures encountered while running `cargo test --workspace` (`ifc-lite-export`, `wall_opening_cut_regression`) — out of scope for this bundle, unrelated to any of the four files touched here.