### PR TITLE
feat(lists,sdk): Bonsai-style /regex/ set & property name matching [#1591]

### DIFF
--- a/.changeset/regex-name-patterns.md
+++ b/.changeset/regex-name-patterns.md
@@ -1,0 +1,6 @@
+---
+"@ifc-lite/lists": minor
+"@ifc-lite/sdk": minor
+---
+
+Support Bonsai-style `/regex/` patterns for property-set / quantity-set and property / quantity names. A name wrapped in slashes (e.g. `/Qto_.*BaseQuantities/`, optionally with flags like `/qto_.*/i`) is matched as a regular expression; a plain name stays an exact match. This lets one list column or query read a value across several matching sets at once, for example `NetVolume` from `Qto_WallBaseQuantities` AND `Qto_SlabBaseQuantities` (issue #1591). Applies to `@ifc-lite/lists` column extraction and filter conditions and to the SDK `bim.query().property()` / `quantity()` getters. `@ifc-lite/lists` exports the new `compileNameMatcher` / `isNamePattern` helpers.

--- a/apps/viewer/src/components/viewer/lists/ListBuilder.tsx
+++ b/apps/viewer/src/components/viewer/lists/ListBuilder.tsx
@@ -36,7 +36,7 @@ import type {
   PropertyCondition,
   ConditionOperator,
 } from '@ifc-lite/lists';
-import { discoverColumns, ENTITY_ATTRIBUTES } from '@ifc-lite/lists';
+import { discoverColumns, ENTITY_ATTRIBUTES, isNamePattern } from '@ifc-lite/lists';
 
 const NO_OPTIONS: readonly string[] = [];
 
@@ -753,9 +753,11 @@ function CustomColumnEntry({
 
   const set = setName.trim();
   const prop = propName.trim();
-  // Slugify like the discovered-column ids (whitespace only), so regex
-  // metacharacters survive and two distinct patterns never collapse to one id.
-  const columnId = `custom-${source}-${set}-${prop}`.toLowerCase().replace(/\s+/g, '-');
+  const isPattern = isNamePattern(set);
+  // Slugify like the discovered-column ids (collapse whitespace) but keep the
+  // original case: regex patterns are case-sensitive, so `/A/` and `/a/` are
+  // distinct sets and must not collapse to one id.
+  const columnId = `custom-${source}-${set}-${prop}`.replace(/\s+/g, '-');
   const canAdd = set.length > 0 && prop.length > 0 && !selectedIds.has(columnId);
 
   const add = () => {
@@ -783,6 +785,11 @@ function CustomColumnEntry({
       <div className="flex items-center gap-1.5">
         <Chip selected={source === 'property'} onClick={() => setSource('property')}>Property</Chip>
         <Chip selected={source === 'quantity'} onClick={() => setSource('quantity')}>Quantity</Chip>
+        {isPattern && (
+          <span className="rounded bg-primary/10 px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-wide text-primary">
+            regex
+          </span>
+        )}
         <button
           onClick={() => setOpen(false)}
           aria-label="Close custom column"

--- a/apps/viewer/src/components/viewer/lists/ListBuilder.tsx
+++ b/apps/viewer/src/components/viewer/lists/ListBuilder.tsx
@@ -712,6 +712,115 @@ function ColumnPicker({ discovered, selectedIds, onAdd, onToggle }: ColumnPicker
           ))}
         </div>
       )}
+
+      {/* Custom / pattern column: type a set + property name directly, with
+          `/regex/` support so one column pulls a value across matching sets
+          (issue #1591 follow-up). Progressive disclosure keeps the picker
+          uncluttered until a power user reaches for it. */}
+      <CustomColumnEntry discovered={discovered} selectedIds={selectedIds} onAdd={onAdd} />
+    </div>
+  );
+}
+
+// ============================================================================
+// Custom / pattern column entry — free-text set + property, regex-aware
+// ============================================================================
+
+function CustomColumnEntry({
+  discovered,
+  selectedIds,
+  onAdd,
+}: {
+  discovered: DiscoveredColumns;
+  selectedIds: Set<string>;
+  onAdd: (col: ColumnDefinition) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [source, setSource] = useState<'property' | 'quantity'>('property');
+  const [setName, setSetName] = useState('');
+  const [propName, setPropName] = useState('');
+
+  const setOptions = useMemo<string[]>(
+    () => Array.from((source === 'quantity' ? discovered.quantities : discovered.properties).keys()).sort(),
+    [discovered, source],
+  );
+  // Suggest property names only when the typed set is an exact discovered set
+  // (a `/regex/` set has no single property list to offer).
+  const propOptions = useMemo<string[]>(
+    () => [...((source === 'quantity' ? discovered.quantities : discovered.properties).get(setName.trim()) ?? [])],
+    [discovered, source, setName],
+  );
+
+  const set = setName.trim();
+  const prop = propName.trim();
+  // Slugify like the discovered-column ids (whitespace only), so regex
+  // metacharacters survive and two distinct patterns never collapse to one id.
+  const columnId = `custom-${source}-${set}-${prop}`.toLowerCase().replace(/\s+/g, '-');
+  const canAdd = set.length > 0 && prop.length > 0 && !selectedIds.has(columnId);
+
+  const add = () => {
+    if (!canAdd) return;
+    onAdd({ id: columnId, source, psetName: set, propertyName: prop, label: prop });
+    // Keep the set + source so several properties from the same (pattern) set
+    // can be added in a row; clear only the property.
+    setPropName('');
+  };
+
+  if (!open) {
+    return (
+      <button
+        onClick={() => setOpen(true)}
+        className="flex w-full items-center gap-1.5 rounded-md border border-dashed border-border px-2 py-1.5 text-xs text-muted-foreground hover:border-primary/50 hover:text-foreground"
+      >
+        <Plus className="h-3.5 w-3.5" /> Custom column
+        <span className="ml-auto font-mono text-[10px] opacity-70">Pset/Qto or /regex/</span>
+      </button>
+    );
+  }
+
+  return (
+    <div className="space-y-2 rounded-md border border-border/60 bg-card p-2.5">
+      <div className="flex items-center gap-1.5">
+        <Chip selected={source === 'property'} onClick={() => setSource('property')}>Property</Chip>
+        <Chip selected={source === 'quantity'} onClick={() => setSource('quantity')}>Quantity</Chip>
+        <button
+          onClick={() => setOpen(false)}
+          aria-label="Close custom column"
+          className="ml-auto shrink-0 text-muted-foreground hover:text-foreground"
+        >
+          <ChevronUp className="h-3.5 w-3.5" />
+        </button>
+      </div>
+      <div className="flex items-center gap-1.5">
+        <ComboInput
+          value={setName}
+          options={setOptions}
+          placeholder={source === 'quantity' ? 'Qto_… or /Qto_.*/' : 'Pset_… or /Pset_.*/'}
+          className="h-7 min-w-0 flex-1 text-xs"
+          onChange={setSetName}
+        />
+        <ComboInput
+          value={propName}
+          options={propOptions}
+          placeholder={source === 'quantity' ? 'NetVolume' : 'FireRating'}
+          className="h-7 min-w-0 flex-1 text-xs"
+          onChange={setPropName}
+        />
+        <Button
+          size="sm"
+          onClick={add}
+          disabled={!canAdd}
+          aria-label="Add custom column"
+          className="h-7 shrink-0 px-2"
+        >
+          <Plus className="h-3.5 w-3.5" />
+        </Button>
+      </div>
+      <p className="text-[11px] leading-relaxed text-muted-foreground">
+        Type an exact set name, or wrap a pattern in{' '}
+        <code className="rounded bg-muted px-1 font-mono text-[10px]">/…/</code> to pull one value across every
+        matching set, e.g. <code className="rounded bg-muted px-1 font-mono text-[10px]">/Qto_.*BaseQuantities/</code>.
+      </p>
     </div>
   );
 }

--- a/packages/lists/src/engine.test.ts
+++ b/packages/lists/src/engine.test.ts
@@ -52,6 +52,9 @@ function createMockProvider(): ListDataProvider {
         { name: 'Length', value: 5.0, type: 0 },
         { name: 'Height', value: 2.8, type: 0 },
         { name: 'Width', value: 0.2, type: 0 },
+        // NetVolume lives in a DIFFERENT set per element type (wall vs slab);
+        // a `/Qto_.*BaseQuantities/` pattern spans both (#1591).
+        { name: 'NetVolume', value: 0.28, type: 2 },
       ]},
     ]],
     [2, [
@@ -59,12 +62,14 @@ function createMockProvider(): ListDataProvider {
         { name: 'Length', value: 3.5, type: 0 },
         { name: 'Height', value: 2.8, type: 0 },
         { name: 'Width', value: 0.15, type: 0 },
+        { name: 'NetVolume', value: 0.147, type: 2 },
       ]},
     ]],
     [3, [
       { name: 'Qto_SlabBaseQuantities', quantities: [
         { name: 'GrossArea', value: 45.2, type: 1 },
         { name: 'GrossVolume', value: 9.04, type: 2 },
+        { name: 'NetVolume', value: 8.5, type: 2 },
       ]},
     ]],
   ]);
@@ -403,6 +408,9 @@ describe('executeList', () => {
     // FireRating: Wall-01='REI 90', Wall-02='EI 30', Slab-01 has no
     // Pset_WallCommon at all (null actualValue is excluded, not a match).
     { source: 'property', psetName: 'Pset_WallCommon', propertyName: 'FireRating', operator: 'notEquals', value: 'EI 30', expected: ['Wall-01'] },
+    // #1591: a regex qset pattern in a condition. NetVolume: Wall-01=0.28,
+    // Wall-02=0.147, Slab-01=8.5 — only the slab exceeds 1.
+    { source: 'quantity', psetName: '/Qto_.*BaseQuantities/', propertyName: 'NetVolume', operator: 'gt', value: 1, expected: ['Slab-01'] },
   ] as const)('filters by $source $operator against $value (psetName=$psetName)', ({ source, psetName, propertyName, operator, value, expected }) => {
     const provider = createMockProvider();
     const def: ListDefinition = {
@@ -417,6 +425,31 @@ describe('executeList', () => {
 
     const result = executeList(def, provider);
     expect(result.rows.map((r) => r.values[0]).sort()).toEqual([...expected]);
+  });
+
+  // #1591: a `/regex/` qset-name pattern pulls the same quantity from whichever
+  // matching set an element carries — NetVolume from Qto_WallBaseQuantities for
+  // walls AND Qto_SlabBaseQuantities for the slab, in one column.
+  it('resolves a quantity via a regex qset-name pattern across sets', () => {
+    const provider = createMockProvider();
+    const def: ListDefinition = {
+      id: 'regex-qty',
+      name: 'T',
+      createdAt: 0,
+      updatedAt: 0,
+      entityTypes: [IfcTypeEnum.IfcWall, IfcTypeEnum.IfcSlab],
+      conditions: [],
+      columns: [
+        { id: 'name', source: 'attribute', propertyName: 'Name' },
+        { id: 'vol', source: 'quantity', psetName: '/Qto_.*BaseQuantities/', propertyName: 'NetVolume' },
+      ],
+    };
+
+    const result = executeList(def, provider);
+    const byName = new Map(result.rows.map((r) => [r.values[0], r.values[1]]));
+    expect(byName.get('Wall-01')).toBe(0.28);
+    expect(byName.get('Wall-02')).toBe(0.147);
+    expect(byName.get('Slab-01')).toBe(8.5);
   });
 
   it('returns null for missing properties', () => {

--- a/packages/lists/src/engine.ts
+++ b/packages/lists/src/engine.ts
@@ -11,6 +11,7 @@
 
 import type { PropertySet, Property, QuantitySet, Quantity } from '@ifc-lite/data';
 import { parsePropertyValue } from '@ifc-lite/encoding';
+import { compileNameMatcher } from './name-pattern.js';
 import type {
   ListDataProvider,
   ListDefinition,
@@ -459,10 +460,15 @@ function getQuantityValue(
  *  callers that need the measure `dataType` (issue #1573) don't have to
  *  re-walk the sets. */
 function findPropertyEntry(psets: PropertySet[], psetName: string, propName: string): Property | undefined {
+  // Set and property names support Bonsai-style `/regex/` patterns, so one
+  // column can pull a value from several psets at once (issue #1591); a plain
+  // name stays an exact match.
+  const matchSet = compileNameMatcher(psetName);
+  const matchProp = compileNameMatcher(propName);
   for (const pset of psets) {
-    if (pset.name === psetName) {
+    if (matchSet(pset.name)) {
       for (const prop of pset.properties) {
-        if (prop.name === propName) return prop;
+        if (matchProp(prop.name)) return prop;
       }
     }
   }
@@ -504,10 +510,13 @@ function resolvePropertyValue(value: unknown): CellValue {
  *  that need the `QuantityType` (issue #1573) don't have to re-walk the
  *  sets. */
 function findQuantityEntry(qsets: QuantitySet[], qsetName: string, quantName: string): Quantity | undefined {
+  // Qset and quantity names support `/regex/` patterns too (see findPropertyEntry).
+  const matchSet = compileNameMatcher(qsetName);
+  const matchQuant = compileNameMatcher(quantName);
   for (const qset of qsets) {
-    if (qset.name === qsetName) {
+    if (matchSet(qset.name)) {
       for (const quant of qset.quantities) {
-        if (quant.name === quantName) return quant;
+        if (matchQuant(quant.name)) return quant;
       }
     }
   }

--- a/packages/lists/src/index.ts
+++ b/packages/lists/src/index.ts
@@ -24,6 +24,9 @@ export { ENTITY_ATTRIBUTES } from './types.js';
 // Engine
 export { executeList, listResultToCSV, summariseListRows } from './engine.js';
 
+// Name pattern matching (Bonsai-style `/regex/` set/property names)
+export { compileNameMatcher, isNamePattern } from './name-pattern.js';
+
 // Column discovery
 export { discoverColumns } from './discovery.js';
 

--- a/packages/lists/src/name-pattern.test.ts
+++ b/packages/lists/src/name-pattern.test.ts
@@ -1,0 +1,63 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it, expect, vi } from 'vitest';
+import { compileNameMatcher, isNamePattern } from './name-pattern.js';
+
+describe('compileNameMatcher', () => {
+  it('matches a plain name exactly and case-sensitively', () => {
+    const m = compileNameMatcher('Qto_WallBaseQuantities');
+    expect(m('Qto_WallBaseQuantities')).toBe(true);
+    expect(m('Qto_SlabBaseQuantities')).toBe(false);
+    expect(m('qto_wallbasequantities')).toBe(false);
+  });
+
+  it('treats a `/regex/` literal as a regular expression', () => {
+    const m = compileNameMatcher('/Qto_.*BaseQuantities/');
+    // The #1591 use case: one pattern spans several quantity sets.
+    expect(m('Qto_WallBaseQuantities')).toBe(true);
+    expect(m('Qto_SlabBaseQuantities')).toBe(true);
+    expect(m('Qto_WallCommon')).toBe(false);
+    expect(m('Pset_WallCommon')).toBe(false);
+  });
+
+  it('honours regex flags', () => {
+    const m = compileNameMatcher('/qto_.*basequantities/i');
+    expect(m('Qto_WallBaseQuantities')).toBe(true);
+  });
+
+  it('anchors are respected inside the literal', () => {
+    const m = compileNameMatcher('/^Pset_/');
+    expect(m('Pset_WallCommon')).toBe(true);
+    expect(m('X_Pset_WallCommon')).toBe(false);
+  });
+
+  it('falls back to an exact literal match (and warns) on an invalid pattern', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const m = compileNameMatcher('/Qto_[/'); // unterminated character class
+      expect(m('Qto_WallBaseQuantities')).toBe(false); // never silently matches
+      expect(m('/Qto_[/')).toBe(true); // matches only its own literal text
+      expect(warn).toHaveBeenCalledOnce();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('does not treat a name with internal slashes as a pattern', () => {
+    // Not slash-delimited at both ends → exact match, no regex.
+    const m = compileNameMatcher('Pset_A/B');
+    expect(m('Pset_A/B')).toBe(true);
+    expect(m('Pset_AXB')).toBe(false);
+  });
+});
+
+describe('isNamePattern', () => {
+  it('recognises valid `/regex/` literals only', () => {
+    expect(isNamePattern('/Qto_.*/')).toBe(true);
+    expect(isNamePattern('/Qto_.*/i')).toBe(true);
+    expect(isNamePattern('Qto_WallBaseQuantities')).toBe(false);
+    expect(isNamePattern('/unterminated[/')).toBe(false); // malformed → not a pattern
+  });
+});

--- a/packages/lists/src/name-pattern.test.ts
+++ b/packages/lists/src/name-pattern.test.ts
@@ -27,6 +27,18 @@ describe('compileNameMatcher', () => {
     expect(m('Qto_WallBaseQuantities')).toBe(true);
   });
 
+  it('strips stateful g/y flags so cached matching stays deterministic', () => {
+    // The matcher is cached and shared across rows; a global/sticky RegExp
+    // advances lastIndex on each .test(), so without stripping g/y the same
+    // name would alternate true/false. Repeated calls must be stable.
+    const m = compileNameMatcher('/Qto_.*BaseQuantities/g');
+    expect(m('Qto_WallBaseQuantities')).toBe(true);
+    expect(m('Qto_WallBaseQuantities')).toBe(true);
+    expect(m('Qto_SlabBaseQuantities')).toBe(true);
+    expect(m('Pset_WallCommon')).toBe(false);
+    expect(m('Pset_WallCommon')).toBe(false);
+  });
+
   it('anchors are respected inside the literal', () => {
     const m = compileNameMatcher('/^Pset_/');
     expect(m('Pset_WallCommon')).toBe(true);

--- a/packages/lists/src/name-pattern.ts
+++ b/packages/lists/src/name-pattern.ts
@@ -1,0 +1,64 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Property-set / property NAME matching for list columns and queries.
+ *
+ * A name wrapped in slashes (`/Qto_.*BaseQuantities/`, optionally with trailing
+ * flags such as `/qto_.+/i`) is treated as a regular expression matched against
+ * the candidate name; anything else is an exact, case-sensitive string match
+ * (the historical behaviour). This lets one column / query pull a value from
+ * several property or quantity sets at once — e.g. `NetVolume` from
+ * `Qto_WallBaseQuantities` AND `Qto_SlabBaseQuantities` — the way Bonsai's
+ * `/regex/` syntax works (issue #1591). IFC set / property names never contain
+ * slashes, so the `/.../` form is unambiguous.
+ */
+
+type NameMatcher = (name: string) => boolean;
+
+// Compiled matchers are cached by pattern string: `findPropertyEntry` /
+// `findQuantityEntry` run per row, and the pattern is fixed per column, so
+// without this a regex column would recompile its RegExp for every element.
+// Distinct patterns are bounded by the user's column/query configs; the cap is
+// a backstop against a pathological loop that mints unique patterns.
+const CACHE_CAP = 256;
+const matcherCache = new Map<string, NameMatcher>();
+
+/** True when `pattern` uses the `/regex/` form (a valid slash-delimited literal). */
+export function isNamePattern(pattern: string): boolean {
+  return parseRegexLiteral(pattern) !== null;
+}
+
+/**
+ * Compile a name pattern into a predicate. `/body/flags` compiles to a RegExp;
+ * anything else (including a malformed literal, which is logged) becomes an
+ * exact, case-sensitive match.
+ */
+export function compileNameMatcher(pattern: string): NameMatcher {
+  const cached = matcherCache.get(pattern);
+  if (cached) return cached;
+
+  const re = parseRegexLiteral(pattern);
+  const matcher: NameMatcher = re ? (name) => re.test(name) : (name) => name === pattern;
+
+  if (matcherCache.size >= CACHE_CAP) matcherCache.clear();
+  matcherCache.set(pattern, matcher);
+  return matcher;
+}
+
+/**
+ * Parse a `/body/flags` regex literal, or return null for a plain name. A
+ * malformed literal is NOT silently swallowed: it's logged and treated as a
+ * plain name (so it matches only itself), keeping behaviour predictable.
+ */
+function parseRegexLiteral(pattern: string): RegExp | null {
+  const m = /^\/(.+)\/([a-z]*)$/.exec(pattern);
+  if (!m) return null;
+  try {
+    return new RegExp(m[1], m[2]);
+  } catch (err) {
+    console.warn(`[lists] invalid name pattern ${JSON.stringify(pattern)}: ${(err as Error).message}`);
+    return null;
+  }
+}

--- a/packages/lists/src/name-pattern.ts
+++ b/packages/lists/src/name-pattern.ts
@@ -56,7 +56,10 @@ function parseRegexLiteral(pattern: string): RegExp | null {
   const m = /^\/(.+)\/([a-z]*)$/.exec(pattern);
   if (!m) return null;
   try {
-    return new RegExp(m[1], m[2]);
+    // Strip the stateful `g`/`y` flags: the compiled matcher is cached and
+    // shared across rows, and `.test()` on a global/sticky RegExp advances
+    // `lastIndex`, which would make matching alternate true/false per call.
+    return new RegExp(m[1], m[2].replace(/[gy]/g, ''));
   } catch (err) {
     console.warn(`[lists] invalid name pattern ${JSON.stringify(pattern)}: ${(err as Error).message}`);
     return null;

--- a/packages/sdk/src/context.test.ts
+++ b/packages/sdk/src/context.test.ts
@@ -264,6 +264,33 @@ describe('QueryNamespace helpers', () => {
     expect(value).toBe(true);
   });
 
+  // #1591: `/regex/` set-name patterns in property()/quantity().
+  it('property() resolves across sets via a regex set-name pattern', () => {
+    const { backend, query } = createMockBackend();
+    query.properties.mockReturnValue([
+      { name: 'Pset_SlabCommon', properties: [{ name: 'LoadBearing', type: 0, value: true }] },
+    ]);
+
+    const bim = createBimContext({ backend });
+    // `/Pset_.*Common/` matches Pset_SlabCommon even though the caller doesn't
+    // know the element's class up front.
+    const value = bim.property({ modelId: 'model-1', expressId: 1 }, '/Pset_.*Common/', 'LoadBearing');
+    expect(value).toBe(true);
+    // A plain (exact) name that doesn't match still returns null.
+    expect(bim.property({ modelId: 'model-1', expressId: 1 }, 'Pset_WallCommon', 'LoadBearing')).toBeNull();
+  });
+
+  it('quantity() resolves across sets via a regex qset-name pattern', () => {
+    const { backend, query } = createMockBackend();
+    query.quantities.mockReturnValue([
+      { name: 'Qto_SlabBaseQuantities', quantities: [{ name: 'NetVolume', type: 2, value: 8.5 }] },
+    ]);
+
+    const bim = createBimContext({ backend });
+    const value = bim.quantity({ modelId: 'model-1', expressId: 1 }, '/Qto_.*BaseQuantities/', 'NetVolume');
+    expect(value).toBe(8.5);
+  });
+
   it('materials() returns structured material data', () => {
     const { backend, query } = createMockBackend();
     query.materials.mockReturnValue({

--- a/packages/sdk/src/namespaces/query.ts
+++ b/packages/sdk/src/namespaces/query.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+import { compileNameMatcher } from '@ifc-lite/lists';
 import type {
   BimBackend,
   EntityRef,
@@ -128,13 +129,22 @@ export class QueryNamespace {
     return this.backend.query.properties(ref);
   }
 
-  /** Get a single property value */
+  /**
+   * Get a single property value. `psetName` / `propName` accept Bonsai-style
+   * `/regex/` patterns (e.g. `/Pset_.*Common/`), so one call can read across
+   * several matching property sets; a plain name is an exact match. Returns the
+   * first match in set/property order.
+   */
   property(ref: EntityRef, psetName: string, propName: string): string | number | boolean | null {
     const psets = this.properties(ref);
-    const pset = psets.find(p => p.name === psetName);
-    if (!pset) return null;
-    const prop = pset.properties.find(p => p.name === propName);
-    return prop?.value ?? null;
+    const matchSet = compileNameMatcher(psetName);
+    const matchProp = compileNameMatcher(propName);
+    for (const pset of psets) {
+      if (!matchSet(pset.name)) continue;
+      const prop = pset.properties.find(p => matchProp(p.name));
+      if (prop) return prop.value ?? null;
+    }
+    return null;
   }
 
   /** Get all quantity sets for an entity */
@@ -167,20 +177,30 @@ export class QueryNamespace {
     return this.backend.query.relationships(ref);
   }
 
-  /** Get a single quantity value. Supports 2-arg (ref, quantityName) or 3-arg (ref, qsetName, quantityName). */
+  /**
+   * Get a single quantity value. Supports 2-arg (ref, quantityName) or 3-arg
+   * (ref, qsetName, quantityName). Qset / quantity names accept Bonsai-style
+   * `/regex/` patterns (e.g. `/Qto_.*BaseQuantities/`), so one call can read a
+   * quantity across several matching sets; a plain name is an exact match.
+   * Returns the first match in set/quantity order.
+   */
   quantity(ref: EntityRef, qsetNameOrQuantityName: string, quantityName?: string): number | null {
     const qsets = this.quantities(ref);
     if (quantityName !== undefined) {
       // 3-arg: (ref, qsetName, quantityName)
-      const qset = qsets.find(q => q.name === qsetNameOrQuantityName);
-      if (!qset) return null;
-      const qty = qset.quantities.find(q => q.name === quantityName);
-      return qty?.value ?? null;
+      const matchSet = compileNameMatcher(qsetNameOrQuantityName);
+      const matchQuant = compileNameMatcher(quantityName);
+      for (const qset of qsets) {
+        if (!matchSet(qset.name)) continue;
+        const qty = qset.quantities.find(q => matchQuant(q.name));
+        if (qty != null) return qty.value ?? null;
+      }
+      return null;
     }
     // 2-arg: (ref, quantityName) — search all qsets
-    const name = qsetNameOrQuantityName;
+    const matchQuant = compileNameMatcher(qsetNameOrQuantityName);
     for (const qset of qsets) {
-      const qty = qset.quantities.find(q => q.name === name);
+      const qty = qset.quantities.find(q => matchQuant(q.name));
       if (qty != null) return qty.value ?? null;
     }
     return null;

--- a/scripts/api-surface.json
+++ b/scripts/api-surface.json
@@ -1828,8 +1828,10 @@
     "ListRow: interface",
     "ListSummary: interface",
     "PropertyCondition: interface",
+    "compileNameMatcher: function",
     "discoverColumns: function",
     "executeList: function",
+    "isNamePattern: function",
     "listResultToCSV: function",
     "summariseListRows: function"
   ],


### PR DESCRIPTION
## What & why

Part of issue #1591. The reporter wants to pull `NetVolume` from several quantity sets at once (`Qto_WallBaseQuantities`, `Qto_SlabBaseQuantities`), the way Bonsai does with a `/Qto_.*BaseQuantities/` pattern. Today every pset/qto name match in ifc-lite is exact `===`, so this is impossible.

This adds regex name patterns. A name wrapped in slashes (optionally with flags, e.g. `/qto_.+/i`) is matched as a regular expression; a plain name stays an exact, case-sensitive match. One column or query can then read a value from whichever matching set an element carries.

> Stacked on #1614 (base branch `feat/1591-lists-federation-columns`). Review/merge that first.

## Implementation

- `@ifc-lite/lists`: new `compileNameMatcher` / `isNamePattern` (`name-pattern.ts`). `/body/flags` compiles to a RegExp; anything else is exact. Compiled matchers are cached (the lookup runs per row); an invalid pattern is logged (never a silent catch) and falls back to an exact literal so it can never silently match everything or nothing. Wired into `findPropertyEntry` / `findQuantityEntry`, so both list columns and filter conditions are pattern-aware.
- `@ifc-lite/sdk`: `bim.query().property()` and `quantity()` accept patterns (reusing the lists matcher), returning the first match in set/property order.

## Tests

- Matcher unit suite: exact, `/regex/`, flags, anchors, internal-slash names, and the invalid-pattern path (warns + exact-literal fallback, never matches everything).
- Engine: a `/Qto_.*BaseQuantities/` column pulls `NetVolume` from both the wall set and the slab set; a regex condition filters on it.
- SDK: `property()` / `quantity()` resolve across sets via a regex set-name pattern.
- `@ifc-lite/lists` 54/54, `@ifc-lite/sdk` context 39/39; all packages build (tsc) clean.

## Changeset & API surface

`@ifc-lite/lists` + `@ifc-lite/sdk` minor. `scripts/api-surface.json` updated for the two new lists exports.

## Deferred (noted)

The SDK `where()` filter clause and the CLI/MCP `HeadlessBackend` filter resolution still exact-match set names, and the Rust export (`EntityRow::lookup`) does too. Extending those to the same matcher is a clean follow-up; this PR covers the interactive list query and the SDK value getters, which is the reporter's use case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Follow-up added: custom / regex column in the builder UI (OP's request)

The issue reporter followed up asking for "a double box where the user could enter them (Bonsai style)" alongside the static picker. The list column picker only offered exact discovered pset/qto names, so the regex above was reachable in filters and the SDK but not as a **column** from the UI.

Added a progressive-disclosure **Custom column** entry to the ColumnPicker: a Property/Quantity toggle plus two inputs (set name with discovered suggestions, property name), matching the existing panel idiom (dashed trigger like "Add filter", Chip toggle, ComboInput pair like the filter editor), collapsed by default to keep the picker uncluttered.

Verified live on `building-architecture.ifc`: a `/Qto_.*BaseQuantities/` + `NetVolume` custom column pulled NetVolume into ONE column from both the wall set (4 IfcWall) and the slab set (3 IfcSlab) - exactly the reporter's Bonsai use case. Viewer-only, no published API change.