### PR TITLE
refactor(geometry): single-home duplicated kernel constants + formulas (T4)

### DIFF
--- a/rust/geometry/src/csg/consolidate.rs
+++ b/rust/geometry/src/csg/consolidate.rs
@@ -269,6 +269,7 @@ impl ClippingProcessor {
     /// Returns the input mesh unchanged if the consolidate fails or yields
     /// nothing — never worse than the raw kernel output.
     pub(crate) fn consolidate_coplanar(mesh: Mesh) -> Mesh {
+        use crate::grid::NORMAL_QUANT_F64 as NORMAL_QUANT;
         use crate::triangulation::{
             project_to_2d_with_basis, triangulate_polygon_with_holes_refined,
         };
@@ -293,7 +294,6 @@ impl ClippingProcessor {
         // plane) lets the i_overlay UNION close the opening hole — a bridging facet
         // over the footprint, caught by `issue_1007_real_opening_no_bridge`.
         const POS_QUANT: f64 = 1.0e6;
-        const NORMAL_QUANT: f64 = 1.0e3;
         let qpos = |p: f64| (p * POS_QUANT).round() as i64;
         let qnorm = |n: f64| (n * NORMAL_QUANT).round() as i64;
 

--- a/rust/geometry/src/facet_weld.rs
+++ b/rust/geometry/src/facet_weld.rs
@@ -70,16 +70,17 @@ use crate::mesh::Mesh;
 use std::collections::BTreeMap;
 
 /// f32-snap / kernel-reconcile grid (metres). Power of two ⇒ `(c/G).round()*G`
-/// is an EXACT f64 op, bit-deterministic across targets. Mirrors
-/// `kernel::mesh_bridge::SNAP_GRID` so welded vertices land exactly where the
-/// kernel would snap them anyway.
-const SNAP_GRID: f64 = 1.0 / 65536.0;
+/// is an EXACT f64 op, bit-deterministic across targets. The kernel's own
+/// canonical grid, so welded vertices land exactly where the kernel would
+/// snap them anyway.
+use crate::kernel::mesh_bridge::SNAP_GRID;
 
 /// Normal-direction quantisation for the plane bucket. 1e3 ⇒ ~0.057° resolution
-/// — matches `consolidate_coplanar`'s `NORMAL_QUANT` so a weld merges exactly
-/// the facets that bucket would otherwise scatter. A real roof pitch / dormer
-/// has a distinct normal bucket and never clusters with the slope.
-const NORMAL_QUANT: f64 = 1.0e3;
+/// — the shared grid also used by `consolidate_coplanar`'s `NORMAL_QUANT`, so
+/// a weld merges exactly the facets that bucket would otherwise scatter. A
+/// real roof pitch / dormer has a distinct normal bucket and never clusters
+/// with the slope.
+use crate::grid::NORMAL_QUANT_F64 as NORMAL_QUANT;
 
 /// Max plane-offset jitter (metres) for two same-normal facets to weld into one
 /// plane cluster. 50 µm comfortably spans the ~15 µm f32 offset jitter but is

--- a/rust/geometry/src/geom_hash.rs
+++ b/rust/geometry/src/geom_hash.rs
@@ -42,9 +42,11 @@
 /// the `tolerance_sweep` test against real revision pairs.
 pub const DEFAULT_GEOM_HASH_TOLERANCE: f64 = 1.0e-3;
 
-/// splitmix64 finalizer — strong avalanche for a single `u64`.
+/// splitmix64 finalizer — strong avalanche for a single `u64`. Shared with
+/// `router::content_hash`'s 128-bit content hash, which uses this SAME
+/// finalizer per lane.
 #[inline]
-fn mix64(mut x: u64) -> u64 {
+pub(crate) fn mix64(mut x: u64) -> u64 {
     x = (x ^ (x >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
     x = (x ^ (x >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
     x ^ (x >> 31)

--- a/rust/geometry/src/grid.rs
+++ b/rust/geometry/src/grid.rs
@@ -1,0 +1,21 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Shared float-noise-tolerance quantisation constants used by more than one
+//! geometry pass. Single-sourced so two independently-evolving passes (e.g. a
+//! weld and the plane-bucketing it feeds) can never drift apart on the SAME
+//! tolerance — see `kernel::mesh_bridge::SNAP_GRID` for the kernel's own
+//! canonical snap grid (that one stays defined in `kernel::mesh_bridge`, since
+//! it is already the kernel's documented canonical constant).
+
+/// Normal-direction quantisation grid (`f64`): a normal component is
+/// multiplied by this and rounded to an integer before bucketing/keying. 1e3
+/// gives ~0.057° resolution. Shared by `facet_weld`'s per-facet plane
+/// clustering and `csg::consolidate`'s plane-bucket key, so a bucket boundary
+/// can never disagree between the two passes.
+pub(crate) const NORMAL_QUANT_F64: f64 = 1.0e3;
+
+/// Same quantisation grid as [`NORMAL_QUANT_F64`], as `f32` for callers
+/// (`mesh_weld`) that key directly off `Mesh`'s f32 normals.
+pub(crate) const NORMAL_QUANT_F32: f32 = 1.0e3;

--- a/rust/geometry/src/kernel/arrangement/classify.rs
+++ b/rust/geometry/src/kernel/arrangement/classify.rs
@@ -196,20 +196,13 @@ fn near_on_surface_tri(c: [f64; 3], t: &Tri, band2: f64) -> Option<[f64; 3]> {
     point_in_tri_proj(c, t, n).then_some(n)
 }
 
-/// The near-coplanar perpendicular band (see [`near_on_surface_normal`]) from the
-/// operand+`c` coordinate magnitude `extent`.
-fn near_band_from_extent(extent: f64) -> f64 {
-    (8.0 * SNAP_GRID).max(extent * (1.0 / 4_194_304.0))
-}
-
 fn on_surface_normal(c: [f64; 3], others: &[Tri]) -> Option<[f64; 3]> {
     others.iter().find_map(|t| on_surface_tri(c, t))
 }
 
-/// Power-of-two grid `mesh_bridge` snaps both operands to (metres); the
-/// `near_on_surface_normal` band below is sized to the scatter this snap
-/// leaves on a TILTED flush face.
-use super::super::mesh_bridge::SNAP_GRID;
+/// Canonical near-coplanar band formula (see [`near_on_surface_normal`]),
+/// defined once in `mesh_bridge` next to the `SNAP_GRID` it is sized from.
+use super::super::mesh_bridge::near_band_from_extent;
 
 /// The NEAR-coplanar analogue of [`on_surface_normal`], used ONLY for a
 /// sub-triangle whose parent face had a near-coplanar overlap with the other
@@ -336,7 +329,7 @@ impl<'a> BComponents<'a> {
         // AABB; also dwarfs any f64 rounding in the slab test. Deterministic
         // FMA-free f64.
         let max_ext = exts.iter().cloned().fold(1.0f64, f64::max);
-        let pad = 4.0 * (8.0 * SNAP_GRID).max(max_ext * (1.0 / 4_194_304.0));
+        let pad = 4.0 * near_band_from_extent(max_ext);
         let aabbs = comps
             .iter()
             .map(|c| {

--- a/rust/geometry/src/kernel/mesh_bridge.rs
+++ b/rust/geometry/src/kernel/mesh_bridge.rs
@@ -27,6 +27,18 @@ fn snap(c: f64) -> f64 {
     (c / SNAP_GRID).round() * SNAP_GRID
 }
 
+/// The near-coplanar perpendicular band (metres) from the operand+point
+/// coordinate magnitude `extent`. `8·SNAP_GRID` is the per-axis-snap scatter
+/// envelope near the origin; the `extent·2⁻²²` term widens it for far-from-
+/// origin operands where f32 import is coarser.
+///
+/// Canonical definition — `tritri`, `classify`, and this module all size their
+/// near-coplanar/scatter bands to this SAME formula, so they call this
+/// function rather than mirroring the expression.
+pub(crate) fn near_band_from_extent(extent: f64) -> f64 {
+    (8.0 * SNAP_GRID).max(extent * (1.0 / 4_194_304.0))
+}
+
 /// `Mesh` → the kernel's triangle list (f32 → f64, snapped to the reconcile
 /// grid). Panic-free: an out-of-range index OR a non-finite (NaN/Inf) coord drops
 /// that triangle rather than indexing past the end or crashing
@@ -203,7 +215,7 @@ fn promote_cutter_verts_onto_host_faces(cutter: &mut [Tri], host: &[Tri]) {
             }
         }
     }
-    let band = (8.0 * SNAP_GRID).max(extent * (1.0 / 4_194_304.0));
+    let band = near_band_from_extent(extent);
     let band2 = band * band;
 
     struct Face {

--- a/rust/geometry/src/kernel/tritri.rs
+++ b/rust/geometry/src/kernel/tritri.rs
@@ -146,9 +146,9 @@ fn plane_interval(tri: &[[f64; 3]; 3], plane: &[[f64; 3]; 3]) -> PlaneInterval {
     }
 }
 
-/// Snap grid used by `mesh_bridge::mesh_to_tris` (metres, power of two). The
-/// near-coplanar band below is sized to the snap-scatter envelope it produces.
-use super::mesh_bridge::SNAP_GRID;
+/// Near-coplanar band formula, canonical in `mesh_bridge` (sized to the
+/// snap-scatter envelope `mesh_bridge::mesh_to_tris` produces).
+use super::mesh_bridge::near_band_from_extent;
 
 #[inline]
 fn ti_sub(a: [f64; 3], b: [f64; 3]) -> [f64; 3] {
@@ -221,7 +221,7 @@ fn near_coplanar(t1: &[[f64; 3]; 3], t2: &[[f64; 3]; 3]) -> bool {
             extent = extent.max(c.abs());
         }
     }
-    let band = (8.0 * SNAP_GRID).max(extent * (1.0 / 4_194_304.0)); // 2^-22
+    let band = near_band_from_extent(extent); // 2^-22
     let band2 = band * band;
     // All three vertices of `t` within `band` of `plane`'s supporting plane?
     let in_slab = |t: &[[f64; 3]; 3], plane: &[[f64; 3]; 3], n: [f64; 3], nn: f64| {

--- a/rust/geometry/src/lib.rs
+++ b/rust/geometry/src/lib.rs
@@ -97,6 +97,10 @@ pub(crate) mod diag;
 pub(crate) mod diagnostics;
 pub(crate) mod error;
 pub(crate) mod geom_hash;
+/// Shared float-noise-tolerance quantisation constants used by more than one
+/// geometry pass (single-sourced so independently-evolving passes can't drift
+/// apart on the same tolerance).
+pub(crate) mod grid;
 pub(crate) mod extrusion;
 pub(crate) mod instancing;
 /// Pure-Rust exact mesh-arrangement CSG kernel — the only CSG kernel, on

--- a/rust/geometry/src/mesh.rs
+++ b/rust/geometry/src/mesh.rs
@@ -700,10 +700,9 @@ impl Mesh {
     /// extreme scale. NaN/Inf triangles are kept (the comparison is false),
     /// i.e. non-finite geometry is left for upstream to handle, never dropped.
     pub fn clean_degenerate(&mut self) {
-        // 1/65536 m — matches kernel::mesh_bridge::SNAP_GRID (power-of-two for
+        // The kernel's canonical reconcile grid (power-of-two for
         // bit-determinism). Sub-grid triangles are below kernel resolution.
-        const RECONCILE_GRID: f64 = 1.0 / 65536.0;
-        self.drop_thin_triangles(RECONCILE_GRID);
+        self.drop_thin_triangles(crate::kernel::mesh_bridge::SNAP_GRID);
     }
 
     /// Drop triangles with ANY vertex outside `[min - pad, max + pad]`, then

--- a/rust/geometry/src/mesh_weld.rs
+++ b/rust/geometry/src/mesh_weld.rs
@@ -40,11 +40,11 @@ use rustc_hash::FxHashMap;
 use std::cell::RefCell;
 
 /// Normal quantization grid: components are multiplied by this and rounded to an
-/// integer before keying. Matches [`crate::facet_weld`]'s `NORMAL_QUANT` and the
-/// `consolidate_coplanar` grid, so the weld merges exactly the f32-jittered
-/// coplanar normals while keeping any real crease (normals that differ by more
-/// than ~1e-3 in a component) split.
-const NORMAL_QUANT: f32 = 1.0e3;
+/// integer before keying. The shared grid also used by [`crate::facet_weld`]'s
+/// `NORMAL_QUANT` and the `consolidate_coplanar` grid, so the weld merges
+/// exactly the f32-jittered coplanar normals while keeping any real crease
+/// (normals that differ by more than ~1e-3 in a component) split.
+use crate::grid::NORMAL_QUANT_F32 as NORMAL_QUANT;
 
 /// UV quantization grid (~0.001 texel-fraction resolution). Coarse enough to
 /// merge f32 UV jitter on a shared corner, far finer than any real texture seam

--- a/rust/geometry/src/rect_fast.rs
+++ b/rust/geometry/src/rect_fast.rs
@@ -30,9 +30,9 @@
 
 use crate::mesh::Mesh;
 
-/// The kernel's reconcile grid (mesh_bridge::SNAP_GRID). Power of two ⇒ the snap
-/// is an exact f64 op ⇒ bit-deterministic native==wasm.
-const SNAP_GRID: f64 = 1.0 / 65536.0;
+/// The kernel's canonical reconcile grid. Power of two ⇒ the snap is an exact
+/// f64 op ⇒ bit-deterministic native==wasm.
+use crate::kernel::mesh_bridge::SNAP_GRID;
 
 #[inline]
 fn snap(c: f64) -> f64 {

--- a/rust/geometry/src/router/content_hash.rs
+++ b/rust/geometry/src/router/content_hash.rs
@@ -27,6 +27,7 @@
 //! ordering beyond the bit pattern), so native x86_64/aarch64 and wasm32 produce
 //! identical keys.
 
+use crate::geom_hash::mix64;
 use ifc_lite_core::EntityDecoder;
 use rustc_hash::FxHashMap;
 
@@ -46,14 +47,6 @@ const CYCLE_SENTINEL: u128 = 0xC1C1_C1C1_C1C1_C1C1_C1C1_C1C1_C1C1_C1C1;
 /// seed so a brep hashed via the fast path and one hashed via the recursive
 /// fallback occupy disjoint key space and never false-merge.
 const FACETED_BREP_TAG: u64 = 0xFACE_7B16_5160_0001;
-
-#[inline]
-fn mix64(mut x: u64) -> u64 {
-    // splitmix64 finalizer — strong avalanche, same as `geom_hash::mix64`.
-    x = (x ^ (x >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
-    x = (x ^ (x >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
-    x ^ (x >> 31)
-}
 
 /// Fold a 64-bit value into a 128-bit running state across two independent lanes.
 #[inline]

--- a/rust/geometry/src/router/voids/mod.rs
+++ b/rust/geometry/src/router/voids/mod.rs
@@ -34,6 +34,11 @@ const CSG_TRIANGLE_RETENTION_DIVISOR: usize = 4;
 const MIN_VALID_TRIANGLES: usize = 4;
 /// Maximum wrapper depth when drilling through mapped/boolean items to find an extrusion.
 const MAX_EXTRUSION_EXTRACT_DEPTH: usize = 32;
+/// Per-axis AABB engulf slack shared by the batched, host-consumed, and
+/// rectangular-fallback engulf checks below, so the three guards can't drift
+/// apart on what counts as "engulfs the host".
+const ENGULF_TOLERANCE: f64 = 0.03;
+const ENGULF_TOLERANCE_F32: f32 = 0.03;
 
 
 
@@ -1361,7 +1366,7 @@ impl GeometryRouter {
                 // near-engulf and redundant-void guards live — batched it can
                 // shave the host's outer shell (the #559171-family residual).
                 let engulfs = {
-                    let tol = 0.03_f64;
+                    let tol = ENGULF_TOLERANCE;
                     let covers = |omin: f64, omax: f64, wmin: f64, wmax: f64| {
                         let slack = (wmax - wmin).abs().max(1.0e-9) * tol;
                         omin <= wmin + slack && omax >= wmax - slack
@@ -1578,7 +1583,7 @@ impl GeometryRouter {
                     // host while its real profile excludes it is not affected.
                     // On a hit the host is fully consumed.
                     let aabb_engulfs = {
-                        let tol = 0.03_f32;
+                        let tol = ENGULF_TOLERANCE_F32;
                         let covers = |omin: f32, omax: f32, hmin: f32, hmax: f32| {
                             let slack = (hmax - hmin).abs().max(1.0e-9) * tol;
                             omin <= hmin + slack && omax >= hmax - slack
@@ -1682,7 +1687,7 @@ impl GeometryRouter {
                         // The 3% per-axis tolerance absorbs an opening that reaches
                         // ~flush with a wall face (its near plane).
                         let engulfs_host = {
-                            let tol = 0.03_f64;
+                            let tol = ENGULF_TOLERANCE;
                             let covers = |omin: f64, omax: f64, wmin: f64, wmax: f64| {
                                 let slack = (wmax - wmin).abs().max(1.0e-9) * tol;
                                 omin <= wmin + slack && omax >= wmax - slack

--- a/rust/geometry/src/router/voids/reveal_tests.rs
+++ b/rust/geometry/src/router/voids/reveal_tests.rs
@@ -50,45 +50,6 @@
         );
     }
 
-    /// Build a simple box mesh (12 triangles) for testing.
-    #[allow(dead_code)]
-    fn make_box_mesh(min: Point3<f64>, max: Point3<f64>) -> Mesh {
-        let mut m = Mesh::with_capacity(24, 36);
-
-        let corners = [
-            Point3::new(min.x, min.y, min.z), // 0
-            Point3::new(max.x, min.y, min.z), // 1
-            Point3::new(max.x, max.y, min.z), // 2
-            Point3::new(min.x, max.y, min.z), // 3
-            Point3::new(min.x, min.y, max.z), // 4
-            Point3::new(max.x, min.y, max.z), // 5
-            Point3::new(max.x, max.y, max.z), // 6
-            Point3::new(min.x, max.y, max.z), // 7
-        ];
-
-        // 6 faces × 4 vertices each with face normals
-        let faces: [(Vector3<f64>, [usize; 4]); 6] = [
-            // Parity-sweep fix: [0, 2, 1, 3] was a crossed (bowtie) quad —
-            // see the sibling `make_box_mesh` above for the full rationale.
-            (Vector3::new(0.0, 0.0, -1.0), [0, 3, 2, 1]), // -Z
-            (Vector3::new(0.0, 0.0, 1.0), [4, 5, 6, 7]),  // +Z
-            (Vector3::new(0.0, -1.0, 0.0), [0, 1, 5, 4]), // -Y
-            (Vector3::new(0.0, 1.0, 0.0), [2, 3, 7, 6]),  // +Y
-            (Vector3::new(-1.0, 0.0, 0.0), [0, 4, 7, 3]), // -X
-            (Vector3::new(1.0, 0.0, 0.0), [1, 2, 6, 5]),  // +X
-        ];
-        for (n, idx) in &faces {
-            let b = m.vertex_count() as u32;
-            m.add_vertex(corners[idx[0]], *n);
-            m.add_vertex(corners[idx[1]], *n);
-            m.add_vertex(corners[idx[2]], *n);
-            m.add_vertex(corners[idx[3]], *n);
-            m.add_triangle(b, b + 1, b + 2);
-            m.add_triangle(b, b + 2, b + 3);
-        }
-        m
-    }
-
     fn make_framed_box_mesh(
         origin: Point3<f64>,
         depth_axis: Vector3<f64>,
@@ -115,7 +76,7 @@
         let mut m = Mesh::with_capacity(24, 36);
         let faces: [[usize; 4]; 6] = [
             // Parity-sweep fix: [0, 2, 1, 3] was a crossed (bowtie) quad —
-            // see `make_box_mesh` above for the full rationale.
+            // see `synthesis::make_box_mesh` for the full rationale.
             [0, 3, 2, 1],
             [4, 5, 6, 7],
             [0, 1, 5, 4],

--- a/rust/processing/tests/module_size_allowlist.txt
+++ b/rust/processing/tests/module_size_allowlist.txt
@@ -33,13 +33,16 @@
      947 rust/geometry/src/csg/mod.rs
      998 rust/geometry/src/extrusion.rs
 # +4: refine_high_aspect_slivers routes its rebuild through Mesh::rebuilt_like so a slivered host keeps its local-frame origin + #1474 placement capture (B7 metadata-loss fix).
-     763 rust/geometry/src/facet_weld.rs
-     408 rust/geometry/src/geom_hash.rs
-     640 rust/geometry/src/kernel/arrangement/classify.rs
+# +1: SNAP_GRID/NORMAL_QUANT single-homed to kernel::mesh_bridge / crate::grid (import replaces local const; doc rewrap costs a line).
+     764 rust/geometry/src/facet_weld.rs
+# +2: mix64 made pub(crate); doc-comment noting the shared use by router::content_hash.
+     410 rust/geometry/src/geom_hash.rs
+     633 rust/geometry/src/kernel/arrangement/classify.rs
      566 rust/geometry/src/kernel/fixed.rs
 # +39: begin()/tripped() budget-guard added to the union & intersection kernel entries (#1109 parity with subtract).
 # +7: union_many threads/documents union_all's new (union, conforming) signal (B8 arrange-many parity).
-     892 rust/geometry/src/kernel/mesh_bridge.rs
+# +12: near_band_from_extent (the snap-scatter band formula) single-homed here, next to canonical SNAP_GRID; tritri/classify import it instead of mirroring the expression.
+     904 rust/geometry/src/kernel/mesh_bridge.rs
      700 rust/geometry/src/kernel/predicates.rs
     1261 rust/geometry/src/kernel/retriangulate.rs
     1529 rust/geometry/src/mesh.rs
@@ -69,7 +72,8 @@
 # admission gate and the sequential CSG path so they can't diverge on the
 # High/Highest small-opening floor (B11 regression, issue #976).
 # +32: engulf-cutter #635 AABB box-cut suppression on a #1109 budget trip (drop `!capped`) + its rewritten rationale comment and a diag_warn! else-branch (correctness: an engulfing box-cut would DELETE the host).
-    1931 rust/geometry/src/router/voids/mod.rs
+# +5: ENGULF_TOLERANCE / ENGULF_TOLERANCE_F32 single-homed (3 sites shared one literal 0.03 tolerance, now one named const each).
+    1936 rust/geometry/src/router/voids/mod.rs
      621 rust/geometry/src/router/voids/probe.rs
     1002 rust/geometry/src/router/voids/synthesis.rs
     1472 rust/geometry/src/space_dcel/mod.rs


### PR DESCRIPTION
Byte-identical de-duplication of load-bearing constants/formulas whose equality is a correctness invariant but was coupled only by "mirrors X" comments. **The determinism manifests are unchanged — that is the acceptance criterion.**

## Unified (5)

- **Snap-scatter band** `(8*SNAP_GRID).max(extent/4194304)`: `near_band_from_extent` promoted to `pub(crate)`; `mesh_bridge`/`tritri`/`classify` call it (identical eval order — inner expr first, then the `*4.0` at the classify site).
- **SNAP_GRID**: `facet_weld`, `rect_fast`, `mesh.rs` (`RECONCILE_GRID`) import the canonical one.
- **NORMAL_QUANT**: new `grid.rs` with `NORMAL_QUANT_F64`/`NORMAL_QUANT_F32` (both `1.0e3`, **no cast between them** — avoids f64→f32 double-rounding); imported via aliases.
- **Engulf tolerance** `0.03`: `ENGULF_TOLERANCE` + `_F32` consts; 3 sites use them.
- **mix64**: `geom_hash::mix64` → `pub(crate)`; `content_hash` imports it (private copy deleted).
- Deleted a dead byte-identical `make_box_mesh` copy in `reveal_tests.rs`.

## Skipped (eval-order safety — reported, not forced)

- `make_box_mesh` vs `make_obb_mesh`: hardcoded axis normals vs cross-product `try_normalize` — routing one through the other changes the f64 path.
- The 4 watertightness edge-pairing fns: genuinely different quantizers (exact f32 bits / 1e-4 / pre-weld / 1e-3) **and** edge semantics (signed balance / undirected count / open-edge count / bool) — not unifiable without behavior change.

## Verification

- `cargo test --workspace`: all green incl `mesh_determinism` (pinned manifest, stable-across-reruns, wasm trig-gap) — **zero output/assertion changes**. Net −26 lines. Ratchet re-pinned. No wasm API change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved geometry consistency by sharing snapping, quantization, and tolerance values across multiple processing paths.
  * Reduced mismatches in near-coplanar and coplanar handling, helping prevent subtle edge-case classification issues.
  * Unified hashing behavior so related routing and geometry code now use the same hash logic.
  * Tightened void-subtraction and mesh cleanup checks for more reliable results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->