### PR TITLE
fix(geometry): budget-guard the union/intersection kernel entries (#1109)

### DIFF
--- a/rust/geometry/src/kernel/budget.rs
+++ b/rust/geometry/src/kernel/budget.rs
@@ -236,6 +236,20 @@ pub fn reset_peak() {
 /// Called from the `.or_else(|| fixed::…)` arms of [`crate::kernel::predicates`]
 /// — the point where a predicate leaves the cheap interval filter for the
 /// expensive fixed-width / BigRational path.
+///
+/// DELIBERATE EXEMPTION — the cached-λ I512/I1024 tier is NOT counted. The
+/// escalations tallied here all RE-DERIVE the degree-4/7 LPI/TPI lambda inside the
+/// `fixed::indirect_*` / `orient2d_2i|3i` / `cmp_lex` arms of `predicates.rs`, and
+/// that lambda recompute is the dominant per-escalation cost the caps were
+/// calibrated against. The hot re-triangulation / arrangement predicates that run
+/// straight off lambdas ALREADY interned — `retriangulate::orient2d_v` /
+/// `cmp_lex_v` (their `fixed::orient2d_from_lam` / `cmp_lex_from_lam` determinant
+/// branch, retriangulate.rs:51) and `arrangement::orient2d_end` (its cached
+/// interval-lambda branch, arrangement/mod.rs:107) — skip that recompute, so they
+/// are intentionally left OUT of the counter. Folding them in would inflate the
+/// count on cheap cached evaluations and re-calibrate the effective cap, shifting
+/// which elements trip and thereby perturbing valid mesh output / determinism; the
+/// counter is kept as a proxy for the recompute-heavy work only.
 #[inline]
 pub fn note_escalation() {
     COUNT.with(|c| c.set(c.get().saturating_add(1)));

--- a/rust/geometry/src/kernel/mesh_bridge.rs
+++ b/rust/geometry/src/kernel/mesh_bridge.rs
@@ -384,9 +384,28 @@ pub fn subtract_many(host: &Mesh, cutters: &[&Mesh]) -> Option<Mesh> {
 
 /// `a ∪ b` as a `Mesh`.
 pub fn union(a: &Mesh, b: &Mesh) -> Mesh {
+    // Enter the #1109 escalation budget exactly like `subtract` does: begin a
+    // fresh PER-BOOLEAN count (this is a distinct operation) while the per-ELEMENT
+    // accumulator is left intact — `begin()` resets only the per-op counter, so a
+    // union inside an over-budget element STILL trips (it is not an element-cap
+    // escape hatch; see `budget::begin` / the `per_element_budget_accumulates_
+    // across_booleans` test). Without this, a union scheduled on a worker thread
+    // after a subtract tripped starts already-tripped and `arrange` bails at its
+    // first pair, silently returning a partial/empty arrangement.
+    super::budget::begin();
     let a = orient_outward(mesh_to_tris(a));
     let b = orient_outward(mesh_to_tris(b));
-    tris_to_mesh(&boolean(&a, &b, BoolOp::Union))
+    let out = boolean(&a, &b, BoolOp::Union);
+    // On a budget trip `arrange` bailed mid-way and `out` is a PARTIAL arrangement.
+    // Discard it and return empty — the graceful-fallback signal the callers already
+    // handle (`csg::union_mesh` degrades to a plain merge; the #960 roof
+    // `build_cutter_union` defers to the sequential path) — never a poisoned mesh.
+    // Deterministic: the trip point is a pure function of the snapped operands, so
+    // native and wasm degrade the SAME union identically (parity).
+    if super::budget::tripped() {
+        return Mesh::new();
+    }
+    tris_to_mesh(&out)
 }
 
 /// `∪ meshes` as one watertight `Mesh` — the N-ary union, computed in a single
@@ -394,17 +413,37 @@ pub fn union(a: &Mesh, b: &Mesh) -> Mesh {
 /// segmented-roof cutters) dissolve without the tearing that left-deep pairwise
 /// accumulation produces. Empty input ⇒ empty mesh.
 pub fn union_many(meshes: &[&Mesh]) -> Mesh {
+    // Participate in the #1109 budget like `subtract` / `union` — fresh per-boolean
+    // count, per-element accumulator preserved (see `union`).
+    super::budget::begin();
     let tri_lists: Vec<Vec<Tri>> =
         meshes.iter().map(|m| orient_outward(mesh_to_tris(m))).collect();
     let refs: Vec<&[Tri]> = tri_lists.iter().map(|t| t.as_slice()).collect();
-    tris_to_mesh(&union_all(&refs))
+    let out = union_all(&refs);
+    // On a budget trip `arrange_many` bailed and `out` is a PARTIAL arrangement.
+    // Return empty so `build_cutter_union` defers to the sequential per-cutter path
+    // instead of feeding a poisoned (non-watertight) cutter union into the subtract.
+    if super::budget::tripped() {
+        return Mesh::new();
+    }
+    tris_to_mesh(&out)
 }
 
 /// `a ∩ b` as a `Mesh`.
 pub fn intersection(a: &Mesh, b: &Mesh) -> Mesh {
+    // Participate in the #1109 budget like `subtract` / `union` — fresh per-boolean
+    // count, per-element accumulator preserved (see `union`).
+    super::budget::begin();
     let a = orient_outward(mesh_to_tris(a));
     let b = orient_outward(mesh_to_tris(b));
-    tris_to_mesh(&boolean(&a, &b, BoolOp::Intersection))
+    let out = boolean(&a, &b, BoolOp::Intersection);
+    // On a budget trip `arrange` bailed and `out` is a PARTIAL arrangement. Return
+    // empty — `csg::intersection_mesh` treats empty as the graceful (disjoint-like)
+    // degrade rather than consuming a poisoned partial intersection.
+    if super::budget::tripped() {
+        return Mesh::new();
+    }
+    tris_to_mesh(&out)
 }
 
 #[cfg(test)]

--- a/rust/processing/tests/module_size_allowlist.txt
+++ b/rust/processing/tests/module_size_allowlist.txt
@@ -34,7 +34,8 @@
      408 rust/geometry/src/geom_hash.rs
      641 rust/geometry/src/kernel/arrangement/classify.rs
      566 rust/geometry/src/kernel/fixed.rs
-     846 rust/geometry/src/kernel/mesh_bridge.rs
+# +39: begin()/tripped() budget-guard added to the union & intersection kernel entries (#1109 parity with subtract).
+     885 rust/geometry/src/kernel/mesh_bridge.rs
      700 rust/geometry/src/kernel/predicates.rs
     1383 rust/geometry/src/kernel/retriangulate.rs
      468 rust/geometry/src/kernel/tritri.rs


### PR DESCRIPTION
## What

The #1109 escalation budget is managed only on the **subtract** path. The kernel's `union` / `union_many` / `intersection` (`mesh_bridge.rs`) neither called `budget::begin()` nor checked `tripped()`, and the budget counters are persistent thread-locals. So after a subtract tripped on a worker thread, the **next union/intersection on that thread started already-tripped**, bailed at its first pair inside `arrange`, and silently returned a partial/empty arrangement (degrading to a plain merge and recording a misattributed failure).

## Fix

`union`, `union_many`, `intersection` now call `budget::begin()` at entry (fresh per-**operation** count, mirroring the subtract wrappers at `csg/mod.rs:466,540`) and `return Mesh::new()` when `tripped()`, discarding the partial arrangement.

Why this is not an element-cap escape hatch: `begin()` resets only the per-**op** counter (`COUNT`/`OP_CAP`); the per-**element** accumulator (`ELEM_COUNT`/`ELEM_CAP`) survives, and `tripped()` reflects both. This is exactly what `per_element_budget_accumulates_across_booleans` pins.

Empty-on-trip is the union/intersection analog of subtract's "return the host un-cut" — every call site already treats empty as the fallback signal:
- `build_cutter_union` (#960 roof): empty `union_many` → sequential `union_meshes` → per-cutter path (never feeds a poisoned cutter into the subtract).
- `union_mesh`: empty → plain merge (overlap not removed) + recorded failure.
- `intersection_mesh`: empty → disjoint-like degrade (already its documented semantics).

Also documents (comment only) why the cached-λ I512 tiers (`retriangulate` `orient2d_v`/`cmp_lex_v`, `arrangement` `orient2d_end`) are deliberately uncounted — they reuse interned lambdas, skipping the dominant recompute the caps are calibrated against.

## Verification

- `cargo test -p ifc-lite-geometry --lib`: 436 passed, 0 failed.
- `issue_1109_budget`, `issue_960_segmented_roof_clip`, `bool_failure_test` (incl. `union_past_legacy_cap_succeeds`, `intersection_past_legacy_cap_succeeds`) all green; pinned manifests unchanged; **no assertion changed**.
- No wasm public-API change (no `.d.ts` regen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)