### PR TITLE
refactor(geometry): narrow lib.rs public modules to pub(crate) (keep the 8 externally-reached)

### DIFF
--- a/rust/geometry/src/bool2d.rs
+++ b/rust/geometry/src/bool2d.rs
@@ -200,7 +200,9 @@ pub fn ensure_cw(contour: &[Point2<f64>]) -> Vec<Point2<f64>> {
     }
 }
 
-/// Simplify a contour by removing collinear points
+/// Simplify a contour by removing collinear points.
+// Test-only since the C3.2 `pub(crate)` narrowing (exercised by `test_simplify_contour`).
+#[allow(dead_code)]
 pub fn simplify_contour(contour: &[Point2<f64>], epsilon: f64) -> Vec<Point2<f64>> {
     if contour.len() <= 3 {
         return contour.to_vec();
@@ -255,32 +257,13 @@ pub fn point_in_contour(point: &Point2<f64>, contour: &[Point2<f64>]) -> bool {
     inside
 }
 
-/// Check if contour A is completely inside contour B
-pub fn contour_inside_contour(inner: &[Point2<f64>], outer: &[Point2<f64>]) -> bool {
-    // All points of inner must be inside outer
-    inner.iter().all(|p| point_in_contour(p, outer))
-}
+// `contour_inside_contour` and `contour_bounds` were deleted here: the C3.2
+// `pub(crate)` narrowing orphaned them (zero callers, production or test), so
+// per the anti-cruft rule they go rather than gain a dead-code allow.
 
-/// Compute bounding box of a contour
-pub fn contour_bounds(contour: &[Point2<f64>]) -> Option<(Point2<f64>, Point2<f64>)> {
-    if contour.is_empty() {
-        return None;
-    }
-
-    let mut min = contour[0];
-    let mut max = contour[0];
-
-    for p in contour.iter().skip(1) {
-        min.x = min.x.min(p.x);
-        min.y = min.y.min(p.y);
-        max.x = max.x.max(p.x);
-        max.y = max.y.max(p.y);
-    }
-
-    Some((min, max))
-}
-
-/// Check if two bounding boxes overlap
+/// Check if two bounding boxes overlap.
+// Test-only since the C3.2 `pub(crate)` narrowing (exercised by `test_bounds_overlap`).
+#[allow(dead_code)]
 pub fn bounds_overlap(
     a_min: &Point2<f64>,
     a_max: &Point2<f64>,

--- a/rust/geometry/src/congruence/mod.rs
+++ b/rust/geometry/src/congruence/mod.rs
@@ -43,8 +43,9 @@ use nalgebra::{Matrix3, Vector3};
 use rustc_hash::FxHashMap;
 use std::sync::{Mutex, OnceLock};
 
-#[allow(unused_imports)] // unused re-export (spike); see module allow above
-pub use report::{analyze_rigid_dedup, RigidDedupReport};
+// `report::analyze_rigid_dedup`/`RigidDedupReport` have no consumer (production
+// or test), so they are not re-exported here; they remain in `report` as spike
+// artifacts under the module-level dead-code allow above.
 
 // ----------------------------------------------------------------------------
 // Analysis collector — populated in processing::tag_direct_instance under the
@@ -78,7 +79,6 @@ pub fn record_local(rep_identity: u128, mesh: &Mesh) {
 ///
 /// No caller today (Phase-0 measurement spike, see module doc above);
 /// narrowing `congruence` to `pub(crate)` in C3.2 surfaced that as unused.
-#[allow(dead_code)]
 pub fn take_locals() -> Vec<(u128, Mesh)> {
     let mut map = collector().lock().expect("analysis collector poisoned");
     let mut out: Vec<(u128, Mesh)> = std::mem::take(&mut *map).into_iter().collect();
@@ -106,7 +106,6 @@ pub fn rigid_enabled() -> bool {
 
 /// Result of classifying a local mesh into the rigid tier.
 #[derive(Clone, Copy)]
-#[allow(dead_code)]
 pub struct RigidClass {
     /// The rigid template's rep_identity (shared by all congruent occurrences).
     pub rigid_id: u128,
@@ -115,7 +114,6 @@ pub struct RigidClass {
     pub canonical_transform: Option<[f64; 16]>,
 }
 
-#[allow(dead_code)]
 struct RigidTemplate {
     welded: Welded,
     rigid_id: u128,
@@ -130,14 +128,12 @@ struct RigidTemplate {
 /// inline on the parallel streaming hot path, where a shared lock serialises the
 /// geometry workers (measured: stalls the 986MB stream).
 #[derive(Default)]
-#[allow(dead_code)]
 pub struct RigidCache {
     templates: Vec<RigidTemplate>,
     buckets: FxHashMap<u64, Vec<usize>>,
 }
 
 /// Row-major canonical->local transform `C = translate(c_cand) · R · translate(-c_tmpl)`.
-#[allow(dead_code)]
 fn canonical_transform_row_major(
     r: &Matrix3<f64>,
     c_tmpl: &Vector3<f64>,
@@ -152,7 +148,6 @@ fn canonical_transform_row_major(
     ]
 }
 
-#[allow(dead_code)]
 impl RigidCache {
     pub fn new() -> Self {
         Self::default()
@@ -219,7 +214,6 @@ impl RigidCache {
 /// the streaming hot path — the architecture the inline attempt got wrong. A
 /// future optimisation shards `locals` by primary signature for rayon parallelism
 /// (congruent meshes share a signature bucket, so shards are independent).
-#[allow(dead_code)]
 pub fn build_rigid_map(locals: &[(u128, Mesh)]) -> std::collections::HashMap<u128, RigidClass> {
     let mut cache = RigidCache::new();
     let mut map = std::collections::HashMap::with_capacity(locals.len());

--- a/rust/geometry/src/congruence/mod.rs
+++ b/rust/geometry/src/congruence/mod.rs
@@ -28,6 +28,12 @@
 //! iterative eigensolver/SVD is fine; production would need the closed-form
 //! Cardano path noted in the design.
 
+// Whole module (mod.rs + engine + report) is a measurement-only spike driven
+// solely by `congruence::tests`; it has no production caller. Narrowing
+// `congruence` to `pub(crate)` in C3.2 surfaced it as dead in non-test builds
+// (it was already unreachable by any external crate), so allow it module-wide.
+#![allow(dead_code)]
+
 mod engine;
 mod report;
 
@@ -37,6 +43,7 @@ use nalgebra::{Matrix3, Vector3};
 use rustc_hash::FxHashMap;
 use std::sync::{Mutex, OnceLock};
 
+#[allow(unused_imports)] // unused re-export (spike); see module allow above
 pub use report::{analyze_rigid_dedup, RigidDedupReport};
 
 // ----------------------------------------------------------------------------
@@ -68,6 +75,10 @@ pub fn record_local(rep_identity: u128, mesh: &Mesh) {
 
 /// Drain the collected distinct local meshes, sorted by rep_identity for
 /// deterministic analysis order.
+///
+/// No caller today (Phase-0 measurement spike, see module doc above);
+/// narrowing `congruence` to `pub(crate)` in C3.2 surfaced that as unused.
+#[allow(dead_code)]
 pub fn take_locals() -> Vec<(u128, Mesh)> {
     let mut map = collector().lock().expect("analysis collector poisoned");
     let mut out: Vec<(u128, Mesh)> = std::mem::take(&mut *map).into_iter().collect();
@@ -87,8 +98,15 @@ pub fn rigid_enabled() -> bool {
     *ENABLED.get_or_init(|| std::env::var("IFC_LITE_RIGID_INSTANCING").is_ok())
 }
 
+// The rest of this "production rigid tier" (RigidClass..build_rigid_map) is
+// driven only by `congruence::tests` today (Phase-0 measurement spike, see
+// module doc above); narrowing `congruence` to `pub(crate)` in C3.2 surfaced
+// it as unused in non-test builds. It was already unreachable by any
+// external crate before that change.
+
 /// Result of classifying a local mesh into the rigid tier.
 #[derive(Clone, Copy)]
+#[allow(dead_code)]
 pub struct RigidClass {
     /// The rigid template's rep_identity (shared by all congruent occurrences).
     pub rigid_id: u128,
@@ -97,6 +115,7 @@ pub struct RigidClass {
     pub canonical_transform: Option<[f64; 16]>,
 }
 
+#[allow(dead_code)]
 struct RigidTemplate {
     welded: Welded,
     rigid_id: u128,
@@ -111,12 +130,14 @@ struct RigidTemplate {
 /// inline on the parallel streaming hot path, where a shared lock serialises the
 /// geometry workers (measured: stalls the 986MB stream).
 #[derive(Default)]
+#[allow(dead_code)]
 pub struct RigidCache {
     templates: Vec<RigidTemplate>,
     buckets: FxHashMap<u64, Vec<usize>>,
 }
 
 /// Row-major canonical->local transform `C = translate(c_cand) · R · translate(-c_tmpl)`.
+#[allow(dead_code)]
 fn canonical_transform_row_major(
     r: &Matrix3<f64>,
     c_tmpl: &Vector3<f64>,
@@ -131,6 +152,7 @@ fn canonical_transform_row_major(
     ]
 }
 
+#[allow(dead_code)]
 impl RigidCache {
     pub fn new() -> Self {
         Self::default()
@@ -197,6 +219,7 @@ impl RigidCache {
 /// the streaming hot path — the architecture the inline attempt got wrong. A
 /// future optimisation shards `locals` by primary signature for rayon parallelism
 /// (congruent meshes share a signature bucket, so shards are independent).
+#[allow(dead_code)]
 pub fn build_rigid_map(locals: &[(u128, Mesh)]) -> std::collections::HashMap<u128, RigidClass> {
     let mut cache = RigidCache::new();
     let mut map = std::collections::HashMap::with_capacity(locals.len());

--- a/rust/geometry/src/extrusion.rs
+++ b/rust/geometry/src/extrusion.rs
@@ -708,48 +708,10 @@ pub fn apply_transform(mesh: &mut Mesh, transform: &Matrix4<f64>) {
     });
 }
 
-/// Apply transformation matrix to mesh with RTC (Relative-to-Center) offset
-///
-/// This is the key function for handling large coordinates (e.g., Swiss UTM).
-/// Instead of directly converting transformed f64 coordinates to f32 (which loses
-/// precision for large values), we:
-/// 1. Apply the full transformation in f64 precision
-/// 2. Subtract the RTC offset (in f64) before converting to f32
-/// 3. This keeps the final f32 values small (~0-1000m range) where precision is excellent
-///
-/// # Arguments
-/// * `mesh` - Mesh to transform
-/// * `transform` - Full transformation matrix (including large translations)
-/// * `rtc_offset` - RTC offset to subtract (typically model centroid)
-#[inline]
-pub fn apply_transform_with_rtc(
-    mesh: &mut Mesh,
-    transform: &Matrix4<f64>,
-    rtc_offset: (f64, f64, f64),
-) {
-    // Transform positions using chunk-based iteration for cache locality
-    mesh.positions.chunks_exact_mut(3).for_each(|chunk| {
-        let point = Point3::new(chunk[0] as f64, chunk[1] as f64, chunk[2] as f64);
-        // Apply full transformation in f64
-        let transformed = transform.transform_point(&point);
-        // Subtract RTC offset in f64 BEFORE converting to f32 - this is the key!
-        chunk[0] = (transformed.x - rtc_offset.0) as f32;
-        chunk[1] = (transformed.y - rtc_offset.1) as f32;
-        chunk[2] = (transformed.z - rtc_offset.2) as f32;
-    });
-
-    // Transform normals (use inverse transpose for correct normal transformation)
-    // Normals don't need RTC offset - they're directions, not positions
-    let normal_matrix = transform.try_inverse().unwrap_or(*transform).transpose();
-
-    mesh.normals.chunks_exact_mut(3).for_each(|chunk| {
-        let normal = Vector3::new(chunk[0] as f64, chunk[1] as f64, chunk[2] as f64);
-        let transformed = (normal_matrix * normal.to_homogeneous()).xyz().normalize();
-        chunk[0] = transformed.x as f32;
-        chunk[1] = transformed.y as f32;
-        chunk[2] = transformed.z as f32;
-    });
-}
+// `apply_transform_with_rtc` was deleted here: the C3.2 `pub(crate)` narrowing
+// orphaned it (zero callers, production or test), so per the anti-cruft rule it
+// goes rather than gain a dead-code allow. The RTC rebase runs in the
+// processing orchestrator (see rust/AGENTS.md), not this per-mesh helper.
 
 #[cfg(test)]
 mod tests {

--- a/rust/geometry/src/lib.rs
+++ b/rust/geometry/src/lib.rs
@@ -68,8 +68,14 @@
 //! - **Complex Breps**: ~200 entities/sec
 //! - **Boolean operations**: ~20 entities/sec
 
-pub mod alignment;
-pub mod bool2d;
+// Module visibility: only 8 modules below are reached externally by sibling
+// crates via a direct submodule path (`ifc_lite_geometry::<module>::...`) and
+// must stay `pub`: csg, csg_capture, kernel, material_layer_index, mesh,
+// projection_outline, rect_fast, space_dcel. Everything else is internal
+// wiring; external consumers reach its types through the root-level `pub use`
+// re-exports below, so those modules are `pub(crate)` (see #C3.2).
+pub(crate) mod alignment;
+pub(crate) mod bool2d;
 /// Deterministic Constrained Delaunay Triangulation + bounded Ruppert
 /// min-angle refinement. Backs the quality triangulators in `triangulation`.
 mod cdt;
@@ -80,7 +86,7 @@ pub mod csg_capture;
 /// Deterministic near-coplanar facet weld for faceted-BREP host meshes.
 /// Corrects f32 import jitter (~0.09°) so authored-coplanar roof slope facets
 /// are EXACTLY coplanar before the exact-kernel opening cut (issue #1007).
-pub mod facet_weld;
+pub(crate) mod facet_weld;
 /// Intra-mesh vertex weld + index dedup applied at the per-element mesh source
 /// (`build_mesh_data`), collapsing the faceted-brep per-face vertex duplication
 /// while keeping creases (distinct normals) split.
@@ -88,32 +94,32 @@ pub mod mesh_weld;
 /// Structured-diagnostics macro shims for the `observability` feature
 /// (tracing when ON, the legacy eprintln fallback when OFF).
 pub(crate) mod diag;
-pub mod diagnostics;
-pub mod error;
-pub mod congruence;
-pub mod geom_hash;
-pub mod extrusion;
-pub mod instancing;
+pub(crate) mod diagnostics;
+pub(crate) mod error;
+pub(crate) mod congruence;
+pub(crate) mod geom_hash;
+pub(crate) mod extrusion;
+pub(crate) mod instancing;
 /// Pure-Rust exact mesh-arrangement CSG kernel — the only CSG kernel, on
 /// every target (see docs/architecture/geometry-pipeline.md).
 pub mod kernel;
 pub mod material_layer_index;
 pub mod mesh;
-pub mod mesh_orient;
-pub mod processors;
-pub mod profile;
-pub mod profile_extractor;
-pub mod profiles;
+pub(crate) mod mesh_orient;
+pub(crate) mod processors;
+pub(crate) mod profile;
+pub(crate) mod profile_extractor;
+pub(crate) mod profiles;
 pub mod projection_outline;
 pub mod rect_fast;
 pub use rect_fast::RectFastStats;
-pub mod router;
-pub mod tessellation;
+pub(crate) mod router;
+pub(crate) mod tessellation;
 pub mod space_dcel;
-pub mod transform;
-pub mod triangulation;
-pub mod void_analysis;
-pub mod void_index;
+pub(crate) mod transform;
+pub(crate) mod triangulation;
+pub(crate) mod void_analysis;
+pub(crate) mod void_index;
 
 // Re-export nalgebra types for convenience
 pub use nalgebra::{Point2, Point3, Vector2, Vector3};

--- a/rust/processing/tests/module_size_allowlist.txt
+++ b/rust/processing/tests/module_size_allowlist.txt
@@ -22,13 +22,13 @@
      655 rust/export/src/model.rs
      611 rust/export/src/step.rs
     1233 rust/geometry/src/alignment.rs
-     568 rust/geometry/src/bool2d.rs
+     551 rust/geometry/src/bool2d.rs
     1875 rust/geometry/src/cdt.rs
      535 rust/geometry/src/congruence/engine.rs
      895 rust/geometry/src/csg/consolidate.rs
     1061 rust/geometry/src/csg/mod.rs
      436 rust/geometry/src/csg/normals.rs
-    1036 rust/geometry/src/extrusion.rs
+     998 rust/geometry/src/extrusion.rs
      759 rust/geometry/src/facet_weld.rs
      408 rust/geometry/src/geom_hash.rs
      641 rust/geometry/src/kernel/arrangement/classify.rs


### PR DESCRIPTION
## What

Narrows the `rust/geometry` (`ifc_lite_geometry`) crate public API surface (C3.2). Of the 28 `pub mod` declarations in `lib.rs`, **20 become `pub(crate)`** and **8 stay `pub`**.

### Kept public (8) — reached by sibling crates via a direct submodule path
`csg`, `csg_capture`, `kernel`, `material_layer_index`, `mesh`, `projection_outline`, `rect_fast`, `space_dcel`

Consumer evidence (direct `ifc_lite_geometry::<module>::...` paths outside the crate):
- `csg`, `csg_capture`, `mesh` -> `rust/csg-thread-bench`, `rust/processing/examples/csg_scaling_bench.rs`
- `kernel` -> `rust/processing/src/element.rs` (`kernel::budget::begin_element()`)
- `projection_outline` -> `rust/wasm-bindings/src/api/mesh_outline.rs`
- `rect_fast` -> `rust/wasm-bindings/src/api/mod.rs` (`rect_fast::param_set_enabled_override`)
- `space_dcel` -> `rust/wasm-bindings/src/api/space_plate.rs`
- `material_layer_index` -> kept public alongside its root `MaterialLayerIndex` re-export (public submodule type surface)

### Narrowed to `pub(crate)` (20)
`alignment`, `bool2d`, `congruence`, `diagnostics`, `error`, `extrusion`, `facet_weld`, `geom_hash`, `instancing`, `mesh_orient`, `processors`, `profile`, `profile_extractor`, `profiles`, `router`, `tessellation`, `transform`, `triangulation`, `void_analysis`, `void_index`

Every external consumer of these already goes through the **root-level `pub use` re-exports** (`GeometryProcessor`, `GeometryRouter`, `Mesh`, `TessellationQuality`, `ExtractedProfile`, `MaterialLayerIndex`, `BoolFailure`, `InstanceMeshRef`, `GeometryDiagnostics`, `RectFastStats`, `AlignmentCurve`, `rotation_angle_about_z`, `extract_profiles`, `collate_and_encode`, ...), all unchanged and still public.

## How I proved no consumer breaks

For each candidate module, grepped the **whole repo** (all crates + `tests/` + `examples/` + `benches/`) for both `ifc_lite_geometry::<module>::` and `use ifc_lite_geometry::<module>`. The only direct-submodule-path hits were the 8 kept-public modules (plus two `geom_hash` mentions that are doc-comment prose, not imports). No narrowed module is imported by direct path anywhere. The compile gate is the real proof: `cargo check --workspace` is clean.

## Dead code the narrowing surfaced

Making these modules `pub(crate)` turned three previously-public-API functions into internally-dead code. Per the anti-cruft rule ("delete dead code with the change that orphans it"), the ones with **zero callers (production or test)** are deleted, not annotated:

- `bool2d::contour_inside_contour`
- `bool2d::contour_bounds`
- `extrusion::apply_transform_with_rtc`

Test-only survivors get a scoped `#[allow(dead_code)]` with a one-line why (`bool2d::simplify_contour`, `bool2d::bounds_overlap`). The `congruence` Phase-0 measurement spike (driven only by `congruence::tests`) gets a single module-level `#![allow(dead_code)]`.

## Ratchet

`bool2d.rs` and `extrusion.rs` shrank below their recorded budgets, so `module_size_allowlist.txt` is ratcheted **down** (bool2d 568->551, extrusion 1036->998). `congruence/engine.rs` returns to exactly its 535 budget (no per-file allow added).

## Verify (local, shared target)

- `cargo check --workspace` -> clean (no warnings)
- `cargo test --workspace --exclude ifc-lite-wasm --no-run` -> compiles (test code still resolves)
- `cargo test -p ifc-lite-geometry` -> green (the only 3 "failures" were a missing fixture `ara3d/advanced_model.ifc`; all 7 pass once fetched)
- `cargo test -p ifc-lite-processing --test module_size_ratchet` -> pass
- `cargo clippy --workspace --exclude ifc-lite-wasm --all-targets -- -D warnings` -> clean

## Breaking change

This shrinks the `ifc_lite_geometry` public API. Any **external crates.io** consumer importing one of the 20 narrowed modules by direct path must switch to the root re-export (the crate is not published to npm, so no changeset).
