### PR TITLE
perf(core): allocation-free IfcType::from_str on the uppercase hot path (~5% CPU)

### DIFF
--- a/.changeset/perf-from-str-no-alloc.md
+++ b/.changeset/perf-from-str-no-alloc.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/wasm": patch
+---
+
+Make `IfcType::from_str` allocation-free on the hot path. It previously called `s.to_uppercase()` (a `String` allocation) on every invocation, and it is called once per scanned entity (millions of times on large models). STEP entity keywords are already uppercase ASCII, so the common case now matches the input slice directly and only rare lowercase/non-ASCII input allocates an owned uppercase copy. Byte-identical: a pure-uppercase-ASCII input equals its own `to_uppercase()`, so both the recognized-type match arms and the `Unknown(crc32_hash(..))` fallback produce the same result. A profiling `sample` attributed ~5% of busy CPU to this allocation on a 109k-element model.


### PR DESCRIPTION
## What

`IfcType::from_str` called `s.to_uppercase()` (a `String` allocation) on **every** call, and it is invoked **once per scanned entity** — millions of times on large models. A profiling `sample` (self-time) attributed **~5% of busy CPU** to this allocation on a 109k-element model.

STEP entity keywords are already uppercase ASCII, so the common case now matches the input slice directly with no allocation; only rare lowercase/non-ASCII input takes the owned-uppercase path.

```rust
let owned;
let upper: &str = if s.bytes().any(|b| b.is_ascii_lowercase()) || !s.is_ascii() {
    owned = s.to_uppercase();
    owned.as_str()
} else {
    s   // already uppercase ASCII — no alloc
};
match upper { /* … */ }
```

## Byte-identical

A pure-uppercase-ASCII `s` equals its own `to_uppercase()`, so both the recognized-type match arms **and** the `Unknown(crc32_hash(upper))` fallback produce the same result. Any non-uppercase input still goes through `to_uppercase()` exactly as before.

- `mesh_output_matches_pinned_manifest` passes with **no re-pin**.
- Unknown-type unit tests pass (`unknown_garbage_excluded`, `keeps_unknown_escape`).

## Notes

- `generated/schema.rs` is generated-once and hand-maintained — there is no active regenerator in-tree (`packages/codegen` emits only TypeScript), and the file is excluded from the module-size ratchet.
- A clean wall-clock A/B is pending a quiet machine (this was measured under concurrent profiling load); the allocation elimination itself is deterministic (one fewer `String` per scanned entity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)