### PR TITLE
fix(geometry): engulf-guard SKIP - keep host un-cut on budget-tripped engulfing cutter (B3)

### DIFF
--- a/rust/geometry/src/kernel/budget.rs
+++ b/rust/geometry/src/kernel/budget.rs
@@ -38,6 +38,14 @@
 use std::cell::Cell;
 use std::sync::atomic::{AtomicU64, Ordering};
 
+/// Serialises every test that mutates the process-global `CAP` / `ELEMENT_CAP`
+/// atomics, so cargo's parallel runner can't race them. Shared crate-wide (not
+/// just this module's tests) so cap-mutating tests in OTHER modules — e.g. the
+/// voids-router engulf-suppression regression — take the SAME lock and never
+/// clobber each other's cap while a boolean runs. Test-only.
+#[cfg(test)]
+pub(crate) static GLOBAL_CAP_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 /// Default per-boolean exact-evaluation cap for the interactive profile.
 ///
 /// Calibrated against the model corpus: the worst healthy boolean (a dense steel
@@ -285,11 +293,6 @@ pub fn element_count() -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Mutex;
-
-    /// Serialises the two tests that mutate the global `CAP` / `ELEMENT_CAP`
-    /// atomics, so cargo's parallel runner can't race them.
-    static GLOBAL_CAP_LOCK: Mutex<()> = Mutex::new(());
 
     /// The cap counts escalations and trips at exactly the configured count,
     /// deterministically; `begin()` resets; unbounded never trips.

--- a/rust/geometry/src/router/voids/flap_clip_tests.rs
+++ b/rust/geometry/src/router/voids/flap_clip_tests.rs
@@ -180,3 +180,178 @@ fn nonzero_origin_host_records_world_space_bbox() {
     assert!(mny > 1900.0 && mxy < 2100.0, "y not world: [{mny}, {mxy}]");
     assert!(mnz > 2900.0 && mxz < 3100.0, "z not world: [{mnz}, {mxz}]");
 }
+
+/// An axis-aligned box mesh centred at `cx` on X (0 on Y/Z) with the given half
+/// extents, via the same `OpeningBox` corner order the router uses.
+fn box_mesh_at(cx: f64, half: [f64; 3]) -> Mesh {
+    OpeningBox {
+        center: Vector3::new(cx, 0.0, 0.0),
+        axes: [Vector3::x(), Vector3::y(), Vector3::z()],
+        half,
+    }
+    .extended_box_mesh([0.0; 3], 0.0)
+}
+
+/// #1109 → #635 engulf-suppression correctness (the decided SKIP fix). When the
+/// per-boolean escalation budget (#1109) trips while cutting a void whose AABB
+/// ENGULFS the host, the router must NOT fall through to the destructive #635
+/// AABB box-cut: that box covers the whole host, so it would DELETE the wall
+/// (silent element loss). It leaves the host UN-CUT instead — a phantom solid is
+/// strictly safer. The companion cut pins the OTHER quadrant: a NON-engulfing
+/// opening under the SAME tripped cap MUST still take the #635 box-cut, proving
+/// the dropped `!capped` term only affects the engulfing case.
+#[test]
+fn budget_tripped_engulfing_cutter_skips_aabb_fallback() {
+    use crate::kernel::budget;
+
+    // We trip via the per-ELEMENT budget, NOT the per-boolean cap. The
+    // per-boolean cap is process-global and read by EVERY boolean on EVERY
+    // thread, so lowering it here would false-trip the CSG that concurrent
+    // (unlocked) sibling tests are running. The per-element cap only bites a
+    // thread that has opened an element scope via `begin_element` — and within
+    // this lib test binary only THIS test and budget.rs's own `per_element`
+    // test (both hold the lock below, and neither runs a sibling's CSG) ever do
+    // — so a per-element cap of 1 is invisible to every other test.
+    //
+    // Serialise against the other cap-mutating tests (they share this lock).
+    let _cap_guard = budget::GLOBAL_CAP_LOCK.lock().unwrap();
+    // Restore BOTH global caps AND reset THIS worker thread's thread-local
+    // element scope to unbounded on the way out (even on panic): thread-locals
+    // persist across tests on a reused worker thread, so a left-armed element
+    // cap would false-trip whatever CSG test cargo schedules next on it.
+    struct RestoreBudget {
+        cap: Option<u64>,
+        ecap: Option<u64>,
+    }
+    impl Drop for RestoreBudget {
+        fn drop(&mut self) {
+            // Re-open an UNBOUNDED element scope on this thread (elem cap 0 ⇒
+            // thread-local ELEM_CAP = u64::MAX, ELEM_COUNT = 0), matching a
+            // thread that never opened a scope, THEN restore the globals.
+            budget::set_element_cap(None);
+            budget::begin_element();
+            budget::set_cap(self.cap);
+            budget::set_element_cap(self.ecap);
+        }
+    }
+    let _restore = RestoreBudget {
+        cap: budget::cap(),
+        ecap: budget::element_cap(),
+    };
+
+    let router = GeometryRouter::new();
+
+    // Box host wall: 2 m (x) × 0.3 m thick (y) × 2 m tall (z), centred at
+    // origin. Every face stays well under the 8:1 sliver-refine threshold, so
+    // the un-cut host passes through the post-loop refine/clip unchanged and its
+    // triangle count is a stable "host present, un-cut" baseline.
+    let host = aabb_box([1.0, 0.15, 1.0]);
+    let host_tris = host.triangle_count();
+
+    // ENGULFING cutter: two disjoint boxes flanking the host in X with a gap
+    // straddling the host centre, merged into ONE cutter mesh. Their COMBINED
+    // AABB covers the host on all three axes (engulf), yet the real solid
+    // EXCLUDES the host centre (the X-gap) — so `opening_engulfs_host_solid` is
+    // false (the host is NOT consumed as a containing void) and the cut reaches
+    // the exact subtract. Each box's Y/Z faces sit a hair (~0.1 mm, off-grid)
+    // beyond the host faces: near-coplanar overlaps that force the exact
+    // predicate cascade off the interval filter, so an element cap of 1 trips.
+    let dy = 1.3e-4;
+    let dz = 1.7e-4;
+    let cutter = {
+        let mut m = box_mesh_at(-0.8, [0.5, 0.15 + dy, 1.0 + dz]); // x ∈ [-1.3, -0.3]
+        m.merge(&box_mesh_at(0.8, [0.5, 0.15 + dy, 1.0 + dz])); //     x ∈ [ 0.3,  1.3]
+        m
+    };
+    // The cutter welds to a closed manifold (two closed boxes), so the
+    // malformed-cutter recut path never claims it and bypasses the target code.
+    assert!(
+        opening_obb_if_malformed(&cutter).is_none(),
+        "engulfing cutter must be well-formed"
+    );
+
+    let (cmn, cmx) = cutter.bounds();
+    let engulf_open = OpeningType::NonRectangular(
+        cutter,
+        Point3::new(cmn.x as f64, cmn.y as f64, cmn.z as f64),
+        Point3::new(cmx.x as f64, cmx.y as f64, cmx.z as f64),
+        None,
+    );
+    let engulf_ctx = VoidContext {
+        merged_openings: vec![engulf_open.clone()],
+        openings: vec![engulf_open],
+        param: None,
+    };
+
+    // Arm a per-element cap of 1 so the FIRST exact escalation trips the
+    // element budget deterministically (the per-boolean cap stays at its
+    // default, untouched, so concurrent tests are unaffected).
+    budget::set_element_cap(Some(1));
+
+    let engulf_id = 91_109_u32;
+    budget::begin_element(); // fresh element scope; element cap 1 is the trip
+    let engulf_result = router.apply_void_context(host.clone(), &engulf_ctx, engulf_id);
+
+    // Host PRESENT and UN-CUT: the engulfing AABB box-cut was suppressed, so the
+    // result is the original host, not an empty (deleted) mesh.
+    assert!(
+        !engulf_result.is_empty(),
+        "engulfing cutter DELETED the host (box-cut fallback not suppressed)"
+    );
+    assert_eq!(
+        engulf_result.triangle_count(),
+        host_tris,
+        "host must be left exactly un-cut (got {} tris, host {host_tris})",
+        engulf_result.triangle_count(),
+    );
+
+    // Exactly ONE failure recorded for this element — the single tripped
+    // boolean — with reason OperandTooLarge (the #1109 budget-trip signature).
+    let failures = router.take_csg_failures();
+    let engulf_fails = failures
+        .get(&engulf_id)
+        .expect("the tripped engulfing cut must record a failure");
+    assert_eq!(
+        engulf_fails.len(),
+        1,
+        "exactly one failure for the single tripped cut (got {engulf_fails:?})"
+    );
+    assert!(
+        matches!(
+            engulf_fails[0].reason,
+            crate::diagnostics::BoolFailureReason::OperandTooLarge { .. }
+        ),
+        "the tripped cut must record OperandTooLarge (got {:?})",
+        engulf_fails[0].reason,
+    );
+
+    // COMPANION (other quadrant): a small NON-engulfing opening centred in the
+    // wall, under the SAME tripped cap, MUST still change the host — the #635
+    // box-cut fires because `engulfs_host` is false, so dropping the `!capped`
+    // term left this case untouched.
+    let small = box_mesh_at(0.0, [0.15, 0.2, 0.15]); // 0.3 × 0.4 × 0.3, through the wall
+    let small_open = OpeningType::NonRectangular(
+        small,
+        Point3::new(-0.15, -0.2, -0.15),
+        Point3::new(0.15, 0.2, 0.15),
+        None,
+    );
+    let small_ctx = VoidContext {
+        merged_openings: vec![small_open.clone()],
+        openings: vec![small_open],
+        param: None,
+    };
+
+    let small_id = 91_635_u32;
+    budget::begin_element();
+    let small_result = router.apply_void_context(host.clone(), &small_ctx, small_id);
+    assert!(
+        !small_result.is_empty(),
+        "a non-engulfing cut must keep the wall"
+    );
+    assert_ne!(
+        small_result.triangle_count(),
+        host_tris,
+        "a non-engulfing opening under the tripped cap must still cut the host (#635 box-cut)"
+    );
+}

--- a/rust/geometry/src/router/voids/mod.rs
+++ b/rust/geometry/src/router/voids/mod.rs
@@ -1691,14 +1691,23 @@ impl GeometryRouter {
                                 && covers(final_min.y, final_max.y, wall_min.y, wall_max.y)
                                 && covers(final_min.z, final_max.z, wall_min.z, wall_max.z)
                         };
-                        // Only suppress the fallback when "unchanged" means the
-                        // kernel found no real cut (a kernel error / no-overlap on
-                        // a grazing engulfing cutter). `capped` keys on the
-                        // historical `OperandTooLarge` rejection (issue #635 /
-                        // #947): the exact kernel has no operand cap so it is
-                        // now always false, but keeping the term costs
-                        // nothing and stays correct if a complexity budget ever
-                        // records it again.
+                        // `capped` keys on the `OperandTooLarge` rejection: the
+                        // #1109 per-boolean/-element escalation budget records it
+                        // when a cut trips mid-arrangement and bails to the un-cut
+                        // host (`csg/mod.rs`), so it is NOT always false — a
+                        // grazing engulfing cutter that would run long trips the
+                        // budget just as it errors on the coincident faces.
+                        // Engulf suppression therefore applies regardless of WHY
+                        // the CSG produced no change (budget trip or kernel error
+                        // on the coincident faces): an engulfing cutter's AABB
+                        // covers the whole host, so the #635 box-cut would delete
+                        // the entire wall — a silent element deletion strictly
+                        // worse than leaving a phantom (un-cut) solid. `capped` is
+                        // now only read by the diagnostic below (it no longer
+                        // gates the suppression), so it is unused in a release
+                        // build that compiles out both the tracing and the
+                        // debug/test `eprintln!` legs of `diag_warn!`.
+                        #[allow(unused_variables)]
                         let capped = clipper.has_operand_too_large_since(failures_before);
                         // Issue #964: suppress the destructive AABB box when the
                         // host already has this void cut into it (a void
@@ -1716,7 +1725,7 @@ impl GeometryRouter {
                         let redundant_void =
                             opening_redundant_with_host(&result, opening_mesh, &probe_axis);
                         let suppress_fallback =
-                            redundant_void || (csg_unchanged && engulfs_host && !capped);
+                            redundant_void || (csg_unchanged && engulfs_host);
                         if !suppress_fallback {
                             // Diagnostic for issue #635: log the opening
                             // triangle count when the AABB fallback actually
@@ -1751,6 +1760,29 @@ impl GeometryRouter {
                                 result = aabb_cut;
                                 host_mutated = true;
                             }
+                        } else {
+                            // The engulfing/redundant-void guard suppressed the
+                            // #635 AABB box-cut. For an engulfing cutter the box
+                            // covers the whole host, so cutting it would DELETE
+                            // the wall; leaving the host un-cut (a phantom solid)
+                            // is the strictly safer degrade. `capped` records
+                            // whether the CSG bailed via the #1109 budget trip
+                            // (`OperandTooLarge`) vs a kernel error on the
+                            // coincident faces.
+                            crate::diag::diag_warn!(
+                                { opening_tris = opening_mesh.triangle_count(),
+                                  capped = capped,
+                                  reason = "engulfing-cutter-fallback-suppressed",
+                                  "voids: AABB fallback suppressed for engulfing cutter (host left un-cut)" }
+                                else {
+                                    #[cfg(any(debug_assertions, test))]
+                                    eprintln!(
+                                        "[issue-635] AABB fallback SUPPRESSED for engulfing cutter: opening={} tris, capped={} (host left un-cut)",
+                                        opening_mesh.triangle_count(),
+                                        capped
+                                    );
+                                }
+                            );
                         }
                     }
                 }

--- a/rust/processing/tests/module_size_allowlist.txt
+++ b/rust/processing/tests/module_size_allowlist.txt
@@ -64,7 +64,8 @@
 # +10: extract min_opening_volume(quality) tier->floor helper shared by the batch
 # admission gate and the sequential CSG path so they can't diverge on the
 # High/Highest small-opening floor (B11 regression, issue #976).
-    1899 rust/geometry/src/router/voids/mod.rs
+# +32: engulf-cutter #635 AABB box-cut suppression on a #1109 budget trip (drop `!capped`) + its rewritten rationale comment and a diag_warn! else-branch (correctness: an engulfing box-cut would DELETE the host).
+    1931 rust/geometry/src/router/voids/mod.rs
      621 rust/geometry/src/router/voids/probe.rs
     1002 rust/geometry/src/router/voids/synthesis.rs
     1472 rust/geometry/src/space_dcel/mod.rs


### PR DESCRIPTION
Decided **SKIP** (maintainer + geometry-kernel review).

## The bug

When the #1109 escalation budget trips while cutting an `IfcOpeningElement` void whose AABB **engulfs** the host, the code fell through to the destructive #635 AABB box-cut, which **deletes the whole host**. That is silent element deletion — the worst outcome for every downstream consumer (vanished wall, zero volume, clash false-negatives). Root cause: a stale comment — the guard's `!capped` term assumed `OperandTooLarge` "is now always false", but #1109 re-purposed that signal, so a budget trip sets `capped = true` and disables the engulf suppression exactly when it's needed.

## Fix

- `suppress_fallback` drops the `!capped` term → an engulfing cutter **never** box-cuts, regardless of budget state (SKIP: host left un-cut, a recognizable/diagnosable phantom-solid degrade). The plain non-engulfing budget-trip case is **unchanged** (#635 box-cut still fires).
- Rewrote the stale "always false" comment; added a `diag_warn!` on the suppressed branch (`reason = engulfing-cutter-fallback-suppressed`) so the skip is observable.

## Test

`budget_tripped_engulfing_cutter_skips_aabb_fallback`: engulfing flush-face cutter under a tripped **per-element** cap → host present, un-cut, one `OperandTooLarge` failure; companion small non-engulfing opening → box-cut still fires. Uses the per-element cap (not the process-global per-boolean cap) to avoid contaminating concurrent sibling tests; `GLOBAL_CAP_LOCK` exposed `pub(crate)` for serialization.

## Verification

- Rebased onto main (merges cleanly with #1599's `min_opening_volume`). `cargo test -p ifc-lite-geometry --lib`: 415 passed, 0 failed. Ratchet 4/4. No wasm API change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)