### PR TITLE
perf(geometry): inline orient_mesh_outward edge adjacency (drop per-edge Vec)

### DIFF
--- a/.changeset/perf-orient-mesh-inline-edges.md
+++ b/.changeset/perf-orient-mesh-inline-edges.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/wasm": patch
+---
+
+Faster mesh orientation: `orient_mesh_outward` (run on every element and sub-mesh to make faceted-brep / merged-body winding consistent and outward) built its edge adjacency in a `FxHashMap<(u32,u32), Vec<usize>>` — one tiny heap `Vec` per welded edge, ~1.5 allocations per triangle, rebuilt from scratch per mesh. That per-edge `Vec` is replaced with an inline fixed-capacity incidence record (two triangle slots + a true count), and the weld/edge maps are pre-reserved. A boundary edge has one incident triangle and a manifold edge exactly two; non-manifold edges (count > 2) are skipped before the slots are read, so only the first two triangles are ever consulted — in the same scan order as before. Output is byte-identical (no mesh-determinism manifest change; verified against the previous implementation across an exhaustive cube-flip + millions of random-topology meshes). It removes ~1.3M tiny allocations per pass on a mesh-heavy model and measures a ~14% faster geometry phase / +16% mesh throughput there (structural steel, Tekla / Revit faceted-brep — the models where CSG is not the bottleneck).

--- a/rust/geometry/src/mesh_orient.rs
+++ b/rust/geometry/src/mesh_orient.rs
@@ -27,6 +27,39 @@
 use crate::Mesh;
 use rustc_hash::FxHashMap;
 
+/// Incident-triangle record for one undirected welded edge. A boundary edge has
+/// one incident triangle and a manifold edge exactly two, so the two triangle
+/// slots are stored INLINE — replacing the old per-edge heap `Vec<usize>`, which
+/// allocated ~1.5 tiny Vecs per triangle and dominated the allocator churn of
+/// this pass on mesh-heavy models. `count` is the TRUE incidence; a value > 2
+/// marks a non-manifold edge, which the propagation skips before ever reading
+/// the slots. Only the first two triangles are consulted, stored in ascending
+/// scan order (identical to the old `Vec` push order), so the BFS traversal —
+/// and therefore every flip decision — is byte-identical.
+#[derive(Clone, Copy, Default)]
+struct EdgeInc {
+    tris: [usize; 2],
+    count: u32,
+}
+
+impl EdgeInc {
+    #[inline]
+    fn push(&mut self, t: usize) {
+        if (self.count as usize) < 2 {
+            self.tris[self.count as usize] = t;
+        }
+        self.count += 1;
+    }
+
+    /// The incident triangles the propagation may consult (the first two, in
+    /// push order). Only reached for `count` of 1 or 2 — the `count > 2` path
+    /// `continue`s first — so this yields exactly what the old `Vec` iterated.
+    #[inline]
+    fn incident(&self) -> &[usize] {
+        &self.tris[..(self.count as usize).min(2)]
+    }
+}
+
 /// Vertex weld grid (10 µm): fine enough not to merge distinct mm-scale features,
 /// coarse enough to weld the (usually bit-equal) coincident flat-shaded
 /// duplicates so shared edges are found. Under-welding only splits a body into
@@ -53,7 +86,8 @@ pub fn orient_mesh_outward(mesh: &mut Mesh) -> bool {
 
     // Weld positions -> welded vertex id; record the welded vid of every corner.
     let q = |v: f32| (v as f64 * WELD).round() as i64;
-    let mut vid_of: FxHashMap<(i64, i64, i64), u32> = FxHashMap::default();
+    let mut vid_of: FxHashMap<(i64, i64, i64), u32> =
+        FxHashMap::with_capacity_and_hasher(vertex_count, Default::default());
     let mut vpos: Vec<[f64; 3]> = Vec::new();
     let mut corner: Vec<u32> = Vec::with_capacity(mesh.indices.len());
     for &idx in &mesh.indices {
@@ -73,7 +107,9 @@ pub fn orient_mesh_outward(mesh: &mut Mesh) -> bool {
     let tv = |t: usize| [corner[3 * t], corner[3 * t + 1], corner[3 * t + 2]];
 
     // Undirected welded edge -> incident triangles. >2 incident ⇒ non-manifold.
-    let mut edge_tris: FxHashMap<(u32, u32), Vec<usize>> = FxHashMap::default();
+    // A closed manifold has ~1.5 edges per triangle; reserve to skip rehashing.
+    let mut edge_tris: FxHashMap<(u32, u32), EdgeInc> =
+        FxHashMap::with_capacity_and_hasher(ntri * 2, Default::default());
     for t in 0..ntri {
         let v = tv(t);
         for &(a, b) in &[(v[0], v[1]), (v[1], v[2]), (v[2], v[0])] {
@@ -120,13 +156,13 @@ pub fn orient_mesh_outward(mesh: &mut Mesh) -> bool {
                 }
                 let key = if a < b { (a, b) } else { (b, a) };
                 let inc = &edge_tris[&key];
-                if inc.len() != 2 {
+                if inc.count != 2 {
                     closed = false; // boundary (1) or non-manifold (>2) edge
                 }
-                if inc.len() > 2 {
+                if inc.count > 2 {
                     continue; // ambiguous — don't propagate across a non-manifold edge
                 }
-                for &nb in inc {
+                for &nb in inc.incident() {
                     if nb == t {
                         continue;
                     }


### PR DESCRIPTION
## What

`orient_mesh_outward` (run on **every** element mesh and sub-mesh to make faceted-brep / merged-body winding consistent and outward) built its edge adjacency in `edge_tris: FxHashMap<(u32,u32), Vec<usize>>` — **one tiny heap `Vec` per welded edge** (~1.5 allocations per triangle), rebuilt from scratch per mesh. This replaces the per-edge `Vec` with an inline `EdgeInc { tris: [usize;2], count: u32 }` (no per-edge heap alloc) and pre-reserves the weld/edge maps.

Surfaced by profiling the geometry phase (the diagnostic kit from #1579): `orient_mesh_outward` was the largest non-CSG geometry self-time function on mesh-heavy models, and its per-edge `Vec` drove most of the pass's allocator churn.

## Why byte-identical

A boundary edge has one incident triangle and a manifold edge exactly two; a non-manifold edge (`count > 2`) is skipped **before** the slots are read, so only the first two triangles are ever consulted — stored in the same ascending scan order the old `Vec` pushed. So the BFS traversal and every flip decision are unchanged. Verified:
- **`mesh_output_matches_pinned_manifest`** passes with no re-pin.
- **Differential fuzz** (old vs new implementation): exhaustive 4096-mask cube-flip sweep + 200k multi-component + **2.0M random-topology** meshes (boundary / non-manifold / degenerate / malformed) → **0 divergence** in the index buffer or return value. An independent adversarial review ran its own 4k-mesh fuzz and reached the same verdict.
- All 5 `mesh_orient` unit tests pass.

## Numbers

Removes ~1.3M tiny allocations per pass on a mesh-heavy model. Snowdon Towers (structural, 864k tris), best-of-N:

| | before | after | Δ |
|---|---|---|---|
| geometry phase | 108 ms | 93 ms | **-13.9%** |
| mesh throughput | 8.0 Mtris/s | 9.3 Mtris/s | **+16%** |

Biggest on the models where CSG is *not* the bottleneck (structural steel, Tekla / Revit faceted-brep). CSG-bound models are unaffected (their geometry is the exact-arithmetic floor).

## Notes

- `EdgeInc` is module-private; the only theoretical caveat (a `u32` count wrapping) needs >2³¹ triangles sharing one edge — a >25 GB buffer, unreachable.
- Independent of #1583 (single-pass entity index) — different files, no conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)