### PR TITLE
refactor: return Result from server main() + tighten parquet_bos panic paths

### DIFF
--- a/apps/server/src/main.rs
+++ b/apps/server/src/main.rs
@@ -22,6 +22,7 @@
 //! - `GET /api/v1/parse/symbolic/:cache_key` - 2D symbol stream (IfcAnnotation + IfcGrid) as JSON
 //! - `GET /api/v1/cache/:key` - Retrieve cached result
 
+use anyhow::Context;
 use axum::http::{header, HeaderValue, Method};
 use axum::{
     extract::DefaultBodyLimit,
@@ -172,7 +173,7 @@ fn build_router(state: AppState) -> Router {
 }
 
 #[tokio::main]
-async fn main() {
+async fn main() -> anyhow::Result<()> {
     // Initialize logging
     tracing_subscriber::fmt()
         .with_env_filter(
@@ -263,6 +264,11 @@ async fn main() {
     let addr = SocketAddr::from(([0, 0, 0, 0], config.port));
     tracing::info!("Listening on http://{}", addr);
 
-    let listener = tokio::net::TcpListener::bind(addr).await.unwrap();
-    axum::serve(listener, app).await.unwrap();
+    let listener = tokio::net::TcpListener::bind(addr)
+        .await
+        .with_context(|| format!("failed to bind to {addr}"))?;
+    axum::serve(listener, app)
+        .await
+        .context("server exited with an error")?;
+    Ok(())
 }

--- a/rust/export/src/error.rs
+++ b/rust/export/src/error.rs
@@ -27,6 +27,18 @@ pub enum ExportError {
         /// oversize; see [`crate::GlbSizeProjection::total_bytes`]).
         bytes: u64,
     },
+    /// A downstream encoder (Arrow/Parquet columnar writer, ZIP container, or
+    /// JSON serializer) rejected the data it was handed. This is an I/O/library
+    /// failure rather than a business-logic outcome — replaces panicking
+    /// `.unwrap()`/`.expect()` calls on writer/serializer results so a malformed
+    /// or resource-exhausted encode returns an error instead of unwinding the
+    /// whole export (see the `parquet_bos` exporter).
+    Serialization {
+        /// What was being serialized/written (e.g. "entities batch", "zip write_all").
+        stage: &'static str,
+        /// The underlying error's `Display` output.
+        detail: String,
+    },
 }
 
 impl ExportError {
@@ -36,6 +48,7 @@ impl ExportError {
         match self {
             ExportError::NoRenderGeometry => "NO_RENDER_GEOMETRY",
             ExportError::TooLarge { .. } => "TOO_LARGE",
+            ExportError::Serialization { .. } => "SERIALIZATION_FAILED",
         }
     }
 }
@@ -54,6 +67,9 @@ impl fmt::Display for ExportError {
                  export as a multi-buffer glTF instead",
                 self.code()
             ),
+            ExportError::Serialization { stage, detail } => {
+                write!(f, "{}: failed to serialize {stage}: {detail}", self.code())
+            }
         }
     }
 }

--- a/rust/export/src/parquet_bos.rs
+++ b/rust/export/src/parquet_bos.rs
@@ -19,7 +19,14 @@ use zip::CompressionMethod;
 
 use ifc_lite_processing::process_geometry;
 
+use crate::error::ExportError;
 use crate::model::{build_export_model, fmt_num, ExportModel};
+
+/// Wrap a downstream encoder error (Arrow/Parquet/zip/serde_json) as
+/// [`ExportError::Serialization`], tagged with the stage that failed.
+fn ser_err<E: std::fmt::Display>(stage: &'static str) -> impl FnOnce(E) -> ExportError {
+    move |e| ExportError::Serialization { stage, detail: e.to_string() }
+}
 
 /// Options for BOS export.
 pub struct ParquetBosOptions {
@@ -38,18 +45,18 @@ fn str_col(vals: Vec<Option<String>>) -> ArrayRef {
 }
 
 /// Serialize one RecordBatch to Parquet bytes.
-fn to_parquet(batch: &RecordBatch) -> Vec<u8> {
+fn to_parquet(batch: &RecordBatch) -> Result<Vec<u8>, ExportError> {
     let mut buf: Vec<u8> = Vec::new();
     {
         let mut writer = ArrowWriter::try_new(&mut buf, batch.schema(), None)
-            .expect("arrow writer");
-        writer.write(batch).expect("write parquet batch");
-        writer.close().expect("close parquet");
+            .map_err(ser_err("arrow writer"))?;
+        writer.write(batch).map_err(ser_err("write parquet batch"))?;
+        writer.close().map_err(ser_err("close parquet"))?;
     }
-    buf
+    Ok(buf)
 }
 
-fn entities_table(model: &ExportModel) -> Vec<u8> {
+fn entities_table(model: &ExportModel) -> Result<Vec<u8>, ExportError> {
     let n = model.entities.len();
     let mut express = Vec::with_capacity(n);
     let mut global = Vec::with_capacity(n);
@@ -76,11 +83,11 @@ fn entities_table(model: &ExportModel) -> Vec<u8> {
         ("ObjectType", str_col(otype)),
         ("HasGeometry", Arc::new(BooleanArray::from(has_geom)) as ArrayRef),
     ])
-    .expect("entities batch");
+    .map_err(ser_err("entities batch"))?;
     to_parquet(&batch)
 }
 
-fn properties_table(model: &ExportModel) -> Vec<u8> {
+fn properties_table(model: &ExportModel) -> Result<Vec<u8>, ExportError> {
     let mut entity = Vec::new();
     let mut pset = Vec::new();
     let mut prop = Vec::new();
@@ -104,11 +111,11 @@ fn properties_table(model: &ExportModel) -> Vec<u8> {
         ("PropType", str_col(ptype)),
         ("ValueString", str_col(value)),
     ])
-    .expect("properties batch");
+    .map_err(ser_err("properties batch"))?;
     to_parquet(&batch)
 }
 
-fn quantities_table(model: &ExportModel) -> Vec<u8> {
+fn quantities_table(model: &ExportModel) -> Result<Vec<u8>, ExportError> {
     let mut entity = Vec::new();
     let mut qset = Vec::new();
     let mut qname = Vec::new();
@@ -132,12 +139,15 @@ fn quantities_table(model: &ExportModel) -> Vec<u8> {
         ("QuantityType", str_col(qtype)),
         ("Value", str_col(value)),
     ])
-    .expect("quantities batch");
+    .map_err(ser_err("quantities batch"))?;
     to_parquet(&batch)
 }
 
-/// Returns (vertex_table, index_table, mesh_table, vertex_count, triangle_count).
-fn geometry_tables(content: &[u8]) -> (Vec<u8>, Vec<u8>, Vec<u8>, usize, usize) {
+/// (vertex_table, index_table, mesh_table, vertex_count, triangle_count) parquet bytes.
+type GeometryTables = (Vec<u8>, Vec<u8>, Vec<u8>, usize, usize);
+
+/// Returns the geometry parquet tables plus vertex/triangle totals.
+fn geometry_tables(content: &[u8]) -> Result<GeometryTables, ExportError> {
     let result = process_geometry(content);
 
     let mut x = Vec::new();
@@ -198,14 +208,14 @@ fn geometry_tables(content: &[u8]) -> (Vec<u8>, Vec<u8>, Vec<u8>, usize, usize) 
         ("NormalY", Arc::new(Float32Array::from(ny)) as ArrayRef),
         ("NormalZ", Arc::new(Float32Array::from(nz)) as ArrayRef),
     ])
-    .expect("vertex batch");
+    .map_err(ser_err("vertex batch"))?;
 
     let ibatch = RecordBatch::try_from_iter(vec![
         ("Index0", Arc::new(UInt32Array::from(i0)) as ArrayRef),
         ("Index1", Arc::new(UInt32Array::from(i1)) as ArrayRef),
         ("Index2", Arc::new(UInt32Array::from(i2)) as ArrayRef),
     ])
-    .expect("index batch");
+    .map_err(ser_err("index batch"))?;
 
     let mbatch = RecordBatch::try_from_iter(vec![
         ("ExpressId", Arc::new(UInt32Array::from(mesh_express)) as ArrayRef),
@@ -214,34 +224,48 @@ fn geometry_tables(content: &[u8]) -> (Vec<u8>, Vec<u8>, Vec<u8>, usize, usize) 
         ("IndexStart", Arc::new(UInt32Array::from(istart)) as ArrayRef),
         ("IndexCount", Arc::new(UInt32Array::from(icount)) as ArrayRef),
     ])
-    .expect("mesh batch");
+    .map_err(ser_err("mesh batch"))?;
 
-    (to_parquet(&vbatch), to_parquet(&ibatch), to_parquet(&mbatch), vcount_total, tricount_total)
+    Ok((
+        to_parquet(&vbatch)?,
+        to_parquet(&ibatch)?,
+        to_parquet(&mbatch)?,
+        vcount_total,
+        tricount_total,
+    ))
 }
 
 /// Export the model + geometry as a `.bos` archive (ZIP of Parquet tables).
-pub fn export_bos(content: &[u8], opts: &ParquetBosOptions) -> Vec<u8> {
+///
+/// Returns [`ExportError::Serialization`] if any downstream encoder (Arrow
+/// writer, Parquet writer, zip container, or the metadata JSON serializer)
+/// rejects the data — no encoder failure here panics the caller.
+pub fn export_bos(content: &[u8], opts: &ParquetBosOptions) -> Result<Vec<u8>, ExportError> {
     let model = build_export_model(content);
 
     let cursor = std::io::Cursor::new(Vec::new());
     let mut zip = zip::ZipWriter::new(cursor);
     let file_opts = SimpleFileOptions::default().compression_method(CompressionMethod::Deflated);
 
-    let mut add = |zip: &mut zip::ZipWriter<std::io::Cursor<Vec<u8>>>, name: &str, bytes: &[u8]| {
-        zip.start_file(name, file_opts).expect("zip start_file");
-        zip.write_all(bytes).expect("zip write");
+    let add = |zip: &mut zip::ZipWriter<std::io::Cursor<Vec<u8>>>,
+               name: &str,
+               bytes: &[u8]|
+     -> Result<(), ExportError> {
+        zip.start_file(name, file_opts).map_err(ser_err("zip start_file"))?;
+        zip.write_all(bytes).map_err(ser_err("zip write"))?;
+        Ok(())
     };
 
-    add(&mut zip, "Entities.parquet", &entities_table(&model));
-    add(&mut zip, "Properties.parquet", &properties_table(&model));
-    add(&mut zip, "Quantities.parquet", &quantities_table(&model));
+    add(&mut zip, "Entities.parquet", &entities_table(&model)?)?;
+    add(&mut zip, "Properties.parquet", &properties_table(&model)?)?;
+    add(&mut zip, "Quantities.parquet", &quantities_table(&model)?)?;
 
     let (mut vcount, mut tricount) = (0usize, 0usize);
     if opts.include_geometry {
-        let (vb, ib, mb, vc, tc) = geometry_tables(content);
-        add(&mut zip, "VertexBuffer.parquet", &vb);
-        add(&mut zip, "IndexBuffer.parquet", &ib);
-        add(&mut zip, "Meshes.parquet", &mb);
+        let (vb, ib, mb, vc, tc) = geometry_tables(content)?;
+        add(&mut zip, "VertexBuffer.parquet", &vb)?;
+        add(&mut zip, "IndexBuffer.parquet", &ib)?;
+        add(&mut zip, "Meshes.parquet", &mb)?;
         vcount = vc;
         tricount = tc;
     }
@@ -258,9 +282,11 @@ pub fn export_bos(content: &[u8], opts: &ParquetBosOptions) -> Vec<u8> {
             json!(["Entities", "Properties", "Quantities"])
         },
     });
-    add(&mut zip, "Metadata.json", serde_json::to_string_pretty(&meta).unwrap().as_bytes());
+    let meta_bytes = serde_json::to_string_pretty(&meta).map_err(ser_err("metadata json"))?;
+    add(&mut zip, "Metadata.json", meta_bytes.as_bytes())?;
 
-    zip.finish().expect("zip finish").into_inner()
+    let zipped = zip.finish().map_err(ser_err("zip finish"))?;
+    Ok(zipped.into_inner())
 }
 
 #[cfg(test)]
@@ -275,7 +301,8 @@ mod tests {
 
     #[test]
     fn duplex_exports_valid_bos() {
-        let bos = export_bos(&fixture("ara3d/duplex.ifc"), &ParquetBosOptions::default());
+        let bos = export_bos(&fixture("ara3d/duplex.ifc"), &ParquetBosOptions::default())
+            .expect("bos export");
         assert!(bos.len() > 1000, "non-trivial archive");
 
         // Re-open the zip and verify the expected tables + parquet magic.


### PR DESCRIPTION
## What

Panic discipline in two pieces of boundary code (C3.3). No behavior change on the happy path; failure paths now surface a clear error instead of a panic backtrace.

### 1. `apps/server/src/main.rs`
`async fn main()` now returns `anyhow::Result<()>`. The two bind-path calls become `?` with `anyhow::Context`:
- `TcpListener::bind(addr)` -> `.with_context(|| format!("failed to bind to {addr}"))?`
- `axum::serve(...)` -> `.context("server exited with an error")?`

A bind failure (port already in use, missing permission) now exits with a readable message and a nonzero code rather than a `.unwrap()` panic. `anyhow` was already a dependency of `apps/server`. All other startup behavior is identical.

### 2. `rust/export/src/parquet_bos.rs`
The production `.expect()`/`.unwrap()` calls on the Arrow writer, Parquet writer, zip container, and the metadata JSON serializer now propagate errors. A new typed variant carries the failing stage:

```rust
ExportError::Serialization { stage: &'static str, detail: String }  // code: "SERIALIZATION_FAILED"
```

`export_bos` and the private table helpers now return `Result<_, ExportError>`. No silent swallowing (no `let _ =`, no empty match arms). The `duplex_exports_valid_bos` test unwraps the new `Result`.

## Public signature change (contained)
`export_bos` changed from `-> Vec<u8>` to `-> Result<Vec<u8>, ExportError>`. It has **zero external callers** — a repo-wide grep finds only the `lib.rs` re-export (behind the `parquet-bos` feature, off in the wasm/default build) and the in-crate test. It does not surface through any published npm package (`@ifc-lite/export`/`@ifc-lite/wasm` build with default features, which exclude `parquet-bos`), so **no changeset** is required.

## Out of scope
`rust/wasm-bindings/src/api/mod.rs` poison-lock recovery is intentionally left to the in-flight C4 PR to avoid a conflict.

## Verify
- `cargo build -p ifc-lite-server` — binary builds, `main` returning `Result` compiles
- `cargo test -p ifc-lite-server` — 40 passed
- `cargo test -p ifc-lite-export --features parquet-bos` — 75 passed
- `cargo check --workspace` (and `--all-features`) — clean
- `cargo clippy -p ifc-lite-server --all-targets -- -D warnings` — clean
- `cargo clippy -p ifc-lite-export --all-features --all-targets -- -D warnings` — clean
- `cargo test -p ifc-lite-processing --test module_size_ratchet` — 4 passed