### PR TITLE
chore: remove content_dedup_enabled() constant-true toggle

### DIFF
--- a/rust/geometry/src/router/mod.rs
+++ b/rust/geometry/src/router/mod.rs
@@ -318,20 +318,6 @@ impl GeometryRouter {
         Arc::new(Mutex::new(FxHashMap::default()))
     }
 
-    /// Whether content-dedup is enabled on the PRODUCTION batch paths (native
-    /// rayon pool + wasm). Re-enabled (was OFF in #1177) now that
-    /// `content_hash::item_signature` has a cached byte-level fast path for
-    /// IfcFacetedBrep — the Tekla-steel hot path. Measured on a 50k-part steel
-    /// model the brep hash dropped from ~8 s (recursive `decode_by_id` per point)
-    /// to ~2 s, below the ~5 s of meshing it skips, flipping dedup from a 0.9x
-    /// loss to a 1.2x win (byte-identical). `item_dedup_key` gates the hash to the
-    /// cheap types, so procedural-geometry models — the ones whose recursive hash
-    /// cost more than it saved — skip dedup entirely and pay nothing. The separate
-    /// `IfcMappedItem` instancing cache is always on regardless.
-    pub fn content_dedup_enabled() -> bool {
-        true
-    }
-
     /// Inject a shared item-dedup cache (see [`Self::new_dedup_cache`]) into this
     /// router. All routers given the SAME `Arc` dedup against one cache, so
     /// byte-identical geometry is meshed once across the whole model regardless of

--- a/rust/processing/src/processor/jobs.rs
+++ b/rust/processing/src/processor/jobs.rs
@@ -146,11 +146,7 @@ pub(super) fn process_entity_job(
 
     let mut local_router = GeometryRouter::with_scale_and_quality(unit_scale, tessellation_quality);
     local_router.set_rtc_offset(rtc_offset);
-    // content-dedup default OFF: its structural hash costs more than the meshing
-    // it skips on real models (see GeometryRouter::content_dedup_enabled).
-    if GeometryRouter::content_dedup_enabled() {
-        local_router.enable_content_dedup_shared(item_dedup_cache.clone());
-    }
+    local_router.enable_content_dedup_shared(item_dedup_cache.clone());
     let local_router = local_router;
 
     let metadata = crate::element::ElementMeshMetadata {

--- a/rust/wasm-bindings/src/api/gpu_meshes/batch.rs
+++ b/rust/wasm-bindings/src/api/gpu_meshes/batch.rs
@@ -137,9 +137,7 @@ impl IfcAPI {
         // Arm content-dedup against the per-worker shared cache so byte-identical
         // geometry (e.g. Tekla parts the exporter failed to share via
         // IfcMappedItem) is meshed ONCE across batches, not once per batch.
-        // content-dedup default OFF: its structural hash costs more than the
-        // meshing it skips on real models (see GeometryRouter::content_dedup_enabled).
-        if GeometryRouter::content_dedup_enabled() {
+        {
             let mut slot = self
                 .cached_item_dedup
                 .lock()


### PR DESCRIPTION
## What

`GeometryRouter::content_dedup_enabled()` returned a hardcoded `true`. Two call sites gated an `if` on it that could therefore never be false:

- `rust/wasm-bindings/src/api/gpu_meshes/batch.rs`
- `rust/processing/src/processor/jobs.rs`

Neither site had an `else`, so unwrapping the `if` loses no logic — content-dedup is always on. The guarded body (`enable_content_dedup_shared` on the shared item-dedup cache) now runs unconditionally, and the dead geometry helper + stale comments are removed.

## Verification

- `cargo test -p ifc-lite-geometry -p ifc-lite-processing`: green (includes the module-size ratchet).
- `cargo build -p ifc-lite-wasm`: clean.
- No wasm public-API change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)