### PR TITLE
feat(bcf,clash): federate BCF topics - source-file Header + multi-model selection [#1591]

### DIFF
--- a/.changeset/bcf-federation-header-files.md
+++ b/.changeset/bcf-federation-header-files.md
@@ -1,0 +1,7 @@
+---
+"@ifc-lite/bcf": minor
+---
+
+`BCFTopic` gains an optional `header?: BCFHeaderFile[]` field: the source IFC file(s) a topic refers to (markup `<Header>`), one entry per distinct model a federated topic spans, so a topic round-trips the provenance of every model it touches (issue #1591).
+
+`writeBCF` now emits the `<Header>` block (version-correct: BCF 2.1 nests `<File>` directly, BCF 3.0 wraps them in `<Files>`), and `readBCF` parses it back into `topic.header`. Both are additive: topics without header files emit no `<Header>` element and existing markup output is unchanged.

--- a/.changeset/clash-bcf-federation-header.md
+++ b/.changeset/clash-bcf-federation-header.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/clash": minor
+---
+
+Clash-to-BCF export (`createBCFFromClashResult`) now records a markup `<Header>` source file per distinct model each clash group spans, derived from the group members' `model` names. A cross-model clash topic therefore round-trips the provenance of both models it references (issue #1591). Topics with no resolvable model name are unaffected.

--- a/apps/viewer/src/components/mcp/playground-dispatcher.ts
+++ b/apps/viewer/src/components/mcp/playground-dispatcher.ts
@@ -786,6 +786,8 @@ const IMPLS: Record<string, ToolImpl> = {
     const project = await createBCFFromClashResult(result, groups, {
       author: 'clash@ifc-lite',
       projectName: 'Clash report',
+      // Resolve the (single) model id to its file name for the BCF Header (#1591).
+      modelNameOf: (id) => (id === m.id ? m.name : id),
       ...(status ? { status } : {}),
       ...(maxTopics != null ? { maxTopics } : {}),
     });

--- a/apps/viewer/src/components/viewer/BCFPanel.tsx
+++ b/apps/viewer/src/components/viewer/BCFPanel.tsx
@@ -92,7 +92,7 @@ export function BCFPanel({ onClose }: BCFPanelProps) {
   const models = useViewerStore((s) => s.models);
 
   // BCF hook for camera/snapshot integration
-  const { createViewpointFromState, applyViewpoint, zoomToTopic, canZoomToTopic } = useBCF();
+  const { createViewpointFromState, headerFilesForViewpoints, applyViewpoint, zoomToTopic, canZoomToTopic } = useBCF();
 
   // Local state
   const [statusFilter, setStatusFilter] = useState('all');
@@ -244,6 +244,16 @@ export function BCFPanel({ onClose }: BCFPanelProps) {
   const handleCreateTopic = useCallback(
     async (data: Partial<BCFTopic>, options?: { includeSnapshot: boolean }) => {
       ensureProject();
+      // Resolve the viewpoint first so the topic's source-file Header can be
+      // derived from the models its selection references before it is stored.
+      let viewpoint = options?.includeSnapshot === false ? null : createViewpoint;
+      if (options?.includeSnapshot !== false && !viewpoint) {
+        viewpoint = await createViewpointFromState({
+          includeSnapshot: true,
+          includeSelection: true,
+          includeHidden: true,
+        });
+      }
       const topic = createBCFTopic({
         title: data.title || 'Untitled',
         description: data.description,
@@ -255,17 +265,10 @@ export function BCFPanel({ onClose }: BCFPanelProps) {
         dueDate: data.dueDate,
         labels: data.labels,
       });
+      // Record the distinct source model(s) this topic touches (#1591 federation).
+      const header = headerFilesForViewpoints(viewpoint ? [viewpoint] : [], topic.creationDate);
+      if (header.length > 0) topic.header = header;
       addTopic(topic);
-      // Attach the previewed viewpoint unless opted out; fall back to a fresh
-      // capture if the preview never resolved.
-      let viewpoint = options?.includeSnapshot === false ? null : createViewpoint;
-      if (options?.includeSnapshot !== false && !viewpoint) {
-        viewpoint = await createViewpointFromState({
-          includeSnapshot: true,
-          includeSelection: true,
-          includeHidden: true,
-        });
-      }
       if (viewpoint) addViewpoint(topic.guid, viewpoint);
       posthog.capture('bcf_topic_created', {
         topic_type: topic.topicType,
@@ -275,7 +278,7 @@ export function BCFPanel({ onClose }: BCFPanelProps) {
       });
       setShowCreateForm(false);
     },
-    [ensureProject, bcfAuthor, addTopic, addViewpoint, createViewpoint, createViewpointFromState]
+    [ensureProject, bcfAuthor, addTopic, addViewpoint, createViewpoint, createViewpointFromState, headerFilesForViewpoints]
   );
 
   // Add comment to topic (optionally associated with a viewpoint)

--- a/apps/viewer/src/components/viewer/compare/useBcfFromChange.ts
+++ b/apps/viewer/src/components/viewer/compare/useBcfFromChange.ts
@@ -36,7 +36,7 @@ export function useBcfFromChange(
   modelList: readonly { name?: string }[],
   selectedKey: string | null,
 ): BcfFromChangeController {
-  const { createViewpointFromState } = useBCF();
+  const { createViewpointFromState, headerFilesForViewpoints } = useBCF();
 
   const [formOpen, setFormOpen] = useState(false);
   const [createdTitle, setCreatedTitle] = useState<string | null>(null);
@@ -93,6 +93,16 @@ export function useBcfFromChange(
           const first = modelList[0]?.name?.replace(/\.(ifc|ifczip)$/i, '') || 'Comparison';
           state.setBcfProject(createBCFProject({ name: `${first}_Issues` }));
         }
+        // Resolve the viewpoint first so the topic's source-file Header can be
+        // derived from the models its selection references before it is stored.
+        let vp = options?.includeSnapshot === false ? null : viewpoint;
+        if (options?.includeSnapshot !== false && !vp) {
+          vp = await createViewpointFromState({
+            includeSnapshot: true,
+            includeSelection: true,
+            includeHidden: false,
+          });
+        }
         const topic = createBCFTopic({
           title: data.title || 'Untitled',
           description: data.description,
@@ -104,17 +114,10 @@ export function useBcfFromChange(
           dueDate: data.dueDate,
           labels: data.labels,
         });
+        // Record the distinct source model(s) this topic touches (#1591 federation).
+        const header = headerFilesForViewpoints(vp ? [vp] : [], topic.creationDate);
+        if (header.length > 0) topic.header = header;
         useViewerStore.getState().addTopic(topic);
-        // Attach the previewed viewpoint unless the user opted out; fall back to
-        // a fresh capture if the preview never resolved.
-        let vp = options?.includeSnapshot === false ? null : viewpoint;
-        if (options?.includeSnapshot !== false && !vp) {
-          vp = await createViewpointFromState({
-            includeSnapshot: true,
-            includeSelection: true,
-            includeHidden: false,
-          });
-        }
         if (vp) useViewerStore.getState().addViewpoint(topic.guid, vp);
         posthog.capture('bcf_topic_created', {
           source: 'compare',
@@ -130,7 +133,7 @@ export function useBcfFromChange(
         submitInFlight.current = false;
       }
     },
-    [modelList, viewpoint, createViewpointFromState],
+    [modelList, viewpoint, createViewpointFromState, headerFilesForViewpoints],
   );
 
   return {

--- a/apps/viewer/src/hooks/bcfHeaderFiles.test.ts
+++ b/apps/viewer/src/hooks/bcfHeaderFiles.test.ts
@@ -1,0 +1,71 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { deriveHeaderFiles } from './bcfHeaderFiles';
+import type { IfcDataStore } from '@ifc-lite/parser';
+import type { FederatedModel } from '@/store/types';
+
+/** Minimal IfcDataStore whose project resolves to `projectGuid` (or none). */
+function fakeStore(projectExpressId: number | undefined, projectGuid = ''): IfcDataStore {
+  return {
+    spatialHierarchy: projectExpressId === undefined ? undefined : { project: { expressId: projectExpressId } },
+    entities: { getGlobalId: (id: number) => (id === projectExpressId ? projectGuid : '') },
+  } as unknown as IfcDataStore;
+}
+
+function fakeModel(name: string, store: IfcDataStore | null): FederatedModel {
+  return { id: name, name, ifcDataStore: store } as unknown as FederatedModel;
+}
+
+describe('deriveHeaderFiles', () => {
+  it('builds one header file per distinct model with name + project guid', () => {
+    const models = new Map<string, FederatedModel>([
+      ['m1', fakeModel('arch.ifc', fakeStore(1, '0ARCHPROJECTGUID000000'))],
+      ['m2', fakeModel('struct.ifc', fakeStore(2, '0STRUCTPROJECTGUID0000'))],
+    ]);
+
+    const files = deriveHeaderFiles(['m1', 'm2'], models, null, '2026-07-04T00:00:00Z');
+    assert.equal(files.length, 2);
+    assert.deepEqual(files[0], {
+      ifcProject: '0ARCHPROJECTGUID000000',
+      isExternal: true,
+      filename: 'arch.ifc',
+      date: '2026-07-04T00:00:00Z',
+      reference: 'arch.ifc',
+    });
+    assert.equal(files[1].filename, 'struct.ifc');
+    assert.equal(files[1].ifcProject, '0STRUCTPROJECTGUID0000');
+  });
+
+  it('de-duplicates repeated model ids', () => {
+    const models = new Map<string, FederatedModel>([['m1', fakeModel('arch.ifc', fakeStore(1, 'G'))]]);
+    const files = deriveHeaderFiles(['m1', 'm1', 'm1'], models, null);
+    assert.equal(files.length, 1);
+  });
+
+  it('skips model ids that are not loaded', () => {
+    const models = new Map<string, FederatedModel>([['m1', fakeModel('arch.ifc', fakeStore(1, 'G'))]]);
+    const files = deriveHeaderFiles(['m1', 'missing'], models, null);
+    assert.deepEqual(files.map((f) => f.filename), ['arch.ifc']);
+  });
+
+  it('leaves ifcProject undefined when the project has no global id', () => {
+    const models = new Map<string, FederatedModel>([['m1', fakeModel('arch.ifc', fakeStore(undefined))]]);
+    const files = deriveHeaderFiles(['m1'], models, null);
+    assert.equal(files[0].ifcProject, undefined);
+  });
+
+  it('resolves the legacy single-model id via the fallback store', () => {
+    const files = deriveHeaderFiles(['legacy'], new Map(), fakeStore(1, '0LEGACYPROJECTGUID0000'));
+    assert.equal(files.length, 1);
+    assert.equal(files[0].filename, 'model.ifc');
+    assert.equal(files[0].ifcProject, '0LEGACYPROJECTGUID0000');
+  });
+
+  it('skips the legacy id when no fallback store is available', () => {
+    assert.deepEqual(deriveHeaderFiles(['legacy'], new Map(), null), []);
+  });
+});

--- a/apps/viewer/src/hooks/bcfHeaderFiles.ts
+++ b/apps/viewer/src/hooks/bcfHeaderFiles.ts
@@ -15,7 +15,7 @@ import type { BCFHeaderFile } from '@ifc-lite/bcf';
 import type { IfcDataStore } from '@ifc-lite/parser';
 import type { FederatedModel } from '@/store/types';
 
-/** Resolve the IfcProject GlobalId for a store (empty string when unavailable). */
+/** Resolve the IfcProject GlobalId for a store (undefined when unavailable). */
 function projectGlobalId(store: IfcDataStore | null | undefined): string | undefined {
   const projectExpressId = store?.spatialHierarchy?.project?.expressId;
   if (projectExpressId === undefined || !store?.entities) return undefined;

--- a/apps/viewer/src/hooks/bcfHeaderFiles.ts
+++ b/apps/viewer/src/hooks/bcfHeaderFiles.ts
@@ -1,0 +1,74 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Shared derivation of BCF markup `<Header>` source-file references (#1591).
+ *
+ * A topic that spans several federated models must record one header file per
+ * distinct source model so the provenance round-trips. This is the single home
+ * for turning a set of modelIds into `BCFHeaderFile[]`, reused by every viewer
+ * topic-creation path (BCFPanel, compare -> BCF).
+ */
+
+import type { BCFHeaderFile } from '@ifc-lite/bcf';
+import type { IfcDataStore } from '@ifc-lite/parser';
+import type { FederatedModel } from '@/store/types';
+
+/** Resolve the IfcProject GlobalId for a store (empty string when unavailable). */
+function projectGlobalId(store: IfcDataStore | null | undefined): string | undefined {
+  const projectExpressId = store?.spatialHierarchy?.project?.expressId;
+  if (projectExpressId === undefined || !store?.entities) return undefined;
+  return store.entities.getGlobalId(projectExpressId) || undefined;
+}
+
+/**
+ * Build one `BCFHeaderFile` per distinct modelId.
+ *
+ * - `filename`/`reference` come from the model display name.
+ * - `ifcProject` is resolved via the model's spatial hierarchy (may be empty,
+ *   which is acceptable per the BCF schema).
+ * - `'legacy'` (the single-model store, when `models` is empty) is resolved via
+ *   the fallback `ifcDataStore`.
+ *
+ * @param date creation date stamped on each file entry (topic creationDate).
+ */
+export function deriveHeaderFiles(
+  modelIds: Iterable<string>,
+  models: ReadonlyMap<string, FederatedModel>,
+  ifcDataStore: IfcDataStore | null | undefined,
+  date?: string,
+): BCFHeaderFile[] {
+  const files: BCFHeaderFile[] = [];
+  const seen = new Set<string>();
+
+  for (const modelId of modelIds) {
+    if (seen.has(modelId)) continue;
+    seen.add(modelId);
+
+    if (modelId === 'legacy') {
+      if (!ifcDataStore) continue;
+      const filename = 'model.ifc';
+      files.push({
+        ifcProject: projectGlobalId(ifcDataStore),
+        isExternal: true,
+        filename,
+        date,
+        reference: filename,
+      });
+      continue;
+    }
+
+    const model = models.get(modelId);
+    if (!model) continue;
+    files.push({
+      ifcProject: projectGlobalId(model.ifcDataStore),
+      isExternal: true,
+      filename: model.name,
+      date,
+      reference: model.name,
+    });
+  }
+
+  return files;
+}

--- a/apps/viewer/src/hooks/useBCF.ts
+++ b/apps/viewer/src/hooks/useBCF.ts
@@ -13,7 +13,7 @@
 
 import { useCallback, useRef } from 'react';
 import { useViewerStore } from '@/store';
-import type { BCFTopic, BCFViewpoint } from '@ifc-lite/bcf';
+import type { BCFTopic, BCFViewpoint, BCFHeaderFile } from '@ifc-lite/bcf';
 import {
   createViewpoint,
   extractViewpointState,
@@ -24,10 +24,13 @@ import {
   type OverlayBBox,
 } from '@ifc-lite/bcf';
 import type { Renderer } from '@ifc-lite/renderer';
+import type { EntityRef } from '@/store/types';
 import {
   globalIdToExpressId as globalIdToExpressIdLookup,
   expressIdToGlobalId as expressIdToGlobalIdLookup,
 } from './bcfIdLookup';
+import { fromGlobalIdFromModels } from '@/store/globalId';
+import { deriveHeaderFiles } from './bcfHeaderFiles';
 
 // ============================================================================
 // Types
@@ -52,6 +55,14 @@ interface CreateViewpointOptions {
 interface UseBCFResult {
   /** Create a viewpoint from current viewer state */
   createViewpointFromState: (options?: CreateViewpointOptions) => Promise<BCFViewpoint | null>;
+  /**
+   * Derive the BCF `<Header>` source files for a topic from the distinct source
+   * models its viewpoint components reference (single-model fallback when none).
+   */
+  headerFilesForViewpoints: (
+    viewpoints: readonly BCFViewpoint[],
+    date?: string,
+  ) => BCFHeaderFile[];
   /** Apply a viewpoint to the viewer */
   applyViewpoint: (viewpoint: BCFViewpoint, animate?: boolean) => void;
   /** Animate the camera to a BCF topic's 3D location (without changing selection/visibility) */
@@ -142,6 +153,10 @@ export function useBCF(options: UseBCFOptions = {}): UseBCFResult {
 
   // Selection and visibility actions
   const setSelectedEntityId = useViewerStore((s) => s.setSelectedEntityId);
+  const setSelectedEntityIds = useViewerStore((s) => s.setSelectedEntityIds);
+  const setSelectedEntity = useViewerStore((s) => s.setSelectedEntity);
+  const addEntitiesToSelection = useViewerStore((s) => s.addEntitiesToSelection);
+  const clearEntitySelection = useViewerStore((s) => s.clearEntitySelection);
   const setHiddenEntities = useViewerStore((s) => s.setHiddenEntities);
   const setIsolatedEntities = useViewerStore((s) => s.setIsolatedEntities);
 
@@ -372,6 +387,42 @@ export function useBCF(options: UseBCFOptions = {}): UseBCFResult {
     ]
   );
 
+  /**
+   * Derive `<Header>` source files for a topic: one per distinct model its
+   * viewpoint components reference. Falls back to the single loaded model when
+   * no components resolve, so a lone-model topic still records its source file.
+   */
+  const headerFilesForViewpoints = useCallback(
+    (viewpoints: readonly BCFViewpoint[], date?: string): BCFHeaderFile[] => {
+      const modelIds = new Set<string>();
+      for (const vp of viewpoints) {
+        const components: { ifcGuid?: string }[] = [
+          ...(vp.components?.selection ?? []),
+          ...(vp.components?.visibility?.exceptions ?? []),
+          ...(vp.components?.coloring?.flatMap((c) => c.components) ?? []),
+        ];
+        for (const comp of components) {
+          if (!comp.ifcGuid) continue;
+          const resolved = globalIdToExpressId(comp.ifcGuid);
+          if (resolved) modelIds.add(resolved.modelId);
+        }
+      }
+
+      // No component resolved to a model: record the single loaded model so a
+      // lone-model topic still carries its provenance.
+      if (modelIds.size === 0) {
+        if (models.size === 1) {
+          modelIds.add(models.keys().next().value!);
+        } else if (models.size === 0 && ifcDataStore) {
+          modelIds.add('legacy');
+        }
+      }
+
+      return deriveHeaderFiles(modelIds, models, ifcDataStore, date);
+    },
+    [globalIdToExpressId, models, ifcDataStore],
+  );
+
   /** Restore only the viewpoint camera (used by zoom-to-topic fallback). */
   const applyViewpointCamera = useCallback(
     (viewpoint: BCFViewpoint, animate = true) => {
@@ -438,26 +489,40 @@ export function useBCF(options: UseBCFOptions = {}): UseBCFResult {
         }
       }
 
-      // Apply selection from BCF components
+      // Apply selection from BCF components. A federated viewpoint can select
+      // elements across several models, so drive BOTH selection channels:
+      // `selectedEntityIds` (global ids) for the renderer highlight, and the
+      // model-aware `selectedEntitiesSet` (local {modelId, expressId} refs) for
+      // property/federation context. (#1591: previously this collapsed to the
+      // first element, losing every other selection and all model context.)
       if (state.selectedGuids.length > 0) {
-        // Convert GlobalId strings to expressIds
-        const selectedExpressIds: number[] = [];
+        const globalIds: number[] = []; // renderer highlight (federated global ids)
+        const refs: EntityRef[] = []; // model-aware multi-selection
         for (const guid of state.selectedGuids) {
           const result = globalIdToExpressId(guid);
-          if (result) {
-            selectedExpressIds.push(result.expressId);
-          }
+          if (!result) continue;
+          // result.expressId is already the federation-offset global id.
+          globalIds.push(result.expressId);
+          // Reverse the offset with the SAME store `models` map the forward
+          // mapping used, not the renderer singleton, so refs can never desync
+          // from globalIds if the registry lags the store.
+          const localRef = fromGlobalIdFromModels(models, result.expressId);
+          if (localRef) refs.push(localRef);
         }
 
-        if (selectedExpressIds.length > 0) {
-          // Select the first entity (primary selection)
-          // The expressId here already includes the federation offset
-          setSelectedEntityId(selectedExpressIds[0]);
-          // Note: Multi-selection would require additional store support
+        if (globalIds.length > 0) {
+          // Reset both channels, then apply the full multi-model selection.
+          clearEntitySelection();
+          setSelectedEntityIds(globalIds);
+          if (refs.length > 0) addEntitiesToSelection(refs);
+          // Pin the primary selection to the first element for consistent
+          // property display / framing (both channels keep the full set).
+          setSelectedEntityId(globalIds[0]);
+          if (refs.length > 0) setSelectedEntity(refs[0]);
         }
       } else {
         // Clear selection if viewpoint has no selection
-        setSelectedEntityId(null);
+        clearEntitySelection();
       }
 
       // Apply visibility from BCF components
@@ -505,7 +570,12 @@ export function useBCF(options: UseBCFOptions = {}): UseBCFResult {
       toggleSectionPlane,
       flipSectionPlane,
       globalIdToExpressId,
+      models,
       setSelectedEntityId,
+      setSelectedEntityIds,
+      setSelectedEntity,
+      addEntitiesToSelection,
+      clearEntitySelection,
       setHiddenEntities,
       setIsolatedEntities,
     ]
@@ -564,6 +634,7 @@ export function useBCF(options: UseBCFOptions = {}): UseBCFResult {
 
   return {
     createViewpointFromState,
+    headerFilesForViewpoints,
     applyViewpoint,
     zoomToTopic,
     canZoomToTopic,

--- a/apps/viewer/src/hooks/useBCF.ts
+++ b/apps/viewer/src/hooks/useBCF.ts
@@ -388,13 +388,27 @@ export function useBCF(options: UseBCFOptions = {}): UseBCFResult {
   );
 
   /**
-   * Derive `<Header>` source files for a topic: one per distinct model its
-   * viewpoint components reference. Falls back to the single loaded model when
-   * no components resolve, so a lone-model topic still records its source file.
+   * Derive `<Header>` source files for a topic: one per distinct model it
+   * references. Falls back to the single loaded model when nothing resolves, so
+   * a lone-model topic still records its source file.
    */
   const headerFilesForViewpoints = useCallback(
     (viewpoints: readonly BCFViewpoint[], date?: string): BCFHeaderFile[] => {
       const modelIds = new Set<string>();
+
+      // Primary source: the live selection's model ids. A topic is created from
+      // the current selection, and the selection knows each element's model
+      // exactly. Resolving component GlobalIds instead would lose a model whose
+      // elements share GlobalIds with another loaded model (revision
+      // federations), collapsing every component onto the first match.
+      const selected = useViewerStore.getState().selectedEntitiesSet;
+      for (const key of selected) {
+        const modelId = key.slice(0, key.indexOf(':'));
+        if (modelId) modelIds.add(modelId);
+      }
+
+      // Also union any model referenced by the viewpoint components but not the
+      // live selection (e.g. hidden/coloured components, or a restored viewpoint).
       for (const vp of viewpoints) {
         const components: { ifcGuid?: string }[] = [
           ...(vp.components?.selection ?? []),
@@ -408,8 +422,8 @@ export function useBCF(options: UseBCFOptions = {}): UseBCFResult {
         }
       }
 
-      // No component resolved to a model: record the single loaded model so a
-      // lone-model topic still carries its provenance.
+      // Nothing resolved: record the single loaded model so a lone-model topic
+      // still carries its provenance.
       if (modelIds.size === 0) {
         if (models.size === 1) {
           modelIds.add(models.keys().next().value!);

--- a/apps/viewer/src/hooks/useClash.ts
+++ b/apps/viewer/src/hooks/useClash.ts
@@ -607,6 +607,8 @@ export function useClash() {
           author: 'clash@ifc-lite',
           projectName: 'Clash report',
           reviewStatusOf,
+          // Resolve model ids to file names for the BCF Header (#1591).
+          modelNameOf: (id) => state.models.get(id)?.name ?? id,
           maxTopics: config.maxTopics,
           ...(snapshotProvider ? { snapshotProvider } : {}),
         });

--- a/packages/bcf/src/reader.ts
+++ b/packages/bcf/src/reader.ts
@@ -29,6 +29,7 @@ import type {
   BCFExtensions,
   BCFDocumentReference,
   BCFBimSnippet,
+  BCFHeaderFile,
 } from './types.js';
 
 /**
@@ -161,6 +162,10 @@ async function readTopic(zip: JSZip, topicFolder: string): Promise<BCFTopic | nu
   const guid = topicMatch[1];
   const topicContent = topicMatch[2];
 
+  // Header (source IFC files) sits before Topic in the markup, so parse it from
+  // the whole document rather than the Topic body.
+  const header = parseHeaderFiles(markupContent);
+
   // Extract topic attributes
   const topicTypeMatch = markupContent.match(/<Topic[^>]*TopicType="([^"]+)"/);
   const topicStatusMatch = markupContent.match(/<Topic[^>]*TopicStatus="([^"]+)"/);
@@ -225,7 +230,44 @@ async function readTopic(zip: JSZip, topicFolder: string): Promise<BCFTopic | nu
     relatedTopics: relatedTopics.length > 0 ? relatedTopics : undefined,
     comments,
     viewpoints,
+    header: header.length > 0 ? header : undefined,
   };
+}
+
+/**
+ * Parse the markup `<Header>` block into source-file references.
+ *
+ * Tolerant of both BCF versions: 2.1 nests `<File>` directly under `<Header>`
+ * and 3.0 wraps them in `<Files>`, so we match every `<File>` inside the header
+ * regardless of the wrapper.
+ */
+function parseHeaderFiles(markupContent: string): BCFHeaderFile[] {
+  const headerMatch = markupContent.match(/<Header>([\s\S]*?)<\/Header>/);
+  if (!headerMatch) return [];
+
+  const files: BCFHeaderFile[] = [];
+  const fileMatches = headerMatch[1].matchAll(/<File\b([^>]*?)(?:\/>|>([\s\S]*?)<\/File>)/g);
+  for (const match of fileMatches) {
+    const attrs = match[1] ?? '';
+    const body = match[2] ?? '';
+
+    const ifcProject = attrs.match(/IfcProject="([^"]*)"/)?.[1];
+    const ifcSpatial = attrs.match(/IfcSpatialStructureElement="([^"]*)"/)?.[1];
+    // BCF 2.1 spells this `isExternal`, 3.0 `IsExternal`; accept either casing
+    // (and the xs:boolean `1`/`0` forms a foreign tool may emit).
+    const isExternalRaw = attrs.match(/\b[Ii]sExternal="([^"]*)"/)?.[1];
+
+    files.push({
+      ifcProject: ifcProject || undefined,
+      ifcSpatialStructureElement: ifcSpatial || undefined,
+      isExternal: isExternalRaw === undefined ? undefined : (isExternalRaw === 'true' || isExternalRaw === '1'),
+      filename: extractElement(body, 'Filename'),
+      date: extractElement(body, 'Date'),
+      reference: extractElement(body, 'Reference'),
+    });
+  }
+
+  return files;
 }
 
 /**

--- a/packages/bcf/src/types.ts
+++ b/packages/bcf/src/types.ts
@@ -79,6 +79,13 @@ export interface BCFTopic {
   comments: BCFComment[];
   /** Viewpoints associated with the topic */
   viewpoints: BCFViewpoint[];
+  /**
+   * Source IFC file(s) this topic refers to (markup `<Header>`). One entry per
+   * distinct model touched by the topic, so a federated topic round-trips the
+   * provenance of every model it spans. Optional: absent for topics with no
+   * resolvable source model.
+   */
+  header?: BCFHeaderFile[];
 }
 
 export interface BCFBimSnippet {

--- a/packages/bcf/src/writer.test.ts
+++ b/packages/bcf/src/writer.test.ts
@@ -477,4 +477,98 @@ describe('BCF Writer', () => {
       description: 'Spec & Requirements',
     });
   });
+
+  // Federation provenance (#1591): a topic that spans multiple models must
+  // round-trip one <Header><File> per source model so the topic re-anchors to
+  // every model it touches, for BCF 2.1 and 3.0.
+  it.each(['2.1', '3.0'] as const)(
+    'should roundtrip header source files (BCF %s)',
+    async (version) => {
+      const topicGuid = generateUuid();
+      const topic: BCFTopic = {
+        guid: topicGuid,
+        title: 'Federated topic',
+        creationDate: '2026-07-04T00:00:00.000Z',
+        creationAuthor: 'test@example.com',
+        viewpoints: [],
+        comments: [],
+        header: [
+          {
+            ifcProject: '0YvCT2_$X3_xJG3rzD8L_8',
+            isExternal: true,
+            filename: 'architecture.ifc',
+            date: '2026-07-01T10:00:00.000Z',
+            reference: 'architecture.ifc',
+          },
+          {
+            ifcProject: '3aB9cd_ef2Gh1Ij4Kl5Mn6',
+            isExternal: false,
+            filename: 'structure.ifc',
+            date: '2026-07-02T11:30:00.000Z',
+            reference: 'structure.ifc',
+          },
+        ],
+      };
+
+      const project: BCFProject = {
+        version,
+        topics: new Map([[topicGuid, topic]]),
+      };
+
+      const blob = await writeBCF(project);
+      const zip = await JSZip.loadAsync(await blobToArrayBuffer(blob));
+      const markupContent = await zip.file(`${topicGuid}/markup.bcf`)?.async('string');
+      expect(markupContent).toBeDefined();
+
+      // Version-specific container: 3.0 wraps <File> in <Files>, 2.1 does not.
+      if (version === '3.0') {
+        expect(markupContent).toContain('<Files>');
+      } else {
+        expect(markupContent).not.toContain('<Files>');
+      }
+      // Header must precede Topic per the markup schema sequence.
+      expect(markupContent!.indexOf('<Header>')).toBeLessThan(markupContent!.indexOf('<Topic'));
+
+      const readProject = await readBCF(await blob.arrayBuffer());
+      const readTopic = readProject.topics.get(topicGuid);
+      expect(readTopic?.header).toHaveLength(2);
+      expect(readTopic?.header?.[0]).toEqual({
+        ifcProject: '0YvCT2_$X3_xJG3rzD8L_8',
+        ifcSpatialStructureElement: undefined,
+        isExternal: true,
+        filename: 'architecture.ifc',
+        date: '2026-07-01T10:00:00.000Z',
+        reference: 'architecture.ifc',
+      });
+      expect(readTopic?.header?.[1]).toMatchObject({
+        ifcProject: '3aB9cd_ef2Gh1Ij4Kl5Mn6',
+        isExternal: false,
+        filename: 'structure.ifc',
+      });
+    },
+  );
+
+  it('should not emit a Header element for topics without source files', async () => {
+    const topicGuid = generateUuid();
+    const topic: BCFTopic = {
+      guid: topicGuid,
+      title: 'No header',
+      creationDate: new Date().toISOString(),
+      creationAuthor: 'test@example.com',
+      viewpoints: [],
+      comments: [],
+    };
+    const project: BCFProject = {
+      version: '2.1',
+      topics: new Map([[topicGuid, topic]]),
+    };
+
+    const blob = await writeBCF(project);
+    const zip = await JSZip.loadAsync(await blobToArrayBuffer(blob));
+    const markupContent = await zip.file(`${topicGuid}/markup.bcf`)?.async('string');
+    expect(markupContent).not.toContain('<Header>');
+
+    const readProject = await readBCF(await blob.arrayBuffer());
+    expect(readProject.topics.get(topicGuid)?.header).toBeUndefined();
+  });
 });

--- a/packages/bcf/src/writer.ts
+++ b/packages/bcf/src/writer.ts
@@ -27,6 +27,7 @@ import type {
   BCFDirection,
   BCFBimSnippet,
   BCFDocumentReference,
+  BCFHeaderFile,
 } from './types.js';
 import { generateUuid } from '@ifc-lite/encoding';
 
@@ -49,7 +50,7 @@ export async function writeBCF(project: BCFProject): Promise<Blob> {
 
   // Write topics
   for (const [guid, topic] of project.topics) {
-    await writeTopicFolder(zip, topic);
+    await writeTopicFolder(zip, topic, project.version);
   }
 
   // Generate zip file
@@ -93,12 +94,16 @@ function writeProjectFile(zip: JSZip, project: BCFProject): void {
 /**
  * Write a topic folder with all its contents
  */
-async function writeTopicFolder(zip: JSZip, topic: BCFTopic): Promise<void> {
+async function writeTopicFolder(
+  zip: JSZip,
+  topic: BCFTopic,
+  version: '2.1' | '3.0',
+): Promise<void> {
   const folder = zip.folder(topic.guid);
   if (!folder) return;
 
   // Write markup.bcf
-  writeMarkupFile(folder, topic);
+  writeMarkupFile(folder, topic, version);
 
   // Write viewpoints
   for (let i = 0; i < topic.viewpoints.length; i++) {
@@ -126,9 +131,16 @@ function snapshotExt(viewpoint: BCFViewpoint): 'png' | 'jpg' {
  * Write markup.bcf file
  * Uses buildingSMART standard format
  */
-function writeMarkupFile(folder: JSZip, topic: BCFTopic): void {
+function writeMarkupFile(folder: JSZip, topic: BCFTopic, version: '2.1' | '3.0'): void {
   let content = `<?xml version="1.0" encoding="UTF-8"?>
-<Markup xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+<Markup xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">`;
+
+  // Header (source IFC files) precedes Topic per the BCF markup schema sequence.
+  if (topic.header && topic.header.length > 0) {
+    content += writeHeader(topic.header, version);
+  }
+
+  content += `
   <Topic Guid="${escapeXml(topic.guid)}"${topic.topicType ? ` TopicType="${escapeXml(topic.topicType)}"` : ''}${topic.topicStatus ? ` TopicStatus="${escapeXml(topic.topicStatus)}"` : ''}>
     <Title>${escapeXml(topic.title)}</Title>`;
 
@@ -548,6 +560,54 @@ function writeBitmap(bitmap: BCFBitmap): string {
       </Up>
       <Height>${bitmap.height}</Height>
     </Bitmap>`;
+}
+
+/**
+ * Write the markup `<Header>` block (source IFC files).
+ *
+ * The container differs by BCF version: 2.1 nests `<File>` directly under
+ * `<Header>`, while 3.0 wraps them in a `<Files>` element. The `<File>` shape
+ * (IfcProject / IfcSpatialStructureElement / isExternal attributes; Filename,
+ * Date, Reference children) is identical across both.
+ */
+function writeHeader(files: BCFHeaderFile[], version: '2.1' | '3.0'): string {
+  const fileIndent = version === '3.0' ? '      ' : '    ';
+  const fileXml = files.map((f) => writeHeaderFile(f, fileIndent, version)).join('');
+
+  if (version === '3.0') {
+    return `\n  <Header>\n    <Files>${fileXml}\n    </Files>\n  </Header>`;
+  }
+  return `\n  <Header>${fileXml}\n  </Header>`;
+}
+
+/** Write a single `<File>` entry inside the markup `<Header>`. */
+function writeHeaderFile(file: BCFHeaderFile, indent: string, version: '2.1' | '3.0'): string {
+  // isExternal defaults to true (an unresolved reference is treated as external).
+  const isExternal = file.isExternal ?? true;
+  // BCF 2.1 spells the attribute `isExternal`; 3.0 renamed it `IsExternal`.
+  const isExternalAttr = version === '3.0' ? 'IsExternal' : 'isExternal';
+
+  let attrs = '';
+  if (file.ifcProject) {
+    attrs += ` IfcProject="${escapeXml(file.ifcProject)}"`;
+  }
+  if (file.ifcSpatialStructureElement) {
+    attrs += ` IfcSpatialStructureElement="${escapeXml(file.ifcSpatialStructureElement)}"`;
+  }
+  attrs += ` ${isExternalAttr}="${isExternal}"`;
+
+  let content = `\n${indent}<File${attrs}>`;
+  if (file.filename) {
+    content += `\n${indent}  <Filename>${escapeXml(file.filename)}</Filename>`;
+  }
+  if (file.date) {
+    content += `\n${indent}  <Date>${escapeXml(file.date)}</Date>`;
+  }
+  if (file.reference) {
+    content += `\n${indent}  <Reference>${escapeXml(file.reference)}</Reference>`;
+  }
+  content += `\n${indent}</File>`;
+  return content;
 }
 
 /**

--- a/packages/clash/src/bcf-bridge.test.ts
+++ b/packages/clash/src/bcf-bridge.test.ts
@@ -421,8 +421,12 @@ describe('BCF round-trip', () => {
   // Federation provenance (#1591): a cross-model clash topic must record one
   // <Header> source file per distinct model it spans, surviving write -> read.
   it('records header source files for every model a clash group spans', async () => {
-    const a: ClashElementRef = { key: 'GUID_A', ref: 1, model: 'architecture.ifc', tag: 'IfcWall' };
-    const b: ClashElementRef = { key: 'GUID_B', ref: 2, model: 'structure.ifc', tag: 'IfcBeam' };
+    // `model` is an opaque model id (viewer uses UUIDs); modelNameOf resolves
+    // it to the display file name for the Header.
+    const a: ClashElementRef = { key: 'GUID_A', ref: 1, model: 'm-arch', tag: 'IfcWall' };
+    const b: ClashElementRef = { key: 'GUID_B', ref: 2, model: 'm-struct', tag: 'IfcBeam' };
+    const modelNameOf = (id: string) =>
+      ({ 'm-arch': 'architecture.ifc', 'm-struct': 'structure.ifc' })[id] ?? id;
     const c = clash('cross-model-1', a, b, 'hard', 'critical', 'ARCxSTR');
     const group = makeGroup('cross-model', 'critical', [c]);
     const result: ClashResult = {
@@ -437,9 +441,10 @@ describe('BCF round-trip', () => {
       settings: { tolerance: 0.002, excludeVoidsAndHosts: true },
     };
 
-    const project = await createBCFFromClashResult(result, [group], { author: 'tester' });
+    const project = await createBCFFromClashResult(result, [group], { author: 'tester', modelNameOf });
     const topic = project.topics.get(uuidFromSeed('cross-model'));
     expect(topic?.header).toBeDefined();
+    // Filenames are the RESOLVED names, not the raw model ids.
     expect(topic?.header?.map((h) => h.filename).sort()).toEqual([
       'architecture.ifc',
       'structure.ifc',

--- a/packages/clash/src/bcf-bridge.test.ts
+++ b/packages/clash/src/bcf-bridge.test.ts
@@ -417,6 +417,44 @@ describe('BCF round-trip', () => {
     expect(map.get('clash-1')?.[0]?.topicGuid).toBe(uuidFromSeed('group-critical'));
     expect(map.get('clash-3')?.[0]?.topicGuid).toBe(uuidFromSeed('group-major'));
   });
+
+  // Federation provenance (#1591): a cross-model clash topic must record one
+  // <Header> source file per distinct model it spans, surviving write -> read.
+  it('records header source files for every model a clash group spans', async () => {
+    const a: ClashElementRef = { key: 'GUID_A', ref: 1, model: 'architecture.ifc', tag: 'IfcWall' };
+    const b: ClashElementRef = { key: 'GUID_B', ref: 2, model: 'structure.ifc', tag: 'IfcBeam' };
+    const c = clash('cross-model-1', a, b, 'hard', 'critical', 'ARCxSTR');
+    const group = makeGroup('cross-model', 'critical', [c]);
+    const result: ClashResult = {
+      clashes: [c],
+      summary: {
+        total: 1,
+        byRule: { ARCxSTR: 1 },
+        byTypePair: {},
+        bySeverity: { critical: 1, major: 0, minor: 0, info: 0 },
+      },
+      rulesRun: [],
+      settings: { tolerance: 0.002, excludeVoidsAndHosts: true },
+    };
+
+    const project = await createBCFFromClashResult(result, [group], { author: 'tester' });
+    const topic = project.topics.get(uuidFromSeed('cross-model'));
+    expect(topic?.header).toBeDefined();
+    expect(topic?.header?.map((h) => h.filename).sort()).toEqual([
+      'architecture.ifc',
+      'structure.ifc',
+    ]);
+
+    // The header must survive a real write -> read round-trip.
+    const { writeBCF } = await import('@ifc-lite/bcf');
+    const blob = await writeBCF(project);
+    const readBack = await readBCF(await blob.arrayBuffer());
+    const readTopic = readBack.topics.get(uuidFromSeed('cross-model'));
+    expect(readTopic?.header?.map((h) => h.filename).sort()).toEqual([
+      'architecture.ifc',
+      'structure.ifc',
+    ]);
+  });
 });
 
 describe('uuidFromSeed', () => {

--- a/packages/clash/src/bcf-bridge.ts
+++ b/packages/clash/src/bcf-bridge.ts
@@ -58,6 +58,13 @@ export interface ClashBcfOptions {
    * `status` for every topic (the pre-review behaviour).
    */
   reviewStatusOf?: (clash: Clash) => ClashReviewStatus;
+  /**
+   * Resolve a `ClashElementRef.model` id to its display file name for the BCF
+   * `<Header>` source files (#1591). The viewer's model ids are opaque UUIDs,
+   * so without this the Header would record UUIDs instead of file names. Omit
+   * when the ids are already human-readable (e.g. the CLI uses file paths).
+   */
+  modelNameOf?: (model: string) => string;
   projectName?: string;
   maxTopics?: number;
   maxMembersPerTopic?: number;
@@ -230,20 +237,24 @@ function buildDescription(
  * distinct source model its members reference (#1591 federation provenance).
  *
  * A clash is cross-model by nature, so a group typically touches two models.
- * The clash package sees only the model display name (`ClashElementRef.model`),
- * not the IfcProject GlobalId, so `ifcProject` is left empty (acceptable per
- * the BCF schema). `filename`/`reference` carry the model name.
+ * `ClashElementRef.model` is a MODEL ID (the viewer uses opaque UUIDs), not a
+ * file name, so callers pass `modelNameOf` to resolve it to the display file
+ * name; it falls back to the id when unresolved. The clash package cannot see
+ * the IfcProject GlobalId, so `ifcProject` is left empty (acceptable per the
+ * BCF schema). `filename`/`reference` carry the resolved name.
  */
-function headerFilesForGroup(group: ClashGroup, date: string): BCFHeaderFile[] {
-  const names = unique(
+function headerFilesForGroup(
+  group: ClashGroup,
+  date: string,
+  modelNameOf?: (model: string) => string,
+): BCFHeaderFile[] {
+  const ids = unique(
     group.members.flatMap((m) => [m.a.model, m.b.model]).filter((n): n is string => Boolean(n)),
   );
-  return names.map((name) => ({
-    isExternal: true,
-    filename: name,
-    date,
-    reference: name,
-  }));
+  return ids.map((id) => {
+    const filename = modelNameOf?.(id) ?? id;
+    return { isExternal: true, filename, date, reference: filename };
+  });
 }
 
 /** Build the topic + framing viewpoint for one group. */
@@ -277,7 +288,7 @@ async function buildTopicForGroup(
   topic.guid = uuidFromSeed(group.id);
   // Record the source model(s) this clash spans so the topic round-trips its
   // provenance across a federation.
-  const header = headerFilesForGroup(group, topic.creationDate);
+  const header = headerFilesForGroup(group, topic.creationDate, opts.modelNameOf);
   if (header.length > 0) topic.header = header;
 
   const selectedGuids = unique(group.members.flatMap((m) => [m.a.key, m.b.key]));

--- a/packages/clash/src/bcf-bridge.ts
+++ b/packages/clash/src/bcf-bridge.ts
@@ -27,6 +27,7 @@ import {
   toARGBColor,
   type BCFProject,
   type BCFTopic,
+  type BCFHeaderFile,
   type ViewerCameraState,
   type ViewerBounds,
 } from '@ifc-lite/bcf';
@@ -224,6 +225,27 @@ function buildDescription(
   return lines.join('\n');
 }
 
+/**
+ * Derive the BCF `<Header>` source files for a clash group: one entry per
+ * distinct source model its members reference (#1591 federation provenance).
+ *
+ * A clash is cross-model by nature, so a group typically touches two models.
+ * The clash package sees only the model display name (`ClashElementRef.model`),
+ * not the IfcProject GlobalId, so `ifcProject` is left empty (acceptable per
+ * the BCF schema). `filename`/`reference` carry the model name.
+ */
+function headerFilesForGroup(group: ClashGroup, date: string): BCFHeaderFile[] {
+  const names = unique(
+    group.members.flatMap((m) => [m.a.model, m.b.model]).filter((n): n is string => Boolean(n)),
+  );
+  return names.map((name) => ({
+    isExternal: true,
+    filename: name,
+    date,
+    reference: name,
+  }));
+}
+
 /** Build the topic + framing viewpoint for one group. */
 async function buildTopicForGroup(
   project: BCFProject,
@@ -253,6 +275,10 @@ async function buildTopicForGroup(
   });
   // Deterministic guid: stable function of the group id (input-only).
   topic.guid = uuidFromSeed(group.id);
+  // Record the source model(s) this clash spans so the topic round-trips its
+  // provenance across a federation.
+  const header = headerFilesForGroup(group, topic.creationDate);
+  if (header.length > 0) topic.header = header;
 
   const selectedGuids = unique(group.members.flatMap((m) => [m.a.key, m.b.key]));
   const coloredGuids = [


### PR DESCRIPTION
## What & why

Final part of issue #1591 ("reach for the stars: BCF should handle federated well"). Two federation gaps:

1. A BCF topic recorded nothing about which IFC file(s) it referenced (`BCFHeaderFile` existed but was never attached or emitted), so an exported topic lost its provenance across a federation.
2. On import, a viewpoint's selection was collapsed to `selectedExpressIds[0]` - a single element - losing every other selected element and all model context.

> Stacked on #1617 (base `feat/1591-clash-ids-model-badge`), itself stacked on #1616 and #1614. Review/merge the base PRs first.

## Record source file(s) per topic

- **`@ifc-lite/bcf`**: `BCFTopic` gains optional `header?: BCFHeaderFile[]`. The writer emits the markup `<Header>` block, version-correct for both releases: BCF 2.1 nests `<File>` directly and spells the attribute `isExternal`; BCF 3.0 wraps files in `<Files>` and spells it `IsExternal`. The reader parses it back, accepting either casing (and the xs:boolean `1`/`0` forms). Headerless topics emit no `<Header>`, so existing output is unchanged.
- **viewer**: a shared `deriveHeaderFiles` helper turns the distinct source models a topic touches into header files (`filename` = model name, `ifcProject` = that model's IfcProject GlobalId). `useBCF`, `BCFPanel`, and compare -> BCF all attach it on topic creation.
- **`@ifc-lite/clash`**: clash -> BCF records a header file per model each clash group spans (name-only; `ifcProject` empty since the clash package only sees model names, acceptable per schema).

## Fix federated import selection

`useBCF.applyViewpoint` now re-applies the viewpoint's selection across ALL models using both canonical selection channels - `setSelectedEntityIds` (federated global ids, renderer highlight) and `addEntitiesToSelection` (local `{modelId, expressId}` refs, model-aware set) - mirroring `useClash.highlightAll`, instead of collapsing to the first element. The reverse global-id mapping uses the store `models` map (the same source the forward mapping uses) so the local refs can never desync from the global ids if the renderer registry lags the store.

## Tests

- `@ifc-lite/bcf`: writer <-> reader header round-trip for BCF 2.1 and 3.0; headerless topic emits no `<Header>`. 100/100.
- `@ifc-lite/clash`: cross-model clash group yields one header file per model, surviving a real write -> read. 137/137.
- viewer: `deriveHeaderFiles` unit suite (dedup, missing-model skip, empty project, legacy fallback). Viewer typecheck clean; API surface unchanged.

## Changesets

`@ifc-lite/bcf` + `@ifc-lite/clash` minor.

## Out of scope (pre-existing, noted)

The `<Header>` is now the only fully version-aware part of the markup writer; the rest of a "3.0" export is still 2.1-shaped (e.g. Comments/Viewpoints emitted after `</Topic>` rather than nested). That is a pre-existing limitation, not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)