### PR TITLE
fix(viewer): ghost-by-default + frame the clash contact region on select (#1466)

### DIFF
--- a/.changeset/remove-dead-camera-zoomtofit.md
+++ b/.changeset/remove-dead-camera-zoomtofit.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/renderer": minor
+---
+
+Remove the unused `Camera.zoomToFit(min, max, duration)` method. It had no callers anywhere in the repo (viewer, SDK, examples, tests) and was superseded by `Camera.frameBounds` (animated fit, keeps view direction) and `Camera.fitBoundsAdaptive` (aspect-aware fit used by the Home view and post-load auto-fit). The exported `Camera` class and the CI-tracked API surface are unchanged; only the dead convenience wrapper is gone. Callers that need an animated fit-to-bounds should use `frameBounds` (the quickstart cheat-sheet was updated to point at it).

--- a/apps/viewer/src/components/viewer/Viewport.tsx
+++ b/apps/viewer/src/components/viewer/Viewport.tsx
@@ -823,7 +823,14 @@ export function Viewport({
           // never top-down or edge-on (#1466). `fitBoundsAdaptive` is the same
           // fit the Home view / post-load auto-fit use, so a clash-sized box
           // gets the compact SE-isometric pose and handles orthographic zoom.
-          camera.fitBoundsAdaptive({ min, max }, { animate: true, duration: 300 });
+          // Pass the real viewport short side (as the Home handler does) so the
+          // fit is viewport-accurate for any policy.
+          const canvas = rendererRef.current?.getCanvas();
+          const canvasShort = Math.min(canvas?.height ?? 0, canvas?.width ?? 0);
+          camera.fitBoundsAdaptive(
+            { min, max },
+            { animate: true, duration: 300, viewportShortPx: canvasShort > 0 ? canvasShort : undefined },
+          );
           calculateScale();
         },
         orbit: (deltaX: number, deltaY: number) => {

--- a/apps/viewer/src/components/viewer/Viewport.tsx
+++ b/apps/viewer/src/components/viewer/Viewport.tsx
@@ -817,6 +817,15 @@ export function Viewport({
             console.warn('[Viewport] frameSelection: Could not get bounds for selected element');
           }
         },
+        frameClashRegion: (min, max) => {
+          // Frame the clash's (already context-padded) contact box from the
+          // canonical isometric pose so the penetration is read at a 3/4 angle,
+          // never top-down or edge-on (#1466). `fitBoundsAdaptive` is the same
+          // fit the Home view / post-load auto-fit use, so a clash-sized box
+          // gets the compact SE-isometric pose and handles orthographic zoom.
+          camera.fitBoundsAdaptive({ min, max }, { animate: true, duration: 300 });
+          calculateScale();
+        },
         orbit: (deltaX: number, deltaY: number) => {
           // Orbit camera from ViewCube drag
           camera.orbit(deltaX, deltaY, false);

--- a/apps/viewer/src/hooks/useClash.ts
+++ b/apps/viewer/src/hooks/useClash.ts
@@ -33,6 +33,7 @@ import { contactClusters, type SharedFaceCluster, type Vec3 } from '@ifc-lite/cl
 import { writeBCF } from '@ifc-lite/bcf';
 import { getGlobalRenderer } from '@/hooks/useBCF';
 import { buildClashPairColors, CLASH_COLOR_A, CLASH_COLOR_OVERLAP } from '@/lib/clash/clash-colors';
+import { clashFramingBounds } from '@/lib/clash/clash-framing';
 import { posthog } from '@/lib/analytics';
 import { downloadBlob } from '@/lib/export/download';
 
@@ -385,9 +386,23 @@ export function useClash() {
       }
       applyFocusMode(globalIds, mode);
       state.setClashSelectedId(clash.id);
-      // frameSelection also frames the clash ids (see Viewport), so the camera
-      // encloses the pair without a selection.
-      requestAnimationFrame(() => state.cameraCallbacks.frameSelection?.());
+      // Frame the CONTACT region (tight overlap box grown by a little context),
+      // not the union of the two whole elements; a long clashing member would
+      // otherwise dominate and push the overlap tiny and off-centre (#1466).
+      // Fall back to frameSelection if the bounds are missing or the isometric
+      // callback isn't registered yet (renderer not mounted).
+      const framing = clash.bounds ? clashFramingBounds(clash.bounds) : null;
+      requestAnimationFrame(() => {
+        const cb = useViewerStore.getState().cameraCallbacks;
+        if (framing && cb.frameClashRegion) {
+          cb.frameClashRegion(
+            { x: framing.min[0], y: framing.min[1], z: framing.min[2] },
+            { x: framing.max[0], y: framing.max[1], z: framing.max[2] },
+          );
+        } else {
+          cb.frameSelection?.();
+        }
+      });
     },
     [refOf, applyFocusMode],
   );

--- a/apps/viewer/src/lib/clash/clash-framing.test.ts
+++ b/apps/viewer/src/lib/clash/clash-framing.test.ts
@@ -5,14 +5,14 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
 
+import type { AABB } from '@ifc-lite/clash';
 import {
   clashFramingBounds,
   CLASH_CONTEXT_PAD_FACTOR,
   CLASH_CONTEXT_PAD_MIN_M,
-  type WorldBox,
 } from './clash-framing.js';
 
-const center = (b: WorldBox): [number, number, number] => [
+const center = (b: AABB): [number, number, number] => [
   (b.min[0] + b.max[0]) / 2,
   (b.min[1] + b.max[1]) / 2,
   (b.min[2] + b.max[2]) / 2,

--- a/apps/viewer/src/lib/clash/clash-framing.test.ts
+++ b/apps/viewer/src/lib/clash/clash-framing.test.ts
@@ -1,0 +1,58 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+
+import {
+  clashFramingBounds,
+  CLASH_CONTEXT_PAD_FACTOR,
+  CLASH_CONTEXT_PAD_MIN_M,
+  type WorldBox,
+} from './clash-framing.js';
+
+const center = (b: WorldBox): [number, number, number] => [
+  (b.min[0] + b.max[0]) / 2,
+  (b.min[1] + b.max[1]) / 2,
+  (b.min[2] + b.max[2]) / 2,
+];
+
+describe('clashFramingBounds (#1466)', () => {
+  it('keeps the overlap centre — the camera looks AT the contact, not off to a beam end', () => {
+    const box = clashFramingBounds({ min: [10, 20, 30], max: [12, 24, 30.4] });
+    assert.deepEqual(center(box), [11, 22, 30.2]);
+  });
+
+  it('grows a sizeable overlap by factor * largest-dimension on every side', () => {
+    // largest dim = 4 (Y) -> pad = 4 * 0.6 = 2.4 (well above the 0.5 floor)
+    const box = clashFramingBounds({ min: [0, 0, 0], max: [1, 4, 2] });
+    const pad = 4 * CLASH_CONTEXT_PAD_FACTOR;
+    assert.equal(pad, 2.4);
+    assert.deepEqual(box.min, [-pad, -pad, -pad]);
+    assert.deepEqual(box.max, [1 + pad, 4 + pad, 2 + pad]);
+  });
+
+  it('applies the minimum-metre floor so a flush / near-zero-thickness overlap still gets context', () => {
+    // A wall-face touch: 0.3 x 0.3 x ~0 -> largest dim 0.3, factor pad 0.18 < 0.5 floor.
+    const box = clashFramingBounds({ min: [0, 0, 0], max: [0.3, 0.3, 0.0] });
+    const pad = CLASH_CONTEXT_PAD_MIN_M;
+    assert.equal(0.3 * CLASH_CONTEXT_PAD_FACTOR < pad, true, 'factor pad must fall below the floor here');
+    // The zero-thickness Z axis expands to a real, human-scale span (2 * floor).
+    assert.equal(box.max[2] - box.min[2], 2 * pad);
+    assert.deepEqual(box.min, [-pad, -pad, -pad]);
+    assert.deepEqual(box.max, [0.3 + pad, 0.3 + pad, pad]);
+  });
+
+  it('produces a strictly non-degenerate box (min < max on every axis) even for a point overlap', () => {
+    const box = clashFramingBounds({ min: [5, 5, 5], max: [5, 5, 5] });
+    for (let i = 0; i < 3; i += 1) assert.ok(box.max[i] > box.min[i], `axis ${i} must be non-degenerate`);
+    assert.deepEqual(center(box), [5, 5, 5]);
+  });
+
+  it('normalises an inverted input box (min/max swapped) instead of producing a negative-size frame', () => {
+    const box = clashFramingBounds({ min: [12, 24, 30.4], max: [10, 20, 30] });
+    assert.deepEqual(center(box), [11, 22, 30.2]);
+    for (let i = 0; i < 3; i += 1) assert.ok(box.max[i] > box.min[i], `axis ${i} must be non-degenerate`);
+  });
+});

--- a/apps/viewer/src/lib/clash/clash-framing.ts
+++ b/apps/viewer/src/lib/clash/clash-framing.ts
@@ -20,13 +20,7 @@
  * a degenerate super-close zoom.
  */
 
-import type { Vec3 } from '@ifc-lite/clash';
-
-/** World-space axis-aligned box, corners as `[x, y, z]` (same shape as `Clash.bounds`). */
-export interface WorldBox {
-  min: Vec3;
-  max: Vec3;
-}
+import type { AABB } from '@ifc-lite/clash';
 
 /** Context margin added on each side, as a fraction of the clash's largest dimension. */
 export const CLASH_CONTEXT_PAD_FACTOR = 0.6;
@@ -39,7 +33,7 @@ export const CLASH_CONTEXT_PAD_MIN_M = 0.5;
  * shows with a little context and a thin/flush overlap never collapses to a
  * point. `min`/`max` are normalised, so an inverted input box is tolerated.
  */
-export function clashFramingBounds(bounds: WorldBox): WorldBox {
+export function clashFramingBounds(bounds: AABB): AABB {
   const loX = Math.min(bounds.min[0], bounds.max[0]);
   const loY = Math.min(bounds.min[1], bounds.max[1]);
   const loZ = Math.min(bounds.min[2], bounds.max[2]);

--- a/apps/viewer/src/lib/clash/clash-framing.ts
+++ b/apps/viewer/src/lib/clash/clash-framing.ts
@@ -1,0 +1,57 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Camera framing box for a focused clash (#1466).
+ *
+ * Clicking a clash used to frame the UNION of the two whole clashing elements'
+ * bounding boxes (via `frameSelection`). For a long member (a beam, a pipe, a
+ * wall) that union is dominated by the element length, so the actual overlap
+ * ended up tiny and off-centre — the "camera feels random / shows mostly the
+ * beam" complaint in #1466.
+ *
+ * Instead we frame the CONTACT region: `Clash.bounds`, which is already the
+ * tight overlap AABB (hard clash) or closest-segment box (clearance/touch) in
+ * the same world frame the renderer draws the overlap-box overlay in (#1362,
+ * #1402). We grow it by a little context so the penetration reads with its
+ * surroundings rather than filling the whole frame, with a floor so a flush /
+ * near-zero-thickness overlap still gets a human-scale neighbourhood instead of
+ * a degenerate super-close zoom.
+ */
+
+import type { Vec3 } from '@ifc-lite/clash';
+
+/** World-space axis-aligned box, corners as `[x, y, z]` (same shape as `Clash.bounds`). */
+export interface WorldBox {
+  min: Vec3;
+  max: Vec3;
+}
+
+/** Context margin added on each side, as a fraction of the clash's largest dimension. */
+export const CLASH_CONTEXT_PAD_FACTOR = 0.6;
+/** Minimum context margin per side (metres) — the floor for tiny / flush overlaps. */
+export const CLASH_CONTEXT_PAD_MIN_M = 0.5;
+
+/**
+ * Grow a clash's contact box into a camera framing box: centred on the overlap,
+ * padded by `max(largestDim * FACTOR, MIN_M)` on every axis so the penetration
+ * shows with a little context and a thin/flush overlap never collapses to a
+ * point. `min`/`max` are normalised, so an inverted input box is tolerated.
+ */
+export function clashFramingBounds(bounds: WorldBox): WorldBox {
+  const loX = Math.min(bounds.min[0], bounds.max[0]);
+  const loY = Math.min(bounds.min[1], bounds.max[1]);
+  const loZ = Math.min(bounds.min[2], bounds.max[2]);
+  const hiX = Math.max(bounds.min[0], bounds.max[0]);
+  const hiY = Math.max(bounds.min[1], bounds.max[1]);
+  const hiZ = Math.max(bounds.min[2], bounds.max[2]);
+
+  const maxDim = Math.max(hiX - loX, hiY - loY, hiZ - loZ);
+  const pad = Math.max(maxDim * CLASH_CONTEXT_PAD_FACTOR, CLASH_CONTEXT_PAD_MIN_M);
+
+  return {
+    min: [loX - pad, loY - pad, loZ - pad],
+    max: [hiX + pad, hiY + pad, hiZ + pad],
+  };
+}

--- a/apps/viewer/src/lib/tours/tours/clash.ts
+++ b/apps/viewer/src/lib/tours/tours/clash.ts
@@ -89,7 +89,7 @@ export const CLASH_TOUR: TourDefinition = {
       panel: 'clash',
       placement: 'left',
       title: 'Zoom to a clash',
-      body: 'Click a result row. The camera flies to the pair, colors each element, and outlines the contact.',
+      body: 'Click a result row. The camera flies to the overlap, fades the rest to translucent context, colors each element, and outlines the contact.',
       arm: (state, ctx) => {
         ctx.baseline.hadResultAtEntry = hadClashResultAtTourStart;
       },
@@ -123,7 +123,7 @@ export const CLASH_TOUR: TourDefinition = {
       panel: 'clash',
       placement: 'left',
       title: 'See it in context',
-      body: 'Switch On select to Ghost or Isolate. Ghost fades everything else to translucent context; Isolate hides it.',
+      body: 'On select starts on Ghost, which fades the rest to translucent context. Switch it to Isolate to hide everything else, or Highlight to keep the full model opaque.',
       // Encode the entry mode as an index (numeric baseline); an unknown
       // value degrades to 0 rather than breaking the comparison.
       arm: (state, ctx) => {

--- a/apps/viewer/src/store/slices/clashSlice.ts
+++ b/apps/viewer/src/store/slices/clashSlice.ts
@@ -184,7 +184,11 @@ export const createClashSlice: StateCreator<ClashSlice, [], [], ClashSlice> = (s
     clashGroupBy: initial.groupBy,
     clashSortBy: 'severity',
     clashHideTouching: false,
-    clashFocusMode: 'highlight',
+    // Ghost (X-Ray context) by default so clicking a clash immediately reveals
+    // the pair through the surrounding geometry instead of leaving it hidden
+    // behind opaque elements: the "many times you won't see anything" problem
+    // in #1466. The user can still switch to Highlight / Isolate in the panel.
+    clashFocusMode: 'ghost',
     clashPresets: buildInitialPresets(),
     clashSelectedId: null,
     clashHighlightColors: null,

--- a/apps/viewer/src/store/types.ts
+++ b/apps/viewer/src/store/types.ts
@@ -250,6 +250,14 @@ export interface CameraCallbacks {
   zoomIn?: () => void;
   zoomOut?: () => void;
   frameSelection?: () => void;
+  /**
+   * Frame an explicit world-space box (min/max corners) from the canonical
+   * isometric view, animating there. Used to frame a focused clash's contact
+   * region head-on (#1466) rather than `frameSelection`, which unions the
+   * selected elements' full bounds and keeps the current (often top-down) view
+   * direction, so a long clashing member dominates and the overlap reads small.
+   */
+  frameClashRegion?: (min: { x: number; y: number; z: number }, max: { x: number; y: number; z: number }) => void;
   orbit?: (deltaX: number, deltaY: number) => void;
   projectToScreen?: (worldPos: { x: number; y: number; z: number }) => { x: number; y: number } | null;
   /**

--- a/docs/guide/quickstart.md
+++ b/docs/guide/quickstart.md
@@ -205,7 +205,7 @@ function setupCameraControls(canvas: HTMLCanvasElement, renderer: Renderer) {
 | `camera.zoom(delta, false, x, y, w, h)` | Zoom towards mouse position (scroll wheel) |
 | `camera.fitToBounds(min, max)` | Fit camera to bounding box |
 | `camera.setPresetView('top')` | Set preset view: 'top', 'front', 'left', etc. |
-| `camera.zoomToFit(min, max, 500)` | Animated zoom to fit (with duration in ms) |
+| `camera.frameBounds(min, max, 500)` | Animated zoom to fit (with duration in ms) |
 
 ## Option 2: Server + Client
 

--- a/packages/renderer/src/camera-animation.ts
+++ b/packages/renderer/src/camera-animation.ts
@@ -184,41 +184,6 @@ export class CameraAnimator {
   }
 
   /**
-   * Animate camera to fit bounds (southeast isometric view)
-   * Y-up coordinate system
-   */
-  async zoomToFit(min: Vec3, max: Vec3, duration = 500): Promise<void> {
-    const center = {
-      x: (min.x + max.x) / 2,
-      y: (min.y + max.y) / 2,
-      z: (min.z + max.z) / 2,
-    };
-    const size = {
-      x: max.x - min.x,
-      y: max.y - min.y,
-      z: max.z - min.z,
-    };
-    const maxSize = Math.max(size.x, size.y, size.z);
-    const distance = maxSize * 2.0;
-
-    const endTarget = center;
-    // Southeast isometric view for Y-up (same as fitToBounds)
-    const endPos = {
-      x: center.x + distance * 0.6,
-      y: center.y + distance * 0.5,
-      z: center.z + distance * 0.6,
-    };
-
-    // Calculate orthoSize for orthographic mode so zoom level resets properly
-    const aspect = this.state.camera.aspect || 1;
-    const endOrthoSize = this.state.projectionMode === 'orthographic'
-      ? Math.max(0.01, maxSize / 2, maxSize / 2 / aspect) * 1.5
-      : undefined;
-
-    return this.animateTo(endPos, endTarget, duration, endOrthoSize);
-  }
-
-  /**
    * Frame/center view on a point (keeps current distance and direction)
    * Standard CAD "Frame Selection" behavior
    */

--- a/packages/renderer/src/camera.ts
+++ b/packages/renderer/src/camera.ts
@@ -160,14 +160,6 @@ export class Camera {
   }
 
   /**
-   * Animate camera to fit bounds (southeast isometric view)
-   * Y-up coordinate system
-   */
-  async zoomToFit(min: Vec3, max: Vec3, duration = 500): Promise<void> {
-    return this.animator.zoomToFit(min, max, duration);
-  }
-
-  /**
    * Frame/center view on a point (keeps current distance and direction)
    * Standard CAD "Frame Selection" behavior
    */


### PR DESCRIPTION
Closes #1466.

Two clash-review UX fixes requested by @BIMvoice, plus a small dead-code removal.

## The problem
Clicking a clash result was confusing for new users:
1. The clashing pair was often **hidden behind opaque geometry** ("many times you won't see anything").
2. The camera **"felt random / from above"**: it framed the union of both *whole* elements from the current view direction, so a long member dominated and the actual overlap read tiny and off to the side.

## The fix

### 1. Ghost by default (`On select`)
`clashFocusMode` now defaults to **Ghost** (X-Ray context) instead of Highlight. Clicking a clash fades the rest of the model to translucent context so the pair shows through immediately. Users can still switch to **Highlight** / **Isolate** in the panel.

The focused pair stays fully solid even inside a ghosted batch: it already carries an opaque colour override (amber / cyan), which promotes it into the opaque render sub-batch (`splitVisibleIdsByPromotion`), and it is in `ghostExceptIds`, so its alpha is never dragged down. No co-selection needed.

### 2. Frame the contact region, from isometric
`focusClash` now frames the **tight contact box** (`clash.bounds`, grown by a small context margin with a floor for flush/thin overlaps) from the **canonical isometric pose**, via a new `frameClashRegion` camera callback backed by `fitBoundsAdaptive` (the same fit the Home view / post-load auto-fit use). This replaces `frameSelection`'s whole-element union that kept the current (often top-down) direction. The overlap is now centred and read at a 3/4 angle, never top-down or edge-on. `selectElement` (step-through of a single side) still frames the whole element, unchanged.

### 3. Remove dead `Camera.zoomToFit`
No callers anywhere in the repo (viewer, SDK, examples, tests); superseded by `frameBounds` / `fitBoundsAdaptive`. Quickstart cheat-sheet re-pointed at `frameBounds`. **Note for review:** it's a public method on the published `@ifc-lite/renderer`, so I added a `minor` changeset — the CI-tracked API surface (`Camera: class`) is unchanged; bump to `major` if you'd rather treat the method removal as breaking.

## Tests & verification
- New pure `clashFramingBounds()` unit test (centre, context factor, min-metre floor, degenerate/inverted boxes).
- `pnpm typecheck` green; renderer suite 196/0; full viewer suite green (0 fail, 2 fixture-skips).
- **Localhost** (demo rev-B duct-vs-wall clash): forced a top-down view (elevation 89 deg), clicked the clash -> camera snapped to a 3/4 iso (31 deg) framed exactly on the overlap centre `[3.1, 1.5, -6]`; `focusMode: ghost`, `ghostExcept: [pair]`, pair solid through translucent context; 0 console errors/warnings.
