### PR TITLE
fix(processing): native self-deadlock in per-worker point cache (nested par_iter re-entrancy)

### DIFF
--- a/.changeset/fix-faceted-brep-deadlock.md
+++ b/.changeset/fix-faceted-brep-deadlock.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/wasm": patch
+---
+
+Fix a native multithreaded self-deadlock in `process_geometry`. The persistent per-worker CartesianPoint cache is a `Vec<Mutex<FxHashMap>>` indexed by `rayon::current_thread_index()` and locked across the whole element job; faceted-brep triangulation nests a rayon `par_iter`, so a worker blocked at that nested join can work-steal another element job onto its own thread index and re-lock the non-reentrant `Mutex` it already holds, deadlocking the pool (reproduced reliably on faceted-brep-heavy models). The cache is now acquired with `try_lock`, and the rare re-entrant work-stolen job falls back to a throwaway cache. Output is byte-identical (the cache is pure memoization of deterministic coordinates, so a miss just re-decodes). The browser meshes single-threaded per worker and was never affected; this corrects the native path (FFI / Python wheel / native harnesses).

--- a/rust/processing/src/processor/mod.rs
+++ b/rust/processing/src/processor/mod.rs
@@ -1289,7 +1289,22 @@ pub fn process_geometry_streaming_filtered_with_options(
             .par_iter()
             .map(|job| {
                 let widx = rayon::current_thread_index().unwrap_or(0) % worker_point_caches.len();
-                let mut worker_point_cache = worker_point_caches[widx].lock().unwrap();
+                // `try_lock`, not `lock`: faceted-brep triangulation nests a rayon
+                // `par_iter`, so a worker blocked at that nested join can work-steal
+                // another element job onto its OWN thread index and re-enter here.
+                // `lock()` on the non-reentrant `Mutex` this thread already holds
+                // would self-deadlock (regression from the persistent per-worker
+                // cache). Each slot is a thread's own index, so `try_lock` only ever
+                // fails on that re-entrant steal; that rare job uses a throwaway
+                // cache instead. Output is byte-identical: the cache is pure
+                // memoization of deterministic coordinates, so a miss just re-decodes.
+                let mut fallback_cache = FxHashMap::default();
+                let mut slot_guard = worker_point_caches[widx].try_lock().ok();
+                let worker_point_cache: &mut FxHashMap<u32, (f64, f64, f64)> =
+                    match slot_guard.as_deref_mut() {
+                        Some(cache) => cache,
+                        None => &mut fallback_cache,
+                    };
                 process_entity_job(
                     job,
                     content,
@@ -1311,7 +1326,7 @@ pub fn process_geometry_streaming_filtered_with_options(
                     &rect_fast_collector,
                     &backstop_collector,
                     &item_dedup_cache,
-                    &mut worker_point_cache,
+                    worker_point_cache,
                     &point_cache_hits_collector,
                     &point_cache_misses_collector,
                     &faceted_brep_ns_collector,

--- a/rust/processing/tests/faceted_brep_deadlock_regression.rs
+++ b/rust/processing/tests/faceted_brep_deadlock_regression.rs
@@ -1,0 +1,69 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Regression for the native nested-`par_iter` re-entrancy self-deadlock
+//! introduced by the persistent per-worker CartesianPoint cache (#1572).
+//!
+//! That cache is a `Vec<Mutex<FxHashMap>>` indexed by `rayon::current_thread_index()`,
+//! locked and held across the whole element job. Faceted-brep triangulation nests
+//! a rayon `par_iter`, so a worker blocked at that nested join can work-steal
+//! another element job onto its OWN thread index and re-lock the non-reentrant
+//! `std::sync::Mutex` it already holds -> self-deadlock. It fires reliably on
+//! faceted-brep-heavy models under the multithreaded native pool (wasm meshes
+//! single-threaded per worker and is unaffected). Fixed by `try_lock` + a
+//! throwaway-cache fallback for the re-entrant job (byte-identical: the cache is
+//! pure memoization of deterministic coordinates).
+//!
+//! This drives a faceted-brep-heavy fixture through the full multithreaded
+//! pipeline several times under a watchdog. A re-introduced deadlock parks the
+//! worker forever, so the timeout fails the test instead of hanging CI.
+
+use std::sync::mpsc;
+use std::time::Duration;
+
+const FIXTURE: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../tests/models/ara3d/schependomlaan.ifc"
+);
+
+#[test]
+fn multithreaded_faceted_brep_pipeline_does_not_deadlock() {
+    let Ok(content) = std::fs::read(FIXTURE) else {
+        eprintln!(
+            "skipping: fixture {FIXTURE} not present — run `pnpm fixtures` \
+             (sha256 in tests/models/manifest.json)"
+        );
+        return;
+    };
+
+    let (tx, rx) = mpsc::channel();
+    let worker = std::thread::spawn(move || {
+        // The deadlock reproduced on the first full-model pass, so a few
+        // multithreaded passes reliably re-trip a reintroduced bug.
+        for _ in 0..3 {
+            let result = ifc_lite_processing::process_geometry(&content);
+            // Sanity: the model does produce geometry (guards against a fixture
+            // that silently stopped exercising the faceted-brep path).
+            assert!(
+                !result.meshes.is_empty(),
+                "fixture produced no meshes — it may no longer exercise faceted breps"
+            );
+        }
+        let _ = tx.send(());
+    });
+
+    // A clean run is a few seconds even in a debug build; 180s is a generous
+    // ceiling. A deadlocked worker never sends, so recv_timeout fires and fails
+    // the test rather than hanging the suite.
+    match rx.recv_timeout(Duration::from_secs(180)) {
+        Ok(()) => {
+            let _ = worker.join();
+        }
+        Err(_) => panic!(
+            "process_geometry deadlocked on a faceted-brep-heavy model — the \
+             nested-par_iter worker-point-cache re-entrancy regression is back \
+             (#1572; fix is `try_lock` in processor/mod.rs)"
+        ),
+    }
+}

--- a/rust/processing/tests/module_size_allowlist.txt
+++ b/rust/processing/tests/module_size_allowlist.txt
@@ -73,7 +73,8 @@
      468 rust/processing/src/georeferencing.rs
      772 rust/processing/src/prepass.rs
 # +24: build the entity index INLINE in the scan loop instead of a separate build_entity_index pass (perf/single-scan; one file walk instead of two).
-    1498 rust/processing/src/processor/mod.rs
+# +15: try_lock the per-worker point cache to fix the nested-par_iter re-entrancy self-deadlock (#1572 regression).
+    1513 rust/processing/src/processor/mod.rs
      440 rust/processing/src/symbolic/items.rs
 # +6: wire per-batch point-cache hit/miss stats into record_pipeline_batch (perf/brep-point-cache-instrumentation).
      773 rust/wasm-bindings/src/api/gpu_meshes/batch.rs


### PR DESCRIPTION
## The bug (regression from #1572, merged today)

`process_geometry`'s persistent per-worker CartesianPoint cache is a `Vec<Mutex<FxHashMap>>` indexed by `rayon::current_thread_index()` and **locked across the whole element job** (`processor/mod.rs`). Faceted-brep triangulation nests a rayon `par_iter` (`faceted.rs:330`, ≥64-face shells). So when a worker blocks at that nested join, rayon **work-steals another element job onto the same thread**, which calls `worker_point_caches[widx].lock()` on the slot it already holds → **self-deadlock** (non-reentrant `std::sync::Mutex`).

- Reproduces **reliably** on faceted-brep-heavy models under the multithreaded native pool. Confirmed here: schependomlaan **hung at 0% CPU on the first pass** pre-fix.
- **Native only** — the browser meshes single-threaded per worker (rayon runs inline on wasm), so wasm was never affected. This corrects the **native path**: FFI bridge, Python wheel, native harnesses (and it's why `perf_probe --suite` intermittently stalled).

## The fix

Acquire the slot with **`try_lock`** instead of `lock`. Each slot is a thread's *own* index, so `try_lock` only ever fails on the re-entrant work-stolen job — that rare job uses a throwaway cache. **Byte-identical output**: the cache is pure memoization of deterministic coordinates, so a miss just re-decodes.

```rust
let mut fallback_cache = FxHashMap::default();
let mut slot_guard = worker_point_caches[widx].try_lock().ok();
let worker_point_cache = match slot_guard {
    Some(ref mut g) => &mut **g,   // uncontended: this thread's own slot
    None => &mut fallback_cache,   // re-entrant steal: don't deadlock, re-decode
};
```

## Verification

- **No deadlock**: schependomlaan completes **5/5** multithreaded runs (hung on attempt 1 before).
- **Byte-identical**: `mesh_output_matches_pinned_manifest` passes with **no manifest re-pin**.
- The #1572 `shared_point_faceted_breps_parse_each_point_once` test still passes; full `ifc-lite-processing` + `ifc-lite-geometry` suites green.
- Adds a **watchdog regression test** (`faceted_brep_deadlock_regression.rs`): drives the multithreaded faceted-brep pipeline and fails on a reintroduced hang via a timeout instead of stalling CI.
- Ratchet budget for `processor/mod.rs` bumped +15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)