### PR TITLE
feat(lists): federation-identity columns (model + leveled spatial) [#1591]

### DIFF
--- a/.changeset/federation-identity-list-columns.md
+++ b/.changeset/federation-identity-list-columns.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/lists": minor
+---
+
+Add federation-identity list columns: a `model` source (source file / model name) and a leveled `spatial` source whose `propertyName` selects `Storey` (default), `Building`, `Site`, or `Project`. Lets a list over several federated models be grouped, sorted, filtered, and exported by which project/site/building/file each row comes from (issue #1591). `ListDataProvider` gains optional `getModelName` / `getProjectName` / `getSiteName` / `getBuildingName` accessors; existing storey-only `spatial` columns keep resolving the storey name.

--- a/apps/viewer/src/components/viewer/lists/ListBuilder.tsx
+++ b/apps/viewer/src/components/viewer/lists/ListBuilder.tsx
@@ -20,7 +20,7 @@ import { ComboInput } from '@/components/ui/combo-input';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Badge } from '@/components/ui/badge';
 import { cn } from '@/lib/utils';
-import { IfcTypeEnum } from '@ifc-lite/data';
+import { IfcTypeEnum, isBuildingLikeSpatialType, type SpatialNode } from '@ifc-lite/data';
 import type { IfcDataStore } from '@ifc-lite/parser';
 import {
   discoverFilterValues,
@@ -107,10 +107,17 @@ const SELECTABLE_TYPES: { type: IfcTypeEnum; label: string }[] = [
 /** Column descriptor shared by the quick-add grid. */
 interface CommonColumn { id: string; source: ColumnDefinition['source']; propertyName: string; label: string }
 
+/** Spatial-container levels a `spatial` column / filter can target, coarse →
+ *  fine written the other way: Storey is the default (back-compat). */
+const SPATIAL_LEVELS = ['Storey', 'Building', 'Site', 'Project'] as const;
+
 /**
  * The first-class columns: built-in attributes plus the spatial / semantic
- * columns. Surfaced as a flat grid so Material / Classification / Storey
- * are as reachable as Name / Class — not buried in a collapsed group.
+ * columns. Surfaced as a flat grid so Material / Classification / Storey /
+ * Site / Building / Project / Model are as reachable as Name / Class — not
+ * buried in a collapsed group. Site / Building / Project / Model identify which
+ * federated file (and where in its spatial tree) each row comes from, so a list
+ * over several models can be grouped and sorted by source (issue #1591).
  */
 const COMMON_COLUMNS: CommonColumn[] = [
   ...ENTITY_ATTRIBUTES.map((a): CommonColumn => ({
@@ -122,6 +129,10 @@ const COMMON_COLUMNS: CommonColumn[] = [
   { id: 'col-material', source: 'material', propertyName: 'Material', label: 'Material' },
   { id: 'col-classification', source: 'classification', propertyName: 'Classification', label: 'Classification' },
   { id: 'col-storey', source: 'spatial', propertyName: 'Storey', label: 'Storey' },
+  { id: 'col-building', source: 'spatial', propertyName: 'Building', label: 'Building' },
+  { id: 'col-site', source: 'spatial', propertyName: 'Site', label: 'Site' },
+  { id: 'col-project', source: 'spatial', propertyName: 'Project', label: 'Project' },
+  { id: 'col-model', source: 'model', propertyName: 'Model', label: 'Model' },
 ];
 
 /** Union the per-provider complete-discovery results into one column set. */
@@ -185,6 +196,41 @@ export function ListBuilder({ providers, stores, initial, onSave, onCancel, onEx
     }
     return Array.from(set).sort();
   }, [stores]);
+
+  // Spatial-filter value suggestions per level. Storey reuses the index-derived
+  // names above; Building / Site / Project come from a cheap spatial-tree walk
+  // (only the handful of container nodes, no element sampling).
+  const spatialNamesByLevel = useMemo<Record<string, string[]>>(() => {
+    const building = new Set<string>();
+    const site = new Set<string>();
+    const project = new Set<string>();
+    for (const store of stores) {
+      const root = store.spatialHierarchy?.project;
+      if (!root) continue;
+      // Resolve real IFC Names (empty for unnamed containers) so the suggestions
+      // match the column values, never the `Entity #N` node placeholder.
+      const walk = (node: SpatialNode) => {
+        const nm = store.entities.getName(node.expressId);
+        if (nm) {
+          if (isBuildingLikeSpatialType(node.type)) building.add(nm);
+          else if (node.type === IfcTypeEnum.IfcSite) site.add(nm);
+          else if (node.type === IfcTypeEnum.IfcProject) project.add(nm);
+        }
+        for (const c of node.children) walk(c);
+      };
+      walk(root);
+    }
+    const sorted = (s: Set<string>) => Array.from(s).sort();
+    return { Storey: storeyNames, Building: sorted(building), Site: sorted(site), Project: sorted(project) };
+  }, [stores, storeyNames]);
+
+  // Loaded model / file names — value suggestions for a `Model` filter, and the
+  // discriminator the Model column surfaces (issue #1591).
+  const modelNames = useMemo<string[]>(() => {
+    const set = new Set<string>();
+    for (const p of providers) { const n = p.getModelName?.(); if (n) set.add(n); }
+    return Array.from(set).sort();
+  }, [providers]);
   const [groupByColumnId, setGroupByColumnId] = useState<string>(initial?.grouping?.columnId ?? '');
   const [sumColumnIds, setSumColumnIds] = useState<Set<string>>(
     new Set(initial?.grouping?.sumColumnIds ?? [])
@@ -384,7 +430,8 @@ export function ListBuilder({ providers, stores, initial, onSave, onCancel, onEx
               conditions={conditions}
               discovered={discovered}
               values={conditionValues}
-              storeys={storeyNames}
+              spatialNames={spatialNamesByLevel}
+              modelNames={modelNames}
               onAdd={addCondition}
               onUpdate={updateCondition}
               onRemove={removeCondition}
@@ -522,7 +569,7 @@ function SelectedColumns({
             {col.label ?? col.propertyName}
             {col.psetName && <span className="ml-1 font-normal text-muted-foreground">· {col.psetName}</span>}
           </span>
-          <ColSourceTag source={col.source} />
+          <ColSourceTag col={col} />
           <button
             onClick={() => onMove(idx, -1)}
             disabled={idx === 0}
@@ -559,12 +606,20 @@ const SOURCE_TAG: Record<ColumnDefinition['source'], string> = {
   material: 'mat',
   classification: 'cls',
   spatial: 'storey',
+  model: 'model',
 };
 
-function ColSourceTag({ source }: { source: ColumnDefinition['source'] }) {
+/** A `spatial` column's tag reflects its level (storey / building / site /
+ *  project); everything else uses the flat per-source tag. */
+function colSourceTag(col: ColumnDefinition): string {
+  if (col.source === 'spatial') return (col.propertyName || 'Storey').toLowerCase();
+  return SOURCE_TAG[col.source];
+}
+
+function ColSourceTag({ col }: { col: ColumnDefinition }) {
   return (
     <span className="shrink-0 rounded bg-muted px-1 text-[9px] font-medium uppercase tracking-wide text-muted-foreground">
-      {SOURCE_TAG[source]}
+      {colSourceTag(col)}
     </span>
   );
 }
@@ -783,7 +838,8 @@ const CONDITION_SOURCES: { source: ConditionSource; label: string }[] = [
   { source: 'quantity', label: 'Quantity' },
   { source: 'material', label: 'Material' },
   { source: 'classification', label: 'Classification' },
-  { source: 'spatial', label: 'Storey' },
+  { source: 'spatial', label: 'Spatial' },
+  { source: 'model', label: 'Model' },
 ];
 
 const OPERATOR_LABEL: Record<ConditionOperator, string> = {
@@ -821,6 +877,8 @@ function defaultConditionFor(source: ConditionSource): PropertyCondition {
       return { source, propertyName: 'Classification', operator: 'contains', value: '' };
     case 'spatial':
       return { source, propertyName: 'Storey', operator: 'equals', value: '' };
+    case 'model':
+      return { source, propertyName: 'Model', operator: 'equals', value: '' };
     case 'attribute':
     default:
       return { source: 'attribute', propertyName: 'Name', operator: 'contains', value: '' };
@@ -834,7 +892,8 @@ function ConditionsBody({
   conditions,
   discovered,
   values,
-  storeys,
+  spatialNames,
+  modelNames,
   onAdd,
   onUpdate,
   onRemove,
@@ -842,7 +901,8 @@ function ConditionsBody({
   conditions: PropertyCondition[];
   discovered: DiscoveredColumns;
   values: ListConditionValues | null;
-  storeys: string[];
+  spatialNames: Record<string, string[]>;
+  modelNames: string[];
   onAdd: (condition: PropertyCondition) => void;
   onUpdate: (idx: number, condition: PropertyCondition) => void;
   onRemove: (idx: number) => void;
@@ -855,7 +915,8 @@ function ConditionsBody({
           condition={condition}
           discovered={discovered}
           values={values}
-          storeys={storeys}
+          spatialNames={spatialNames}
+          modelNames={modelNames}
           onChange={(next) => onUpdate(idx, next)}
           onRemove={() => onRemove(idx)}
         />
@@ -874,14 +935,16 @@ function ConditionRow({
   condition,
   discovered,
   values,
-  storeys,
+  spatialNames,
+  modelNames,
   onChange,
   onRemove,
 }: {
   condition: PropertyCondition;
   discovered: DiscoveredColumns;
   values: ListConditionValues | null;
-  storeys: string[];
+  spatialNames: Record<string, string[]>;
+  modelNames: string[];
   onChange: (next: PropertyCondition) => void;
   onRemove: () => void;
 }) {
@@ -889,6 +952,7 @@ function ConditionRow({
   const showValue = condition.operator !== 'exists';
   const isProperty = condition.source === 'property';
   const isQuantity = condition.source === 'quantity';
+  const isSpatial = condition.source === 'spatial';
   const showSetFields = isProperty || isQuantity;
 
   const setNameOptions = useMemo<string[]>(() => {
@@ -910,16 +974,18 @@ function ConditionRow({
         return values?.propertyValues.get(propValueKey(condition.psetName ?? '', condition.propertyName)) ?? NO_OPTIONS;
       case 'material': return values?.materials ?? NO_OPTIONS;
       case 'classification': return values?.classifications ?? NO_OPTIONS;
-      case 'spatial': return storeys;
+      case 'spatial': return spatialNames[condition.propertyName] ?? spatialNames.Storey ?? NO_OPTIONS;
+      case 'model': return modelNames;
       default: return NO_OPTIONS;
     }
-  }, [condition.source, condition.psetName, condition.propertyName, values, storeys]);
+  }, [condition.source, condition.psetName, condition.propertyName, values, spatialNames, modelNames]);
 
   const valuePlaceholder =
-    condition.source === 'spatial' ? 'storey name'
-      : condition.source === 'material' ? 'material'
-        : condition.source === 'classification' ? 'code or name'
-          : 'value';
+    condition.source === 'spatial' ? `${(condition.propertyName || 'Storey').toLowerCase()} name`
+      : condition.source === 'model' ? 'model / file'
+        : condition.source === 'material' ? 'material'
+          : condition.source === 'classification' ? 'code or name'
+            : 'value';
 
   return (
     <div className="flex flex-wrap items-center gap-1.5 rounded-md border border-border/60 bg-card px-2 py-1.5 text-xs">
@@ -943,6 +1009,19 @@ function ConditionRow({
         >
           {ENTITY_ATTRIBUTES.map((a) => (
             <option key={a} value={a}>{a}</option>
+          ))}
+        </select>
+      )}
+
+      {isSpatial && (
+        <select
+          value={condition.propertyName || 'Storey'}
+          onChange={(e) => onChange({ ...condition, propertyName: e.target.value, value: '' })}
+          className={SELECT_CLASS}
+          aria-label="Spatial level"
+        >
+          {SPATIAL_LEVELS.map((level) => (
+            <option key={level} value={level}>{level}</option>
           ))}
         </select>
       )}

--- a/apps/viewer/src/components/viewer/lists/ListBuilder.tsx
+++ b/apps/viewer/src/components/viewer/lists/ListBuilder.tsx
@@ -20,7 +20,8 @@ import { ComboInput } from '@/components/ui/combo-input';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Badge } from '@/components/ui/badge';
 import { cn } from '@/lib/utils';
-import { IfcTypeEnum, isBuildingLikeSpatialType, type SpatialNode } from '@ifc-lite/data';
+import { IfcTypeEnum } from '@ifc-lite/data';
+import { collectSpatialContainerNames } from '@/utils/spatialHierarchy';
 import type { IfcDataStore } from '@ifc-lite/parser';
 import {
   discoverFilterValues,
@@ -204,21 +205,13 @@ export function ListBuilder({ providers, stores, initial, onSave, onCancel, onEx
     const building = new Set<string>();
     const site = new Set<string>();
     const project = new Set<string>();
+    // Reuse the shared collector so the site / building-like / project
+    // classification can't drift from the column resolver (#1591 review).
     for (const store of stores) {
-      const root = store.spatialHierarchy?.project;
-      if (!root) continue;
-      // Resolve real IFC Names (empty for unnamed containers) so the suggestions
-      // match the column values, never the `Entity #N` node placeholder.
-      const walk = (node: SpatialNode) => {
-        const nm = store.entities.getName(node.expressId);
-        if (nm) {
-          if (isBuildingLikeSpatialType(node.type)) building.add(nm);
-          else if (node.type === IfcTypeEnum.IfcSite) site.add(nm);
-          else if (node.type === IfcTypeEnum.IfcProject) project.add(nm);
-        }
-        for (const c of node.children) walk(c);
-      };
-      walk(root);
+      const names = collectSpatialContainerNames(store.spatialHierarchy, (id) => store.entities.getName(id));
+      names.sites.forEach((n) => site.add(n));
+      names.buildings.forEach((n) => building.add(n));
+      names.projects.forEach((n) => project.add(n));
     }
     const sorted = (s: Set<string>) => Array.from(s).sort();
     return { Storey: storeyNames, Building: sorted(building), Site: sorted(site), Project: sorted(project) };

--- a/apps/viewer/src/components/viewer/lists/ListPanel.tsx
+++ b/apps/viewer/src/components/viewer/lists/ListPanel.tsx
@@ -91,7 +91,7 @@ export function ListPanel({ onClose }: ListPanelProps) {
         // Skip native-metadata models — they don't have a parsed
         // IfcDataStore, so the list provider can't query them.
         if (!model.ifcDataStore) continue;
-        pairs.push({ modelId, provider: createListDataProvider(model.ifcDataStore), store: model.ifcDataStore });
+        pairs.push({ modelId, provider: createListDataProvider(model.ifcDataStore, model.name), store: model.ifcDataStore });
       }
     } else if (ifcDataStore) {
       pairs.push({ modelId: 'default', provider: createListDataProvider(ifcDataStore), store: ifcDataStore });

--- a/apps/viewer/src/lib/lists/adapter.ts
+++ b/apps/viewer/src/lib/lists/adapter.ts
@@ -23,6 +23,7 @@ import type { PropertySet, QuantitySet } from '@ifc-lite/data';
 import { ENTITY_ATTRIBUTES } from '@ifc-lite/lists';
 import type { ListDataProvider, ListClassificationRef, DiscoveredColumns } from '@ifc-lite/lists';
 import { resolveEntityPredefinedType } from '../entity-predefined-type.js';
+import { buildSpatialAncestryIndex, type SpatialAncestryIndex } from '../../utils/spatialHierarchy.js';
 
 /** Collect every material-name string an element exposes — top-level
  *  material plus layer / constituent / profile names and list members. */
@@ -41,8 +42,13 @@ function materialNamesOf(info: MaterialInfo | null): string[] {
 /**
  * Create a ListDataProvider backed by an IfcDataStore.
  * The provider handles on-demand WASM extraction transparently.
+ *
+ * `modelName` is the source model / file display name used by the `model`
+ * federation-identity column; pass the `FederatedModel.name` so a list over
+ * several models can tell which file each row came from. Defaults to '' for the
+ * single-model legacy path where there's nothing to disambiguate.
  */
-export function createListDataProvider(store: IfcDataStore): ListDataProvider {
+export function createListDataProvider(store: IfcDataStore, modelName = ''): ListDataProvider {
   // Cache for on-demand attribute extraction (description, objectType, tag)
   // These are not stored during initial parse to keep load times fast,
   // but are needed for list display. Cache avoids re-parsing per column.
@@ -82,6 +88,18 @@ export function createListDataProvider(store: IfcDataStore): ListDataProvider {
   // Complete column discovery is cached — the provider outlives a builder
   // open, and the scan touches every entity that declares a pset/qto.
   let columnsCache: DiscoveredColumns | null = null;
+
+  // Spatial ancestry (element -> containing Site / Building name, + the model's
+  // Project name) is precomputed once in a single tree pass, then O(1) per
+  // element. Cached because the provider outlives a run and the Site / Building
+  // columns hit it per row.
+  let ancestryCache: SpatialAncestryIndex | null = null;
+  function ancestry(): SpatialAncestryIndex {
+    if (!ancestryCache) {
+      ancestryCache = buildSpatialAncestryIndex(store.spatialHierarchy, (id) => store.entities.getName(id));
+    }
+    return ancestryCache;
+  }
 
   const usesOnDemandProps = !!store.onDemandPropertyMap && store.source?.length > 0;
   const usesOnDemandQtos = !!store.onDemandQuantityMap && store.source?.length > 0;
@@ -144,6 +162,22 @@ export function createListDataProvider(store: IfcDataStore): ListDataProvider {
       const storeyId = hierarchy.elementToStorey.get(entityId);
       if (!storeyId) return '';
       return store.entities.getName(storeyId) || '';
+    },
+
+    getBuildingName(entityId: number): string {
+      return ancestry().buildingOf(entityId);
+    },
+
+    getSiteName(entityId: number): string {
+      return ancestry().siteOf(entityId);
+    },
+
+    getProjectName(): string {
+      return ancestry().projectName;
+    },
+
+    getModelName(): string {
+      return modelName;
     },
 
     discoverAllColumns(): DiscoveredColumns {

--- a/apps/viewer/src/utils/spatialHierarchy.test.ts
+++ b/apps/viewer/src/utils/spatialHierarchy.test.ts
@@ -11,7 +11,7 @@ import {
   RelationshipType,
   StringTable,
 } from '@ifc-lite/data';
-import { rebuildSpatialHierarchy, rebuildOnDemandMaps, registerAuthoredElement, buildSpatialAncestryIndex } from './spatialHierarchy';
+import { rebuildSpatialHierarchy, rebuildOnDemandMaps, registerAuthoredElement, buildSpatialAncestryIndex, collectSpatialContainerNames } from './spatialHierarchy';
 
 describe('registerAuthoredElement', () => {
   function baseHierarchy() {
@@ -346,6 +346,78 @@ describe('buildSpatialAncestryIndex', () => {
     const idx = buildSpatialAncestryIndex(h, (id) => et.getName(id));
     assert.equal(idx.buildingOf(6), 'Building');
     assert.equal(idx.siteOf(6), 'Site');
+  });
+
+  // Nested same-type containers (IfcSite within IfcSite). The element's nearest
+  // site is the INNER site; an unnamed inner site must NOT inherit the outer
+  // site's name (it is a different, unnamed site), so it resolves to ''.
+  it('does not inherit an ancestor site name across same-type nesting', () => {
+    const strings = new StringTable();
+    const eb = new EntityTableBuilder(6, strings);
+    eb.add(1, 'IFCPROJECT', 'p0', 'Project', '', '');
+    eb.add(2, 'IFCSITE', 's-outer', 'Environment', '', '');
+    eb.add(3, 'IFCSITE', 's-inner', '', '', ''); // unnamed nested site
+    eb.add(4, 'IFCBUILDING', 'b0', 'House', '', '');
+    eb.add(5, 'IFCBUILDINGSTOREY', 'st0', 'Level 1', '', '');
+    eb.add(6, 'IFCWALL', 'w0', 'Wall', '', '', true);
+    const rels = new RelationshipGraphBuilder();
+    rels.addEdge(1, 2, RelationshipType.Aggregates, 100);
+    rels.addEdge(2, 3, RelationshipType.Aggregates, 101); // site within site
+    rels.addEdge(3, 4, RelationshipType.Aggregates, 102);
+    rels.addEdge(4, 5, RelationshipType.Aggregates, 103);
+    rels.addEdge(5, 6, RelationshipType.ContainsElements, 104);
+    const et = eb.build();
+    const h = rebuildSpatialHierarchy(et, rels.build());
+    assert.ok(h);
+    const idx = buildSpatialAncestryIndex(h, (id) => et.getName(id));
+    assert.equal(idx.siteOf(6), ''); // NOT 'Environment'
+    assert.equal(idx.buildingOf(6), 'House');
+  });
+
+  it('uses the nearest named site when a nested inner site IS named', () => {
+    const strings = new StringTable();
+    const eb = new EntityTableBuilder(5, strings);
+    eb.add(1, 'IFCPROJECT', 'p0', 'Project', '', '');
+    eb.add(2, 'IFCSITE', 's-outer', 'Environment', '', '');
+    eb.add(3, 'IFCSITE', 's-inner', 'House Site', '', ''); // named nested site
+    eb.add(4, 'IFCBUILDINGSTOREY', 'st0', 'Level 1', '', '');
+    eb.add(5, 'IFCWALL', 'w0', 'Wall', '', '', true);
+    const rels = new RelationshipGraphBuilder();
+    rels.addEdge(1, 2, RelationshipType.Aggregates, 100);
+    rels.addEdge(2, 3, RelationshipType.Aggregates, 101);
+    rels.addEdge(3, 4, RelationshipType.Aggregates, 102);
+    rels.addEdge(4, 5, RelationshipType.ContainsElements, 103);
+    const et = eb.build();
+    const h = rebuildSpatialHierarchy(et, rels.build());
+    assert.ok(h);
+    const idx = buildSpatialAncestryIndex(h, (id) => et.getName(id));
+    assert.equal(idx.siteOf(5), 'House Site');
+  });
+});
+
+describe('collectSpatialContainerNames', () => {
+  it('collects distinct named site / building / project names, skipping unnamed', () => {
+    const strings = new StringTable();
+    const eb = new EntityTableBuilder(6, strings);
+    eb.add(1, 'IFCPROJECT', 'p0', 'My Project', '', '');
+    eb.add(2, 'IFCSITE', 's0', 'North Site', '', '');
+    eb.add(3, 'IFCBRIDGE', 'br', 'Bridge A', '', ''); // building-like (IFC4X3)
+    eb.add(4, 'IFCBUILDING', 'b0', '', '', ''); // unnamed building -> skipped
+    eb.add(5, 'IFCBUILDINGSTOREY', 'st0', 'Level 1', '', ''); // storey -> not a level
+    eb.add(6, 'IFCWALL', 'w0', 'Wall', '', '', true);
+    const rels = new RelationshipGraphBuilder();
+    rels.addEdge(1, 2, RelationshipType.Aggregates, 100);
+    rels.addEdge(2, 3, RelationshipType.Aggregates, 101);
+    rels.addEdge(2, 4, RelationshipType.Aggregates, 102);
+    rels.addEdge(4, 5, RelationshipType.Aggregates, 103);
+    rels.addEdge(5, 6, RelationshipType.ContainsElements, 104);
+    const et = eb.build();
+    const h = rebuildSpatialHierarchy(et, rels.build());
+    assert.ok(h);
+    const names = collectSpatialContainerNames(h, (id) => et.getName(id));
+    assert.deepEqual(names.projects, ['My Project']);
+    assert.deepEqual(names.sites, ['North Site']);
+    assert.deepEqual(names.buildings, ['Bridge A']); // facility included; unnamed building skipped
   });
 });
 

--- a/apps/viewer/src/utils/spatialHierarchy.test.ts
+++ b/apps/viewer/src/utils/spatialHierarchy.test.ts
@@ -11,7 +11,7 @@ import {
   RelationshipType,
   StringTable,
 } from '@ifc-lite/data';
-import { rebuildSpatialHierarchy, rebuildOnDemandMaps, registerAuthoredElement } from './spatialHierarchy';
+import { rebuildSpatialHierarchy, rebuildOnDemandMaps, registerAuthoredElement, buildSpatialAncestryIndex } from './spatialHierarchy';
 
 describe('registerAuthoredElement', () => {
   function baseHierarchy() {
@@ -250,6 +250,102 @@ describe('rebuildSpatialHierarchy', () => {
     assert.equal(hierarchy.elementToStorey.get(4), 3);
     assert.equal(hierarchy.elementToStorey.get(5), 3);
     assert.equal(hierarchy.elementToStorey.get(6), 3);
+  });
+});
+
+describe('buildSpatialAncestryIndex', () => {
+  it('resolves project / site / building names for a contained element', () => {
+    const strings = new StringTable();
+    const eb = new EntityTableBuilder(5, strings);
+    eb.add(1, 'IFCPROJECT', 'p0', 'My Project', '', '');
+    eb.add(2, 'IFCSITE', 's0', 'North Site', '', '');
+    eb.add(3, 'IFCBUILDING', 'b0', 'Tower A', '', '');
+    eb.add(4, 'IFCBUILDINGSTOREY', 'st0', 'Level 1', '', '');
+    eb.add(5, 'IFCWALL', 'w0', 'Wall', '', '', true);
+    const rels = new RelationshipGraphBuilder();
+    rels.addEdge(1, 2, RelationshipType.Aggregates, 100);
+    rels.addEdge(2, 3, RelationshipType.Aggregates, 101);
+    rels.addEdge(3, 4, RelationshipType.Aggregates, 102);
+    rels.addEdge(4, 5, RelationshipType.ContainsElements, 103);
+    const et = eb.build();
+    const h = rebuildSpatialHierarchy(et, rels.build());
+    assert.ok(h);
+    const idx = buildSpatialAncestryIndex(h, (id) => et.getName(id));
+    assert.equal(idx.projectName, 'My Project');
+    assert.equal(idx.siteOf(5), 'North Site');
+    assert.equal(idx.buildingOf(5), 'Tower A');
+    // A container queried by its own id resolves self-inclusively.
+    assert.equal(idx.siteOf(2), 'North Site');
+    assert.equal(idx.buildingOf(3), 'Tower A');
+  });
+
+  it('resolves IFC4X3 facilities (IfcBridge) at the building level', () => {
+    const strings = new StringTable();
+    const eb = new EntityTableBuilder(4, strings);
+    eb.add(1, 'IFCPROJECT', '0', 'Infra Project', '', '');
+    eb.add(2, 'IFCBRIDGE', '1', 'Bridge A', '', '');
+    eb.add(3, 'IFCBRIDGEPART', '2', 'Deck', '', '');
+    eb.add(4, 'IFCWALL', '3', 'Barrier', '', '', true);
+    const rels = new RelationshipGraphBuilder();
+    rels.addEdge(1, 2, RelationshipType.Aggregates, 10);
+    rels.addEdge(2, 3, RelationshipType.Aggregates, 11);
+    rels.addEdge(3, 4, RelationshipType.ContainsElements, 12);
+    const et = eb.build();
+    const h = rebuildSpatialHierarchy(et, rels.build());
+    assert.ok(h);
+    const idx = buildSpatialAncestryIndex(h, (id) => et.getName(id));
+    assert.equal(idx.buildingOf(4), 'Bridge A');
+    assert.equal(idx.siteOf(4), ''); // no IfcSite in this tree
+  });
+
+  it('returns "" for an unnamed container and an unplaced element', () => {
+    const strings = new StringTable();
+    const eb = new EntityTableBuilder(5, strings);
+    eb.add(1, 'IFCPROJECT', 'p0', 'Project', '', '');
+    eb.add(2, 'IFCSITE', 's0', 'Site', '', '');
+    eb.add(3, 'IFCBUILDING', 'b0', '', '', ''); // unnamed building
+    eb.add(4, 'IFCBUILDINGSTOREY', 'st0', 'Level 1', '', '');
+    eb.add(5, 'IFCWALL', 'w0', 'Wall', '', '', true);
+    const rels = new RelationshipGraphBuilder();
+    rels.addEdge(1, 2, RelationshipType.Aggregates, 100);
+    rels.addEdge(2, 3, RelationshipType.Aggregates, 101);
+    rels.addEdge(3, 4, RelationshipType.Aggregates, 102);
+    rels.addEdge(4, 5, RelationshipType.ContainsElements, 103);
+    const et = eb.build();
+    const h = rebuildSpatialHierarchy(et, rels.build());
+    assert.ok(h);
+    const idx = buildSpatialAncestryIndex(h, (id) => et.getName(id));
+    // Unnamed IfcBuilding resolves to '' (not the `Entity #N` node placeholder).
+    assert.equal(idx.buildingOf(5), '');
+    assert.equal(idx.siteOf(5), 'Site');
+    // An element the hierarchy doesn't place resolves to ''.
+    assert.equal(idx.siteOf(9999), '');
+    assert.equal(idx.buildingOf(9999), '');
+  });
+
+  it('resolves parts reachable only through the storey reverse index', () => {
+    // A wall part is aggregated under the wall (not directly contained); it
+    // inherits the wall's storey, so ancestry resolves via elementToStorey.
+    const strings = new StringTable();
+    const eb = new EntityTableBuilder(6, strings);
+    eb.add(1, 'IFCPROJECT', 'p0', 'Project', '', '');
+    eb.add(2, 'IFCSITE', 's0', 'Site', '', '');
+    eb.add(3, 'IFCBUILDING', 'b0', 'Building', '', '');
+    eb.add(4, 'IFCBUILDINGSTOREY', 'st0', 'Level 1', '', '');
+    eb.add(5, 'IFCWALL', 'w0', 'Wall', '', '', true);
+    eb.add(6, 'IFCBUILDINGELEMENTPART', 'part', 'Layer A', '', '', true);
+    const rels = new RelationshipGraphBuilder();
+    rels.addEdge(1, 2, RelationshipType.Aggregates, 100);
+    rels.addEdge(2, 3, RelationshipType.Aggregates, 101);
+    rels.addEdge(3, 4, RelationshipType.Aggregates, 102);
+    rels.addEdge(4, 5, RelationshipType.ContainsElements, 103);
+    rels.addEdge(5, 6, RelationshipType.Aggregates, 104);
+    const et = eb.build();
+    const h = rebuildSpatialHierarchy(et, rels.build());
+    assert.ok(h);
+    const idx = buildSpatialAncestryIndex(h, (id) => et.getName(id));
+    assert.equal(idx.buildingOf(6), 'Building');
+    assert.equal(idx.siteOf(6), 'Site');
   });
 });
 

--- a/apps/viewer/src/utils/spatialHierarchy.ts
+++ b/apps/viewer/src/utils/spatialHierarchy.ts
@@ -11,6 +11,7 @@
 import {
   IfcTypeEnum,
   RelationshipType,
+  isBuildingLikeSpatialType,
   type SpatialHierarchy,
   type SpatialNode,
   type EntityTable,
@@ -44,6 +45,82 @@ function findSpatialNode(node: SpatialNode, expressId: number): SpatialNode | nu
     if (hit) return hit;
   }
   return null;
+}
+
+/**
+ * Nearest-ancestor spatial identity for an element, resolved from a built
+ * spatial hierarchy. `siteOf` / `buildingOf` return the containing IfcSite /
+ * IfcBuilding name (or '' when the element is unplaced, or the container is
+ * unnamed); `projectName` is the model's single IfcProject name.
+ */
+export interface SpatialAncestryIndex {
+  projectName: string;
+  siteOf(elementId: number): string;
+  buildingOf(elementId: number): string;
+}
+
+/**
+ * Precompute each element's containing IfcSite / IfcBuilding name from a spatial
+ * hierarchy in a single depth-first pass, so a per-element lookup is O(1) and
+ * never re-walks the tree. Used by federated views (Lists columns, panels) to
+ * label which project / site / building an element belongs to.
+ *
+ * `getName` resolves an entity's real IFC `Name` — pass the store's
+ * `entities.getName` so an UNNAMED container resolves to '' (matching how the
+ * storey column behaves), rather than the `SpatialNode.name` placeholder the
+ * hierarchy builder synthesizes (`Entity #N`). "Building" spans every
+ * building-like spatial type (IFC4X3 IfcFacility / IfcBridge / IfcRoad / …), so
+ * infrastructure federations resolve too.
+ *
+ * Coverage: elements listed directly under a container node (`node.elements`)
+ * resolve via that node; a spatial container queried by its own id resolves to
+ * its own site/building; parts and other aggregated descendants reachable only
+ * through the storey reverse index (`elementToStorey`) resolve via their
+ * storey. Elements the hierarchy doesn't place resolve to ''.
+ */
+export function buildSpatialAncestryIndex(
+  hierarchy: SpatialHierarchy | undefined | null,
+  getName: (expressId: number) => string,
+): SpatialAncestryIndex {
+  // container node id -> nearest {site, building} name (self-inclusive).
+  const ancestry = new Map<number, { site: string; building: string }>();
+  // element id -> the container node that directly lists it in `elements`.
+  const elementToContainer = new Map<number, number>();
+  let projectName = '';
+
+  if (hierarchy?.project) {
+    const root = hierarchy.project;
+    projectName = getName(root.expressId) || '';
+    const walk = (node: SpatialNode, site: string, building: string): void => {
+      const nextSite = node.type === IfcTypeEnum.IfcSite ? (getName(node.expressId) || site) : site;
+      const nextBuilding = isBuildingLikeSpatialType(node.type) ? (getName(node.expressId) || building) : building;
+      ancestry.set(node.expressId, { site: nextSite, building: nextBuilding });
+      for (const el of node.elements) {
+        if (!elementToContainer.has(el)) elementToContainer.set(el, node.expressId);
+      }
+      for (const child of node.children) walk(child, nextSite, nextBuilding);
+    };
+    walk(root, '', '');
+  }
+
+  const containerFor = (elementId: number): number | undefined => {
+    if (ancestry.has(elementId)) return elementId; // the element IS a spatial container
+    const direct = elementToContainer.get(elementId);
+    if (direct !== undefined) return direct;
+    return hierarchy?.elementToStorey.get(elementId); // parts/aggregated descendants
+  };
+
+  return {
+    projectName,
+    siteOf(elementId: number): string {
+      const c = containerFor(elementId);
+      return c === undefined ? '' : (ancestry.get(c)?.site ?? '');
+    },
+    buildingOf(elementId: number): string {
+      const c = containerFor(elementId);
+      return c === undefined ? '' : (ancestry.get(c)?.building ?? '');
+    },
+  };
 }
 
 /**

--- a/apps/viewer/src/utils/spatialHierarchy.ts
+++ b/apps/viewer/src/utils/spatialHierarchy.ts
@@ -48,10 +48,56 @@ function findSpatialNode(node: SpatialNode, expressId: number): SpatialNode | nu
 }
 
 /**
+ * Classify a spatial node into the federation-identity container level it
+ * represents, or null when it is none of those. The single home for the
+ * site / building-like / project rules (building-like spans IFC4X3 facilities),
+ * shared by `buildSpatialAncestryIndex` and `collectSpatialContainerNames` so
+ * the classification can never drift between them.
+ */
+function spatialContainerLevel(node: SpatialNode): 'site' | 'building' | 'project' | null {
+  if (node.type === IfcTypeEnum.IfcSite) return 'site';
+  if (isBuildingLikeSpatialType(node.type)) return 'building';
+  if (node.type === IfcTypeEnum.IfcProject) return 'project';
+  return null;
+}
+
+/**
+ * Collect the distinct REAL IFC names of every IfcSite / building-like /
+ * IfcProject container in a hierarchy (unnamed containers contribute nothing,
+ * matching the column values). `getName` resolves an entity's real Name.
+ * Powers the spatial-filter value suggestions, sharing node classification with
+ * `buildSpatialAncestryIndex`.
+ */
+export function collectSpatialContainerNames(
+  hierarchy: SpatialHierarchy | undefined | null,
+  getName: (expressId: number) => string,
+): { sites: string[]; buildings: string[]; projects: string[] } {
+  const sites = new Set<string>();
+  const buildings = new Set<string>();
+  const projects = new Set<string>();
+  const root = hierarchy?.project;
+  if (root) {
+    const walk = (node: SpatialNode): void => {
+      const name = getName(node.expressId);
+      if (name) {
+        const level = spatialContainerLevel(node);
+        if (level === 'site') sites.add(name);
+        else if (level === 'building') buildings.add(name);
+        else if (level === 'project') projects.add(name);
+      }
+      for (const child of node.children) walk(child);
+    };
+    walk(root);
+  }
+  const sorted = (s: Set<string>) => Array.from(s).sort();
+  return { sites: sorted(sites), buildings: sorted(buildings), projects: sorted(projects) };
+}
+
+/**
  * Nearest-ancestor spatial identity for an element, resolved from a built
  * spatial hierarchy. `siteOf` / `buildingOf` return the containing IfcSite /
- * IfcBuilding name (or '' when the element is unplaced, or the container is
- * unnamed); `projectName` is the model's single IfcProject name.
+ * IfcBuilding name (or '' when the element is unplaced, or the nearest such
+ * container is unnamed); `projectName` is the model's single IfcProject name.
  */
 export interface SpatialAncestryIndex {
   projectName: string;
@@ -92,8 +138,14 @@ export function buildSpatialAncestryIndex(
     const root = hierarchy.project;
     projectName = getName(root.expressId) || '';
     const walk = (node: SpatialNode, site: string, building: string): void => {
-      const nextSite = node.type === IfcTypeEnum.IfcSite ? (getName(node.expressId) || site) : site;
-      const nextBuilding = isBuildingLikeSpatialType(node.type) ? (getName(node.expressId) || building) : building;
+      // A site / building-like node takes its OWN name (or '' when unnamed). It
+      // does NOT inherit the ancestor's name across same-type nesting: an
+      // unnamed IfcSite nested in a named IfcSite is a different, unnamed site,
+      // so it resolves to '' (consistent with the storey column), not the outer
+      // name. Non-container nodes (storeys, spaces) propagate the parent's.
+      const level = spatialContainerLevel(node);
+      const nextSite = level === 'site' ? getName(node.expressId) : site;
+      const nextBuilding = level === 'building' ? getName(node.expressId) : building;
       ancestry.set(node.expressId, { site: nextSite, building: nextBuilding });
       for (const el of node.elements) {
         if (!elementToContainer.has(el)) elementToContainer.set(el, node.expressId);

--- a/packages/lists/src/engine.test.ts
+++ b/packages/lists/src/engine.test.ts
@@ -87,6 +87,19 @@ function createMockProvider(): ListDataProvider {
     [3, 'Level 0'],
   ]);
 
+  // Federation-identity fixtures (#1591): both walls sit in Building A, the
+  // slab in Building B; all share one site and one source model.
+  const buildingNames = new Map<number, string>([
+    [1, 'Building A'],
+    [2, 'Building A'],
+    [3, 'Building B'],
+  ]);
+  const siteNames = new Map<number, string>([
+    [1, 'Main Site'],
+    [2, 'Main Site'],
+    [3, 'Main Site'],
+  ]);
+
   const predefinedTypes = new Map<number, string>([
     [1, 'SOLIDWALL'],
     // entity 2 intentionally has no PredefinedType
@@ -107,6 +120,10 @@ function createMockProvider(): ListDataProvider {
     getMaterialNames: (id) => materialNames.get(id) ?? [],
     getClassifications: (id) => classifications.get(id) ?? [],
     getStoreyName: (id) => storeyNames.get(id) ?? '',
+    getBuildingName: (id) => buildingNames.get(id) ?? '',
+    getSiteName: (id) => siteNames.get(id) ?? '',
+    getProjectName: () => 'Sample Project',
+    getModelName: () => 'model-a.ifc',
     getEntityPredefinedType: (id) => predefinedTypes.get(id) ?? '',
   };
 }
@@ -292,6 +309,51 @@ describe('executeList', () => {
     expect(result.rows[1].values).toEqual(['Wall-02', 'Brick, Rigid Insulation', null, 'Level 1']);
   });
 
+  // #1591: federation-identity columns — the source model plus the spatial
+  // container at each level (Project / Site / Building / Storey), so a list over
+  // several models can be grouped and sorted by where each row comes from.
+  it('extracts the model and leveled spatial columns', () => {
+    const provider = createMockProvider();
+    const def: ListDefinition = {
+      id: 'fed-cols',
+      name: 'Test',
+      createdAt: 0,
+      updatedAt: 0,
+      entityTypes: [IfcTypeEnum.IfcWall, IfcTypeEnum.IfcSlab],
+      conditions: [],
+      columns: [
+        { id: 'name', source: 'attribute', propertyName: 'Name' },
+        { id: 'model', source: 'model', propertyName: 'Model' },
+        { id: 'project', source: 'spatial', propertyName: 'Project' },
+        { id: 'site', source: 'spatial', propertyName: 'Site' },
+        { id: 'building', source: 'spatial', propertyName: 'Building' },
+        { id: 'storey', source: 'spatial', propertyName: 'Storey' },
+      ],
+    };
+
+    const result = executeList(def, provider);
+    const byName = new Map(result.rows.map((r) => [r.values[0], r.values]));
+    expect(byName.get('Wall-01')).toEqual(['Wall-01', 'model-a.ifc', 'Sample Project', 'Main Site', 'Building A', 'Level 0']);
+    expect(byName.get('Slab-01')).toEqual(['Slab-01', 'model-a.ifc', 'Sample Project', 'Main Site', 'Building B', 'Level 0']);
+  });
+
+  // A `spatial` column authored before the level existed carries an empty
+  // propertyName; it must still resolve the storey name (back-compat with
+  // persisted lists / the pre-#1591 Storey chip).
+  it('defaults a level-less spatial column to Storey', () => {
+    const provider = createMockProvider();
+    const result = executeList({
+      id: 'sp-default',
+      name: 'T',
+      createdAt: 0,
+      updatedAt: 0,
+      entityTypes: [IfcTypeEnum.IfcWall],
+      conditions: [],
+      columns: [{ id: 'sp', source: 'spatial', propertyName: '' }],
+    }, provider);
+    expect(result.rows[0].values[0]).toBe('Level 0');
+  });
+
   // Condition filtering across every condition source. entityTypes: []
   // targets all elements the provider can enumerate (no class constraint),
   // so these rows also pin the class-less targeting semantics.
@@ -306,6 +368,12 @@ describe('executeList', () => {
     // Wall-02 has no classification, so `exists` excludes it.
     { source: 'classification', propertyName: 'Classification', operator: 'exists', value: '', expected: ['Slab-01', 'Wall-01'] },
     { source: 'spatial', propertyName: 'Storey', operator: 'equals', value: 'Level 0', expected: ['Slab-01', 'Wall-01'] },
+    // #1591: leveled spatial + model filters. Building B holds only the slab;
+    // every element shares one site and one source model.
+    { source: 'spatial', propertyName: 'Building', operator: 'equals', value: 'Building B', expected: ['Slab-01'] },
+    { source: 'spatial', propertyName: 'Site', operator: 'equals', value: 'Main Site', expected: ['Slab-01', 'Wall-01', 'Wall-02'] },
+    { source: 'model', propertyName: 'Model', operator: 'equals', value: 'model-a.ifc', expected: ['Slab-01', 'Wall-01', 'Wall-02'] },
+    { source: 'model', propertyName: 'Model', operator: 'equals', value: 'other.ifc', expected: [] },
   ] as const)('filters by $source $operator "$value"', ({ source, propertyName, operator, value, expected }) => {
     const provider = createMockProvider();
     const def: ListDefinition = {

--- a/packages/lists/src/engine.ts
+++ b/packages/lists/src/engine.ts
@@ -260,9 +260,35 @@ function getConditionValue(
     case 'quantity':
       return getQuantityValue(entityId, condition.psetName ?? '', condition.propertyName, provider);
     case 'spatial':
-      return provider.getStoreyName?.(entityId) || null;
+      return getSpatialValue(entityId, condition.propertyName, provider);
+    case 'model':
+      return provider.getModelName?.() || null;
     default:
       return null;
+  }
+}
+
+/**
+ * Resolve a `spatial` column/condition to a spatial-container name at the
+ * requested level. `propertyName` selects the level; an empty or unrecognised
+ * level falls back to `Storey`, so lists authored before the level existed
+ * keep resolving the storey name. `Project` is constant per model.
+ */
+function getSpatialValue(
+  entityId: number,
+  level: string,
+  provider: ListDataProvider,
+): CellValue {
+  switch (level) {
+    case 'Building':
+      return provider.getBuildingName?.(entityId) || null;
+    case 'Site':
+      return provider.getSiteName?.(entityId) || null;
+    case 'Project':
+      return provider.getProjectName?.() || null;
+    case 'Storey':
+    default:
+      return provider.getStoreyName?.(entityId) || null;
   }
 }
 
@@ -366,7 +392,10 @@ function extractColumnValues(
         break;
       }
       case 'spatial':
-        values[i] = provider.getStoreyName?.(entityId) || null;
+        values[i] = getSpatialValue(entityId, col.propertyName, provider);
+        break;
+      case 'model':
+        values[i] = provider.getModelName?.() || null;
         break;
       default:
         values[i] = null;

--- a/packages/lists/src/types.ts
+++ b/packages/lists/src/types.ts
@@ -71,6 +71,20 @@ export interface ListDataProvider {
   getClassifications?(expressId: number): ListClassificationRef[];
   /** Building-storey name the element belongs to, or '' when unplaced. */
   getStoreyName?(expressId: number): string;
+  /** IfcBuilding name containing the element, or '' when unplaced. Used by the
+   *  `spatial` column at `Building` level. */
+  getBuildingName?(expressId: number): string;
+  /** IfcSite name containing the element, or '' when unplaced. Used by the
+   *  `spatial` column at `Site` level. */
+  getSiteName?(expressId: number): string;
+  /** IfcProject.Name for this model — constant for every element the provider
+   *  serves (one IfcProject per file). Used by the `spatial` column at
+   *  `Project` level. '' when the model has no named project. */
+  getProjectName?(): string;
+  /** Source model / file display name — constant for every element the
+   *  provider serves. Used by the `model` column to identify which federated
+   *  file a row comes from. '' when unknown (e.g. single-model legacy path). */
+  getModelName?(): string;
   /** IFC `PredefinedType` enum token (e.g. "FLOOR", "FLOORING"), or '' when
    *  the element has none. Used by the `PredefinedType` attribute column. */
   getEntityPredefinedType?(expressId: number): string;
@@ -144,12 +158,16 @@ export interface PropertyCondition {
    * - `property` / `quantity` — a pset / qto value (uses `psetName`)
    * - `material` — any of the element's material names (multi-valued)
    * - `classification` — any classification code or name (multi-valued)
-   * - `spatial` — the element's building-storey name
+   * - `spatial` — a spatial-container name; `propertyName` selects the level
+   *   (`Storey` (default), `Building`, `Site`, or `Project`)
+   * - `model` — the source model / file name (federation identity)
    */
-  source: 'attribute' | 'property' | 'quantity' | 'material' | 'classification' | 'spatial';
+  source: 'attribute' | 'property' | 'quantity' | 'material' | 'classification' | 'spatial' | 'model';
   /** Property set name (for property/quantity sources) */
   psetName?: string;
-  /** Property name within the set. Ignored for material/classification/spatial. */
+  /** Attribute / property / quantity name, or the spatial level for `spatial`
+   *  (`Storey` | `Building` | `Site` | `Project`). Ignored for
+   *  material/classification/model. */
   propertyName: string;
   operator: ConditionOperator;
   value: string | number | boolean;
@@ -173,12 +191,16 @@ export interface ColumnDefinition {
   id: string;
   /**
    * Where the column value comes from. `material` / `classification` are
-   * multi-valued (joined with ", "); `spatial` is the element's storey name.
+   * multi-valued (joined with ", "); `spatial` is a spatial-container name at
+   * the level named by `propertyName` (`Storey` (default) | `Building` | `Site`
+   * | `Project`); `model` is the source model / file name (federation identity).
    */
-  source: 'attribute' | 'property' | 'quantity' | 'material' | 'classification' | 'spatial';
+  source: 'attribute' | 'property' | 'quantity' | 'material' | 'classification' | 'spatial' | 'model';
   /** For property: pset name. For quantity: qset name. */
   psetName?: string;
-  /** Attribute name or property/quantity name. Ignored for material/classification/spatial. */
+  /** Attribute / property / quantity name, or the spatial level for `spatial`
+   *  (`Storey` | `Building` | `Site` | `Project`). Ignored for
+   *  material/classification/model. */
   propertyName: string;
   /** Display label override */
   label?: string;


### PR DESCRIPTION
## What & why

Part of issue #1591. When several IFC models are federated in the viewer, a list runs once per model and flattens every model's rows into one table. Today the only federation datum a row carries is an internal `modelId`, never a visible column, so you cannot tell which file (or project / site / building) a row came from.

This adds federation-identity columns to the Lists feature. Because grouping, sorting, filtering, and CSV/xlsx/PDF export are all generic over columns, adding the column is all it takes to also get "group by source project", "sort by site", etc. for free, which is exactly what the issue asks for.

## Columns added

- **Model** (`source: 'model'`) resolves the source file / model name (`FederatedModel.name`) - the robust federation discriminator, unique per loaded file.
- **Project / Site / Building** via a now-leveled **spatial** source (`propertyName` selects `Storey` (default), `Building`, `Site`, or `Project`). Storey already existed and is unchanged.

All are addable as quick-add chips in the column picker and as filter dimensions (leveled `Spatial` + a `Model` filter, with value suggestions).

## Implementation

- `packages/lists` (published, additive): `ColumnDefinition.source` / `PropertyCondition.source` gain `model`; a `getSpatialValue` helper resolves the leveled spatial value and is shared by column extraction and condition filtering (so columns and filters can never disagree). `ListDataProvider` gains optional `getModelName` / `getProjectName` / `getSiteName` / `getBuildingName`. Storey-only columns keep resolving the storey name (back-compat with persisted lists).
- viewer: `buildSpatialAncestryIndex` in `utils/spatialHierarchy.ts` precomputes each element's containing Site / Building plus the model's Project in a single DFS (O(1) per lookup, cached per model). Container names resolve via `entities.getName` so an unnamed container yields `''` (matching the storey column), and "Building" spans building-like IFC4X3 facilities (`IfcBridge` / `IfcRoad` / ...). The per-model list provider (built in `adapter.ts`) implements the new getters; `ListBuilder` gains the chips and filters.

The single canonical per-model load path is untouched; this only reads already-parsed spatial hierarchy + the existing models map.

## Tests

- `@ifc-lite/lists` engine: new column extraction (model + Project/Site/Building/Storey), the level-less back-compat default, and condition filtering by leveled spatial + model. 45/45 pass.
- `buildSpatialAncestryIndex`: contained element, IFC4X3 facility at building level, unnamed container yields `''`, unplaced element yields `''`, and parts reachable only via the storey reverse index. 15/15 in the util suite.
- Full repo typecheck green; viewer typecheck green.

## Changeset

`@ifc-lite/lists` minor (additive API).

## Follow-ups (rest of #1591, stacked on this branch)

Regex/pattern set-name matching; source-model badges in Clash + IDS; BCF federated round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Lists can now show and use federation-identity fields, including model name and spatial levels for project, site, building, and storey.
  * Spatial columns and filters now support choosing the level they refer to, with improved grouping, sorting, filtering, and export behavior.

* **Bug Fixes**
  * Spatial values now resolve more consistently across different hierarchy levels, including fallback behavior for existing storey-based columns.
  * List results now better reflect the originating model and location for federated content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->