### PR TITLE
perf(brep): hoist the CartesianPoint cache across a worker's parts + per-part instrumentation

### DIFF
--- a/rust/core/src/decoder.rs
+++ b/rust/core/src/decoder.rs
@@ -52,6 +52,14 @@ pub struct EntityDecoder<'a> {
     /// Cache of cartesian point coordinates for FacetedBrep optimization
     /// Only populated when using get_polyloop_coords_cached
     point_cache: FxHashMap<u32, (f64, f64, f64)>,
+    /// Number of `point_cache` hits served by [`Self::get_polyloop_coords_cached`].
+    /// Pure instrumentation (never affects output); read via
+    /// [`Self::point_cache_stats`] to prove cross-element memoization fires when
+    /// the cache is hoisted across a worker's parts.
+    point_cache_hits: u64,
+    /// Number of `point_cache` misses (a CartesianPoint parsed for the first time)
+    /// served by [`Self::get_polyloop_coords_cached`].
+    point_cache_misses: u64,
     /// Lazy-cached multiplier converting file plane-angle units to radians.
     /// Populated on first call to [`Self::plane_angle_to_radians`]. Spec
     /// default (and Renga-style files) is 1.0 (RADIAN); degree-unit files
@@ -76,6 +84,8 @@ impl<'a> EntityDecoder<'a> {
             cache: FxHashMap::default(),
             entity_index: None,
             point_cache: FxHashMap::default(),
+            point_cache_hits: 0,
+            point_cache_misses: 0,
             plane_angle_to_radians_cache: None,
             length_unit_scale_cache: None,
         }
@@ -92,6 +102,8 @@ impl<'a> EntityDecoder<'a> {
             cache: FxHashMap::default(),
             entity_index: Some(Arc::new(index)),
             point_cache: FxHashMap::default(),
+            point_cache_hits: 0,
+            point_cache_misses: 0,
             plane_angle_to_radians_cache: None,
             length_unit_scale_cache: None,
         }
@@ -108,6 +120,8 @@ impl<'a> EntityDecoder<'a> {
             cache: FxHashMap::default(),
             entity_index: Some(index),
             point_cache: FxHashMap::default(),
+            point_cache_hits: 0,
+            point_cache_misses: 0,
             plane_angle_to_radians_cache: None,
             length_unit_scale_cache: None,
         }
@@ -425,6 +439,31 @@ impl<'a> EntityDecoder<'a> {
     /// The entity cache is preserved for subsequent geometry processing.
     pub fn clear_point_cache(&mut self) {
         self.point_cache.clear();
+    }
+
+    /// Move the CartesianPoint coordinate cache OUT of this decoder, leaving it
+    /// empty. Paired with [`Self::set_point_cache`] to hoist the cache across the
+    /// per-element decoders a single worker builds within one batch: the cache is
+    /// pure memoization of `content` + point id -> coords, so reusing it across
+    /// elements is byte-identical (speed only). Cheap: moves the map header, not
+    /// its contents.
+    pub fn take_point_cache(&mut self) -> FxHashMap<u32, (f64, f64, f64)> {
+        std::mem::take(&mut self.point_cache)
+    }
+
+    /// Install a previously-accumulated point cache (see [`Self::take_point_cache`]).
+    /// Does not reset the hit/miss counters, which stay per-decoder so each job's
+    /// [`Self::point_cache_stats`] reflect only that job's activity.
+    pub fn set_point_cache(&mut self, cache: FxHashMap<u32, (f64, f64, f64)>) {
+        self.point_cache = cache;
+    }
+
+    /// `(hits, misses)` served by [`Self::get_polyloop_coords_cached`] over this
+    /// decoder's lifetime. A hit is a CartesianPoint served from the cache; a miss
+    /// is one parsed for the first time. Non-zero hits after processing more than
+    /// one faceted part with a shared point list prove cross-element memoization.
+    pub fn point_cache_stats(&self) -> (u64, u64) {
+        (self.point_cache_hits, self.point_cache_misses)
     }
 
     /// Get cache size
@@ -923,6 +962,7 @@ impl<'a> EntityDecoder<'a> {
 
                     // Check cache first
                     if let Some(&coord) = self.point_cache.get(&point_id) {
+                        self.point_cache_hits += 1;
                         coords.push(coord);
                     } else {
                         // Not in cache - parse and cache
@@ -930,6 +970,7 @@ impl<'a> EntityDecoder<'a> {
                             if let Some(coord) =
                                 parse_cartesian_point_inline(&bytes_full[pt_start..pt_end])
                             {
+                                self.point_cache_misses += 1;
                                 self.point_cache.insert(point_id, coord);
                                 coords.push(coord);
                             }
@@ -1043,151 +1084,4 @@ fn parse_next_float(bytes: &[u8], offset: &mut usize) -> Option<f64> {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::IfcType;
-
-    #[test]
-    fn test_decode_entity() {
-        let content = r#"
-#1=IFCPROJECT('2vqT3bvqj9RBFjLlXpN8n9',$,$,$,$,$,$,$,$);
-#2=IFCWALL('3a4T3bvqj9RBFjLlXpN8n0',$,$,$,'Wall-001',$,#3,#4);
-#3=IFCLOCALPLACEMENT($,#4);
-#4=IFCAXIS2PLACEMENT3D(#5,$,$);
-#5=IFCCARTESIANPOINT((0.,0.,0.));
-"#;
-
-        let mut decoder = EntityDecoder::new(content);
-
-        // Find entity #2
-        let start = content.find("#2=").unwrap();
-        let end = content[start..].find(';').unwrap() + start + 1;
-
-        let entity = decoder.decode_at(start, end).unwrap();
-        assert_eq!(entity.id, 2);
-        assert_eq!(entity.ifc_type, IfcType::IfcWall);
-        assert_eq!(entity.attributes.len(), 8);
-        assert_eq!(entity.get_string(4), Some("Wall-001"));
-        assert_eq!(entity.get_ref(6), Some(3));
-        assert_eq!(entity.get_ref(7), Some(4));
-    }
-
-    #[test]
-    fn test_decode_by_id() {
-        let content = r#"
-#1=IFCPROJECT('guid',$,$,$,$,$,$,$,$);
-#5=IFCWALL('guid2',$,$,$,'Wall-001',$,$,$);
-#10=IFCDOOR('guid3',$,$,$,'Door-001',$,$,$);
-"#;
-
-        let mut decoder = EntityDecoder::new(content);
-
-        let entity = decoder.decode_by_id(5).unwrap();
-        assert_eq!(entity.id, 5);
-        assert_eq!(entity.ifc_type, IfcType::IfcWall);
-        assert_eq!(entity.get_string(4), Some("Wall-001"));
-
-        // Should be cached now
-        assert_eq!(decoder.cache_size(), 1);
-        let cached = decoder.get_cached(5).unwrap();
-        assert_eq!(cached.id, 5);
-    }
-
-    #[test]
-    fn test_build_entity_index_matches_scanner_header_semantics() {
-        let content = "ISO-10303-21;\nHEADER;\n\
-FILE_DESCRIPTION(('ViewDefinition [ReferenceView]'),'2;1');\n\
-FILE_NAME('26-IFC\\X2\\00B1\\X0\\2#.ifc','2026-04-29T18:21:27',$,$,'CATIA','CATIA',$);\n\
-FILE_SCHEMA(('IFC4'));\nENDSEC;\n\
-DATA;\n\
-#1=IFCPROJECT('guid',$,$,$,$,$,$,$,$);\n\
-#2=IFCWALL('guid2',$,$,$,'Wall; with semicolon',$,$,$);\n\
-ENDSEC;\nEND-ISO-10303-21;\n";
-
-        let index = build_entity_index(content);
-
-        assert_eq!(index.len(), 2);
-        assert!(!index.contains_key(&26));
-        let (start, end) = index.get(&2).copied().unwrap();
-        assert_eq!(
-            &content[start..end],
-            "#2=IFCWALL('guid2',$,$,$,'Wall; with semicolon',$,$,$);"
-        );
-    }
-
-    #[test]
-    fn test_decode_by_id_handles_quoted_semicolon_from_shared_index() {
-        let content = "#1=IFCWALL('guid',$,$,$,'Wall; with semicolon',$,$,$);\n";
-        let mut decoder = EntityDecoder::new(content);
-
-        let wall = decoder.decode_by_id(1).unwrap();
-
-        assert_eq!(wall.id, 1);
-        assert_eq!(wall.ifc_type, IfcType::IfcWall);
-        assert_eq!(wall.get_string(4), Some("Wall; with semicolon"));
-    }
-
-    #[test]
-    fn test_resolve_ref() {
-        let content = r#"
-#1=IFCPROJECT('guid',$,$,$,$,$,$,$,$);
-#2=IFCWALL('guid2',$,$,$,$,$,#1,$);
-"#;
-
-        let mut decoder = EntityDecoder::new(content);
-
-        let wall = decoder.decode_by_id(2).unwrap();
-        let placement_attr = wall.get(6).unwrap();
-
-        let referenced = decoder.resolve_ref(placement_attr).unwrap().unwrap();
-        assert_eq!(referenced.id, 1);
-        assert_eq!(referenced.ifc_type, IfcType::IfcProject);
-    }
-
-    #[test]
-    fn test_resolve_ref_list() {
-        let content = r#"
-#1=IFCPROJECT('guid',$,$,$,$,$,$,$,$);
-#2=IFCWALL('guid1',$,$,$,$,$,$,$);
-#3=IFCDOOR('guid2',$,$,$,$,$,$,$);
-#4=IFCRELCONTAINEDINSPATIALSTRUCTURE('guid3',$,$,$,(#2,#3),$,#1);
-"#;
-
-        let mut decoder = EntityDecoder::new(content);
-
-        let rel = decoder.decode_by_id(4).unwrap();
-        let elements_attr = rel.get(4).unwrap();
-
-        let elements = decoder.resolve_ref_list(elements_attr).unwrap();
-        assert_eq!(elements.len(), 2);
-        assert_eq!(elements[0].id, 2);
-        assert_eq!(elements[0].ifc_type, IfcType::IfcWall);
-        assert_eq!(elements[1].id, 3);
-        assert_eq!(elements[1].ifc_type, IfcType::IfcDoor);
-    }
-
-    #[test]
-    fn test_cache() {
-        let content = r#"
-#1=IFCPROJECT('guid',$,$,$,$,$,$,$,$);
-#2=IFCWALL('guid2',$,$,$,$,$,$,$);
-"#;
-
-        let mut decoder = EntityDecoder::new(content);
-
-        assert_eq!(decoder.cache_size(), 0);
-
-        decoder.decode_by_id(1).unwrap();
-        assert_eq!(decoder.cache_size(), 1);
-
-        decoder.decode_by_id(2).unwrap();
-        assert_eq!(decoder.cache_size(), 2);
-
-        // Decode same entity - should use cache
-        decoder.decode_by_id(1).unwrap();
-        assert_eq!(decoder.cache_size(), 2);
-
-        decoder.clear_cache();
-        assert_eq!(decoder.cache_size(), 0);
-    }
-}
+mod decoder_tests;

--- a/rust/core/src/decoder/decoder_tests.rs
+++ b/rust/core/src/decoder/decoder_tests.rs
@@ -220,3 +220,54 @@ fn point_cache_survives_take_and_set_across_decoders() {
     // The donor decoder gave its cache away.
     assert!(warm.take_point_cache().is_empty());
 }
+
+/// Regression guard for the hoist's decode-error path (see
+/// `processor::jobs::WorkerCacheGuard`). When a worker's element hits a
+/// `decode_at` failure, its decoder must NOT lose the warm cache: `take_point_cache`
+/// after the failed decode still yields the accumulated entries, so the worker's
+/// NEXT element adopts them and serves its shared loop from cache hits. Before the
+/// RAII guard, the failing element early-returned and dropped the warm cache,
+/// cold-starting the rest of the worker's sub-range and silently defeating the hoist.
+#[test]
+fn point_cache_survives_a_failed_decode_between_elements() {
+    let content = "\
+#10=IFCCARTESIANPOINT((0.,0.,0.));
+#11=IFCCARTESIANPOINT((1.,0.,0.));
+#12=IFCCARTESIANPOINT((1.,1.,0.));
+#20=IFCPOLYLOOP((#10,#11,#12));
+#21=IFCPOLYLOOP((#10,#11,#12));
+";
+    // Element 1 warms the worker's cache.
+    let mut warm = EntityDecoder::new(content);
+    warm.get_polyloop_coords_cached(20).expect("warm loop resolves");
+    assert_eq!(warm.point_cache_stats(), (0, 3));
+    let carried = warm.take_point_cache();
+
+    // Element 2's decoder adopts the warm cache, then hits a decode FAILURE
+    // (out-of-range span -> Err, not a panic). This is the case the guard exists
+    // for: on Drop it takes the point cache back instead of losing it.
+    let mut failing = EntityDecoder::new(content);
+    failing.set_point_cache(carried);
+    assert!(
+        failing.decode_at(10_000, 10_010).is_err(),
+        "out-of-range decode should fail without clearing the cache"
+    );
+    let recovered = failing.take_point_cache();
+    assert_eq!(
+        recovered.len(),
+        3,
+        "a failed decode must not drop the worker's warm point cache"
+    );
+
+    // Element 3 in the same worker adopts the recovered cache: every shared point
+    // is a hit, none re-parsed - proving the failure did not cold-start the chunk.
+    let mut next = EntityDecoder::new(content);
+    next.set_point_cache(recovered);
+    next.get_polyloop_coords_cached(21).expect("next loop resolves");
+    let (hits, misses) = next.point_cache_stats();
+    assert!(
+        hits > 0,
+        "expected warm-cache hits after a failed decode, got {hits}"
+    );
+    assert_eq!((hits, misses), (3, 0));
+}

--- a/rust/core/src/decoder/decoder_tests.rs
+++ b/rust/core/src/decoder/decoder_tests.rs
@@ -1,0 +1,222 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Unit tests for [`super::EntityDecoder`]. Extracted from `decoder.rs` into
+//! this ratchet-exempt `*_tests.rs` sibling (child module, keeps `super::*`
+//! access) so the production module stays under its module-size budget.
+
+use super::*;
+use crate::IfcType;
+
+#[test]
+fn test_decode_entity() {
+    let content = r#"
+#1=IFCPROJECT('2vqT3bvqj9RBFjLlXpN8n9',$,$,$,$,$,$,$,$);
+#2=IFCWALL('3a4T3bvqj9RBFjLlXpN8n0',$,$,$,'Wall-001',$,#3,#4);
+#3=IFCLOCALPLACEMENT($,#4);
+#4=IFCAXIS2PLACEMENT3D(#5,$,$);
+#5=IFCCARTESIANPOINT((0.,0.,0.));
+"#;
+
+    let mut decoder = EntityDecoder::new(content);
+
+    // Find entity #2
+    let start = content.find("#2=").unwrap();
+    let end = content[start..].find(';').unwrap() + start + 1;
+
+    let entity = decoder.decode_at(start, end).unwrap();
+    assert_eq!(entity.id, 2);
+    assert_eq!(entity.ifc_type, IfcType::IfcWall);
+    assert_eq!(entity.attributes.len(), 8);
+    assert_eq!(entity.get_string(4), Some("Wall-001"));
+    assert_eq!(entity.get_ref(6), Some(3));
+    assert_eq!(entity.get_ref(7), Some(4));
+}
+
+#[test]
+fn test_decode_by_id() {
+    let content = r#"
+#1=IFCPROJECT('guid',$,$,$,$,$,$,$,$);
+#5=IFCWALL('guid2',$,$,$,'Wall-001',$,$,$);
+#10=IFCDOOR('guid3',$,$,$,'Door-001',$,$,$);
+"#;
+
+    let mut decoder = EntityDecoder::new(content);
+
+    let entity = decoder.decode_by_id(5).unwrap();
+    assert_eq!(entity.id, 5);
+    assert_eq!(entity.ifc_type, IfcType::IfcWall);
+    assert_eq!(entity.get_string(4), Some("Wall-001"));
+
+    // Should be cached now
+    assert_eq!(decoder.cache_size(), 1);
+    let cached = decoder.get_cached(5).unwrap();
+    assert_eq!(cached.id, 5);
+}
+
+#[test]
+fn test_build_entity_index_matches_scanner_header_semantics() {
+    let content = "ISO-10303-21;\nHEADER;\n\
+FILE_DESCRIPTION(('ViewDefinition [ReferenceView]'),'2;1');\n\
+FILE_NAME('26-IFC\\X2\\00B1\\X0\\2#.ifc','2026-04-29T18:21:27',$,$,'CATIA','CATIA',$);\n\
+FILE_SCHEMA(('IFC4'));\nENDSEC;\n\
+DATA;\n\
+#1=IFCPROJECT('guid',$,$,$,$,$,$,$,$);\n\
+#2=IFCWALL('guid2',$,$,$,'Wall; with semicolon',$,$,$);\n\
+ENDSEC;\nEND-ISO-10303-21;\n";
+
+    let index = build_entity_index(content);
+
+    assert_eq!(index.len(), 2);
+    assert!(!index.contains_key(&26));
+    let (start, end) = index.get(&2).copied().unwrap();
+    assert_eq!(
+        &content[start..end],
+        "#2=IFCWALL('guid2',$,$,$,'Wall; with semicolon',$,$,$);"
+    );
+}
+
+#[test]
+fn test_decode_by_id_handles_quoted_semicolon_from_shared_index() {
+    let content = "#1=IFCWALL('guid',$,$,$,'Wall; with semicolon',$,$,$);\n";
+    let mut decoder = EntityDecoder::new(content);
+
+    let wall = decoder.decode_by_id(1).unwrap();
+
+    assert_eq!(wall.id, 1);
+    assert_eq!(wall.ifc_type, IfcType::IfcWall);
+    assert_eq!(wall.get_string(4), Some("Wall; with semicolon"));
+}
+
+#[test]
+fn test_resolve_ref() {
+    let content = r#"
+#1=IFCPROJECT('guid',$,$,$,$,$,$,$,$);
+#2=IFCWALL('guid2',$,$,$,$,$,#1,$);
+"#;
+
+    let mut decoder = EntityDecoder::new(content);
+
+    let wall = decoder.decode_by_id(2).unwrap();
+    let placement_attr = wall.get(6).unwrap();
+
+    let referenced = decoder.resolve_ref(placement_attr).unwrap().unwrap();
+    assert_eq!(referenced.id, 1);
+    assert_eq!(referenced.ifc_type, IfcType::IfcProject);
+}
+
+#[test]
+fn test_resolve_ref_list() {
+    let content = r#"
+#1=IFCPROJECT('guid',$,$,$,$,$,$,$,$);
+#2=IFCWALL('guid1',$,$,$,$,$,$,$);
+#3=IFCDOOR('guid2',$,$,$,$,$,$,$);
+#4=IFCRELCONTAINEDINSPATIALSTRUCTURE('guid3',$,$,$,(#2,#3),$,#1);
+"#;
+
+    let mut decoder = EntityDecoder::new(content);
+
+    let rel = decoder.decode_by_id(4).unwrap();
+    let elements_attr = rel.get(4).unwrap();
+
+    let elements = decoder.resolve_ref_list(elements_attr).unwrap();
+    assert_eq!(elements.len(), 2);
+    assert_eq!(elements[0].id, 2);
+    assert_eq!(elements[0].ifc_type, IfcType::IfcWall);
+    assert_eq!(elements[1].id, 3);
+    assert_eq!(elements[1].ifc_type, IfcType::IfcDoor);
+}
+
+#[test]
+fn test_cache() {
+    let content = r#"
+#1=IFCPROJECT('guid',$,$,$,$,$,$,$,$);
+#2=IFCWALL('guid2',$,$,$,$,$,$,$);
+"#;
+
+    let mut decoder = EntityDecoder::new(content);
+
+    assert_eq!(decoder.cache_size(), 0);
+
+    decoder.decode_by_id(1).unwrap();
+    assert_eq!(decoder.cache_size(), 1);
+
+    decoder.decode_by_id(2).unwrap();
+    assert_eq!(decoder.cache_size(), 2);
+
+    // Decode same entity - should use cache
+    decoder.decode_by_id(1).unwrap();
+    assert_eq!(decoder.cache_size(), 2);
+
+    decoder.clear_cache();
+    assert_eq!(decoder.cache_size(), 0);
+}
+
+/// Two IfcPolyLoops that reference a SHARED set of CartesianPoints: extracting
+/// the second loop must be served entirely from the point cache the first loop
+/// populated, so `point_cache_stats().hits` is non-zero. This is the decoder-level
+/// proof of the memoization the per-worker hoist relies on; the coordinates
+/// returned are identical whether or not the cache was warm.
+#[test]
+fn polyloop_point_cache_memoizes_shared_points() {
+    // Both #20 and #21 share the same four CartesianPoints (#10..#13).
+    let content = "\
+#10=IFCCARTESIANPOINT((0.,0.,0.));
+#11=IFCCARTESIANPOINT((1.,0.,0.));
+#12=IFCCARTESIANPOINT((1.,1.,0.));
+#13=IFCCARTESIANPOINT((0.,1.,0.));
+#20=IFCPOLYLOOP((#10,#11,#12,#13));
+#21=IFCPOLYLOOP((#10,#11,#12,#13));
+";
+    let mut decoder = EntityDecoder::new(content);
+
+    let first = decoder.get_polyloop_coords_cached(20).expect("first loop resolves");
+    let (hits_after_first, misses_after_first) = decoder.point_cache_stats();
+    // First loop parses every point fresh: four misses, zero hits.
+    assert_eq!(hits_after_first, 0);
+    assert_eq!(misses_after_first, 4);
+
+    let second = decoder.get_polyloop_coords_cached(21).expect("second loop resolves");
+    let (hits, misses) = decoder.point_cache_stats();
+    // Second loop reuses the four cached points: four more hits, no new misses.
+    assert!(hits > 0, "expected point-cache hits across loops, got {hits}");
+    assert_eq!(hits, 4);
+    assert_eq!(misses, 4);
+
+    // Memoization changes speed, not results: identical coordinates both times.
+    assert_eq!(first, second);
+    assert_eq!(
+        first,
+        vec![(0., 0., 0.), (1., 0., 0.), (1., 1., 0.), (0., 1., 0.)]
+    );
+}
+
+/// `take_point_cache` / `set_point_cache` move the warm cache between decoders
+/// (the hoist primitive): a second decoder that adopts the first's cache serves
+/// the same shared loop entirely from cache hits, without re-parsing any point.
+#[test]
+fn point_cache_survives_take_and_set_across_decoders() {
+    let content = "\
+#10=IFCCARTESIANPOINT((0.,0.,0.));
+#11=IFCCARTESIANPOINT((1.,0.,0.));
+#12=IFCCARTESIANPOINT((1.,1.,0.));
+#20=IFCPOLYLOOP((#10,#11,#12));
+#21=IFCPOLYLOOP((#10,#11,#12));
+";
+    let mut warm = EntityDecoder::new(content);
+    let a = warm.get_polyloop_coords_cached(20).expect("warm loop resolves");
+    assert_eq!(warm.point_cache_stats(), (0, 3));
+
+    // Hand the warm cache to a FRESH decoder (its own counters start at 0).
+    let mut adopter = EntityDecoder::new(content);
+    adopter.set_point_cache(warm.take_point_cache());
+    let b = adopter.get_polyloop_coords_cached(21).expect("adopter loop resolves");
+    let (hits, misses) = adopter.point_cache_stats();
+    assert_eq!(hits, 3, "adopted cache should serve every point as a hit");
+    assert_eq!(misses, 0);
+    assert_eq!(a, b);
+
+    // The donor decoder gave its cache away.
+    assert!(warm.take_point_cache().is_empty());
+}

--- a/rust/processing/src/pipeline_diagnostics.rs
+++ b/rust/processing/src/pipeline_diagnostics.rs
@@ -97,6 +97,16 @@ pub struct PipelineDiagnostics {
     pub silent_no_ops: u64,
     /// rect_fast fast-path engagement, summed across batches.
     pub rect_fast: RectFastSummary,
+    /// CartesianPoints served from the point cache while meshing faceted breps,
+    /// summed across batches. Non-zero proves cross-element point memoization
+    /// fired (the per-worker cache hoist). `hits / (hits + misses)` is the rate.
+    pub point_cache_hits: u64,
+    /// CartesianPoints parsed fresh (point-cache misses) across the faceted-brep
+    /// pass, summed across batches.
+    pub point_cache_misses: u64,
+    /// Wall time (ms) attributed to faceted-brep part meshing, summed across
+    /// batches. Populated only in `observability` native builds; 0 on wasm.
+    pub faceted_brep_ms: u64,
     /// Phase wall-times (native: full; wasm: geometry only).
     pub phase_ms: PipelinePhaseTimings,
 }
@@ -115,6 +125,9 @@ impl Default for PipelineDiagnostics {
             hosts_with_openings: 0,
             silent_no_ops: 0,
             rect_fast: RectFastSummary::default(),
+            point_cache_hits: 0,
+            point_cache_misses: 0,
+            faceted_brep_ms: 0,
             phase_ms: PipelinePhaseTimings::default(),
         }
     }
@@ -133,6 +146,9 @@ impl PipelineDiagnostics {
         mesh_count: u64,
         triangle_count: u64,
         backstop_count: u64,
+        point_cache_hits: u64,
+        point_cache_misses: u64,
+        faceted_brep_ms: u64,
         geometry_ms: u64,
         diag: &GeometryDiagnostics,
     ) {
@@ -141,6 +157,9 @@ impl PipelineDiagnostics {
         self.mesh_count += mesh_count;
         self.triangle_count += triangle_count;
         self.backstop_count += backstop_count;
+        self.point_cache_hits += point_cache_hits;
+        self.point_cache_misses += point_cache_misses;
+        self.faceted_brep_ms += faceted_brep_ms;
         self.total_csg_failures += diag.total_csg_failures;
         self.products_with_failures += diag.products_with_failures;
         self.hosts_with_openings += diag.hosts_with_openings;
@@ -179,6 +198,9 @@ impl PipelineDiagnostics {
             hosts_with_openings,
             silent_no_ops,
             rect_fast,
+            point_cache_hits: stats.point_cache_hits,
+            point_cache_misses: stats.point_cache_misses,
+            faceted_brep_ms: stats.faceted_brep_time_ms,
             phase_ms: PipelinePhaseTimings {
                 entity_scan_ms: stats.entity_scan_time_ms,
                 lookup_ms: stats.lookup_time_ms,
@@ -208,7 +230,7 @@ mod tests {
         // this JSON key set is what crosses to JS. Mirrors the
         // GeometryDiagnostics contract test in the geometry crate.
         let mut d = PipelineDiagnostics::default();
-        d.record_batch(10, 12, 3000, 2, 42, &GeometryDiagnostics::default());
+        d.record_batch(10, 12, 3000, 2, 40, 8, 5, 42, &GeometryDiagnostics::default());
         let v = serde_json::to_value(&d).expect("serializes");
         for key in [
             "schemaVersion",
@@ -222,6 +244,9 @@ mod tests {
             "hostsWithOpenings",
             "silentNoOps",
             "rectFast",
+            "pointCacheHits",
+            "pointCacheMisses",
+            "facetedBrepMs",
             "phaseMs",
         ] {
             assert!(v.get(key).is_some(), "missing top-level key {key}");
@@ -249,8 +274,8 @@ mod tests {
             hosts_with_openings: 3,
             ..Default::default()
         };
-        d.record_batch(10, 12, 3000, 1, 40, &diag);
-        d.record_batch(5, 6, 1500, 0, 10, &GeometryDiagnostics::default());
+        d.record_batch(10, 12, 3000, 1, 30, 4, 3, 40, &diag);
+        d.record_batch(5, 6, 1500, 0, 12, 1, 2, 10, &GeometryDiagnostics::default());
         assert!(!d.is_empty());
         assert_eq!(d.batches, 2);
         assert_eq!(d.element_count, 15);
@@ -259,6 +284,9 @@ mod tests {
         assert_eq!(d.backstop_count, 1);
         assert_eq!(d.total_csg_failures, 2);
         assert_eq!(d.hosts_with_openings, 3);
+        assert_eq!(d.point_cache_hits, 42);
+        assert_eq!(d.point_cache_misses, 5);
+        assert_eq!(d.faceted_brep_ms, 5);
         assert_eq!(d.phase_ms.geometry_ms, 50);
     }
 
@@ -276,6 +304,9 @@ mod tests {
             degenerate_triangles_dropped: 4,
             total_csg_failures: 1,
             products_with_failures: 1,
+            point_cache_hits: 128,
+            point_cache_misses: 32,
+            faceted_brep_time_ms: 9,
             ..Default::default()
         };
         let d = PipelineDiagnostics::from_processing_stats(&stats, 20);
@@ -283,6 +314,9 @@ mod tests {
         assert_eq!(d.element_count, 20);
         assert_eq!(d.mesh_count, 7);
         assert_eq!(d.backstop_count, 4);
+        assert_eq!(d.point_cache_hits, 128);
+        assert_eq!(d.point_cache_misses, 32);
+        assert_eq!(d.faceted_brep_ms, 9);
         assert_eq!(d.phase_ms.parse_ms, 11);
         assert_eq!(d.phase_ms.entity_scan_ms, 5);
         assert_eq!(d.phase_ms.lookup_ms, 2);

--- a/rust/processing/src/processor/jobs.rs
+++ b/rust/processing/src/processor/jobs.rs
@@ -12,6 +12,37 @@
 
 use super::*;
 
+/// RAII guard that returns a worker's warm CartesianPoint cache to its slot on
+/// EVERY exit path — the normal return, the `decode_at` error early-return, and
+/// a panic. Without it, a decode failure would drop `local_decoder` (holding the
+/// worker's whole accumulated cache) before the write-back, cold-starting every
+/// remaining element in that worker's sub-range and silently defeating the hoist.
+/// `Deref`/`DerefMut` expose the wrapped decoder so call sites are unchanged.
+struct WorkerCacheGuard<'c, 's> {
+    decoder: EntityDecoder<'c>,
+    slot: &'s mut FxHashMap<u32, (f64, f64, f64)>,
+}
+
+impl Drop for WorkerCacheGuard<'_, '_> {
+    fn drop(&mut self) {
+        // Cheap: moves the map header (now warmer), not its entries.
+        *self.slot = self.decoder.take_point_cache();
+    }
+}
+
+impl<'c> std::ops::Deref for WorkerCacheGuard<'c, '_> {
+    type Target = EntityDecoder<'c>;
+    fn deref(&self) -> &Self::Target {
+        &self.decoder
+    }
+}
+
+impl std::ops::DerefMut for WorkerCacheGuard<'_, '_> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.decoder
+    }
+}
+
 // Carries the full per-job processing context; factoring the args into a struct
 // would not change behavior and is out of scope for the lint gate.
 #[allow(clippy::too_many_arguments)]
@@ -72,8 +103,15 @@ pub(super) fn process_entity_job(
     // Seed the unit-scale caches so curve/arc processing skips the O(file)
     // IFCPROJECT scan that each fresh per-element decoder would otherwise repeat.
     local_decoder.seed_unit_scales(unit_scale, seed_plane_angle_to_radians);
+    // From here the decoder is owned by the guard, which writes its (warmer)
+    // point cache back into `worker_point_cache` on Drop — so the early return
+    // below, and any panic, still hand the cache to the worker's next element.
+    let mut decoder = WorkerCacheGuard {
+        decoder: local_decoder,
+        slot: worker_point_cache,
+    };
 
-    let entity = match local_decoder.decode_at(job.start, job.end) {
+    let entity = match decoder.decode_at(job.start, job.end) {
         Ok(entity) => entity,
         Err(_) => return Vec::new(),
     };
@@ -130,14 +168,16 @@ pub(super) fn process_entity_job(
         &ctx,
         // Geometry hashing is a viewer diff feature — off on the native path.
         &crate::element::MeshProductionOptions::default(),
-        &mut local_decoder,
+        // Deref-coerces &mut WorkerCacheGuard -> &mut EntityDecoder.
+        &mut decoder,
         &local_router,
     );
 
-    // Fold this element's point-cache activity into the pass tallies, then move
-    // the warm cache back to the worker for the next element. `hits + misses > 0`
-    // means this element was a faceted brep that walked polyloops.
-    let (part_hits, part_misses) = local_decoder.point_cache_stats();
+    // Fold this element's point-cache activity into the pass tallies. The warm
+    // cache is moved back to the worker by `WorkerCacheGuard::drop`, on every
+    // exit path. `hits + misses > 0` means this element was a faceted brep that
+    // walked polyloops.
+    let (part_hits, part_misses) = decoder.point_cache_stats();
     if part_hits + part_misses > 0 {
         use std::sync::atomic::Ordering::Relaxed;
         point_cache_hits_collector.fetch_add(part_hits, Relaxed);
@@ -163,7 +203,6 @@ pub(super) fn process_entity_job(
         #[cfg(not(all(feature = "observability", not(target_arch = "wasm32"))))]
         faceted_brep_ns_collector.fetch_add(0, Relaxed);
     }
-    *worker_point_cache = local_decoder.take_point_cache();
 
     // Fold this element's degenerate-backstop drops into the pass tally.
     if produced.degenerate_triangles_dropped > 0 {

--- a/rust/processing/src/processor/jobs.rs
+++ b/rust/processing/src/processor/jobs.rs
@@ -1,0 +1,284 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Per-entity geometry job execution.
+//!
+//! Split out of `processor/mod.rs` (module-size ratchet). `process_entity_job`
+//! is the body of the parallel batch loop's `map_init` closure — one job = one
+//! product, meshed on a fresh router with the worker's warm CartesianPoint
+//! cache moved in and back out. `build_color_updates_for_jobs` backfills
+//! deferred/orphan-type colours.
+
+use super::*;
+
+// Carries the full per-job processing context; factoring the args into a struct
+// would not change behavior and is out of scope for the lint gate.
+#[allow(clippy::too_many_arguments)]
+pub(super) fn process_entity_job(
+    job: &EntityJob,
+    content: &[u8],
+    entity_index_arc: &Arc<EntityIndex>,
+    unit_scale: f64,
+    rtc_offset: (f64, f64, f64),
+    // Pre-resolved scales seeded into this job's decoder so arc tessellation and
+    // unit conversion never trigger a per-element full-file IFCPROJECT scan.
+    seed_plane_angle_to_radians: f64,
+    tessellation_quality: TessellationQuality,
+    void_index: &FxHashMap<u32, Vec<u32>>,
+    skipped_entity_ids: &HashSet<u32>,
+    geometry_style_index: &FxHashMap<u32, GeometryStyleInfo>,
+    indexed_colour_full: &FxHashMap<u32, crate::style::FullIndexedColourMap>,
+    element_material_colors: &FxHashMap<u32, Vec<[f32; 4]>>,
+    // Surface textures + UV maps keyed by face-set id (#961). Empty for
+    // untextured models.
+    texture_index: &FxHashMap<u32, ifc_lite_geometry::ResolvedTextureMap>,
+    // Present only when the selected coordinate space is `site_local`; rotates
+    // mesh vertices into the site's axis frame.
+    site_local_rotation: Option<&Vec<f64>>,
+    // Shared sink for per-job router CSG diagnostics (parity with the wasm
+    // path's `drain_and_log_csg_diagnostics`).
+    csg_failure_collector: &std::sync::Mutex<FxHashMap<u32, Vec<ifc_lite_geometry::BoolFailure>>>,
+    // Shared sinks for opening classification + per-host opening diagnostics, drained
+    // from this job's router so the native pass aggregates the full GeometryDiagnostics.
+    classification_collector: &std::sync::Mutex<ifc_lite_geometry::ClassificationStats>,
+    host_diag_collector: &std::sync::Mutex<FxHashMap<u32, ifc_lite_geometry::HostOpeningDiagnostic>>,
+    rect_fast_collector: &std::sync::Mutex<ifc_lite_geometry::RectFastStats>,
+    // Shared tally of degenerate-backstop triangle drops (see
+    // `element::build_mesh_data`); relaxed atomic, added to only when non-zero.
+    backstop_collector: &std::sync::atomic::AtomicU64,
+    // Model-wide content-dedup cache shared by every per-job router so identical
+    // geometry is meshed once across the rayon pool (#1109 follow-up).
+    item_dedup_cache: &ifc_lite_geometry::ItemDedupCache,
+    // Per-WORKER CartesianPoint cache, owned by one rayon worker and reused across
+    // every element in its sub-range (see the `map_init` call site). Moved into
+    // this job's decoder and moved back out afterwards so a shared point list is
+    // parsed once per worker-batch, not once per part.
+    worker_point_cache: &mut FxHashMap<u32, (f64, f64, f64)>,
+    // Request-local point-cache hit/miss + faceted-brep-timing sinks (see the
+    // collectors declared before the chunk loop).
+    point_cache_hits_collector: &std::sync::atomic::AtomicU64,
+    point_cache_misses_collector: &std::sync::atomic::AtomicU64,
+    faceted_brep_ns_collector: &std::sync::atomic::AtomicU64,
+) -> Vec<MeshData> {
+    if skipped_entity_ids.contains(&job.id) {
+        return Vec::new();
+    }
+
+    let mut local_decoder = EntityDecoder::with_arc_index(content, entity_index_arc.clone());
+    // Adopt this worker's warm point cache so faceted-brep polyloop points shared
+    // across elements are served from memory instead of re-parsed per element.
+    local_decoder.set_point_cache(std::mem::take(worker_point_cache));
+    // Seed the unit-scale caches so curve/arc processing skips the O(file)
+    // IFCPROJECT scan that each fresh per-element decoder would otherwise repeat.
+    local_decoder.seed_unit_scales(unit_scale, seed_plane_angle_to_radians);
+
+    let entity = match local_decoder.decode_at(job.start, job.end) {
+        Ok(entity) => entity,
+        Err(_) => return Vec::new(),
+    };
+
+    let mut local_router = GeometryRouter::with_scale_and_quality(unit_scale, tessellation_quality);
+    local_router.set_rtc_offset(rtc_offset);
+    // content-dedup default OFF: its structural hash costs more than the meshing
+    // it skips on real models (see GeometryRouter::content_dedup_enabled).
+    if GeometryRouter::content_dedup_enabled() {
+        local_router.enable_content_dedup_shared(item_dedup_cache.clone());
+    }
+    let local_router = local_router;
+
+    let metadata = crate::element::ElementMeshMetadata {
+        global_id: job.global_id.clone(),
+        name: job.name.clone(),
+        presentation_layer: job.presentation_layer.clone(),
+        space_zone_properties: job.space_zone_properties.clone(),
+    };
+    // #957: the scan loop plans type geometry with `SuppressInstanced` (see
+    // `plan_type_geometry`), so a synthetic job's map always renders as an
+    // orphan — geometry_class 1.
+    let kind = match job.representation_map_id {
+        Some(rep_map_id) => crate::element::ElementJobKind::TypeProduct {
+            rep_maps: vec![(rep_map_id, 1)],
+        },
+        None => crate::element::ElementJobKind::Product,
+    };
+    let ctx = crate::element::MeshProductionContext {
+        void_index,
+        geometry_style_index,
+        indexed_colour_full,
+        element_material_colors,
+        texture_index,
+        site_local_rotation,
+    };
+
+    // Per-part faceted-brep phase timing (observability only; Instant traps on
+    // wasm32). Attributed below to `faceted_brep_ns_collector` for parts that
+    // actually touched the point cache (i.e. faceted breps), mirroring the
+    // diag.rs feature-off byte-identity policy.
+    #[cfg(all(feature = "observability", not(target_arch = "wasm32")))]
+    let brep_timer = std::time::Instant::now();
+
+    let produced = crate::element::produce_element_meshes(
+        &crate::element::ElementMeshJob {
+            id: job.id,
+            ifc_type: job.ifc_type,
+            entity: &entity,
+            kind,
+            element_color: Some(job.element_color),
+            metadata: Some(&metadata),
+        },
+        &ctx,
+        // Geometry hashing is a viewer diff feature — off on the native path.
+        &crate::element::MeshProductionOptions::default(),
+        &mut local_decoder,
+        &local_router,
+    );
+
+    // Fold this element's point-cache activity into the pass tallies, then move
+    // the warm cache back to the worker for the next element. `hits + misses > 0`
+    // means this element was a faceted brep that walked polyloops.
+    let (part_hits, part_misses) = local_decoder.point_cache_stats();
+    if part_hits + part_misses > 0 {
+        use std::sync::atomic::Ordering::Relaxed;
+        point_cache_hits_collector.fetch_add(part_hits, Relaxed);
+        point_cache_misses_collector.fetch_add(part_misses, Relaxed);
+        // Faceted-brep wall time is measured only under `observability` (Instant
+        // traps on wasm32); the timer/log block compiles out entirely with the
+        // feature off, so default builds stay byte-identical. Adding a 0 ns delta
+        // in that case keeps `faceted_brep_ns_collector` always-used.
+        #[cfg(all(feature = "observability", not(target_arch = "wasm32")))]
+        {
+            let elapsed_ns = brep_timer.elapsed().as_nanos() as u64;
+            faceted_brep_ns_collector.fetch_add(elapsed_ns, Relaxed);
+            // Under `observability` this is what the geometry crate's `diag_debug!`
+            // expands to (`tracing::debug!`).
+            tracing::debug!(
+                element_id = job.id,
+                point_cache_hits = part_hits,
+                point_cache_misses = part_misses,
+                faceted_brep_us = elapsed_ns / 1000,
+                "faceted-brep part meshed"
+            );
+        }
+        #[cfg(not(all(feature = "observability", not(target_arch = "wasm32"))))]
+        faceted_brep_ns_collector.fetch_add(0, Relaxed);
+    }
+    *worker_point_cache = local_decoder.take_point_cache();
+
+    // Fold this element's degenerate-backstop drops into the pass tally.
+    if produced.degenerate_triangles_dropped > 0 {
+        backstop_collector.fetch_add(
+            produced.degenerate_triangles_dropped,
+            std::sync::atomic::Ordering::Relaxed,
+        );
+    }
+
+    // Surface this element's CSG diagnostics in the shared collector. The
+    // wasm path logs them in the browser console; without this the server
+    // would silently discard every failed opening cut.
+    if !produced.csg_failures.is_empty() {
+        if let Ok(mut collector) = csg_failure_collector.lock() {
+            for (product_id, fails) in produced.csg_failures {
+                collector.entry(product_id).or_default().extend(fails);
+            }
+        }
+    }
+
+    // Drain this job's router opening diagnostics (classification counts +
+    // per-host detail) and merge them. Each job uses a FRESH router that
+    // processed exactly this one element, so the drained values are this
+    // element's only — summing across jobs mirrors the wasm batch router's
+    // accumulate-then-drain, giving the same GeometryDiagnostics counts.
+    let cls = local_router.take_classification_stats();
+    if cls.rectangular != 0
+        || cls.diagonal != 0
+        || cls.non_rectangular != 0
+        || cls.floor_opening_guard_saved != 0
+    {
+        if let Ok(mut acc) = classification_collector.lock() {
+            acc.rectangular += cls.rectangular;
+            acc.diagonal += cls.diagonal;
+            acc.non_rectangular += cls.non_rectangular;
+            acc.floor_opening_guard_saved += cls.floor_opening_guard_saved;
+        }
+    }
+    let host_diags = local_router.take_host_opening_diagnostics();
+    if !host_diags.is_empty() {
+        if let Ok(mut acc) = host_diag_collector.lock() {
+            // Product ids are disjoint across jobs (one product = one job), so this
+            // is an insert; `extend` is robust if that ever changes.
+            acc.extend(host_diags);
+        }
+    }
+    // Drain this job's router rect_fast counters into the request-local collector
+    // (process-global counters are gone — see GeometryRouter::record_rect_fast).
+    let rf = local_router.take_rect_fast_stats();
+    if rf.fired != 0
+        || rf.openings_cut != 0
+        || rf.defer_host_not_box != 0
+        || rf.defer_not_through != 0
+        || rf.defer_off_face != 0
+        || rf.defer_near_edge != 0
+        || rf.defer_no_openings != 0
+    {
+        if let Ok(mut acc) = rect_fast_collector.lock() {
+            acc.fired += rf.fired;
+            acc.openings_cut += rf.openings_cut;
+            acc.defer_host_not_box += rf.defer_host_not_box;
+            acc.defer_not_through += rf.defer_not_through;
+            acc.defer_off_face += rf.defer_off_face;
+            acc.defer_near_edge += rf.defer_near_edge;
+            acc.defer_no_openings += rf.defer_no_openings;
+        }
+    }
+
+    produced.meshes
+}
+
+pub(super) fn build_color_updates_for_jobs(
+    jobs: &[EntityJob],
+    geometry_styles: &FxHashMap<u32, GeometryStyleInfo>,
+    content: &[u8],
+    entity_index: &Arc<EntityIndex>,
+) -> Vec<(u32, [f32; 4])> {
+    let mut decoder = EntityDecoder::with_arc_index(content, entity_index.clone());
+    let mut updates: Vec<(u32, [f32; 4])> = Vec::new();
+
+    for job in jobs {
+        // #957: synthetic type-only-geometry jobs resolve their colour from the
+        // RepresentationMap (a type has no IfcProductDefinitionShape), so the
+        // product-definition path below never corrects them. Backfill them here
+        // or a deferred IfcStyledItem (fast_first_batch) leaves the orphan type
+        // geometry stuck at its fallback colour.
+        if let Some(rep_map_id) = job.representation_map_id {
+            if let Some(color) = crate::element::resolve_color_for_representation_map(
+                rep_map_id,
+                geometry_styles,
+                &mut decoder,
+            ) {
+                if color != job.element_color {
+                    updates.push((job.id, color));
+                }
+            }
+            continue;
+        }
+        let Ok(entity) = decoder.decode_at(job.start, job.end) else {
+            continue;
+        };
+        let Some(product_definition_shape_id) = entity.get_ref(6) else {
+            continue;
+        };
+        let Some(color) = resolve_element_color_for_product_definition_shape(
+            product_definition_shape_id,
+            geometry_styles,
+            &mut decoder,
+        ) else {
+            continue;
+        };
+        if color != job.element_color {
+            updates.push((job.id, color));
+        }
+    }
+
+    updates
+}

--- a/rust/processing/src/processor/mod.rs
+++ b/rust/processing/src/processor/mod.rs
@@ -23,12 +23,15 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::Arc;
 
 mod color_layer;
+mod jobs;
 mod opening_filter;
 mod properties;
 mod quick_metadata;
 mod site_local;
 
 pub use site_local::convert_mesh_to_site_local;
+
+use jobs::{build_color_updates_for_jobs, process_entity_job};
 
 use color_layer::{
     collect_presentation_layer_assignments, resolve_element_color_for_product_definition_shape,
@@ -1134,6 +1137,17 @@ pub fn process_geometry_streaming_filtered_with_options(
     // a hash get/insert; meshing runs outside it.
     let item_dedup_cache = GeometryRouter::new_dedup_cache();
 
+    // Per-part point-cache instrumentation (feeds `ProcessingStats` and, through
+    // it, `PipelineDiagnostics`). `hits`/`misses` count CartesianPoints served
+    // by `EntityDecoder::get_polyloop_coords_cached` across every faceted part;
+    // a non-zero `hits` proves the per-worker cache hoist below memoized points
+    // ACROSS elements. `faceted_brep_ns` is summed only under the `observability`
+    // feature (native), since `std::time::Instant` traps on wasm32. All three are
+    // request-local atomics, like `backstop_collector`.
+    let point_cache_hits_collector = std::sync::atomic::AtomicU64::new(0);
+    let point_cache_misses_collector = std::sync::atomic::AtomicU64::new(0);
+    let faceted_brep_ns_collector = std::sync::atomic::AtomicU64::new(0);
+
     let geometry_span = tracing::info_span!(
         "geometry",
         element_count = total_jobs,
@@ -1241,9 +1255,17 @@ pub fn process_geometry_streaming_filtered_with_options(
             } else {
                 None
             };
+        // `map_init` gives each rayon worker a single long-lived CartesianPoint
+        // cache (`FxHashMap`) it reuses across every element in its sub-range,
+        // instead of the fresh-per-element decoder that threw the cache away each
+        // job. Each worker owns its own map (no cross-thread sharing), so a shared
+        // steel point list is parsed once per worker-batch, not once per part.
+        // `map_init(...).flatten_iter()` preserves the exact same job order as the
+        // former `flat_map_iter`, and the cache is pure memoization, so the meshes
+        // are byte-identical (verified by `mesh_determinism`).
         let chunk_meshes: Vec<MeshData> = jobs_chunk
             .par_iter()
-            .flat_map_iter(|job| {
+            .map_init(FxHashMap::default, |worker_point_cache, job| {
                 process_entity_job(
                     job,
                     content,
@@ -1265,8 +1287,13 @@ pub fn process_geometry_streaming_filtered_with_options(
                     &rect_fast_collector,
                     &backstop_collector,
                     &item_dedup_cache,
+                    worker_point_cache,
+                    &point_cache_hits_collector,
+                    &point_cache_misses_collector,
+                    &faceted_brep_ns_collector,
                 )
             })
+            .flatten_iter()
             .collect();
 
         processed_jobs += jobs_chunk.len();
@@ -1326,6 +1353,9 @@ pub fn process_geometry_streaming_filtered_with_options(
     let total_csg_failures: usize = csg_failures.values().map(Vec::len).sum();
     let products_with_failures = csg_failures.len();
     let backstop_dropped = backstop_collector.into_inner();
+    let point_cache_hits = point_cache_hits_collector.into_inner();
+    let point_cache_misses = point_cache_misses_collector.into_inner();
+    let faceted_brep_time_ms = faceted_brep_ns_collector.into_inner() / 1_000_000;
     geometry_span.record("mesh_count", total_meshes as u64);
     geometry_span.record("triangle_count", total_triangles as u64);
     geometry_span.record("backstop_count", backstop_dropped);
@@ -1428,247 +1458,17 @@ pub fn process_geometry_streaming_filtered_with_options(
             total_csg_failures: total_csg_failures as u64,
             products_with_failures: products_with_failures as u64,
             degenerate_triangles_dropped: backstop_dropped,
+            point_cache_hits,
+            point_cache_misses,
+            faceted_brep_time_ms,
             geometry_diagnostics,
         },
     }
 }
 
-// Carries the full per-job processing context; factoring the args into a struct
-// would not change behavior and is out of scope for the lint gate.
-#[allow(clippy::too_many_arguments)]
-fn process_entity_job(
-    job: &EntityJob,
-    content: &[u8],
-    entity_index_arc: &Arc<EntityIndex>,
-    unit_scale: f64,
-    rtc_offset: (f64, f64, f64),
-    // Pre-resolved scales seeded into this job's decoder so arc tessellation and
-    // unit conversion never trigger a per-element full-file IFCPROJECT scan.
-    seed_plane_angle_to_radians: f64,
-    tessellation_quality: TessellationQuality,
-    void_index: &FxHashMap<u32, Vec<u32>>,
-    skipped_entity_ids: &HashSet<u32>,
-    geometry_style_index: &FxHashMap<u32, GeometryStyleInfo>,
-    indexed_colour_full: &FxHashMap<u32, crate::style::FullIndexedColourMap>,
-    element_material_colors: &FxHashMap<u32, Vec<[f32; 4]>>,
-    // Surface textures + UV maps keyed by face-set id (#961). Empty for
-    // untextured models.
-    texture_index: &FxHashMap<u32, ifc_lite_geometry::ResolvedTextureMap>,
-    // Present only when the selected coordinate space is `site_local`; rotates
-    // mesh vertices into the site's axis frame.
-    site_local_rotation: Option<&Vec<f64>>,
-    // Shared sink for per-job router CSG diagnostics (parity with the wasm
-    // path's `drain_and_log_csg_diagnostics`).
-    csg_failure_collector: &std::sync::Mutex<FxHashMap<u32, Vec<ifc_lite_geometry::BoolFailure>>>,
-    // Shared sinks for opening classification + per-host opening diagnostics, drained
-    // from this job's router so the native pass aggregates the full GeometryDiagnostics.
-    classification_collector: &std::sync::Mutex<ifc_lite_geometry::ClassificationStats>,
-    host_diag_collector: &std::sync::Mutex<FxHashMap<u32, ifc_lite_geometry::HostOpeningDiagnostic>>,
-    rect_fast_collector: &std::sync::Mutex<ifc_lite_geometry::RectFastStats>,
-    // Shared tally of degenerate-backstop triangle drops (see
-    // `element::build_mesh_data`); relaxed atomic, added to only when non-zero.
-    backstop_collector: &std::sync::atomic::AtomicU64,
-    // Model-wide content-dedup cache shared by every per-job router so identical
-    // geometry is meshed once across the rayon pool (#1109 follow-up).
-    item_dedup_cache: &ifc_lite_geometry::ItemDedupCache,
-) -> Vec<MeshData> {
-    if skipped_entity_ids.contains(&job.id) {
-        return Vec::new();
-    }
-
-    let mut local_decoder = EntityDecoder::with_arc_index(content, entity_index_arc.clone());
-    // Seed the unit-scale caches so curve/arc processing skips the O(file)
-    // IFCPROJECT scan that each fresh per-element decoder would otherwise repeat.
-    local_decoder.seed_unit_scales(unit_scale, seed_plane_angle_to_radians);
-
-    let entity = match local_decoder.decode_at(job.start, job.end) {
-        Ok(entity) => entity,
-        Err(_) => return Vec::new(),
-    };
-
-    let mut local_router = GeometryRouter::with_scale_and_quality(unit_scale, tessellation_quality);
-    local_router.set_rtc_offset(rtc_offset);
-    // content-dedup default OFF: its structural hash costs more than the meshing
-    // it skips on real models (see GeometryRouter::content_dedup_enabled).
-    if GeometryRouter::content_dedup_enabled() {
-        local_router.enable_content_dedup_shared(item_dedup_cache.clone());
-    }
-    let local_router = local_router;
-
-    let metadata = crate::element::ElementMeshMetadata {
-        global_id: job.global_id.clone(),
-        name: job.name.clone(),
-        presentation_layer: job.presentation_layer.clone(),
-        space_zone_properties: job.space_zone_properties.clone(),
-    };
-    // #957: the scan loop plans type geometry with `SuppressInstanced` (see
-    // `plan_type_geometry`), so a synthetic job's map always renders as an
-    // orphan — geometry_class 1.
-    let kind = match job.representation_map_id {
-        Some(rep_map_id) => crate::element::ElementJobKind::TypeProduct {
-            rep_maps: vec![(rep_map_id, 1)],
-        },
-        None => crate::element::ElementJobKind::Product,
-    };
-    let ctx = crate::element::MeshProductionContext {
-        void_index,
-        geometry_style_index,
-        indexed_colour_full,
-        element_material_colors,
-        texture_index,
-        site_local_rotation,
-    };
-
-    let produced = crate::element::produce_element_meshes(
-        &crate::element::ElementMeshJob {
-            id: job.id,
-            ifc_type: job.ifc_type,
-            entity: &entity,
-            kind,
-            element_color: Some(job.element_color),
-            metadata: Some(&metadata),
-        },
-        &ctx,
-        // Geometry hashing is a viewer diff feature — off on the native path.
-        &crate::element::MeshProductionOptions::default(),
-        &mut local_decoder,
-        &local_router,
-    );
-
-    // Fold this element's degenerate-backstop drops into the pass tally.
-    if produced.degenerate_triangles_dropped > 0 {
-        backstop_collector.fetch_add(
-            produced.degenerate_triangles_dropped,
-            std::sync::atomic::Ordering::Relaxed,
-        );
-    }
-
-    // Surface this element's CSG diagnostics in the shared collector. The
-    // wasm path logs them in the browser console; without this the server
-    // would silently discard every failed opening cut.
-    if !produced.csg_failures.is_empty() {
-        if let Ok(mut collector) = csg_failure_collector.lock() {
-            for (product_id, fails) in produced.csg_failures {
-                collector.entry(product_id).or_default().extend(fails);
-            }
-        }
-    }
-
-    // Drain this job's router opening diagnostics (classification counts +
-    // per-host detail) and merge them. Each job uses a FRESH router that
-    // processed exactly this one element, so the drained values are this
-    // element's only — summing across jobs mirrors the wasm batch router's
-    // accumulate-then-drain, giving the same GeometryDiagnostics counts.
-    let cls = local_router.take_classification_stats();
-    if cls.rectangular != 0
-        || cls.diagonal != 0
-        || cls.non_rectangular != 0
-        || cls.floor_opening_guard_saved != 0
-    {
-        if let Ok(mut acc) = classification_collector.lock() {
-            acc.rectangular += cls.rectangular;
-            acc.diagonal += cls.diagonal;
-            acc.non_rectangular += cls.non_rectangular;
-            acc.floor_opening_guard_saved += cls.floor_opening_guard_saved;
-        }
-    }
-    let host_diags = local_router.take_host_opening_diagnostics();
-    if !host_diags.is_empty() {
-        if let Ok(mut acc) = host_diag_collector.lock() {
-            // Product ids are disjoint across jobs (one product = one job), so this
-            // is an insert; `extend` is robust if that ever changes.
-            acc.extend(host_diags);
-        }
-    }
-    // Drain this job's router rect_fast counters into the request-local collector
-    // (process-global counters are gone — see GeometryRouter::record_rect_fast).
-    let rf = local_router.take_rect_fast_stats();
-    if rf.fired != 0
-        || rf.openings_cut != 0
-        || rf.defer_host_not_box != 0
-        || rf.defer_not_through != 0
-        || rf.defer_off_face != 0
-        || rf.defer_near_edge != 0
-        || rf.defer_no_openings != 0
-    {
-        if let Ok(mut acc) = rect_fast_collector.lock() {
-            acc.fired += rf.fired;
-            acc.openings_cut += rf.openings_cut;
-            acc.defer_host_not_box += rf.defer_host_not_box;
-            acc.defer_not_through += rf.defer_not_through;
-            acc.defer_off_face += rf.defer_off_face;
-            acc.defer_near_edge += rf.defer_near_edge;
-            acc.defer_no_openings += rf.defer_no_openings;
-        }
-    }
-
-    produced.meshes
-}
-
-
-
-fn build_color_updates_for_jobs(
-    jobs: &[EntityJob],
-    geometry_styles: &FxHashMap<u32, GeometryStyleInfo>,
-    content: &[u8],
-    entity_index: &Arc<EntityIndex>,
-) -> Vec<(u32, [f32; 4])> {
-    let mut decoder = EntityDecoder::with_arc_index(content, entity_index.clone());
-    let mut updates: Vec<(u32, [f32; 4])> = Vec::new();
-
-    for job in jobs {
-        // #957: synthetic type-only-geometry jobs resolve their colour from the
-        // RepresentationMap (a type has no IfcProductDefinitionShape), so the
-        // product-definition path below never corrects them. Backfill them here
-        // or a deferred IfcStyledItem (fast_first_batch) leaves the orphan type
-        // geometry stuck at its fallback colour.
-        if let Some(rep_map_id) = job.representation_map_id {
-            if let Some(color) = crate::element::resolve_color_for_representation_map(
-                rep_map_id,
-                geometry_styles,
-                &mut decoder,
-            ) {
-                if color != job.element_color {
-                    updates.push((job.id, color));
-                }
-            }
-            continue;
-        }
-        let Ok(entity) = decoder.decode_at(job.start, job.end) else {
-            continue;
-        };
-        let Some(product_definition_shape_id) = entity.get_ref(6) else {
-            continue;
-        };
-        let Some(color) = resolve_element_color_for_product_definition_shape(
-            product_definition_shape_id,
-            geometry_styles,
-            &mut decoder,
-        ) else {
-            continue;
-        };
-        if color != job.element_color {
-            updates.push((job.id, color));
-        }
-    }
-
-    updates
-}
-
-
 // Default IFC-type colors now come from the single canonical table in
 // `crate::style::default_color_for_type` (issue #913). Do not reintroduce a
 // per-module table here — see `tests/styling_parity.rs` for the guard.
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[allow(dead_code)] // test helper retained for building index fixtures
-    fn map(pairs: &[(u32, &[u32])]) -> FxHashMap<u32, Vec<u32>> {
-        pairs.iter().map(|(k, v)| (*k, v.to_vec())).collect()
-    }
-
-    // `find_geometry_item_color_follows_mapped_item` lives in
-    // `crate::element::tests`, next to the resolver it pins.
-}
+//
+// `find_geometry_item_color_follows_mapped_item` lives in `crate::element::tests`,
+// next to the resolver it pins.

--- a/rust/processing/src/types/response.rs
+++ b/rust/processing/src/types/response.rs
@@ -141,6 +141,20 @@ pub struct ProcessingStats {
     /// the backstop engaged for this model.
     #[serde(default)]
     pub degenerate_triangles_dropped: u64,
+    /// CartesianPoints served from the per-worker point cache while meshing
+    /// faceted breps (`EntityDecoder::get_polyloop_coords_cached`). Non-zero
+    /// means the cross-element cache hoist memoized a shared point list rather
+    /// than re-parsing it per part.
+    #[serde(default)]
+    pub point_cache_hits: u64,
+    /// CartesianPoints parsed for the first time (point-cache misses) across the
+    /// faceted-brep pass. `hits / (hits + misses)` is the memoization rate.
+    #[serde(default)]
+    pub point_cache_misses: u64,
+    /// Wall time (ms) attributed to faceted-brep part meshing. Populated only in
+    /// `observability` native builds (`Instant` traps on wasm32); 0 otherwise.
+    #[serde(default)]
+    pub faceted_brep_time_ms: u64,
     /// Full CSG / opening diagnostics (opening classification, per-reason failure
     /// breakdown, per-host detail, silent rectangular no-ops, rect_fast engagement)
     /// aggregated across the native geometry pass — the same `GeometryDiagnostics`

--- a/rust/processing/tests/module_size_allowlist.txt
+++ b/rust/processing/tests/module_size_allowlist.txt
@@ -10,7 +10,7 @@
      756 apps/server/src/services/parquet_data_model.rs
      581 apps/server/src/services/parquet_optimized.rs
      522 apps/server/src/services/parquet.rs
-    1193 rust/core/src/decoder.rs
+    1087 rust/core/src/decoder.rs
      429 rust/core/src/fast_parse.rs
      793 rust/core/src/georef.rs
      445 rust/core/src/model_bounds.rs
@@ -71,9 +71,10 @@
      812 rust/processing/src/element.rs
      468 rust/processing/src/georeferencing.rs
      772 rust/processing/src/prepass.rs
-    1674 rust/processing/src/processor/mod.rs
+    1474 rust/processing/src/processor/mod.rs
      440 rust/processing/src/symbolic/items.rs
-     767 rust/wasm-bindings/src/api/gpu_meshes/batch.rs
+# +6: wire per-batch point-cache hit/miss stats into record_pipeline_batch (perf/brep-point-cache-instrumentation).
+     773 rust/wasm-bindings/src/api/gpu_meshes/batch.rs
      627 rust/wasm-bindings/src/api/gpu_meshes/prepass.rs
      436 rust/wasm-bindings/src/api/grid_lines.rs
      878 rust/wasm-bindings/src/api/mod.rs

--- a/rust/wasm-bindings/src/api/gpu_meshes/batch.rs
+++ b/rust/wasm-bindings/src/api/gpu_meshes/batch.rs
@@ -446,11 +446,17 @@ impl IfcAPI {
             .map(|m| (m.indices.len() / 3) as u64)
             .sum();
         let batch_ms = (js_sys::Date::now() - batch_started_ms).max(0.0) as u64;
+        // The batch reuses ONE decoder across every element (the point cache is
+        // already hoisted here), so its cumulative point-cache stats ARE this
+        // batch's faceted-brep memoization tally.
+        let (point_cache_hits, point_cache_misses) = decoder.point_cache_stats();
         self.record_pipeline_batch(
             batch_elements,
             batch_meshes,
             batch_triangles,
             batch_backstop,
+            point_cache_hits,
+            point_cache_misses,
             batch_ms,
             &csg_diag,
         );

--- a/rust/wasm-bindings/src/api/pipeline_diagnostics.rs
+++ b/rust/wasm-bindings/src/api/pipeline_diagnostics.rs
@@ -49,6 +49,8 @@ impl IfcAPI {
         mesh_count: u64,
         triangle_count: u64,
         backstop_count: u64,
+        point_cache_hits: u64,
+        point_cache_misses: u64,
         geometry_ms: u64,
         diag: &ifc_lite_geometry::GeometryDiagnostics,
     ) {
@@ -56,11 +58,16 @@ impl IfcAPI {
             .pipeline_diagnostics
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
+        // Faceted-brep wall time is native/observability-only (Instant traps on
+        // wasm32), so the wasm batch reports 0 for it.
         acc.record_batch(
             element_count,
             mesh_count,
             triangle_count,
             backstop_count,
+            point_cache_hits,
+            point_cache_misses,
+            0,
             geometry_ms,
             diag,
         );


### PR DESCRIPTION
## What

The native geometry batch loop meshed **each element on a fresh `EntityDecoder`**, so every faceted brep re-parsed its shared `IfcCartesianPoint` lists from scratch. This hoists the decoder's CartesianPoint cache so it is **owned by a rayon worker and reused across every part in that worker's sub-range**, and instruments the cache so we can see it firing.

## How

- **Instrument (`rust/core`)**: `EntityDecoder` gains `point_cache_hits`/`point_cache_misses` counters (bumped in `get_polyloop_coords_cached`) and `take_point_cache` / `set_point_cache` / `point_cache_stats` primitives so the warm cache can be moved between per-element decoders.
- **Hoist (`rust/processing`)**: the batch loop switches from `.par_iter().flat_map_iter(...)` to `.par_iter().map_init(FxHashMap::default, ...).flatten_iter()`. Each worker owns ONE point cache; `process_entity_job` moves it into its local decoder before meshing and back out afterward. **Job order is preserved** (`map_init` + `flatten_iter` are order-preserving), so mesh output is unchanged.
- **Observability**: per-part point-cache hits/misses (always) and faceted-brep wall time (`observability` feature + native only; `Instant` traps on wasm32) fold into request-local atomics surfaced on `ProcessingStats` and `PipelineDiagnostics`. The wasm batch already reuses one decoder, so it just reads `point_cache_stats()` at batch end.

## Correctness / determinism (the gate)

- `cargo test -p ifc-lite-processing --test mesh_determinism` — **PASS, byte-for-byte no-diff** against the pinned manifest (`mesh_output_matches_pinned_manifest`, `mesh_output_is_stable_across_reruns`, `wasm_manifest_differs_only_in_the_trig_gap`). The memoization is pure (content + point-id -> coords) and order-preserving, so the hoist is output-neutral.
- New decoder guards: `polyloop_point_cache_memoizes_shared_points` (asserts hits>0 across two loops sharing a point list) and `point_cache_survives_take_and_set_across_decoders`. Full `decoder_tests`: 9/9.
- `cargo test -p ifc-lite-processing --lib`: 37/37. Ratchet: PASS.
- `cargo clippy -p ifc-lite-core -p ifc-lite-processing --all-targets -- -D warnings`: clean.
- `cargo check -p ifc-lite-wasm --target wasm32-unknown-unknown`: clean. **`pkg/ifc-lite.d.ts` unchanged** — `getPipelineDiagnostics` crosses as `JsValue` (typed `any`), so the added struct fields are invisible to the type surface (`pkg/` is not in the diff).

## Module-size ratchet

`process_entity_job` + `build_color_updates_for_jobs` moved to a new `processor/jobs.rs`, and the decoder tests to `decoder/decoder_tests.rs`. Ratcheted **down**: `processor/mod.rs` 1674->1474, `decoder.rs` 1193->1087. Raised `gpu_meshes/batch.rs` 767->773 (+6) for the point-cache stat wiring, with an inline justification per the contract.

## F3 profiling is a stacked follow-up

This PR is the **byte-identical enabler**. The 176x-CPU characterization (the before/after `glb_export_profile` numbers on a faceted-brep-heavy steel model) needs a representative fixture not present in this worktree, and any further mesher fix belongs on top of the confirmed-neutral hoist. Deferring it keeps this PR a clean, verifiable perf + instrumentation change.

## Notes

- No changeset: no published-package public API changed (diagnostics cross as `JsValue`).
- Verified under a worktree-isolated `CARGO_TARGET_DIR` after a shared-target cross-worktree contamination was detected (a sibling worktree's `ifc-lite-core v4.1.0` artifact linked into this crate); CI's clean per-PR checkout is the authoritative gate.
