### PR TITLE
perf(core): Arc the DecodedEntity attribute tree (refcount-bump clones, ~8% faster)

### DIFF
--- a/.changeset/perf-arc-decoded-attributes.md
+++ b/.changeset/perf-arc-decoded-attributes.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/wasm": patch
+---
+
+Make `DecodedEntity.attributes` an `Arc<Vec<AttributeValue>>` so cloning a decoded entity is a refcount bump instead of a deep clone of the whole attribute tree. The decoder deep-clones on every cache insert AND every cache hit (`decode_at`/`decode_by_id`), which was a large share of the allocator traffic in both parse and geometry on big models. Decoded attributes are never mutated after construction, so the sharing is sound and the read-through getters are unchanged. Byte-identical (mesh-determinism manifest unchanged, no re-pin). Measured ~8% faster total / ~10% parse / ~12% entity-scan on schependomlaan (47MB, 714k entities), scaling with entity count; it also cuts per-worker re-decode cost in the browser.

--- a/rust/core/src/schema_gen.rs
+++ b/rust/core/src/schema_gen.rs
@@ -244,12 +244,15 @@ impl AttributeValue {
     }
 }
 
-/// Decoded IFC entity with attributes
+/// Decoded IFC entity. `attributes` is behind an `Arc` so cloning a
+/// `DecodedEntity` (the decoder clones on every cache insert AND every cache
+/// hit) is a refcount bump, not a deep clone of the attribute tree. Attributes
+/// are never mutated after construction, so sharing is sound and byte-identical.
 #[derive(Debug, Clone)]
 pub struct DecodedEntity {
     pub id: u32,
     pub ifc_type: IfcType,
-    pub attributes: Vec<AttributeValue>,
+    pub attributes: std::sync::Arc<Vec<AttributeValue>>,
 }
 
 impl DecodedEntity {
@@ -258,7 +261,7 @@ impl DecodedEntity {
         Self {
             id,
             ifc_type,
-            attributes,
+            attributes: std::sync::Arc::new(attributes),
         }
     }
 

--- a/rust/processing/tests/module_size_allowlist.txt
+++ b/rust/processing/tests/module_size_allowlist.txt
@@ -17,7 +17,8 @@
      445 rust/core/src/model_bounds.rs
      601 rust/core/src/parser/scanner.rs
      463 rust/core/src/parser/tokenizer.rs
-     550 rust/core/src/schema_gen.rs
+# +3: Arc<Vec<AttributeValue>> so DecodedEntity clone is a refcount bump not a deep attribute-tree clone (perf/decode-churn).
+    553 rust/core/src/schema_gen.rs
      990 rust/core/src/units.rs
 # +4: build the index once in parallel on the fail-closed try_/project_glb_size large-model GLB paths (perf/parallel-scan).
     3947 rust/export/src/gltf.rs


### PR DESCRIPTION
## What

The decoder deep-clones the entire `Vec<AttributeValue>` on **every cache insert AND every cache hit** (`decode_at` / `decode_by_id`). On big models that deep-clone is a large share of the allocator traffic in *both* the parse and geometry phases (a profiling deep-dive measured allocator/memory management at ~40% of all busy CPU on a 109k-element model). Making `DecodedEntity.attributes` an `Arc<Vec<AttributeValue>>` turns all of those clones into refcount bumps.

Decoded attributes are never mutated after construction — all access is through the read-through getters (`get`/`get_ref`/`get_string`/`get_float`/`get_list`), no `&mut` or field assignment reaches them — so the sharing is sound.

## Byte-identical

- `mesh_output_matches_pinned_manifest` passes with **no re-pin**.
- Mechanical: the whole workspace builds unchanged (nothing constructs `DecodedEntity` by struct literal; the change is the field type + `Arc::new` in the constructor).
- The shared values are exactly what a deep clone would have produced.

## Numbers (A/B, schependomlaan 47MB / 714k entities, best-of-9)

| | main | this | delta |
|---|---|---|---|
| total | 371ms | 340ms | **-8.4%** |
| parse | 293ms | 265ms | **-9.6%** |
| entity_scan | 224ms | 197ms | **-12%** |
| geometry | 78ms | 74ms | -5% |

Scales with entity count (larger on big models), and helps the browser — each geometry worker re-decodes the file, so the clone reduction lands in the per-worker meshing loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)