### PR TITLE
fix(geometry): preserve placement metadata across post-placement mesh rebuilds (B7)

### DIFF
--- a/rust/geometry/src/facet_weld.rs
+++ b/rust/geometry/src/facet_weld.rs
@@ -599,23 +599,27 @@ pub fn refine_high_aspect_slivers(mesh: &Mesh) -> Mesh {
 
     // Rebuild a flat mesh from the refined canonical triangles, re-deriving a
     // per-face flat normal (the input may not carry usable normals after a cut).
-    let mut out = Mesh::with_capacity(tris.len() * 3, tris.len() * 3);
+    let mut positions: Vec<f32> = Vec::with_capacity(tris.len() * 9);
+    let mut normals: Vec<f32> = Vec::with_capacity(tris.len() * 9);
+    let mut indices: Vec<u32> = Vec::with_capacity(tris.len() * 3);
     for t in &tris {
         let a = cpos[t[0]];
         let b = cpos[t[1]];
         let c = cpos[t[2]];
         let n = tri_normal(a, b, c).map(|(n, _)| n).unwrap_or([0.0, 0.0, 1.0]);
-        let base = (out.positions.len() / 3) as u32;
+        let base = (positions.len() / 3) as u32;
         for p in [a, b, c] {
-            out.positions
-                .extend_from_slice(&[p[0] as f32, p[1] as f32, p[2] as f32]);
-            out.normals
-                .extend_from_slice(&[n[0] as f32, n[1] as f32, n[2] as f32]);
+            positions.extend_from_slice(&[p[0] as f32, p[1] as f32, p[2] as f32]);
+            normals.extend_from_slice(&[n[0] as f32, n[1] as f32, n[2] as f32]);
         }
-        out.indices.extend_from_slice(&[base, base + 1, base + 2]);
+        indices.extend_from_slice(&[base, base + 1, base + 2]);
     }
-    out.rtc_applied = mesh.rtc_applied;
-    out
+    // Carry the host's placement / frame metadata (origin, rtc, #1474 capture)
+    // forward. This pass runs AFTER placement, so a bare rebuild would reset the
+    // local-frame origin + #1474 capture to defaults and mis-place exactly the
+    // hosts whose cuts slivered. `instance_meta` is dropped (the refined mesh no
+    // longer matches its canonical rep) — see `Mesh::rebuilt_like`.
+    mesh.rebuilt_like(positions, normals, indices)
 }
 
 #[cfg(test)]

--- a/rust/geometry/src/mesh.rs
+++ b/rust/geometry/src/mesh.rs
@@ -159,6 +159,52 @@ impl Mesh {
         }
     }
 
+    /// Build a mesh with FRESH geometry buffers (`positions` / `normals` /
+    /// `indices`) that carries THIS mesh's placement/frame metadata forward:
+    /// `origin` (RTC / local-frame translation), `rtc_applied`, `local_bounds`
+    /// and `local_to_world` (the #1474 placement capture).
+    ///
+    /// This is the correct constructor for an in-place rebuild pass that
+    /// REPLACES the vertex buffers of an already-placed mesh (sliver refine,
+    /// subdivide, weld). Constructing a bare `Mesh` and copying back only a
+    /// field or two silently resets `origin` and the #1474 capture to their
+    /// defaults, which mis-places the rebuilt host at the world origin on
+    /// local-framed (large / georeferenced) models — see facet_weld's
+    /// sliver-refine and this module's `subdivide_once` / `weld_impl`.
+    ///
+    /// `instance_meta` is intentionally NOT carried. Every such rebuild CHANGES
+    /// the vertices, so the mesh no longer reproduces its representation's
+    /// canonical geometry; carrying the (vertex-invariant) `rep_identity`
+    /// forward would let the GPU-instancing collator dedup this changed mesh
+    /// against an *unrefined* sibling that shares the same `rep_identity` and
+    /// draw the wrong geometry. Dropping it mirrors the void-cut path, which
+    /// nulls `instance_meta` for exactly this reason.
+    ///
+    /// # Precondition
+    ///
+    /// The new buffers MUST NOT extend the mesh's spatial extent beyond the
+    /// original: the carried `local_bounds` stays valid only because it remains
+    /// a *superset* of the rebuilt vertices' extent. This holds for every
+    /// current caller — sliver-refine and subdivide insert edge/interior
+    /// midpoints (convex combinations that lie inside the existing hull), and
+    /// weld only merges/moves coincident vertices to a snapped position (a
+    /// subset extent). A future caller that GROWS the extent (adds vertices
+    /// outside the original hull) must NOT use this constructor for
+    /// `local_bounds`: it has to recompute `local_bounds` from the new positions
+    /// or pass through a variant that sets it to `None`.
+    pub fn rebuilt_like(&self, positions: Vec<f32>, normals: Vec<f32>, indices: Vec<u32>) -> Mesh {
+        Mesh {
+            positions,
+            normals,
+            indices,
+            rtc_applied: self.rtc_applied,
+            origin: self.origin,
+            instance_meta: None,
+            local_bounds: self.local_bounds,
+            local_to_world: self.local_to_world,
+        }
+    }
+
     /// Create a mesh from a single triangle
     pub fn from_triangle(
         v0: &Point3<f64>,
@@ -370,13 +416,10 @@ impl Mesh {
             // four sub-triangles, preserving the parent winding
             indices.extend_from_slice(&[a, ab, ca, ab, b, bc, ca, bc, c, ab, bc, ca]);
         }
-        Mesh {
-            positions,
-            normals,
-            indices,
-            rtc_applied: self.rtc_applied,
-            origin: self.origin,
-        instance_meta: None, local_bounds: None, local_to_world: None }
+        // Adding midpoints changes the vertex buffers, so carry the placement /
+        // frame metadata (origin, rtc, #1474 capture) but drop instance_meta
+        // (this mesh no longer matches its canonical rep) via `rebuilt_like`.
+        self.rebuilt_like(positions, normals, indices)
     }
 
     /// Remove triangle indices that reference vertices beyond the positions array.
@@ -865,13 +908,10 @@ fn weld_impl(mesh: &Mesh, position_eps: f32, average_normals: bool) -> Mesh {
         new_indices.push(i2);
     }
 
-    Mesh {
-        positions: new_positions,
-        normals: new_normals,
-        indices: new_indices,
-        rtc_applied: mesh.rtc_applied,
-        origin: mesh.origin,
-    instance_meta: None, local_bounds: None, local_to_world: None }
+    // Welding collapses / moves vertices, so carry the placement / frame
+    // metadata (origin, rtc, #1474 capture) but drop instance_meta (the welded
+    // mesh no longer matches its canonical rep) via `rebuilt_like`.
+    mesh.rebuilt_like(new_positions, new_normals, new_indices)
 }
 
 #[cfg(test)]
@@ -1080,6 +1120,60 @@ mod tests {
                 (len_sq - 1.0).abs() < 1e-4,
                 "welded normal must be unit length, got |n|^2 = {}",
                 len_sq
+            );
+        }
+    }
+
+    /// #1474 / B7 regression guard: a vertex-changing rebuild MUST carry the
+    /// mesh's placement/frame metadata (origin, rtc_applied, local_bounds,
+    /// local_to_world) forward and MUST drop instance_meta (the changed vertices
+    /// no longer match the canonical rep). Directly exercises `rebuilt_like` and
+    /// the two public seams that route through it (`subdivided`,
+    /// `welded_by_position`). Pure unit test — no fixture.
+    #[test]
+    fn rebuild_carries_placement_metadata_and_drops_instancing() {
+        // One triangle, placed: non-default origin/rtc + a set #1474 capture and
+        // an attached instance side-channel.
+        let mut m = mesh_from_tris(&[[[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [1.0, 1.0, 0.0]]]);
+        m.origin = [100.0, 200.0, 300.0];
+        m.rtc_applied = true;
+        m.local_bounds = Some([0.0, 0.0, 0.0, 1.0, 1.0, 0.0]);
+        let l2w: [f64; 16] = [
+            1.0, 0.0, 0.0, 10.0, //
+            0.0, 1.0, 0.0, 20.0, //
+            0.0, 0.0, 1.0, 30.0, //
+            0.0, 0.0, 0.0, 1.0,
+        ];
+        m.local_to_world = Some(l2w);
+        m.instance_meta = Some(InstanceMeta {
+            transform: l2w,
+            local_transform: None,
+            canonical_transform: None,
+            rep_identity: 0xDEAD_BEEF,
+            instanceable: true,
+        });
+
+        // Metadata carried; instancing dropped. Assert on every seam.
+        let via_ctor = m.rebuilt_like(vec![0.0, 0.0, 0.0], vec![0.0, 0.0, 1.0], vec![]);
+        let via_subdivide = m.subdivided(1);
+        let via_weld = m.welded_by_position(1e-6);
+
+        for (label, out) in [
+            ("rebuilt_like", &via_ctor),
+            ("subdivided", &via_subdivide),
+            ("welded_by_position", &via_weld),
+        ] {
+            assert_eq!(out.origin, [100.0, 200.0, 300.0], "{label}: origin must carry");
+            assert!(out.rtc_applied, "{label}: rtc_applied must carry");
+            assert_eq!(
+                out.local_bounds,
+                Some([0.0, 0.0, 0.0, 1.0, 1.0, 0.0]),
+                "{label}: local_bounds (#1474) must carry"
+            );
+            assert_eq!(out.local_to_world, Some(l2w), "{label}: local_to_world (#1474) must carry");
+            assert!(
+                out.instance_meta.is_none(),
+                "{label}: instance_meta must be dropped (vertices changed -> not the canonical rep)"
             );
         }
     }

--- a/rust/processing/tests/module_size_allowlist.txt
+++ b/rust/processing/tests/module_size_allowlist.txt
@@ -33,7 +33,8 @@
     1061 rust/geometry/src/csg/mod.rs
      436 rust/geometry/src/csg/normals.rs
      998 rust/geometry/src/extrusion.rs
-     759 rust/geometry/src/facet_weld.rs
+# +4: refine_high_aspect_slivers routes its rebuild through Mesh::rebuilt_like so a slivered host keeps its local-frame origin + #1474 placement capture (B7 metadata-loss fix).
+     763 rust/geometry/src/facet_weld.rs
      408 rust/geometry/src/geom_hash.rs
      641 rust/geometry/src/kernel/arrangement/classify.rs
      566 rust/geometry/src/kernel/fixed.rs


### PR DESCRIPTION
## What

Several mesh-rebuild sites constructed a fresh `Mesh` and copied back only a field or two, silently dropping `origin` (RTC/local-frame), `local_bounds`, and `local_to_world` (#1474 placement capture). The worst was `facet_weld::refine_high_aspect_slivers`, which runs **after** placement inside the void cut and carried only `rtc_applied` — so exactly the hosts whose cuts slivered lost their placement capture.

## Fix

- `Mesh::rebuilt_like(&self, positions, normals, indices)` — fresh geometry buffers carrying `origin`, `rtc_applied`, `local_bounds`, `local_to_world` from `self`.
- **`instance_meta` is invalidated (dropped), not carried**: `rep_identity` is a vertex-invariant 128-bit geometry-identity hash the instance collator dedups on, so carrying it after a vertex-changing rebuild would let a refined mesh be deduped against an unrefined sibling and draw wrong geometry. All three sites change vertices → all drop it, matching the existing void-cut precedent (`voided.instance_meta = None`) and `Mesh::clear()`. (No-op for that field — the old code already nulled it everywhere; the bug was the placement fields.)
- Routes `refine_high_aspect_slivers`, `subdivide_once`, `weld_impl` through it. Early-return no-op paths (clone/empty) untouched.

## Output invariance

**Byte-identical geometry** (positions/normals/indices unchanged) — only metadata carry changed. `geometry_correctness_harness`: 0 snapshot diffs. The `mesh_determinism` manifest (which *does* hash `origin`) passes unchanged → **no re-pin needed** (the fixture's hosts don't sliver / carry zero origin).

## Verification

- `cargo test -p ifc-lite-geometry -p ifc-lite-processing`: 0 failures, incl. the #1474 `local_bounds` capture test, instancing, facet_weld, mesh weld/subdivide. Ratchet: `facet_weld.rs` 759→763 (+4). No wasm API change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)