### PR TITLE
test(export): fix flaky merged-export byte-parity test (unpinned header timestamp)

### DIFF
--- a/packages/export/src/merged-exporter.test.ts
+++ b/packages/export/src/merged-exporter.test.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { MergedExporter, type MergeModelInput } from './merged-exporter.js';
 import type { IfcDataStore } from '@ifc-lite/parser';
 import { MutablePropertyView as LiveMutablePropertyView } from '@ifc-lite/mutations';
@@ -104,16 +104,28 @@ describe('MergedExporter', () => {
     ]);
     const options = { schema: 'IFC4' as const, projectStrategy: 'keep-first' as const };
 
-    const bytesResult = await new MergedExporter([model1, model2]).exportAsync(options);
-    const blobResult = await new MergedExporter([model1, model2]).exportBlobAsync(options);
+    // The two paths differ only in how they assemble already-rendered bytes, so
+    // their output must be byte-identical. The STEP header embeds a wall-clock
+    // FILE_NAME timestamp (generateHeader -> new Date()), captured independently
+    // by each call; without pinning the clock, the two sequential exports flake
+    // whenever they straddle a second boundary. Freeze *only* Date (real timers
+    // stay live so the exporter's event-loop yielding still runs).
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+    try {
+      const bytesResult = await new MergedExporter([model1, model2]).exportAsync(options);
+      const blobResult = await new MergedExporter([model1, model2]).exportBlobAsync(options);
 
-    const blobBytes = new Uint8Array(await blobResult.content.arrayBuffer());
-    expect(blobBytes).toEqual(bytesResult.content);
-    expect(blobResult.content.size).toBe(bytesResult.content.byteLength);
-    // Stats parity: the Blob path reports the same size and counts.
-    expect(blobResult.stats.fileSize).toBe(bytesResult.stats.fileSize);
-    expect(blobResult.stats.totalEntityCount).toBe(bytesResult.stats.totalEntityCount);
-    expect(blobResult.stats.modelCount).toBe(bytesResult.stats.modelCount);
+      const blobBytes = new Uint8Array(await blobResult.content.arrayBuffer());
+      expect(blobBytes).toEqual(bytesResult.content);
+      expect(blobResult.content.size).toBe(bytesResult.content.byteLength);
+      // Stats parity: the Blob path reports the same size and counts.
+      expect(blobResult.stats.fileSize).toBe(bytesResult.stats.fileSize);
+      expect(blobResult.stats.totalEntityCount).toBe(bytesResult.stats.totalEntityCount);
+      expect(blobResult.stats.modelCount).toBe(bytesResult.stats.modelCount);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('should export a single model unchanged', () => {


### PR DESCRIPTION
## What broke

The release CI on the Changesets **"version packages"** PR (#1581) went red. It was **not** a shipped bug and nothing was published — that PR is still open. The red came from a single flaky test:

`packages/export/src/merged-exporter.test.ts` → *"exportBlobAsync produces byte-identical content to exportAsync"*.

The `Build + WASM + Rust + Node` required check is just the aggregate gate; it flipped red because `node-tests` failed on this one test.

## Root cause

The test calls both export paths **sequentially**:

```ts
const bytesResult = await new MergedExporter([m1, m2]).exportAsync(options);
const blobResult  = await new MergedExporter([m1, m2]).exportBlobAsync(options);
```

Each path builds the STEP header via `generateHeader()`, which embeds a live wall-clock `FILE_NAME` timestamp (`step-serializers.ts:210`: `new Date().toISOString()...`). `MergedExporter.buildHeader()` doesn't pin a `timeStamp`, so the two calls capture the clock independently. When they straddle a second boundary the timestamps differ (`...T16**3159**` vs `...T16**3200**`) and the byte-identical assertion fails.

The failing-run diff is exactly those timestamp digits: expected bytes `49,53,57` (`"159"`) vs received `50,48,48` (`"200"`).

This is a latent defect in the **test**, not the product — the two paths only differ in how they assemble already-rendered bytes. It can flake on any PR; #1581 just got unlucky.

## Fix

Freeze **only** `Date` around both exports (real timers stay live so the exporter's event-loop yielding still runs), so both headers get the same timestamp. Mirrors the `timeStamp: 'TS'` pinning already used in `source-header-roundtrip.test.ts`.

Test-only change. No published behaviour affected → no changeset.

## Verification

- `merged-exporter` test run 5× consecutively: green every time (was intermittently red before).
- Full `@ifc-lite/export` suite: 196 passed / 28 skipped.
- Typecheck clean.

## Note (out of scope)

The CI "Node tests" job also logged a `Segmentation fault (core dumped)` (exit 139) *after* the assertion failure — a teardown-time crash in the test process, not the cause of this red and not reproducible locally in the export suite. Worth a separate look if it recurs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability for export output comparisons by making time-dependent checks deterministic.
  * Added stronger validation that two export paths produce identical results, including file size and content counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->