### PR TITLE
perf(core): memchr2 the STEP entity-end scan + a unified perf diagnostic kit

### DIFF
--- a/.changeset/perf-memchr2-step-scan.md
+++ b/.changeset/perf-memchr2-step-scan.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/wasm": patch
+---
+
+Faster STEP parsing: the entity scanner's `find_entity_end` now uses a SIMD `memchr2` scan for the record terminator instead of a per-byte loop. It runs on every entity of every model, through both the entity-index build and the processor scan loop (they share the scanner), and parse is single-threaded, so it directly reduces time-to-first-geometry. Measured: isolated scanner walk -36% to -64%, full parse phase -12% to -30%, total load -8% to -19% across a range of models (small architecture to a 218 MB MEP model). Output is byte-identical (no mesh-determinism manifest change).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,17 @@ strip = true
 inherits = "release"
 panic = "unwind"
 
+# Profiling profile: release-grade optimization with symbols retained and
+# panic=unwind, so `samply record` on a profiled binary produces a symbolized
+# flamegraph and per-element `catch_unwind` isolation still fires. Used by the
+# `perf_probe` harness and `scripts/perf/flame.sh` (see `scripts/perf/README.md`).
+# `strip`/`debug` override the release defaults; the rest is inherited.
+[profile.profiling]
+inherits = "release"
+strip = false
+debug = "line-tables-only"
+panic = "unwind"
+
 
 [profile.dev.package.bnum]
 opt-level = 3

--- a/rust/core/src/parser/scanner.rs
+++ b/rust/core/src/parser/scanner.rs
@@ -207,45 +207,44 @@ impl<'a> EntityScanner<'a> {
     /// Find the terminating semicolon of an entity, skipping over quoted strings.
     /// IFC strings are enclosed in single quotes ('...') and can contain semicolons.
     /// Returns the offset of the semicolon from the start of the slice.
+    ///
+    /// SIMD scan: instead of inspecting every byte, `memchr2` jumps straight to
+    /// the next quote or semicolon. The overwhelming majority of records are
+    /// string-free geometry primitives (`#7=IFCCARTESIANPOINT((1.,2.,3.));`), so
+    /// the common case resolves the terminator in a single vectorized hop rather
+    /// than a per-byte loop. Semantics are byte-identical to the scalar walk:
+    /// the first `;` outside a quoted string, with doubled `''` treated as an
+    /// escaped in-string quote per STEP (ISO 10303-21). This is the single
+    /// hottest structural-scan function and runs on every entity of every model
+    /// (native and wasm), through both `build_entity_index` and the processor
+    /// scan loop, which share this scanner.
     #[inline]
     fn find_entity_end(&self, content: &[u8]) -> Option<usize> {
         let mut pos = 0;
-        let len = content.len();
-        let mut in_string = false;
 
-        while pos < len {
-            let b = content[pos];
+        loop {
+            // Outside a quoted string: jump to the next quote or the
+            // terminating semicolon in one SIMD pass.
+            pos += memchr::memchr2(b'\'', b';', &content[pos..])?;
+            if content[pos] == b';' {
+                return Some(pos);
+            }
 
-            if in_string {
-                if b == b'\'' {
-                    // Check for escaped quote ('') - if next char is also quote, skip both
-                    if pos + 1 < len && content[pos + 1] == b'\'' {
-                        pos += 2; // Skip escaped quote
-                        continue;
-                    }
-                    in_string = false;
+            // content[pos] == b'\'' : entered a quoted string. Scan to the
+            // closing quote, treating a doubled '' as an escaped quote.
+            pos += 1;
+            loop {
+                pos += memchr::memchr(b'\'', &content[pos..])?;
+                if content.get(pos + 1) == Some(&b'\'') {
+                    // Escaped quote ('') - skip both, stay in the string.
+                    pos += 2;
+                    continue;
                 }
+                // Closing quote.
                 pos += 1;
-            } else {
-                match b {
-                    b'\'' => {
-                        in_string = true;
-                        pos += 1;
-                    }
-                    b';' => {
-                        return Some(pos);
-                    }
-                    b'\n' => {
-                        // Entity definitions can span multiple lines in some IFC files
-                        pos += 1;
-                    }
-                    _ => {
-                        pos += 1;
-                    }
-                }
+                break;
             }
         }
-        None
     }
 
     /// Find all entities of a specific type

--- a/rust/core/tests/scanner_string_terminator.rs
+++ b/rust/core/tests/scanner_string_terminator.rs
@@ -1,0 +1,66 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Regression for #1579: `EntityScanner::find_entity_end` was rewritten from a
+//! per-byte scalar walk to a `memchr2` SIMD scan. Its contract must stay
+//! byte-identical: a record ends at the first `;` that is OUTSIDE a quoted
+//! string, and a doubled `''` inside a string is an escaped quote, not a close.
+//! These cases are exercised through the public `build_entity_index` so the
+//! record boundaries (byte spans) are asserted end to end. An off-by-one in the
+//! terminator scan would split a record at an in-string `;` and mis-index the
+//! following entity.
+
+use ifc_lite_core::build_entity_index;
+
+#[test]
+fn in_string_semicolons_and_escaped_quotes_do_not_terminate_a_record() {
+    // #1's string contains a bare ';', an escaped '' and another ';'. If the
+    // scanner stopped at the inner ';', #1's span would be truncated and #2
+    // would be mis-indexed.
+    let content = b"ISO-10303-21;\nHEADER;\nENDSEC;\nDATA;\n\
+#1=IFCLABEL('a;b '' c;d');\n\
+#2=IFCTEXT('plain');\n\
+ENDSEC;\nEND-ISO-10303-21;\n";
+
+    let idx = build_entity_index(content);
+    assert!(idx.contains_key(&1), "entity #1 must be indexed");
+    assert!(idx.contains_key(&2), "entity #2 must be indexed");
+
+    // #1's byte span must reach the REAL terminator (after the closing quote),
+    // so the whole in-string payload is contained.
+    let (s1, e1) = idx[&1];
+    let rec1 = std::str::from_utf8(&content[s1..e1]).unwrap();
+    assert!(
+        rec1.contains("c;d')"),
+        "record #1 was terminated early at an in-string ';': {rec1:?}"
+    );
+    assert!(
+        rec1.trim_end().ends_with(';'),
+        "record #1 must end at the record-terminating ';': {rec1:?}"
+    );
+
+    // #2 must be the plain text record, proving the scan resumed correctly
+    // after #1's string closed.
+    let (s2, e2) = idx[&2];
+    let rec2 = std::str::from_utf8(&content[s2..e2]).unwrap();
+    assert!(rec2.contains("IFCTEXT('plain')"), "record #2 wrong: {rec2:?}");
+}
+
+#[test]
+fn trailing_escaped_quote_at_string_end_still_finds_the_terminator() {
+    // The closing quote is immediately preceded by an escaped '' (three quotes
+    // `'''`: one escaped pair that decodes to a literal quote, then the real
+    // close). The scanner must consume the escape, recognize the true closing
+    // quote, then find the terminating ';'. A boundary bug here would run the
+    // string on and miss #2. Decoded value of #1 is `ab'`.
+    let content = b"DATA;\n#1=IFCLABEL('ab''');\n#2=IFCLABEL('next');\nENDSEC;\n";
+    let idx = build_entity_index(content);
+    assert!(idx.contains_key(&1), "entity #1 must be indexed");
+    assert!(idx.contains_key(&2), "entity #2 must be indexed");
+    let (s2, e2) = idx[&2];
+    assert!(
+        std::str::from_utf8(&content[s2..e2]).unwrap().contains("'next'"),
+        "record #2 mis-indexed after a trailing escaped quote"
+    );
+}

--- a/rust/processing/examples/perf_probe.rs
+++ b/rust/processing/examples/perf_probe.rs
@@ -1,0 +1,370 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! `perf_probe` - one command to attribute load time across the whole native
+//! pipeline (the same Rust code the browser runs through WASM), so a lever can
+//! be found and re-measured instead of guessed.
+//!
+//! It drains the timings the pipeline already publishes
+//! (`ProcessingStats.{parse,entity_scan,lookup,preprocess,geometry,total}_time_ms`,
+//! the faceted-brep point cache, CSG-failure counts) plus an isolated
+//! `build_entity_index` scan, and reports the parse-vs-geometry split with
+//! sub-phase breakdown per fixture. It also drains the always-on CSG op census
+//! (`--census`) so boolean workload is visible next to wall time.
+//!
+//! ```text
+//! # human table (best-of-N, N=3 by default):
+//! cargo run --profile profiling -p ifc-lite-processing --example perf_probe -- \
+//!     tests/models/ara3d/schependomlaan.ifc --iters 5 --census
+//!
+//! # the default suite (every catalogued heavy fixture that is on disk):
+//! cargo run --profile profiling -p ifc-lite-processing --example perf_probe -- --suite
+//!
+//! # machine-readable (JSON to stdout, table to stderr):
+//! cargo run --profile profiling -p ifc-lite-processing --example perf_probe -- \
+//!     --suite --json > /tmp/perf.json
+//! ```
+//!
+//! Build with `--profile profiling` (release-grade opt + symbols + panic=unwind)
+//! so a `samply record` on the produced binary yields a symbolized flamegraph;
+//! `--features observability` additionally fills `faceted_brep_time_ms`.
+//!
+//! This is a measurement harness, NOT a regression gate: run on a quiet machine,
+//! it already reports best-of-N to shave scheduler/GC noise, but treat single
+//! runs as noisy and compare medians across runs.
+//!
+//! WASM parity note: `std::time::Instant` traps on wasm32, so in the browser
+//! only `geometry_ms`/`total_ms` are self-timed; the parse/scan phases run in
+//! JS workers and are timed there (viewer `ifc_model_loaded` PostHog milestones
+//! and the console `[stream]` timeline). The *algorithmic* hotspots this probe
+//! surfaces are identical on both targets because the Rust code is shared; the
+//! WASM-only concerns (per-worker file re-decode, no-threads, memory bandwidth)
+//! are orchestration-level and covered by the viewer benchmark, not here. See
+//! `scripts/perf/README.md`.
+
+use std::time::Instant;
+
+use ifc_lite_core::build_entity_index;
+use ifc_lite_geometry::csg::{reset_csg_census, take_csg_census};
+use ifc_lite_processing::{process_geometry, ProcessingStats};
+
+/// One fixture's best-of-N measurement plus the isolated scan.
+struct Probe {
+    path: String,
+    file_mb: f64,
+    entities: usize,
+    index_build_ms: f64,
+    // Best-of-N run (selected by minimum total_time_ms).
+    stats: ProcessingStats,
+    all_totals_ms: Vec<u64>,
+    census: Option<CensusSummary>,
+}
+
+/// Aggregate of the always-on CSG op census for one run.
+#[derive(Default)]
+struct CensusSummary {
+    subtract: u64,
+    union: u64,
+    intersection: u64,
+    clip: u64,
+    /// Sum of operand triangle counts across every recorded boolean - the real
+    /// heavy-path kernel workload (analytic box clips never reach the census).
+    operand_tris: u64,
+}
+
+fn summarize_census() -> CensusSummary {
+    let mut s = CensusSummary::default();
+    for r in take_csg_census() {
+        match r.op {
+            0 => s.subtract += 1,
+            1 => s.union += 1,
+            2 => s.intersection += 1,
+            3 => s.clip += 1,
+            _ => {}
+        }
+        s.operand_tris += r.a_tris as u64 + r.b_tris as u64;
+    }
+    s
+}
+
+fn run(path: &str, iters: usize, want_census: bool) -> Option<Probe> {
+    let content = match std::fs::read(path) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("skip {path}: {e}");
+            return None;
+        }
+    };
+    let file_mb = content.len() as f64 / 1.048_576e6;
+
+    // Isolated scan: build_entity_index alone times the pure structural scan
+    // that the pipeline otherwise folds into entity_scan_ms. Best-of-3.
+    let mut index_build_ms = f64::INFINITY;
+    let mut entities = 0usize;
+    for _ in 0..3 {
+        let t = Instant::now();
+        let idx = build_entity_index(&content);
+        let ms = t.elapsed().as_secs_f64() * 1e3;
+        entities = idx.len();
+        index_build_ms = index_build_ms.min(ms);
+    }
+
+    // Full pipeline, best-of-N by total_time_ms. Census (if requested) is
+    // drained from the run that was kept, so the op counts match the timing.
+    let mut best: Option<ProcessingStats> = None;
+    let mut best_total = u64::MAX;
+    let mut best_census: Option<CensusSummary> = None;
+    let mut all_totals_ms = Vec::with_capacity(iters);
+    for _ in 0..iters.max(1) {
+        if want_census {
+            reset_csg_census();
+        }
+        let result = process_geometry(&content);
+        let census = if want_census {
+            Some(summarize_census())
+        } else {
+            None
+        };
+        all_totals_ms.push(result.stats.total_time_ms);
+        if result.stats.total_time_ms <= best_total {
+            best_total = result.stats.total_time_ms;
+            best = Some(result.stats);
+            best_census = census;
+        }
+    }
+
+    Some(Probe {
+        path: path.to_string(),
+        file_mb,
+        entities,
+        index_build_ms,
+        stats: best?,
+        all_totals_ms,
+        census: best_census,
+    })
+}
+
+fn pct(part: u64, whole: u64) -> f64 {
+    if whole == 0 {
+        0.0
+    } else {
+        part as f64 / whole as f64 * 100.0
+    }
+}
+
+fn print_human(p: &Probe) {
+    let s = &p.stats;
+    let total = s.total_time_ms.max(1);
+    let parse = s.parse_time_ms;
+    let geom = s.geometry_time_ms;
+    let tris = s.total_triangles;
+    let mtris_s = if geom > 0 {
+        tris as f64 / (geom as f64 / 1e3) / 1e6
+    } else {
+        0.0
+    };
+    let cache_refs = s.point_cache_hits + s.point_cache_misses;
+    let hit_rate = pct(s.point_cache_hits, cache_refs);
+
+    eprintln!("\n=== {} ===", p.path);
+    eprintln!(
+        "  {:.1} MB | {} entities | {} meshes | {} verts | {} tris | {:.2} Mtris/s (geom)",
+        p.file_mb, p.entities, s.total_meshes, s.total_vertices, tris, mtris_s,
+    );
+    eprintln!(
+        "  best total {} ms  (runs: {:?} ms)",
+        s.total_time_ms, p.all_totals_ms
+    );
+    eprintln!("  phase                    ms        % total");
+    eprintln!(
+        "  parse (pre-geometry)  {:>8}   {:>5.1}%",
+        parse,
+        pct(parse, total)
+    );
+    eprintln!(
+        "    - index-scan alone  {:>8.1}   {:>5.1}%   (isolated build_entity_index)",
+        p.index_build_ms,
+        pct(p.index_build_ms as u64, total)
+    );
+    eprintln!(
+        "    - entity_scan       {:>8}   {:>5.1}%",
+        s.entity_scan_time_ms,
+        pct(s.entity_scan_time_ms, total)
+    );
+    eprintln!(
+        "    - lookup/styles     {:>8}   {:>5.1}%",
+        s.lookup_time_ms,
+        pct(s.lookup_time_ms, total)
+    );
+    eprintln!(
+        "    - preprocess        {:>8}   {:>5.1}%",
+        s.preprocess_time_ms,
+        pct(s.preprocess_time_ms, total)
+    );
+    eprintln!(
+        "  geometry              {:>8}   {:>5.1}%",
+        geom,
+        pct(geom, total)
+    );
+    if s.faceted_brep_time_ms > 0 {
+        eprintln!(
+            "    - faceted-brep      {:>8}   {:>5.1}%   (observability build)",
+            s.faceted_brep_time_ms,
+            pct(s.faceted_brep_time_ms, total)
+        );
+    }
+    if cache_refs > 0 {
+        eprintln!(
+            "  brep point-cache      {} hits / {} misses ({:.1}% memoized)",
+            s.point_cache_hits, s.point_cache_misses, hit_rate
+        );
+    }
+    if s.total_csg_failures > 0 {
+        eprintln!(
+            "  csg failures          {} across {} products",
+            s.total_csg_failures, s.products_with_failures
+        );
+    }
+    if s.degenerate_triangles_dropped > 0 {
+        eprintln!(
+            "  degenerate dropped    {}",
+            s.degenerate_triangles_dropped
+        );
+    }
+    if let Some(c) = &p.census {
+        eprintln!(
+            "  csg census            {} subtract / {} union / {} intersect / {} clip | {} operand-tris",
+            c.subtract, c.union, c.intersection, c.clip, c.operand_tris
+        );
+    }
+}
+
+fn print_json(probes: &[Probe]) {
+    // Hand-rolled to avoid pulling serde_json into an example; the shape is
+    // small and stable. Emits one object per fixture.
+    let mut out = String::from("[\n");
+    for (i, p) in probes.iter().enumerate() {
+        let s = &p.stats;
+        let census = p
+            .census
+            .as_ref()
+            .map(|c| {
+                format!(
+                    r#","csg":{{"subtract":{},"union":{},"intersection":{},"clip":{},"operandTris":{}}}"#,
+                    c.subtract, c.union, c.intersection, c.clip, c.operand_tris
+                )
+            })
+            .unwrap_or_default();
+        out.push_str(&format!(
+            concat!(
+                "  {{",
+                r#""path":{:?},"fileMb":{:.3},"entities":{},"meshes":{},"vertices":{},"triangles":{},"#,
+                r#""indexBuildMs":{:.2},"parseMs":{},"entityScanMs":{},"lookupMs":{},"preprocessMs":{},"#,
+                r#""geometryMs":{},"facetedBrepMs":{},"totalMs":{},"allTotalsMs":{:?},"#,
+                r#""pointCacheHits":{},"pointCacheMisses":{},"csgFailures":{},"degenerateDropped":{}{}}}"#,
+            ),
+            p.path,
+            p.file_mb,
+            p.entities,
+            s.total_meshes,
+            s.total_vertices,
+            s.total_triangles,
+            p.index_build_ms,
+            s.parse_time_ms,
+            s.entity_scan_time_ms,
+            s.lookup_time_ms,
+            s.preprocess_time_ms,
+            s.geometry_time_ms,
+            s.faceted_brep_time_ms,
+            s.total_time_ms,
+            p.all_totals_ms,
+            s.point_cache_hits,
+            s.point_cache_misses,
+            s.total_csg_failures,
+            s.degenerate_triangles_dropped,
+            census,
+        ));
+        out.push_str(if i + 1 < probes.len() { ",\n" } else { "\n" });
+    }
+    out.push(']');
+    println!("{out}");
+}
+
+/// Catalogued heavy fixtures worth profiling, in rough phase-stress order.
+/// Skipped silently when not fetched (`pnpm fixtures <path>`).
+const SUITE: &[&str] = &[
+    "tests/models/ara3d/schependomlaan.ifc",           // arch, void-CSG
+    "tests/models/ifc5/Tekla_House_TeklaHouse.ifcx",   // steel, faceted-brep
+    "tests/models/various/01_BIMcollab_Example_ARC.ifc", // mid arch
+    "tests/models/ara3d/AC-20-Smiley-West-10-Bldg.ifc", // small arch
+    "tests/models/ara3d/ISSUE_053_20181220Holter_Tower_10.ifc", // big parse
+    "tests/models/various/O-S1-BWK-BIM architectural - BIM bouwkundig.ifc", // largest
+];
+
+fn main() {
+    let mut iters = 3usize;
+    let mut json = false;
+    let mut census = false;
+    let mut suite = false;
+    let mut fixtures: Vec<String> = Vec::new();
+
+    let mut args = std::env::args().skip(1);
+    while let Some(a) = args.next() {
+        match a.as_str() {
+            "--iters" => {
+                iters = args
+                    .next()
+                    .and_then(|v| v.parse().ok())
+                    .filter(|n| *n >= 1)
+                    .unwrap_or_else(|| {
+                        eprintln!("--iters expects a positive integer");
+                        std::process::exit(2);
+                    });
+            }
+            "--json" => json = true,
+            "--census" => census = true,
+            "--suite" => suite = true,
+            other if other.starts_with("--") => {
+                eprintln!("unknown flag: {other}");
+                eprintln!("usage: perf_probe [<file.ifc>...] [--suite] [--iters N] [--census] [--json]");
+                std::process::exit(2);
+            }
+            other => fixtures.push(other.to_string()),
+        }
+    }
+    if suite {
+        for f in SUITE {
+            fixtures.push((*f).to_string());
+        }
+    }
+    if fixtures.is_empty() {
+        eprintln!("usage: perf_probe [<file.ifc>...] [--suite] [--iters N] [--census] [--json]");
+        eprintln!("  no fixtures given; try --suite (uses catalogued models on disk)");
+        std::process::exit(2);
+    }
+
+    eprintln!(
+        "perf_probe: {} fixture(s), best-of-{}{}",
+        fixtures.len(),
+        iters,
+        if census { ", +csg-census" } else { "" }
+    );
+
+    let mut probes = Vec::new();
+    for f in &fixtures {
+        if let Some(p) = run(f, iters, census) {
+            print_human(&p);
+            probes.push(p);
+        }
+    }
+
+    if json {
+        print_json(&probes);
+    }
+
+    if probes.is_empty() {
+        eprintln!("\nno fixtures measured (all missing?). Fetch with: pnpm fixtures <path>");
+        std::process::exit(1);
+    }
+}

--- a/rust/processing/examples/perf_probe.rs
+++ b/rust/processing/examples/perf_probe.rs
@@ -73,14 +73,23 @@ struct CensusSummary {
     operand_tris: u64,
 }
 
+// CSG op codes as recorded in `CsgOpRecord.op` (a `u8`, not an exported enum).
+// Mirrors ifc_lite_geometry's census numbering; kept as named constants so a
+// reorder there surfaces as a one-line change here rather than silently
+// swapping the reported counts.
+const OP_SUBTRACT: u8 = 0;
+const OP_UNION: u8 = 1;
+const OP_INTERSECTION: u8 = 2;
+const OP_CLIP: u8 = 3;
+
 fn summarize_census() -> CensusSummary {
     let mut s = CensusSummary::default();
     for r in take_csg_census() {
         match r.op {
-            0 => s.subtract += 1,
-            1 => s.union += 1,
-            2 => s.intersection += 1,
-            3 => s.clip += 1,
+            OP_SUBTRACT => s.subtract += 1,
+            OP_UNION => s.union += 1,
+            OP_INTERSECTION => s.intersection += 1,
+            OP_CLIP => s.clip += 1,
             _ => {}
         }
         s.operand_tris += r.a_tris as u64 + r.b_tris as u64;

--- a/rust/processing/examples/perf_probe.rs
+++ b/rust/processing/examples/perf_probe.rs
@@ -300,13 +300,16 @@ fn print_json(probes: &[Probe]) {
     println!("{out}");
 }
 
-/// Catalogued heavy fixtures worth profiling, in rough phase-stress order.
-/// Skipped silently when not fetched (`pnpm fixtures <path>`).
+/// Catalogued public manifest fixtures worth profiling, in rough phase-stress
+/// order. All are STEP `.ifc` (the probe drives `process_geometry`, the STEP
+/// path; IFCX/IFC5 use a separate pipeline and would report zero here) and all
+/// are fetchable with `pnpm fixtures <path>`; each is skipped silently when not
+/// on disk.
 const SUITE: &[&str] = &[
-    "tests/models/ara3d/schependomlaan.ifc",           // arch, void-CSG
-    "tests/models/ifc5/Tekla_House_TeklaHouse.ifcx",   // steel, faceted-brep
+    "tests/models/ara3d/AC20-FZK-Haus.ifc",              // small arch
+    "tests/models/various/01_Snowdon_Towers_Sample_Structural(1).ifc", // structural
     "tests/models/various/01_BIMcollab_Example_ARC.ifc", // mid arch
-    "tests/models/ara3d/AC-20-Smiley-West-10-Bldg.ifc", // small arch
+    "tests/models/ara3d/schependomlaan.ifc",            // arch, void-CSG, parse-heavy
     "tests/models/ara3d/ISSUE_053_20181220Holter_Tower_10.ifc", // big parse
     "tests/models/various/O-S1-BWK-BIM architectural - BIM bouwkundig.ifc", // largest
 ];

--- a/scripts/perf/README.md
+++ b/scripts/perf/README.md
@@ -1,0 +1,141 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+     License, v. 2.0. If a copy of the MPL was not distributed with this
+     file, You can obtain one at https://mozilla.org/MPL/2.0/. -->
+
+# Performance diagnosis kit
+
+One place to answer "where does load time go, and what is the biggest lever?"
+for both the **native** Rust pipeline (CLI/server/exporter) and the **WASM**
+viewer path. The two run the *same* Rust code (`process_geometry` ->
+`produce_element_meshes`), so native profiling finds the algorithmic hotspots
+that also dominate in the browser; the WASM-only concerns (per-worker file
+re-decode, no threads, memory bandwidth) are orchestration-level and are read
+off the viewer's own telemetry (below).
+
+## TL;DR
+
+```bash
+# per-phase parse-vs-geometry attribution across the heavy fixtures on disk:
+scripts/perf/probe.sh --suite --census
+
+# one fixture, more iterations, JSON for diffing runs:
+scripts/perf/probe.sh tests/models/ara3d/schependomlaan.ifc --iters 5 --json > /tmp/a.json
+
+# symbolized flamegraph (opens Firefox profiler) to see WHICH function:
+scripts/perf/flame.sh tests/models/ara3d/schependomlaan.ifc
+```
+
+Fetch a fixture first if missing: `pnpm fixtures ara3d/schependomlaan.ifc`.
+
+## The native probe (`perf_probe`)
+
+`rust/processing/examples/perf_probe.rs`, wrapped by `probe.sh`. It drains the
+timings the pipeline already publishes (`ProcessingStats`) plus an isolated
+`build_entity_index` scan, best-of-N, and prints the split:
+
+```
+  parse (pre-geometry)   <ms>   <%>     <- single-threaded; gates time-to-first-geometry
+    - index-scan alone   <ms>   <%>     <- isolated build_entity_index (structural scan)
+    - entity_scan        <ms>   <%>     <- scan loop + job/quick-metadata building
+    - lookup/styles      <ms>   <%>     <- style/material/void resolution
+    - preprocess         <ms>   <%>     <- unit scales, RTC detect, site transforms
+  geometry               <ms>   <%>     <- rayon-parallel; CSG-dominated on heavy models
+    - faceted-brep       <ms>   <%>     <- only with OBS=1 (features observability)
+  brep point-cache       <hits>/<misses> (<rate>% memoized)
+  csg census             <subtract/union/intersect/clip> | <operand-tris>
+```
+
+Flags: `--suite` (all catalogued heavy fixtures on disk), `--iters N`,
+`--census` (CSG op distribution), `--json` (stdout; table stays on stderr),
+`OBS=1` env (build with `observability` to fill `faceted_brep_time_ms`).
+
+Why `--profile profiling`: release-grade opt but keeps symbols and
+`panic=unwind`, so `samply` gets a symbolized flamegraph and per-element
+`catch_unwind` isolation still fires. (Plain `release` strips symbols;
+`server-release` keeps unwind but strips.)
+
+### Reading it
+
+- **`parse` large** -> the win is in the **single-threaded** scan/decode path;
+  it hits every model and is the time-to-first-geometry gate in the viewer.
+- **`geometry` large** -> CSG/brep bound; check `csg census` operand-tris and the
+  dead-end ledger below before touching the kernel.
+- `index-scan alone` vs `entity_scan`: the gap is job-list + quick-metadata
+  building layered on the raw scan.
+
+## Flamegraph (`flame.sh`)
+
+`samply record` on the profiling binary, opens the Firefox profiler. Click into
+`ifc_lite_processing::...` for parse, `ifc_lite_geometry::kernel::...` for CSG.
+Install once: `cargo install samply`.
+
+## The WASM / viewer side
+
+The browser can't use `std::time::Instant` (traps on wasm32), so parse phases
+are timed in JS. Diagnose there with:
+
+- **PostHog `ifc_model_loaded`** (project IFClite 199147): per-load milestones
+  `file_read_ms, metadata_complete_ms, first_geometry_batch_ms,
+  first_visible_geometry_ms, stream_complete_ms, total_elapsed_ms` + mesh/vert/tri
+  counts. Emitted in `apps/viewer/src/hooks/useIfcLoader.ts`. This is the
+  **user-facing** truth (time-to-first-paint, time-to-complete).
+- **Console `[stream]` timeline** (`packages/geometry/src/geometry-parallel.ts`)
+  and `[useIfc] TOTAL LOAD TIME` lines: `meta @`, `styles @`, `entity-index @`,
+  worker-ready, first-batch. The CI benchmark scrapes these.
+- **`?perfMem=1`** -> `memoryAccounting` `[mem-summary]` (JS heap, per-worker WASM
+  heap, geometry bytes, transport bytes; `apps/viewer/src/lib/perf/memoryAccounting.ts`).
+- **CI viewer benchmark** (`.github/workflows/benchmark.yml`, advisory): 6 load
+  milestones vs `tests/benchmark/baseline.json`, flags >50% regressions on a PR.
+  Run locally: `pnpm test:benchmark:viewer:ci`; check:
+  `node scripts/check-benchmark-regression.js --advisory`.
+- **`?geomWorkers=N`** and `window.__ifc_lite_viewer_store__` for live poking.
+
+WASM-specific structural cost (not in the native probe, by design):
+- **Per-worker file re-decode**: each of N geometry workers re-decodes the whole
+  file + rebuilds its own entity index (`packages/geometry/src/worker-count.ts`),
+  the ~5x peak-memory driver. Worker count is memory-clamped, not CPU-bound
+  (`SMALL_FILE_MB=24`, >512 MB caps to 3-4). More workers do **not** speed up
+  CSG (memory-bandwidth bound) - see ledger.
+- **No wasm threads in the live path**: `init_thread_pool` exists only in the
+  `threads` bundle (off by default); cross-worker parallelism is the JS pool.
+
+## Specialized harnesses (when the probe is too coarse)
+
+| Tool | Question it answers |
+|------|--------------------|
+| `rust/processing/examples/csg_scaling_bench.rs` (`--features csg-capture`) | Does native CSG scale with cores? (captures + replays the void-cut corpus under 1/2/4/8 threads) |
+| `rust/export/examples/glb_export_profile.rs` | GLB export phase split (index / mesh / assemble+serialize) + per-type triangle mass |
+| `rust/csg-thread-bench/` (detached crate, `build.sh` + `web/serve.mjs`) | Threaded-WASM CSG: atomics tax + SharedArrayBuffer scaling in the browser |
+
+## Lever ledger (read before spiking)
+
+Encoded so a spike does not re-walk a dead end. History lives in the PRs cited.
+
+### Shipped wins
+- **Fast first-geometry** (#1185): ship index/styles/first-wave at scan-complete;
+  22s -> 11.8s wall to first paint. Overlap parse + geometry.
+- **Faceted-brep dedup** (#1184) + **CartesianPoint cache hoist** (#1568/#1572):
+  memoize shared points across parts; big win on steel/Tekla.
+- **Local-frame f32 collapse** (#1114): per-element origin removes far-from-origin
+  jitter and shrinks coordinates.
+- **Worker right-sizing** (#1431): `SMALL_FILE_MB` 64->24, -21% peak, 0 regression.
+- **SharedEntityIndex** (#1445): ~600 MB less peak on huge files.
+- **Vertex weld at faceted-brep source** (#1562): closes the volume-metric gap.
+
+### Dead ends (do NOT re-spike without a new mechanism)
+- **More geometry workers** -> zero CSG speedup: memory-bandwidth bound, not CPU.
+- **Void-cut dedup** (#1286-P5 / #1571): ~4% eligible on real models (plan-rotated
+  walls ineligible AND costliest); world-frame cut can't be byte-identical. PARKED.
+- **Content-dedup** (#1130): hash re-decodes the subtree, 20-30% slower net. OFF.
+- **Manifold WASM / BSP kernel**: deleted at M9; pure-Rust exact kernel is the only
+  one. C++ accelerator was a dead end.
+- **Rect-fast void path**: correct where it fires but barely fires (0 on Revit/Tekla);
+  not the lever.
+- **CSG exact-arith**: ~15ms/cut floor is the arithmetic cost; the only lever there
+  is *doing fewer/cheaper cuts* (analytic bypass), not faster exact CSG.
+
+### Standing constraints
+- Geometry is **client-side only** (no server meshing).
+- One mesh home: `produce_element_meshes` - a fix in one pipeline diverges the other.
+- Parity gates: `mesh_determinism` manifests (x86_64 + arm64 + wasm32),
+  `styling_parity`, `exact_predicate_determinism`. A real output change re-pins them.

--- a/scripts/perf/flame.sh
+++ b/scripts/perf/flame.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#
+# Symbolized flamegraph of the native pipeline on one fixture, via samply
+# (https://github.com/mstange/samply -> `cargo install samply`). Opens the
+# Firefox-profiler UI so parse/geometry hotspots are clickable down to the
+# function. The `profiling` cargo profile keeps symbols + panic=unwind.
+#
+#   scripts/perf/flame.sh tests/models/ara3d/schependomlaan.ifc
+#   scripts/perf/flame.sh tests/models/ifc5/Tekla_House_TeklaHouse.ifcx --iters 1
+#
+# Use --iters 1 for a single clean pass in the flamegraph (default 3 stacks
+# three passes, useful for a warmer, denser sample).
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+[ -f "$HOME/.cargo/env" ] && source "$HOME/.cargo/env"
+
+if ! command -v samply >/dev/null 2>&1; then
+  echo "samply not found. Install it: cargo install samply" >&2
+  exit 1
+fi
+if [ "$#" -lt 1 ]; then
+  echo "usage: scripts/perf/flame.sh <file.ifc> [perf_probe args...]" >&2
+  exit 2
+fi
+
+cargo build --profile profiling -p ifc-lite-processing --example perf_probe >&2
+BIN="$ROOT/target/profiling/examples/perf_probe"
+echo "samply record $BIN $*" >&2
+exec samply record "$BIN" "$@"

--- a/scripts/perf/flame.sh
+++ b/scripts/perf/flame.sh
@@ -9,7 +9,7 @@
 # function. The `profiling` cargo profile keeps symbols + panic=unwind.
 #
 #   scripts/perf/flame.sh tests/models/ara3d/schependomlaan.ifc
-#   scripts/perf/flame.sh tests/models/ifc5/Tekla_House_TeklaHouse.ifcx --iters 1
+#   scripts/perf/flame.sh tests/models/ara3d/AC20-FZK-Haus.ifc --iters 1
 #
 # Use --iters 1 for a single clean pass in the flamegraph (default 3 stacks
 # three passes, useful for a warmer, denser sample).

--- a/scripts/perf/probe.sh
+++ b/scripts/perf/probe.sh
@@ -21,5 +21,8 @@ if [ "${OBS:-0}" = "1" ]; then
   FEATURES=(--features observability)
 fi
 
-cargo build --profile profiling -p ifc-lite-processing --example perf_probe "${FEATURES[@]}" >&2
+# `${FEATURES[@]+"${FEATURES[@]}"}` expands to nothing when the array is empty
+# without tripping `set -u` on macOS's default bash 3.2 (which treats an empty
+# array expansion as an unbound variable; fixed in bash 4.4).
+cargo build --profile profiling -p ifc-lite-processing --example perf_probe ${FEATURES[@]+"${FEATURES[@]}"} >&2
 exec "$ROOT/target/profiling/examples/perf_probe" "$@"

--- a/scripts/perf/probe.sh
+++ b/scripts/perf/probe.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#
+# Build + run the native perf probe (per-phase parse-vs-geometry attribution).
+# All args pass through to the `perf_probe` example.
+#
+#   scripts/perf/probe.sh --suite --census
+#   scripts/perf/probe.sh tests/models/ara3d/schependomlaan.ifc --iters 5
+#   scripts/perf/probe.sh --suite --json > /tmp/perf.json
+#
+# Add OBS=1 to build with `--features observability` (fills faceted_brep_time_ms).
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+[ -f "$HOME/.cargo/env" ] && source "$HOME/.cargo/env"
+
+FEATURES=()
+if [ "${OBS:-0}" = "1" ]; then
+  FEATURES=(--features observability)
+fi
+
+cargo build --profile profiling -p ifc-lite-processing --example perf_probe "${FEATURES[@]}" >&2
+exec "$ROOT/target/profiling/examples/perf_probe" "$@"


### PR DESCRIPTION
## What

Two things, one investigation:

1. **The lever.** The STEP scanner's `find_entity_end` walked every byte of each entity record to find the terminating `;`. Profiling showed it's the single hottest structural-scan function: it runs per entity through **both** `build_entity_index` **and** the processor scan loop (they share `EntityScanner`), and parse is **single-threaded**, so it gates time-to-first-geometry (and is paid N× via per-worker re-decode in the browser). Rewritten to `memchr2('\'', ';')` — the overwhelming majority of records are string-free geometry primitives (`#7=IFCCARTESIANPOINT((1.,2.,3.));`), so the terminator is found in one vectorized hop.

2. **The kit that found it** (`scripts/perf/` + `rust/processing/examples/perf_probe.rs`): a unified native probe that drains the per-phase timings `ProcessingStats` already publishes (parse vs geometry, with an isolated `build_entity_index` scan + CSG census), a samply flamegraph wrapper, and a README tying the native probe to the WASM viewer telemetry plus a lever ledger (shipped wins + dead-ends).

## Why it matters

"CSG is 85-90% of load" only holds for steel/MEP. Parse scales with entity **count**, so on entity-heavy architecture it dominates: schependomlaan (47 MB, 714k entities) is **82% parse, 18% geometry**. This is the most user-facing lever — it speeds up every model's load and first-paint, native and browser.

## Numbers (best-of-N, `profiling` profile)

| Fixture | isolated scanner walk | parse phase | total load |
|---|---|---|---|
| schependomlaan 47 MB | 56.5 → 36.1 ms (**-36%**) | -14% | -8% |
| BIMcollab 17 MB | 19.9 → 10.4 ms (**-48%**) | -30% | **-19%** |
| Smiley 5.8 MB | 7.8 → 4.5 ms (**-42%**) | -28% | -12% |
| MEP 218 MB | 213 → 94 ms (**-56%**) | -16% | -10% |

## Correctness

**Byte-identical output** — semantics unchanged (first `;` outside a quoted string; doubled `''` is an escaped in-string quote per ISO 10303-21). Verified:
- `mesh_determinism::mesh_output_matches_pinned_manifest` — passes with **no manifest re-pin**
- `gltf::export_is_byte_deterministic`, `bounded_glb_with_index_is_byte_identical` — pass
- full `ifc-lite-core` / `-processing` / `-export` suites green; malformed-input edge cases (`truncated_missing_semicolon`, `unterminated_string`, `random_byte_sweep`) green
- clippy clean; compiles for `wasm32-unknown-unknown`; wasm bundle rebuilds with no committed `.d.ts` drift

## Notes

- `[profile.profiling]` added to the root Cargo.toml (release opt + symbols + panic=unwind) so samply symbolicates and per-element `catch_unwind` still fires.
- Follow-on parse levers this kit surfaced (not in this PR): the double file-walk (`build_entity_index` + scan loop both run the scanner) and `IfcType::from_str`'s per-call `to_uppercase()` allocation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved STEP file parsing speed, especially on larger models, with no change to output results.

* **New Features**
  * Added a profiling build mode for gathering performance data with optimized binaries and debug symbols.
  * Added a new performance probe utility for measuring parse and processing timings.
  * Added helper scripts to run the probe and generate flamegraphs.

* **Documentation**
  * Added guidance for using the performance toolkit and interpreting timing results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->