### PR TITLE
fix(geometry): batch void-admission honors the sequential tier volume floor (#976)

### DIFF
--- a/rust/geometry/src/router/voids/mod.rs
+++ b/rust/geometry/src/router/voids/mod.rs
@@ -524,6 +524,19 @@ struct ParamRectCut {
 }
 
 impl GeometryRouter {
+    /// Tier-conditional minimum opening volume (m³) floor. Shared by the batch
+    /// admission gate and the sequential CSG path so the two can never diverge
+    /// (B11 / issue #976): the 0.1 L default filters legacy-BSP CSG artefacts,
+    /// but at High/Highest quality it relaxes to ~1e-9 m³ so genuine small
+    /// openings (bolt holes / sleeves in thin plates) still get cut instead of
+    /// being silently skipped.
+    #[inline]
+    fn min_opening_volume(quality: TessellationQuality) -> f64 {
+        match quality {
+            TessellationQuality::High | TessellationQuality::Highest => 1e-9,
+            _ => MIN_OPENING_VOLUME,
+        }
+    }
 
     /// Process element with void subtraction (openings)
     /// Process element with voids using optimized plane clipping
@@ -1329,7 +1342,7 @@ impl GeometryRouter {
                 let open_vol = (omx.x - omn.x) as f64
                     * (omx.y - omn.y) as f64
                     * (omx.z - omn.z) as f64;
-                if open_vol < MIN_OPENING_VOLUME {
+                if open_vol < Self::min_opening_volume(self.tessellation_quality) {
                     continue;
                 }
                 let depth_dir = extrusion_dir
@@ -1549,10 +1562,7 @@ impl GeometryRouter {
                     // thin plates. At the two highest quality levels keep those
                     // holes (the exact kernel is stable on small cutters); only
                     // reject numerically degenerate cutters there. (issue #976)
-                    let min_open_vol = match self.tessellation_quality {
-                        TessellationQuality::High | TessellationQuality::Highest => 1e-9_f32,
-                        _ => MIN_OPENING_VOLUME as f32,
-                    };
+                    let min_open_vol = Self::min_opening_volume(self.tessellation_quality) as f32;
                     if open_vol < min_open_vol {
                         continue;
                     }

--- a/rust/processing/tests/module_size_allowlist.txt
+++ b/rust/processing/tests/module_size_allowlist.txt
@@ -60,7 +60,10 @@
      497 rust/geometry/src/router/voids_2d.rs
      618 rust/geometry/src/router/voids/aabb_clip.rs
      871 rust/geometry/src/router/voids/geom.rs
-    1889 rust/geometry/src/router/voids/mod.rs
+# +10: extract min_opening_volume(quality) tier->floor helper shared by the batch
+# admission gate and the sequential CSG path so they can't diverge on the
+# High/Highest small-opening floor (B11 regression, issue #976).
+    1899 rust/geometry/src/router/voids/mod.rs
      621 rust/geometry/src/router/voids/probe.rs
     1002 rust/geometry/src/router/voids/synthesis.rs
     1472 rust/geometry/src/space_dcel/mod.rs


### PR DESCRIPTION
## What

The sequential void-cut path relaxes its minimum-opening-volume floor from 0.1 L to 1e-9 at High/Highest quality so tiny real openings (bolt holes, sleeves; #976) still get cut. The **batch admission gate** hardcoded the 0.1 L floor unconditionally, so at exactly those quality levels small openings were silently demoted to the slower sequential path.

## Fix

Extract `min_opening_volume(quality)` (1e-9 at High/Highest, 0.1 L otherwise — **byte-identical** to the sequential values) and call it at **both** the batch admission gate and the sequential site, so the two tiers can never diverge again. Tier-conditional, not a blanket relax: Medium/Low stay at 0.1 L (the batch path is not flooded with dust openings).

## Notes

- Same kernel, same cut — a small High/Highest opening now takes the batch path instead of sequential. If that reorders triangles on a determinism fixture, CI's determinism gate will flag it as a (correct) re-pin. Locally no assertion moved.
- Ratchet: `voids/mod.rs` 1889→1899, allowlist row refreshed with justification.

## Verification

- `cargo test -p ifc-lite-geometry voids`: green.
- `cargo test -p ifc-lite-processing --test module_size_ratchet`: green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)