### PR TITLE
fix(geometry): unify body-rep predicate + Surface3D; keep it out of RTC voting (B5)

### DIFF
--- a/rust/geometry/src/router/layers.rs
+++ b/rust/geometry/src/router/layers.rs
@@ -393,25 +393,14 @@ fn element_is_single_unshifted_item(
             continue;
         }
         // Only inspect body-style representations — axis/curve/footprint
-        // don't contribute to the sliced mesh.
+        // don't contribute to the sliced mesh. Uses the single canonical
+        // body-geometry predicate so this stays in lockstep with the meshing
+        // path (a mapped/surface item disqualifies slicing below regardless,
+        // via item_has_identity_position).
         let is_body = shape_rep
             .get(2)
             .and_then(|a| a.as_string())
-            .map(|s| {
-                matches!(
-                    s,
-                    "Body"
-                        | "SweptSolid"
-                        | "SolidModel"
-                        | "Brep"
-                        | "CSG"
-                        | "Clipping"
-                        | "SurfaceModel"
-                        | "Tessellation"
-                        | "AdvancedSweptSolid"
-                        | "AdvancedBrep"
-                )
-            })
+            .map(super::is_body_representation)
             .unwrap_or(false);
         if !is_body {
             continue;

--- a/rust/geometry/src/router/mod.rs
+++ b/rust/geometry/src/router/mod.rs
@@ -165,9 +165,17 @@ pub struct GeometryRouter {
 }
 
 /// Whether an `IfcShapeRepresentation.RepresentationType` names a meshable
-/// body/surface (as opposed to a curve/axis/annotation). Shared by the void
-/// probe (opening extraction) and RTC-offset detection so both agree on what
-/// counts as real geometry.
+/// body/surface (as opposed to a curve/axis/annotation/footprint/box). This is
+/// the SINGLE canonical definition of "renderable 3D geometry", shared by the
+/// element meshing path (`processing.rs`), the void probe (opening extraction),
+/// RTC-offset detection, and material-layer slicing so every site agrees on what
+/// counts as real geometry. Drift here is a bug: an element meshed as body but
+/// judged non-body by RTC detection casts a spurious origin vote (see
+/// `rtc_offset::sample_element_translation`).
+///
+/// `MappedRepresentation` is included (its `IfcMappedItem`s expand to real
+/// solids); callers that specifically mean DIRECT (non-mapped) geometry use
+/// [`is_direct_body_representation`] instead.
 pub(super) fn is_body_representation(rep_type: &str) -> bool {
     matches!(
         rep_type,
@@ -180,9 +188,18 @@ pub(super) fn is_body_representation(rep_type: &str) -> bool {
             | "MappedRepresentation"
             | "SolidModel"
             | "SurfaceModel"
+            | "Surface3D"
             | "AdvancedSweptSolid"
             | "AdvancedBrep"
     )
+}
+
+/// Whether a `RepresentationType` names DIRECT (non-mapped) body geometry, i.e.
+/// [`is_body_representation`] minus the `MappedRepresentation` sentinel. Used to
+/// decide whether an element's `MappedRepresentation` duplicates geometry it
+/// already carries directly (and so can be skipped to avoid double-meshing).
+pub(super) fn is_direct_body_representation(rep_type: &str) -> bool {
+    rep_type != "MappedRepresentation" && is_body_representation(rep_type)
 }
 
 impl GeometryRouter {

--- a/rust/geometry/src/router/processing.rs
+++ b/rust/geometry/src/router/processing.rs
@@ -99,31 +99,12 @@ impl GeometryRouter {
         // First pass: check if we have any direct geometry representations
         // This prevents duplication when both direct and MappedRepresentation exist
         let has_direct_geometry = representations.iter().any(|rep| {
-            if rep.ifc_type != IfcType::IfcShapeRepresentation {
-                return false;
-            }
-            if let Some(rep_type_attr) = rep.get(2) {
-                if let Some(rep_type) = rep_type_attr.as_string() {
-                    matches!(
-                        rep_type,
-                        "Body"
-                            | "SweptSolid"
-                            | "SolidModel"
-                            | "Brep"
-                            | "CSG"
-                            | "Clipping"
-                            | "SurfaceModel"
-                            | "Surface3D"
-                            | "Tessellation"
-                            | "AdvancedSweptSolid"
-                            | "AdvancedBrep"
-                    )
-                } else {
-                    false
-                }
-            } else {
-                false
-            }
+            rep.ifc_type == IfcType::IfcShapeRepresentation
+                && rep
+                    .get(2)
+                    .and_then(|a| a.as_string())
+                    .map(super::is_direct_body_representation)
+                    .unwrap_or(false)
         });
 
         for shape_rep in representations {
@@ -141,22 +122,8 @@ impl GeometryRouter {
                         continue;
                     }
 
-                    // Only process solid geometry representations
-                    if !matches!(
-                        rep_type,
-                        "Body"
-                            | "SweptSolid"
-                            | "SolidModel"
-                            | "Brep"
-                            | "CSG"
-                            | "Clipping"
-                            | "SurfaceModel"
-                            | "Surface3D"
-                            | "Tessellation"
-                            | "MappedRepresentation"
-                            | "AdvancedSweptSolid"
-                            | "AdvancedBrep"
-                    ) {
+                    // Only process solid/surface geometry representations
+                    if !super::is_body_representation(rep_type) {
                         continue; // Skip non-solid representations like 'Axis', 'Curve2D', etc.
                     }
                 }
@@ -257,31 +224,12 @@ impl GeometryRouter {
 
         // Check if we have direct geometry
         let has_direct_geometry = representations.iter().any(|rep| {
-            if rep.ifc_type != IfcType::IfcShapeRepresentation {
-                return false;
-            }
-            if let Some(rep_type_attr) = rep.get(2) {
-                if let Some(rep_type) = rep_type_attr.as_string() {
-                    matches!(
-                        rep_type,
-                        "Body"
-                            | "SweptSolid"
-                            | "SolidModel"
-                            | "Brep"
-                            | "CSG"
-                            | "Clipping"
-                            | "SurfaceModel"
-                            | "Surface3D"
-                            | "Tessellation"
-                            | "AdvancedSweptSolid"
-                            | "AdvancedBrep"
-                    )
-                } else {
-                    false
-                }
-            } else {
-                false
-            }
+            rep.ifc_type == IfcType::IfcShapeRepresentation
+                && rep
+                    .get(2)
+                    .and_then(|a| a.as_string())
+                    .map(super::is_direct_body_representation)
+                    .unwrap_or(false)
         });
 
         for shape_rep in representations {
@@ -296,22 +244,8 @@ impl GeometryRouter {
                         continue;
                     }
 
-                    // Only process solid geometry representations
-                    if !matches!(
-                        rep_type,
-                        "Body"
-                            | "SweptSolid"
-                            | "SolidModel"
-                            | "Brep"
-                            | "CSG"
-                            | "Clipping"
-                            | "SurfaceModel"
-                            | "Surface3D"
-                            | "Tessellation"
-                            | "MappedRepresentation"
-                            | "AdvancedSweptSolid"
-                            | "AdvancedBrep"
-                    ) {
+                    // Only process solid/surface geometry representations
+                    if !super::is_body_representation(rep_type) {
                         continue;
                     }
                 }

--- a/rust/geometry/src/router/rtc_offset.rs
+++ b/rust/geometry/src/router/rtc_offset.rs
@@ -9,6 +9,26 @@ use super::GeometryRouter;
 use crate::LARGE_COORD_THRESHOLD_METERS;
 use ifc_lite_core::{has_geometry_by_name, DecodedEntity, EntityDecoder, IfcType};
 
+/// Whether a near-origin element with this `RepresentationType` may cast a
+/// "no-shift" `(0,0,0)` RTC vote when the vertex probe can't cheaply read a
+/// coordinate. This is [`is_body_representation`](super::is_body_representation)
+/// MINUS `"Surface3D"` — meshable does NOT imply RTC-votable.
+///
+/// A `Surface3D` rep (`IfcBSplineSurfaceWithKnots`, `IfcSectionedSurface`,
+/// trimmed/curve-bounded surfaces) keeps its geometry in absolute model-space
+/// control points that `sample_first_geometry_vertex` cannot navigate, so a
+/// near-origin identity-placed Surface3D element would fall through to voting
+/// its placement `(0,0,0)` even though its real geometry can sit on a national
+/// grid hundreds of km away. On IFC4X3 corridor models with many such surfaces
+/// ahead of a few large-coordinate solids, those origin votes drag the median
+/// to zero and/or exhaust the 50-sample budget, suppressing a legitimate
+/// rebase — the #1526 curve-only pollution rebuilt via Surface3D. So Surface3D
+/// must ABSTAIN here, like a curve/axis rep. Scoped to RTC voting only: the
+/// meshing / void / layer paths still treat Surface3D as body geometry.
+fn is_rtc_votable_representation(rep_type: &str) -> bool {
+    rep_type != "Surface3D" && super::is_body_representation(rep_type)
+}
+
 impl GeometryRouter {
     /// Compute median-based RTC offset from sampled translations.
     /// Returns `(0,0,0)` if empty or coordinates are within 10km of origin.
@@ -112,11 +132,17 @@ impl GeometryRouter {
         Some((tx, ty, tz))
     }
 
-    /// True when the element carries at least one meshable body/surface shape
-    /// representation (as opposed to only curve/axis/footprint representations,
-    /// e.g. an IfcAlignmentSegment). Used to decide whether an origin-placed
-    /// element with no cheaply-samplable vertex may still cast a "no shift"
-    /// (0,0,0) vote during RTC detection.
+    /// True when the element carries at least one RTC-votable body shape
+    /// representation (see [`is_rtc_votable_representation`]), as opposed to
+    /// only curve/axis/footprint reps (e.g. an IfcAlignmentSegment) OR a
+    /// `Surface3D` rep whose coordinates the vertex probe cannot read. Used to
+    /// decide whether an origin-placed element with no cheaply-samplable vertex
+    /// may still cast a "no shift" (0,0,0) vote during RTC detection.
+    ///
+    /// NOTE: this uses [`is_rtc_votable_representation`], NOT
+    /// [`is_body_representation`](super::is_body_representation) — the two
+    /// differ only in `Surface3D`, which is meshable but not RTC-votable (see
+    /// the predicate's doc; #1526).
     fn element_has_body_representation(
         &self,
         entity: &DecodedEntity,
@@ -145,7 +171,7 @@ impl GeometryRouter {
                 && sr
                     .get(2)
                     .and_then(|a| a.as_string())
-                    .map(super::is_body_representation)
+                    .map(is_rtc_votable_representation)
                     .unwrap_or(false)
         })
     }

--- a/rust/processing/tests/module_size_allowlist.txt
+++ b/rust/processing/tests/module_size_allowlist.txt
@@ -56,9 +56,12 @@
      781 rust/geometry/src/rect_fast.rs
      586 rust/geometry/src/router/diagnostics.rs
      659 rust/geometry/src/router/layers.rs
-     572 rust/geometry/src/router/mod.rs
+# +1: unify body-rep predicate — added is_direct_body_representation + docs; net removes ~60 lines from processing.rs and ~12 from layers.rs (crate trends down).
+     573 rust/geometry/src/router/mod.rs
     1072 rust/geometry/src/router/processing.rs
-     446 rust/geometry/src/router/rtc_offset.rs
+# +26: is_rtc_votable_representation predicate + doc — Surface3D is meshable but must NOT cast RTC votes (#1526 pollution via absolute-coord surfaces).
+     472 rust/geometry/src/router/rtc_offset.rs
+     497 rust/geometry/src/router/voids_2d.rs
      618 rust/geometry/src/router/voids/aabb_clip.rs
      871 rust/geometry/src/router/voids/geom.rs
 # +10: extract min_opening_volume(quality) tier->floor helper shared by the batch

--- a/rust/processing/tests/rtc_surface3d_pollution.rs
+++ b/rust/processing/tests/rtc_surface3d_pollution.rs
@@ -1,0 +1,154 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Regression for the Surface3D variant of issue #1526: RTC-offset detection
+//! must not be poisoned by origin-placed elements whose ONLY representation is
+//! a `Surface3D` (B-spline / sectioned / trimmed surface).
+//!
+//! `Surface3D` geometry is MESHABLE (so the router's canonical
+//! `is_body_representation` counts it), but it stores its coordinates in
+//! absolute model-space control points that the cheap RTC vertex probe
+//! (`sample_first_geometry_vertex`) cannot navigate. If such a near-origin,
+//! identity-placed element were treated as RTC-votable it would fall through
+//! to voting its placement translation `(0,0,0)` — a spurious "no shift" vote.
+//! On IFC4X3 corridor models with many such surface elements ahead of a few
+//! national-grid tessellated/Brep solids, those origin votes drag the per-axis
+//! median to zero (and/or exhaust the 50-sample budget), suppressing a
+//! legitimate rebase and leaving the real solids to render as f32 jitter
+//! hundreds of km from the origin.
+//!
+//! This is the exact shape of the curve-only pollution regression
+//! (`rtc_curve_only_pollution.rs`), rebuilt via `Surface3D`. It FAILS if
+//! `Surface3D` is RTC-votable and PASSES once the RTC vote gate excludes it
+//! (`is_rtc_votable_representation` in `router/rtc_offset.rs`), while the
+//! meshing / void / layer paths keep treating `Surface3D` as body geometry.
+//!
+//! Uses INLINE minimal IFC so the test runs in CI without external fixtures.
+
+use ifc_lite_processing::process_geometry;
+
+/// Large world coordinates the real solid is authored at (metres). Well past
+/// the 10 km RTC threshold, mirroring the national-grid magnitudes in #1526.
+const SOLID_X: f64 = 200_000.0;
+const SOLID_Y: f64 = 6_000_000.0;
+const SOLID_Z: f64 = 100.0;
+
+/// One origin-placed proxy whose ONLY representation is a `Surface3D`
+/// containing a bare bilinear `IfcBSplineSurfaceWithKnots`. The RTC vertex
+/// probe has no case for B-spline surfaces, so it cannot read a coordinate and
+/// (correctly) the element must ABSTAIN rather than vote its `(0,0,0)`
+/// placement. Numbered from a caller-supplied base so several can coexist
+/// without id collisions.
+fn surface3d_proxy(base: u32, guid: &str) -> String {
+    let c0 = base;
+    let c1 = base + 1;
+    let c2 = base + 2;
+    let c3 = base + 3;
+    let bspline = base + 4;
+    let rep = base + 5;
+    let pds = base + 6;
+    let pt = base + 7;
+    let ax = base + 8;
+    let plc = base + 9;
+    let proxy = base + 10;
+    format!(
+        "#{c0}=IFCCARTESIANPOINT((0.,0.,0.));\n\
+         #{c1}=IFCCARTESIANPOINT((1.,0.,0.));\n\
+         #{c2}=IFCCARTESIANPOINT((0.,1.,0.));\n\
+         #{c3}=IFCCARTESIANPOINT((1.,1.,0.));\n\
+         #{bspline}=IFCBSPLINESURFACEWITHKNOTS(1,1,((#{c0},#{c1}),(#{c2},#{c3})),\
+.UNSPECIFIED.,.F.,.F.,.F.,(2,2),(2,2),(0.,1.),(0.,1.),.UNSPECIFIED.);\n\
+         #{rep}=IFCSHAPEREPRESENTATION(#6,'Surface','Surface3D',(#{bspline}));\n\
+         #{pds}=IFCPRODUCTDEFINITIONSHAPE($,$,(#{rep}));\n\
+         #{pt}=IFCCARTESIANPOINT((0.,0.,0.));\n\
+         #{ax}=IFCAXIS2PLACEMENT3D(#{pt},$,$);\n\
+         #{plc}=IFCLOCALPLACEMENT($,#{ax});\n\
+         #{proxy}=IFCBUILDINGELEMENTPROXY('{guid}',$,'surf',$,$,#{plc},#{pds},$,$);\n"
+    )
+}
+
+fn model() -> String {
+    // Header + shared context/units. Six origin-placed Surface3D-only proxies
+    // (a strict majority of the samples) followed by one tessellated solid at
+    // large world coordinates with identity placement.
+    let mut s = String::from(
+        "ISO-10303-21;\n\
+         HEADER;\n\
+         FILE_DESCRIPTION((''),'2;1');\n\
+         FILE_NAME('','2026-01-01T00:00:00',(''),(''),'t','t','');\n\
+         FILE_SCHEMA(('IFC4X3_ADD2'));\n\
+         ENDSEC;\n\
+         DATA;\n\
+         #1=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);\n\
+         #2=IFCUNITASSIGNMENT((#1));\n\
+         #3=IFCCARTESIANPOINT((0.,0.,0.));\n\
+         #4=IFCAXIS2PLACEMENT3D(#3,$,$);\n\
+         #5=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.E-05,#4,$);\n\
+         #6=IFCGEOMETRICREPRESENTATIONSUBCONTEXT('Body','Model',*,*,*,*,#5,$,.MODEL_VIEW.,$);\n\
+         #7=IFCPROJECT('01tEAnIV5BixApwp1YzpwS',$,'t',$,$,$,$,(#5),#2);\n",
+    );
+
+    // Many origin-placed Surface3D-only proxies FIRST — if they were votable
+    // their (0,0,0) placement votes would dominate the median (and, in a real
+    // corridor, exhaust the sample budget) before the solid is ever seen.
+    for (i, guid) in [
+        "21tEAnIV5BixApwp1YzpwS",
+        "31tEAnIV5BixApwp1YzpwS",
+        "41tEAnIV5BixApwp1YzpwS",
+        "51tEAnIV5BixApwp1YzpwS",
+        "61tEAnIV5BixApwp1YzpwS",
+        "71tEAnIV5BixApwp1YzpwS",
+    ]
+    .iter()
+    .enumerate()
+    {
+        s.push_str(&surface3d_proxy(100 + (i as u32) * 20, guid));
+    }
+
+    // Tessellated solid (a small tetra-ish faceset) at the large anchor. Its
+    // vertices ARE readable by the RTC probe, so it should drive the offset.
+    s.push_str(&format!(
+        "#20=IFCCARTESIANPOINTLIST3D((({x},{y},{z}),({x1},{y},{z}),({x},{y1},{z}),({x},{y},{z1})));\n\
+         #21=IFCTRIANGULATEDFACESET(#20,$,$,((1,2,3),(1,2,4),(1,3,4),(2,3,4)),$);\n\
+         #22=IFCSHAPEREPRESENTATION(#6,'Body','Tessellation',(#21));\n\
+         #23=IFCPRODUCTDEFINITIONSHAPE($,$,(#22));\n\
+         #24=IFCCARTESIANPOINT((0.,0.,0.));\n\
+         #25=IFCAXIS2PLACEMENT3D(#24,$,$);\n\
+         #26=IFCLOCALPLACEMENT($,#25);\n\
+         #27=IFCBUILDINGELEMENTPROXY('11tEAnIV5BixApwp1YzpwS',$,'solid',$,$,#26,#23,$,$);\n",
+        x = SOLID_X,
+        y = SOLID_Y,
+        z = SOLID_Z,
+        x1 = SOLID_X + 1.0,
+        y1 = SOLID_Y + 1.0,
+        z1 = SOLID_Z + 1.0,
+    ));
+
+    s.push_str("ENDSEC;\nEND-ISO-10303-21;\n");
+    s
+}
+
+#[test]
+fn rtc_offset_survives_surface3d_origin_entities() {
+    let result = process_geometry(&model());
+    let shift = result.metadata.coordinate_info.origin_shift;
+
+    // The offset must anchor on the large-coordinate tessellated solid, NOT be
+    // dragged to (0,0,0) by the six origin-placed Surface3D proxies. This fails
+    // if Surface3D is RTC-votable (their spurious (0,0,0) votes win the median).
+    assert!(
+        result.metadata.coordinate_info.is_geo_referenced,
+        "model with a 200 km solid must be flagged geo-referenced despite the Surface3D proxies"
+    );
+    assert!(
+        (shift[0] - SOLID_X).abs() < 10.0,
+        "RTC X should anchor near the solid ({SOLID_X}), got {} (Surface3D origin votes polluted the median)",
+        shift[0]
+    );
+    assert!(
+        (shift[1] - SOLID_Y).abs() < 10.0,
+        "RTC Y should anchor near the solid ({SOLID_Y}), got {} (Surface3D origin votes polluted the median)",
+        shift[1]
+    );
+}


### PR DESCRIPTION
## What

"What counts as body geometry" was hand-rolled in several drifted sites (`processing.rs` matched the rep-type strings 4x, one copy including `Surface3D` while the canonical `is_body_representation` did not).

## Meshing / void-probe / layers — unified (byte-identical)

`is_body_representation` is now the single canonical predicate (12-string union incl. `Surface3D`). The genuine `MappedRepresentation` exclusion is preserved as `is_direct_body_representation` for the `has_direct_geometry` callers. `processing.rs` (4 hand-matches), `voids/probe`, `layers` all delegate. Verified **byte-identical** to the prior meshing behavior — pure de-duplication; the meshed-element set is unchanged.

## RTC voting — deliberately narrower (the important part)

Adversarial review caught that folding `Surface3D` into the *shared* predicate would leak into **RTC georef voting**: `Surface3D` control-point/directrix coordinates are absolute model-space that the RTC vertex-probe cannot read, so a near-origin identity-placed `Surface3D` element would start casting a spurious `(0,0,0)` "no-shift" vote **and consume a `MAX_SAMPLES` slot** (it abstained before). On an IFC4x3 corridor/civil model with many such elements before a few national-grid solids, that drags the per-axis median to zero and suppresses a legitimate rebase — the **#1526 curve-only pollution rebuilt via Surface3D**.

So RTC uses a dedicated `is_rtc_votable_representation` that **excludes `Surface3D`** (`!= "Surface3D" && is_body_representation`), preserving the exact pre-change RTC behavior (near-origin Surface3D-only elements abstain, like curve reps). `meshable != RTC-votable`.

New test `rtc_offset_survives_surface3d_origin_entities` (mirrors `rtc_curve_only_pollution`): 6 origin `Surface3D` proxies + 1 national-grid (200km) solid → RTC must still anchor on the solid. **Proven discriminating**: fails if Surface3D is votable, passes with the exclusion.

## Verification

- `cargo test -p ifc-lite-geometry -p ifc-lite-processing`: 667 passed. Both pollution tests + `federated_models_produce_usable_rtc_offsets` + `geom_hash rtc_invariance` green.
- Determinism manifest unaffected (meshed-element set unchanged; synthetic fixture is origin-local). Ratchet 4/4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)