### PR TITLE
fix: wire up + complete list/material unit display (#1573 follow-ups)

### DIFF
--- a/apps/viewer/src/components/mcp/playground-dispatcher.ts
+++ b/apps/viewer/src/components/mcp/playground-dispatcher.ts
@@ -27,7 +27,9 @@
  * for those.
  */
 
-import { IfcParser, type IfcDataStore, extractLengthUnitScale } from '@ifc-lite/parser';
+import { IfcParser, type IfcDataStore, extractLengthUnitScale, extractProjectUnits } from '@ifc-lite/parser';
+import { QuantityType } from '@ifc-lite/data';
+import { formatQuantityUnit } from '@/lib/units/display';
 import {
   BsddNamespace,
   createBimContext,
@@ -673,14 +675,23 @@ const IMPLS: Record<string, ToolImpl> = {
     const qsets = m.bim.quantities(ref);
     let vol: number | null = null;
     for (const q of qsets) for (const x of q.quantities) if (/Volume/i.test(x.name) && typeof x.value === 'number') { vol = x.value; break; }
-    return { text: vol == null ? 'No Volume quantity present.' : `Volume = ${vol.toFixed(3)} m³.`, structured: { volume: vol } };
+    // Label with the file's declared VOLUMEUNIT (issue #1573) rather than
+    // assuming m³ — the quantity value is stored in whatever unit the
+    // project declares.
+    const unit = m.store.source.length > 0
+      ? formatQuantityUnit(QuantityType.Volume, extractProjectUnits(m.store.source, m.store.entityIndex))
+      : 'm³';
+    return { text: vol == null ? 'No Volume quantity present.' : `Volume = ${vol.toFixed(3)} ${unit}.`, structured: { volume: vol, unit } };
   },
   async geometry_area(m, args) {
     const ref = resolveRef(m, args);
     const qsets = m.bim.quantities(ref);
     let area: number | null = null;
     for (const q of qsets) for (const x of q.quantities) if (/Area/i.test(x.name) && typeof x.value === 'number') { area = x.value; break; }
-    return { text: area == null ? 'No Area quantity present.' : `Area = ${area.toFixed(3)} m².`, structured: { area } };
+    const unit = m.store.source.length > 0
+      ? formatQuantityUnit(QuantityType.Area, extractProjectUnits(m.store.source, m.store.entityIndex))
+      : 'm²';
+    return { text: area == null ? 'No Area quantity present.' : `Area = ${area.toFixed(3)} ${unit}.`, structured: { area, unit } };
   },
 
   // ── Clash detection ───────────────────────────────────────────────────────

--- a/apps/viewer/src/components/viewer/PropertiesPanel.tsx
+++ b/apps/viewer/src/components/viewer/PropertiesPanel.tsx
@@ -1674,7 +1674,7 @@ export function PropertiesPanel() {
                             key={`matpset-${group.materialId}-${pset.name}`}
                             pset={{
                               name: pset.name,
-                              properties: pset.properties.map((p) => ({ name: p.name, value: p.value, isMutated: false })),
+                              properties: pset.properties.map((p) => ({ name: p.name, value: p.value, isMutated: false, dataType: p.dataType })),
                             }}
                             projectUnits={renderedProjectUnits}
                             unitDisplayOverrides={unitDisplayOverrides}

--- a/apps/viewer/src/components/viewer/lists/ListPanel.tsx
+++ b/apps/viewer/src/components/viewer/lists/ListPanel.tsx
@@ -41,6 +41,7 @@ import {
   createListDataProvider,
 } from '@/lib/lists';
 import type { ListDefinition, ListResult, ListDataProvider, ListGrouping } from '@/lib/lists';
+import { mergeResultColumns } from '@/lib/lists/merge-result-columns';
 import { extractProjectUnits, ProjectUnits, type IfcDataStore } from '@ifc-lite/parser';
 import { ListBuilder } from './ListBuilder';
 import { ListResultsTable } from './ListResultsTable';
@@ -101,18 +102,19 @@ export function ListPanel({ onClose }: ListPanelProps) {
   const allProviders = useMemo(() => modelProviderPairs.map((p) => p.provider), [modelProviderPairs]);
   const allStores = useMemo(() => modelProviderPairs.map((p) => p.store), [modelProviderPairs]);
 
-  // The file's declared units, for exporting quantity/measure columns
-  // converted into the user's display-unit override (issue #1573). A
-  // federation of models with different declared units is a real (if rare)
-  // possibility the list pipeline doesn't otherwise resolve per-row, so this
-  // picks the FIRST loaded store's units as the export-wide unit source —
-  // the same simplification already made by `numericCols`/`columnWidths`
-  // sampling only the first N rows for their own per-column decisions.
-  const projectUnits = useMemo(() => {
-    const store = allStores[0];
-    if (!store?.source?.length || !store?.entityIndex) return ProjectUnits.empty();
-    return extractProjectUnits(store.source, store.entityIndex);
-  }, [allStores]);
+  // Every loaded model's declared units, keyed by the same modelId the rows
+  // carry (issue #1573 follow-up) — the single per-model source both the
+  // on-screen table and the export resolve quantity/measure columns against
+  // (`resolveListColumnUnits`), so a federation of models with different
+  // declared units converts each row from ITS OWN model's unit rather than
+  // assuming every row shares the first model's units.
+  const modelUnits = useMemo(() => {
+    const map = new Map<string, ProjectUnits>();
+    for (const { modelId, store } of modelProviderPairs) {
+      map.set(modelId, store.source.length > 0 ? extractProjectUnits(store.source, store.entityIndex) : ProjectUnits.empty());
+    }
+    return map;
+  }, [modelProviderPairs]);
 
   const hasData = allProviders.length > 0;
 
@@ -138,8 +140,13 @@ export function ListPanel({ onClose }: ListPanelProps) {
         // across federated models (and isn't dropped on the merge).
         const { groups, summary } = summariseListRows(definition, allRows);
 
+        // Merge each part's execution-time quantityType/dataType onto the
+        // columns (P0 fix, #1573 follow-up): `definition.columns` alone never
+        // carries them, which silently killed the export unit conversion.
+        const columns = mergeResultColumns(resultParts, definition.columns);
+
         setListResult({
-          columns: definition.columns,
+          columns,
           rows: allRows,
           totalCount: allRows.length,
           executionTime: totalTime,
@@ -316,7 +323,7 @@ export function ListPanel({ onClose }: ListPanelProps) {
           listName={editingList?.name}
           grouping={editingList?.grouping}
           onGroupingChange={handleGroupingFromTable}
-          projectUnits={projectUnits}
+          modelUnits={modelUnits}
         />
       )}
 

--- a/apps/viewer/src/components/viewer/lists/ListResultsTable.tsx
+++ b/apps/viewer/src/components/viewer/lists/ListResultsTable.tsx
@@ -26,6 +26,7 @@ import { useEntityListMultiSelect, type MultiSelectItem } from '@/hooks/useEntit
 import type { ListResult, ListRow, ColumnDefinition, ListGrouping } from '@ifc-lite/lists';
 import type { ProjectUnits } from '@ifc-lite/parser';
 import { exportList, buildExportModel, EXPORT_LABELS, type ExportFormat } from '@/lib/lists/export';
+import { resolveListColumnUnits } from '@/lib/units/list-column-units';
 import { posthog } from '@/lib/analytics';
 import { cn } from '@/lib/utils';
 import { columnToAutoColor } from '@/lib/lists/columnToAutoColor';
@@ -45,15 +46,15 @@ interface ListResultsTableProps {
   grouping?: ListGrouping;
   /** Persist a grouping change made from the table back to the definition. */
   onGroupingChange?: (grouping: ListGrouping | undefined) => void;
-  /** The file's declared units, so quantity/measure columns export converted
-   *  into the user's display-unit override (issue #1573). A federation
-   *  resolves to the FIRST loaded store's units — true per-row/per-model
-   *  units aren't threaded through the list pipeline (see ListPanel.tsx).
-   *  Omitted keeps the legacy raw-value, no-unit export. */
-  projectUnits?: ProjectUnits;
+  /** Per-model declared units (issue #1573 follow-up), keyed by the same
+   *  `modelId` every `ListRow` carries — lets quantity/measure columns
+   *  render (and export) CONVERTED into one resolved target unit via
+   *  `resolveListColumnUnits`, the same resolver `buildExportModel` uses, so
+   *  the on-screen table and the export can never disagree. */
+  modelUnits: Map<string, ProjectUnits>;
 }
 
-export function ListResultsTable({ result, listName, grouping, onGroupingChange, projectUnits }: ListResultsTableProps) {
+export function ListResultsTable({ result, listName, grouping, onGroupingChange, modelUnits }: ListResultsTableProps) {
   const unitDisplayOverrides = useViewerStore((s) => s.unitDisplayOverrides);
   const parentRef = useRef<HTMLDivElement>(null);
   const [searchQuery, setSearchQuery] = useState('');
@@ -86,6 +87,13 @@ export function ListResultsTable({ result, listName, grouping, onGroupingChange,
   const columns = result.columns;
   const numericCols = useMemo(() => detectNumericColumns(columns, result.rows), [columns, result.rows]);
 
+  // Single per-column unit resolution (issue #1573 follow-up), shared with
+  // `buildExportModel` so the table and the export can never disagree.
+  const unitResolver = useMemo(
+    () => resolveListColumnUnits(columns, modelUnits, unitDisplayOverrides),
+    [columns, modelUnits, unitDisplayOverrides],
+  );
+
   const visibilityFilteredRows = useMemo(() => {
     if (!filterByVisibility) return result.rows;
     const visibleSet = new Set<string>();
@@ -107,11 +115,21 @@ export function ListResultsTable({ result, listName, grouping, onGroupingChange,
       row.values.some((v) => v !== null && String(v).toLowerCase().includes(q)));
   }, [visibilityFilteredRows, searchQuery]);
 
+  // Sorts on the RAW value (single-model monotonic either way; a federated
+  // column mixing declared units sorts by each row's pre-conversion number —
+  // pre-existing, units aren't resolved per-row for sorting).
   const sortedRows = useMemo(() => {
     if (sortCol === null) return filteredRows;
     return [...filteredRows].sort((a, b) =>
       compareCells(a.values[sortCol], b.values[sortCol]) * (sortDir === 'asc' ? 1 : -1));
   }, [filteredRows, sortCol, sortDir]);
+
+  // Rows as DISPLAYED (converted via `unitResolver`) — cell rendering, group
+  // subtotals, and the grand-totals row all agree with the export (#1573).
+  const displayRows = useMemo(
+    () => sortedRows.map((r) => ({ ...r, values: r.values.map((v, i) => unitResolver.convertCell(i, v, r.modelId)) })),
+    [sortedRows, unitResolver],
+  );
 
   // ── Grouping / aggregation derived from the definition ──
   const groupByColumnId = grouping?.columnId ?? '';
@@ -127,19 +145,19 @@ export function ListResultsTable({ result, listName, grouping, onGroupingChange,
   }>(() => {
     if (isGrouped) {
       const sort = sortCol === null ? null : { colIdx: sortCol, dir: sortDir };
-      const view = buildGroupedView(sortedRows, columns, { columnId: groupByColumnId, sumColumnIds }, expandedGroups, sort);
+      const view = buildGroupedView(displayRows, columns, { columnId: groupByColumnId, sumColumnIds }, expandedGroups, sort);
       return {
         items: view.items, groupCount: view.groupCount, totals: view.totals,
         groupKeys: view.items.filter((i) => i.kind === 'group').map((i) => (i as { key: string }).key),
       };
     }
     return {
-      items: sortedRows.map((row): DisplayItem => ({ kind: 'row', row })),
+      items: displayRows.map((row): DisplayItem => ({ kind: 'row', row })),
       groupCount: 0,
-      totals: flatTotals(sortedRows, columns, sumColumnIds),
+      totals: flatTotals(displayRows, columns, sumColumnIds),
       groupKeys: [],
     };
-  }, [isGrouped, sortedRows, columns, groupByColumnId, sumColumnIds, expandedGroups, sortCol, sortDir]);
+  }, [isGrouped, displayRows, columns, groupByColumnId, sumColumnIds, expandedGroups, sortCol, sortDir]);
 
   const columnWidths = useMemo(
     () => columns.map((c, i) => widthOverrides[c.id] ?? autoColumnWidth(c.label ?? c.propertyName, result.rows, i)),
@@ -217,7 +235,7 @@ export function ListResultsTable({ result, listName, grouping, onGroupingChange,
       numericCols,
       columnWidths,
       generatedAt: new Date().toLocaleString(),
-      projectUnits,
+      modelUnits,
       unitDisplayOverrides,
     });
     void exportList(format, model);
@@ -228,7 +246,7 @@ export function ListResultsTable({ result, listName, grouping, onGroupingChange,
       row_count: sortedRows.length,
       column_count: columns.length,
     });
-  }, [listName, columns, sortedRows, grouping, sortCol, sortDir, numericCols, columnWidths, projectUnits, unitDisplayOverrides]);
+  }, [listName, columns, sortedRows, grouping, sortCol, sortDir, numericCols, columnWidths, modelUnits, unitDisplayOverrides]);
 
   // Flat, ordered list of the selectable rows (group headers excluded) and a
   // lookup from a row to its position, so Shift+click range-select works over
@@ -336,6 +354,7 @@ export function ListResultsTable({ result, listName, grouping, onGroupingChange,
               const colored = activeLensId === AUTO_COLOR_FROM_LIST_ID && colorByColIdx === colIdx;
               const groupedBy = groupByColumnId === col.id;
               const summed = sumColumnIds.includes(col.id);
+              const unit = unitResolver.unitSymbol(colIdx);
               return (
                 <div
                   key={col.id}
@@ -348,7 +367,7 @@ export function ListResultsTable({ result, listName, grouping, onGroupingChange,
                 >
                   <button className="flex min-w-0 flex-1 items-center gap-1 hover:text-foreground" onClick={() => handleHeaderClick(colIdx)}>
                     {groupedBy && <ChevronDown className="h-3 w-3 shrink-0 text-primary" aria-label="grouped" />}
-                    <span className="truncate">{col.label ?? col.propertyName}</span>
+                    <span className="truncate">{col.label ?? col.propertyName}{unit ? ` (${unit})` : ''}</span>
                     {summed && <span className="text-primary">Σ</span>}
                     {sortCol === colIdx && (sortDir === 'asc' ? <ArrowUp className="h-3 w-3 shrink-0" /> : <ArrowDown className="h-3 w-3 shrink-0" />)}
                   </button>

--- a/apps/viewer/src/components/viewer/properties/MaterialTotalsPanel.tsx
+++ b/apps/viewer/src/components/viewer/properties/MaterialTotalsPanel.tsx
@@ -26,6 +26,7 @@ import {
   type IfcDataStore,
 } from '@ifc-lite/parser';
 import { QuantityType } from '@ifc-lite/data';
+import { resolveQuantityDisplay } from '@/lib/units/display';
 import { PropertySetCard } from './PropertySetCard';
 import type { PropertySet } from './encodingUtils';
 
@@ -62,6 +63,28 @@ function formatNumber(value: number): string {
   if (Math.abs(value) >= 1000) return value.toLocaleString(undefined, { maximumFractionDigits: 0 });
   if (Math.abs(value) >= 1) return value.toLocaleString(undefined, { maximumFractionDigits: 2 });
   return value.toLocaleString(undefined, { maximumFractionDigits: 4 });
+}
+
+/** Render an aggregated total with its resolved unit (issue #1573 follow-up):
+ *  the display-unit override when set, else the file's declared/SI-default
+ *  unit — same resolution as the property/quantity cards below, just with
+ *  `formatNumber`'s magnitude-adaptive precision instead of `formatConverted`
+ *  so large totals stay readable. NOTE: the totals loop sums raw quantity
+ *  values across `allStores` (materials of the same name are merged across the
+ *  federation), but the unit label + any override conversion here use only the
+ *  SELECTED store's declared units. For a single-store model that is exact; a
+ *  federation whose stores declare different volume/area/mass units mixes raw
+ *  values before this label is applied — a pre-existing concern (the block was
+ *  previously hardcoded m³/m²/kg) that this label does not attempt to fix. */
+function formatTotal(
+  value: number,
+  quantityType: number,
+  projectUnits: ProjectUnits,
+  overrides: Record<string, string>,
+): string {
+  const disp = resolveQuantityDisplay(value, quantityType, projectUnits, overrides);
+  const shown = disp.converted ?? value;
+  return disp.unit ? `${formatNumber(shown)} ${disp.unit}` : formatNumber(shown);
 }
 
 export function MaterialTotalsPanel({ materialId, modelId }: { materialId: number; modelId: string }) {
@@ -210,13 +233,13 @@ export function MaterialTotalsPanel({ materialId, modelId }: { materialId: numbe
             <div className="divide-y divide-amber-100 dark:divide-amber-900/30">
               <TotalRow label="Elements" value={totals.elementCount.toLocaleString()} />
               {totals.hasVolume && (
-                <TotalRow label="Volume" value={`${formatNumber(totals.volume)} m³`} />
+                <TotalRow label="Volume" value={formatTotal(totals.volume, QuantityType.Volume, projectUnits, unitDisplayOverrides)} />
               )}
               {totals.hasArea && (
-                <TotalRow label="Area" value={`${formatNumber(totals.area)} m²`} />
+                <TotalRow label="Area" value={formatTotal(totals.area, QuantityType.Area, projectUnits, unitDisplayOverrides)} />
               )}
               {totals.hasWeight && (
-                <TotalRow label="Weight" value={`${formatNumber(totals.weight)} kg`} />
+                <TotalRow label="Weight" value={formatTotal(totals.weight, QuantityType.Weight, projectUnits, unitDisplayOverrides)} />
               )}
             </div>
             {totals.elementCount > 0 && !totals.hasVolume && (
@@ -265,7 +288,7 @@ export function MaterialTotalsPanel({ materialId, modelId }: { materialId: numbe
                 group.psets.map((pset) => {
                   const psetView: PropertySet = {
                     name: pset.name,
-                    properties: pset.properties.map((p) => ({ name: p.name, value: p.value, isMutated: false })),
+                    properties: pset.properties.map((p) => ({ name: p.name, value: p.value, isMutated: false, dataType: p.dataType })),
                   };
                   return <PropertySetCard key={`${group.materialId}-${pset.name}`} pset={psetView} projectUnits={projectUnits} unitDisplayOverrides={unitDisplayOverrides} />;
                 }),

--- a/apps/viewer/src/lib/lists/export/model.test.ts
+++ b/apps/viewer/src/lib/lists/export/model.test.ts
@@ -72,7 +72,7 @@ describe('buildExportModel display-unit conversion (#1573)', () => {
       numericCols: [false, true],
       columnWidths: [120, 120],
       generatedAt: 'now',
-      projectUnits: ProjectUnits.empty(),
+      modelUnits: new Map([['m', ProjectUnits.empty()]]),
       unitDisplayOverrides: { VOLUMEUNIT: 'l' }, // 1 m³ = 1000 L
     });
 
@@ -93,7 +93,7 @@ describe('buildExportModel display-unit conversion (#1573)', () => {
       numericCols: [false, true],
       columnWidths: [120, 120],
       generatedAt: 'now',
-      projectUnits: ProjectUnits.empty(),
+      modelUnits: new Map([['m', ProjectUnits.empty()]]),
       unitDisplayOverrides: {},
     });
 
@@ -101,10 +101,7 @@ describe('buildExportModel display-unit conversion (#1573)', () => {
     assert.deepStrictEqual(m.rows, [['A', 1]]);
   });
 
-  it('seeds the column unit from the first row with a finite value, not a null first row', () => {
-    // First row is null for the quantity column — a naive "peek at row 0"
-    // would freeze the header on the file default while row 2 still
-    // converts underneath it (header/value mismatch).
+  it('converts every row (not just the first) — no more "seed row" needed since the target unit is resolved ahead of the rows', () => {
     const m = buildExportModel({
       title: 'List',
       columns: volumeColumns,
@@ -112,7 +109,7 @@ describe('buildExportModel display-unit conversion (#1573)', () => {
       numericCols: [false, true],
       columnWidths: [120, 120],
       generatedAt: 'now',
-      projectUnits: ProjectUnits.empty(),
+      modelUnits: new Map([['m', ProjectUnits.empty()]]),
       unitDisplayOverrides: { VOLUMEUNIT: 'l' },
     });
 
@@ -131,7 +128,7 @@ describe('buildExportModel display-unit conversion (#1573)', () => {
       numericCols: [true],
       columnWidths: [120],
       generatedAt: 'now',
-      projectUnits: ProjectUnits.empty(),
+      modelUnits: new Map([['m', ProjectUnits.empty()]]),
       unitDisplayOverrides: { VOLUMETRICFLOWRATEUNIT: 'm3h' },
     });
 
@@ -141,7 +138,7 @@ describe('buildExportModel display-unit conversion (#1573)', () => {
     assert.ok(Math.abs((converted as number) - 50) < 1e-6);
   });
 
-  it('leaves values and labels untouched when projectUnits/overrides are omitted (legacy callers)', () => {
+  it('leaves values and labels untouched when modelUnits/overrides are omitted (legacy callers)', () => {
     const m = buildExportModel({
       title: 'List',
       columns: volumeColumns,
@@ -154,5 +151,32 @@ describe('buildExportModel display-unit conversion (#1573)', () => {
     assert.strictEqual(m.columns[1].unit, undefined);
     assert.strictEqual(m.columns[1].label, 'Volume');
     assert.deepStrictEqual(m.rows, [['A', 1]]);
+  });
+
+  it('federated: a 2-entry modelUnits map converts each row from ITS OWN model (mm vs m declared length)', () => {
+    const mmModel = new Map([['LENGTHUNIT', { symbol: 'mm', siScale: 1e-3 }]]);
+    const mModel = new Map([['LENGTHUNIT', { symbol: 'm', siScale: 1 }]]);
+    const columns: ColumnDefinition[] = [
+      { id: 'len', source: 'quantity', psetName: 'Qto', propertyName: 'Length', quantityType: 0 /* Length */ },
+    ];
+    const m = buildExportModel({
+      title: 'List',
+      columns,
+      rows: [
+        { entityId: 1, modelId: 'mmModel', values: [1000] },
+        { entityId: 2, modelId: 'mModel', values: [1] },
+      ],
+      numericCols: [true],
+      columnWidths: [120],
+      generatedAt: 'now',
+      modelUnits: new Map([
+        ['mmModel', new ProjectUnits(mmModel, null)],
+        ['mModel', new ProjectUnits(mModel, null)],
+      ]),
+      unitDisplayOverrides: { LENGTHUNIT: 'm' },
+    });
+
+    assert.strictEqual(m.columns[0].unit, 'm');
+    assert.deepStrictEqual(m.rows, [[1], [1]]); // 1000mm -> 1m, and 1m -> 1m
   });
 });

--- a/apps/viewer/src/lib/lists/export/model.ts
+++ b/apps/viewer/src/lib/lists/export/model.ts
@@ -12,7 +12,7 @@
 import type { CellValue, ColumnDefinition, ListRow, ListGrouping } from '@ifc-lite/lists';
 import type { ProjectUnits } from '@ifc-lite/parser';
 import { buildGroupBuckets, orderGroups, type GroupSort } from '@/lib/lists/group-sort';
-import { resolveMeasureDisplay, resolveQuantityDisplay } from '@/lib/units/display';
+import { resolveListColumnUnits } from '@/lib/units/list-column-units';
 
 export interface ExportColumn {
   id: string;
@@ -24,7 +24,7 @@ export interface ExportColumn {
   /** Resolved display unit symbol for this column — the file's declared/
    *  default unit, or the user's display-unit override (issue #1573).
    *  Undefined for non-measure columns, or when the model was built without
-   *  `projectUnits`. Already folded into `label` (`"NetVolume (m³/h)"`) so
+   *  `modelUnits`. Already folded into `label` (`"NetVolume (m³/h)"`) so
    *  writers don't need to special-case it; kept here too for callers that
    *  want the symbol on its own. */
   unit?: string;
@@ -62,18 +62,21 @@ export interface BuildModelInput {
   columnWidths: number[];
   generatedAt: string;
   /**
-   * The file's declared units (issue #1573) — when provided alongside
+   * Per-model declared units (issue #1573 follow-up), keyed by the same
+   * `modelId` every `ListRow` carries — when provided alongside
    * `unitDisplayOverrides`, quantity columns (`ColumnDefinition.quantityType`)
    * and measure property columns (`ColumnDefinition.dataType`, both populated
-   * by `executeList`) export CONVERTED into the overridden unit, with the
-   * resolved symbol folded into the column label. Omitted keeps the legacy
-   * raw-value, no-unit export.
+   * by `executeList`) export CONVERTED into ONE resolved target unit (see
+   * `resolveListColumnUnits`), with the resolved symbol folded into the
+   * column label. Omitted (or empty) keeps the legacy raw-value, no-unit
+   * export. This is the SAME resolver the on-screen table
+   * (`ListResultsTable`) uses, so the two can never disagree.
    */
-  projectUnits?: ProjectUnits;
+  modelUnits?: Map<string, ProjectUnits>;
   /** Per-unit-type display-unit overrides — see `unitDisplayOverrides` in the
    *  viewer store's `unitDisplaySlice`. `{}` (or omitted) exports every
-   *  measure column in the file's declared unit (still labelled), with no
-   *  values converted. */
+   *  measure column in the file's declared (first-contributing model's) unit
+   *  (still labelled), with no values converted. */
   unitDisplayOverrides?: Record<string, string>;
 }
 
@@ -89,7 +92,7 @@ export function displayCell(value: CellValue): string {
 }
 
 export function buildExportModel(input: BuildModelInput): ExportModel {
-  const { columns, rows, grouping, sort, numericCols, columnWidths, title, generatedAt, projectUnits, unitDisplayOverrides } = input;
+  const { columns, rows, grouping, sort, numericCols, columnWidths, title, generatedAt, modelUnits, unitDisplayOverrides } = input;
   const sumColumnIds = grouping?.sumColumnIds ?? [];
   const exportCols: ExportColumn[] = columns.map((c, i) => ({
     id: c.id,
@@ -99,51 +102,29 @@ export function buildExportModel(input: BuildModelInput): ExportModel {
     width: columnWidths[i] ?? 120,
   }));
 
-  // Display-unit conversion (issue #1573): quantity/property measure columns
-  // export CONVERTED into the overridden unit, same math as the Properties
-  // panel (`resolveQuantityDisplay`/`resolveMeasureDisplay`), with the
+  // Display-unit conversion (issue #1573 follow-up): quantity/property
+  // measure columns export CONVERTED into ONE resolved target unit via the
+  // resolver shared with the on-screen table (`ListResultsTable`), with the
   // resolved symbol folded into the column label. A NEW row-values array is
   // built rather than mutating `rows[i].values` in place — those arrays are
   // the live on-screen `ListRow`s (shared with sort/group/colour-by), so
   // converting for export must never leak back into them.
-  const convertibleCols = projectUnits && unitDisplayOverrides
-    ? columns.map((c, i) => ({ c, i })).filter(({ c }) => c.quantityType !== undefined || !!c.dataType)
-    : [];
+  const resolver = modelUnits && modelUnits.size > 0 && unitDisplayOverrides
+    ? resolveListColumnUnits(columns, modelUnits, unitDisplayOverrides)
+    : null;
 
-  const resolveDisplay = (c: ColumnDefinition, value: CellValue) =>
-    c.quantityType !== undefined
-      ? resolveQuantityDisplay(typeof value === 'number' ? value : NaN, c.quantityType, projectUnits!, unitDisplayOverrides!)
-      : resolveMeasureDisplay(value, c.dataType, projectUnits!, unitDisplayOverrides!);
-
-  // Resolve each convertible column's label from a REPRESENTATIVE row (the
-  // first with a finite numeric value), not just `rows[0]`: an override only
-  // reports its symbol once it sees a convertible value (see
-  // `resolveQuantityDisplay`'s contract), so seeding from a row that happens
-  // to be null/non-numeric would freeze the header on the file's default
-  // unit while the actual (later) rows convert correctly underneath it —
-  // a header/value mismatch. Falls back to a non-finite probe (still labels
-  // with the file default) only when no row has data for that column at all.
-  for (const { c, i } of convertibleCols) {
-    const seed = rows.find((r) => typeof r.values[i] === 'number' && Number.isFinite(r.values[i] as number));
-    const disp = resolveDisplay(c, seed ? seed.values[i] : null);
-    if (disp.unit) {
-      exportCols[i].unit = disp.unit;
-      exportCols[i].label = `${exportCols[i].label} (${disp.unit})`;
-    }
+  if (resolver) {
+    columns.forEach((_, i) => {
+      const unit = resolver.unitSymbol(i);
+      if (unit) {
+        exportCols[i].unit = unit;
+        exportCols[i].label = `${exportCols[i].label} (${unit})`;
+      }
+    });
   }
 
-  const convertRowValues = (values: CellValue[]): CellValue[] => {
-    if (convertibleCols.length === 0) return values;
-    const next = values.slice();
-    for (const { c, i } of convertibleCols) {
-      const disp = resolveDisplay(c, next[i]);
-      if (disp.converted !== null) next[i] = disp.converted;
-    }
-    return next;
-  };
-
-  const convertedRows: ListRow[] = convertibleCols.length > 0
-    ? rows.map((r) => ({ ...r, values: convertRowValues(r.values) }))
+  const convertedRows: ListRow[] = resolver
+    ? rows.map((r) => ({ ...r, values: r.values.map((v, i) => resolver.convertCell(i, v, r.modelId)) }))
     : rows;
 
   const sumIdx = sumColumnIds

--- a/apps/viewer/src/lib/lists/list-units-integration.test.ts
+++ b/apps/viewer/src/lib/lists/list-units-integration.test.ts
@@ -1,0 +1,116 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * End-to-end regression for the #1573 list-export unit wiring. The original
+ * #1580 shipped this feature DEAD: `executeList` resolved a column's
+ * `quantityType`/`dataType`, but `ListPanel` rebuilt the result from the raw
+ * `definition.columns`, dropping the annotation, so the export conversion never
+ * fired. The piece-wise tests passed because they hand-fed annotated columns.
+ *
+ * This test runs the REAL chain (`executeList` -> `mergeResultColumns` ->
+ * `buildExportModel`) over a stub provider and asserts a value gets converted
+ * from an annotation the test itself never writes. It fails if any link stops
+ * carrying the measure type.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { executeList, type ListDataProvider, type ListDefinition } from '@ifc-lite/lists';
+import { IfcTypeEnum, QuantityType, type QuantitySet } from '@ifc-lite/data';
+import { ProjectUnits } from '@ifc-lite/parser';
+import { mergeResultColumns } from './merge-result-columns.js';
+import { buildExportModel } from './export/model.js';
+
+/** Minimal provider: one IfcWall with a NetVolume quantity (2.5, VOLUME). */
+function stubProvider(qsets: QuantitySet[]): ListDataProvider {
+  return {
+    getEntitiesByType: (t) => (t === IfcTypeEnum.IfcWall ? [1] : []),
+    getEntityName: () => 'Wall-1',
+    getEntityGlobalId: (id) => `guid-${id}`,
+    getEntityDescription: () => '',
+    getEntityObjectType: () => '',
+    getEntityTag: () => '',
+    getEntityTypeName: () => 'IfcWall',
+    getPropertySets: () => [],
+    getQuantitySets: () => qsets,
+  };
+}
+
+describe('list-export unit wiring end-to-end (#1573)', () => {
+  it('converts a quantity column whose measure type only executeList knew', () => {
+    // The column carries NO quantityType — executeList must resolve it.
+    const definition: ListDefinition = {
+      id: 'l1',
+      name: 'Walls',
+      createdAt: 0,
+      updatedAt: 0,
+      entityTypes: [IfcTypeEnum.IfcWall],
+      conditions: [],
+      columns: [{ id: 'vol', source: 'quantity', psetName: 'Qto', propertyName: 'NetVolume' }],
+    };
+    const provider = stubProvider([
+      { name: 'Qto', quantities: [{ name: 'NetVolume', value: 2.5, type: QuantityType.Volume }] },
+    ]);
+
+    const result = executeList(definition, provider, 'm1');
+    // executeList annotated the RESULT column; the authoring schema is untouched.
+    assert.strictEqual(result.columns[0].quantityType, QuantityType.Volume);
+    assert.strictEqual(definition.columns[0].quantityType, undefined);
+
+    const merged = mergeResultColumns([result], definition.columns);
+    assert.strictEqual(merged[0].quantityType, QuantityType.Volume);
+
+    // Export with a Volume override to litres: 2.5 m³ -> 2500 L, header labeled.
+    const modelUnits = new Map([['m1', ProjectUnits.empty()]]);
+    const model = buildExportModel({
+      title: 'Walls',
+      columns: merged,
+      rows: result.rows,
+      numericCols: [true],
+      columnWidths: [120],
+      generatedAt: 'now',
+      modelUnits,
+      unitDisplayOverrides: { VOLUMEUNIT: 'l' },
+    });
+
+    assert.match(model.columns[0].label, /\(L\)/, 'header carries the target unit');
+    const exported = model.rows[0][0];
+    assert.ok(
+      typeof exported === 'number' && Math.abs(exported - 2500) < 1e-6,
+      `expected 2500 L, got ${String(exported)}`,
+    );
+  });
+
+  it('leaves the column un-converted when the annotation is dropped (proves the assertion has teeth)', () => {
+    // Simulate the #1580 bug: export from the raw definition columns (no merge).
+    const definition: ListDefinition = {
+      id: 'l1',
+      name: 'Walls',
+      createdAt: 0,
+      updatedAt: 0,
+      entityTypes: [IfcTypeEnum.IfcWall],
+      conditions: [],
+      columns: [{ id: 'vol', source: 'quantity', psetName: 'Qto', propertyName: 'NetVolume' }],
+    };
+    const provider = stubProvider([
+      { name: 'Qto', quantities: [{ name: 'NetVolume', value: 2.5, type: QuantityType.Volume }] },
+    ]);
+    const result = executeList(definition, provider, 'm1');
+
+    const model = buildExportModel({
+      title: 'Walls',
+      columns: definition.columns, // the bug: raw columns, annotation dropped
+      rows: result.rows,
+      numericCols: [true],
+      columnWidths: [120],
+      generatedAt: 'now',
+      modelUnits: new Map([['m1', ProjectUnits.empty()]]),
+      unitDisplayOverrides: { VOLUMEUNIT: 'l' },
+    });
+    // No annotation -> no conversion, no unit label: the raw 2.5 survives.
+    assert.doesNotMatch(model.columns[0].label ?? '', /\(L\)/);
+    assert.strictEqual(model.rows[0][0], 2.5);
+  });
+});

--- a/apps/viewer/src/lib/lists/merge-result-columns.test.ts
+++ b/apps/viewer/src/lib/lists/merge-result-columns.test.ts
@@ -1,0 +1,62 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import type { ColumnDefinition, ListResult } from '@ifc-lite/lists';
+import { mergeResultColumns } from './merge-result-columns.js';
+
+const base: ColumnDefinition[] = [
+  { id: 'qty', source: 'quantity', psetName: 'Qto', propertyName: 'Volume' },
+  { id: 'name', source: 'attribute', propertyName: 'Name' },
+];
+
+function result(columns: ColumnDefinition[]): ListResult {
+  return { columns, rows: [], totalCount: 0, executionTime: 0 };
+}
+
+describe('mergeResultColumns (P0 fix, #1573 follow-up)', () => {
+  it('first-defined-wins: part A resolved col0.quantityType, part B did not', () => {
+    const partA = result([{ ...base[0], quantityType: 2 }, { ...base[1] }]);
+    const partB = result([{ ...base[0] }, { ...base[1] }]);
+
+    const merged = mergeResultColumns([partA, partB], base);
+
+    assert.strictEqual(merged[0].quantityType, 2);
+    // The base authoring schema is never mutated in place.
+    assert.strictEqual(base[0].quantityType, undefined);
+  });
+
+  it('falls back to a later part when an earlier part resolved nothing for that column', () => {
+    const partA = result([{ ...base[0] }, { ...base[1] }]);
+    const partB = result([{ ...base[0], quantityType: 2 }, { ...base[1] }]);
+
+    const merged = mergeResultColumns([partA, partB], base);
+
+    assert.strictEqual(merged[0].quantityType, 2);
+  });
+
+  it('carries dataType the same way for property/measure columns', () => {
+    const propBase: ColumnDefinition[] = [{ id: 'flow', source: 'property', psetName: 'Pset', propertyName: 'Flow' }];
+    const partA = result([{ ...propBase[0], dataType: 'IFCVOLUMETRICFLOWRATEMEASURE' }]);
+    const partB = result([{ ...propBase[0] }]);
+
+    const merged = mergeResultColumns([partA, partB], propBase);
+
+    assert.strictEqual(merged[0].dataType, 'IFCVOLUMETRICFLOWRATEMEASURE');
+  });
+
+  it('returns the base columns untouched when no part resolved anything', () => {
+    const partA = result([{ ...base[0] }, { ...base[1] }]);
+    const partB = result([{ ...base[0] }, { ...base[1] }]);
+
+    const merged = mergeResultColumns([partA, partB], base);
+
+    assert.deepStrictEqual(merged, base);
+  });
+
+  it('returns the base columns when there are no parts', () => {
+    assert.strictEqual(mergeResultColumns([], base), base);
+  });
+});

--- a/apps/viewer/src/lib/lists/merge-result-columns.ts
+++ b/apps/viewer/src/lib/lists/merge-result-columns.ts
@@ -1,0 +1,46 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Merge the per-column `quantityType`/`dataType` that `executeList` resolves
+ * (execution-time only, see `ColumnDefinition` in `@ifc-lite/lists`) across a
+ * federation's per-model results (P0 fix, issue #1573 follow-up).
+ *
+ * `ListPanel` executes a list once per loaded model and flattens the rows,
+ * but was passing the *authoring* `definition.columns` - which never carry
+ * `quantityType`/`dataType` - to `setListResult`, silently discarding the
+ * annotation each `executeList` call had just resolved. That left the list
+ * export's unit-conversion filter (`ColumnDefinition.quantityType !==
+ * undefined || dataType`) matching nothing, so #1580's conversion never ran
+ * in the live app despite passing tests (the tests fed the annotation in by
+ * hand instead of going through `executeList`).
+ */
+
+import type { ColumnDefinition, ListResult } from '@ifc-lite/lists';
+
+/**
+ * For each column index, use the first `parts` entry whose column carries a
+ * `quantityType` or `dataType` (first-defined-wins across models — the same
+ * measure/quantity column resolves identically regardless of which model
+ * happened to populate it first). Falls back to `base` untouched when no
+ * part has anything for that column. Never mutates `base` or any part.
+ */
+export function mergeResultColumns(parts: ListResult[], base: ColumnDefinition[]): ColumnDefinition[] {
+  if (parts.length === 0) return base;
+
+  let changed = false;
+  const merged = base.map((col, i) => {
+    for (const part of parts) {
+      const partCol = part.columns[i];
+      if (partCol && (partCol.quantityType !== undefined || partCol.dataType !== undefined)) {
+        if (partCol.quantityType === col.quantityType && partCol.dataType === col.dataType) return col;
+        changed = true;
+        return { ...col, quantityType: partCol.quantityType, dataType: partCol.dataType };
+      }
+    }
+    return col;
+  });
+
+  return changed ? merged : base;
+}

--- a/apps/viewer/src/lib/units/convert.test.ts
+++ b/apps/viewer/src/lib/units/convert.test.ts
@@ -5,7 +5,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
 
-import { convertValue, resolveFromUnit } from './convert.js';
+import { convertValue, resolveFromUnit, type LinearUnit } from './convert.js';
 import { alternativesForUnitType } from './alternatives.js';
 
 function option(unitType: string, id: string) {
@@ -40,6 +40,16 @@ describe('convertValue', () => {
     const celsius = option('THERMODYNAMICTEMPERATUREUNIT', 'c');
     const result = convertValue(273.15, kelvin, celsius);
     assert.ok(Math.abs(result - 0) < 1e-9, `expected 0, got ${result}`);
+  });
+
+  // #1573 follow-up: `to` accepts any plain LinearUnit (no `id`/`symbol`),
+  // not just a curated `UnitOption` — the Lists single-target normalization
+  // resolver targets a file-declared unit directly.
+  it('accepts a plain LinearUnit (no id/symbol) as the target', () => {
+    const from: LinearUnit = { scale: 1e-3 }; // mm
+    const to: LinearUnit = { scale: 1 }; // m, a bare file-declared unit
+    const result = convertValue(1000, from, to);
+    assert.strictEqual(result, 1);
   });
 });
 

--- a/apps/viewer/src/lib/units/convert.ts
+++ b/apps/viewer/src/lib/units/convert.ts
@@ -9,7 +9,7 @@
  */
 
 import type { ResolvedUnit } from '@ifc-lite/parser';
-import { alternativesForUnitType, type UnitOption } from './alternatives.js';
+import { alternativesForUnitType } from './alternatives.js';
 
 /** A linear (plus optional affine offset) unit descriptor: converts a value
  *  in this unit to the SI base via `value*scale + (offset??0)`. */
@@ -20,8 +20,11 @@ export interface LinearUnit {
 
 /** Convert `value` (expressed in `from`) into `to`'s unit. Both go through
  *  the shared SI base, so a from/to pair with different offsets (e.g. °C ->
- *  K) round-trips correctly. */
-export function convertValue(value: number, from: LinearUnit, to: UnitOption): number {
+ *  K) round-trips correctly. `to` accepts any {@link LinearUnit} (a
+ *  `UnitOption` already is one) so a file-declared unit - not just a curated
+ *  alternative - can be a conversion target (issue #1573 follow-up: the
+ *  Lists single-target normalization resolver). */
+export function convertValue(value: number, from: LinearUnit, to: LinearUnit): number {
   const siBase = value * from.scale + (from.offset ?? 0);
   return (siBase - (to.offset ?? 0)) / to.scale;
 }

--- a/apps/viewer/src/lib/units/list-column-units.test.ts
+++ b/apps/viewer/src/lib/units/list-column-units.test.ts
@@ -1,0 +1,205 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+
+import { extractProjectUnits, type EntityIndex, type EntityRef, type ProjectUnits } from '@ifc-lite/parser';
+import { QuantityType } from '@ifc-lite/data';
+import type { ColumnDefinition } from '@ifc-lite/lists';
+import { resolveListColumnUnits } from './list-column-units.js';
+
+// Minimal IFC STEP fixtures — mirrors the `indexIfc` helper in display.test.ts
+// / project-units.parity.test.ts (issue #1573).
+function indexIfc(content: string): { source: Uint8Array; entityIndex: EntityIndex } {
+  const source = new TextEncoder().encode(content);
+  const byId = new Map<number, EntityRef>();
+  const byType = new Map<string, number[]>();
+  const re = /^#(\d+)=([A-Z0-9_]+)\(/;
+  let offset = 0;
+  let lineNumber = 0;
+  for (const line of content.split('\n')) {
+    lineNumber += 1;
+    const m = re.exec(line);
+    if (m) {
+      const expressId = Number(m[1]);
+      const type = m[2];
+      byId.set(expressId, { expressId, type, byteOffset: offset, byteLength: line.length, lineNumber });
+      const list = byType.get(type) ?? [];
+      list.push(expressId);
+      byType.set(type, list);
+    }
+    offset += line.length + 1;
+  }
+  return { source, entityIndex: { byId, byType } };
+}
+
+function unitsFromSource(content: string): ProjectUnits {
+  const { source, entityIndex } = indexIfc(content);
+  return extractProjectUnits(source, entityIndex);
+}
+
+// LENGTHUNIT declared in mm, plus a derived VOLUMETRICFLOWRATEUNIT (m³/s) —
+// mirrors the fixture in display.test.ts / project-units.parity.test.ts.
+const MM_MODEL = unitsFromSource(`ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''),'2;1');
+FILE_NAME('t.ifc','2026-01-01T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC4X3_ADD2'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('0001projectaaaaaaaaaaa',$,'P',$,$,$,$,$,#2);
+#2=IFCUNITASSIGNMENT((#3,#10));
+#3=IFCSIUNIT(*,.LENGTHUNIT.,.MILLI.,.METRE.);
+#6=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+#7=IFCDERIVEDUNITELEMENT(#6,3);
+#8=IFCSIUNIT(*,.TIMEUNIT.,$,.SECOND.);
+#9=IFCDERIVEDUNITELEMENT(#8,-1);
+#10=IFCDERIVEDUNIT((#7,#9),.VOLUMETRICFLOWRATEUNIT.,$,$);
+ENDSEC;
+END-ISO-10303-21;
+`);
+
+// LENGTHUNIT declared in feet (IfcConversionBasedUnit -> 0.3048 m).
+const FT_MODEL = unitsFromSource(`ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''),'2;1');
+FILE_NAME('t.ifc','2026-01-01T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC4X3_ADD2'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('0001projectbbbbbbbbbbb',$,'P',$,$,$,$,$,#2);
+#2=IFCUNITASSIGNMENT((#3));
+#3=IFCCONVERSIONBASEDUNIT($,.LENGTHUNIT.,'FOOT',#4);
+#4=IFCMEASUREWITHUNIT(0.3048,#5);
+#5=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+ENDSEC;
+END-ISO-10303-21;
+`);
+
+// THERMODYNAMICTEMPERATUREUNIT declared as DEGREE_CELSIUS (an affine unit:
+// °C -> K is +273.15, not a pure scale).
+const CELSIUS_MODEL = unitsFromSource(`ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''),'2;1');
+FILE_NAME('t.ifc','2026-01-01T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC4X3_ADD2'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('0001projectccccccccccc',$,'P',$,$,$,$,$,#2);
+#2=IFCUNITASSIGNMENT((#3));
+#3=IFCSIUNIT(*,.THERMODYNAMICTEMPERATUREUNIT.,$,.DEGREE_CELSIUS.);
+ENDSEC;
+END-ISO-10303-21;
+`);
+
+describe('resolveListColumnUnits (issue #1573 follow-up)', () => {
+  it('does not shift a declared-°C column with no override (affine target/source symmetry)', () => {
+    // Regression: the target was built as {offset:0} while the source recovered
+    // +273.15, so a °C column silently rendered/exported +273.15 with no override.
+    const columns: ColumnDefinition[] = [
+      { id: 'temp', source: 'property', psetName: 'Pset', propertyName: 'T', dataType: 'IFCTHERMODYNAMICTEMPERATUREMEASURE' },
+    ];
+    const resolver = resolveListColumnUnits(columns, new Map([['m1', CELSIUS_MODEL]]), {});
+    assert.strictEqual(resolver.unitSymbol(0), '°C');
+    assert.strictEqual(resolver.convertCell(0, 20, 'm1'), 20); // NOT 293.15
+  });
+
+  it('converts declared-°C to K with an override, applying the offset exactly once', () => {
+    const columns: ColumnDefinition[] = [
+      { id: 'temp', source: 'property', psetName: 'Pset', propertyName: 'T', dataType: 'IFCTHERMODYNAMICTEMPERATUREMEASURE' },
+    ];
+    const resolver = resolveListColumnUnits(columns, new Map([['m1', CELSIUS_MODEL]]), { THERMODYNAMICTEMPERATUREUNIT: 'k' });
+    assert.strictEqual(resolver.unitSymbol(0), 'K');
+    assert.ok(Math.abs((resolver.convertCell(0, 20, 'm1') as number) - 293.15) < 1e-9);
+  });
+
+  it('is an exact identity (no FP drift) for a non-SI unit with no override', () => {
+    // Regression: `v * s / s` is not an FP identity for scale 0.3048, so 877 ft
+    // became 876.9999999999999 and leaked into the raw-number XLSX export.
+    const columns: ColumnDefinition[] = [
+      { id: 'len', source: 'quantity', psetName: 'Qto', propertyName: 'Length', quantityType: QuantityType.Length },
+    ];
+    const resolver = resolveListColumnUnits(columns, new Map([['ftModel', FT_MODEL]]), {});
+    assert.strictEqual(resolver.unitSymbol(0), 'ft');
+    assert.strictEqual(resolver.convertCell(0, 877, 'ftModel'), 877); // exact
+  });
+
+  it('converts a measure property column (m³/s -> m³/h) with an override', () => {
+    const columns: ColumnDefinition[] = [
+      { id: 'flow', source: 'property', psetName: 'Pset', propertyName: 'Flow', dataType: 'IFCVOLUMETRICFLOWRATEMEASURE' },
+    ];
+    const resolver = resolveListColumnUnits(columns, new Map([['m1', MM_MODEL]]), { VOLUMETRICFLOWRATEUNIT: 'm3h' });
+
+    assert.strictEqual(resolver.unitSymbol(0), 'm³/h');
+    const converted = resolver.convertCell(0, 0.013888888888888888, 'm1');
+    assert.ok(typeof converted === 'number' && Math.abs(converted - 50) < 1e-6);
+  });
+
+  it('converts a Length quantity column (mm-model -> m) with an override', () => {
+    const columns: ColumnDefinition[] = [
+      { id: 'len', source: 'quantity', psetName: 'Qto', propertyName: 'Length', quantityType: QuantityType.Length },
+    ];
+    const resolver = resolveListColumnUnits(columns, new Map([['m1', MM_MODEL]]), { LENGTHUNIT: 'm' });
+
+    assert.strictEqual(resolver.unitSymbol(0), 'm');
+    assert.strictEqual(resolver.convertCell(0, 1000, 'm1'), 1);
+  });
+
+  it('federated: mm + ft models, override to m, converts each row from ITS OWN model', () => {
+    const columns: ColumnDefinition[] = [
+      { id: 'len', source: 'quantity', psetName: 'Qto', propertyName: 'Length', quantityType: QuantityType.Length },
+    ];
+    const modelUnits = new Map([['mmModel', MM_MODEL], ['ftModel', FT_MODEL]]);
+    const resolver = resolveListColumnUnits(columns, modelUnits, { LENGTHUNIT: 'm' });
+
+    assert.strictEqual(resolver.unitSymbol(0), 'm');
+    assert.ok(Math.abs((resolver.convertCell(0, 1000, 'mmModel') as number) - 1) < 1e-9);
+    assert.ok(Math.abs((resolver.convertCell(0, 1, 'ftModel') as number) - 0.3048) < 1e-9);
+  });
+
+  it('passes non-numeric values through unchanged', () => {
+    const columns: ColumnDefinition[] = [
+      { id: 'len', source: 'quantity', psetName: 'Qto', propertyName: 'Length', quantityType: QuantityType.Length },
+    ];
+    const resolver = resolveListColumnUnits(columns, new Map([['m1', MM_MODEL]]), { LENGTHUNIT: 'm' });
+
+    assert.strictEqual(resolver.convertCell(0, null, 'm1'), null);
+    assert.strictEqual(resolver.convertCell(0, 'n/a', 'm1'), 'n/a');
+  });
+
+  it('passes values through unchanged for an unrecognized modelId', () => {
+    const columns: ColumnDefinition[] = [
+      { id: 'len', source: 'quantity', psetName: 'Qto', propertyName: 'Length', quantityType: QuantityType.Length },
+    ];
+    const resolver = resolveListColumnUnits(columns, new Map([['m1', MM_MODEL]]), { LENGTHUNIT: 'm' });
+
+    assert.strictEqual(resolver.convertCell(0, 1000, 'unknownModel'), 1000);
+  });
+
+  it('with no override, targets the first-contributing model (by modelUnits insertion order) and converts every row into it', () => {
+    const columns: ColumnDefinition[] = [
+      { id: 'len', source: 'quantity', psetName: 'Qto', propertyName: 'Length', quantityType: QuantityType.Length },
+    ];
+
+    const mmFirst = resolveListColumnUnits(columns, new Map([['mmModel', MM_MODEL], ['ftModel', FT_MODEL]]), {});
+    assert.strictEqual(mmFirst.unitSymbol(0), 'mm');
+    assert.strictEqual(mmFirst.convertCell(0, 1000, 'mmModel'), 1000); // identity: mm -> mm
+    assert.ok(Math.abs((mmFirst.convertCell(0, 1, 'ftModel') as number) - 304.8) < 1e-9); // 1 ft -> 304.8 mm
+
+    // Flipping insertion order flips the target — proves it's the Map's
+    // order, not a hardcoded "first array element".
+    const ftFirst = resolveListColumnUnits(columns, new Map([['ftModel', FT_MODEL], ['mmModel', MM_MODEL]]), {});
+    assert.strictEqual(ftFirst.unitSymbol(0), 'ft');
+    assert.strictEqual(ftFirst.convertCell(0, 1, 'ftModel'), 1); // identity: ft -> ft
+    assert.ok(Math.abs((ftFirst.convertCell(0, 1000, 'mmModel') as number) - 3.280839895013123) < 1e-9); // 1000mm -> ft
+  });
+
+  it('unitSymbol returns null for a non-convertible column', () => {
+    const columns: ColumnDefinition[] = [{ id: 'name', source: 'attribute', propertyName: 'Name' }];
+    const resolver = resolveListColumnUnits(columns, new Map([['m1', MM_MODEL]]), {});
+    assert.strictEqual(resolver.unitSymbol(0), null);
+    assert.strictEqual(resolver.convertCell(0, 'Wall-01', 'm1'), 'Wall-01');
+  });
+});

--- a/apps/viewer/src/lib/units/list-column-units.ts
+++ b/apps/viewer/src/lib/units/list-column-units.ts
@@ -1,0 +1,127 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Single per-column unit resolution shared by the Lists on-screen table and
+ * its export (issue #1573 follow-up). Given the columns (with
+ * `quantityType`/`dataType` populated by `executeList`), the per-model
+ * declared units, and the user's display-unit overrides, this picks ONE
+ * target unit per convertible column and converts every row into it -
+ * single-target normalization, not "convert each row into its own model's
+ * unit" - so a summed / federated column is correct-by-construction (a sum
+ * across mixed-unit models is meaningless otherwise) and the on-screen table
+ * and the export can never disagree, because both call this resolver.
+ */
+
+import type { CellValue, ColumnDefinition } from '@ifc-lite/lists';
+import { measureUnit, type ProjectUnits, type ResolvedUnit } from '@ifc-lite/parser';
+import { alternativesForUnitType } from './alternatives.js';
+import { convertValue, resolveFromUnit, type LinearUnit } from './convert.js';
+import { QUANTITY_TYPE_UNIT } from './display.js';
+
+/** The unit-KIND a column resolves to: the unit-type token used to look up
+ *  declared units / overrides, plus the SI default symbol to fall back to
+ *  when no model declares it. */
+interface ColumnUnitKind {
+  unitType: string;
+  defaultSymbol: string;
+}
+
+/** `undefined` for a column with no unit semantics (not a quantity, and not
+ *  a typed measure property) - i.e. non-convertible. */
+function columnUnitKind(col: ColumnDefinition): ColumnUnitKind | undefined {
+  if (col.quantityType !== undefined) {
+    const entry = QUANTITY_TYPE_UNIT[col.quantityType];
+    return entry ? { unitType: entry.unitType, defaultSymbol: entry.defaultSymbol } : undefined;
+  }
+  if (col.dataType) {
+    const m = measureUnit(col.dataType);
+    if (m?.kind === 'typed') return { unitType: m.unitType, defaultSymbol: m.defaultSymbol };
+  }
+  return undefined;
+}
+
+interface TargetUnit extends LinearUnit {
+  symbol: string;
+}
+
+/** Resolves ONE target unit per column and converts raw cell values (given
+ *  their owning row's modelId) into it. */
+export interface ListColumnUnitResolver {
+  /** The column's target display symbol, or `null` when it isn't
+   *  convertible (no quantity/measure unit semantics). */
+  unitSymbol(colIndex: number): string | null;
+  /** Convert `rawValue` (as declared by model `modelId`) into the column's
+   *  target unit. Passes through unchanged - never throws - for a
+   *  non-convertible column, a non-finite/non-numeric value, or an
+   *  unrecognized `modelId` (its source unit can't be resolved safely). */
+  convertCell(colIndex: number, rawValue: CellValue, modelId: string): CellValue;
+}
+
+/**
+ * Build the shared resolver. `modelUnits` insertion order determines
+ * "first-contributing" (the model whose declared unit becomes the target)
+ * when no override picks the target explicitly.
+ */
+export function resolveListColumnUnits(
+  columns: ColumnDefinition[],
+  modelUnits: Map<string, ProjectUnits>,
+  overrides: Record<string, string>,
+): ListColumnUnitResolver {
+  const kinds = columns.map(columnUnitKind);
+  const targets = kinds.map((kind) => (kind ? resolveTarget(kind, modelUnits, overrides) : undefined));
+
+  return {
+    unitSymbol(colIndex) {
+      return targets[colIndex]?.symbol ?? null;
+    },
+    convertCell(colIndex, rawValue, modelId) {
+      const kind = kinds[colIndex];
+      const target = targets[colIndex];
+      if (!kind || !target) return rawValue;
+      if (typeof rawValue !== 'number' || !Number.isFinite(rawValue)) return rawValue;
+      const pu = modelUnits.get(modelId);
+      if (!pu) return rawValue; // unrecognized model — can't resolve its source unit safely
+      const fileUnit: ResolvedUnit = pu.resolvedForUnitType(kind.unitType) ?? { symbol: kind.defaultSymbol, siScale: 1 };
+      const from = resolveFromUnit(kind.unitType, fileUnit);
+      // Identity short-circuit: when the row's declared unit already equals the
+      // target (single model, no override — the common case), skip the round
+      // trip. `v * s / s` is NOT an FP identity for non-power-of-two scales
+      // (877 in a foot file would become 876.9999999999999 and leak into the
+      // raw-number XLSX export), and it also sidesteps any offset asymmetry.
+      if (from.scale === target.scale && (from.offset ?? 0) === (target.offset ?? 0)) return rawValue;
+      return convertValue(rawValue, from, target);
+    },
+  };
+}
+
+/** Pick the target unit for a column: the override when it names a valid
+ *  curated alternative, else the first model (in `modelUnits` insertion
+ *  order) that declares this unit-type, else the measure's SI default. */
+function resolveTarget(
+  kind: ColumnUnitKind,
+  modelUnits: Map<string, ProjectUnits>,
+  overrides: Record<string, string>,
+): TargetUnit {
+  const overrideId = overrides[kind.unitType];
+  if (overrideId) {
+    const option = alternativesForUnitType(kind.unitType).find((o) => o.id === overrideId);
+    if (option) return { scale: option.scale, offset: option.offset, symbol: option.symbol };
+  }
+  // Resolve the target through `resolveFromUnit` too, so the source and target
+  // sides of the SAME declared unit are computed symmetrically. `ResolvedUnit`
+  // carries only a scale, but `resolveFromUnit` recovers a curated unit's affine
+  // offset by symbol (e.g. a file declaring DEGREE_CELSIUS): building the target
+  // as `{offset: 0}` while the source recovers `+273.15` would shift every
+  // temperature by 273.15 with no override set.
+  for (const pu of modelUnits.values()) {
+    const declared = pu.resolvedForUnitType(kind.unitType);
+    if (declared) {
+      const lin = resolveFromUnit(kind.unitType, declared);
+      return { scale: lin.scale, offset: lin.offset, symbol: declared.symbol };
+    }
+  }
+  const def = resolveFromUnit(kind.unitType, { symbol: kind.defaultSymbol, siScale: 1 });
+  return { scale: def.scale, offset: def.offset, symbol: kind.defaultSymbol };
+}


### PR DESCRIPTION
Follow-ups to #1580 (issue #1573), built with the same procedure: adversarial review of the plan **and** the result (Fable), fixes, regression tests, viewer-only (no changeset).

## The P0 the adversarial review caught

#1580's "apply the display-unit converter to list exports" was **dead code in the live app**. `executeList` resolved each column's `quantityType`/`dataType`, but `ListPanel` rebuilt the result from the raw `definition.columns`, dropping the annotation — so `buildExportModel`'s convertible-column filter never matched and no list value was ever converted or labeled. The piece-wise tests passed only because they hand-fed annotated columns, masking the wiring gap. (The properties-panel display + converter — the core of #1573 — always worked; this was only the list-export surface.)

## What this does

**Fix the wiring + complete list unit display**
- `mergeResultColumns()` carries the per-column measure metadata from each model's `executeList` result onto the merged columns (first-defined-wins).
- New shared resolver `list-column-units.ts`: ONE target unit per column (override, else first-contributing model's declared unit, else SI default), used by **both** the on-screen table and the export so they can't disagree. Single-target normalization makes federated sums correct-by-construction; a per-model units map converts each row from its **own** model's declared unit (federated mixed-unit correctness — the second follow-up).
- `convertValue`'s target generalized to any `LinearUnit`.

**Material properties + totals** (parser already carried the measure `dataType`; two viewer consumers were dropping it): material measure properties now show units in both the Materials tab and the element panel; `MaterialTotalsPanel` totals resolve the file unit + converter instead of hardcoded m³/m²/kg. MCP playground volume/area tool text resolves the file unit too.

## Adversarial result review found (and this PR fixes)

- **Temperature affine regression:** the resolver built the source unit via `resolveFromUnit` (which recovers a °C offset) but the target as `{offset: 0}` — a declared-°C column shifted every value +273.15 with no override. Now source and target resolve symmetrically. Regression-tested.
- **FP noise into XLSX:** unconditional `v*s/s` round-trip turned `877` (foot file) into `876.9999999999999` in the raw-number XLSX export. Added an identity short-circuit. Regression-tested.
- **Untested wiring:** the exact bug class (unit-tested pieces, dead wiring) now has an end-to-end test running the real `executeList → mergeResultColumns → buildExportModel` chain, asserting a value converts from an annotation the test never writes.

## Verified

- `viewer typecheck` clean; the new/affected unit suites (resolver 10, merge, integration, convert, model) + full viewer suite green (1409 pass, 0 fail); `@ifc-lite/lists` 39/39.
- Live on the real VZT.ifc: the Lists panel executes and renders; app loads with zero console errors. (List row-level browser drive was limited by constructing the store's internal type key from outside the adapter; the conversion path itself is covered by the integration + resolver tests and a traced review of the shared resolver used by both table and export.)

## Descoped (noted, not implemented)

Search-result export units; IFC2X3 material property subtypes (parser returns null for them today); explicit per-property/quantity `Unit` overrides (attrs[3]/[2]) — #1580/#1573 label such values with the project unit even when the property carries its own unit (rare mislabel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
