### PR TITLE
refactor(geometry): surface + document arrange_many non-conformity — union tolerates it (B8)

### DIFF
--- a/rust/geometry/src/kernel/arrangement/boolean.rs
+++ b/rust/geometry/src/kernel/arrangement/boolean.rs
@@ -20,15 +20,33 @@ use num_traits::ToPrimitive;
 /// A sub-triangle of mesh `k` is on `∂(∪meshes)` iff its OUTER side (`+n`) lies
 /// outside every other mesh. Identical co-oriented faces shared by several meshes
 /// (e.g. duplicated cutter prisms) are kept once, owned by the LOWEST mesh index.
-pub fn union_all(meshes: &[&[Tri]]) -> Vec<Tri> {
+///
+/// Returns `(union, conforming)`. `conforming == false` ⇒ the N-way arrangement
+/// left an unrecovered constraint ([`MultiArrangement::unrecovered`]): some
+/// sub-triangle STRADDLES another operand's boundary and its centroid
+/// classification is unreliable, so the union may be TORN. This is the SAME
+/// non-conformity condition [`difference_all`] HARD-REJECTS — surfaced here as a
+/// signal a torn union is distinct from an EMPTY one, where before it was
+/// silently discarded (`arrange_many`'s `_unrecovered`) and indistinguishable.
+///
+/// Unlike `difference_all`, the union still RETURNS its best-effort triangles even
+/// when `!conforming`: its sole caller (the #960 segmented-roof cutter-union via
+/// [`crate::kernel::mesh_bridge::union_many`]) verifies the DOWNSTREAM subtract,
+/// and the exact batched union — even a technically torn one — is a strictly
+/// better cutter than the sequential fallback, which reintroduces the seam sliver
+/// #960 eliminated (House.ifc wall #4148: exact union → correct 8984 mm; the
+/// sequential fallback → a 9850 mm full-height sliver). A caller WITHOUT its own
+/// output verification must treat `!conforming` as "do not trust; fall back."
+pub fn union_all(meshes: &[&[Tri]]) -> (Vec<Tri>, bool) {
     if meshes.is_empty() {
-        return Vec::new();
+        return (Vec::new(), true);
     }
     if meshes.len() == 1 {
-        return meshes[0].to_vec();
+        return (meshes[0].to_vec(), true);
     }
     use std::collections::HashMap;
     let arr = arrange_many(meshes);
+    let conforming = arr.unrecovered == 0;
     let exts: Vec<f64> = meshes.iter().map(|m| operand_extent(m)).collect();
     // Owner map: oriented (winding-preserving) Vid key → lowest mesh index that
     // KEEPS that face. A later mesh's identical co-oriented copy is dropped.
@@ -74,7 +92,7 @@ pub fn union_all(meshes: &[&[Tri]]) -> Vec<Tri> {
             }
         }
     }
-    out
+    (out, conforming)
 }
 
 /// Step `step·n̂` off `c` along the unit-normalised `dir`. Deterministic FMA-free

--- a/rust/geometry/src/kernel/arrangement/mod.rs
+++ b/rust/geometry/src/kernel/arrangement/mod.rs
@@ -256,6 +256,14 @@ pub struct MultiArrangement {
     pub interner: Interner,
     /// `subtris[k]` = mesh `k`'s conforming sub-triangles (interned Vids).
     pub subtris: Vec<Vec<[Vid; 3]>>,
+    /// Total constraint sub-segments the per-mesh re-triangulations could not
+    /// force as edges (summed over every mesh's `Mesh2d::unrecovered`). Non-zero
+    /// ⇒ the operands do not fully conform along their intersections, so a
+    /// straddling sub-triangle's centroid classification in [`union_all`] is
+    /// unreliable (the union can silently tear). Mirrors [`Arrangement::unrecovered`]
+    /// so [`union_all`] can SIGNAL the same non-conformity condition
+    /// [`difference_all`] hard-rejects (it was previously discarded into a `_`).
+    pub unrecovered: usize,
 }
 
 /// Conforming arrangement of `meshes` (N operands) over ONE interner.
@@ -314,6 +322,11 @@ pub fn arrange_many(meshes: &[&[Tri]]) -> MultiArrangement {
     }
     let mut interner = Interner::new();
     let mut subtris = Vec::with_capacity(n);
+    // Accumulate unrecovered constraints across EVERY mesh's re-triangulation
+    // (mirrors the binary `arrange`, which sums over both operands). `union_all`
+    // surfaces any non-zero total as its non-conformity signal, so it must not be
+    // discarded here (it previously was, into a `_unrecovered`).
+    let mut unrecovered = 0usize;
     for k in 0..n {
         let cop_parent: Vec<bool> = cop[k].iter().map(|c| !c.is_empty()).collect();
         let cons: Vec<Vec<Constraint>> = (0..meshes[k].len())
@@ -325,12 +338,11 @@ pub fn arrange_many(meshes: &[&[Tri]]) -> MultiArrangement {
             .collect();
         // `union_all` classifies every sub-triangle against each other mesh via the
         // off-plane `solid_side` probe, so it needs no per-sub coplanar flag here.
-        let mut _unrecovered = 0usize;
         let (tris, _coplanar) =
-            retriangulate_each(meshes[k], &cons, &pts[k], &cop_parent, &mut interner, &mut _unrecovered);
+            retriangulate_each(meshes[k], &cons, &pts[k], &cop_parent, &mut interner, &mut unrecovered);
         subtris.push(tris);
     }
-    MultiArrangement { interner, subtris }
+    MultiArrangement { interner, subtris, unrecovered }
 }
 
 /// Re-triangulate each original triangle over the shared interner. Returns the

--- a/rust/geometry/src/kernel/arrangement/tests.rs
+++ b/rust/geometry/src/kernel/arrangement/tests.rs
@@ -258,7 +258,8 @@ fn nary_union_of_abutting_and_duplicate_prisms_is_watertight() {
     let b2 = box_mesh([2., 0., 0.], [3., 1., 1.]);
     let b1_dup = b1.clone();
     let meshes: Vec<&[Tri]> = vec![&b0, &b1, &b2, &b1_dup];
-    let u = super::union_all(&meshes);
+    let (u, conforming) = super::union_all(&meshes);
+    assert!(conforming, "clean abutting/duplicate prisms must conform (no unrecovered constraints)");
     let (boundary, nonmanifold) = edge_audit(&u);
     assert_eq!(boundary, 0, "N-ary union has {boundary} open boundary edges");
     assert_eq!(nonmanifold, 0, "N-ary union has {nonmanifold} non-manifold edges");

--- a/rust/geometry/src/kernel/mesh_bridge.rs
+++ b/rust/geometry/src/kernel/mesh_bridge.rs
@@ -419,13 +419,20 @@ pub fn union_many(meshes: &[&Mesh]) -> Mesh {
     let tri_lists: Vec<Vec<Tri>> =
         meshes.iter().map(|m| orient_outward(mesh_to_tris(m))).collect();
     let refs: Vec<&[Tri]> = tri_lists.iter().map(|t| t.as_slice()).collect();
-    let out = union_all(&refs);
-    // On a budget trip `arrange_many` bailed and `out` is a PARTIAL arrangement.
-    // Return empty so `build_cutter_union` defers to the sequential per-cutter path
-    // instead of feeding a poisoned (non-watertight) cutter union into the subtract.
+    let (out, conforming) = union_all(&refs);
+    // #1109 budget trip ⇒ `arrange_many` bailed and `out` is PARTIAL; return empty so
+    // `build_cutter_union` defers to the sequential per-cutter path instead of feeding
+    // a poisoned (non-watertight) cutter union into the subtract.
     if super::budget::tripped() {
         return Mesh::new();
     }
+    // `!conforming` ⇒ an unrecovered constraint left the arrangement non-conforming —
+    // `union_all` now SURFACES the condition `difference_all` hard-rejects (vs the old
+    // silent discard). We deliberately trust the union anyway: the sole caller (#960
+    // `build_cutter_union`) verifies the downstream subtract, and the exact batched
+    // union — even a torn one — beats the sequential fallback that reintroduces the
+    // seam sliver #960 removed (wall #4148: exact → 8984 mm; fallback → 9850 mm).
+    let _ = conforming;
     tris_to_mesh(&out)
 }
 

--- a/rust/processing/tests/module_size_allowlist.txt
+++ b/rust/processing/tests/module_size_allowlist.txt
@@ -38,7 +38,8 @@
      641 rust/geometry/src/kernel/arrangement/classify.rs
      566 rust/geometry/src/kernel/fixed.rs
 # +39: begin()/tripped() budget-guard added to the union & intersection kernel entries (#1109 parity with subtract).
-     885 rust/geometry/src/kernel/mesh_bridge.rs
+# +7: union_many threads/documents union_all's new (union, conforming) signal (B8 arrange-many parity).
+     892 rust/geometry/src/kernel/mesh_bridge.rs
      700 rust/geometry/src/kernel/predicates.rs
     1383 rust/geometry/src/kernel/retriangulate.rs
      468 rust/geometry/src/kernel/tritri.rs


### PR DESCRIPTION
## The finding (B8 premise refuted)

The review's B8 asked to make `union_all` hard-reject non-conformity like `difference_all` does. **Empirically, that regresses #960.** Instrumented on House.ifc: wall #4148 (12 cutters) has `unrecovered = 13` and a genuinely torn batched union (214 tris, **16 open boundary edges**) — yet subtracting that torn-but-**exact** union yields the **correct** roof (maxZ 8984mm). Hard-rejecting routes it to the sequential left-deep union (the exact tearing #960 was built to avoid), which reintroduces the seam sliver (maxZ **9850mm**) — strictly *less* correct. **The exact batched union, even non-conforming, is the best available cutter.**

## What this ships (signal-only, zero behavior change)

- `MultiArrangement` gains `unrecovered: usize` (stops discarding it into `_unrecovered`), mirroring binary `arrange` — available for observability and the future root-cause fix.
- `union_all` returns `(tris, conforming)`; `union_many` **trusts** the union and **documents why it must not reject** (the #960 finding), making the `difference_all` (rejects) vs `union_all` (tolerates) asymmetry explicit so it can't be silently "fixed" back into a regression.
- Test asserts clean prisms conform.

## Output invariance

**Byte-identical** — `issue_960_segmented_roof_clip` output unchanged; the boolean manifest is difference-only; no union topology hash → **no re-pin**. 0 tests shifted outcome.

## Open follow-up (out of scope)

The true root-cause fix is to make `arrange_many` actually *recover* those 13 constraints so the union is watertight (`boundary = 0`), after which a hard reject would be safe and never fire. That's a deeper, determinism-sensitive exact-kernel change.

## Verification

- `cargo test -p ifc-lite-geometry kernel`: 75 passed; lib 414; `issue_960` byte-identical; `-p ifc-lite-geometry -p ifc-lite-processing`: 672 passed. Ratchet: `mesh_bridge.rs` 885→892. No wasm API change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)