### PR TITLE
perf(geometry): reuse per-worker scratch in the mesh-assembly funnel (~3.7% geometry)

### DIFF
--- a/.changeset/perf-mesh-assembly-scratch.md
+++ b/.changeset/perf-mesh-assembly-scratch.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/wasm": patch
+---
+
+Reuse per-worker scratch buffers in the mesh-assembly funnel. `orient_mesh_outward` and `weld_indexed` allocated fresh maps/Vecs once per mesh (~100k+ times on a big model); they now take + put back a `thread_local!` scratch buffer (cleared before each use), turning allocate-fill-free cycles into allocate-once-clear-many. `thread_local!` makes it per-worker-thread by construction, so it is safe inside faceted-brep's nested `par_iter` (no shared-buffer race, no re-entrant borrow) and needs no lock. Byte-identical (buffer reuse only; the fill sequence and output order are unchanged; mesh-determinism manifest passes with no re-pin). Measured ~3.7-3.8% off the geometry phase. Both files stay under the 400-line module-size limit (no ratchet bump).

--- a/rust/geometry/src/mesh_orient.rs
+++ b/rust/geometry/src/mesh_orient.rs
@@ -26,6 +26,7 @@
 
 use crate::Mesh;
 use rustc_hash::FxHashMap;
+use std::cell::RefCell;
 
 /// Incident-triangle record for one undirected welded edge. A boundary edge has
 /// one incident triangle and a manifold edge exactly two, so the two triangle
@@ -67,6 +68,40 @@ impl EdgeInc {
 /// vertices and is the dangerous direction, so the grid stays fine.
 const WELD: f64 = 1.0e5;
 
+/// Per-worker reusable scratch for [`orient_mesh_outward`], cleared (never freed)
+/// between meshes. The pass runs once per assembled submesh (~109k times on a
+/// mesh-heavy model), so each fresh call's two `FxHashMap`s + six `Vec`s were
+/// ~4-6% of busy CPU on pure-brep/steel models; pooling makes it allocate-once,
+/// clear-many. BYTE-IDENTICAL: neither map is ever iterated — both are only
+/// `.entry()`-inserted (order fixed by the deterministic scan) and keyed-looked-up,
+/// so bucket count / residual capacity can't reach the output; every `Vec` is
+/// fully overwritten before it is read. A cleared, reused buffer replays the
+/// identical fill sequence, so the flip decisions and `indices.swap`s are unchanged.
+#[derive(Default)]
+struct OrientScratch {
+    vid_of: FxHashMap<(i64, i64, i64), u32>,
+    vpos: Vec<[f64; 3]>,
+    corner: Vec<u32>,
+    edge_tris: FxHashMap<(u32, u32), EdgeInc>,
+    flip: Vec<bool>,
+    visited: Vec<bool>,
+    comp: Vec<usize>,
+    stack: Vec<usize>,
+}
+
+thread_local! {
+    /// One scratch per rayon worker (and the main / wasm single thread). A
+    /// `thread_local!`, not the `Vec<Mutex<_>>` worker-slot pattern: this LEAF
+    /// buffer never crosses a crate boundary, needs no lock (so no deadlock risk,
+    /// unlike the CartesianPoint cache #1572), and works when
+    /// `rayon::current_thread_index()` is `None` (direct calls, tests, wasm). Each
+    /// worker owns its instance — no cross-thread sharing, fully deterministic.
+    /// Re-entrancy is TAKE / put-back (below): the `RefCell` borrow is never held
+    /// across the computation, so a nested-`par_iter` re-entrant call on the same
+    /// thread mints a fresh scratch instead of panicking on a double borrow.
+    static ORIENT_SCRATCH: RefCell<Option<OrientScratch>> = const { RefCell::new(None) };
+}
+
 /// Orient every connected component of `mesh` consistently and outward, in place.
 /// Returns `true` iff any triangle's winding was flipped (the caller must then
 /// recompute normals — the existing ones were baked with the old winding).
@@ -76,7 +111,7 @@ pub fn orient_mesh_outward(mesh: &mut Mesh) -> bool {
         return false;
     }
     // Bail cleanly on malformed buffers instead of panicking on an out-of-range
-    // index below.
+    // index below. (Before any scratch is taken — the bail path allocates nothing.)
     let vertex_count = mesh.positions.len() / 3;
     if !mesh.positions.len().is_multiple_of(3)
         || mesh.indices.iter().any(|&idx| idx as usize >= vertex_count)
@@ -84,12 +119,26 @@ pub fn orient_mesh_outward(mesh: &mut Mesh) -> bool {
         return false;
     }
 
+    // Take this worker's warm scratch (or mint one on the first call / a re-entrant
+    // borrow). The momentary `.with` borrow is never held across the pass, so a
+    // nested-`par_iter` re-entrant call on this thread can't trip a double borrow;
+    // the scratch is handed back on the single return path (byte-for-byte the
+    // pre-pool algorithm). The disjoint `&mut` field bindings (the borrow checker
+    // splits struct fields) let a read-only closure borrow one buffer while another
+    // is mutated.
+    let mut scratch = ORIENT_SCRATCH.with(|c| c.borrow_mut().take()).unwrap_or_default();
+    let OrientScratch { vid_of, vpos, corner, edge_tris, flip, visited, comp, stack } =
+        &mut scratch;
+    // Clear (retain capacity) before use so no stale data leaks in; the reserves
+    // restore the original `with_capacity` sizing.
+    vid_of.clear();
+    vid_of.reserve(vertex_count);
+    vpos.clear();
+    corner.clear();
+    corner.reserve(mesh.indices.len());
+
     // Weld positions -> welded vertex id; record the welded vid of every corner.
     let q = |v: f32| (v as f64 * WELD).round() as i64;
-    let mut vid_of: FxHashMap<(i64, i64, i64), u32> =
-        FxHashMap::with_capacity_and_hasher(vertex_count, Default::default());
-    let mut vpos: Vec<[f64; 3]> = Vec::new();
-    let mut corner: Vec<u32> = Vec::with_capacity(mesh.indices.len());
     for &idx in &mesh.indices {
         let b = idx as usize * 3;
         let key = (
@@ -108,8 +157,8 @@ pub fn orient_mesh_outward(mesh: &mut Mesh) -> bool {
 
     // Undirected welded edge -> incident triangles. >2 incident ⇒ non-manifold.
     // A closed manifold has ~1.5 edges per triangle; reserve to skip rehashing.
-    let mut edge_tris: FxHashMap<(u32, u32), EdgeInc> =
-        FxHashMap::with_capacity_and_hasher(ntri * 2, Default::default());
+    edge_tris.clear();
+    edge_tris.reserve(ntri * 2);
     for t in 0..ntri {
         let v = tv(t);
         for &(a, b) in &[(v[0], v[1]), (v[1], v[2]), (v[2], v[0])] {
@@ -121,17 +170,22 @@ pub fn orient_mesh_outward(mesh: &mut Mesh) -> bool {
         }
     }
 
-    let mut flip = vec![false; ntri];
-    let mut visited = vec![false; ntri];
+    // `clear()` + `resize(ntri, false)` reproduces the original `vec![false; ntri]`.
+    flip.clear();
+    flip.resize(ntri, false);
+    visited.clear();
+    visited.resize(ntri, false);
     let mut any_flip = false;
 
     for seed in 0..ntri {
         if visited[seed] {
             continue;
         }
-        // BFS the component, propagating a consistent orientation.
-        let mut comp: Vec<usize> = Vec::new();
-        let mut stack = vec![seed];
+        // BFS the component, propagating a consistent orientation. `comp`/`stack`
+        // are cleared per component (pre-pool freshly allocated them) — identical order.
+        comp.clear();
+        stack.clear();
+        stack.push(seed);
         visited[seed] = true;
         let mut orientable = true;
         // Only a CLOSED manifold (every welded edge shared by exactly two tris) has
@@ -183,7 +237,7 @@ pub fn orient_mesh_outward(mesh: &mut Mesh) -> bool {
         }
 
         if !orientable || !closed {
-            for &t in &comp {
+            for &t in comp.iter() {
                 flip[t] = false; // open / non-orientable — leave winding as authored
             }
             continue;
@@ -191,7 +245,7 @@ pub fn orient_mesh_outward(mesh: &mut Mesh) -> bool {
 
         // Flip the whole CLOSED component outward (positive signed volume).
         let mut vol6 = 0.0f64;
-        for &t in &comp {
+        for &t in comp.iter() {
             let v = tv(t);
             let (i0, i1, i2) = if flip[t] {
                 (v[0], v[2], v[1])
@@ -203,7 +257,7 @@ pub fn orient_mesh_outward(mesh: &mut Mesh) -> bool {
                 + a[2] * (b[0] * c[1] - b[1] * c[0]);
         }
         if vol6 < 0.0 {
-            for &t in &comp {
+            for &t in comp.iter() {
                 flip[t] = !flip[t];
             }
         }
@@ -215,6 +269,8 @@ pub fn orient_mesh_outward(mesh: &mut Mesh) -> bool {
             any_flip = true;
         }
     }
+    // Field borrows have ended (NLL); hand the now-warm scratch back to this worker.
+    ORIENT_SCRATCH.with(|c| *c.borrow_mut() = Some(scratch));
     any_flip
 }
 

--- a/rust/geometry/src/mesh_weld.rs
+++ b/rust/geometry/src/mesh_weld.rs
@@ -37,6 +37,7 @@
 //! a quantized UV), no float comparison, FMA-free.
 
 use rustc_hash::FxHashMap;
+use std::cell::RefCell;
 
 /// Normal quantization grid: components are multiplied by this and rounded to an
 /// integer before keying. Matches [`crate::facet_weld`]'s `NORMAL_QUANT` and the
@@ -65,6 +66,32 @@ fn vkey(p: &[f32], n: &[f32], uv: [f32; 2]) -> VKey {
         (uv[0] * UV_QUANT).round() as i32,
         (uv[1] * UV_QUANT).round() as i32,
     )
+}
+
+/// Per-worker reusable scratch for [`weld_indexed`]'s INTERNAL buffers, cleared
+/// (never freed) between meshes. The output buffers (`out_pos`/`out_nrm`/…) still
+/// allocate (they escape to the caller); only the transient `map`/`remap`/
+/// `first_vert` — allocated and dropped per element by the pre-pool code — are
+/// pooled. BYTE-IDENTICAL: `map` is only `.get()`/`.insert()`-ed, never iterated
+/// (so its bucket count / residual capacity can't reach the output); `remap` is
+/// fully overwritten; `first_vert` is refilled by push in first-seen order and
+/// iterated in push order. A cleared, reused buffer replays the identical fill.
+#[derive(Default)]
+struct WeldScratch {
+    map: FxHashMap<VKey, u32>,
+    remap: Vec<u32>,
+    first_vert: Vec<u32>,
+}
+
+thread_local! {
+    /// One scratch per rayon worker (and the main / wasm single thread): a
+    /// `thread_local!`, not the shared worker-slot pattern, since these LEAF buffers
+    /// never cross a crate boundary, need no lock, and work when
+    /// `rayon::current_thread_index()` is `None`. Re-entrancy is TAKE / put-back (the
+    /// `RefCell` borrow is never held across the hash pass), so a re-entrant call
+    /// mints a fresh scratch rather than panicking — though `weld_indexed` runs no
+    /// rayon and cannot re-enter on the same thread.
+    static WELD_SCRATCH: RefCell<Option<WeldScratch>> = const { RefCell::new(None) };
 }
 
 /// Weld `positions`/`normals` (3 floats per vertex, equal length), optional
@@ -100,14 +127,22 @@ pub fn weld_indexed(
         return None; // malformed: caller keeps the (unvalidated) originals
     }
 
-    // Single hash pass: assign each distinct key a first-seen id, record the
-    // source vertex that minted it, and fill the remap. `first_vert` doubles as
-    // the merge detector — if it ends the same length as `nverts`, no two
-    // vertices collided and the remap is the identity.
-    let mut map: FxHashMap<VKey, u32> = FxHashMap::default();
+    // Take this worker's warm scratch (or mint one). The `.with` borrow is momentary
+    // at both ends, never held across the hash pass (re-entrancy-safe); the scratch
+    // is handed back on the single return path below. Disjoint `&mut` field bindings.
+    let mut scratch = WELD_SCRATCH.with(|c| c.borrow_mut().take()).unwrap_or_default();
+    let WeldScratch { map, remap, first_vert } = &mut scratch;
+
+    // Single hash pass: assign each distinct key a first-seen id, record the source
+    // vertex that minted it, and fill the remap. `first_vert` doubles as the merge
+    // detector — same length as `nverts` ⇒ nothing collided, the remap is identity.
+    // Clear (retain capacity) before use so no stale data leaks in; `remap` is resized
+    // to all-zero (every slot is overwritten by `remap[v] = id` below).
+    map.clear();
     map.reserve(nverts);
-    let mut remap = vec![0u32; nverts];
-    let mut first_vert: Vec<u32> = Vec::new();
+    remap.clear();
+    remap.resize(nverts, 0u32);
+    first_vert.clear();
     for v in 0..nverts {
         let p = &positions[v * 3..v * 3 + 3];
         let n = &normals[v * 3..v * 3 + 3];
@@ -128,26 +163,30 @@ pub fn weld_indexed(
     }
 
     let unique = first_vert.len();
-    if unique == nverts {
+    let out = if unique == nverts {
         // Nothing merged: the identity remap reproduces the input exactly.
-        return None;
-    }
-
-    // Merges happened: gather the first-seen vertex per id (byte-identical to
-    // extending on first insert above) and remap the indices.
-    let mut out_pos: Vec<f32> = Vec::with_capacity(unique * 3);
-    let mut out_nrm: Vec<f32> = Vec::with_capacity(unique * 3);
-    let mut out_uv: Vec<f32> = Vec::with_capacity(if uvs.is_some() { unique * 2 } else { 0 });
-    for &fv in &first_vert {
-        let fv = fv as usize;
-        out_pos.extend_from_slice(&positions[fv * 3..fv * 3 + 3]);
-        out_nrm.extend_from_slice(&normals[fv * 3..fv * 3 + 3]);
-        if let Some(u) = uvs {
-            out_uv.extend_from_slice(&u[fv * 2..fv * 2 + 2]);
+        None
+    } else {
+        // Merges happened: gather the first-seen vertex per id (byte-identical to
+        // extending on first insert above) and remap the indices.
+        let mut out_pos: Vec<f32> = Vec::with_capacity(unique * 3);
+        let mut out_nrm: Vec<f32> = Vec::with_capacity(unique * 3);
+        let mut out_uv: Vec<f32> =
+            Vec::with_capacity(if uvs.is_some() { unique * 2 } else { 0 });
+        for &fv in first_vert.iter() {
+            let fv = fv as usize;
+            out_pos.extend_from_slice(&positions[fv * 3..fv * 3 + 3]);
+            out_nrm.extend_from_slice(&normals[fv * 3..fv * 3 + 3]);
+            if let Some(u) = uvs {
+                out_uv.extend_from_slice(&u[fv * 2..fv * 2 + 2]);
+            }
         }
-    }
-    let out_idx: Vec<u32> = indices.iter().map(|&i| remap[i as usize]).collect();
-    Some((out_pos, out_nrm, uvs.map(|_| out_uv), out_idx))
+        let out_idx: Vec<u32> = indices.iter().map(|&i| remap[i as usize]).collect();
+        Some((out_pos, out_nrm, uvs.map(|_| out_uv), out_idx))
+    };
+    // Field borrows have ended (NLL); hand the now-warm scratch back to this worker.
+    WELD_SCRATCH.with(|c| *c.borrow_mut() = Some(scratch));
+    out
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## What

`orient_mesh_outward` and `weld_indexed` allocated fresh maps/Vecs **once per mesh** — ~100k+ times on a big model, a measured ~4-6% of busy CPU on the mesh-assembly funnel. They now take + put back a `thread_local!` scratch buffer (cleared before each use), turning allocate-fill-free into allocate-once-clear-many.

## Why it's safe

- **`thread_local!` is per-worker-thread by construction**, so it's correct inside faceted-brep's **nested `par_iter`** (each rayon worker has its own scratch — no shared-buffer race, no re-entrant `RefCell` borrow) and needs no lock.
- **Cleared before each use** → the fill sequence is identical to a fresh buffer → output order + values unchanged.

## Byte-identical

- `mesh_output_matches_pinned_manifest` passes with **no re-pin**.
- `faceted_brep_deadlock_regression` passes (37.6s, no hang — the change is inside the nested par_iter path).
- clippy `-D warnings` clean; orient/weld unit tests green.
- Both files stay **under the 400-line ratchet** (mesh_orient.rs 392, mesh_weld.rs 398) — no budget bump (helpers inlined via take/put-back on a single NLL return path).

## Numbers (interleaved min-of-10, geometry phase)

- advanced_model (2.8M verts, 11471 meshes): 704 → 678ms = **3.7%**
- schependomlaan: 78 → 75ms = **3.8%**

Modest but consistent — the allocator-churn reduction the pooling targets. Stacks with the just-merged alloc-churn cluster (#1592/#1596/#1601) on the geometry stream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Reduced allocation overhead during mesh processing, which should improve geometry workflow speed and lower memory churn.
  * Mesh orientation and vertex welding now reuse internal temporary buffers, helping repeated operations run more efficiently.
  * Output behavior remains unchanged, including ordering and results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->