### PR TITLE
fix(geometry): consolidate IfcAxis2Placement3D parsing + guard degenerate placements (NaN geometry)

### DIFF
--- a/rust/geometry/src/cdt.rs
+++ b/rust/geometry/src/cdt.rs
@@ -165,6 +165,13 @@ struct Cdt {
     track: bool,
     /// Quality target used by the tracking hooks.
     cos_min_angle: f64,
+    /// Set when an insertion hits a "can't happen" topology invariant (e.g. a
+    /// shared edge whose neighbour has no apex vertex). Rather than panic, the
+    /// insertion bails and every `Option`-returning entry point (`build_from`,
+    /// the incremental refinement driver) treats the CDT as unbuildable and
+    /// returns `None`, so the caller falls back to ear-clipping — matching how
+    /// every other degenerate case in this module degrades.
+    failed: bool,
 }
 
 /// The next refinement step chosen for a triangulation (see `Cdt::next_action`).
@@ -229,6 +236,7 @@ impl Cdt {
             skinny: BTreeSet::new(),
             track: false,
             cos_min_angle: COS_MIN_ANGLE,
+            failed: false,
         };
         cdt.tris.push(Tri {
             v: [super_base, super_base + 1, super_base + 2],
@@ -240,6 +248,9 @@ impl Cdt {
         // Incremental Delaunay insertion in canonical index order.
         for vi in 0..n_input {
             cdt.insert_point(vi);
+        }
+        if cdt.failed {
+            return None; // an insertion tripped a topology invariant — fall back to ear-clipping
         }
         if !cdt.enforce_constraints() {
             return None;
@@ -262,6 +273,9 @@ impl Cdt {
     /// the incremental-refinement entry skips the O(T) `locate` scan (the
     /// caller walked to it via [`Cdt::locate_from`]).
     fn insert_point_at(&mut self, vi: usize, start: usize) {
+        if self.failed {
+            return; // a prior insertion tripped a topology invariant; stop touching topology
+        }
         let p = self.points[vi];
         // Region of the seed = region of every cavity triangle (the cavity BFS
         // never crosses a constraint), inherited by the re-fan below.
@@ -508,12 +522,14 @@ impl Cdt {
         // both parents in lockstep. Each child inherits its OWN parent's
         // region flag — the two regions can differ across a constraint edge.
         let region_nb = self.inside.get(nb).copied().unwrap_or(false);
-        let d = self.tris[nb]
-            .v
-            .iter()
-            .copied()
-            .find(|&x| x != a && x != b)
-            .expect("cdt: neighbour across a shared edge must have an apex vertex");
+        let Some(d) = self.tris[nb].v.iter().copied().find(|&x| x != a && x != b) else {
+            // "Can't happen": the neighbour across a shared edge must have a
+            // third (apex) vertex. Degrade to ear-clipping instead of panicking
+            // — `t` is already retired above, so leave the CDT flagged
+            // unbuildable and let the entry point return `None`.
+            self.failed = true;
+            return;
+        };
         let outer_of = |s: &Self, t: usize, x: usize, y: usize| -> usize {
             s.tris[t].edge_of(x, y).map(|oe| s.tris[t].n[oe]).unwrap_or(NONE)
         };
@@ -1358,6 +1374,9 @@ fn refine_to_fixpoint(
                 break;
             };
             cdt.insert_steiner(p, loc);
+            if cdt.failed {
+                return None; // Steiner insertion tripped a topology invariant — ear-clip fallback
+            }
             steiner += 1;
         }
         return Some(cdt);

--- a/rust/geometry/src/processors/extrusion.rs
+++ b/rust/geometry/src/processors/extrusion.rs
@@ -100,7 +100,13 @@ impl GeometryProcessor for ExtrudedAreaSolidProcessor {
             .and_then(|v: &AttributeValue| v.as_float())
             .unwrap_or(1.0);
 
-        let local_direction = Vector3::new(dir_x, dir_y, dir_z).normalize();
+        let direction = Vector3::new(dir_x, dir_y, dir_z);
+        if direction.norm_squared() <= f64::EPSILON {
+            return Err(Error::geometry(
+                "ExtrudedAreaSolid has zero-length ExtrudedDirection".to_string(),
+            ));
+        }
+        let local_direction = direction.normalize();
 
         // Get depth
         let depth = entity

--- a/rust/geometry/src/processors/helpers.rs
+++ b/rust/geometry/src/processors/helpers.rs
@@ -73,44 +73,9 @@ pub(super) fn parse_axis2_placement_3d(
         Vector3::new(1.0, 0.0, 0.0)
     };
 
-    // Normalize axes
-    let z_axis_final = z_axis.normalize();
-    let x_axis_normalized = x_axis.normalize();
-
-    // Ensure X is orthogonal to Z (project X onto plane perpendicular to Z)
-    let dot_product = x_axis_normalized.dot(&z_axis_final);
-    let x_axis_orthogonal = x_axis_normalized - z_axis_final * dot_product;
-    let x_axis_final = if x_axis_orthogonal.norm() > 1e-6 {
-        x_axis_orthogonal.normalize()
-    } else {
-        // X and Z are parallel or nearly parallel - use a default perpendicular direction
-        if z_axis_final.z.abs() < 0.9 {
-            Vector3::new(0.0, 0.0, 1.0).cross(&z_axis_final).normalize()
-        } else {
-            Vector3::new(1.0, 0.0, 0.0).cross(&z_axis_final).normalize()
-        }
-    };
-
-    // Y axis is cross product of Z and X (right-hand rule: Y = Z × X)
-    let y_axis = z_axis_final.cross(&x_axis_final).normalize();
-
-    // Build transformation matrix
-    // Columns represent world-space directions of local axes
-    let mut transform = Matrix4::identity();
-    transform[(0, 0)] = x_axis_final.x;
-    transform[(1, 0)] = x_axis_final.y;
-    transform[(2, 0)] = x_axis_final.z;
-    transform[(0, 1)] = y_axis.x;
-    transform[(1, 1)] = y_axis.y;
-    transform[(2, 1)] = y_axis.z;
-    transform[(0, 2)] = z_axis_final.x;
-    transform[(1, 2)] = z_axis_final.y;
-    transform[(2, 2)] = z_axis_final.z;
-    transform[(0, 3)] = location.x;
-    transform[(1, 3)] = location.y;
-    transform[(2, 3)] = location.z;
-
-    Ok(transform)
+    // Orthonormalize + assemble via the shared builder (canonical Gram–Schmidt
+    // with the degenerate-axis fallback baked in).
+    Ok(crate::transform::build_axis2_matrix(location, z_axis, x_axis))
 }
 
 /// Parse IfcCartesianPoint from a parent entity at the given attribute index
@@ -231,13 +196,13 @@ pub(super) fn get_axis2_placement_transform_by_id(
         .and_then(|id| get_direction_by_id(id, decoder))
         .unwrap_or(Vector3::new(1.0, 0.0, 0.0));
 
-    // Compute Y axis as Z cross X
-    let y_axis = z_axis.cross(&x_axis).normalize();
-    let x_axis = y_axis.cross(&z_axis).normalize();
-
-    Ok(Matrix4::new(
-        x_axis.x, y_axis.x, z_axis.x, location.0, x_axis.y, y_axis.y, z_axis.y, location.1,
-        x_axis.z, y_axis.z, z_axis.z, location.2, 0.0, 0.0, 0.0, 1.0,
+    // Orthonormalize + assemble via the shared builder so the degenerate-axis
+    // (RefDirection ∥ Axis) fallback is applied here too, instead of normalizing
+    // a zero cross-product into a NaN matrix.
+    Ok(crate::transform::build_axis2_matrix(
+        Point3::new(location.0, location.1, location.2),
+        z_axis,
+        x_axis,
     ))
 }
 

--- a/rust/geometry/src/profile_extractor.rs
+++ b/rust/geometry/src/profile_extractor.rs
@@ -615,32 +615,9 @@ fn parse_axis2_placement_3d(
         Vector3::new(1.0, 0.0, 0.0)
     };
 
-    let z = z_axis.normalize();
-
-    // Gram–Schmidt: ensure X is orthogonal to Z
-    let dot = x_axis_raw.dot(&z);
-    let x_orth = x_axis_raw - z * dot;
-    let x = if x_orth.norm() > 1e-6 {
-        x_orth.normalize()
-    } else {
-        // Fallback if X and Z are nearly parallel
-        if z.z.abs() < 0.9 {
-            Vector3::new(0.0, 0.0, 1.0).cross(&z).normalize()
-        } else {
-            Vector3::new(1.0, 0.0, 0.0).cross(&z).normalize()
-        }
-    };
-    let y = z.cross(&x).normalize();
-
-    // Column-major construction: columns = [x | y | z | loc]
-    #[rustfmt::skip]
-    let m = Matrix4::new(
-        x.x, y.x, z.x, location.x,
-        x.y, y.y, z.y, location.y,
-        x.z, y.z, z.z, location.z,
-        0.0, 0.0, 0.0, 1.0,
-    );
-    Ok(m)
+    // Orthonormalize + assemble via the shared builder (canonical Gram–Schmidt
+    // with the degenerate-axis fallback baked in).
+    Ok(crate::transform::build_axis2_matrix(location, z_axis, x_axis_raw))
 }
 
 /// Parse IfcCartesianPoint from a parent entity at the given attribute index.

--- a/rust/geometry/src/router/transforms/parsers.rs
+++ b/rust/geometry/src/router/transforms/parsers.rs
@@ -48,27 +48,10 @@ impl GeometryRouter {
             Vector3::new(1.0, 0.0, 0.0)
         };
 
-        // Y axis is cross product of Z and X
-        let y_axis = z_axis.cross(&x_axis).normalize();
-        let x_axis = y_axis.cross(&z_axis).normalize();
-        let z_axis = z_axis.normalize();
-
-        // Build transformation matrix
-        let mut transform = Matrix4::identity();
-        transform[(0, 0)] = x_axis.x;
-        transform[(1, 0)] = x_axis.y;
-        transform[(2, 0)] = x_axis.z;
-        transform[(0, 1)] = y_axis.x;
-        transform[(1, 1)] = y_axis.y;
-        transform[(2, 1)] = y_axis.z;
-        transform[(0, 2)] = z_axis.x;
-        transform[(1, 2)] = z_axis.y;
-        transform[(2, 2)] = z_axis.z;
-        transform[(0, 3)] = location.x;
-        transform[(1, 3)] = location.y;
-        transform[(2, 3)] = location.z;
-
-        Ok(transform)
+        // Orthonormalize + assemble via the shared builder so the
+        // degenerate-axis (RefDirection ∥ Axis) fallback is applied here too,
+        // instead of normalizing a zero cross-product into a NaN matrix.
+        Ok(crate::transform::build_axis2_matrix(location, z_axis, x_axis))
     }
 
     /// Parse IfcCartesianPoint

--- a/rust/geometry/src/transform.rs
+++ b/rust/geometry/src/transform.rs
@@ -57,6 +57,26 @@ pub fn parse_axis2_placement_3d(
         Vector3::new(1.0, 0.0, 0.0)
     };
 
+    Ok(build_axis2_matrix(location, z_axis, x_axis))
+}
+
+/// Orthonormalize a placement's raw axes + location into a column-major 4×4
+/// transform (columns = world-space local X, Y, Z, then translation).
+///
+/// `z_axis` is the raw Axis (local +Z), `x_axis` the raw RefDirection (local
+/// +X); both are normalized here. This is the single home for the
+/// degenerate-axis fallback: when RefDirection is parallel to Axis the projected
+/// X collapses, so instead of normalizing a zero vector (which yields a NaN
+/// matrix) we pick a deterministic perpendicular direction. The math is the
+/// canonical Gram–Schmidt (normalize Z, project RefDirection onto the plane ⟂ Z,
+/// then Y = Z × X). Every `IfcAxis2Placement3D` parser in the crate keeps its
+/// own attribute extraction / default-axis choices and shares only this
+/// orthonormalization + assembly, so the guard can never drift out of a fork.
+pub(crate) fn build_axis2_matrix(
+    location: Point3<f64>,
+    z_axis: Vector3<f64>,
+    x_axis: Vector3<f64>,
+) -> Matrix4<f64> {
     // Normalize axes
     let z_axis_final = z_axis.normalize();
     let x_axis_normalized = x_axis.normalize();
@@ -94,7 +114,7 @@ pub fn parse_axis2_placement_3d(
     transform[(1, 3)] = location.y;
     transform[(2, 3)] = location.z;
 
-    Ok(transform)
+    transform
 }
 
 /// Parse IfcCartesianPoint from an entity attribute
@@ -240,46 +260,7 @@ pub fn parse_axis2_placement_3d_from_id(
         Vector3::new(1.0, 0.0, 0.0)
     };
 
-    // Normalize axes
-    let z_axis_final = z_axis.normalize();
-    let x_axis_normalized = x_axis.normalize();
-
-    // Ensure X is orthogonal to Z (project X onto plane perpendicular to Z)
-    let dot_product = x_axis_normalized.dot(&z_axis_final);
-    let x_axis_orthogonal = x_axis_normalized - z_axis_final * dot_product;
-    let x_axis_final = if x_axis_orthogonal.norm() > 1e-6 {
-        x_axis_orthogonal.normalize()
-    } else {
-        // X and Z are parallel or nearly parallel - use a default perpendicular direction
-        if z_axis_final.z.abs() < 0.9 {
-            Vector3::new(0.0, 0.0, 1.0).cross(&z_axis_final).normalize()
-        } else {
-            Vector3::new(1.0, 0.0, 0.0).cross(&z_axis_final).normalize()
-        }
-    };
-
-    // Y axis is cross product of Z and X (right-hand rule: Y = Z × X)
-    let y_axis = z_axis_final.cross(&x_axis_final).normalize();
-
-    // Build transformation matrix using Matrix4::new constructor (column-major)
-    Ok(Matrix4::new(
-        x_axis_final.x,
-        y_axis.x,
-        z_axis_final.x,
-        location.x,
-        x_axis_final.y,
-        y_axis.y,
-        z_axis_final.y,
-        location.y,
-        x_axis_final.z,
-        y_axis.z,
-        z_axis_final.z,
-        location.z,
-        0.0,
-        0.0,
-        0.0,
-        1.0,
-    ))
+    Ok(build_axis2_matrix(location, z_axis, x_axis))
 }
 
 /// Parse IfcDirection entity

--- a/rust/processing/tests/module_size_allowlist.txt
+++ b/rust/processing/tests/module_size_allowlist.txt
@@ -24,7 +24,8 @@
      611 rust/export/src/step.rs
     1233 rust/geometry/src/alignment.rs
      551 rust/geometry/src/bool2d.rs
-    1875 rust/geometry/src/cdt.rs
+# +19: split_on_edge now sets a failed flag and bails to the ear-clip fallback instead of the lone .expect() panic.
+    1894 rust/geometry/src/cdt.rs
      895 rust/geometry/src/csg/consolidate.rs
     1061 rust/geometry/src/csg/mod.rs
      436 rust/geometry/src/csg/normals.rs


### PR DESCRIPTION
## What

Four forks of the `IfcAxis2Placement3D` orthonormalization existed; two dropped the degenerate-axis guard the canonical parser has. A placement whose `RefDirection` is parallel to `Axis` produced a NaN matrix (`z.cross(x).normalize()` on a ~zero vector) that propagated silently into geometry. Same class: `processors/extrusion.rs` had no zero-length `ExtrudedDirection` guard (the tapered processor already did).

## Change

- Extract `transform.rs::build_axis2_matrix(location, z, x)` — the canonical normalize + Gram-Schmidt + **degenerate-axis fallback** + column-major assembly.
- Route all **six** placement-to-matrix sites through it (`transform.rs` x2, `processors/helpers.rs` x2, `profile_extractor.rs`, `router/transforms/parsers.rs`). Each keeps its own attribute extraction and defaults verbatim; only the math block is shared. **Bit-identical for valid axis-aligned placements.**
- Add the zero-length `ExtrudedDirection` guard to `processors/extrusion.rs`.
- `cdt.rs`: the module's only production `.expect()` (`split_on_edge`) now bails via a `failed` flag so the existing ear-clip fallback fires instead of panicking; both `Option`-returning entry points discard the half-built CDT before anything reads it (verified by trace).

## Intended behavior change (adversarially reviewed)

`get_axis2_placement_transform_by_id` (SurfaceOfLinearExtrusion / AdvancedBrep positions) now **normalizes the placement Z axis** per ISO 10303-42. The old raw-Z matrix scaled AdvancedBrep local frames on non-unit `Axis` DirectionRatios (distorted cylindrical-face geometry via `try_inverse`); bit-identical on the common exact axis-aligned unit case. **Pinned `mesh_determinism` manifests verified unaffected (3/3 local, synthetic fixture is axis-aligned.)** If a real fixture with a non-unit AdvancedBrep Axis flips CI determinism/ifcopenshell-parity, that is a correct re-pin.

## Follow-up (out of scope)

The two `IfcCartesianTransformationOperator3D` parsers still carry the same unguarded `z.cross(x)` NaN pattern (different IFC entity with Scale semantics).

## Verification

- `cargo test -p ifc-lite-geometry`: 436 passed, 0 failed (transform axis2 fallback/parity + cdt tests included).
- `cargo build -p ifc-lite-processing -p ifc-lite-wasm`: clean.
- Net −69 lines. No wasm public-API change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved geometry processing for axis-based placements by using a shared, more robust transform calculation.
  * Added safer handling for zero-length extrusion directions, with a clear geometry error instead of a crash.

* **Bug Fixes**
  * Prevented triangulation refinement from panicking on invalid topology; it now fails gracefully and can fall back to a simpler approach.
  * Better handles nearly parallel or degenerate axes when building placement transforms.

* **Chores**
  * Updated an internal module size allowance to reflect the revised geometry logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->