### PR TITLE
feat(cli): honor --quiet/--verbose across commands + --product/--type geometry diagnostics

### DIFF
--- a/.changeset/cli-diagnose-geometry-filters.md
+++ b/.changeset/cli-diagnose-geometry-filters.md
@@ -1,0 +1,8 @@
+---
+"@ifc-lite/cli": minor
+"@ifc-lite/geometry": minor
+---
+
+`diagnose-geometry` gains `--product <expressId|GlobalId>` and `--type <IfcType>` flags to narrow the worst-failing-hosts detail list to a single product or IFC type. Worst-failing hosts now also report a world-space bounding box and final triangle count when a void cut captured them, surfaced in both `--json` and the human-readable report.
+
+Fixed `--quiet`/`--verbose` on `diagnose-geometry`: its status line ("Wrote diagnostics to...") now routes through the leveled logger like every other command, so `--quiet` actually silences it instead of always printing to stdout via a raw `console.log`. The JSON/report payload itself is unaffected by verbosity, same as every other command.

--- a/packages/cli/src/commands/diagnose-geometry.test.ts
+++ b/packages/cli/src/commands/diagnose-geometry.test.ts
@@ -1,0 +1,135 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { readFile, unlink } from 'node:fs/promises';
+import { isExpressId, filterWorstHosts, diagnoseGeometryCommand } from './diagnose-geometry.js';
+import { logger } from '../logger.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+// Committed viewer demo sample (not the network-fetched tests/models/ fixture
+// set) — small, fast to parse, always present, so this suite never needs
+// `pnpm fixtures`.
+const SAMPLE_IFC = join(__dirname, '../../../../apps/viewer/public/samples/hello-wall.ifc');
+
+describe('isExpressId', () => {
+  it('is true for a bare numeric string', () => {
+    expect(isExpressId('42')).toBe(true);
+    expect(isExpressId('0')).toBe(true);
+  });
+
+  it('is false for an IFC GlobalId (base64-like, never purely numeric)', () => {
+    expect(isExpressId('2O2Fr$t4X7Zf8NOew3FKau')).toBe(false);
+    expect(isExpressId('0YvCT2_$X3_xJG3rzD8L_8')).toBe(false);
+  });
+
+  it('is false for a mixed or empty string', () => {
+    expect(isExpressId('42a')).toBe(false);
+    expect(isExpressId('')).toBe(false);
+  });
+});
+
+describe('filterWorstHosts', () => {
+  const hosts = [
+    { productId: 1, ifcType: 'IfcWall', openings: 1, csgFailures: 3 },
+    { productId: 2, ifcType: 'IfcSlab', openings: 2, csgFailures: 1 },
+    { productId: 3, ifcType: 'IfcWall', openings: 1, csgFailures: 2 },
+  ];
+
+  it('filters by productId', () => {
+    expect(filterWorstHosts(hosts, { productId: 2 })).toEqual([hosts[1]]);
+  });
+
+  it('filters by ifcType', () => {
+    expect(filterWorstHosts(hosts, { ifcType: 'IfcWall' })).toEqual([hosts[0], hosts[2]]);
+  });
+
+  it('filters by both productId and ifcType (AND semantics)', () => {
+    expect(filterWorstHosts(hosts, { productId: 3, ifcType: 'IfcWall' })).toEqual([hosts[2]]);
+    expect(filterWorstHosts(hosts, { productId: 3, ifcType: 'IfcSlab' })).toEqual([]);
+  });
+
+  it('returns everything when no filter is given', () => {
+    expect(filterWorstHosts(hosts, {})).toEqual(hosts);
+  });
+
+  it('returns an empty array when nothing matches', () => {
+    expect(filterWorstHosts(hosts, { productId: 999 })).toEqual([]);
+  });
+});
+
+describe('diagnoseGeometryCommand', () => {
+  let stdoutSpy: ReturnType<typeof vi.spyOn>;
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    stdoutSpy.mockRestore();
+    stderrSpy.mockRestore();
+    logger.configure({ level: 'info' });
+  });
+
+  function stdoutText(): string {
+    return stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
+  }
+
+  it('--json prints a JSON payload (or `null` for a clean model) to stdout', async () => {
+    await diagnoseGeometryCommand([SAMPLE_IFC, '--json']);
+    const text = stdoutText().trim();
+    expect(() => JSON.parse(text)).not.toThrow();
+  }, 30_000);
+
+  it('prints the human-readable report (or the no-diagnostics line) without --json', async () => {
+    await diagnoseGeometryCommand([SAMPLE_IFC]);
+    const text = stdoutText();
+    expect(text.length).toBeGreaterThan(0);
+    // Never valid JSON — always the prose report or the fixed sentinel line.
+    expect(() => JSON.parse(text.trim())).toThrow();
+  }, 30_000);
+
+  it('--quiet suppresses the "Wrote diagnostics to..." status line but keeps the file payload intact', async () => {
+    const outPath = join(__dirname, '..', '..', '__diag_test_out__.json');
+    logger.configure({ level: 'error' });
+    try {
+      await diagnoseGeometryCommand([SAMPLE_IFC, '--out', outPath, '--quiet']);
+      expect(stderrSpy).not.toHaveBeenCalled();
+      const written = await readFile(outPath, 'utf-8');
+      expect(() => JSON.parse(written)).not.toThrow();
+    } finally {
+      await unlink(outPath).catch(() => undefined);
+    }
+  }, 30_000);
+
+  it('--product with a numeric express ID that matches nothing prints a sensible message, not a crash', async () => {
+    await diagnoseGeometryCommand([SAMPLE_IFC, '--product', '999999999']);
+    const text = stdoutText();
+    expect(text.length).toBeGreaterThan(0);
+  }, 30_000);
+
+  it('--type filtering does not crash on a clean model with no worstHosts', async () => {
+    await diagnoseGeometryCommand([SAMPLE_IFC, '--type', 'IfcWall']);
+    const text = stdoutText();
+    expect(text.length).toBeGreaterThan(0);
+  }, 30_000);
+
+  it('--product with an unresolvable GlobalId fails closed with a clear error (does not crash silently)', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((() => {
+      throw new Error('process.exit called');
+    }) as unknown) as (code?: number) => never);
+    try {
+      await expect(
+        diagnoseGeometryCommand([SAMPLE_IFC, '--product', 'not-a-real-guid-value']),
+      ).rejects.toThrow('process.exit called');
+      expect(stderrSpy.mock.calls.some((c) => String(c[0]).includes('no entity found with GlobalId'))).toBe(true);
+    } finally {
+      exitSpy.mockRestore();
+    }
+  }, 30_000);
+});

--- a/packages/cli/src/commands/diagnose-geometry.test.ts
+++ b/packages/cli/src/commands/diagnose-geometry.test.ts
@@ -99,7 +99,12 @@ describe('diagnoseGeometryCommand', () => {
     logger.configure({ level: 'error' });
     try {
       await diagnoseGeometryCommand([SAMPLE_IFC, '--out', outPath, '--quiet']);
-      expect(stderrSpy).not.toHaveBeenCalled();
+      // Narrow: --quiet must swallow the "Wrote diagnostics to…" status line,
+      // but WASM init / the parser may legitimately touch stderr, so assert on
+      // the specific line rather than total silence (PR #1564 review).
+      expect(
+        stderrSpy.mock.calls.every((c) => !String(c[0]).includes('Wrote diagnostics to')),
+      ).toBe(true);
       const written = await readFile(outPath, 'utf-8');
       expect(() => JSON.parse(written)).not.toThrow();
     } finally {
@@ -117,6 +122,17 @@ describe('diagnoseGeometryCommand', () => {
     await diagnoseGeometryCommand([SAMPLE_IFC, '--type', 'IfcWall']);
     const text = stdoutText();
     expect(text.length).toBeGreaterThan(0);
+  }, 30_000);
+
+  it('a filter that matches no worst host still prints the full aggregate report, not just a "no match" line', async () => {
+    // A type that is never a CSG-failing host on this clean sample: the filtered
+    // worstHosts list is empty, but the file-wide aggregate report must survive
+    // (PR #1564 review — do not hide totalCsgFailures / classification context).
+    await diagnoseGeometryCommand([SAMPLE_IFC, '--type', 'IfcNonExistentType']);
+    const text = stdoutText();
+    // The aggregate report header + counts are present regardless of the filter.
+    expect(text).toContain('Geometry diagnostics');
+    expect(text).toContain('CSG failures:');
   }, 30_000);
 
   it('--product with an unresolvable GlobalId fails closed with a clear error (does not crash silently)', async () => {

--- a/packages/cli/src/commands/diagnose-geometry.ts
+++ b/packages/cli/src/commands/diagnose-geometry.ts
@@ -20,7 +20,7 @@ import { readFile, writeFile } from 'node:fs/promises';
 import { GeometryProcessor, type GeometryDiagnostics } from '@ifc-lite/geometry';
 import { getFlag, hasFlag, fatal } from '../output.js';
 import { logger } from '../logger.js';
-import { loadIfcFile } from '../loader.js';
+import { loadIfcBytes } from '../loader.js';
 import { formatGeometryReport, NO_DIAGNOSTICS_LINE } from '../geometry-report.js';
 
 type WorstHost = GeometryDiagnostics['worstHosts'][number];
@@ -73,8 +73,12 @@ export async function diagnoseGeometryCommand(args: string[]): Promise<void> {
         productId = parseInt(productArg, 10);
       } else {
         // GlobalId: resolve via the columnar parser's entity table (the wasm
-        // diagnostics pass never surfaces GlobalIds, only express IDs).
-        const store = await loadIfcFile(filePath);
+        // diagnostics pass never surfaces GlobalIds, only express IDs). Parse
+        // the bytes ALREADY in memory rather than re-reading the file from disk
+        // — the geometry pass above already loaded them, so this avoids a
+        // redundant disk read (the wasm IfcAPI exposes no GlobalId lookup, so a
+        // columnar parse is still required to map GlobalId → expressId).
+        const store = await loadIfcBytes(bytes, filePath);
         const resolved = store.entities.getExpressIdByGlobalId(productArg);
         if (resolved === -1) {
           fatal(`--product: no entity found with GlobalId "${productArg}"`);
@@ -101,13 +105,21 @@ export async function diagnoseGeometryCommand(args: string[]): Promise<void> {
     process.stdout.write(NO_DIAGNOSTICS_LINE + '\n');
     return;
   }
+  // Always print the full aggregate report — `formatGeometryReport` renders the
+  // file-wide counts (totalCsgFailures, failuresByReason, classification, …)
+  // and handles an empty `worstHosts` list gracefully. When a --product/--type
+  // filter narrowed the list to nothing we append a note rather than hiding the
+  // aggregate context behind a bare "no match" line (PR #1564 review).
+  const report = formatGeometryReport(diag);
   if ((productArg !== undefined || typeArg !== undefined) && diag.worstHosts.length === 0) {
     process.stdout.write(
-      'No worst-failing host record matches --product/--type ' +
-        '(diagnose-geometry only tracks the bounded top-N hosts that recorded a CSG failure; ' +
-        'a filtered-out product may simply have none).\n',
+      report +
+        '\n\n' +
+        '(No worst-failing host record matches --product/--type — diagnose-geometry ' +
+        'only tracks the bounded top-N hosts that recorded a CSG failure; a filtered-out ' +
+        'product may simply have none.)\n',
     );
     return;
   }
-  process.stdout.write(formatGeometryReport(diag) + '\n');
+  process.stdout.write(report + '\n');
 }

--- a/packages/cli/src/commands/diagnose-geometry.ts
+++ b/packages/cli/src/commands/diagnose-geometry.ts
@@ -9,43 +9,105 @@
  * rect_fast fast-path engagement, and the worst-failing hosts. The same contract
  * the viewer surfaces on the streaming `complete` event and the server attaches to
  * `ProcessingStats.geometry_diagnostics`. Use `--json` for the raw object.
+ *
+ * `--product <expressId|GlobalId>` and `--type <IfcType>` narrow the
+ * `worstHosts` detail list (the ONLY per-product records this contract
+ * carries — a bounded top-N of hosts that recorded a CSG failure; aggregate
+ * counts always describe the whole file, filters only narrow which
+ * per-product rows are shown/printed).
  */
-import { readFile } from 'node:fs/promises';
-import { GeometryProcessor } from '@ifc-lite/geometry';
+import { readFile, writeFile } from 'node:fs/promises';
+import { GeometryProcessor, type GeometryDiagnostics } from '@ifc-lite/geometry';
 import { getFlag, hasFlag, fatal } from '../output.js';
+import { logger } from '../logger.js';
+import { loadIfcFile } from '../loader.js';
 import { formatGeometryReport, NO_DIAGNOSTICS_LINE } from '../geometry-report.js';
+
+type WorstHost = GeometryDiagnostics['worstHosts'][number];
+
+/** True for a bare STEP express ID ("42"), false for a GlobalId ("0YvCT2..."). */
+export function isExpressId(raw: string): boolean {
+  return /^\d+$/.test(raw);
+}
+
+/**
+ * Narrow the bounded `worstHosts` list to a single product and/or IFC type.
+ * Pure so it's directly unit-testable without a wasm/model round-trip.
+ */
+export function filterWorstHosts(
+  hosts: WorstHost[],
+  opts: { productId?: number; ifcType?: string },
+): WorstHost[] {
+  return hosts.filter((h) => {
+    if (opts.productId !== undefined && h.productId !== opts.productId) return false;
+    if (opts.ifcType && h.ifcType !== opts.ifcType) return false;
+    return true;
+  });
+}
 
 export async function diagnoseGeometryCommand(args: string[]): Promise<void> {
   const filePath = args.find((a) => !a.startsWith('-'));
   if (!filePath) {
-    fatal('Usage: ifc-lite diagnose-geometry <file.ifc> [--json] [--out file.json]');
+    fatal(
+      'Usage: ifc-lite diagnose-geometry <file.ifc> [--json] [--out file.json] ' +
+        '[--product <expressId|GlobalId>] [--type <IfcType>]',
+    );
     return;
   }
   const asJson = hasFlag(args, '--json');
   const outPath = getFlag(args, '--out');
+  const productArg = getFlag(args, '--product');
+  const typeArg = getFlag(args, '--type');
 
   const buf = await readFile(filePath);
   const bytes = new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength);
 
   const gp = new GeometryProcessor();
   await gp.init();
-  const diag = gp.diagnoseGeometry(bytes);
+  let diag = gp.diagnoseGeometry(bytes);
+
+  if (diag && (productArg !== undefined || typeArg !== undefined)) {
+    let productId: number | undefined;
+    if (productArg !== undefined) {
+      if (isExpressId(productArg)) {
+        productId = parseInt(productArg, 10);
+      } else {
+        // GlobalId: resolve via the columnar parser's entity table (the wasm
+        // diagnostics pass never surfaces GlobalIds, only express IDs).
+        const store = await loadIfcFile(filePath);
+        const resolved = store.entities.getExpressIdByGlobalId(productArg);
+        if (resolved === -1) {
+          fatal(`--product: no entity found with GlobalId "${productArg}"`);
+          return;
+        }
+        productId = resolved;
+      }
+    }
+    diag = { ...diag, worstHosts: filterWorstHosts(diag.worstHosts, { productId, ifcType: typeArg }) };
+  }
 
   if (asJson || outPath) {
     const json = JSON.stringify(diag ?? null, null, 2);
     if (outPath) {
-      const { writeFile } = await import('node:fs/promises');
       await writeFile(outPath, json);
-      console.log(`Wrote diagnostics to ${outPath}`);
+      logger.info(`Wrote diagnostics to ${outPath}`);
     } else {
-      console.log(json);
+      process.stdout.write(json + '\n');
     }
     return;
   }
 
   if (!diag) {
-    console.log(NO_DIAGNOSTICS_LINE);
+    process.stdout.write(NO_DIAGNOSTICS_LINE + '\n');
     return;
   }
-  console.log(formatGeometryReport(diag));
+  if ((productArg !== undefined || typeArg !== undefined) && diag.worstHosts.length === 0) {
+    process.stdout.write(
+      'No worst-failing host record matches --product/--type ' +
+        '(diagnose-geometry only tracks the bounded top-N hosts that recorded a CSG failure; ' +
+        'a filtered-out product may simply have none).\n',
+    );
+    return;
+  }
+  process.stdout.write(formatGeometryReport(diag) + '\n');
 }

--- a/packages/cli/src/geometry-report.test.ts
+++ b/packages/cli/src/geometry-report.test.ts
@@ -1,0 +1,131 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it, expect } from 'vitest';
+import type { GeometryDiagnostics } from '@ifc-lite/geometry';
+import { formatGeometryReport, NO_DIAGNOSTICS_LINE } from './geometry-report.js';
+
+function makeDiagnostics(partial: Partial<GeometryDiagnostics> = {}): GeometryDiagnostics {
+  return {
+    schemaVersion: 1,
+    totalCsgFailures: 0,
+    productsWithFailures: 0,
+    hostsWithOpenings: 0,
+    classification: { rectangular: 0, diagonal: 0, nonRectangular: 0, total: 0 },
+    failuresByReason: [],
+    silentNoOps: 0,
+    rectFast: {
+      fired: 0, openingsCut: 0, deferHostNotBox: 0, deferNotThrough: 0,
+      deferOffFace: 0, deferNearEdge: 0, deferNoOpenings: 0,
+    },
+    worstHosts: [],
+    ...partial,
+  };
+}
+
+describe('NO_DIAGNOSTICS_LINE', () => {
+  it('is a stable, human-readable sentinel', () => {
+    expect(NO_DIAGNOSTICS_LINE).toMatch(/no.*diagnostics/i);
+  });
+});
+
+describe('formatGeometryReport', () => {
+  it('prints aggregate counts and classification breakdown', () => {
+    const report = formatGeometryReport(makeDiagnostics({
+      totalCsgFailures: 5,
+      productsWithFailures: 2,
+      hostsWithOpenings: 3,
+      classification: { rectangular: 4, diagonal: 1, nonRectangular: 0, total: 5 },
+      silentNoOps: 1,
+    }));
+    expect(report).toContain('CSG failures:        5 across 2 product(s)');
+    expect(report).toContain('Hosts with openings: 3');
+    expect(report).toContain('Openings classified: 5 (rectangular 4, diagonal 1, non-rectangular 0)');
+    expect(report).toContain('Silent rect no-ops:  1');
+  });
+
+  it('lists failures by reason, sorted as given', () => {
+    const report = formatGeometryReport(makeDiagnostics({
+      failuresByReason: [
+        { reason: 'DifferenceEmptiedHost', count: 3 },
+        { reason: 'KernelError', count: 1 },
+      ],
+    }));
+    expect(report).toContain('Failures by reason:');
+    expect(report).toContain('DifferenceEmptiedHost');
+    expect(report).toContain('KernelError');
+  });
+
+  it('omits the failures-by-reason section when empty', () => {
+    const report = formatGeometryReport(makeDiagnostics());
+    expect(report).not.toContain('Failures by reason:');
+  });
+
+  it('always prints the rect_fast summary line', () => {
+    const report = formatGeometryReport(makeDiagnostics({
+      rectFast: {
+        fired: 10, openingsCut: 8, deferHostNotBox: 1, deferNotThrough: 2,
+        deferOffFace: 0, deferNearEdge: 1, deferNoOpenings: 0,
+      },
+    }));
+    expect(report).toContain('rect_fast: fired 10, openings cut 8');
+    expect(report).toContain('host-not-box 1');
+  });
+
+  it('lists worst-failing hosts with productId, ifcType, failures, openings', () => {
+    const report = formatGeometryReport(makeDiagnostics({
+      worstHosts: [
+        { productId: 42, ifcType: 'IfcWall', openings: 2, csgFailures: 3, firstFailureLabel: 'KernelError' },
+      ],
+    }));
+    expect(report).toContain('Worst-failing hosts:');
+    expect(report).toContain('#42 IfcWall: 3 failure(s), 2 opening(s) [KernelError]');
+  });
+
+  it('omits the worst-hosts section when empty', () => {
+    const report = formatGeometryReport(makeDiagnostics());
+    expect(report).not.toContain('Worst-failing hosts:');
+  });
+
+  it('prints bbox and triangle count when present on a worst host', () => {
+    const report = formatGeometryReport(makeDiagnostics({
+      worstHosts: [
+        {
+          productId: 7, ifcType: 'IfcSlab', openings: 1, csgFailures: 1,
+          bbox: { min: [-1, -2, 0], max: [3, 4, 5] },
+          triangleCount: 1280,
+        },
+      ],
+    }));
+    expect(report).toContain('bbox=[-1.00, -2.00, 0.00] – [3.00, 4.00, 5.00]');
+    expect(report).toContain('triangles=1,280');
+  });
+
+  it('does not crash and prints no bbox/triangle line when a host has neither', () => {
+    const report = formatGeometryReport(makeDiagnostics({
+      worstHosts: [{ productId: 9, ifcType: 'IfcDoor', openings: 1, csgFailures: 1 }],
+    }));
+    expect(report).toContain('#9 IfcDoor: 1 failure(s), 1 opening(s)');
+    expect(report).not.toContain('undefined');
+    expect(report).not.toContain('bbox=');
+    expect(report).not.toContain('triangles=');
+  });
+
+  it('prints only the triangle count when bbox is absent (and vice versa)', () => {
+    const triOnly = formatGeometryReport(makeDiagnostics({
+      worstHosts: [{ productId: 1, ifcType: 'IfcWall', openings: 1, csgFailures: 1, triangleCount: 42 }],
+    }));
+    expect(triOnly).toContain('triangles=42');
+    expect(triOnly).not.toContain('bbox=');
+
+    const bboxOnly = formatGeometryReport(makeDiagnostics({
+      worstHosts: [{
+        productId: 2, ifcType: 'IfcWall', openings: 1, csgFailures: 1,
+        bbox: { min: [0, 0, 0], max: [1, 1, 1] },
+      }],
+    }));
+    expect(bboxOnly).toContain('bbox=');
+    expect(bboxOnly).not.toContain('triangles=');
+  });
+});

--- a/packages/cli/src/geometry-report.ts
+++ b/packages/cli/src/geometry-report.ts
@@ -52,8 +52,29 @@ export function formatGeometryReport(d: GeometryDiagnostics): string {
       lines.push(
         `  #${h.productId} ${h.ifcType}: ${h.csgFailures} failure(s), ${h.openings} opening(s)${label}`,
       );
+      const detail = formatHostDetail(h);
+      if (detail) lines.push(`      ${detail}`);
     }
   }
 
   return lines.join('\n');
+}
+
+/**
+ * Render a worst-failing host's optional per-product detail (bbox + triangle
+ * count). Both fields are opt-in — only captured when a void cut ran for that
+ * host (see `HostBbox`/`triangle_count` in the Rust `WorstHost` contract) — so
+ * this returns `undefined` rather than printing "undefined" when neither was
+ * recorded.
+ */
+function formatHostDetail(h: GeometryDiagnostics['worstHosts'][number]): string | undefined {
+  const parts: string[] = [];
+  if (h.bbox) {
+    const fmt = (v: number) => (Number.isFinite(v) ? v.toFixed(2) : String(v));
+    parts.push(`bbox=[${h.bbox.min.map(fmt).join(', ')}] – [${h.bbox.max.map(fmt).join(', ')}]`);
+  }
+  if (h.triangleCount !== undefined) {
+    parts.push(`triangles=${h.triangleCount.toLocaleString()}`);
+  }
+  return parts.length > 0 ? parts.join('  ') : undefined;
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -68,6 +68,7 @@ const HELP = `
     props     <file.ifc> --id <N>                 All properties for a single entity
     export    <file.ifc> --format csv|json|ifc|hbjson  Export data / Honeybee energy model
     diagnose-geometry <file.ifc> [--json]        CSG / opening diagnostics (failures, classification)
+                      [--product ID|GUID] [--type T]  Filter worst-hosts detail to one product/type
     ids       <file.ifc> <rules.ids>              Validate against IDS rules
     bcf       <create|list|add-comment>           Work with BCF collaboration files
     clash     <file.ifc> [--matrix] [--bcf F]      Detect geometric clashes between elements
@@ -114,6 +115,9 @@ const HELP = `
     ifc-lite props model.ifc --id 42
     ifc-lite export model.ifc --format csv --type IfcWall --columns Name,Type,GlobalId
     ifc-lite export model.ifc --format json --type IfcWall,IfcDoor
+    ifc-lite diagnose-geometry model.ifc --json
+    ifc-lite diagnose-geometry model.ifc --type IfcWall
+    ifc-lite diagnose-geometry model.ifc --product 0YvCT2_$X3_xJG3rzD8L_8
     ifc-lite ids model.ifc requirements.ids --json
     ifc-lite bcf create --title "Missing door" --out issue.bcf
     ifc-lite clash model.ifc --matrix --json

--- a/packages/cli/src/loader.ts
+++ b/packages/cli/src/loader.ts
@@ -20,17 +20,33 @@ import { createStreamingViewerAdapter, createStreamingVisibilityAdapter } from '
  */
 export async function loadIfcFile(filePath: string): Promise<IfcDataStore> {
   const buffer = await readFile(filePath);
+  return loadIfcBytes(buffer, filePath);
+}
 
+/**
+ * Parse IFC bytes ALREADY in memory into an IfcDataStore — same validation and
+ * console-capture as {@link loadIfcFile}, but without a disk read. Lets callers
+ * that already hold the file buffer (e.g. `diagnose-geometry`, which read the
+ * bytes once for the geometry pass) resolve GlobalId→expressId without a second
+ * `readFile` of the same file. `label` is only used in error messages.
+ */
+export async function loadIfcBytes(
+  bytes: Uint8Array,
+  label = 'input',
+): Promise<IfcDataStore> {
   // Validate the file is a STEP/IFC file
-  if (buffer.byteLength === 0) {
-    process.stderr.write(`Error: ${filePath} is empty (0 bytes)\n`);
+  if (bytes.byteLength === 0) {
+    process.stderr.write(`Error: ${label} is empty (0 bytes)\n`);
     process.exit(1);
   }
 
-  // Check for STEP file signature ("ISO-10303-21") in the first 256 bytes
-  const headerSnippet = buffer.subarray(0, Math.min(buffer.byteLength, 256)).toString('ascii');
+  // Check for STEP file signature ("ISO-10303-21") in the first 256 bytes.
+  // TextDecoder (not Buffer.toString) so a plain Uint8Array view works too.
+  const headerSnippet = new TextDecoder('latin1').decode(
+    bytes.subarray(0, Math.min(bytes.byteLength, 256)),
+  );
   if (!headerSnippet.includes('ISO-10303-21')) {
-    process.stderr.write(`Error: ${filePath} is not a valid IFC/STEP file\n`);
+    process.stderr.write(`Error: ${label} is not a valid IFC/STEP file\n`);
     process.exit(1);
   }
 
@@ -50,17 +66,18 @@ export async function loadIfcFile(filePath: string): Promise<IfcDataStore> {
     logger.debug(`parser: ${parts.map(String).join(' ')}`);
   };
   try {
-    // Ensure we pass the exact slice — Node Buffers may be views into
-    // a larger pooled ArrayBuffer, so buffer.buffer can include extra bytes.
-    const arrayBuffer = buffer.buffer.slice(
-      buffer.byteOffset,
-      buffer.byteOffset + buffer.byteLength,
+    // Ensure we pass the exact slice — Node Buffers / Uint8Array views may be
+    // windows into a larger pooled ArrayBuffer, so `.buffer` can include extra
+    // bytes.
+    const arrayBuffer = bytes.buffer.slice(
+      bytes.byteOffset,
+      bytes.byteOffset + bytes.byteLength,
     ) as ArrayBuffer;
     const store = await parser.parseColumnar(arrayBuffer, {
       // The structured diagnostic channel, captured directly.
       onDiagnostic: (m: string) => logger.debug(`parser: ${m}`),
     });
-    store.fileSize = buffer.byteLength;
+    store.fileSize = bytes.byteLength;
     return store;
   } finally {
     console.log = origLog;

--- a/packages/geometry/src/diagnostics.test.ts
+++ b/packages/geometry/src/diagnostics.test.ts
@@ -71,6 +71,32 @@ describe('mergeGeometryDiagnostics', () => {
     expect(a.worstHosts[0].csgFailures).toBe(2); // operand a not mutated
   });
 
+  it('keeps the first-captured bbox/triangleCount when folding worstHosts (not summed)', () => {
+    const a = make({
+      worstHosts: [{
+        productId: 5, ifcType: 'IfcWall', openings: 1, csgFailures: 2,
+        bbox: { min: [0, 0, 0], max: [1, 2, 3] }, triangleCount: 120,
+      }],
+    });
+    const b = make({
+      worstHosts: [{
+        productId: 5, ifcType: 'IfcWall', openings: 2, csgFailures: 3,
+        bbox: { min: [9, 9, 9], max: [10, 10, 10] }, triangleCount: 999,
+      }],
+    });
+    const m = mergeGeometryDiagnostics(a, b)!;
+    expect(m.worstHosts[0].bbox).toEqual({ min: [0, 0, 0], max: [1, 2, 3] });
+    expect(m.worstHosts[0].triangleCount).toBe(120);
+  });
+
+  it('leaves bbox/triangleCount undefined when neither operand captured them', () => {
+    const a = make({ worstHosts: [{ productId: 5, ifcType: 'IfcWall', openings: 1, csgFailures: 2 }] });
+    const b = make({ worstHosts: [{ productId: 5, ifcType: 'IfcWall', openings: 1, csgFailures: 1 }] });
+    const m = mergeGeometryDiagnostics(a, b)!;
+    expect(m.worstHosts[0].bbox).toBeUndefined();
+    expect(m.worstHosts[0].triangleCount).toBeUndefined();
+  });
+
   it('concatenates + ranks + caps worstHosts at 16', () => {
     const aHosts = Array.from({ length: 10 }, (_, i) => ({
       productId: i, ifcType: 'IfcWall', openings: 1, csgFailures: i,
@@ -84,5 +110,65 @@ describe('mergeGeometryDiagnostics', () => {
     expect(m.worstHosts[0].csgFailures).toBe(109);
     // every kept entry outranks every dropped one
     expect(Math.min(...m.worstHosts.map((h) => h.csgFailures))).toBeGreaterThan(3);
+  });
+});
+
+describe('the streaming `complete` event payload (geometry.worker.ts:901)', () => {
+  // The worker attaches diagnostics with `...(session.diagnostics ? { diagnostics: session.diagnostics } : {})`
+  // so a clean load (no CSG issues) omits the field entirely rather than sending
+  // an all-zero object — callers must gate on presence (`if (event.diagnostics)`),
+  // not just truthy counts. This test mirrors that exact conditional-spread and
+  // pins the full field shape (including the per-product bbox/triangleCount
+  // detail) without needing a real Worker or a full model load.
+  function buildCompleteEvent(diagnostics: GeometryDiagnostics | null) {
+    return { type: 'complete' as const, totalMeshes: 10, ...(diagnostics ? { diagnostics } : {}) };
+  }
+
+  it('omits `diagnostics` entirely on a clean load', () => {
+    const event = buildCompleteEvent(null);
+    expect(event).not.toHaveProperty('diagnostics');
+  });
+
+  it('attaches the full GeometryDiagnostics contract, including per-product bbox/triangleCount, when populated', () => {
+    const diagnostics = make({
+      totalCsgFailures: 1,
+      productsWithFailures: 1,
+      hostsWithOpenings: 1,
+      classification: { rectangular: 1, diagonal: 0, nonRectangular: 0, total: 1 },
+      worstHosts: [{
+        productId: 42,
+        ifcType: 'IfcWall',
+        openings: 1,
+        csgFailures: 1,
+        firstFailureLabel: 'KernelError',
+        bbox: { min: [0, 0, 0], max: [2, 3, 4] },
+        triangleCount: 256,
+      }],
+    });
+
+    const event = buildCompleteEvent(diagnostics);
+    expect(event).toHaveProperty('diagnostics');
+    const wh = event.diagnostics!.worstHosts[0];
+    expect(wh).toMatchObject({
+      productId: 42,
+      ifcType: 'IfcWall',
+      openings: 1,
+      csgFailures: 1,
+      firstFailureLabel: 'KernelError',
+    });
+    expect(wh.bbox).toEqual({ min: [0, 0, 0], max: [2, 3, 4] });
+    expect(wh.triangleCount).toBe(256);
+    expect(typeof wh.productId).toBe('number');
+    expect(typeof wh.ifcType).toBe('string');
+  });
+
+  it('leaves bbox/triangleCount absent on a worstHosts entry that never captured a cut effect', () => {
+    const diagnostics = make({
+      worstHosts: [{ productId: 7, ifcType: 'IfcSlab', openings: 1, csgFailures: 1 }],
+    });
+    const event = buildCompleteEvent(diagnostics);
+    const wh = event.diagnostics!.worstHosts[0];
+    expect(wh.bbox).toBeUndefined();
+    expect(wh.triangleCount).toBeUndefined();
   });
 });

--- a/packages/geometry/src/diagnostics.ts
+++ b/packages/geometry/src/diagnostics.ts
@@ -64,6 +64,12 @@ export interface GeometryDiagnostics {
     openings: number;
     csgFailures: number;
     firstFailureLabel?: string;
+    /** World-space AABB of the host mesh, when a void cut captured it.
+     *  Mirrors the `{min, max}` shape used by `MeshData.localBounds`. */
+    bbox?: { min: [number, number, number]; max: [number, number, number] };
+    /** Final triangle count of the host's mesh (post-cut when a void
+     *  subtraction ran, otherwise the pre-cut count). */
+    triangleCount?: number;
   }>;
 }
 
@@ -103,6 +109,11 @@ export function mergeGeometryDiagnostics(
       prev.csgFailures += h.csgFailures;
       prev.openings += h.openings;
       prev.firstFailureLabel = prev.firstFailureLabel ?? h.firstFailureLabel;
+      // bbox/triangleCount describe a single physical host's mesh, not a
+      // per-batch tally — keep the first captured value rather than summing
+      // (matches the firstFailureLabel precedent above).
+      prev.bbox = prev.bbox ?? h.bbox;
+      prev.triangleCount = prev.triangleCount ?? h.triangleCount;
     } else {
       hostById.set(h.productId, { ...h });
     }

--- a/rust/geometry/src/router/diagnostics.rs
+++ b/rust/geometry/src/router/diagnostics.rs
@@ -371,6 +371,18 @@ pub struct RectFastSummary {
     pub defer_no_openings: u64,
 }
 
+/// Axis-aligned bounding box of a worst-failing host's mesh, world coords
+/// (post void-subtraction when a cut ran). Mirrors the `{min, max}` shape the
+/// rest of the geometry contract already uses for AABBs (see
+/// `packages/geometry/src/types.ts` `MeshData.localBounds`), so TS consumers
+/// don't need a second bbox convention.
+#[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HostBbox {
+    pub min: [f32; 3],
+    pub max: [f32; 3],
+}
+
 /// One of the worst-failing host elements (bounded top-N, opt-in detail).
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -380,6 +392,16 @@ pub struct WorstHost {
     pub openings: u64,
     pub csg_failures: u64,
     pub first_failure_label: Option<String>,
+    /// World-space AABB of the host mesh, when captured by
+    /// `record_host_cut_effect` (opt-in per-product detail, #C1). `None` when
+    /// no void cut touched this host (e.g. the failure came from a
+    /// non-router CSG path).
+    pub bbox: Option<HostBbox>,
+    /// Final triangle count of the host's mesh: post-cut (`tris_after`) when a
+    /// void subtraction ran, falling back to the pre-cut count
+    /// (`tris_before`) when it didn't (the un-cut host is what actually
+    /// renders in that case). `None` when neither was captured.
+    pub triangle_count: Option<u64>,
 }
 
 /// Compatibility handshake for the [`GeometryDiagnostics`] contract, serialized
@@ -531,6 +553,11 @@ pub fn aggregate_diagnostics(
             openings: hd.openings.len() as u64,
             csg_failures: hd.csg_failure_count as u64,
             first_failure_label: hd.first_failure_label.clone(),
+            bbox: hd.host_bounds.map(|(min, max)| HostBbox {
+                min: [min.0, min.1, min.2],
+                max: [max.0, max.1, max.2],
+            }),
+            triangle_count: hd.tris_after.or(hd.tris_before).map(|t| t as u64),
         })
         .collect();
 
@@ -556,155 +583,4 @@ pub fn aggregate_diagnostics(
 }
 
 #[cfg(test)]
-mod diagnostics_contract_tests {
-    use super::*;
-    use crate::diagnostics::{BoolFailure, BoolFailureReason, BoolOp};
-    use crate::rect_fast::RectFastStats;
-
-    #[test]
-    fn aggregate_empty_is_all_zero() {
-        let d = aggregate_diagnostics(
-            ClassificationStats::default(),
-            &FxHashMap::default(),
-            &FxHashMap::default(),
-            RectFastStats::default(),
-            16,
-        );
-        assert_eq!(d.total_csg_failures, 0);
-        assert_eq!(d.products_with_failures, 0);
-        assert!(d.failures_by_reason.is_empty());
-        assert!(d.worst_hosts.is_empty());
-        assert!(!d.has_issues());
-    }
-
-    #[test]
-    fn aggregate_summarizes_failures_hosts_classification_and_silent_noops() {
-        let mut csg: FxHashMap<u32, Vec<BoolFailure>> = FxHashMap::default();
-        csg.insert(
-            5,
-            vec![BoolFailure::new(BoolOp::Difference, BoolFailureReason::DifferenceEmptiedHost)],
-        );
-        csg.insert(
-            7,
-            vec![
-                BoolFailure::new(BoolOp::Difference, BoolFailureReason::DifferenceEmptiedHost),
-                BoolFailure::new(BoolOp::Difference, BoolFailureReason::KernelOutputInvalid),
-            ],
-        );
-
-        let mut hosts: FxHashMap<u32, HostOpeningDiagnostic> = FxHashMap::default();
-        // A FAILED host (also unchanged tris) — must NOT be counted as a silent
-        // no-op because it recorded an explicit failure.
-        hosts.insert(
-            7,
-            HostOpeningDiagnostic {
-                host_type: "IfcWallStandardCase".into(),
-                csg_failure_count: 2,
-                first_failure_label: Some("DifferenceEmptiedHost".into()),
-                tris_before: Some(120),
-                tris_after: Some(120),
-                rect_boxes_processed: 1,
-                ..Default::default()
-            },
-        );
-        // A TRUE silent no-op host: rect cutters ran, tris unchanged, NO failure.
-        hosts.insert(
-            9,
-            HostOpeningDiagnostic {
-                host_type: "IfcSlab".into(),
-                csg_failure_count: 0,
-                tris_before: Some(50),
-                tris_after: Some(50),
-                rect_boxes_processed: 2,
-                ..Default::default()
-            },
-        );
-
-        let cls = ClassificationStats {
-            rectangular: 3,
-            diagonal: 1,
-            non_rectangular: 0,
-            floor_opening_guard_saved: 0,
-        };
-        let rf = RectFastStats { fired: 2, openings_cut: 4, ..Default::default() };
-
-        let d = aggregate_diagnostics(cls, &csg, &hosts, rf, 16);
-        assert_eq!(d.total_csg_failures, 3);
-        assert_eq!(d.products_with_failures, 2);
-        assert_eq!(d.hosts_with_openings, 2);
-        assert_eq!(d.classification.total, 4);
-        assert_eq!(d.classification.rectangular, 3);
-        // Only host 9 (clean, unchanged tris) counts; host 7 failed, so it is NOT
-        // a silent no-op.
-        assert_eq!(d.silent_no_ops, 1);
-        assert_eq!(d.rect_fast.fired, 2);
-        // Sorted desc by count: DifferenceEmptiedHost=2 then KernelOutputInvalid=1.
-        assert_eq!(d.failures_by_reason[0].reason, "DifferenceEmptiedHost");
-        assert_eq!(d.failures_by_reason[0].count, 2);
-        assert_eq!(d.worst_hosts.len(), 1);
-        assert_eq!(d.worst_hosts[0].product_id, 7);
-        assert_eq!(d.worst_hosts[0].csg_failures, 2);
-        assert!(d.has_issues());
-    }
-
-    #[test]
-    fn serializes_camelcase_keys_matching_the_ts_contract() {
-        // Guard the serde rename_all against drift from the @ifc-lite/geometry
-        // GeometryDiagnostics TS interface. The wasm getter uses the same renames
-        // via serde-wasm-bindgen, so this JSON key set is what crosses to JS.
-        let mut hosts: FxHashMap<u32, HostOpeningDiagnostic> = FxHashMap::default();
-        hosts.insert(
-            7,
-            HostOpeningDiagnostic {
-                host_type: "IfcWall".into(),
-                csg_failure_count: 1,
-                first_failure_label: Some("KernelError".into()),
-                ..Default::default()
-            },
-        );
-        let mut csg: FxHashMap<u32, Vec<BoolFailure>> = FxHashMap::default();
-        csg.insert(7, vec![BoolFailure::new(BoolOp::Difference, BoolFailureReason::KernelOutputInvalid)]);
-        let d = aggregate_diagnostics(
-            ClassificationStats { rectangular: 1, ..Default::default() },
-            &csg,
-            &hosts,
-            RectFastStats::default(),
-            16,
-        );
-        let v = serde_json::to_value(&d).expect("serializes");
-        for key in [
-            "totalCsgFailures",
-            "productsWithFailures",
-            "hostsWithOpenings",
-            "classification",
-            "failuresByReason",
-            "silentNoOps",
-            "rectFast",
-            "worstHosts",
-        ] {
-            assert!(v.get(key).is_some(), "missing top-level key {key}");
-        }
-        assert!(v["classification"].get("nonRectangular").is_some());
-        assert!(v["rectFast"].get("deferHostNotBox").is_some());
-        let wh = &v["worstHosts"][0];
-        for key in ["productId", "ifcType", "openings", "csgFailures", "firstFailureLabel"] {
-            assert!(wh.get(key).is_some(), "missing worstHosts key {key}");
-        }
-        let fr = &v["failuresByReason"][0];
-        assert!(fr.get("reason").is_some() && fr.get("count").is_some());
-    }
-
-    #[test]
-    fn schema_version_round_trips_and_defaults() {
-        let d = GeometryDiagnostics::default();
-        assert_eq!(d.schema_version, GEOMETRY_DIAGNOSTICS_SCHEMA_VERSION);
-        let json = serde_json::to_string(&d).unwrap();
-        assert!(json.contains("\"schemaVersion\":1"), "serialized unconditionally: {json}");
-        let back: GeometryDiagnostics = serde_json::from_str(&json).unwrap();
-        assert_eq!(back.schema_version, GEOMETRY_DIAGNOSTICS_SCHEMA_VERSION);
-        // A pre-versioned producer (field absent) deserializes to 0, distinguishable.
-        let legacy: GeometryDiagnostics =
-            serde_json::from_str(&json.replace("\"schemaVersion\":1,", "")).unwrap();
-        assert_eq!(legacy.schema_version, 0);
-    }
-}
+mod diagnostics_contract_tests;

--- a/rust/geometry/src/router/diagnostics/diagnostics_contract_tests.rs
+++ b/rust/geometry/src/router/diagnostics/diagnostics_contract_tests.rs
@@ -1,0 +1,201 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Split out of `router/diagnostics.rs` (module-size ratchet, #C1): the
+//! `GeometryDiagnostics` contract tests, including the serde camelCase
+//! key-stability guard that pins the JSON shape crossing the wasm boundary.
+
+use super::*;
+use crate::diagnostics::{BoolFailure, BoolFailureReason, BoolOp};
+use crate::rect_fast::RectFastStats;
+
+#[test]
+fn aggregate_empty_is_all_zero() {
+    let d = aggregate_diagnostics(
+        ClassificationStats::default(),
+        &FxHashMap::default(),
+        &FxHashMap::default(),
+        RectFastStats::default(),
+        16,
+    );
+    assert_eq!(d.total_csg_failures, 0);
+    assert_eq!(d.products_with_failures, 0);
+    assert!(d.failures_by_reason.is_empty());
+    assert!(d.worst_hosts.is_empty());
+    assert!(!d.has_issues());
+}
+
+#[test]
+fn aggregate_summarizes_failures_hosts_classification_and_silent_noops() {
+    let mut csg: FxHashMap<u32, Vec<BoolFailure>> = FxHashMap::default();
+    csg.insert(
+        5,
+        vec![BoolFailure::new(BoolOp::Difference, BoolFailureReason::DifferenceEmptiedHost)],
+    );
+    csg.insert(
+        7,
+        vec![
+            BoolFailure::new(BoolOp::Difference, BoolFailureReason::DifferenceEmptiedHost),
+            BoolFailure::new(BoolOp::Difference, BoolFailureReason::KernelOutputInvalid),
+        ],
+    );
+
+    let mut hosts: FxHashMap<u32, HostOpeningDiagnostic> = FxHashMap::default();
+    // A FAILED host (also unchanged tris) — must NOT be counted as a silent
+    // no-op because it recorded an explicit failure.
+    hosts.insert(
+        7,
+        HostOpeningDiagnostic {
+            host_type: "IfcWallStandardCase".into(),
+            csg_failure_count: 2,
+            first_failure_label: Some("DifferenceEmptiedHost".into()),
+            tris_before: Some(120),
+            tris_after: Some(120),
+            rect_boxes_processed: 1,
+            host_bounds: Some(((0.0, 0.0, 0.0), (1.0, 2.0, 3.0))),
+            ..Default::default()
+        },
+    );
+    // A TRUE silent no-op host: rect cutters ran, tris unchanged, NO failure.
+    hosts.insert(
+        9,
+        HostOpeningDiagnostic {
+            host_type: "IfcSlab".into(),
+            csg_failure_count: 0,
+            tris_before: Some(50),
+            tris_after: Some(50),
+            rect_boxes_processed: 2,
+            ..Default::default()
+        },
+    );
+
+    let cls = ClassificationStats {
+        rectangular: 3,
+        diagonal: 1,
+        non_rectangular: 0,
+        floor_opening_guard_saved: 0,
+    };
+    let rf = RectFastStats { fired: 2, openings_cut: 4, ..Default::default() };
+
+    let d = aggregate_diagnostics(cls, &csg, &hosts, rf, 16);
+    assert_eq!(d.total_csg_failures, 3);
+    assert_eq!(d.products_with_failures, 2);
+    assert_eq!(d.hosts_with_openings, 2);
+    assert_eq!(d.classification.total, 4);
+    assert_eq!(d.classification.rectangular, 3);
+    // Only host 9 (clean, unchanged tris) counts; host 7 failed, so it is NOT
+    // a silent no-op.
+    assert_eq!(d.silent_no_ops, 1);
+    assert_eq!(d.rect_fast.fired, 2);
+    // Sorted desc by count: DifferenceEmptiedHost=2 then KernelOutputInvalid=1.
+    assert_eq!(d.failures_by_reason[0].reason, "DifferenceEmptiedHost");
+    assert_eq!(d.failures_by_reason[0].count, 2);
+    assert_eq!(d.worst_hosts.len(), 1);
+    assert_eq!(d.worst_hosts[0].product_id, 7);
+    assert_eq!(d.worst_hosts[0].csg_failures, 2);
+    // bbox/triangle_count (#C1) thread through from the host diagnostic's
+    // captured cut effect (tris_after wins over tris_before when both are set).
+    let bbox = d.worst_hosts[0].bbox.expect("host_bounds captured");
+    assert_eq!(bbox.min, [0.0, 0.0, 0.0]);
+    assert_eq!(bbox.max, [1.0, 2.0, 3.0]);
+    assert_eq!(d.worst_hosts[0].triangle_count, Some(120));
+    assert!(d.has_issues());
+}
+
+#[test]
+fn worst_host_triangle_count_falls_back_to_tris_before_when_no_cut_ran() {
+    // A host that failed before any void cut effect was recorded (tris_after
+    // never set) should still report tris_before — the un-cut mesh is what
+    // actually renders in that case.
+    let mut hosts: FxHashMap<u32, HostOpeningDiagnostic> = FxHashMap::default();
+    hosts.insert(
+        3,
+        HostOpeningDiagnostic {
+            host_type: "IfcSlab".into(),
+            csg_failure_count: 1,
+            first_failure_label: Some("EmptyOperand".into()),
+            tris_before: Some(80),
+            tris_after: None,
+            ..Default::default()
+        },
+    );
+    let mut csg: FxHashMap<u32, Vec<BoolFailure>> = FxHashMap::default();
+    csg.insert(3, vec![BoolFailure::new(BoolOp::Difference, BoolFailureReason::EmptyOperand)]);
+    let d = aggregate_diagnostics(ClassificationStats::default(), &csg, &hosts, RectFastStats::default(), 16);
+    assert_eq!(d.worst_hosts[0].triangle_count, Some(80));
+    assert!(d.worst_hosts[0].bbox.is_none());
+}
+
+#[test]
+fn serializes_camelcase_keys_matching_the_ts_contract() {
+    // Guard the serde rename_all against drift from the @ifc-lite/geometry
+    // GeometryDiagnostics TS interface. The wasm getter uses the same renames
+    // via serde-wasm-bindgen, so this JSON key set is what crosses to JS.
+    let mut hosts: FxHashMap<u32, HostOpeningDiagnostic> = FxHashMap::default();
+    hosts.insert(
+        7,
+        HostOpeningDiagnostic {
+            host_type: "IfcWall".into(),
+            csg_failure_count: 1,
+            first_failure_label: Some("KernelError".into()),
+            tris_before: Some(40),
+            tris_after: Some(36),
+            host_bounds: Some(((-1.0, -1.0, 0.0), (1.0, 1.0, 3.0))),
+            ..Default::default()
+        },
+    );
+    let mut csg: FxHashMap<u32, Vec<BoolFailure>> = FxHashMap::default();
+    csg.insert(7, vec![BoolFailure::new(BoolOp::Difference, BoolFailureReason::KernelOutputInvalid)]);
+    let d = aggregate_diagnostics(
+        ClassificationStats { rectangular: 1, ..Default::default() },
+        &csg,
+        &hosts,
+        RectFastStats::default(),
+        16,
+    );
+    let v = serde_json::to_value(&d).expect("serializes");
+    for key in [
+        "totalCsgFailures",
+        "productsWithFailures",
+        "hostsWithOpenings",
+        "classification",
+        "failuresByReason",
+        "silentNoOps",
+        "rectFast",
+        "worstHosts",
+    ] {
+        assert!(v.get(key).is_some(), "missing top-level key {key}");
+    }
+    assert!(v["classification"].get("nonRectangular").is_some());
+    assert!(v["rectFast"].get("deferHostNotBox").is_some());
+    let wh = &v["worstHosts"][0];
+    for key in [
+        "productId",
+        "ifcType",
+        "openings",
+        "csgFailures",
+        "firstFailureLabel",
+        "bbox",
+        "triangleCount",
+    ] {
+        assert!(wh.get(key).is_some(), "missing worstHosts key {key}");
+    }
+    assert!(wh["bbox"].get("min").is_some() && wh["bbox"].get("max").is_some());
+    let fr = &v["failuresByReason"][0];
+    assert!(fr.get("reason").is_some() && fr.get("count").is_some());
+}
+
+#[test]
+fn schema_version_round_trips_and_defaults() {
+    let d = GeometryDiagnostics::default();
+    assert_eq!(d.schema_version, GEOMETRY_DIAGNOSTICS_SCHEMA_VERSION);
+    let json = serde_json::to_string(&d).unwrap();
+    assert!(json.contains("\"schemaVersion\":1"), "serialized unconditionally: {json}");
+    let back: GeometryDiagnostics = serde_json::from_str(&json).unwrap();
+    assert_eq!(back.schema_version, GEOMETRY_DIAGNOSTICS_SCHEMA_VERSION);
+    // A pre-versioned producer (field absent) deserializes to 0, distinguishable.
+    let legacy: GeometryDiagnostics =
+        serde_json::from_str(&json.replace("\"schemaVersion\":1,", "")).unwrap();
+    assert_eq!(legacy.schema_version, 0);
+}

--- a/rust/geometry/src/router/voids/flap_clip_tests.rs
+++ b/rust/geometry/src/router/voids/flap_clip_tests.rs
@@ -1,0 +1,182 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Void-flap clipping + malformed-cutter recovery tests, plus the world-space
+//! host-bbox diagnostic regression guards (PR #1564 review). Split out of
+//! `voids/mod.rs` to keep that module under its size-ratchet budget, mirroring
+//! the sibling `reveal_tests` module.
+
+use super::*;
+
+fn box_cutter_mesh(half: [f64; 3], garbage: &[[f64; 3]]) -> Mesh {
+    // 8 corners of an axis-aligned box centred at origin + far garbage verts.
+    let mut m = Mesh::new();
+    for sx in [-1.0, 1.0] {
+        for sy in [-1.0, 1.0] {
+            for sz in [-1.0, 1.0] {
+                m.positions.extend_from_slice(&[
+                    (sx * half[0]) as f32,
+                    (sy * half[1]) as f32,
+                    (sz * half[2]) as f32,
+                ]);
+            }
+        }
+    }
+    for g in garbage {
+        m.positions
+            .extend_from_slice(&[g[0] as f32, g[1] as f32, g[2] as f32]);
+    }
+    m
+}
+
+/// A cutter with far garbage "fins" is detected as malformed and its real
+/// opening box is recovered (the fins are excluded).
+#[test]
+fn opening_obb_detects_malformed_and_recovers_box() {
+    let cutter = box_cutter_mesh([1.0, 0.1, 1.2], &[[0.0, 9.0, 0.0], [0.0, -9.0, 0.0]]);
+    let b = opening_obb_if_malformed(&cutter).expect("malformed cutter -> box");
+    let mut half = b.half;
+    half.sort_by(|a, c| a.partial_cmp(c).unwrap());
+    assert!((half[0] - 0.1).abs() < 0.05, "thin half {:?}", b.half);
+    assert!((half[1] - 1.0).abs() < 0.05, "mid half {:?}", b.half);
+    assert!((half[2] - 1.2).abs() < 0.05, "long half {:?}", b.half);
+}
+
+/// A well-formed cutter (no far cluster) is NOT reshaped.
+#[test]
+fn opening_obb_skips_wellformed_cutter() {
+    let cutter = box_cutter_mesh([1.0, 0.1, 1.2], &[]);
+    assert!(opening_obb_if_malformed(&cutter).is_none());
+}
+
+/// A watertight TALL cutter — a roof/gable void authored as a closed prism
+/// reaching far up (here ~900 m) to clip a wall down to the roofline — is a
+/// VALID SOLID, so its far (top) vertices are STRUCTURAL, not garbage. The
+/// closed-manifold gate must spare it: flagging it malformed re-cut every
+/// roof-capped wall as a flat horizontal slab, slicing the gable off (the
+/// #1440 false-positive). `aabb_box` welds to a closed box, mirroring the
+/// `IfcClosedShell` roof cutters that triggered the regression.
+#[test]
+fn watertight_tall_roof_cutter_is_not_flagged_malformed() {
+    let tall = aabb_box([0.6, 0.15, 450.0]);
+    assert!(
+        cutter_is_closed_manifold(&tall),
+        "a closed box prism must read as a valid solid"
+    );
+    assert!(
+        opening_obb_if_malformed(&tall).is_none(),
+        "a watertight tall cutter must never be reshaped as 'malformed'"
+    );
+}
+
+fn signed_volume(m: &Mesh) -> f64 {
+    let v = |i: u32| {
+        let b = i as usize * 3;
+        [m.positions[b] as f64, m.positions[b + 1] as f64, m.positions[b + 2] as f64]
+    };
+    m.indices
+        .chunks_exact(3)
+        .map(|t| {
+            let (a, b, c) = (v(t[0]), v(t[1]), v(t[2]));
+            (a[0] * (b[1] * c[2] - b[2] * c[1]) + a[1] * (b[2] * c[0] - b[0] * c[2])
+                + a[2] * (b[0] * c[1] - b[1] * c[0]))
+                / 6.0
+        })
+        .sum::<f64>()
+        .abs()
+}
+
+/// An axis-aligned box mesh (helper) via the canonical corner order.
+fn aabb_box(half: [f64; 3]) -> Mesh {
+    let axes = [Vector3::x(), Vector3::y(), Vector3::z()];
+    let bx = OpeningBox { center: Vector3::zeros(), axes, half };
+    bx.extended_box_mesh([0.0; 3], 0.0)
+}
+
+/// `recut_malformed_openings` carves a clean through-opening AND preserves
+/// the wall AROUND it — the regression where a plain triangle-drop also
+/// removed the legitimate wall above/below the opening.
+#[test]
+fn recut_carves_opening_and_preserves_wall_around_it() {
+    // Solid wall box: 4 (x) x 0.3 (y) x 3 (z) centred at origin.
+    let mut host = aabb_box([2.0, 0.15, 1.5]);
+    let host_vol = signed_volume(&host);
+    // A 1 x 1 window through it (thin axis y; recut extends it through).
+    let bx = OpeningBox {
+        center: Vector3::zeros(),
+        axes: [Vector3::x(), Vector3::y(), Vector3::z()],
+        half: [0.5, 0.079, 0.5],
+    };
+    recut_malformed_openings(&mut host, std::slice::from_ref(&bx));
+    assert!(!host.is_empty(), "recut emptied the wall");
+    // Wall extent preserved on every face axis (no over-cut of the wall
+    // above/below/beside the opening).
+    let (lo, hi) = host.bounds();
+    assert!((hi.z - 1.5).abs() < 0.02, "wall top removed (z max {})", hi.z);
+    assert!((lo.z + 1.5).abs() < 0.02, "wall bottom removed (z min {})", lo.z);
+    assert!((hi.x - 2.0).abs() < 0.02, "wall side removed (x max {})", hi.x);
+    // The opening prism (~1 x 0.3 x 1 = 0.3 m^3) was actually carved out.
+    let cut_vol = signed_volume(&host);
+    assert!(
+        cut_vol < host_vol - 0.2,
+        "opening not carved (host {host_vol:.3}, cut {cut_vol:.3})"
+    );
+}
+
+/// `world_host_bounds` folds `mesh.origin` back into the local AABB so the
+/// per-host `bbox` diagnostic is WORLD-space (#1474 local-frame-consumer
+/// bug class), not the near-zero local frame the wasm path stores.
+#[test]
+fn world_host_bounds_folds_the_origin_back_in() {
+    let mut host = aabb_box([2.0, 0.15, 1.5]);
+    // Local bounds are centred on zero; a nonzero origin is the wasm default.
+    host.origin = [1000.0, 2000.0, 3000.0];
+    let ((mnx, mny, mnz), (mxx, mxy, mxz)) = world_host_bounds(&host);
+    // world = origin + local extent, not the ±2 / ±0.15 / ±1.5 local box.
+    assert!((mnx - 998.0).abs() < 0.01, "min.x {mnx}");
+    assert!((mxx - 1002.0).abs() < 0.01, "max.x {mxx}");
+    assert!((mny - 1999.85).abs() < 0.01, "min.y {mny}");
+    assert!((mxy - 2000.15).abs() < 0.01, "max.y {mxy}");
+    assert!((mnz - 2998.5).abs() < 0.01, "min.z {mnz}");
+    assert!((mxz - 3001.5).abs() < 0.01, "max.z {mxz}");
+}
+
+/// End-to-end: a host stored in a per-element local frame (nonzero
+/// `mesh.origin`, the wasm default) reports a WORLD-space `bbox` in the
+/// drained per-host diagnostic — NOT the near-zero local box. Regression
+/// guard for the origin being cleared in `apply_void_context` before the
+/// bounds were captured (PR #1564 review).
+#[test]
+fn nonzero_origin_host_records_world_space_bbox() {
+    let router = GeometryRouter::new();
+    let mut host = aabb_box([2.0, 0.15, 1.5]);
+    host.origin = [1000.0, 2000.0, 3000.0];
+
+    // A clean axis-aligned through-cut, expressed in WORLD coords (as real
+    // Rectangular openings are); `apply_void_context` relativises it by the
+    // host origin so it lands on the local box.
+    let o = host.origin;
+    let opening = OpeningType::Rectangular(
+        Point3::new(o[0] - 0.5, o[1] - 0.5, o[2] - 0.5),
+        Point3::new(o[0] + 0.5, o[1] + 0.5, o[2] + 0.5),
+        None,
+    );
+    let ctx = VoidContext {
+        merged_openings: vec![opening.clone()],
+        openings: vec![opening],
+        param: None,
+    };
+
+    let element_id = 4242u32;
+    let _ = router.apply_void_context(host, &ctx, element_id);
+
+    let diags = router.take_host_opening_diagnostics();
+    let hd = diags.get(&element_id).expect("host cut effect recorded");
+    let ((mnx, mny, mnz), (mxx, mxy, mxz)) =
+        hd.host_bounds.expect("host_bounds captured on the cut path");
+    // World coords (~1000/2000/3000), not the local ±2 box centred on zero.
+    assert!(mnx > 900.0 && mxx < 1100.0, "x not world: [{mnx}, {mxx}]");
+    assert!(mny > 1900.0 && mxy < 2100.0, "y not world: [{mny}, {mxy}]");
+    assert!(mnz > 2900.0 && mxz < 3100.0, "z not world: [{mnz}, {mxz}]");
+}

--- a/rust/geometry/src/router/voids/mod.rs
+++ b/rust/geometry/src/router/voids/mod.rs
@@ -442,6 +442,27 @@ fn recut_malformed_openings(result: &mut Mesh, boxes: &[OpeningBox]) {
 /// collapse on the coarse world grid (#1310 review). A world-framed cutter
 /// (`origin == 0` — the native and ≤100-vertex default) reduces to the plain
 /// `position - host_origin` and stays byte-identical.
+/// World-space AABB of a host mesh: its local `bounds()` with `mesh.origin`
+/// folded back in (world = origin + position). Folded in f64 so a
+/// georeferenced host (large origin) keeps as much precision as the f32
+/// diagnostic surface allows, rather than reporting near-zero local coords.
+fn world_host_bounds(mesh: &Mesh) -> ((f32, f32, f32), (f32, f32, f32)) {
+    let o = mesh.origin;
+    let (mn, mx) = mesh.bounds();
+    (
+        (
+            (mn.x as f64 + o[0]) as f32,
+            (mn.y as f64 + o[1]) as f32,
+            (mn.z as f64 + o[2]) as f32,
+        ),
+        (
+            (mx.x as f64 + o[0]) as f32,
+            (mx.y as f64 + o[1]) as f32,
+            (mx.z as f64 + o[2]) as f32,
+        ),
+    )
+}
+
 fn translate_cutter_mesh(mesh: &Mesh, host_origin: [f64; 3]) -> Mesh {
     let o = mesh.origin;
     let mut positions = Vec::with_capacity(mesh.positions.len());
@@ -853,10 +874,22 @@ impl GeometryRouter {
             }
         }
 
+        // WORLD-space host AABB for the per-host diagnostic (`bbox`), captured
+        // HERE — before the local-frame branch below zeroes `mesh.origin` and
+        // before `try_cut_wall_local_frame` rotates the mesh into its own frame.
+        // On the wasm/local-frame default the host is stored relative to a
+        // nonzero `mesh.origin` (world = origin + position), so bounds taken
+        // after the clear would be local/near-zero and misdirect
+        // `diagnose-geometry --product/--type` (the #1474 local-frame-consumer
+        // bug class: every world-space reader must fold `MeshData.origin`). The
+        // origin is folded in f64 so georeferenced hosts report true world
+        // coords, then cast to the f32 diagnostic surface.
+        let host_world_bounds = world_host_bounds(&mesh);
+
         let origin = mesh.origin;
         if origin == [0.0, 0.0, 0.0] && ctx.all_cutters_world_framed() {
             // Legacy/world frame on host AND cutters: no relativization needed.
-            return self.apply_void_context_inner(mesh, ctx, element_id);
+            return self.apply_void_context_inner(mesh, ctx, element_id, host_world_bounds);
         }
         // Work entirely in the host's local frame (origin 0 on every operand).
         // `relativized_by` folds each cutter's OWN origin and subtracts the host
@@ -865,7 +898,8 @@ impl GeometryRouter {
         // openings did not (origin == 0 but cutters are local-framed).
         mesh.origin = [0.0, 0.0, 0.0];
         let local_ctx = ctx.relativized_by(origin);
-        let mut result = self.apply_void_context_inner(mesh, &local_ctx, element_id);
+        let mut result =
+            self.apply_void_context_inner(mesh, &local_ctx, element_id, host_world_bounds);
         result.origin = origin;
         result
     }
@@ -926,6 +960,7 @@ impl GeometryRouter {
         mesh: &Mesh,
         ctx: &VoidContext,
         element_id: u32,
+        host_world_bounds: ((f32, f32, f32), (f32, f32, f32)),
     ) -> Option<Mesh> {
         if ctx.merged_openings.is_empty() {
             return None;
@@ -1022,23 +1057,30 @@ impl GeometryRouter {
             param: None,
         };
 
-        let result_local = self.apply_void_context_inner(host_local, &local_ctx, element_id);
+        // Forward the WORLD host bounds captured before this rotation so the
+        // diagnostic reports world coords, not wall-frame (rotated/centred) ones.
+        let result_local =
+            self.apply_void_context_inner(host_local, &local_ctx, element_id, host_world_bounds);
         Some(mesh_from_frame(&result_local, &axes, center))
     }
 
     // `host_mutated` is set just before an early `break`, so the final write is
     // intentionally never read back; keep the flag for readability of the branch.
     #[allow(unused_assignments)]
-    fn apply_void_context_inner(&self, mesh: Mesh, ctx: &VoidContext, element_id: u32) -> Mesh {
-        // Capture the input triangle count + bounds so the per-host
-        // diagnostic can flag the "cuts attempted but produced no
-        // change" case — the silent-no-op signature when an opening
-        // box doesn't intersect the host mesh.
+    fn apply_void_context_inner(
+        &self,
+        mesh: Mesh,
+        ctx: &VoidContext,
+        element_id: u32,
+        host_bounds_capture: ((f32, f32, f32), (f32, f32, f32)),
+    ) -> Mesh {
+        // Capture the input triangle count so the per-host diagnostic can flag
+        // the "cuts attempted but produced no change" case — the silent-no-op
+        // signature when an opening box doesn't intersect the host mesh. The
+        // WORLD-space host AABB (`host_bounds_capture`) is passed in from
+        // `apply_void_context` (captured before the origin clear / frame
+        // rotation), not recomputed here from the possibly local-framed `mesh`.
         let tris_before = mesh.triangle_count();
-        let host_bounds_capture = {
-            let (mn, mx) = mesh.bounds();
-            ((mn.x, mn.y, mn.z), (mx.x, mx.y, mx.z))
-        };
         if ctx.is_noop() {
             return mesh;
         }
@@ -1049,7 +1091,8 @@ impl GeometryRouter {
         // The world-space tilted cut at large coordinates over-cuts and
         // fragments badly. Scoped to plan-rotated walls; everything else falls
         // through to the world path unchanged.
-        if let Some(cut) = self.try_cut_wall_local_frame(&mesh, ctx, element_id) {
+        if let Some(cut) = self.try_cut_wall_local_frame(&mesh, ctx, element_id, host_bounds_capture)
+        {
             return cut;
         }
 
@@ -1843,121 +1886,4 @@ impl GeometryRouter {
 }
 
 #[cfg(test)]
-mod flap_clip_tests {
-    use super::*;
-
-    fn box_cutter_mesh(half: [f64; 3], garbage: &[[f64; 3]]) -> Mesh {
-        // 8 corners of an axis-aligned box centred at origin + far garbage verts.
-        let mut m = Mesh::new();
-        for sx in [-1.0, 1.0] {
-            for sy in [-1.0, 1.0] {
-                for sz in [-1.0, 1.0] {
-                    m.positions.extend_from_slice(&[
-                        (sx * half[0]) as f32,
-                        (sy * half[1]) as f32,
-                        (sz * half[2]) as f32,
-                    ]);
-                }
-            }
-        }
-        for g in garbage {
-            m.positions
-                .extend_from_slice(&[g[0] as f32, g[1] as f32, g[2] as f32]);
-        }
-        m
-    }
-
-    /// A cutter with far garbage "fins" is detected as malformed and its real
-    /// opening box is recovered (the fins are excluded).
-    #[test]
-    fn opening_obb_detects_malformed_and_recovers_box() {
-        let cutter = box_cutter_mesh([1.0, 0.1, 1.2], &[[0.0, 9.0, 0.0], [0.0, -9.0, 0.0]]);
-        let b = opening_obb_if_malformed(&cutter).expect("malformed cutter -> box");
-        let mut half = b.half;
-        half.sort_by(|a, c| a.partial_cmp(c).unwrap());
-        assert!((half[0] - 0.1).abs() < 0.05, "thin half {:?}", b.half);
-        assert!((half[1] - 1.0).abs() < 0.05, "mid half {:?}", b.half);
-        assert!((half[2] - 1.2).abs() < 0.05, "long half {:?}", b.half);
-    }
-
-    /// A well-formed cutter (no far cluster) is NOT reshaped.
-    #[test]
-    fn opening_obb_skips_wellformed_cutter() {
-        let cutter = box_cutter_mesh([1.0, 0.1, 1.2], &[]);
-        assert!(opening_obb_if_malformed(&cutter).is_none());
-    }
-
-    /// A watertight TALL cutter — a roof/gable void authored as a closed prism
-    /// reaching far up (here ~900 m) to clip a wall down to the roofline — is a
-    /// VALID SOLID, so its far (top) vertices are STRUCTURAL, not garbage. The
-    /// closed-manifold gate must spare it: flagging it malformed re-cut every
-    /// roof-capped wall as a flat horizontal slab, slicing the gable off (the
-    /// #1440 false-positive). `aabb_box` welds to a closed box, mirroring the
-    /// `IfcClosedShell` roof cutters that triggered the regression.
-    #[test]
-    fn watertight_tall_roof_cutter_is_not_flagged_malformed() {
-        let tall = aabb_box([0.6, 0.15, 450.0]);
-        assert!(
-            cutter_is_closed_manifold(&tall),
-            "a closed box prism must read as a valid solid"
-        );
-        assert!(
-            opening_obb_if_malformed(&tall).is_none(),
-            "a watertight tall cutter must never be reshaped as 'malformed'"
-        );
-    }
-
-    fn signed_volume(m: &Mesh) -> f64 {
-        let v = |i: u32| {
-            let b = i as usize * 3;
-            [m.positions[b] as f64, m.positions[b + 1] as f64, m.positions[b + 2] as f64]
-        };
-        m.indices
-            .chunks_exact(3)
-            .map(|t| {
-                let (a, b, c) = (v(t[0]), v(t[1]), v(t[2]));
-                (a[0] * (b[1] * c[2] - b[2] * c[1]) + a[1] * (b[2] * c[0] - b[0] * c[2])
-                    + a[2] * (b[0] * c[1] - b[1] * c[0]))
-                    / 6.0
-            })
-            .sum::<f64>()
-            .abs()
-    }
-
-    /// An axis-aligned box mesh (helper) via the canonical corner order.
-    fn aabb_box(half: [f64; 3]) -> Mesh {
-        let axes = [Vector3::x(), Vector3::y(), Vector3::z()];
-        let bx = OpeningBox { center: Vector3::zeros(), axes, half };
-        bx.extended_box_mesh([0.0; 3], 0.0)
-    }
-
-    /// `recut_malformed_openings` carves a clean through-opening AND preserves
-    /// the wall AROUND it — the regression where a plain triangle-drop also
-    /// removed the legitimate wall above/below the opening.
-    #[test]
-    fn recut_carves_opening_and_preserves_wall_around_it() {
-        // Solid wall box: 4 (x) x 0.3 (y) x 3 (z) centred at origin.
-        let mut host = aabb_box([2.0, 0.15, 1.5]);
-        let host_vol = signed_volume(&host);
-        // A 1 x 1 window through it (thin axis y; recut extends it through).
-        let bx = OpeningBox {
-            center: Vector3::zeros(),
-            axes: [Vector3::x(), Vector3::y(), Vector3::z()],
-            half: [0.5, 0.079, 0.5],
-        };
-        recut_malformed_openings(&mut host, std::slice::from_ref(&bx));
-        assert!(!host.is_empty(), "recut emptied the wall");
-        // Wall extent preserved on every face axis (no over-cut of the wall
-        // above/below/beside the opening).
-        let (lo, hi) = host.bounds();
-        assert!((hi.z - 1.5).abs() < 0.02, "wall top removed (z max {})", hi.z);
-        assert!((lo.z + 1.5).abs() < 0.02, "wall bottom removed (z min {})", lo.z);
-        assert!((hi.x - 2.0).abs() < 0.02, "wall side removed (x max {})", hi.x);
-        // The opening prism (~1 x 0.3 x 1 = 0.3 m^3) was actually carved out.
-        let cut_vol = signed_volume(&host);
-        assert!(
-            cut_vol < host_vol - 0.2,
-            "opening not carved (host {host_vol:.3}, cut {cut_vol:.3})"
-        );
-    }
-}
+mod flap_clip_tests;

--- a/rust/processing/tests/module_size_allowlist.txt
+++ b/rust/processing/tests/module_size_allowlist.txt
@@ -59,7 +59,7 @@
      497 rust/geometry/src/router/voids_2d.rs
      618 rust/geometry/src/router/voids/aabb_clip.rs
      871 rust/geometry/src/router/voids/geom.rs
-    1963 rust/geometry/src/router/voids/mod.rs
+    1889 rust/geometry/src/router/voids/mod.rs
      621 rust/geometry/src/router/voids/probe.rs
     1002 rust/geometry/src/router/voids/synthesis.rs
     1472 rust/geometry/src/space_dcel/mod.rs

--- a/rust/processing/tests/module_size_allowlist.txt
+++ b/rust/processing/tests/module_size_allowlist.txt
@@ -51,7 +51,7 @@
      706 rust/geometry/src/profiles/simplify.rs
      781 rust/geometry/src/rect_fast.rs
      461 rust/geometry/src/router/clipping.rs
-     710 rust/geometry/src/router/diagnostics.rs
+     586 rust/geometry/src/router/diagnostics.rs
      659 rust/geometry/src/router/layers.rs
      572 rust/geometry/src/router/mod.rs
     1072 rust/geometry/src/router/processing.rs


### PR DESCRIPTION
## What changed

**diagnose-geometry filters + per-product detail**
- New `--product <expressId|GlobalId>` and `--type <IfcType>` flags narrow the `worstHosts` detail list to a single product or IFC type. GlobalIds are resolved via the columnar parser's entity table (`EntityTable.getExpressIdByGlobalId`); a GlobalId that doesn't resolve fails closed with a clear error instead of silently matching nothing.
- Each worst-failing host now reports a world-space bounding box (`bbox: {min,max}`) and a final triangle count (`triangleCount`) when a void cut captured them (the data was already computed by `record_host_cut_effect`, just not threaded into the public contract). Both fields are additive/optional and serialize camelCase, matching the existing `MeshData.localBounds` shape convention.
- Surfaced in both `--json` and the human-readable report (`formatGeometryReport`); a host with neither field prints cleanly, no `undefined` leakage.
- A `--product`/`--type` filter matching nothing prints an explanatory message rather than an empty/confusing report — `worstHosts` is a bounded top-N of hosts that *failed*, so a clean product legitimately has no row there.

**--quiet/--verbose**
- Global verbosity (`--quiet`/`--verbose`/`--debug`/`--log-level`) was already wired through a shared `logger` singleton configured once in `index.ts` before dispatch (landed in #1512, prior to this branch's base commit) — 27 of 29 commands already route chatter through it correctly and leave primary payload (JSON/table output) unaffected by `--quiet`, matching the documented "`--quiet` = errors only" contract.
- The actual gap: `diagnose-geometry` was the one command still using a raw `console.log` for everything, including its non-essential "Wrote diagnostics to..." status line. Fixed by routing that line through `logger.info` (now correctly silenced under `--quiet`) and using direct `process.stdout.write` for the JSON/report payload (never suppressed, consistent with `info`/`query`/every other command).
- I deliberately did **not** add a global `console.log`-suppression wrapper around command dispatch. That would have been a regression: it would silence the *primary output* of commands like `info`/`query` under `--quiet` today (verified empirically — `ifc-lite info file.ifc --quiet` currently prints its full table, by design, since `--quiet` only gates diagnostic chatter, not payload). The existing convention (logger for chatter, direct stdout for payload) already solves this correctly across the CLI; `diagnose-geometry` just hadn't been updated to follow it.

## Why

`diagnose-geometry`'s only per-product output (`worstHosts`) had no way to zoom in on one element or type, and carried no size/location detail, making it hard to actually go find the offending geometry in a large model. The `--quiet` gap on this one command meant `--out`-based scripting picked up an extra unsuppressable status line.

## How I tested it

- `pnpm --filter @ifc-lite/cli test` — 139/139 passed (7 files)
- `pnpm --filter @ifc-lite/geometry test` — 120/120 passed (13 files)
- `cargo test -p ifc-lite-geometry -p ifc-lite-processing -p ifc-lite-wasm` — all green, including the new `HostBbox`/`triangle_count` unit tests and the serde camelCase key-stability guard (`serializes_camelcase_keys_matching_the_ts_contract`)
- `pnpm typecheck` (full monorepo, 32 packages) — clean
- `pnpm --filter @ifc-lite/cli build` — clean
- Manual smoke tests against real IFC fixtures (`duplex.ifc`, `advanced_model.ifc`, the committed `apps/viewer/public/samples/*.ifc` demo files):
  - `diagnose-geometry <file> --json` — valid JSON, `worstHosts` present with the new fields when populated
  - `diagnose-geometry <file> --quiet --out <path>` — no stderr/stdout chatter, file payload intact
  - `diagnose-geometry <file> --type IfcWall` / `--product <id>` / `--product <GlobalId>` — filters correctly, resolves GlobalIds, fails closed on an unresolvable GlobalId, prints a sensible message when nothing matches
  - Note: every real fixture available locally (including two ~2-35MB ara3d models) currently produces **zero** CSG failures, so `worstHosts` was empty on all of them — the exact kernel handles them cleanly. The bbox/triangleCount *population* logic is proven by Rust unit tests with synthetic failing hosts (`aggregate_summarizes_failures_hosts_classification_and_silent_noops`, `worst_host_triangle_count_falls_back_to_tris_before_when_no_cut_ran`) plus the serde round-trip test, not by a live failing fixture.

## Risks

- Touches `rust/geometry/src/router/diagnostics.rs`, which crosses the wasm boundary into `packages/geometry`'s public `GeometryDiagnostics` type — both fields are additive/optional, so this is backwards compatible for any consumer still on the old shape.
- Split the inline `#[cfg(test)]` module out of `diagnostics.rs` into `router/diagnostics/diagnostics_contract_tests.rs` to stay under the module-size ratchet budget (`rust/processing/tests/module_size_allowlist.txt`, was 710, now 586 — a net shrink, not just a raise). No behavior change, same module path (`router::diagnostics::diagnostics_contract_tests`).
- `--quiet` fix is scoped to the one command that was inconsistent (`diagnose-geometry`); I did not touch the shared dispatcher (`index.ts`'s `main()`) since it already does the right thing for the other 28 commands — see the "why not a global wrapper" note above.

## Changeset

`.changeset/cli-diagnose-geometry-filters.md` — `@ifc-lite/cli` minor, `@ifc-lite/geometry` minor. `pnpm api-surface:update` was not run: neither change adds/removes/renames a top-level export (only additive optional fields on the existing `GeometryDiagnostics` interface, which `scripts/api-surface.json` tracks at name+kind granularity, not per-field).

🤖 Generated with [Claude Code](https://claude.com/claude-code)