### PR TITLE
fix(ci): bump IfcOpenShell parity pin 0.8.2 -> 0.8.5 (aarch64 wheel)

### DIFF
--- a/tools/ifcopenshell_reference/requirements.lock
+++ b/tools/ifcopenshell_reference/requirements.lock
@@ -1,3 +1,9 @@
-ifcopenshell==0.8.2
+# IfcOpenShell dropped Linux aarch64 wheels for 0.8.2/0.8.3 (the arm CI runner
+# could no longer resolve 0.8.2); 0.8.4 is the earliest release with an
+# aarch64/py3.12 wheel. Pinned to the latest available patch. The nightly
+# `full` job regenerates the reference dumps from this engine, so a pin bump is
+# a reviewed change - it warns (does not fail) when the committed reference
+# goes stale.
+ifcopenshell==0.8.5
 numpy==2.0.2
 shapely==2.0.7


### PR DESCRIPTION
## Problem

The nightly **IfcOpenShell parity** `full` job ([failing run](https://github.com/LTplus-AG/ifc-lite/actions/runs/28697749983/job/85111793332)) died at the reference-engine install step:

```
ERROR: Could not find a version that satisfies the requirement ifcopenshell==0.8.2
       (from versions: 0.8.4, 0.8.4.post1, 0.8.5)
ERROR: No matching distribution found for ifcopenshell==0.8.2
```

The job runs on `ubuntu-24.04-arm` (Linux aarch64, py3.12). PyPI ships **no aarch64 wheel** for `ifcopenshell` 0.8.2 or 0.8.3 (verified: 0 aarch64 files for either). `0.8.4` is the first release with a `py312 manylinux_2_31 aarch64` wheel, so pip could only offer 0.8.4/0.8.4.post1/0.8.5.

## Fix

Bump the pin in `tools/ifcopenshell_reference/requirements.lock` to the latest available patch, `0.8.5`, with a comment recording why. `numpy`/`shapely` pins are unchanged (0.8.5 declares unpinned `numpy`/`shapely` deps, so 2.0.2 / 2.0.7 still satisfy).

## Blast radius

- The `full` job **regenerates** the reference dumps from the pinned engine, so the bump is a reviewed engine change, not a silent one. If 0.8.5 geometry diverges from the committed 0.8.2 reference for any corpus model, the job emits a **non-fatal** `::warning:: committed reference is stale` (it does not fail on staleness).
- The per-PR **required `quick` lane** does not install the engine; it compares ifc-lite against the committed 0.8.2 reference and is untouched by this change.
- Not a published package (`tools/ifcopenshell_reference` is out-of-band tooling, not a pnpm/Cargo workspace member) so no changeset.