### PR TITLE
chore(geometry): drop dead guard_saved diagnostics, bump schema version

### DIFF
--- a/rust/geometry/src/router/diagnostics.rs
+++ b/rust/geometry/src/router/diagnostics.rs
@@ -22,11 +22,6 @@ pub struct ClassificationStats {
     /// Openings classified as `NonRectangular` — full CSG path
     /// (no operand cap on the exact kernel).
     pub non_rectangular: usize,
-    /// Openings the OLD heuristic would have flagged as floor-opening
-    /// (vertical extrusion, dir.z.abs() > 0.95) but the host is a
-    /// wall-class element — so the classifier fix kept them on the
-    /// rectangular path. Non-zero here = the fix activated.
-    pub floor_opening_guard_saved: usize,
 }
 
 /// Per-host opening diagnostic captured during void processing.
@@ -78,9 +73,6 @@ pub struct OpeningDiagnostic {
     /// Vertex count of the opening's mesh — high counts (>100) force the
     /// non-rectangular path regardless of extrusion direction.
     pub vertex_count: usize,
-    /// Whether the host-aware floor-opening guard saved this opening
-    /// from being mis-routed onto the CSG path.
-    pub guard_saved: bool,
 }
 
 /// Discriminator for [`OpeningDiagnostic::kind`]. Mirrors `OpeningType`
@@ -227,7 +219,6 @@ impl GeometryRouter {
             ClassificationKind::Rectangular => s.rectangular += 1,
             ClassificationKind::Diagonal => s.diagonal += 1,
             ClassificationKind::NonRectangular => s.non_rectangular += 1,
-            ClassificationKind::FloorOpeningGuardSaved => s.floor_opening_guard_saved += 1,
         }
     }
 
@@ -316,20 +307,12 @@ impl GeometryRouter {
 }
 
 /// Internal classification-branch tag for `bump_classification`. Mirrors
-/// the variants of `OpeningType` plus the "the host-aware guard saved
-/// this opening from the floor-opening path" sentinel.
+/// the variants of `OpeningType`.
 #[derive(Debug, Clone, Copy)]
 pub(crate) enum ClassificationKind {
     Rectangular,
     Diagonal,
     NonRectangular,
-    /// Retained for backwards compatibility. After main's per-item geometry
-    /// classification superseded the host-aware floor-opening heuristic this
-    /// variant is no longer bumped (the per-item path makes the same call
-    /// without the global guard). The field on `Stats` remains so older
-    /// JSON consumers don't see schema breakage.
-    #[allow(dead_code)]
-    FloorOpeningGuardSaved,
 }
 
 // ───────────────────────── Public diagnostics contract ─────────────────────
@@ -414,7 +397,11 @@ pub struct WorstHost {
 /// Changelog:
 /// - 1: initial versioned contract (the #1439 shape; a deserialized 0 means a
 ///   pre-versioned producer).
-pub const GEOMETRY_DIAGNOSTICS_SCHEMA_VERSION: u32 = 1;
+/// - 2: removed the permanently-dead `guard_saved` signal — every producer
+///   passed `false`, so `OpeningDiagnostic.guard_saved` and the
+///   `floor_opening_guard_saved` counter were always 0. Field removal, not
+///   just a rename, hence the bump.
+pub const GEOMETRY_DIAGNOSTICS_SCHEMA_VERSION: u32 = 2;
 
 /// Aggregate CSG / opening diagnostics for one geometry pass — the public
 /// diagnostics contract. Built by [`aggregate_diagnostics`] from drained router

--- a/rust/geometry/src/router/diagnostics/diagnostics_contract_tests.rs
+++ b/rust/geometry/src/router/diagnostics/diagnostics_contract_tests.rs
@@ -70,12 +70,7 @@ fn aggregate_summarizes_failures_hosts_classification_and_silent_noops() {
         },
     );
 
-    let cls = ClassificationStats {
-        rectangular: 3,
-        diagonal: 1,
-        non_rectangular: 0,
-        floor_opening_guard_saved: 0,
-    };
+    let cls = ClassificationStats { rectangular: 3, diagonal: 1, non_rectangular: 0 };
     let rf = RectFastStats { fired: 2, openings_cut: 4, ..Default::default() };
 
     let d = aggregate_diagnostics(cls, &csg, &hosts, rf, 16);
@@ -191,11 +186,11 @@ fn schema_version_round_trips_and_defaults() {
     let d = GeometryDiagnostics::default();
     assert_eq!(d.schema_version, GEOMETRY_DIAGNOSTICS_SCHEMA_VERSION);
     let json = serde_json::to_string(&d).unwrap();
-    assert!(json.contains("\"schemaVersion\":1"), "serialized unconditionally: {json}");
+    assert!(json.contains("\"schemaVersion\":2"), "serialized unconditionally: {json}");
     let back: GeometryDiagnostics = serde_json::from_str(&json).unwrap();
     assert_eq!(back.schema_version, GEOMETRY_DIAGNOSTICS_SCHEMA_VERSION);
     // A pre-versioned producer (field absent) deserializes to 0, distinguishable.
     let legacy: GeometryDiagnostics =
-        serde_json::from_str(&json.replace("\"schemaVersion\":1,", "")).unwrap();
+        serde_json::from_str(&json.replace("\"schemaVersion\":2,", "")).unwrap();
     assert_eq!(legacy.schema_version, 0);
 }

--- a/rust/geometry/src/router/voids/synthesis.rs
+++ b/rust/geometry/src/router/voids/synthesis.rs
@@ -7,7 +7,7 @@
 use super::geom::*;
 use super::{GeometryRouter, OpeningType, NORMALIZE_EPSILON};
 use crate::{Mesh, Point3, Vector3};
-use ifc_lite_core::{DecodedEntity, EntityDecoder, IfcType};
+use ifc_lite_core::{DecodedEntity, EntityDecoder};
 
 impl GeometryRouter {
 
@@ -50,18 +50,6 @@ impl GeometryRouter {
     ) -> Vec<OpeningType> {
         use super::super::{ClassificationKind, OpeningDiagnostic, OpeningKindDiag};
 
-        // Only treat vertical-extrusion openings as "floor openings" when
-        // the host is an actual horizontal-surface element. For walls, a
-        // vertical (Z) opening extrusion is just how Revit/Archicad encode
-        // door / window openings — it should still take the rectangular
-        // AABB clip path. Pre-this-change the heuristic mis-tagged every
-        // vertical-extrusion opening as a floor opening, routing wall
-        // openings through the (cap-limited, error-prone) CSG path.
-        let host_is_horizontal_surface = matches!(
-            host.ifc_type,
-            IfcType::IfcSlab | IfcType::IfcRoof | IfcType::IfcCovering
-        );
-
         // Per-opening diagnostic accumulator for this host. Pushed to the
         // router's `host_opening_diagnostics` map before we return.
         let mut host_diag: Vec<OpeningDiagnostic> = Vec::with_capacity(opening_ids.len());
@@ -88,20 +76,10 @@ impl GeometryRouter {
             let vertex_count = opening_mesh.positions.len() / 3;
 
             // Local helper: record both the aggregate counter bump and a
-            // per-host diagnostic line in one place. `guard_saved` is the
-            // per-opening flag (whether the host-aware floor-opening guard
-            // kept this opening on the rectangular path).
-            let mut bump = |router: &Self,
-                            ck: ClassificationKind,
-                            kind: OpeningKindDiag,
-                            guard_saved: bool| {
+            // per-host diagnostic line in one place.
+            let mut bump = |router: &Self, ck: ClassificationKind, kind: OpeningKindDiag| {
                 router.bump_classification(ck);
-                host_diag.push(OpeningDiagnostic {
-                    opening_id,
-                    kind,
-                    vertex_count,
-                    guard_saved,
-                });
+                host_diag.push(OpeningDiagnostic { opening_id, kind, vertex_count });
             };
 
             // Probe per-item geometry up front. An opening that holds several
@@ -138,7 +116,6 @@ impl GeometryRouter {
                     self,
                     ClassificationKind::NonRectangular,
                     OpeningKindDiag::NonRectangular,
-                    false,
                 );
                 openings.push(OpeningType::NonRectangular(
                     opening_mesh,
@@ -149,20 +126,13 @@ impl GeometryRouter {
             } else if !item_bounds_with_dir.is_empty() {
                     // Per-item geometry-driven classification (origin/main).
                     // The earlier "is_floor_opening" host-aware heuristic
-                    // (preserved here only via diagnostics) routed every
-                    // Z-extruded opening through full CSG, which silently
-                    // failed for roof windows on shallow-slope roofs and
-                    // left the host uncut. The frame-based DiagonalRectangular
-                    // path handles tilted rectangular openings — including
-                    // rotated-footprint floor openings — so reserve
-                    // NonRectangular for genuinely curved or arched voids.
-                    //
-                    // The host-is-horizontal flag is no longer used as a
-                    // routing signal but is retained as a diagnostic field
-                    // so we can still observe the historic guard population
-                    // in regression sweeps.
-                    let _host_is_horizontal = host_is_horizontal_surface;
-
+                    // routed every Z-extruded opening through full CSG, which
+                    // silently failed for roof windows on shallow-slope roofs
+                    // and left the host uncut. The frame-based
+                    // DiagonalRectangular path handles tilted rectangular
+                    // openings — including rotated-footprint floor openings —
+                    // so reserve NonRectangular for genuinely curved or arched
+                    // voids.
                     let item_meshes = self
                         .get_opening_item_meshes_world(&opening_entity, decoder)
                         .unwrap_or_default();
@@ -184,7 +154,6 @@ impl GeometryRouter {
                                         self,
                                         ClassificationKind::NonRectangular,
                                         OpeningKindDiag::NonRectangular,
-                                        false,
                                     );
                                     openings.push(OpeningType::NonRectangular(
                                         item_mesh,
@@ -197,7 +166,6 @@ impl GeometryRouter {
                                         self,
                                         ClassificationKind::Diagonal,
                                         OpeningKindDiag::Diagonal,
-                                        false,
                                     );
                                     openings.push(OpeningType::DiagonalRectangular(
                                         item_mesh, frame,
@@ -207,7 +175,6 @@ impl GeometryRouter {
                                         self,
                                         ClassificationKind::Rectangular,
                                         OpeningKindDiag::Rectangular,
-                                        false,
                                     );
                                     openings.push(OpeningType::Rectangular(
                                         min_pt,
@@ -220,7 +187,6 @@ impl GeometryRouter {
                                     self,
                                     ClassificationKind::Rectangular,
                                     OpeningKindDiag::Rectangular,
-                                    false,
                                 );
                                 openings.push(OpeningType::Rectangular(
                                     min_pt,
@@ -232,7 +198,6 @@ impl GeometryRouter {
                                     self,
                                     ClassificationKind::NonRectangular,
                                     OpeningKindDiag::NonRectangular,
-                                    false,
                                 );
                                 openings.push(OpeningType::NonRectangular(
                                     item_mesh,
@@ -248,7 +213,6 @@ impl GeometryRouter {
                                 self,
                                 ClassificationKind::Rectangular,
                                 OpeningKindDiag::Rectangular,
-                                false,
                             );
                             openings.push(OpeningType::Rectangular(
                                 min_pt, max_pt, extrusion_dir,
@@ -275,7 +239,6 @@ impl GeometryRouter {
                         self,
                         ClassificationKind::Rectangular,
                         OpeningKindDiag::Rectangular,
-                        false,
                     );
                     openings.push(OpeningType::Rectangular(min_f64, max_f64, None));
                 }
@@ -615,31 +578,6 @@ impl GeometryRouter {
         (new_min, new_max)
     }
 
-    /// Push the opening MESH's caps a hair PAST the host along `dir` so a FLUSH
-    /// cap interface becomes a clean TRANSVERSAL crossing before the exact-kernel
-    /// subtract. Returns the mesh UNCHANGED unless a real flush-cap condition is
-    /// present — the conservative default, so a normal through-opening, an
-    /// off-axis `dir`, a recess, or an already-poking-through opening is untouched.
-    ///
-    /// WHY (the #1007 flush roof-opening sliver, PART A): an opening solid whose
-    /// cap is authored EXACTLY flush with a host surface meets that surface as a
-    /// near-coplanar interface, not a crossing. On a TILTED, f32-imported, faceted
-    /// BREP roof the host facets under the cap each sit a fraction of a degree off
-    /// the cap plane (~0.1° measured on #1112), so the exact kernel neither sees a
-    /// clean transversal crossing NOR an exactly-coplanar pair — it leaves a sliver
-    /// bridging the hole. Pushing the flush cap a hair past the surface makes EVERY
-    /// host facet under the footprint a genuine transversal crossing, which the
-    /// exact kernel cuts cleanly and deterministically (0% footprint coverage on
-    /// both #1112 openings; plain f32 vertex translation ⇒ native==wasm).
-    ///
-    /// FLUSH DETECTION is against the host SURFACE, not its AABB: a cap is extended
-    /// only when a host TRIANGLE parallel to it (`|n·dir| ≈ 1`) lies ON the cap's
-    /// plane. That is what separates the #1112 roof cap (flush with a roof facet
-    /// INTERIOR to the host's projected extent) from a wall #552611 horizontal slot
-    /// whose caps float inside the wall with no host facet there — extending the
-    /// latter along its authored +Z extrusion would cut the wall in half. A
-    /// non-flush cap (a recess inner cap, a clean transversal cap) is left in place,
-    /// so a pocket is never converted to a through-hole.
     /// An axis-aligned box `[min,max]` as a closed 12-triangle outward-wound mesh —
     /// the cutter solid for a RECTANGULAR opening routed through the exact subtract
     /// (PART B). 24 verts (4 per face) so each face carries its own outward normal.
@@ -861,6 +799,31 @@ impl GeometryRouter {
         out
     }
 
+    /// Push the opening MESH's caps a hair PAST the host along `dir` so a FLUSH
+    /// cap interface becomes a clean TRANSVERSAL crossing before the exact-kernel
+    /// subtract. Returns the mesh UNCHANGED unless a real flush-cap condition is
+    /// present — the conservative default, so a normal through-opening, an
+    /// off-axis `dir`, a recess, or an already-poking-through opening is untouched.
+    ///
+    /// WHY (the #1007 flush roof-opening sliver, PART A): an opening solid whose
+    /// cap is authored EXACTLY flush with a host surface meets that surface as a
+    /// near-coplanar interface, not a crossing. On a TILTED, f32-imported, faceted
+    /// BREP roof the host facets under the cap each sit a fraction of a degree off
+    /// the cap plane (~0.1° measured on #1112), so the exact kernel neither sees a
+    /// clean transversal crossing NOR an exactly-coplanar pair — it leaves a sliver
+    /// bridging the hole. Pushing the flush cap a hair past the surface makes EVERY
+    /// host facet under the footprint a genuine transversal crossing, which the
+    /// exact kernel cuts cleanly and deterministically (0% footprint coverage on
+    /// both #1112 openings; plain f32 vertex translation ⇒ native==wasm).
+    ///
+    /// FLUSH DETECTION is against the host SURFACE, not its AABB: a cap is extended
+    /// only when a host TRIANGLE parallel to it (`|n·dir| ≈ 1`) lies ON the cap's
+    /// plane. That is what separates the #1112 roof cap (flush with a roof facet
+    /// INTERIOR to the host's projected extent) from a wall #552611 horizontal slot
+    /// whose caps float inside the wall with no host facet there — extending the
+    /// latter along its authored +Z extrusion would cut the wall in half. A
+    /// non-flush cap (a recess inner cap, a clean transversal cap) is left in place,
+    /// so a pocket is never converted to a through-hole.
     pub(super) fn extend_opening_mesh_through_host(
         opening_mesh: &Mesh,
         host_mesh: &Mesh,

--- a/rust/processing/src/processor/jobs.rs
+++ b/rust/processing/src/processor/jobs.rs
@@ -257,16 +257,11 @@ pub(super) fn process_entity_job(
     // element's only — summing across jobs mirrors the wasm batch router's
     // accumulate-then-drain, giving the same GeometryDiagnostics counts.
     let cls = local_router.take_classification_stats();
-    if cls.rectangular != 0
-        || cls.diagonal != 0
-        || cls.non_rectangular != 0
-        || cls.floor_opening_guard_saved != 0
-    {
+    if cls.rectangular != 0 || cls.diagonal != 0 || cls.non_rectangular != 0 {
         if let Ok(mut acc) = classification_collector.lock() {
             acc.rectangular += cls.rectangular;
             acc.diagonal += cls.diagonal;
             acc.non_rectangular += cls.non_rectangular;
-            acc.floor_opening_guard_saved += cls.floor_opening_guard_saved;
         }
     }
     let host_diags = local_router.take_host_opening_diagnostics();

--- a/rust/wasm-bindings/src/api/csg_diagnostics.rs
+++ b/rust/wasm-bindings/src/api/csg_diagnostics.rs
@@ -60,9 +60,8 @@ pub(super) fn drain_and_log_csg_diagnostics(
         // is a failure to surface.
         web_sys::console::info_1(
             &format!(
-                "[IFC-LITE] Opening classifier: rect={} diag={} non_rect={} \
-                 floor_opening_guard_saved={} (total={cls_total})",
-                cls.rectangular, cls.diagonal, cls.non_rectangular, cls.floor_opening_guard_saved
+                "[IFC-LITE] Opening classifier: rect={} diag={} non_rect={} (total={cls_total})",
+                cls.rectangular, cls.diagonal, cls.non_rectangular
             )
             .into(),
         );


### PR DESCRIPTION
## What

The `guard_saved` diagnostic channel is permanently dead: every producer passed `false`, so `OpeningDiagnostic.guard_saved` and the `floor_opening_guard_saved` counter were always 0 while a comment claimed the signal was live.

- `synthesis.rs`: drop `guard_saved` from the diagnostic bump path (8 call sites) and the dead `host_is_horizontal_surface` computation. Also relocates an orphaned rustdoc block from `make_box_mesh` onto its real subject `extend_opening_mesh_through_host`.
- `diagnostics.rs`: remove `OpeningDiagnostic.guard_saved`, `ClassificationStats.floor_opening_guard_saved`, and the `ClassificationKind::FloorOpeningGuardSaved` variant; **bump `GEOMETRY_DIAGNOSTICS_SCHEMA_VERSION` 1 → 2** (field removal, not a rename).
- Downstream consumers of the removed counter updated: `processing/jobs.rs` (collector merge) and `wasm-bindings/csg_diagnostics.rs` (`console.info` string — internal logging, not a wasm-bindgen signature, so no `.d.ts` change).
- `diagnostics_contract_tests.rs` updated to `schemaVersion: 2`.

## Adversarial checks

- No insta snapshot pins this payload (grepped `.snap` for `schemaVersion`/`guard_saved` — zero hits).
- No TS/viewer/PostHog code reads `guard_saved`/`floor_opening_guard_saved` by name (grepped `packages/`, `apps/` — zero hits), so the schema bump breaks no JSON consumer.

## Verification

- `cargo test -p ifc-lite-geometry diagnostics`: 8/8 (incl. schema round-trip + camelCase serde guard).
- `cargo test -p ifc-lite-processing --test native_geometry_diagnostics` + module-size ratchet: green.
- `cargo check --target wasm32-unknown-unknown -p ifc-lite-wasm`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)