### PR TITLE
fix(viewer): apply meridian convergence to the WebGPU-viewer sun (#1408 follow-up)

### DIFF
--- a/apps/viewer/src/hooks/useSolarEnvironment.ts
+++ b/apps/viewer/src/hooks/useSolarEnvironment.ts
@@ -34,6 +34,9 @@ export interface SolarEnvironmentGeoref {
 interface SiteOrigin {
   latitude: number;
   longitude: number;
+  /** Meridian convergence (radians): needed to place the sun on true north,
+   *  not grid north, in the grid-aligned WebGPU scene (#1408). */
+  gamma: number;
 }
 
 export function useSolarEnvironment(georef: SolarEnvironmentGeoref | null): void {
@@ -64,7 +67,9 @@ export function useSolarEnvironment(georef: SolarEnvironmentGeoref | null): void
           georef?.lengthUnitScale ?? 1,
         );
         if (!cancelled) {
-          setOrigin(resolved ? { latitude: resolved.latitude, longitude: resolved.longitude } : null);
+          setOrigin(resolved
+            ? { latitude: resolved.latitude, longitude: resolved.longitude, gamma: resolved.gamma }
+            : null);
         }
       } catch {
         if (!cancelled) setOrigin(null);
@@ -86,6 +91,7 @@ export function useSolarEnvironment(georef: SolarEnvironmentGeoref | null): void
       enu,
       mapConversion?.xAxisAbscissa ?? 1,
       mapConversion?.xAxisOrdinate ?? 0,
+      origin.gamma,
     ));
 
     // Panel readout — only when CesiumOverlay isn't publishing it.

--- a/apps/viewer/src/lib/geo/cesium-bridge.ts
+++ b/apps/viewer/src/lib/geo/cesium-bridge.ts
@@ -37,6 +37,11 @@ import {
 import { getEffectiveHorizontalScale, resolveMapUnitToMetreScale } from './geo-scale';
 import { shouldPreferOrthometricTerrain } from './cesium-placement';
 import { egm96Undulation } from './egm96-undulation';
+import { viewerToEnuRotation, type ViewerToEnuRotation } from './viewer-enu-rotation';
+
+// Re-exported so existing importers keep resolving it from the bridge; the
+// definition now lives in the dependency-free `viewer-enu-rotation` leaf.
+export { viewerToEnuRotation, type ViewerToEnuRotation } from './viewer-enu-rotation';
 
 export interface GeodesicPosition {
   longitude: number;
@@ -93,6 +98,12 @@ export interface CesiumModelOriginInfo extends GeodesicPosition {
   easting: number;
   northing: number;
   horizontalScale: number;
+  /**
+   * Meridian convergence (radians) at this origin: the angle from grid north
+   * to true north. Computed once here so the camera frame, the model placement
+   * and the WebGPU sun all read the same value. See #1408.
+   */
+  gamma: number;
 }
 
 export async function computeCesiumModelOrigin(
@@ -142,6 +153,7 @@ export async function computeCesiumModelOrigin(
       easting,
       northing,
       horizontalScale,
+      gamma: computeGridConvergence(projDef, easting, northing, lon, lat),
     };
   } catch {
     return null;
@@ -193,46 +205,6 @@ export function computeGridConvergence(
   const north = (lat2 - lat) * mPerDegLat;
   // grid-north's bearing measured from true north is atan2(east, north) = -gamma.
   return Math.atan2(-east, north);
-}
-
-/**
- * In-plane coefficients of the viewer-to-ENU rotation. `vy` maps straight to
- * ENU up, so only the East/North rows depend on (vx, vz).
- */
-export interface ViewerToEnuRotation {
-  eastFromVx: number;
-  eastFromVz: number;
-  northFromVx: number;
-  northFromVz: number;
-}
-
-/**
- * Build the viewer-to-ENU rotation: the Helmert grid alignment (IfcMapConversion
- * XAxisAbscissa/Ordinate, scaled by hScale) composed with the meridian
- * convergence R(gamma) that turns grid axes into the true-north ENU frame
- * Cesium uses (east = R(gamma) applied to the Helmert grid vectors).
- *
- * SINGLE SOURCE OF TRUTH: both the camera frame (`createCesiumBridge`) and the
- * model-placement matrix (`buildModelMatrix`, via `bridge.viewerRotation`)
- * derive their viewer-to-ENU rotation from this one function, so the model and
- * the camera can never disagree on which way is north on the basemap. See #1408.
- */
-export function viewerToEnuRotation(
-  hScale: number,
-  absc: number,
-  ordi: number,
-  gamma: number,
-): ViewerToEnuRotation {
-  const cg = Math.cos(gamma);
-  const sg = Math.sin(gamma);
-  const ce = hScale * absc;
-  const co = hScale * ordi;
-  return {
-    eastFromVx: cg * ce - sg * co,
-    eastFromVz: cg * co + sg * ce,
-    northFromVx: sg * ce + cg * co,
-    northFromVz: sg * co - cg * ce,
-  };
 }
 
 export async function createCesiumBridge(
@@ -292,8 +264,7 @@ export async function createCesiumBridge(
   // (up = vy). The model-placement matrix reuses the very same `rot` via
   // `bridge.viewerRotation` so the two never drift. Viewer-space deltas are
   // already metres, so no lengthUnitScale.
-  const gamma = computeGridConvergence(projDef, origin.easting, origin.northing, originLon, originLat);
-  const rot = viewerToEnuRotation(hScale, absc, ordi, gamma);
+  const rot = viewerToEnuRotation(hScale, absc, ordi, origin.gamma);
   const m00 = rot.eastFromVx;      // east  from vx
   const m01 = 0;                   // east  from vy
   const m02 = rot.eastFromVz;      // east  from vz

--- a/apps/viewer/src/lib/geo/solar-direction.test.ts
+++ b/apps/viewer/src/lib/geo/solar-direction.test.ts
@@ -5,6 +5,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
 import { enuToViewerDirection, sunLightingForAltitude } from './solar-direction.js';
+import { viewerToEnuRotation } from './viewer-enu-rotation.js';
 
 function assertVecClose(actual: number[], expected: number[], eps = 1e-9) {
   for (let i = 0; i < 3; i++) {
@@ -44,6 +45,39 @@ describe('enuToViewerDirection', () => {
   it('returns a unit vector', () => {
     const v = enuToViewerDirection({ e: 3, n: 4, u: 5 }, 0.6, -0.8);
     assert.ok(Math.abs(Math.hypot(...v) - 1) < 1e-9);
+  });
+
+  it('is the EXACT inverse of the full viewer-to-ENU rotation, including gamma (#1408)', () => {
+    const absc = 2 * Math.cos(Math.PI / 6); // 30deg Helmert, unnormalized x2
+    const ordi = 2 * Math.sin(Math.PI / 6);
+    const gamma = 0.135; // ~7.7deg meridian convergence
+
+    // viewer dir -> ENU (bridge rotation, with gamma) -> back to viewer == identity.
+    const rot = viewerToEnuRotation(1, Math.cos(Math.PI / 6), Math.sin(Math.PI / 6), gamma);
+    const n0 = Math.hypot(0.3, 0.2, -0.9);
+    const v = [0.3 / n0, 0.2 / n0, -0.9 / n0];
+    const enu = {
+      e: rot.eastFromVx * v[0] + rot.eastFromVz * v[2],
+      n: rot.northFromVx * v[0] + rot.northFromVz * v[2],
+      u: v[1],
+    };
+    assertVecClose(enuToViewerDirection(enu, absc, ordi, gamma), v);
+  });
+
+  it('omitting gamma equals gamma=0 (backward compatible default)', () => {
+    const enu = { e: 0.3, n: 0.8, u: 0.52 };
+    assertVecClose(enuToViewerDirection(enu, 0.6, 0.8), enuToViewerDirection(enu, 0.6, 0.8, 0));
+  });
+
+  it('gamma rotates the sun by the convergence vs the grid-only mapping', () => {
+    const gamma = 0.135;
+    const enu = { e: 0.5, n: 0.5, u: Math.SQRT1_2 }; // e,n > 0 so no atan2 wrap
+    const grid = enuToViewerDirection(enu, 1, 0, 0);
+    const withGamma = enuToViewerDirection(enu, 1, 0, gamma);
+    // Horizontal bearing from grid north (viewer -Z), +east = atan2(vx, -vz).
+    const bearing = (w: number[]) => Math.atan2(w[0], -w[2]);
+    assert.ok(Math.abs((bearing(withGamma) - bearing(grid)) - gamma) < 1e-9,
+      `expected the sun bearing to shift by exactly gamma (${gamma})`);
   });
 });
 

--- a/apps/viewer/src/lib/geo/solar-direction.ts
+++ b/apps/viewer/src/lib/geo/solar-direction.ts
@@ -7,49 +7,45 @@
  * viewer's world space, and shape the sun's photometric properties from its
  * altitude (warm low sun, twilight fade, night).
  *
- * Frame math: the inverse of the Helmert grid alignment (IfcMapConversion
- * XAxisAbscissa/Ordinate):
+ * Frame math: the exact inverse of the bridge's viewer-to-ENU rotation
+ * (`viewerToEnuRotation`): the Helmert grid alignment (IfcMapConversion
+ * XAxisAbscissa/Ordinate) composed with the meridian convergence R(gamma).
+ * That rotation is orthonormal, so the ENU-to-viewer inverse is its transpose:
  *
- *   east  = absc·vx + ordi·vz
- *   north = ordi·vx − absc·vz
- *   up    = vy
- *
- * With (absc, ordi) normalized that matrix is orthonormal, so the inverse is
- * the transpose:
- *
- *   vx = absc·e + ordi·n
+ *   vx = eastFromVx*e + northFromVx*n
  *   vy = u
- *   vz = ordi·e − absc·n
+ *   vz = eastFromVz*e + northFromVz*n
  *
- * Sanity check at no rotation (absc=1, ordi=0): east→+X, up→+Y, north→−Z.
- *
- * NOTE: this is the GRID-only inverse; it does NOT include the meridian
- * convergence R(gamma) that `cesium-bridge.ts` (viewerToEnuRotation) folds into
- * the camera and model placement. So on high-convergence CRSs the WebGPU-viewer
- * sun azimuth is off true north by ~gamma. The Cesium sun (cesium-sun.ts) is
- * unaffected: it drives the sun through true-ENU (eastNorthUpToFixedFrame).
- * Threading gamma here is a tracked follow-up.
+ * Sanity check at no rotation (absc=1, ordi=0, gamma=0): east->+X, up->+Y,
+ * north->-Z. Passing gamma keeps the WebGPU sun consistent with the model
+ * placement and the Cesium sun (which drives the sun through true-ENU);
+ * omitting it left the sun off true north by ~gamma on high-convergence CRSs.
+ * See #1408.
  */
 
 import type { Enu } from '@ifc-lite/solar';
+import { viewerToEnuRotation } from './viewer-enu-rotation';
 
 /**
- * Convert an ENU unit direction to viewer/world space (Y-up) using the
- * model's IfcMapConversion XAxisAbscissa/Ordinate rotation. Defaults match
- * IFC's "no rotation" convention (cos=1, sin=0).
+ * Convert an ENU unit direction to viewer/world space (Y-up) using the inverse
+ * of the model's viewer-to-ENU rotation: the IfcMapConversion XAxisAbscissa/
+ * Ordinate grid alignment plus the meridian convergence `gamma`. Defaults match
+ * IFC's "no rotation" convention (cos=1, sin=0) with zero convergence.
  */
 export function enuToViewerDirection(
   enu: Enu,
   xAxisAbscissa = 1,
   xAxisOrdinate = 0,
+  gamma = 0,
 ): [number, number, number] {
-  // The IFC pair may be unnormalized direction cosines — normalize first.
+  // The IFC pair may be unnormalized direction cosines; normalize so the
+  // rotation is orthonormal and its transpose is the exact inverse.
   const len = Math.hypot(xAxisAbscissa, xAxisOrdinate) || 1;
-  const a = xAxisAbscissa / len;
-  const o = xAxisOrdinate / len;
-  const vx = a * enu.e + o * enu.n;
+  const rot = viewerToEnuRotation(1, xAxisAbscissa / len, xAxisOrdinate / len, gamma);
+  // ENU -> viewer is the transpose of the viewer -> ENU rotation.
+  const vx = rot.eastFromVx * enu.e + rot.northFromVx * enu.n;
   const vy = enu.u;
-  const vz = o * enu.e - a * enu.n;
+  const vz = rot.eastFromVz * enu.e + rot.northFromVz * enu.n;
   const vlen = Math.hypot(vx, vy, vz) || 1;
   return [vx / vlen, vy / vlen, vz / vlen];
 }

--- a/apps/viewer/src/lib/geo/viewer-enu-rotation.ts
+++ b/apps/viewer/src/lib/geo/viewer-enu-rotation.ts
@@ -1,0 +1,51 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The viewer-to-ENU rotation shared by everything that has to agree on which
+ * way is north on the basemap: the Cesium camera frame, the 3D model
+ * placement, and the WebGPU-viewer sun. Kept as a zero-dependency leaf so both
+ * `cesium-bridge.ts` (heavyweight, pulls proj4/terrain/...) and the lightweight
+ * `solar-direction.ts` can reuse it without coupling. See #1408 / #1557.
+ */
+
+/**
+ * In-plane coefficients of the viewer-to-ENU rotation. `vy` maps straight to
+ * ENU up, so only the East/North rows depend on (vx, vz).
+ */
+export interface ViewerToEnuRotation {
+  eastFromVx: number;
+  eastFromVz: number;
+  northFromVx: number;
+  northFromVz: number;
+}
+
+/**
+ * Build the viewer-to-ENU rotation: the Helmert grid alignment (IfcMapConversion
+ * XAxisAbscissa/Ordinate, scaled by hScale) composed with the meridian
+ * convergence R(gamma) that turns grid axes into the true-north ENU frame
+ * Cesium uses (east = R(gamma) applied to the Helmert grid vectors).
+ *
+ * SINGLE SOURCE OF TRUTH: the camera frame (`createCesiumBridge`), the model
+ * placement (`buildModelMatrix`, via `bridge.viewerRotation`) and the WebGPU
+ * sun (`enuToViewerDirection`, which transposes it) all derive their rotation
+ * from this one function, so they can never disagree on north. See #1408.
+ */
+export function viewerToEnuRotation(
+  hScale: number,
+  absc: number,
+  ordi: number,
+  gamma: number,
+): ViewerToEnuRotation {
+  const cg = Math.cos(gamma);
+  const sg = Math.sin(gamma);
+  const ce = hScale * absc;
+  const co = hScale * ordi;
+  return {
+    eastFromVx: cg * ce - sg * co,
+    eastFromVz: cg * co + sg * ce,
+    northFromVx: sg * ce + cg * co,
+    northFromVz: sg * co - cg * ce,
+  };
+}


### PR DESCRIPTION
## Summary

Third and final #1408 follow-up (after #1554 camera/view and #1557 model placement): the WebGPU-viewer sun ignored the meridian convergence, so on high-convergence CRSs its shadows were rotated off true north.

## The bug

The Cesium bridge places the model with the grid-to-true-north convergence gamma (#1408, #1557) and the Cesium sun runs through true-ENU. But the WebGPU-viewer sun mapped the true-north ENU sun into viewer space with a **grid-only** inverse (`enuToViewerDirection`, no gamma), so the WebGPU sun/shadows were rotated off true north by ~gamma (up to ~8 deg for Krovak, sub-degree for RD).

Empirically confirmed: the grid-only mapping fails to round-trip through the bridge rotation (err ~0.135 ~ 7.75 deg); a true-azimuth-135 sun was placed at 135 deg but should be 142.75 deg (= 135 + gamma). The with-gamma version round-trips exactly.

## Fix (DRY)

- `enuToViewerDirection` is now the exact inverse (transpose) of the shared viewer-to-ENU rotation, reusing `viewerToEnuRotation` with gamma. Backward-compatible at gamma=0.
- gamma is computed **once** in `computeCesiumModelOrigin`, so the camera frame, model placement and sun all read one value; threaded through `useSolarEnvironment`.
- Extracted `viewerToEnuRotation` into a dependency-free leaf module (`viewer-enu-rotation.ts`) so `solar-direction` (a lightweight leaf feeding the hot render path) no longer reaches into the heavy `cesium-bridge`. Re-exported from the bridge for back-compat.

Sign is correct by construction (exact inverse of the #1557-verified forward rotation) and pinned by tests.

## Tests

Round-trip through the shared rotation with gamma, a gamma-shifts-bearing-by-gamma assertion, and a gamma-default backward-compat check. Full geo suite green (110/110); viewer typecheck clean.

## Result

All three render paths (Cesium camera, Cesium/WebGPU model, WebGPU sun) now agree on north for georeferenced models, completing the #1408 convergence work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)