### PR TITLE
perf(processing): build the STEP entity index in one file walk, not two

### DIFF
--- a/.changeset/perf-single-pass-entity-index.md
+++ b/.changeset/perf-single-pass-entity-index.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/wasm": patch
+---
+
+Faster STEP parsing: build the entity index in a single file walk instead of two. The pipeline previously scanned the whole file once in `build_entity_index` and again in the processor scan loop (both drive the same `EntityScanner`). The index is now built inline during the existing scan loop, so the file is traversed once. Parse is single-threaded, so this shaves the time-to-first-geometry gate; the saving is one full scanner traversal and scales with file size (measured -9% on the entity-scan phase and -7% on total load for a 47 MB model; larger on bigger files). Output is byte-identical (no mesh-determinism manifest change): the inline index is provably the same map `build_entity_index` produced, and the scan-phase decoder only needs local `decode_at` (no index) until the completed index is installed before the first reference resolution.

--- a/rust/core/src/decoder.rs
+++ b/rust/core/src/decoder.rs
@@ -127,6 +127,14 @@ impl<'a> EntityDecoder<'a> {
         }
     }
 
+    /// Install a pre-built index into this decoder. Used when the caller already
+    /// built the index during another pass (e.g. the processor scan loop) so the
+    /// decoder does not lazily rebuild it via `build_index`. Set it before any
+    /// `decode_by_id`/ref-resolving call; afterwards `build_index` no-ops.
+    pub fn set_entity_index(&mut self, index: Arc<EntityIndex>) {
+        self.entity_index = Some(index);
+    }
+
     /// Build entity index for O(1) lookups
     /// This scans the file once and maps entity IDs to byte offsets
     fn build_index(&mut self) {

--- a/rust/processing/src/processor/mod.rs
+++ b/rust/processing/src/processor/mod.rs
@@ -12,7 +12,7 @@ use crate::types::response::{
     QuickMetadataEntitySummary,
 };
 use ifc_lite_core::{
-    build_entity_index, DecodedEntity, EntityDecoder,
+    DecodedEntity, EntityDecoder,
     EntityIndex, EntityScanner, IfcType,
 };
 use ifc_lite_geometry::TessellationQuality;
@@ -480,16 +480,24 @@ pub fn process_geometry_streaming_filtered_with_options(
     );
     let scan_guard = scan_span.clone().entered();
 
-    // Build the entity index (fast SIMD-accelerated single pass), unless a caller
-    // injected one built from the same `content` to share across passes.
-    let entity_index = tracing::debug_span!("entity_index").in_scope(|| {
-        options
-            .entity_index
-            .clone()
-            .unwrap_or_else(|| Arc::new(build_entity_index(content)))
-    });
-    let mut decoder = EntityDecoder::with_arc_index(content, entity_index.clone());
-    tracing::debug!("Built entity index");
+    // The entity index (expressId -> byte span) is built INLINE in the scan loop
+    // below rather than in a separate `build_entity_index` pass, so the file is
+    // walked once instead of twice. A caller that injected an index reuses it and
+    // skips the inline build. `decode_at` during the scan needs no index (it parses
+    // local bytes), so the scan-phase decoder starts index-less; the completed
+    // index is installed before the first ref-resolving call (`resolve_prepass`).
+    let provided_index = options.entity_index.clone();
+    let building_index = provided_index.is_none();
+    let mut inline_index: EntityIndex = if building_index {
+        FxHashMap::with_capacity_and_hasher(content.len() / 50, Default::default())
+    } else {
+        FxHashMap::default()
+    };
+    let mut decoder = match &provided_index {
+        Some(idx) => EntityDecoder::with_arc_index(content, idx.clone()),
+        None => EntityDecoder::new(content),
+    };
+    tracing::debug!("Entity index will be built inline during the scan");
 
     // Styled items / indexed colour maps / material chain / voids / fills /
     // aggregates are span-stashed during the scan and resolved afterwards by
@@ -559,6 +567,9 @@ pub fn process_geometry_streaming_filtered_with_options(
 
     while let Some((id, type_name, start, end)) = scanner.next_entity() {
         total_entities += 1;
+        if building_index {
+            inline_index.insert(id, (start, end));
+        }
         if let Some(spatial_nodes) = quick_spatial_nodes.as_mut() {
             // Case-insensitive check without allocating a new uppercase string.
             if is_quick_spatial_type_ci(type_name) {
@@ -793,6 +804,19 @@ pub fn process_geometry_streaming_filtered_with_options(
             });
         }
     }
+
+    // The inline index is now complete — identical to `build_entity_index` over
+    // the same scanner. Install it into the decoder so `resolve_prepass` and the
+    // downstream phases resolve refs against it, and expose it (as before) to the
+    // geometry workers further down.
+    let entity_index: Arc<EntityIndex> = match provided_index {
+        Some(idx) => idx,
+        None => {
+            let arc = Arc::new(inline_index);
+            decoder.set_entity_index(arc.clone());
+            arc
+        }
+    };
 
     // ── Shared post-scan resolution (`crate::prepass`) ──
     // Styled items (orphan vs attached, defer-aware), IfcIndexedColourMap,

--- a/rust/processing/tests/module_size_allowlist.txt
+++ b/rust/processing/tests/module_size_allowlist.txt
@@ -10,7 +10,8 @@
      756 apps/server/src/services/parquet_data_model.rs
      581 apps/server/src/services/parquet_optimized.rs
      522 apps/server/src/services/parquet.rs
-    1087 rust/core/src/decoder.rs
+# +8: add set_entity_index setter so the processor can install its inline-built index (perf/single-scan).
+    1095 rust/core/src/decoder.rs
      429 rust/core/src/fast_parse.rs
      793 rust/core/src/georef.rs
      445 rust/core/src/model_bounds.rs
@@ -71,7 +72,8 @@
      812 rust/processing/src/element.rs
      468 rust/processing/src/georeferencing.rs
      772 rust/processing/src/prepass.rs
-    1474 rust/processing/src/processor/mod.rs
+# +24: build the entity index INLINE in the scan loop instead of a separate build_entity_index pass (perf/single-scan; one file walk instead of two).
+    1498 rust/processing/src/processor/mod.rs
      440 rust/processing/src/symbolic/items.rs
 # +6: wire per-batch point-cache hit/miss stats into record_pipeline_batch (perf/brep-point-cache-instrumentation).
      773 rust/wasm-bindings/src/api/gpu_meshes/batch.rs


### PR DESCRIPTION
## What

`process_geometry` walked the STEP file **twice**: once in `build_entity_index` (to build the `expressId -> byte-span` map) and again in the processor scan loop — both driving the same `EntityScanner`. This builds the index **inline during the existing scan loop**, so the file is traversed once. Parse is single-threaded, so this shaves the time-to-first-geometry gate.

Follow-on to #1579 (memchr2 scanner), using the same diagnostic kit.

## Numbers (schependomlaan 47 MB / 714k entities, best-of-N, quiet machine, same-session A/B)

| phase | before (double-walk) | after (single-pass) | Δ |
|---|---|---|---|
| entity_scan | 226 ms | 205 ms | **-9.3%** |
| parse | 303 ms | 271 ms | **-10.6%** |
| total load | 382 ms | 354 ms | **-7.3%** |

The saving is one full scanner traversal; it scales with file size (a ~200 MB model saves ~90 ms).

## Byte-identical (no manifest re-pin)

Triple-verified:
- **`mesh_output_matches_pinned_manifest`** passes with no re-pin (the byte-exact mesh-output gate).
- **Independent adversarial review** of the 7 invariants: the inline `insert(id,(start,end))` sits at the very top of the loop before all 12 `continue` paths (every entity indexed, last-wins on dup ids); the scan-phase decoder only calls `decode_at` (parses local bytes, never touches the index) until the completed index is installed via the new `EntityDecoder::set_entity_index` right before the first `resolve_prepass` reference resolution, after which `build_index()` no-ops; the caller-injected-index path (`process_geometry_with_index`) is unchanged; identical `content.len()/50` capacity.
- Same scanner now feeds both the index and the dispatch, removing even the theoretical two-scanner-disagreement window.

## Notes

- `build_entity_index` stays exported — it has ~90 other callers outside this pipeline.
- Module-size ratchet budgets bumped for the two touched files (`decoder.rs` +8, `processor/mod.rs` +24) per the allowlist's refresh-on-change contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)