### PR TITLE
fix(viewer): keep element picking working after federating a georeferenced model (#1570)

### DIFF
--- a/apps/viewer/src/components/viewer/Viewport.tsx
+++ b/apps/viewer/src/components/viewer/Viewport.tsx
@@ -12,6 +12,7 @@ import type { MeshData, CoordinateInfo, PointCloudAsset } from '@ifc-lite/geomet
 import { useViewerStore, resolveEntityRef, type MeasurePoint, type SnapVisualization } from '@/store';
 import { LIGHTING_PRESETS } from '@/lib/lighting-presets';
 import { presetViewRotation } from '@/lib/preset-view-orientation';
+import { isGeometryLoadStreaming } from '@/lib/pick-gating';
 import { sunLightingForAltitude } from '@/lib/geo/solar-direction';
 import {
   useSelectionState,
@@ -653,11 +654,12 @@ export function Viewport({
   // Helper: get pick options with visibility filtering
   const getPickOptions = () => {
     const currentState = useViewerStore.getState();
-    const currentProgress = currentState.progress;
-    const currentIsStreaming = currentState.geometryStreamingActive
-      || (currentProgress !== null && currentProgress.percent < 100);
     return {
-      isStreaming: currentIsStreaming,
+      // `isStreaming` gates picking off during an active load. It must stay
+      // false once a load has finished — a federated georef model leaves
+      // `progress` stuck at 90%, which would otherwise disable picking forever
+      // for every loaded model (#1570). See isGeometryLoadStreaming.
+      isStreaming: isGeometryLoadStreaming(currentState),
       hiddenIds: hiddenEntitiesRef.current,
       isolatedIds: isolatedEntitiesRef.current,
     };

--- a/apps/viewer/src/hooks/useIfcLoader.ts
+++ b/apps/viewer/src/hooks/useIfcLoader.ts
@@ -1391,6 +1391,13 @@ export function useIfcLoader() {
       });
       setLoading(false);
       setGeometryStreamingActive(false);
+      // Normalize progress to a terminal state, mirroring the loading /
+      // streaming flags reset above. A federated georef model runs
+      // finalizeModel AFTER the streaming 'Complete' 100% and re-sets progress
+      // to 'Aligning georeferenced model' 90%; without this reset it sticks
+      // below 100%, and getPickOptions() then reports isStreaming=true forever,
+      // disabling ALL element picking once a second model is loaded (#1570).
+      setProgress({ phase: 'Complete', percent: 100 });
     } catch (err) {
       console.error(`[useIfc] loadFile THREW (session=${currentSession}, current=${loadSessionRef.current}):`, err);
       if (loadSessionRef.current !== currentSession) return;

--- a/apps/viewer/src/lib/pick-gating.test.ts
+++ b/apps/viewer/src/lib/pick-gating.test.ts
@@ -1,0 +1,72 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { isGeometryLoadStreaming } from './pick-gating.js';
+
+// `isGeometryLoadStreaming` is the gate behind `getPickOptions().isStreaming`:
+// when it returns true, `PickingManager.pick()` bails to null. These tests pin
+// the exact regression from #1570 — a federated georeferenced model leaves
+// `progress` stuck below 100% after the load has finished, which must NOT keep
+// element picking disabled.
+
+describe('isGeometryLoadStreaming', () => {
+  it('reports streaming while geometry is actively streaming', () => {
+    assert.equal(
+      isGeometryLoadStreaming({
+        geometryStreamingActive: true,
+        loading: true,
+        progress: { phase: 'Streaming', percent: 40 },
+      }),
+      true,
+    );
+  });
+
+  it('reports streaming for an in-flight load below 100% even without the streaming flag', () => {
+    assert.equal(
+      isGeometryLoadStreaming({
+        geometryStreamingActive: false,
+        loading: true,
+        progress: { phase: 'Processing geometry', percent: 50 },
+      }),
+      true,
+    );
+  });
+
+  // Regression #1570: two georeferenced IFC files. Finalizing the second
+  // (federated) model runs after the streaming "Complete" and re-sets progress
+  // to "Aligning georeferenced model" 90%. Once the load has finished
+  // (loading=false, geometryStreamingActive=false) that stale 90% must NOT keep
+  // picking disabled — otherwise no element in EITHER model is selectable.
+  it('does NOT report streaming when a finished load left progress stuck below 100% (#1570)', () => {
+    assert.equal(
+      isGeometryLoadStreaming({
+        geometryStreamingActive: false,
+        loading: false,
+        progress: { phase: 'Aligning georeferenced model', percent: 90 },
+      }),
+      false,
+    );
+  });
+
+  it('does NOT report streaming once fully complete', () => {
+    assert.equal(
+      isGeometryLoadStreaming({
+        geometryStreamingActive: false,
+        loading: false,
+        progress: { phase: 'Complete', percent: 100 },
+      }),
+      false,
+    );
+    assert.equal(
+      isGeometryLoadStreaming({
+        geometryStreamingActive: false,
+        loading: false,
+        progress: null,
+      }),
+      false,
+    );
+  });
+});

--- a/apps/viewer/src/lib/pick-gating.ts
+++ b/apps/viewer/src/lib/pick-gating.ts
@@ -1,0 +1,30 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/** Subset of the loading slice that gates element picking. */
+export interface PickGatingState {
+  /** Authoritative "geometry is actively streaming into the scene" flag. */
+  geometryStreamingActive: boolean;
+  /** True for the whole span of an in-flight `loadFile`, false once it finishes. */
+  loading: boolean;
+  /** Loader progress. Its `percent` is a DISPLAY value, not a load-state flag. */
+  progress: { phase: string; percent: number; indeterminate?: boolean } | null;
+}
+
+/**
+ * Whether geometry is still streaming/loading, so element picking must be
+ * suppressed (a mid-stream pick is slow and hits an incomplete scene).
+ *
+ * `geometryStreamingActive` is the authoritative signal. The `progress.percent`
+ * check is only a secondary guard, and `percent` is a display value that can
+ * outlive a load: the federated georef-alignment phase leaves `progress` at
+ * `{ phase: 'Aligning georeferenced model', percent: 90 }` AFTER the model is
+ * fully loaded. Gating that secondary signal on `loading` prevents a stale
+ * sub-100 progress from disabling picking forever once a second model has
+ * finished loading (#1570).
+ */
+export function isGeometryLoadStreaming(state: PickGatingState): boolean {
+  if (state.geometryStreamingActive) return true;
+  return state.loading && state.progress !== null && state.progress.percent < 100;
+}


### PR DESCRIPTION
Fixes #1570 — "Element select does not work when 2 IFC files loaded".

## Root cause

Both files in the report are georeferenced (EPSG:5514) with slightly different map offsets, so loading the **second** (federated) model triggers `finalizeModel`'s georef alignment, which calls `setProgress({ phase: 'Aligning georeferenced model', percent: 90 })` (`useIfcLoader.ts`).

For the IFC streaming path that finalize runs in a **deferred promise** awaited later, so its 90% lands *after* the stream already set `Complete 100%`. The `loadFile` completion reset `loading` and `geometryStreamingActive` but **not** `progress`, so `progress` stuck at 90%.

`getPickOptions()` then computed `isStreaming = geometryStreamingActive || (progress.percent < 100)` = `true` forever, and `PickingManager.pick()` (`if (options?.isStreaming) return null`) bailed on **every** click — disabling selection for both the anchor and the federated model.

## Fix

- **`useIfcLoader.ts`**: reset `progress` to a terminal `Complete/100` at the `loadFile` completion, mirroring the `loading`/`geometryStreamingActive` resets right above it (the completion handler was incomplete).
- **`lib/pick-gating.ts`** (new): pure `isGeometryLoadStreaming()` that gates the fragile `progress.percent` signal on `loading`, so a stale sub-100 progress can never disable picking once a load has finished. Wired into `Viewport.tsx:getPickOptions`.
- **`lib/pick-gating.test.ts`** (new): pins the regression.

All in `apps/viewer` (private app — no changeset).

## Verification

Reproduced locally in the WebGPU viewer with the reporter's exact two files:

| | before | after |
|---|---|---|
| `progress` after 2nd model | `Aligning georeferenced model` 90% (stuck) | `Complete` 100% |
| picking (2 models) | 0 / 8 clicks select | 6 / 6 on anchor; federated model resolves too (globalId 456208 -> vzt local 76360, offset 379848) |

- New test passes; `pnpm --filter viewer typecheck` clean; full viewer suite **1310 tests, 0 fail**.

## Notes (pre-existing, out of scope)

- The cache-hit and server-load early returns also don't set a terminal `Complete`; harmless now that the pick gate is guarded on `loading`.
- The `loadFile` terminal block isn't re-guarded on the load session after its awaits (pre-existing for the `loading`/`streaming` setters this fix sits beside). Not a regression here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved picking behavior in the viewer so elements remain selectable after loading finishes, even if progress briefly appears stuck below 100%.
  * Fixed an issue where picking could stay disabled after a model load completed, especially during sequential federated model loads.

* **Tests**
  * Added coverage for streaming and completed-load scenarios to prevent regressions in picking behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->