### PR TITLE
feat(viewer): source-decoupled mesh cache for 150-400MB files (prototype, ?meshCache=1)

### DIFF
--- a/.changeset/mesh-cache-source-hash-option.md
+++ b/.changeset/mesh-cache-source-hash-option.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/cache": minor
+---
+
+Add an optional `sourceHash` to `CacheWriteOptions`. When provided, `BinaryCacheWriter.write` stores it verbatim in the header and skips the internal full-buffer `xxhash64(sourceBuffer)`, so a caller that validates the source by other means (e.g. a strengthened cache key) does not pay a full-file main-thread hash on write. Default behaviour is unchanged when the option is omitted.

--- a/.changeset/mesh-cache-source-hash-option.md
+++ b/.changeset/mesh-cache-source-hash-option.md
@@ -2,4 +2,4 @@
 "@ifc-lite/cache": minor
 ---
 
-Add an optional `sourceHash` to `CacheWriteOptions`. When provided, `BinaryCacheWriter.write` stores it verbatim in the header and skips the internal full-buffer `xxhash64(sourceBuffer)`, so a caller that validates the source by other means (e.g. a strengthened cache key) does not pay a full-file main-thread hash on write. Default behaviour is unchanged when the option is omitted.
+Add `CacheWriteOptions.omitSourceHash`. When set, `BinaryCacheWriter.write` skips the full-file `xxhash64(sourceBuffer)`, stores `sourceHash = 0n`, and sets the new `HeaderFlags.SourceHashUnset` — for callers that validate the source another way and don't want a large source to pay a full-file main-thread hash on write. `CacheHeaderInfo` gains `hasSourceHash`; `reader.read({ sourceBuffer })` skips header validation for such entries (instead of fail-closing), and `reader.validate()` throws a clear error rather than returning a misleading `false`. Default behaviour (the writer hashes the whole source) is unchanged, and entries written before this flag existed still validate normally.

--- a/apps/viewer/src/hooks/cacheTier.test.ts
+++ b/apps/viewer/src/hooks/cacheTier.test.ts
@@ -5,7 +5,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
 
-import { classifyCacheTier, type CacheTierOptions } from './cacheTier.js';
+import { classifyCacheTier, planCacheWrite, type CacheTierOptions } from './cacheTier.js';
 
 // Mirror the production constants (ifcConfig.ts). Not imported: ifcConfig reads
 // import.meta.env at module load and can't be evaluated under `node:test`.
@@ -47,5 +47,35 @@ describe('classifyCacheTier', () => {
 
   it('does not cache files above the mesh-only ceiling even with the flag on', () => {
     assert.equal(classifyCacheTier(MAX_MESH_ONLY + 1, on), 'none');
+  });
+});
+
+describe('planCacheWrite', () => {
+  it('persists the source for the <=150MB tier (default path UNCHANGED)', () => {
+    // The source tier persists the source regardless of the mesh-only flag: the
+    // classic <=150MB behaviour must not regress when the tier is on OR off.
+    for (const opts of [on, off]) {
+      const plan = planCacheWrite(MAX_SOURCE, opts);
+      assert.deepEqual(plan, { tier: 'source', shouldCache: true, persistSource: true });
+    }
+    const plan = planCacheWrite(MIN, on);
+    assert.equal(plan.persistSource, true);
+    assert.equal(plan.shouldCache, true);
+  });
+
+  it('does NOT persist the source for the mesh-only tier (150-400MB, enabled)', () => {
+    const plan = planCacheWrite(MAX_SOURCE + 1, on);
+    assert.deepEqual(plan, { tier: 'mesh-only', shouldCache: true, persistSource: false });
+    assert.deepEqual(planCacheWrite(MAX_MESH_ONLY, on), {
+      tier: 'mesh-only', shouldCache: true, persistSource: false,
+    });
+  });
+
+  it('does not cache (shouldCache=false) when too small, too big, or mesh-only disabled', () => {
+    assert.equal(planCacheWrite(MIN - 1, on).shouldCache, false);
+    assert.equal(planCacheWrite(MAX_MESH_ONLY + 1, on).shouldCache, false);
+    // Kill switch: a 150-400MB file is not cached when the tier is disabled.
+    const disabled = planCacheWrite(MAX_SOURCE + 1, off);
+    assert.deepEqual(disabled, { tier: 'none', shouldCache: false, persistSource: false });
   });
 });

--- a/apps/viewer/src/hooks/cacheTier.test.ts
+++ b/apps/viewer/src/hooks/cacheTier.test.ts
@@ -5,7 +5,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
 
-import { classifyCacheTier, planCacheWrite, type CacheTierOptions } from './cacheTier.js';
+import { classifyCacheTier, planCacheWrite, decideMeshOnlyCacheHit, type CacheTierOptions } from './cacheTier.js';
 
 // Mirror the production constants (ifcConfig.ts). Not imported: ifcConfig reads
 // import.meta.env at module load and can't be evaluated under `node:test`.
@@ -77,5 +77,39 @@ describe('planCacheWrite', () => {
     // Kill switch: a 150-400MB file is not cached when the tier is disabled.
     const disabled = planCacheWrite(MAX_SOURCE + 1, off);
     assert.deepEqual(disabled, { tier: 'none', shouldCache: false, persistSource: false });
+  });
+});
+
+describe('decideMeshOnlyCacheHit', () => {
+  it('MISSES when the fresh mtime differs from the stored one (a real on-disk edit)', () => {
+    assert.equal(
+      decideMeshOnlyCacheHit({ storedMtime: 1000, freshMtime: 2000, hasFullHash: true }),
+      'miss',
+    );
+    // Even without a full hash to fall back on, a changed mtime is a miss.
+    assert.equal(
+      decideMeshOnlyCacheHit({ storedMtime: 1000, freshMtime: 2000, hasFullHash: false }),
+      'miss',
+    );
+  });
+
+  it('SERVES when the mtimes match (then the caller background-revalidates)', () => {
+    assert.equal(
+      decideMeshOnlyCacheHit({ storedMtime: 1000, freshMtime: 1000, hasFullHash: true }),
+      'serve',
+    );
+    assert.equal(
+      decideMeshOnlyCacheHit({ storedMtime: 1000, freshMtime: 1000, hasFullHash: false }),
+      'serve',
+    );
+  });
+
+  it('when mtime is UNAVAILABLE, serves only if a full hash can revalidate (never serve unvalidated)', () => {
+    // 0 / undefined mtime = unknown. With a full hash → serve (background check
+    // will validate); without one → miss (don't serve unvalidated).
+    assert.equal(decideMeshOnlyCacheHit({ storedMtime: 0, freshMtime: 1000, hasFullHash: true }), 'serve');
+    assert.equal(decideMeshOnlyCacheHit({ storedMtime: 0, freshMtime: 1000, hasFullHash: false }), 'miss');
+    assert.equal(decideMeshOnlyCacheHit({ freshMtime: 1000, hasFullHash: true }), 'serve');
+    assert.equal(decideMeshOnlyCacheHit({ hasFullHash: false }), 'miss');
   });
 });

--- a/apps/viewer/src/hooks/cacheTier.test.ts
+++ b/apps/viewer/src/hooks/cacheTier.test.ts
@@ -1,0 +1,51 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+
+import { classifyCacheTier, type CacheTierOptions } from './cacheTier.js';
+
+// Mirror the production constants (ifcConfig.ts). Not imported: ifcConfig reads
+// import.meta.env at module load and can't be evaluated under `node:test`.
+const MB = 1024 * 1024;
+const MIN = 10 * MB; // CACHE_SIZE_THRESHOLD
+const MAX_SOURCE = 150 * MB; // CACHE_MAX_SOURCE_SIZE
+const MAX_MESH_ONLY = 400 * MB; // CACHE_MESH_ONLY_MAX_SIZE
+
+const base: Omit<CacheTierOptions, 'meshOnlyEnabled'> = {
+  minSize: MIN,
+  maxSourceSize: MAX_SOURCE,
+  maxMeshOnlySize: MAX_MESH_ONLY,
+};
+const on: CacheTierOptions = { ...base, meshOnlyEnabled: true };
+const off: CacheTierOptions = { ...base, meshOnlyEnabled: false };
+
+describe('classifyCacheTier', () => {
+  it('does not cache files below the min threshold', () => {
+    assert.equal(classifyCacheTier(MIN - 1, on), 'none');
+    assert.equal(classifyCacheTier(0, on), 'none');
+  });
+
+  it('uses the source tier from the min threshold up to and including 150MB', () => {
+    assert.equal(classifyCacheTier(MIN, on), 'source');
+    assert.equal(classifyCacheTier(MAX_SOURCE, on), 'source');
+    // The source tier never depends on the mesh-only flag.
+    assert.equal(classifyCacheTier(MAX_SOURCE, off), 'source');
+  });
+
+  it('uses the mesh-only tier in (150MB, 400MB] when the flag is on', () => {
+    assert.equal(classifyCacheTier(MAX_SOURCE + 1, on), 'mesh-only');
+    assert.equal(classifyCacheTier(MAX_MESH_ONLY, on), 'mesh-only');
+  });
+
+  it('never uses the mesh-only tier when the flag is off (no <=150MB regression)', () => {
+    assert.equal(classifyCacheTier(MAX_SOURCE + 1, off), 'none');
+    assert.equal(classifyCacheTier(MAX_MESH_ONLY, off), 'none');
+  });
+
+  it('does not cache files above the mesh-only ceiling even with the flag on', () => {
+    assert.equal(classifyCacheTier(MAX_MESH_ONLY + 1, on), 'none');
+  });
+});

--- a/apps/viewer/src/hooks/cacheTier.ts
+++ b/apps/viewer/src/hooks/cacheTier.ts
@@ -75,3 +75,34 @@ export function planCacheWrite(byteLength: number, opts: CacheTierOptions): Cach
     persistSource: tier === 'source',
   };
 }
+
+/**
+ * Whether a MESH-ONLY cache hit may be served, given the file's modified-time
+ * guard and whether a full-file validation hash is available.
+ *
+ * The mesh-only tier hydrates cached geometry against the FRESH source buffer,
+ * so a source that changed since the entry was written would form a silent
+ * chimera (old geometry + new properties). The spread-sampled cache key can't
+ * catch a byte-length-preserving in-place edit that lands between its sample
+ * windows (a GUID/coordinate patch), so this gate is the real validation:
+ *   - both mtimes known and DIFFERENT  → `miss` (a real on-disk edit; reparse);
+ *   - mtime cannot confirm AND no full hash to revalidate → `miss` (never serve
+ *     unvalidated);
+ *   - otherwise → `serve` (mtime confirms it, or the caller can background-
+ *     revalidate the full hash and reload on mismatch).
+ *
+ * `lastModified` of `0`/`undefined` counts as "unknown" (some `File`s lack it).
+ * The classic source-persisting tier does NOT use this — it serves the cached
+ * source alongside the cached geometry, so a hit is always self-consistent.
+ */
+export function decideMeshOnlyCacheHit(opts: {
+  storedMtime?: number;
+  freshMtime?: number;
+  hasFullHash: boolean;
+}): 'serve' | 'miss' {
+  const { storedMtime, freshMtime, hasFullHash } = opts;
+  const mtimeKnown = !!storedMtime && !!freshMtime;
+  if (mtimeKnown && storedMtime !== freshMtime) return 'miss';
+  if (!mtimeKnown && !hasFullHash) return 'miss';
+  return 'serve';
+}

--- a/apps/viewer/src/hooks/cacheTier.ts
+++ b/apps/viewer/src/hooks/cacheTier.ts
@@ -5,19 +5,24 @@
 /**
  * Which persisted-cache tier a model of a given byte length qualifies for.
  *   - `none`: too small to bother caching (parses fast), or too big for any
- *     tier, or the mesh-only prototype is disabled and the file is >150MB.
+ *     tier, or the mesh-only tier is disabled (kill switch) and the file is >150MB.
  *   - `source`: the classic tier — persist tables + geometry AND the source
  *     buffer, so lazy property/quantity accessors + re-export read the source
- *     directly from IndexedDB. Unchanged by the mesh-only prototype.
- *   - `mesh-only`: the source-decoupled tier (bet B, prototype). Persist tables
- *     + geometry + instanced shards WITHOUT the source; on re-open the freshly
- *     read file buffer hydrates the accessors and validates the hit via the
- *     header's full-source hash.
+ *     directly from IndexedDB.
+ *   - `mesh-only`: the source-decoupled tier. Persist tables + geometry +
+ *     instanced shards WITHOUT the source (too big for IndexedDB at 150-400MB);
+ *     on re-open the freshly read file buffer hydrates the accessors. The hit is
+ *     validated by the strengthened cache key (see `sourceFingerprint.ts`), not
+ *     a full-file hash, so repeat opens have no main-thread stall.
+ *
+ * The ONLY difference between the two caching tiers is `persistSource` (and the
+ * size band that selects them) — the save/load code is otherwise shared, so
+ * {@link planCacheWrite} derives both in one place.
  */
 export type CacheTier = 'none' | 'source' | 'mesh-only';
 
 export interface CacheTierOptions {
-  /** Is the mesh-only prototype enabled (`?meshCache=1`)? */
+  /** Is the mesh-only tier enabled? Default on; the kill switch is `?meshCache=0`. */
   meshOnlyEnabled: boolean;
   /** Below this, don't cache — small files parse fast (`CACHE_SIZE_THRESHOLD`). */
   minSize: number;
@@ -25,6 +30,15 @@ export interface CacheTierOptions {
   maxSourceSize: number;
   /** Up to and including this, use the mesh-only tier (`CACHE_MESH_ONLY_MAX_SIZE`). */
   maxMeshOnlySize: number;
+}
+
+/** The write decision for a model: its tier and whether to persist the source. */
+export interface CachePlan {
+  tier: CacheTier;
+  /** `true` unless the tier is `none` — whether to cache this model at all. */
+  shouldCache: boolean;
+  /** `true` only for the `source` tier — whether the raw source is persisted. */
+  persistSource: boolean;
 }
 
 /**
@@ -37,12 +51,27 @@ export interface CacheTierOptions {
  * `CACHE_*` constants; tests pass representative values.
  *
  * The mesh-only tier only fires for files strictly larger than the source tier's
- * ceiling AND only when the prototype flag is on, so the classic <=150MB path is
- * byte-for-byte unchanged.
+ * ceiling AND only when enabled, so the classic <=150MB path is byte-for-byte
+ * unchanged whether the mesh-only tier is on or off.
  */
 export function classifyCacheTier(byteLength: number, opts: CacheTierOptions): CacheTier {
   if (byteLength < opts.minSize) return 'none';
   if (byteLength <= opts.maxSourceSize) return 'source';
   if (opts.meshOnlyEnabled && byteLength <= opts.maxMeshOnlySize) return 'mesh-only';
   return 'none';
+}
+
+/**
+ * Single home for the tier decision AND the `persistSource` derivation, so the
+ * loader never re-derives `persistSource` from the tier name and the two tiers
+ * can't drift. `source` persists the source; `mesh-only` does not; `none`
+ * doesn't cache.
+ */
+export function planCacheWrite(byteLength: number, opts: CacheTierOptions): CachePlan {
+  const tier = classifyCacheTier(byteLength, opts);
+  return {
+    tier,
+    shouldCache: tier !== 'none',
+    persistSource: tier === 'source',
+  };
 }

--- a/apps/viewer/src/hooks/cacheTier.ts
+++ b/apps/viewer/src/hooks/cacheTier.ts
@@ -1,0 +1,48 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Which persisted-cache tier a model of a given byte length qualifies for.
+ *   - `none`: too small to bother caching (parses fast), or too big for any
+ *     tier, or the mesh-only prototype is disabled and the file is >150MB.
+ *   - `source`: the classic tier — persist tables + geometry AND the source
+ *     buffer, so lazy property/quantity accessors + re-export read the source
+ *     directly from IndexedDB. Unchanged by the mesh-only prototype.
+ *   - `mesh-only`: the source-decoupled tier (bet B, prototype). Persist tables
+ *     + geometry + instanced shards WITHOUT the source; on re-open the freshly
+ *     read file buffer hydrates the accessors and validates the hit via the
+ *     header's full-source hash.
+ */
+export type CacheTier = 'none' | 'source' | 'mesh-only';
+
+export interface CacheTierOptions {
+  /** Is the mesh-only prototype enabled (`?meshCache=1`)? */
+  meshOnlyEnabled: boolean;
+  /** Below this, don't cache — small files parse fast (`CACHE_SIZE_THRESHOLD`). */
+  minSize: number;
+  /** Up to and including this, use the source-persisting tier (`CACHE_MAX_SOURCE_SIZE`). */
+  maxSourceSize: number;
+  /** Up to and including this, use the mesh-only tier (`CACHE_MESH_ONLY_MAX_SIZE`). */
+  maxMeshOnlySize: number;
+}
+
+/**
+ * Classify the cache tier for a primary model by its source byte length.
+ *
+ * Thresholds are injected (not imported) so this stays a pure, node-testable
+ * function: `ifcConfig` — where the real constants live — reads `import.meta.env`
+ * at module load and can't be imported under the Node test runner (same reason
+ * `acquireFileBuffer` injects `STREAM_SAB_THRESHOLD`). The loader passes the real
+ * `CACHE_*` constants; tests pass representative values.
+ *
+ * The mesh-only tier only fires for files strictly larger than the source tier's
+ * ceiling AND only when the prototype flag is on, so the classic <=150MB path is
+ * byte-for-byte unchanged.
+ */
+export function classifyCacheTier(byteLength: number, opts: CacheTierOptions): CacheTier {
+  if (byteLength < opts.minSize) return 'none';
+  if (byteLength <= opts.maxSourceSize) return 'source';
+  if (opts.meshOnlyEnabled && byteLength <= opts.maxMeshOnlySize) return 'mesh-only';
+  return 'none';
+}

--- a/apps/viewer/src/hooks/geometryCacheKey.ts
+++ b/apps/viewer/src/hooks/geometryCacheKey.ts
@@ -9,7 +9,11 @@ import { FORMAT_VERSION } from '@ifc-lite/cache';
  *
  * The key folds together everything that changes the *bytes* of the cached
  * geometry so a stale entry can never be served for a different input:
- *   - `byteLength` + `fingerprint`: identify the source file content
+ *   - `byteLength` + `fingerprint`: identify the source file content. The
+ *     fingerprint is the spread-sampled hash from `computeSourceFingerprint`
+ *     (head + tail + interior windows + exact length), so a KEY MATCH IS THE
+ *     VALIDATION — a genuinely different file cannot key the same entry, which
+ *     is why the source-decoupled tier needs no full-file hash on read/write.
  *   - `FORMAT_VERSION`: a format bump invalidates incompatible entries
  *   - `mergeLayers`: the multi-layer-wall merge flag is a load-time WASM
  *     tessellation input (issue #540). It was previously absent from the key,

--- a/apps/viewer/src/hooks/geometryCacheKey.ts
+++ b/apps/viewer/src/hooks/geometryCacheKey.ts
@@ -9,11 +9,16 @@ import { FORMAT_VERSION } from '@ifc-lite/cache';
  *
  * The key folds together everything that changes the *bytes* of the cached
  * geometry so a stale entry can never be served for a different input:
- *   - `byteLength` + `fingerprint`: identify the source file content. The
- *     fingerprint is the spread-sampled hash from `computeSourceFingerprint`
- *     (head + tail + interior windows + exact length), so a KEY MATCH IS THE
- *     VALIDATION — a genuinely different file cannot key the same entry, which
- *     is why the source-decoupled tier needs no full-file hash on read/write.
+ *   - `byteLength` + `fingerprint`: identify the source file content for LOOKUP.
+ *     The fingerprint is the spread-sampled hash from `computeSourceFingerprint`
+ *     (head + tail + interior windows + exact length). It is a strong KEY, not a
+ *     content validation: being O(1) it never reads the bytes between its sample
+ *     windows, so a byte-length-preserving in-place edit in a gap keys the same
+ *     entry. That is fine for the source-persisting tier (cached geometry + cached
+ *     source are self-consistent); the source-decoupled (mesh-only) tier, which
+ *     hydrates against the fresh buffer, validates a hit separately via the mtime
+ *     guard + a full-file hash (see `sourceFingerprint.ts` and
+ *     `cacheTier.decideMeshOnlyCacheHit`).
  *   - `FORMAT_VERSION`: a format bump invalidates incompatible entries
  *   - `mergeLayers`: the multi-layer-wall merge flag is a load-time WASM
  *     tessellation input (issue #540). It was previously absent from the key,

--- a/apps/viewer/src/hooks/sourceFingerprint.test.ts
+++ b/apps/viewer/src/hooks/sourceFingerprint.test.ts
@@ -1,0 +1,150 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { computeSourceFingerprint } from './sourceFingerprint.js';
+import { buildGeometryCacheKey } from './geometryCacheKey.js';
+
+/**
+ * Reference implementation of the OLD, weak fingerprint this PR replaces: FNV-1a
+ * over the first 4KB + last 4KB, 32 bits, ignoring the entire interior of the
+ * file. Kept here ONLY to PROVE (below) that a file pair which collides on the
+ * old key is distinguished by the new spread-sampled fingerprint.
+ */
+function oldWeakFingerprint(buffer: ArrayBuffer): string {
+  const CHUNK_SIZE = 4096;
+  const view = new Uint8Array(buffer);
+  const len = view.length;
+  let hash = 2166136261;
+  const firstEnd = Math.min(CHUNK_SIZE, len);
+  for (let i = 0; i < firstEnd; i++) {
+    hash ^= view[i];
+    hash = Math.imul(hash, 16777619);
+  }
+  if (len > CHUNK_SIZE) {
+    const lastStart = Math.max(CHUNK_SIZE, len - CHUNK_SIZE);
+    for (let i = lastStart; i < len; i++) {
+      hash ^= view[i];
+      hash = Math.imul(hash, 16777619);
+    }
+  }
+  return (hash >>> 0).toString(16);
+}
+
+/** Deterministic pseudo-random fill so both files have "real" varied content. */
+function fill(len: number, seed: number): ArrayBuffer {
+  const buf = new ArrayBuffer(len);
+  const view = new Uint8Array(buf);
+  let x = seed >>> 0;
+  for (let i = 0; i < len; i++) {
+    // xorshift32
+    x ^= x << 13; x >>>= 0;
+    x ^= x >> 17;
+    x ^= x << 5; x >>>= 0;
+    view[i] = x & 0xff;
+  }
+  return buf;
+}
+
+describe('computeSourceFingerprint', () => {
+  it('is deterministic (same bytes → same hash) and filename-safe hex', () => {
+    const buf = fill(1_000_000, 1);
+    const a = computeSourceFingerprint(buf);
+    const b = computeSourceFingerprint(buf.slice(0));
+    assert.equal(a.hex, b.hex);
+    assert.equal(a.hash, b.hash);
+    assert.equal(a.hex, a.hash.toString(16));
+    assert.match(a.hex, /^[0-9a-f]+$/);
+  });
+
+  it('changes when the exact byte length changes (length folded into the hash)', () => {
+    const a = computeSourceFingerprint(fill(1_000_000, 7));
+    const b = computeSourceFingerprint(fill(1_000_001, 7));
+    assert.notEqual(a.hex, b.hex);
+  });
+
+  it('detects a change in the file HEAD (first 64KB) that the old key missed', () => {
+    // A 1MB file; flip one byte at 32KB — outside the old first/last-4KB windows
+    // (so the old key collides) but inside the new 64KB head window.
+    const a = fill(1_048_576, 42);
+    const b = a.slice(0);
+    new Uint8Array(b)[32 * 1024] ^= 0xff;
+
+    // The old weak key collides: same length + same first/last 4KB.
+    assert.equal(oldWeakFingerprint(a), oldWeakFingerprint(b));
+    assert.equal(
+      buildGeometryCacheKey(a.byteLength, oldWeakFingerprint(a), false),
+      buildGeometryCacheKey(b.byteLength, oldWeakFingerprint(b), false),
+      'sanity: the two files DO collide on the old weak key',
+    );
+
+    // The strengthened fingerprint distinguishes them → different cache key →
+    // the second file is NOT served the first file's cached geometry.
+    const fpA = computeSourceFingerprint(a);
+    const fpB = computeSourceFingerprint(b);
+    assert.notEqual(fpA.hex, fpB.hex);
+    assert.notEqual(
+      buildGeometryCacheKey(a.byteLength, fpA.hex, false),
+      buildGeometryCacheKey(b.byteLength, fpB.hex, false),
+    );
+  });
+
+  it('detects a genuinely different INTERIOR (same header/footer/length) the old key missed', () => {
+    // Model two files that share the first/last 4KB and exact length (so the old
+    // weak key collides) but differ throughout the interior — exactly how two
+    // real, independently-authored IFC models relate once you look past the STEP
+    // header. The interior differs across the whole body, so it intersects the
+    // new spread's interior sample windows and is caught.
+    const a = fill(1_048_576, 99);
+    const b = a.slice(0);
+    const vb = new Uint8Array(b);
+    for (let i = 8 * 1024; i < b.byteLength - 8 * 1024; i += 617 /* prime stride */) {
+      vb[i] ^= 0xff;
+    }
+
+    assert.equal(oldWeakFingerprint(a), oldWeakFingerprint(b), 'old key collides (first/last 4KB unchanged)');
+    assert.notEqual(
+      computeSourceFingerprint(a).hex,
+      computeSourceFingerprint(b).hex,
+      'new fingerprint catches the differing interior',
+    );
+  });
+
+  it('samples inside a fixed interior window (a change there is always caught)', () => {
+    // A byte change landing squarely on an interior sample window is caught even
+    // when it is nowhere near the head/tail — proving the interior windows carry
+    // real discriminating power, not just the head/tail.
+    const len = 4_000_000;
+    const a = fill(len, 71);
+    // Center of the 4th of 8 interior windows: floor(len * 4 / 9).
+    const sampled = Math.floor((len * 4) / 9);
+    const b = a.slice(0);
+    new Uint8Array(b)[sampled] ^= 0xff;
+    assert.notEqual(computeSourceFingerprint(a).hex, computeSourceFingerprint(b).hex);
+  });
+
+  it('detects a change in the file TAIL (last 64KB)', () => {
+    const a = fill(1_048_576, 123);
+    const b = a.slice(0);
+    new Uint8Array(b)[1_048_576 - 100] ^= 0xff;
+    assert.notEqual(computeSourceFingerprint(a).hex, computeSourceFingerprint(b).hex);
+  });
+
+  it('handles tiny buffers (smaller than one window) without error', () => {
+    const a = computeSourceFingerprint(fill(100, 3));
+    const b = computeSourceFingerprint(fill(100, 4));
+    assert.match(a.hex, /^[0-9a-f]+$/);
+    assert.notEqual(a.hex, b.hex);
+  });
+
+  it('accepts a Uint8Array view as well as an ArrayBuffer', () => {
+    const buf = fill(200_000, 55);
+    assert.equal(
+      computeSourceFingerprint(buf).hex,
+      computeSourceFingerprint(new Uint8Array(buf)).hex,
+    );
+  });
+});

--- a/apps/viewer/src/hooks/sourceFingerprint.test.ts
+++ b/apps/viewer/src/hooks/sourceFingerprint.test.ts
@@ -147,4 +147,26 @@ describe('computeSourceFingerprint', () => {
       computeSourceFingerprint(new Uint8Array(buf)).hex,
     );
   });
+
+  it('FALSE-HITS a byte-length-preserving edit in a sampler GAP (documents the O(1) blind spot)', () => {
+    // The whole point of the O(1) sampler is that it does NOT read the bytes
+    // between its windows. A same-length in-place edit there (a GUID patch, a
+    // scripted same-width coordinate edit) is INVISIBLE to the fingerprint, so it
+    // keys the same cache entry. This is why the fingerprint is only the LOOKUP
+    // key and the mesh-only tier validates a hit by mtime + a full-file hash.
+    const len = 4_000_000;
+    const a = fill(len, 202);
+    const b = a.slice(0);
+    // 700_000 is between interior window 1 (~444_444) and window 2 (~888_888),
+    // outside the 64KB head/tail — a genuine sampler gap.
+    const gapOffset = 700_000;
+    new Uint8Array(b)[gapOffset] ^= 0xff;
+
+    assert.equal(a.byteLength, b.byteLength, 'edit preserves the byte length');
+    assert.equal(
+      computeSourceFingerprint(a).hex,
+      computeSourceFingerprint(b).hex,
+      'a gap edit is invisible to the fingerprint (the documented limitation)',
+    );
+  });
 });

--- a/apps/viewer/src/hooks/sourceFingerprint.ts
+++ b/apps/viewer/src/hooks/sourceFingerprint.ts
@@ -5,47 +5,43 @@
 import { xxhash64 } from '@ifc-lite/cache';
 
 /**
- * Spread-sampled source fingerprint — the collision-safe content identity that
- * both keys the persisted cache and VALIDATES a hit (`buildGeometryCacheKey`
- * folds {@link SourceFingerprint.hex} into the key, so a key match *is* the
- * validation). It replaces the old first-4KB+last-4KB FNV-32 fingerprint, which
- * ignored the entire interior of the file and only had 32 bits of entropy.
+ * Spread-sampled source fingerprint — a fast, strong cache KEY, NOT a full
+ * content validation. `buildGeometryCacheKey` folds {@link SourceFingerprint.hex}
+ * into the key so the RIGHT entry is looked up; it replaces the old
+ * first-4KB+last-4KB FNV-32 fingerprint (32 bits, interior-blind) with a wider
+ * 64-bit hash over a head/tail/interior spread plus the exact byte length.
  *
- * ## Why this removes the repeat-open stall
- * The mesh-only cache tier does not persist the >150MB source, so it used to
- * recompute a full-file `xxhash64` on every repeat open to validate the hit
- * against the header hash — a 0.7-1.7s PURE-JS main-thread stall that scaled
- * with file size. This samples a fixed ~100KB spread regardless of file size
- * (O(1) in the file length, sub-millisecond even on a 400MB file), so making
- * the KEY the validation lets us drop the full-file hash entirely: no stall on
- * read, and no full-file hash on write either (the writer stores {@link
- * SourceFingerprint.hash} in its header cheaply — see `useIfcCache.saveToCache`).
+ * ## O(1) sampler — and its deliberate blind spot
+ * It touches a FIXED ~160KB spread regardless of file size (head {@link
+ * HEAD_TAIL_BYTES} + tail {@link HEAD_TAIL_BYTES} + {@link INTERIOR_WINDOWS}
+ * interior windows + the 8-byte length), so it is sub-millisecond even on a
+ * 400MB file. That O(1) speed is exactly why it CANNOT be the validation: it
+ * never reads the bytes BETWEEN its sample windows. A byte-length-preserving
+ * in-place edit that lands in a gap — a GUID patch (GUIDs are a fixed 22 chars),
+ * a scripted same-width coordinate/string edit — produces an IDENTICAL
+ * fingerprint. For the source-PERSISTING tier that is harmless (it serves cached
+ * geometry AND cached source together — self-consistent), but for the
+ * source-DECOUPLED (mesh-only) tier, which hydrates cached geometry against the
+ * FRESH buffer, an unvalidated gap-edit hit would be a silent chimera (old
+ * geometry + new properties).
  *
- * ## Why the key match is collision-safe
- * The cache key is `ifc-{exactByteLength}-{hex}-v{fmt}...`, so a stale hit needs
- * a genuinely DIFFERENT file that matches on ALL of:
- *   1. exact byte length (to the byte — folded into both the key and the hash),
- *   2. the first {@link HEAD_TAIL_BYTES} (the ISO-10303-21 header, FILE_NAME
- *      timestamp/author, FILE_SCHEMA, and start of DATA — essentially unique per
- *      model),
- *   3. the last {@link HEAD_TAIL_BYTES} (tail entities + ENDSEC/END-ISO),
- *   4. {@link INTERIOR_WINDOWS} interior windows at fixed fractional offsets, and
- *   5. a 64-bit xxhash collision over the concatenated sample.
- * Requiring all of that simultaneously for two real IFC files is astronomically
- * impossible — far beyond the ~2^-64 of the hash alone. This is strictly
- * stronger than the old key (proved by `sourceFingerprint.test.ts`: a pair that
- * collides on the old weak key is distinguished here), which also closes a
- * latent hazard in the source-persisting tier where an old-key collision could
- * have paired one file's cached geometry with another file's persisted source.
+ * ## Validation lives elsewhere — NOT in this fingerprint
+ * A mesh-only hit is validated by the source File's `lastModified` (mtime guard:
+ * any real on-disk edit bumps it → safe miss) plus a TRUE full-file content hash
+ * (SHA-256, computed off the main thread and re-checked in the background to
+ * catch the deliberate mtime-preserving gap edit → purge + reload). See
+ * `cacheTier.decideMeshOnlyCacheHit`, `utils/sourceContentHash.ts`, and
+ * `useIfcLoader`. This fingerprint's only job is to key the lookup cheaply and
+ * make a false key-hit (a genuinely different file mapping to the same entry)
+ * astronomically rare, so the mtime / full-hash gate almost never has to reject
+ * one. It is still strictly stronger than the old weak key (proved in
+ * `sourceFingerprint.test.ts`), but strength of the KEY is a performance
+ * property, not the safety guarantee.
  */
 export interface SourceFingerprint {
   /** Filename-safe hex of {@link hash} — the content component of the cache key. */
   hex: string;
-  /**
-   * The same value as a 64-bit int, for the cache header's `sourceHash` field
-   * (passed to `BinaryCacheWriter.write({ sourceHash })` so the write path never
-   * pays a full-file hash). It is a cheap content hash, not the full-file hash.
-   */
+  /** The same value as a 64-bit int (the numeric form of {@link hex}). */
   hash: bigint;
 }
 

--- a/apps/viewer/src/hooks/sourceFingerprint.ts
+++ b/apps/viewer/src/hooks/sourceFingerprint.ts
@@ -1,0 +1,106 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { xxhash64 } from '@ifc-lite/cache';
+
+/**
+ * Spread-sampled source fingerprint — the collision-safe content identity that
+ * both keys the persisted cache and VALIDATES a hit (`buildGeometryCacheKey`
+ * folds {@link SourceFingerprint.hex} into the key, so a key match *is* the
+ * validation). It replaces the old first-4KB+last-4KB FNV-32 fingerprint, which
+ * ignored the entire interior of the file and only had 32 bits of entropy.
+ *
+ * ## Why this removes the repeat-open stall
+ * The mesh-only cache tier does not persist the >150MB source, so it used to
+ * recompute a full-file `xxhash64` on every repeat open to validate the hit
+ * against the header hash — a 0.7-1.7s PURE-JS main-thread stall that scaled
+ * with file size. This samples a fixed ~100KB spread regardless of file size
+ * (O(1) in the file length, sub-millisecond even on a 400MB file), so making
+ * the KEY the validation lets us drop the full-file hash entirely: no stall on
+ * read, and no full-file hash on write either (the writer stores {@link
+ * SourceFingerprint.hash} in its header cheaply — see `useIfcCache.saveToCache`).
+ *
+ * ## Why the key match is collision-safe
+ * The cache key is `ifc-{exactByteLength}-{hex}-v{fmt}...`, so a stale hit needs
+ * a genuinely DIFFERENT file that matches on ALL of:
+ *   1. exact byte length (to the byte — folded into both the key and the hash),
+ *   2. the first {@link HEAD_TAIL_BYTES} (the ISO-10303-21 header, FILE_NAME
+ *      timestamp/author, FILE_SCHEMA, and start of DATA — essentially unique per
+ *      model),
+ *   3. the last {@link HEAD_TAIL_BYTES} (tail entities + ENDSEC/END-ISO),
+ *   4. {@link INTERIOR_WINDOWS} interior windows at fixed fractional offsets, and
+ *   5. a 64-bit xxhash collision over the concatenated sample.
+ * Requiring all of that simultaneously for two real IFC files is astronomically
+ * impossible — far beyond the ~2^-64 of the hash alone. This is strictly
+ * stronger than the old key (proved by `sourceFingerprint.test.ts`: a pair that
+ * collides on the old weak key is distinguished here), which also closes a
+ * latent hazard in the source-persisting tier where an old-key collision could
+ * have paired one file's cached geometry with another file's persisted source.
+ */
+export interface SourceFingerprint {
+  /** Filename-safe hex of {@link hash} — the content component of the cache key. */
+  hex: string;
+  /**
+   * The same value as a 64-bit int, for the cache header's `sourceHash` field
+   * (passed to `BinaryCacheWriter.write({ sourceHash })` so the write path never
+   * pays a full-file hash). It is a cheap content hash, not the full-file hash.
+   */
+  hash: bigint;
+}
+
+/** Bytes sampled from each end of the file (head + tail). */
+export const HEAD_TAIL_BYTES = 64 * 1024;
+/** Size of each evenly-spaced interior sample window. */
+export const INTERIOR_WINDOW_BYTES = 4 * 1024;
+/** Number of interior windows sampled between the head and the tail. */
+export const INTERIOR_WINDOWS = 8;
+
+/**
+ * Compute the {@link SourceFingerprint} for a source buffer. Touches at most
+ * `8 + 2*HEAD_TAIL_BYTES + INTERIOR_WINDOWS*INTERIOR_WINDOW_BYTES` (~160KB)
+ * regardless of file size, so it is constant-time in the file length.
+ */
+export function computeSourceFingerprint(buffer: ArrayBuffer | Uint8Array): SourceFingerprint {
+  const view = buffer instanceof Uint8Array ? buffer : new Uint8Array(buffer);
+  const len = view.length;
+
+  const parts: Uint8Array[] = [];
+
+  // 8-byte little-endian length prefix folds the exact size into the hash (it is
+  // also a distinct key component, so a length change alone always misses).
+  const lenBuf = new Uint8Array(8);
+  new DataView(lenBuf.buffer).setBigUint64(0, BigInt(len), true);
+  parts.push(lenBuf);
+
+  // Head window.
+  parts.push(view.subarray(0, Math.min(HEAD_TAIL_BYTES, len)));
+
+  // Tail window (only when it does not overlap the head).
+  if (len > HEAD_TAIL_BYTES) {
+    parts.push(view.subarray(Math.max(HEAD_TAIL_BYTES, len - HEAD_TAIL_BYTES), len));
+  }
+
+  // Interior windows at evenly spaced fractional offsets i/(N+1), clamped to
+  // stay inside the buffer. On small files these overlap the head/tail — that is
+  // fine (the head/tail already fully cover a small file's content).
+  for (let i = 1; i <= INTERIOR_WINDOWS; i++) {
+    const center = Math.floor((len * i) / (INTERIOR_WINDOWS + 1));
+    const maxStart = Math.max(0, len - INTERIOR_WINDOW_BYTES);
+    const start = Math.min(Math.max(0, center - (INTERIOR_WINDOW_BYTES >> 1)), maxStart);
+    parts.push(view.subarray(start, Math.min(start + INTERIOR_WINDOW_BYTES, len)));
+  }
+
+  // Concatenate the windows into one contiguous sample for a single hash pass.
+  let total = 0;
+  for (const p of parts) total += p.length;
+  const sample = new Uint8Array(total);
+  let off = 0;
+  for (const p of parts) {
+    sample.set(p, off);
+    off += p.length;
+  }
+
+  const hash = xxhash64(sample);
+  return { hex: hash.toString(16), hash };
+}

--- a/apps/viewer/src/hooks/useIfcCache.ts
+++ b/apps/viewer/src/hooks/useIfcCache.ts
@@ -14,7 +14,6 @@ import {
   BinaryCacheWriter,
   BinaryCacheReader,
   SchemaVersion,
-  xxhash64,
   type CachedEntityIndexColumns,
   type CacheDataStore,
   type GeometryData,
@@ -182,27 +181,15 @@ export function useIfcCache() {
 
       const reader = new BinaryCacheReader();
 
-      // Source-decoupled (mesh-only) tier validation: when the entry persisted NO
-      // source buffer but the caller handed us the freshly read file bytes, verify
-      // the cache header's full-source xxhash64 against that fresh buffer. This
-      // upgrades the weak 4KB fingerprint cache key to full-content validation, so
-      // a fingerprint+size collision (a DIFFERENT file keyed the same) can never
-      // serve stale geometry. On mismatch we throw → the catch below deletes the
-      // entry and returns success:false, and the loader falls back to a normal
-      // parse (a validated miss, not a crash). The classic source-persisting tier
-      // keeps its exact prior behaviour (this branch is skipped when a source was
-      // persisted).
-      if (!cacheResult.sourceBuffer && fallbackSourceBuffer) {
-        const header = reader.readHeader(cacheResult.buffer);
-        const freshHash = xxhash64(new Uint8Array(fallbackSourceBuffer));
-        if (header.sourceHash !== freshHash) {
-          throw new Error(
-            `mesh-only cache validation failed for ${fileName}: source hash mismatch ` +
-            `(header ${header.sourceHash.toString(16)} vs fresh ${freshHash.toString(16)})`,
-          );
-        }
-      }
-
+      // No full-file hash on the repeat-open path (the #1 un-flag blocker). The
+      // hit is already validated by the strengthened, spread-sampled cache key
+      // (`sourceFingerprint.ts`): a key match means the exact byte length AND a
+      // 64-bit hash of a ~160KB spread (head + tail + interior windows) match, so
+      // a genuinely different file can never key the same entry. That makes the
+      // former ~0.7-1.7s `xxhash64(fullSource)` recompute here redundant, and
+      // dropping it removes the main-thread stall for BOTH cache tiers. A
+      // truncated/corrupt cache buffer still fails fast in `reader.read` below →
+      // the catch deletes the entry and returns a graceful miss.
       const result = await reader.read(cacheResult.buffer);
       const cacheReadTime = performance.now() - cacheLoadStart;
 
@@ -373,16 +360,20 @@ export function useIfcCache() {
     geometry: GeometryData,
     sourceBuffer: ArrayBuffer,
     fileName: string,
-    options: { persistSource?: boolean } = {}
+    options: { persistSource?: boolean; sourceHash?: bigint } = {}
   ): Promise<void> => {
     // `persistSource` (default true) is the classic <=150MB tier: the raw source
     // is stored alongside the cache so lazy property/quantity accessors + re-export
-    // read it from IndexedDB. The mesh-only tier (150-400MB, prototype) passes
-    // false: the source is too big to persist, so it is omitted from IndexedDB and
-    // rehydrated from the freshly read buffer on re-open. The cache buffer ALWAYS
-    // embeds xxhash64(source) in its header (the writer computes it from
-    // `sourceBuffer` regardless), so a mesh-only hit stays validatable on load.
-    const { persistSource = true } = options;
+    // read it from IndexedDB. The mesh-only tier (150-400MB) passes false: the
+    // source is too big to persist, so it is omitted from IndexedDB and rehydrated
+    // from the freshly read buffer on re-open.
+    //
+    // `sourceHash` is the cheap spread-sample hash the loader already computed for
+    // the cache key (`computeSourceFingerprint`). Passing it to the writer stores
+    // it in the header verbatim and SKIPS the full-file `xxhash64(sourceBuffer)`,
+    // so even a 400MB cold-load write pays no full-file main-thread hash. The hit
+    // is validated by the key on read, not this header value.
+    const { persistSource = true, sourceHash } = options;
     try {
       console.log(`[useIfcCache] Starting cache write for: ${fileName} (persistSource=${persistSource})`);
       const writer = new BinaryCacheWriter();
@@ -401,7 +392,7 @@ export function useIfcCache() {
       };
 
       console.log('[useIfcCache] Writing cache buffer...');
-      const cacheBuffer = await writer.write(cacheDataStore, geometry, sourceBuffer, { includeGeometry: true });
+      const cacheBuffer = await writer.write(cacheDataStore, geometry, sourceBuffer, { includeGeometry: true, sourceHash });
       console.log('[useIfcCache] Cache buffer written:', cacheBuffer.byteLength, 'bytes');
 
       console.log('[useIfcCache] Saving to cache storage...');

--- a/apps/viewer/src/hooks/useIfcCache.ts
+++ b/apps/viewer/src/hooks/useIfcCache.ts
@@ -20,6 +20,7 @@ import {
 } from '@ifc-lite/cache';
 import { SpatialHierarchyBuilder, StepTokenizer, CompactEntityIndex, CompactEntityIndexBuilder, extractLengthUnitScale, attachDataStoreAccessors, type IfcDataStore, type IfcStoreData } from '@ifc-lite/parser';
 import { buildSpatialIndexGuarded } from '../utils/loadingUtils.js';
+import { computeFullSourceHash } from '../utils/sourceContentHash.js';
 import type { MeshData } from '@ifc-lite/geometry';
 
 import { useShallow } from 'zustand/react/shallow';
@@ -360,7 +361,7 @@ export function useIfcCache() {
     geometry: GeometryData,
     sourceBuffer: ArrayBuffer,
     fileName: string,
-    options: { persistSource?: boolean; sourceHash?: bigint } = {}
+    options: { persistSource?: boolean; lastModified?: number } = {}
   ): Promise<void> => {
     // `persistSource` (default true) is the classic <=150MB tier: the raw source
     // is stored alongside the cache so lazy property/quantity accessors + re-export
@@ -368,12 +369,14 @@ export function useIfcCache() {
     // source is too big to persist, so it is omitted from IndexedDB and rehydrated
     // from the freshly read buffer on re-open.
     //
-    // `sourceHash` is the cheap spread-sample hash the loader already computed for
-    // the cache key (`computeSourceFingerprint`). Passing it to the writer stores
-    // it in the header verbatim and SKIPS the full-file `xxhash64(sourceBuffer)`,
-    // so even a 400MB cold-load write pays no full-file main-thread hash. The hit
-    // is validated by the key on read, not this header value.
-    const { persistSource = true, sourceHash } = options;
+    // The header's full-file `xxhash64` is OMITTED (`omitSourceHash`) so a 400MB
+    // cold-load write pays no full-file main-thread hash. The source-decoupled hit
+    // is instead validated by the source File's `lastModified` (mtime guard) plus
+    // a TRUE full-file SHA-256 computed OFF the main thread (`computeFullSourceHash`,
+    // via Web Crypto), both stored in the IndexedDB record — distinct from the
+    // header hash and the key's spread fingerprint. This whole block is
+    // backgrounded on a cold load, so the off-thread hash costs the user nothing.
+    const { persistSource = true, lastModified } = options;
     try {
       console.log(`[useIfcCache] Starting cache write for: ${fileName} (persistSource=${persistSource})`);
       const writer = new BinaryCacheWriter();
@@ -391,9 +394,23 @@ export function useIfcCache() {
         entityIndex: dataStore.entityIndex,
       };
 
+      // Compute the true full-file validation hash off the main thread (runs in
+      // parallel with the cache-buffer serialization below). ONLY for the
+      // source-decoupled tier: the source-persisting tier serves cached geometry
+      // AND cached source together (self-consistent) and never consults it, so
+      // its <=150MB write path stays exactly as it was.
+      const fullHashPromise = persistSource
+        ? Promise.resolve<string | null>(null)
+        : computeFullSourceHash(sourceBuffer);
+
       console.log('[useIfcCache] Writing cache buffer...');
-      const cacheBuffer = await writer.write(cacheDataStore, geometry, sourceBuffer, { includeGeometry: true, sourceHash });
+      const cacheBuffer = await writer.write(cacheDataStore, geometry, sourceBuffer, {
+        includeGeometry: true,
+        omitSourceHash: true,
+      });
       console.log('[useIfcCache] Cache buffer written:', cacheBuffer.byteLength, 'bytes');
+
+      const fullSourceHash = (await fullHashPromise) ?? undefined;
 
       console.log('[useIfcCache] Saving to cache storage...');
       await setCached(
@@ -402,8 +419,9 @@ export function useIfcCache() {
         fileName,
         sourceBuffer.byteLength,
         persistSource ? sourceBuffer : undefined,
+        { lastModified, fullSourceHash },
       );
-      console.log(`[useIfcCache] ✓ Cache saved successfully (${persistSource ? 'with' : 'without'} source)`);
+      console.log(`[useIfcCache] ✓ Cache saved successfully (${persistSource ? 'with' : 'without'} source, mtime=${lastModified ?? 'n/a'}, fullHash=${fullSourceHash ? 'yes' : 'no'})`);
     } catch (err) {
       console.error('[useIfcCache] Failed to cache model:', err);
       console.error('[useIfcCache] Error stack:', err instanceof Error ? err.stack : 'No stack trace');

--- a/apps/viewer/src/hooks/useIfcCache.ts
+++ b/apps/viewer/src/hooks/useIfcCache.ts
@@ -14,6 +14,7 @@ import {
   BinaryCacheWriter,
   BinaryCacheReader,
   SchemaVersion,
+  xxhash64,
   type CachedEntityIndexColumns,
   type CacheDataStore,
   type GeometryData,
@@ -180,6 +181,28 @@ export function useIfcCache() {
       setGeometryResult(null);
 
       const reader = new BinaryCacheReader();
+
+      // Source-decoupled (mesh-only) tier validation: when the entry persisted NO
+      // source buffer but the caller handed us the freshly read file bytes, verify
+      // the cache header's full-source xxhash64 against that fresh buffer. This
+      // upgrades the weak 4KB fingerprint cache key to full-content validation, so
+      // a fingerprint+size collision (a DIFFERENT file keyed the same) can never
+      // serve stale geometry. On mismatch we throw → the catch below deletes the
+      // entry and returns success:false, and the loader falls back to a normal
+      // parse (a validated miss, not a crash). The classic source-persisting tier
+      // keeps its exact prior behaviour (this branch is skipped when a source was
+      // persisted).
+      if (!cacheResult.sourceBuffer && fallbackSourceBuffer) {
+        const header = reader.readHeader(cacheResult.buffer);
+        const freshHash = xxhash64(new Uint8Array(fallbackSourceBuffer));
+        if (header.sourceHash !== freshHash) {
+          throw new Error(
+            `mesh-only cache validation failed for ${fileName}: source hash mismatch ` +
+            `(header ${header.sourceHash.toString(16)} vs fresh ${freshHash.toString(16)})`,
+          );
+        }
+      }
+
       const result = await reader.read(cacheResult.buffer);
       const cacheReadTime = performance.now() - cacheLoadStart;
 
@@ -349,10 +372,19 @@ export function useIfcCache() {
     dataStore: IfcDataStore,
     geometry: GeometryData,
     sourceBuffer: ArrayBuffer,
-    fileName: string
+    fileName: string,
+    options: { persistSource?: boolean } = {}
   ): Promise<void> => {
+    // `persistSource` (default true) is the classic <=150MB tier: the raw source
+    // is stored alongside the cache so lazy property/quantity accessors + re-export
+    // read it from IndexedDB. The mesh-only tier (150-400MB, prototype) passes
+    // false: the source is too big to persist, so it is omitted from IndexedDB and
+    // rehydrated from the freshly read buffer on re-open. The cache buffer ALWAYS
+    // embeds xxhash64(source) in its header (the writer computes it from
+    // `sourceBuffer` regardless), so a mesh-only hit stays validatable on load.
+    const { persistSource = true } = options;
     try {
-      console.log('[useIfcCache] Starting cache write for:', fileName);
+      console.log(`[useIfcCache] Starting cache write for: ${fileName} (persistSource=${persistSource})`);
       const writer = new BinaryCacheWriter();
 
       // Adapt dataStore to cache format
@@ -373,8 +405,14 @@ export function useIfcCache() {
       console.log('[useIfcCache] Cache buffer written:', cacheBuffer.byteLength, 'bytes');
 
       console.log('[useIfcCache] Saving to cache storage...');
-      await setCached(cacheKey, cacheBuffer, fileName, sourceBuffer.byteLength, sourceBuffer);
-      console.log('[useIfcCache] ✓ Cache saved successfully');
+      await setCached(
+        cacheKey,
+        cacheBuffer,
+        fileName,
+        sourceBuffer.byteLength,
+        persistSource ? sourceBuffer : undefined,
+      );
+      console.log(`[useIfcCache] ✓ Cache saved successfully (${persistSource ? 'with' : 'without'} source)`);
     } catch (err) {
       console.error('[useIfcCache] Failed to cache model:', err);
       console.error('[useIfcCache] Error stack:', err instanceof Error ? err.stack : 'No stack trace');

--- a/apps/viewer/src/hooks/useIfcLoader.ts
+++ b/apps/viewer/src/hooks/useIfcLoader.ts
@@ -14,7 +14,8 @@ import { useCallback, useRef } from 'react';
 import { flushSync } from 'react-dom';
 import { useShallow } from 'zustand/react/shallow';
 import { getViewerStoreApi, useViewerStore, type FederatedModel } from '@/store';
-import { getGeomWorkerOverride, resolveLoadTessellationTier } from '../store/constants.js';
+import { getGeomWorkerOverride, resolveLoadTessellationTier, isMeshOnlyCacheEnabled } from '../store/constants.js';
+import { classifyCacheTier } from './cacheTier.js';
 import { IfcParser, detectFormat, unwrapIfcZip, type IfcDataStore } from '@ifc-lite/parser';
 import { WorkerParser } from '@ifc-lite/parser/browser';
 import { memoryAccounting } from '../lib/perf/memoryAccounting.js';
@@ -31,7 +32,7 @@ import { buildSpatialIndexGuarded, buildSpatialIndexForModel } from '../utils/lo
 import { buildGeometryCacheKey } from './geometryCacheKey.js';
 import { type GeometryData } from '@ifc-lite/cache';
 
-import { SERVER_URL, USE_SERVER, CACHE_SIZE_THRESHOLD, CACHE_MAX_SOURCE_SIZE, getDynamicBatchConfig } from '../utils/ifcConfig.js';
+import { SERVER_URL, USE_SERVER, CACHE_SIZE_THRESHOLD, CACHE_MAX_SOURCE_SIZE, CACHE_MESH_ONLY_MAX_SIZE, getDynamicBatchConfig } from '../utils/ifcConfig.js';
 import {
   calculateMeshBounds,
   createCoordinateInfo,
@@ -1267,14 +1268,23 @@ export function useIfcLoader() {
                 // for bounds computation alone).
                 buildSpatialIndexGuarded(allMeshes, dataStore, setIfcDataStore);
 
-                // Cache the result in the background (files between 10 MB and 150 MB).
-                // Files above CACHE_MAX_SOURCE_SIZE are not cached because the
-                // source buffer is required for on-demand property/quantity
-                // extraction, spatial hierarchy elevations, and IFC re-export.
-                // Caching without it would silently degrade those features.
+                // Cache the result in the background. Two tiers (see cacheTier.ts):
+                //  - `source` (10-150MB): persist tables + geometry AND the source
+                //    buffer, so lazy property/quantity accessors + IFC re-export read
+                //    it straight from IndexedDB. Unchanged behaviour.
+                //  - `mesh-only` (150-400MB, prototype behind `?meshCache=1`): the
+                //    source is too big to persist, so cache tables + geometry WITHOUT
+                //    it; on re-open the freshly read buffer rehydrates the accessors
+                //    (validated against the header's full-source hash).
+                // Files above 400MB (or the mesh-only flag off) are not cached.
+                const cacheTier = classifyCacheTier(buffer.byteLength, {
+                  meshOnlyEnabled: isMeshOnlyCacheEnabled(),
+                  minSize: CACHE_SIZE_THRESHOLD,
+                  maxSourceSize: CACHE_MAX_SOURCE_SIZE,
+                  maxMeshOnlySize: CACHE_MESH_ONLY_MAX_SIZE,
+                });
                 if (
-                  buffer.byteLength >= CACHE_SIZE_THRESHOLD &&
-                  buffer.byteLength <= CACHE_MAX_SOURCE_SIZE &&
+                  cacheTier !== 'none' &&
                   allMeshes.length > 0 &&
                   finalCoordinateInfo
                 ) {
@@ -1289,7 +1299,9 @@ export function useIfcLoader() {
                     // restore the flat meshes only and drop all instanced occurrences.
                     ...(allInstancedShards.length > 0 ? { instancedShards: allInstancedShards } : {}),
                   };
-                  await saveToCache(cacheKey, dataStore, geometryData, buffer, file.name);
+                  await saveToCache(cacheKey, dataStore, geometryData, buffer, file.name, {
+                    persistSource: cacheTier === 'source',
+                  });
                 }
 
                 // Release closure references to MeshData objects after a delay.

--- a/apps/viewer/src/hooks/useIfcLoader.ts
+++ b/apps/viewer/src/hooks/useIfcLoader.ts
@@ -15,7 +15,8 @@ import { flushSync } from 'react-dom';
 import { useShallow } from 'zustand/react/shallow';
 import { getViewerStoreApi, useViewerStore, type FederatedModel } from '@/store';
 import { getGeomWorkerOverride, resolveLoadTessellationTier, isMeshOnlyCacheEnabled } from '../store/constants.js';
-import { classifyCacheTier } from './cacheTier.js';
+import { planCacheWrite } from './cacheTier.js';
+import { computeSourceFingerprint } from './sourceFingerprint.js';
 import { IfcParser, detectFormat, unwrapIfcZip, type IfcDataStore } from '@ifc-lite/parser';
 import { WorkerParser } from '@ifc-lite/parser/browser';
 import { memoryAccounting } from '../lib/perf/memoryAccounting.js';
@@ -100,33 +101,6 @@ export type LoadTarget =
       /** Shared RTC offset from the earliest existing model (IFC Z-up). */
       sharedRtcOffset?: { x: number; y: number; z: number };
     };
-
-/**
- * Compute a fast content fingerprint from the first and last 4KB of a buffer.
- * Uses FNV-1a hash for speed — no crypto overhead, sufficient to distinguish
- * files with identical name and byte length.
- */
-function computeFastFingerprint(buffer: ArrayBuffer): string {
-  const CHUNK_SIZE = 4096;
-  const view = new Uint8Array(buffer);
-  const len = view.length;
-
-  // FNV-1a hash
-  let hash = 2166136261; // FNV offset basis (32-bit)
-  const firstEnd = Math.min(CHUNK_SIZE, len);
-  for (let i = 0; i < firstEnd; i++) {
-    hash ^= view[i];
-    hash = Math.imul(hash, 16777619); // FNV prime
-  }
-  if (len > CHUNK_SIZE) {
-    const lastStart = Math.max(CHUNK_SIZE, len - CHUNK_SIZE);
-    for (let i = lastStart; i < len; i++) {
-      hash ^= view[i];
-      hash = Math.imul(hash, 16777619);
-    }
-  }
-  return (hash >>> 0).toString(16);
-}
 
 /**
  * Geometry stream watchdog. Delegates to the package-level helper so the
@@ -625,9 +599,13 @@ export function useIfcLoader() {
         }
       }
 
-      // Cache key uses filename + size + content fingerprint + format version
-      // Fingerprint prevents collisions for different files with the same name and size
-      const fingerprint = computeFastFingerprint(buffer);
+      // Cache key = size + spread-sampled content fingerprint + format version.
+      // The fingerprint (`sourceFingerprint.ts`) hashes a ~160KB spread (head +
+      // tail + interior windows) plus the exact byte length, so a key match is
+      // itself the validation — a genuinely different file can't key the same
+      // entry. `.hash` is reused as the cache header's `sourceHash` so the write
+      // path never pays a full-file hash either.
+      const fingerprint = computeSourceFingerprint(buffer);
       // Snapshot the merge-layers flag *before* the cache lookup: it is a
       // load-time WASM tessellation input (issue #540) and must discriminate
       // the cache key, otherwise toggling it + reloading serves geometry built
@@ -652,7 +630,7 @@ export function useIfcLoader() {
       // added the geometryClass tag the Model/Types switch needs).
       const cacheKey = buildGeometryCacheKey(
         buffer.byteLength,
-        fingerprint,
+        fingerprint.hex,
         mergeLayersAtLoad,
         undefined,
         skipSmallCutsAtLoad,
@@ -660,9 +638,22 @@ export function useIfcLoader() {
       );
       console.log(`[useIfc] loadFile "${file.name}" session=${currentSession} mergeLayers=${mergeLayersAtLoad} geomMode=${geometryModeAtLoad} tier=${loadTessellationTier ?? 'medium'} cacheKey=${cacheKey}`);
 
+      // Decide the cache tier ONCE (single source of truth for read + write, see
+      // cacheTier.ts): the source tier (<=150MB) always caches; the mesh-only
+      // tier (150-400MB) caches only while enabled (kill switch `?meshCache=0`);
+      // nothing else caches. Gating the READ on `shouldCache` too makes the kill
+      // switch complete — with it off, a previously written mesh-only entry is
+      // NOT served (and files outside any band skip a pointless lookup).
+      const cachePlan = planCacheWrite(buffer.byteLength, {
+        meshOnlyEnabled: isMeshOnlyCacheEnabled(),
+        minSize: CACHE_SIZE_THRESHOLD,
+        maxSourceSize: CACHE_MAX_SOURCE_SIZE,
+        maxMeshOnlySize: CACHE_MESH_ONLY_MAX_SIZE,
+      });
+
       // Cache + server are PRIMARY-ONLY: a federated add is WASM-only with no
       // cache/server round-trip (matches the former parseStepBufferViewerModel).
-      if (target.kind === 'primary' && buffer.byteLength >= CACHE_SIZE_THRESHOLD) {
+      if (target.kind === 'primary' && cachePlan.shouldCache) {
         setProgress({ phase: 'Checking cache', percent: 5 });
         const cacheResult = await getCached(cacheKey);
         if (cacheResult) {
@@ -1260,7 +1251,9 @@ export function useIfcLoader() {
 
                 await finalizeModel(dataStore, useViewerStore.getState().geometryResult, getSchemaVersion(dataStore), {
                   loadState: 'complete',
-                  cacheState: buffer.byteLength >= CACHE_SIZE_THRESHOLD ? 'writing' : 'none',
+                  // Only show "writing" when this file will actually be cached
+                  // under the current plan (respects the size bands + kill switch).
+                  cacheState: cachePlan.shouldCache ? 'writing' : 'none',
                 });
                 // Build spatial index from meshes in time-sliced chunks (non-blocking).
                 // Previously this was synchronous inside requestIdleCallback, blocking
@@ -1268,23 +1261,20 @@ export function useIfcLoader() {
                 // for bounds computation alone).
                 buildSpatialIndexGuarded(allMeshes, dataStore, setIfcDataStore);
 
-                // Cache the result in the background. Two tiers (see cacheTier.ts):
+                // Cache the result in the background, reusing the `cachePlan`
+                // decided once above (single source of truth for read + write).
+                // The two tiers differ ONLY in `persistSource` and the size band:
                 //  - `source` (10-150MB): persist tables + geometry AND the source
                 //    buffer, so lazy property/quantity accessors + IFC re-export read
-                //    it straight from IndexedDB. Unchanged behaviour.
-                //  - `mesh-only` (150-400MB, prototype behind `?meshCache=1`): the
-                //    source is too big to persist, so cache tables + geometry WITHOUT
-                //    it; on re-open the freshly read buffer rehydrates the accessors
-                //    (validated against the header's full-source hash).
-                // Files above 400MB (or the mesh-only flag off) are not cached.
-                const cacheTier = classifyCacheTier(buffer.byteLength, {
-                  meshOnlyEnabled: isMeshOnlyCacheEnabled(),
-                  minSize: CACHE_SIZE_THRESHOLD,
-                  maxSourceSize: CACHE_MAX_SOURCE_SIZE,
-                  maxMeshOnlySize: CACHE_MESH_ONLY_MAX_SIZE,
-                });
+                //    it straight from IndexedDB.
+                //  - `mesh-only` (150-400MB, on by default; kill switch `?meshCache=0`):
+                //    the source is too big to persist, so cache tables + geometry
+                //    WITHOUT it; on re-open the freshly read buffer rehydrates the
+                //    accessors. The hit is validated by the strengthened cache key,
+                //    so repeat opens have no main-thread hash stall.
+                // Files above 400MB (or with the mesh-only kill switch set) are not cached.
                 if (
-                  cacheTier !== 'none' &&
+                  cachePlan.shouldCache &&
                   allMeshes.length > 0 &&
                   finalCoordinateInfo
                 ) {
@@ -1300,7 +1290,8 @@ export function useIfcLoader() {
                     ...(allInstancedShards.length > 0 ? { instancedShards: allInstancedShards } : {}),
                   };
                   await saveToCache(cacheKey, dataStore, geometryData, buffer, file.name, {
-                    persistSource: cacheTier === 'source',
+                    persistSource: cachePlan.persistSource,
+                    sourceHash: fingerprint.hash,
                   });
                 }
 

--- a/apps/viewer/src/hooks/useIfcLoader.ts
+++ b/apps/viewer/src/hooks/useIfcLoader.ts
@@ -10,13 +10,14 @@
  * Extracted from useIfc.ts for better separation of concerns
  */
 
-import { useCallback, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { flushSync } from 'react-dom';
 import { useShallow } from 'zustand/react/shallow';
 import { getViewerStoreApi, useViewerStore, type FederatedModel } from '@/store';
 import { getGeomWorkerOverride, resolveLoadTessellationTier, isMeshOnlyCacheEnabled } from '../store/constants.js';
-import { planCacheWrite } from './cacheTier.js';
+import { planCacheWrite, decideMeshOnlyCacheHit } from './cacheTier.js';
 import { computeSourceFingerprint } from './sourceFingerprint.js';
+import { computeFullSourceHash } from '../utils/sourceContentHash.js';
 import { IfcParser, detectFormat, unwrapIfcZip, type IfcDataStore } from '@ifc-lite/parser';
 import { WorkerParser } from '@ifc-lite/parser/browser';
 import { memoryAccounting } from '../lib/perf/memoryAccounting.js';
@@ -43,7 +44,7 @@ import {
 import { applyColorUpdatesToMeshes } from './meshColorUpdates.js';
 
 // Cache hook
-import { useIfcCache, getCached } from './useIfcCache.js';
+import { useIfcCache, getCached, deleteCached } from './useIfcCache.js';
 
 // Server hook
 import { useIfcServer } from './useIfcServer.js';
@@ -175,6 +176,48 @@ export function useIfcLoader() {
 
   // Server operations from extracted hook
   const { loadFromServer } = useIfcServer();
+
+  // Latest `loadFile`, so the background revalidation can reload without being a
+  // dependency of `loadFile` itself (avoids a definition cycle). Kept current by
+  // the effect below.
+  const loadFileRef = useRef<((file: File, target?: LoadTarget) => Promise<void>) | null>(null);
+
+  /**
+   * Background revalidation for a SERVED source-decoupled (mesh-only) cache hit:
+   * confirm the TRUE full-file hash of the fresh buffer matches what was stored
+   * at write. The mtime guard already rejected any normal on-disk edit before
+   * serving; this closes the deliberate mtime-PRESERVED in-place edit (a GUID or
+   * same-width coordinate patch the O(1) spread key can't see) that the mtime
+   * guard alone would miss. On mismatch: purge the stale entry and auto-reload
+   * (a full reparse) with a notice. Runs off the main thread (Web Crypto), so it
+   * never blocks the instant hit it follows.
+   */
+  const revalidateSourceDecoupledHit = useCallback(async (args: {
+    file: File;
+    target: LoadTarget;
+    buffer: ArrayBufferLike;
+    cacheKey: string;
+    expectedHash: string;
+    session: number;
+  }): Promise<void> => {
+    try {
+      const freshHash = await computeFullSourceHash(args.buffer);
+      // Web Crypto unavailable → can't revalidate; the mtime guard already vetted
+      // this hit, so leave it served rather than churning a reload.
+      if (freshHash === null) return;
+      if (freshHash === args.expectedHash) return; // validated: byte-identical source
+
+      console.warn(`[useIfc] source-decoupled cache was stale (full-hash mismatch) — reloading "${args.file.name}"`);
+      await deleteCached(args.cacheKey);
+      // A newer load superseded this one: the entry is purged; don't yank the
+      // user off whatever they loaded next.
+      if (loadSessionRef.current !== args.session) return;
+      toast.info(`"${args.file.name}" changed since it was cached — reloading with the current file.`);
+      await loadFileRef.current?.(args.file, args.target);
+    } catch (err) {
+      console.warn('[useIfc] background cache revalidation failed', err);
+    }
+  }, []);
 
   const loadFile = useCallback(async (
     file: File,
@@ -657,20 +700,54 @@ export function useIfcLoader() {
         setProgress({ phase: 'Checking cache', percent: 5 });
         const cacheResult = await getCached(cacheKey);
         if (cacheResult) {
-          // Pass the freshly read file buffer as the source fallback: the
-          // desktop cache doesn't persist a sourceBuffer, and without one the
-          // restored store can't carry the lazy entity accessors.
-          const cacheLoadResult = await loadFromCache(cacheResult, file.name, cacheKey, buffer);
-          if (cacheLoadResult.success) {
-            const state = useViewerStore.getState();
-            await finalizeModel(state.ifcDataStore, state.geometryResult, getSchemaVersion(state.ifcDataStore), {
-              loadState: 'complete',
-              cacheState: 'hit',
-            });
-            console.log(`[useIfc] TOTAL LOAD TIME (from cache): ${(performance.now() - totalStartTime).toFixed(0)}ms`);
-            posthog.capture('ifc_model_loaded', { format, file_size_mb: Math.round(fileSizeMB * 100) / 100, load_target: target.kind, load_path: 'cache', total_elapsed_ms: Math.round(performance.now() - totalStartTime) });
-            setLoading(false);
-            return;
+          // A source-decoupled (mesh-only) entry persisted NO source, so it will
+          // hydrate cached geometry against the FRESH buffer — validate the source
+          // before serving. The O(1) spread key can't see a byte-length-preserving
+          // in-place edit that falls between its sample windows, so the mtime guard
+          // is the real gate: a changed on-disk mtime → MISS (reparse); an
+          // unvalidatable hit (no mtime AND no full hash) → MISS. The classic
+          // source-persisting tier serves cached geometry + cached source together
+          // (self-consistent), so it skips this entirely.
+          const isSourceDecoupled = !cacheResult.sourceBuffer;
+          const mayServe = !isSourceDecoupled || decideMeshOnlyCacheHit({
+            storedMtime: cacheResult.lastModified,
+            freshMtime: file.lastModified,
+            hasFullHash: !!cacheResult.fullSourceHash,
+          }) === 'serve';
+
+          if (!mayServe) {
+            console.warn(`[useIfc] source-decoupled cache MISS (source changed / unvalidatable) — reparsing "${file.name}"`);
+            await deleteCached(cacheKey);
+          } else {
+            // Pass the freshly read file buffer as the source fallback: the
+            // desktop cache doesn't persist a sourceBuffer, and without one the
+            // restored store can't carry the lazy entity accessors.
+            const cacheLoadResult = await loadFromCache(cacheResult, file.name, cacheKey, buffer);
+            if (cacheLoadResult.success) {
+              const state = useViewerStore.getState();
+              await finalizeModel(state.ifcDataStore, state.geometryResult, getSchemaVersion(state.ifcDataStore), {
+                loadState: 'complete',
+                cacheState: 'hit',
+              });
+              console.log(`[useIfc] TOTAL LOAD TIME (from cache): ${(performance.now() - totalStartTime).toFixed(0)}ms`);
+              posthog.capture('ifc_model_loaded', { format, file_size_mb: Math.round(fileSizeMB * 100) / 100, load_target: target.kind, load_path: 'cache', total_elapsed_ms: Math.round(performance.now() - totalStartTime) });
+              setLoading(false);
+              // Belt-and-suspenders for the source-decoupled tier: revalidate the
+              // TRUE full-file hash off the main thread and, if the source changed
+              // with its mtime preserved, purge + auto-reload. Fire-and-forget so
+              // the instant hit above is never delayed.
+              if (isSourceDecoupled && cacheResult.fullSourceHash) {
+                void revalidateSourceDecoupledHit({
+                  file,
+                  target,
+                  buffer,
+                  cacheKey,
+                  expectedHash: cacheResult.fullSourceHash,
+                  session: currentSession,
+                });
+              }
+              return;
+            }
           }
         }
       }
@@ -1291,7 +1368,9 @@ export function useIfcLoader() {
                   };
                   await saveToCache(cacheKey, dataStore, geometryData, buffer, file.name, {
                     persistSource: cachePlan.persistSource,
-                    sourceHash: fingerprint.hash,
+                    // mtime guard for a source-decoupled hit (the full-file
+                    // validation hash is computed off-thread inside saveToCache).
+                    lastModified: file.lastModified,
                   });
                 }
 
@@ -1431,7 +1510,13 @@ export function useIfcLoader() {
       setLoading(false);
       setGeometryStreamingActive(false);
     }
-  }, [setLoading, setGeometryStreamingActive, setError, setProgress, setIfcDataStore, setGeometryResult, appendGeometryBatch, appendInstancedShards, updateMeshColors, updateCoordinateInfo, loadFromCache, saveToCache, loadFromServer]);
+  }, [setLoading, setGeometryStreamingActive, setError, setProgress, setIfcDataStore, setGeometryResult, appendGeometryBatch, appendInstancedShards, updateMeshColors, updateCoordinateInfo, loadFromCache, saveToCache, loadFromServer, revalidateSourceDecoupledHit]);
+
+  // Keep the ref pointed at the latest loadFile so a background revalidation can
+  // trigger a reparse-reload without loadFile depending on itself.
+  useEffect(() => {
+    loadFileRef.current = loadFile;
+  }, [loadFile]);
 
   return { loadFile };
 }

--- a/apps/viewer/src/services/cacheService.ts
+++ b/apps/viewer/src/services/cacheService.ts
@@ -13,6 +13,16 @@
 // ============================================================================
 
 /**
+ * Extra validation metadata persisted with a cache entry (mesh-only tier):
+ * the source File's `lastModified` and a TRUE full-file content hash, used to
+ * validate a source-decoupled hit against the fresh buffer. See `ifc-cache.ts`.
+ */
+export interface CacheEntryMeta {
+  lastModified?: number;
+  fullSourceHash?: string;
+}
+
+/**
  * Result from cache lookup
  */
 export interface CacheResult {
@@ -20,6 +30,10 @@ export interface CacheResult {
   buffer: ArrayBuffer;
   /** Original IFC source file for on-demand property extraction */
   sourceBuffer?: ArrayBuffer;
+  /** Source File `lastModified` (ms) stored at write; mesh-only mtime guard. */
+  lastModified?: number;
+  /** True full-file content hash (SHA-256 hex) stored at write; mesh-only revalidation. */
+  fullSourceHash?: string;
 }
 
 /**
@@ -35,7 +49,8 @@ export type SetCachedFn = (
   data: ArrayBuffer,
   fileName: string,
   fileSize: number,
-  sourceBuffer?: ArrayBuffer
+  sourceBuffer?: ArrayBuffer,
+  meta?: CacheEntryMeta,
 ) => Promise<void>;
 
 /**
@@ -103,10 +118,11 @@ export async function setCached(
   data: ArrayBuffer,
   fileName: string,
   fileSize: number,
-  sourceBuffer?: ArrayBuffer
+  sourceBuffer?: ArrayBuffer,
+  meta?: CacheEntryMeta,
 ): Promise<void> {
   const service = await getCacheService();
-  return service.setCached(key, data, fileName, fileSize, sourceBuffer);
+  return service.setCached(key, data, fileName, fileSize, sourceBuffer, meta);
 }
 
 /**

--- a/apps/viewer/src/services/ifc-cache.test.ts
+++ b/apps/viewer/src/services/ifc-cache.test.ts
@@ -76,6 +76,20 @@ describe('ifc-cache quota + robustness (blocker #2)', () => {
     restoreNavigator();
   });
 
+  it('round-trips the mesh-only validation metadata (lastModified + fullSourceHash)', async () => {
+    // These fields are the source-decoupled tier's real validation guard, so a
+    // hit can reject a changed source instead of forming a chimera.
+    await setCached('meta', patterned(8 * KB, 8), 'meta.ifc', 8 * KB, undefined, {
+      lastModified: 1_720_000_000_123,
+      fullSourceHash: 'deadbeef'.repeat(8),
+    });
+    const got = await getCached('meta');
+    assert.ok(got);
+    assert.equal(got!.lastModified, 1_720_000_000_123);
+    assert.equal(got!.fullSourceHash, 'deadbeef'.repeat(8));
+    assert.equal(got!.sourceBuffer, undefined, 'mesh-only entries persist no source');
+  });
+
   it('round-trips a large single record (buffer + source) byte-identical', async () => {
     // Proves a single large IndexedDB record writes AND reads back intact, so
     // the mesh-only geometry blob does not need chunking: the per-entry ceiling

--- a/apps/viewer/src/services/ifc-cache.test.ts
+++ b/apps/viewer/src/services/ifc-cache.test.ts
@@ -1,0 +1,211 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+// fake-indexeddb installs a Node-compatible IDB implementation on
+// `globalThis.indexedDB` (+ the IDB* constructors) via the `/auto` entry.
+import 'fake-indexeddb/auto';
+
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  setCached,
+  getCached,
+  clearCache,
+  openDatabase,
+  ensureRoomForEntry,
+  evictToFree,
+  availableQuotaBytes,
+  PER_ENTRY_MAX_BYTES,
+} from './ifc-cache.js';
+
+const KB = 1024;
+const MB = 1024 * 1024;
+
+/** A buffer filled with a key-derived pattern so we can assert byte-identity. */
+function patterned(bytes: number, seed: number): ArrayBuffer {
+  const buf = new ArrayBuffer(bytes);
+  const view = new Uint8Array(buf);
+  for (let i = 0; i < bytes; i++) view[i] = (i * 31 + seed) & 0xff;
+  return buf;
+}
+
+function bytesEqual(a: ArrayBuffer, b: ArrayBuffer): boolean {
+  if (a.byteLength !== b.byteLength) return false;
+  const va = new Uint8Array(a);
+  const vb = new Uint8Array(b);
+  for (let i = 0; i < va.length; i++) if (va[i] !== vb[i]) return false;
+  return true;
+}
+
+const delay = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+// --- navigator.storage.estimate stubbing (Safari-robustness paths) -----------
+const savedNavigator = Object.getOwnPropertyDescriptor(globalThis, 'navigator');
+
+/** Install a `navigator.storage.estimate` that reports the given quota/usage. */
+function stubEstimate(quota: number | undefined, usage: number | undefined): void {
+  Object.defineProperty(globalThis, 'navigator', {
+    value: { storage: { estimate: async () => ({ quota, usage }) } },
+    configurable: true,
+    writable: true,
+  });
+}
+
+/** Simulate Safari / older browsers where the Storage estimate API is absent. */
+function stubEstimateUnavailable(): void {
+  Object.defineProperty(globalThis, 'navigator', {
+    value: {}, // no `.storage`
+    configurable: true,
+    writable: true,
+  });
+}
+
+function restoreNavigator(): void {
+  if (savedNavigator) Object.defineProperty(globalThis, 'navigator', savedNavigator);
+  else delete (globalThis as Record<string, unknown>).navigator;
+}
+
+describe('ifc-cache quota + robustness (blocker #2)', () => {
+  beforeEach(async () => {
+    await clearCache();
+    stubEstimateUnavailable();
+  });
+  afterEach(() => {
+    restoreNavigator();
+  });
+
+  it('round-trips a large single record (buffer + source) byte-identical', async () => {
+    // Proves a single large IndexedDB record writes AND reads back intact, so
+    // the mesh-only geometry blob does not need chunking: the per-entry ceiling
+    // (PER_ENTRY_MAX_BYTES) + graceful-skip cover the only failure (Safari
+    // rejecting an oversized blob), and everything under it round-trips.
+    const buffer = patterned(24 * MB, 1);
+    const source = patterned(16 * MB, 2);
+    await setCached('big', buffer, 'big.ifc', source.byteLength, source);
+
+    const got = await getCached('big');
+    assert.ok(got, 'large record must be retrievable');
+    assert.ok(bytesEqual(got!.buffer, buffer), 'cache buffer round-trips byte-identical');
+    assert.ok(got!.sourceBuffer && bytesEqual(got!.sourceBuffer, source), 'source round-trips byte-identical');
+  });
+
+  it('estimate-unavailable → falls back to the per-entry ceiling and still writes', async () => {
+    // availableQuotaBytes returns Infinity when the Storage API is absent, so
+    // ensureRoomForEntry relies on the ceiling alone rather than refusing writes.
+    assert.equal(await availableQuotaBytes(), Infinity);
+    await setCached('u', patterned(64 * KB, 3), 'u.ifc', 64 * KB);
+    const got = await getCached('u');
+    assert.ok(got, 'write proceeds when the estimate API is unavailable');
+  });
+
+  it('estimate available → availableQuotaBytes reports quota minus usage', async () => {
+    stubEstimate(500 * MB, 200 * MB);
+    assert.equal(await availableQuotaBytes(), 300 * MB);
+    stubEstimate(undefined, undefined); // malformed estimate → treat as unavailable
+    assert.equal(await availableQuotaBytes(), Infinity);
+  });
+
+  it('refuses an oversized record (per-entry ceiling) without allocating it', async () => {
+    const db = await openDatabase();
+    // Pass a byte COUNT above the ceiling — no giant allocation needed.
+    assert.equal(await ensureRoomForEntry(db, PER_ENTRY_MAX_BYTES + 1, 'x'), false);
+    assert.equal(await ensureRoomForEntry(db, 10 * MB, 'x'), true);
+  });
+
+  it('quota exhausted (cannot free enough) → graceful skip; existing entries survive; no throw', async () => {
+    // Seed a keeper while quota looks fine.
+    await setCached('keep', patterned(32 * KB, 4), 'keep.ifc', 32 * KB);
+
+    // Now the origin quota is nearly full and eviction cannot free the 128MB
+    // headroom (there is nothing large to evict), so the write must be skipped.
+    stubEstimate(1 * MB, 1 * MB - 4 * KB); // ~4KB free
+    await assert.doesNotReject(
+      setCached('new', patterned(2 * MB, 5), 'new.ifc', 2 * MB),
+      'a quota failure must never throw (a cache write can never break the load)',
+    );
+
+    assert.equal(await getCached('new'), null, 'the over-quota entry was not written');
+    const keep = await getCached('keep');
+    assert.ok(keep && bytesEqual(keep.buffer, patterned(32 * KB, 4)), 'the surviving entry is intact');
+  });
+
+  it('non-fatal when the put itself fails (transaction error/abort)', async () => {
+    // Simulate a Safari "blob too large" rejection at put time (the estimate said
+    // there was room). setCached must resolve, not reject or hang.
+    const proto = (globalThis as unknown as { IDBObjectStore: { prototype: { put: unknown } } }).IDBObjectStore.prototype;
+    const originalPut = proto.put;
+    proto.put = function put(): never {
+      throw new DOMException('simulated quota', 'QuotaExceededError');
+    };
+    try {
+      await assert.doesNotReject(
+        setCached('boom', patterned(16 * KB, 6), 'boom.ifc', 16 * KB),
+        'a put failure must be caught and non-fatal',
+      );
+      assert.equal(await getCached('boom'), null);
+    } finally {
+      proto.put = originalPut;
+    }
+    // The cache is still usable after the failure.
+    await setCached('after', patterned(16 * KB, 7), 'after.ifc', 16 * KB);
+    assert.ok(await getCached('after'), 'cache still works after a transient put failure');
+  });
+});
+
+describe('ifc-cache LRU eviction correctness (blocker #2)', () => {
+  // Seed three entries oldest→newest with distinct createdAt (real-time gaps),
+  // each 2KB, under an unlimited quota (no eviction during seeding).
+  async function seedThree(): Promise<void> {
+    await clearCache();
+    stubEstimateUnavailable();
+    await setCached('a', patterned(2 * KB, 10), 'a.ifc', 2 * KB);
+    await delay(4);
+    await setCached('b', patterned(2 * KB, 11), 'b.ifc', 2 * KB);
+    await delay(4);
+    await setCached('c', patterned(2 * KB, 12), 'c.ifc', 2 * KB);
+  }
+
+  beforeEach(seedThree);
+  afterEach(restoreNavigator);
+
+  it('evicts oldest-by-createdAt first (LRU), leaving the newest', async () => {
+    const db = await openDatabase();
+    // Free ~3KB: evict 'a' (2KB, still short), then 'b' (4KB total ≥ 3KB) → stop.
+    const enough = await evictToFree(db, 3 * KB, '__none__');
+    assert.equal(enough, true);
+    assert.equal(await getCached('a'), null, 'oldest evicted');
+    assert.equal(await getCached('b'), null, 'next-oldest evicted');
+    assert.ok(await getCached('c'), 'newest survives (LRU order honoured)');
+  });
+
+  it('never evicts the keepKey (the entry being written), even if it is the oldest', async () => {
+    const db = await openDatabase();
+    // Free ~3KB while keepKey 'a' (the OLDEST) is skipped → evicts 'b' then 'c'.
+    const enough = await evictToFree(db, 3 * KB, 'a');
+    assert.equal(enough, true);
+    assert.ok(await getCached('a'), 'keepKey preserved despite being the oldest');
+    assert.equal(await getCached('b'), null);
+    assert.equal(await getCached('c'), null);
+  });
+
+  it('is non-destructive when it cannot free enough (keeps every entry)', async () => {
+    const db = await openDatabase();
+    // Target exceeds the combined size of all eligible entries → delete NOTHING,
+    // so we never throw away caches for a write that would be skipped anyway.
+    const enough = await evictToFree(db, 1024 * MB, '__none__');
+    assert.equal(enough, false);
+    assert.ok(await getCached('a'), 'a survives a failed eviction');
+    assert.ok(await getCached('b'), 'b survives a failed eviction');
+    assert.ok(await getCached('c'), 'c survives a failed eviction');
+  });
+
+  it('leaves surviving entries byte-identical (no corruption of neighbours)', async () => {
+    const db = await openDatabase();
+    await evictToFree(db, 2 * KB, '__none__'); // evict just 'a'
+    assert.equal(await getCached('a'), null);
+    const c = await getCached('c');
+    assert.ok(c && bytesEqual(c.buffer, patterned(2 * KB, 12)), 'survivor is uncorrupted');
+  });
+});

--- a/apps/viewer/src/services/ifc-cache.ts
+++ b/apps/viewer/src/services/ifc-cache.ts
@@ -20,6 +20,20 @@ interface CacheEntry {
   fileName: string;
   fileSize: number;
   createdAt: number;
+  /**
+   * The source File's `lastModified` (ms epoch) at write. On a mesh-only hit,
+   * a differing fresh mtime means the on-disk file changed → treat as a miss.
+   * `0`/absent = unknown (fall back to the full-hash revalidation).
+   */
+  lastModified?: number;
+  /**
+   * TRUE full-file content hash of the source (SHA-256 hex) at write. Used to
+   * VALIDATE a mesh-only hit against the fresh buffer in the background — this is
+   * the source-of-truth guard the O(1) spread key can't provide. Stored here in
+   * the record, DISTINCT from the header's `sourceHash` and the key's spread
+   * fingerprint. Absent when Web Crypto was unavailable at write.
+   */
+  fullSourceHash?: string;
 }
 
 /**
@@ -195,6 +209,16 @@ export function openDatabase(): Promise<IDBDatabase> {
 export interface CacheResult {
   buffer: ArrayBuffer;
   sourceBuffer?: ArrayBuffer;
+  /** Source File `lastModified` (ms) stored at write; see {@link CacheEntry}. */
+  lastModified?: number;
+  /** True full-file content hash (SHA-256 hex) stored at write; see {@link CacheEntry}. */
+  fullSourceHash?: string;
+}
+
+/** Extra validation metadata persisted alongside a cache entry (mesh-only tier). */
+export interface CacheEntryMeta {
+  lastModified?: number;
+  fullSourceHash?: string;
 }
 
 /**
@@ -214,6 +238,8 @@ export async function getCached(key: string): Promise<CacheResult | null> {
           resolve({
             buffer: entry.buffer,
             sourceBuffer: entry.sourceBuffer,
+            lastModified: entry.lastModified,
+            fullSourceHash: entry.fullSourceHash,
           });
         } else {
           resolve(null);
@@ -239,7 +265,8 @@ export async function setCached(
   buffer: ArrayBuffer,
   fileName: string,
   fileSize: number,
-  sourceBuffer?: ArrayBuffer
+  sourceBuffer?: ArrayBuffer,
+  meta?: CacheEntryMeta,
 ): Promise<void> {
   try {
     const db = await openDatabase();
@@ -281,6 +308,8 @@ export async function setCached(
         fileName,
         fileSize,
         createdAt: Date.now(),
+        lastModified: meta?.lastModified,
+        fullSourceHash: meta?.fullSourceHash,
       };
 
       tx.oncomplete = () => done();

--- a/apps/viewer/src/services/ifc-cache.ts
+++ b/apps/viewer/src/services/ifc-cache.ts
@@ -28,7 +28,7 @@ interface CacheEntry {
  * caps source at 400MB but its decoded geometry can be larger, so the ceiling is
  * comfortably above that while still catching a runaway blob.
  */
-const PER_ENTRY_MAX_BYTES = 1.5 * 1024 * 1024 * 1024;
+export const PER_ENTRY_MAX_BYTES = 1.5 * 1024 * 1024 * 1024;
 
 /**
  * Free-space headroom to keep below the origin quota after a write, so we never
@@ -36,7 +36,7 @@ const PER_ENTRY_MAX_BYTES = 1.5 * 1024 * 1024 * 1024;
  * trip browser eviction of the whole origin). A fixed 128MB is enough to clear
  * the edge without over-reserving on large quotas.
  */
-const QUOTA_HEADROOM_BYTES = 128 * 1024 * 1024;
+export const QUOTA_HEADROOM_BYTES = 128 * 1024 * 1024;
 
 let dbPromise: Promise<IDBDatabase> | null = null;
 
@@ -50,7 +50,7 @@ function entryBytes(buffer: ArrayBuffer, sourceBuffer?: ArrayBuffer): number {
  * `Infinity` when the Storage API is unavailable (older Safari / blocked) so the
  * caller falls back to the per-entry ceiling alone rather than refusing writes.
  */
-async function availableQuotaBytes(): Promise<number> {
+export async function availableQuotaBytes(): Promise<number> {
   try {
     if (typeof navigator !== 'undefined' && navigator.storage?.estimate) {
       const { quota, usage } = await navigator.storage.estimate();
@@ -65,29 +65,45 @@ async function availableQuotaBytes(): Promise<number> {
 }
 
 /**
- * Evict least-recently-created entries (oldest `createdAt` first) until at least
- * `targetBytes` have been freed or the store is exhausted, skipping `keepKey`
- * (the entry we're about to (over)write). Returns the bytes actually freed.
+ * Free at least `targetBytes` by evicting least-recently-created entries (oldest
+ * `createdAt` first), skipping `keepKey` (the entry we're about to (over)write).
+ *
+ * NON-DESTRUCTIVE ON FAILURE: it first walks the eligible entries oldest-first
+ * and only deletes them if their combined size actually reaches `targetBytes`.
+ * If even evicting every eligible entry would fall short, it deletes NOTHING and
+ * returns `false`. This matters for a large model on a tight-quota device (e.g.
+ * mobile Safari): without it, we would throw away the user's other cached models
+ * to make room for a write that can't fit anyway — a pure loss. Returns whether
+ * enough room was freed (all deletions commit in one transaction).
  */
-function evictOldestUntilFreed(db: IDBDatabase, targetBytes: number, keepKey: string): Promise<number> {
+export function evictToFree(db: IDBDatabase, targetBytes: number, keepKey: string): Promise<boolean> {
   return new Promise((resolve, reject) => {
     const tx = db.transaction(STORE_NAME, 'readwrite');
     const store = tx.objectStore(STORE_NAME);
     const cursorReq = store.index('createdAt').openCursor(); // ascending = oldest first
-    let freed = 0;
+    const victims: IDBValidKey[] = [];
+    let cumulative = 0;
+    let enough = false;
 
     cursorReq.onsuccess = () => {
       const cursor = cursorReq.result;
-      if (!cursor || freed >= targetBytes) return; // done; tx will complete
-      const entry = cursor.value as CacheEntry;
-      if (entry.key !== keepKey) {
-        freed += entryBytes(entry.buffer, entry.sourceBuffer);
-        cursor.delete();
+      if (cursor && cumulative < targetBytes) {
+        const entry = cursor.value as CacheEntry;
+        if (entry.key !== keepKey) {
+          cumulative += entryBytes(entry.buffer, entry.sourceBuffer);
+          victims.push(cursor.primaryKey);
+        }
+        cursor.continue();
+        return;
       }
-      cursor.continue();
+      // Cursor exhausted or target reached: commit deletions only if they help.
+      enough = cumulative >= targetBytes;
+      if (enough) {
+        for (const key of victims) store.delete(key);
+      }
     };
     cursorReq.onerror = () => reject(cursorReq.error);
-    tx.oncomplete = () => resolve(freed);
+    tx.oncomplete = () => resolve(enough);
     tx.onerror = () => reject(tx.error);
     tx.onabort = () => reject(tx.error);
   });
@@ -98,7 +114,7 @@ function evictOldestUntilFreed(db: IDBDatabase, targetBytes: number, keepKey: st
  * Storage API reports a tight quota) LRU-evict older entries until it fits.
  * Returns `true` when the write should proceed, `false` when it must be skipped.
  */
-async function ensureRoomForEntry(db: IDBDatabase, bytes: number, keepKey: string): Promise<boolean> {
+export async function ensureRoomForEntry(db: IDBDatabase, bytes: number, keepKey: string): Promise<boolean> {
   if (bytes > PER_ENTRY_MAX_BYTES) {
     console.warn(`[IFC Cache] Entry ${(bytes / 1024 / 1024).toFixed(0)}MB exceeds per-entry ceiling; skipping cache write`);
     return false;
@@ -110,23 +126,22 @@ async function ensureRoomForEntry(db: IDBDatabase, bytes: number, keepKey: strin
   if (available >= required) return true;
 
   const need = required - available;
-  let freed = 0;
   try {
-    freed = await evictOldestUntilFreed(db, need, keepKey);
+    const freedEnough = await evictToFree(db, need, keepKey);
+    if (freedEnough) return true;
   } catch (err) {
     console.warn('[IFC Cache] LRU eviction failed; skipping cache write', err);
     return false;
   }
-  if (available + freed >= required) return true;
 
-  console.warn(`[IFC Cache] Insufficient quota headroom (need ${(need / 1024 / 1024).toFixed(0)}MB, freed ${(freed / 1024 / 1024).toFixed(0)}MB); skipping cache write`);
+  console.warn(`[IFC Cache] Insufficient quota headroom (need ${(need / 1024 / 1024).toFixed(0)}MB after eviction); skipping cache write`);
   return false;
 }
 
 /**
  * Open the IndexedDB database
  */
-function openDatabase(): Promise<IDBDatabase> {
+export function openDatabase(): Promise<IDBDatabase> {
   if (dbPromise) return dbPromise;
 
   dbPromise = new Promise((resolve, reject) => {
@@ -235,8 +250,28 @@ export async function setCached(
     const roomOk = await ensureRoomForEntry(db, entryBytes(buffer, sourceBuffer), key);
     if (!roomOk) return; // non-fatal: a cache miss next open is a slow load, not a crash
 
-    return new Promise((resolve, reject) => {
-      const tx = db.transaction(STORE_NAME, 'readwrite');
+    // A cache write must NEVER break the load (AGENTS.md; task blocker #2): every
+    // failure mode here is caught and turned into a non-fatal skip. We resolve
+    // (not reject) on failure so callers can `await` without a try/catch, and we
+    // wire the transaction's abort/error too — a QuotaExceededError or a
+    // blob-too-large record on Safari often surfaces as a tx abort rather than a
+    // request error, and without this the promise would hang forever.
+    await new Promise<void>((resolve) => {
+      let settled = false;
+      const done = () => {
+        if (settled) return;
+        settled = true;
+        resolve();
+      };
+      let tx: IDBTransaction;
+      try {
+        tx = db.transaction(STORE_NAME, 'readwrite');
+      } catch (err) {
+        // e.g. InvalidStateError if the connection is closing.
+        console.warn('[IFC Cache] Could not open write transaction; skipping cache write', err);
+        done();
+        return;
+      }
       const store = tx.objectStore(STORE_NAME);
 
       const entry: CacheEntry = {
@@ -248,16 +283,29 @@ export async function setCached(
         createdAt: Date.now(),
       };
 
-      const request = store.put(entry);
-
-      request.onsuccess = () => {
-        resolve();
+      tx.oncomplete = () => done();
+      tx.onabort = () => {
+        console.warn('[IFC Cache] Cache write transaction aborted (quota / blob too large); skipping', tx.error);
+        done();
+      };
+      tx.onerror = () => {
+        console.warn('[IFC Cache] Cache write transaction error; skipping', tx.error);
+        done();
       };
 
-      request.onerror = () => {
-        console.error('[IFC Cache] Failed to cache entry:', request.error);
-        reject(request.error);
-      };
+      try {
+        const request = store.put(entry);
+        request.onerror = () => {
+          // Prevent the error from also aborting the tx as an unhandled error;
+          // the tx.onabort above still resolves us non-fatally.
+          console.warn('[IFC Cache] Failed to cache entry (quota / blob too large); skipping', request.error);
+        };
+      } catch (err) {
+        // Synchronous throw from put() (e.g. DataCloneError on an unclonable value).
+        console.warn('[IFC Cache] Cache put threw; skipping cache write', err);
+        try { tx.abort(); } catch { /* already inactive */ }
+        done();
+      }
     });
   } catch (err) {
     console.warn('[IFC Cache] Cache write failed:', err);

--- a/apps/viewer/src/services/ifc-cache.ts
+++ b/apps/viewer/src/services/ifc-cache.ts
@@ -22,7 +22,106 @@ interface CacheEntry {
   createdAt: number;
 }
 
+/**
+ * Per-entry hard ceiling (1.5GB). A single cache record above this is refused so
+ * one pathological model can't blow the whole origin quota. The mesh-only tier
+ * caps source at 400MB but its decoded geometry can be larger, so the ceiling is
+ * comfortably above that while still catching a runaway blob.
+ */
+const PER_ENTRY_MAX_BYTES = 1.5 * 1024 * 1024 * 1024;
+
+/**
+ * Free-space headroom to keep below the origin quota after a write, so we never
+ * write right up to the limit (a full quota fails future writes app-wide and can
+ * trip browser eviction of the whole origin). A fixed 128MB is enough to clear
+ * the edge without over-reserving on large quotas.
+ */
+const QUOTA_HEADROOM_BYTES = 128 * 1024 * 1024;
+
 let dbPromise: Promise<IDBDatabase> | null = null;
+
+/** Bytes a cache record occupies on disk (cache buffer + optional source). */
+function entryBytes(buffer: ArrayBuffer, sourceBuffer?: ArrayBuffer): number {
+  return buffer.byteLength + (sourceBuffer?.byteLength ?? 0);
+}
+
+/**
+ * Best-effort free bytes remaining in the origin's storage quota. Returns
+ * `Infinity` when the Storage API is unavailable (older Safari / blocked) so the
+ * caller falls back to the per-entry ceiling alone rather than refusing writes.
+ */
+async function availableQuotaBytes(): Promise<number> {
+  try {
+    if (typeof navigator !== 'undefined' && navigator.storage?.estimate) {
+      const { quota, usage } = await navigator.storage.estimate();
+      if (typeof quota === 'number' && typeof usage === 'number') {
+        return Math.max(0, quota - usage);
+      }
+    }
+  } catch (err) {
+    console.warn('[IFC Cache] storage.estimate() failed; skipping quota guard', err);
+  }
+  return Infinity;
+}
+
+/**
+ * Evict least-recently-created entries (oldest `createdAt` first) until at least
+ * `targetBytes` have been freed or the store is exhausted, skipping `keepKey`
+ * (the entry we're about to (over)write). Returns the bytes actually freed.
+ */
+function evictOldestUntilFreed(db: IDBDatabase, targetBytes: number, keepKey: string): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readwrite');
+    const store = tx.objectStore(STORE_NAME);
+    const cursorReq = store.index('createdAt').openCursor(); // ascending = oldest first
+    let freed = 0;
+
+    cursorReq.onsuccess = () => {
+      const cursor = cursorReq.result;
+      if (!cursor || freed >= targetBytes) return; // done; tx will complete
+      const entry = cursor.value as CacheEntry;
+      if (entry.key !== keepKey) {
+        freed += entryBytes(entry.buffer, entry.sourceBuffer);
+        cursor.delete();
+      }
+      cursor.continue();
+    };
+    cursorReq.onerror = () => reject(cursorReq.error);
+    tx.oncomplete = () => resolve(freed);
+    tx.onerror = () => reject(tx.error);
+    tx.onabort = () => reject(tx.error);
+  });
+}
+
+/**
+ * Make room for a `bytes`-sized entry: refuse oversized records, then (if the
+ * Storage API reports a tight quota) LRU-evict older entries until it fits.
+ * Returns `true` when the write should proceed, `false` when it must be skipped.
+ */
+async function ensureRoomForEntry(db: IDBDatabase, bytes: number, keepKey: string): Promise<boolean> {
+  if (bytes > PER_ENTRY_MAX_BYTES) {
+    console.warn(`[IFC Cache] Entry ${(bytes / 1024 / 1024).toFixed(0)}MB exceeds per-entry ceiling; skipping cache write`);
+    return false;
+  }
+
+  const available = await availableQuotaBytes();
+  if (available === Infinity) return true; // no quota signal — rely on the ceiling
+  const required = bytes + QUOTA_HEADROOM_BYTES;
+  if (available >= required) return true;
+
+  const need = required - available;
+  let freed = 0;
+  try {
+    freed = await evictOldestUntilFreed(db, need, keepKey);
+  } catch (err) {
+    console.warn('[IFC Cache] LRU eviction failed; skipping cache write', err);
+    return false;
+  }
+  if (available + freed >= required) return true;
+
+  console.warn(`[IFC Cache] Insufficient quota headroom (need ${(need / 1024 / 1024).toFixed(0)}MB, freed ${(freed / 1024 / 1024).toFixed(0)}MB); skipping cache write`);
+  return false;
+}
 
 /**
  * Open the IndexedDB database
@@ -129,6 +228,13 @@ export async function setCached(
 ): Promise<void> {
   try {
     const db = await openDatabase();
+
+    // Quota/eviction guard (prerequisite for the mesh-only tier — entries can be
+    // 100s of MB): refuse oversized records and LRU-evict older entries when the
+    // origin quota is tight, so a large write can't blow the quota app-wide.
+    const roomOk = await ensureRoomForEntry(db, entryBytes(buffer, sourceBuffer), key);
+    if (!roomOk) return; // non-fatal: a cache miss next open is a slow load, not a crash
+
     return new Promise((resolve, reject) => {
       const tx = db.transaction(STORE_NAME, 'readwrite');
       const store = tx.objectStore(STORE_NAME);

--- a/apps/viewer/src/store/constants.ts
+++ b/apps/viewer/src/store/constants.ts
@@ -116,7 +116,11 @@ function getInitialMergeLayers(): boolean {
 export const GEOM_WORKERS_STORAGE_KEY = 'ifc-lite-geom-workers';
 export const GEOM_TIER_STORAGE_KEY = 'ifc-lite-geom-tier';
 
-/** localStorage key for the source-decoupled mesh-only cache prototype flag. */
+/**
+ * localStorage key for the source-decoupled mesh-only cache KILL SWITCH. The
+ * tier is on by default; this key holds `'0'` only when the user disabled it via
+ * `?meshCache=0` (absent = default on). See `isMeshOnlyCacheEnabled`.
+ */
 export const MESH_ONLY_CACHE_STORAGE_KEY = 'ifc-lite-mesh-cache';
 
 // Auto-low tessellation density for heavy models. The on-screen load already
@@ -242,34 +246,56 @@ export function getGeomTierOverride(): TessellationQuality | undefined {
 }
 
 /**
- * Is the source-decoupled mesh-only cache tier enabled? Prototype flag (bet B):
- * caches tables + geometry + instanced shards WITHOUT the source buffer for
- * large (150-400MB) files so REPEAT opens skip the 10-90s parse+mesh. Mirrors
- * `getGeomWorkerOverride`: `?meshCache=1` enables AND persists to localStorage
- * (survives the reload that a re-measure needs, and a shared link carries it);
- * `?meshCache=0` clears it. Default OFF — the <=150MB source-persisting tier is
+ * Pure decision for the source-decoupled mesh-only cache tier, split out for
+ * node:test (the outer {@link isMeshOnlyCacheEnabled} reads `window`/
+ * `localStorage`). Default ON — the tier is unflagged for 150-400MB files. The
+ * kill switch is `?meshCache=0` (persisted so it sticks across reloads and rides
+ * a shared link); `?meshCache=1` clears the kill switch back to the default.
+ *
+ * @param param  the `meshCache` URL query value, or `null` if absent
+ * @param stored the persisted `MESH_ONLY_CACHE_STORAGE_KEY` value, or `null`
+ * @returns `enabled` plus the persistence side-effect the caller should apply
+ *   (`persist: '0'` writes the kill switch; `clear: true` removes it).
+ */
+export function resolveMeshCacheDecision(
+  param: string | null,
+  stored: string | null,
+): { enabled: boolean; persist?: '0'; clear?: boolean } {
+  if (param === '0' || param === 'false' || param === 'off') {
+    return { enabled: false, persist: '0' };
+  }
+  if (param === '1' || param === 'true' || param === 'on') {
+    return { enabled: true, clear: true };
+  }
+  // Default ON unless the kill switch was persisted.
+  return { enabled: stored !== '0' };
+}
+
+/**
+ * Is the source-decoupled mesh-only cache tier enabled? It caches tables +
+ * geometry + instanced shards WITHOUT the source buffer for large (150-400MB)
+ * files so REPEAT opens skip the 10-90s parse+mesh. ON BY DEFAULT — the kill
+ * switch `?meshCache=0` disables it (persisted to localStorage so it sticks
+ * across the reload a re-measure needs, and a shared link carries it);
+ * `?meshCache=1` clears the kill switch. The <=150MB source-persisting tier is
  * unaffected either way (it never consults this flag).
  */
 export function isMeshOnlyCacheEnabled(): boolean {
-  if (typeof window === 'undefined') return false;
+  if (typeof window === 'undefined') return false; // SSR never runs the cache path
+  const param = new URLSearchParams(window.location.search).get('meshCache');
   try {
-    const param = new URLSearchParams(window.location.search).get('meshCache');
-    if (param != null) {
-      if (param === '1' || param === 'true' || param === 'on') {
-        localStorage.setItem(MESH_ONLY_CACHE_STORAGE_KEY, '1');
-        return true;
-      }
-      if (param === '0' || param === 'false' || param === 'off') {
-        localStorage.removeItem(MESH_ONLY_CACHE_STORAGE_KEY);
-        return false;
-      }
-    }
-    return localStorage.getItem(MESH_ONLY_CACHE_STORAGE_KEY) === '1';
+    const stored = localStorage.getItem(MESH_ONLY_CACHE_STORAGE_KEY);
+    const decision = resolveMeshCacheDecision(param, stored);
+    if (decision.persist) localStorage.setItem(MESH_ONLY_CACHE_STORAGE_KEY, decision.persist);
+    else if (decision.clear) localStorage.removeItem(MESH_ONLY_CACHE_STORAGE_KEY);
+    return decision.enabled;
   } catch (err) {
-    // Blocked/unavailable storage (Safari private mode) — treat as disabled,
-    // but don't swallow silently (AGENTS.md: no silent catch).
-    console.warn('[mesh-cache] flag read failed; treating as disabled', err);
-    return false;
+    // Blocked/unavailable storage (Safari private mode): can't read or persist
+    // the kill switch, but an explicit `?meshCache=0` in the URL must STILL
+    // disable the tier for this load; otherwise fall back to default-on. Don't
+    // swallow silently (AGENTS.md: no silent catch).
+    console.warn('[mesh-cache] storage unavailable; honouring URL param, else default-on', err);
+    return resolveMeshCacheDecision(param, null).enabled;
   }
 }
 

--- a/apps/viewer/src/store/constants.ts
+++ b/apps/viewer/src/store/constants.ts
@@ -116,6 +116,9 @@ function getInitialMergeLayers(): boolean {
 export const GEOM_WORKERS_STORAGE_KEY = 'ifc-lite-geom-workers';
 export const GEOM_TIER_STORAGE_KEY = 'ifc-lite-geom-tier';
 
+/** localStorage key for the source-decoupled mesh-only cache prototype flag. */
+export const MESH_ONLY_CACHE_STORAGE_KEY = 'ifc-lite-mesh-cache';
+
 // Auto-low tessellation density for heavy models. The on-screen load already
 // skips tiny detail boolean cuts on every load (#1286), which removes the
 // exact-tier escalations that dominate boolean-heavy steel; this is the
@@ -236,6 +239,38 @@ export function getGeomTierOverride(): TessellationQuality | undefined {
     console.warn('[geom-tier] override read failed; using heuristic', err);
   }
   return undefined;
+}
+
+/**
+ * Is the source-decoupled mesh-only cache tier enabled? Prototype flag (bet B):
+ * caches tables + geometry + instanced shards WITHOUT the source buffer for
+ * large (150-400MB) files so REPEAT opens skip the 10-90s parse+mesh. Mirrors
+ * `getGeomWorkerOverride`: `?meshCache=1` enables AND persists to localStorage
+ * (survives the reload that a re-measure needs, and a shared link carries it);
+ * `?meshCache=0` clears it. Default OFF — the <=150MB source-persisting tier is
+ * unaffected either way (it never consults this flag).
+ */
+export function isMeshOnlyCacheEnabled(): boolean {
+  if (typeof window === 'undefined') return false;
+  try {
+    const param = new URLSearchParams(window.location.search).get('meshCache');
+    if (param != null) {
+      if (param === '1' || param === 'true' || param === 'on') {
+        localStorage.setItem(MESH_ONLY_CACHE_STORAGE_KEY, '1');
+        return true;
+      }
+      if (param === '0' || param === 'false' || param === 'off') {
+        localStorage.removeItem(MESH_ONLY_CACHE_STORAGE_KEY);
+        return false;
+      }
+    }
+    return localStorage.getItem(MESH_ONLY_CACHE_STORAGE_KEY) === '1';
+  } catch (err) {
+    // Blocked/unavailable storage (Safari private mode) — treat as disabled,
+    // but don't swallow silently (AGENTS.md: no silent catch).
+    console.warn('[mesh-cache] flag read failed; treating as disabled', err);
+    return false;
+  }
 }
 
 /**

--- a/apps/viewer/src/store/meshCacheFlag.test.ts
+++ b/apps/viewer/src/store/meshCacheFlag.test.ts
@@ -1,0 +1,112 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  resolveMeshCacheDecision,
+  isMeshOnlyCacheEnabled,
+  MESH_ONLY_CACHE_STORAGE_KEY,
+} from './constants.js';
+
+describe('resolveMeshCacheDecision (pure kill-switch logic)', () => {
+  it('defaults ON when no URL param and no persisted kill switch (un-flagged default)', () => {
+    assert.deepEqual(resolveMeshCacheDecision(null, null), { enabled: true });
+  });
+
+  it('stays ON when a legacy opt-in value ("1") is persisted', () => {
+    assert.deepEqual(resolveMeshCacheDecision(null, '1'), { enabled: true });
+  });
+
+  it('is OFF only when the kill switch "0" is persisted', () => {
+    assert.deepEqual(resolveMeshCacheDecision(null, '0'), { enabled: false });
+  });
+
+  it('?meshCache=0 disables AND persists the kill switch', () => {
+    for (const v of ['0', 'false', 'off']) {
+      assert.deepEqual(resolveMeshCacheDecision(v, null), { enabled: false, persist: '0' });
+    }
+  });
+
+  it('?meshCache=1 re-enables AND clears the persisted kill switch', () => {
+    for (const v of ['1', 'true', 'on']) {
+      assert.deepEqual(resolveMeshCacheDecision(v, '0'), { enabled: true, clear: true });
+    }
+  });
+});
+
+// End-to-end through the window/localStorage-reading wrapper. Stubs the two
+// globals it reads and restores them so no other test file is affected.
+describe('isMeshOnlyCacheEnabled (window + localStorage)', () => {
+  const savedWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
+  const savedLocalStorage = Object.getOwnPropertyDescriptor(globalThis, 'localStorage');
+
+  function stub(search: string, initial: Record<string, string> = {}): Map<string, string> {
+    const store = new Map<string, string>(Object.entries(initial));
+    const localStorage = {
+      getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+      setItem: (k: string, v: string) => { store.set(k, v); },
+      removeItem: (k: string) => { store.delete(k); },
+    };
+    Object.defineProperty(globalThis, 'window', {
+      value: { location: { search }, localStorage },
+      configurable: true,
+      writable: true,
+    });
+    Object.defineProperty(globalThis, 'localStorage', {
+      value: localStorage,
+      configurable: true,
+      writable: true,
+    });
+    return store;
+  }
+
+  afterEach(() => {
+    if (savedWindow) Object.defineProperty(globalThis, 'window', savedWindow);
+    else delete (globalThis as Record<string, unknown>).window;
+    if (savedLocalStorage) Object.defineProperty(globalThis, 'localStorage', savedLocalStorage);
+    else delete (globalThis as Record<string, unknown>).localStorage;
+  });
+
+  it('is ON by default (no param, nothing persisted)', () => {
+    stub('');
+    assert.equal(isMeshOnlyCacheEnabled(), true);
+  });
+
+  it('stays OFF after ?meshCache=0 persisted the kill switch', () => {
+    const store = stub('?meshCache=0');
+    assert.equal(isMeshOnlyCacheEnabled(), false);
+    assert.equal(store.get(MESH_ONLY_CACHE_STORAGE_KEY), '0');
+    // A later plain load (no param) keeps the persisted kill switch → still OFF.
+    stub('', { [MESH_ONLY_CACHE_STORAGE_KEY]: '0' });
+    assert.equal(isMeshOnlyCacheEnabled(), false);
+  });
+
+  it('?meshCache=1 clears a persisted kill switch and re-enables', () => {
+    const store = stub('?meshCache=1', { [MESH_ONLY_CACHE_STORAGE_KEY]: '0' });
+    assert.equal(isMeshOnlyCacheEnabled(), true);
+    assert.equal(store.has(MESH_ONLY_CACHE_STORAGE_KEY), false);
+  });
+
+  it('honours ?meshCache=0 even when storage is blocked (Safari private mode)', () => {
+    // localStorage throws on access → the URL kill switch must still win, and a
+    // plain load (no param) falls back to default-on.
+    const throwing = {
+      getItem: () => { throw new DOMException('blocked', 'SecurityError'); },
+      setItem: () => { throw new DOMException('blocked', 'SecurityError'); },
+      removeItem: () => { throw new DOMException('blocked', 'SecurityError'); },
+    };
+    const install = (search: string) => {
+      Object.defineProperty(globalThis, 'window', {
+        value: { location: { search }, localStorage: throwing }, configurable: true, writable: true,
+      });
+      Object.defineProperty(globalThis, 'localStorage', { value: throwing, configurable: true, writable: true });
+    };
+    install('?meshCache=0');
+    assert.equal(isMeshOnlyCacheEnabled(), false, 'kill switch works without storage');
+    install('');
+    assert.equal(isMeshOnlyCacheEnabled(), true, 'defaults on without storage');
+  });
+});

--- a/apps/viewer/src/utils/ifcConfig.ts
+++ b/apps/viewer/src/utils/ifcConfig.ts
@@ -56,10 +56,13 @@ export const CACHE_MAX_SOURCE_SIZE = 150 * 1024 * 1024;
  *  the `fallbackSourceBuffer` path `loadFromCache` already supports), so repeat
  *  opens skip the 10-90s parse+mesh while keeping full feature fidelity.
  *
- *  The hit is validated by the strengthened, spread-sampled cache key
- *  (`sourceFingerprint.ts`) — a key match means the exact byte length AND a
- *  64-bit hash of a ~160KB spread match — so repeat opens do no full-file hash
- *  and have no main-thread stall. */
+ *  The spread-sampled cache key (`sourceFingerprint.ts`) only keys the lookup;
+ *  because it hydrates cached geometry against the FRESH buffer, a hit is
+ *  VALIDATED by the source File's `lastModified` (mtime guard) plus a TRUE
+ *  full-file hash re-checked off the main thread (see
+ *  `cacheTier.decideMeshOnlyCacheHit` + `utils/sourceContentHash.ts`), so a
+ *  changed source is a safe miss/reload rather than a silent chimera — with no
+ *  main-thread stall on the repeat open. */
 export const CACHE_MESH_ONLY_MAX_SIZE = 400 * 1024 * 1024;
 
 /**

--- a/apps/viewer/src/utils/ifcConfig.ts
+++ b/apps/viewer/src/utils/ifcConfig.ts
@@ -46,6 +46,21 @@ export const CACHE_SIZE_THRESHOLD = 10 * 1024 * 1024;
  *  and including it would make the IndexedDB write prohibitively large. */
 export const CACHE_MAX_SOURCE_SIZE = 150 * 1024 * 1024;
 
+/** Maximum file size eligible for the SOURCE-DECOUPLED "mesh-only" cache tier
+ *  (400MB, prototype behind the `?meshCache=1` flag — see `isMeshOnlyCacheEnabled`).
+ *
+ *  Files in (CACHE_MAX_SOURCE_SIZE, CACHE_MESH_ONLY_MAX_SIZE] are too big to
+ *  persist their source buffer in IndexedDB, but their tables + entityIndex +
+ *  geometry + instanced shards CAN be cached without it. On re-open the freshly
+ *  read file buffer hydrates the lazy property/quantity/export accessors (exactly
+ *  the `fallbackSourceBuffer` path `loadFromCache` already supports), so repeat
+ *  opens skip the 10-90s parse+mesh while keeping full feature fidelity.
+ *
+ *  The cache buffer still embeds `xxhash64(fullSource)` in its header, so the
+ *  hit is validated against the fresh buffer on load (see `loadFromCache`),
+ *  upgrading the weak 4KB fingerprint key to full-content validation. */
+export const CACHE_MESH_ONLY_MAX_SIZE = 400 * 1024 * 1024;
+
 /**
  * File size at which the browser-File-API entry path streams directly into a
  * `SharedArrayBuffer` instead of going through `await file.arrayBuffer()`.

--- a/apps/viewer/src/utils/ifcConfig.ts
+++ b/apps/viewer/src/utils/ifcConfig.ts
@@ -47,7 +47,7 @@ export const CACHE_SIZE_THRESHOLD = 10 * 1024 * 1024;
 export const CACHE_MAX_SOURCE_SIZE = 150 * 1024 * 1024;
 
 /** Maximum file size eligible for the SOURCE-DECOUPLED "mesh-only" cache tier
- *  (400MB, prototype behind the `?meshCache=1` flag — see `isMeshOnlyCacheEnabled`).
+ *  (400MB, ON BY DEFAULT; kill switch `?meshCache=0` — see `isMeshOnlyCacheEnabled`).
  *
  *  Files in (CACHE_MAX_SOURCE_SIZE, CACHE_MESH_ONLY_MAX_SIZE] are too big to
  *  persist their source buffer in IndexedDB, but their tables + entityIndex +
@@ -56,9 +56,10 @@ export const CACHE_MAX_SOURCE_SIZE = 150 * 1024 * 1024;
  *  the `fallbackSourceBuffer` path `loadFromCache` already supports), so repeat
  *  opens skip the 10-90s parse+mesh while keeping full feature fidelity.
  *
- *  The cache buffer still embeds `xxhash64(fullSource)` in its header, so the
- *  hit is validated against the fresh buffer on load (see `loadFromCache`),
- *  upgrading the weak 4KB fingerprint key to full-content validation. */
+ *  The hit is validated by the strengthened, spread-sampled cache key
+ *  (`sourceFingerprint.ts`) — a key match means the exact byte length AND a
+ *  64-bit hash of a ~160KB spread match — so repeat opens do no full-file hash
+ *  and have no main-thread stall. */
 export const CACHE_MESH_ONLY_MAX_SIZE = 400 * 1024 * 1024;
 
 /**

--- a/apps/viewer/src/utils/sourceContentHash.test.ts
+++ b/apps/viewer/src/utils/sourceContentHash.test.ts
@@ -1,0 +1,91 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { computeFullSourceHash } from './sourceContentHash.js';
+import { computeSourceFingerprint } from '../hooks/sourceFingerprint.js';
+import { decideMeshOnlyCacheHit } from '../hooks/cacheTier.js';
+
+/** Deterministic pseudo-random fill (xorshift32) so both files vary "for real". */
+function fill(len: number, seed: number): ArrayBuffer {
+  const buf = new ArrayBuffer(len);
+  const view = new Uint8Array(buf);
+  let x = seed >>> 0;
+  for (let i = 0; i < len; i++) {
+    x ^= x << 13; x >>>= 0;
+    x ^= x >> 17;
+    x ^= x << 5; x >>>= 0;
+    view[i] = x & 0xff;
+  }
+  return buf;
+}
+
+describe('computeFullSourceHash (SHA-256, off-thread validation hash)', () => {
+  it('matches the known SHA-256 of the empty input', async () => {
+    const hash = await computeFullSourceHash(new Uint8Array(0));
+    assert.equal(hash, 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855');
+  });
+
+  it('is deterministic and lowercase hex', async () => {
+    const buf = fill(50_000, 9);
+    const a = await computeFullSourceHash(buf);
+    const b = await computeFullSourceHash(buf.slice(0));
+    assert.equal(a, b);
+    assert.match(a!, /^[0-9a-f]{64}$/);
+  });
+
+  it('accepts an ArrayBuffer and an equivalent Uint8Array view identically', async () => {
+    const buf = fill(20_000, 11);
+    assert.equal(
+      await computeFullSourceHash(buf),
+      await computeFullSourceHash(new Uint8Array(buf)),
+    );
+  });
+
+  it('changes for ANY single-byte edit, including one in a fingerprint GAP', async () => {
+    const a = fill(4_000_000, 202);
+    const b = a.slice(0);
+    new Uint8Array(b)[700_000] ^= 0xff; // a sampler-gap byte
+    assert.notEqual(await computeFullSourceHash(a), await computeFullSourceHash(b));
+  });
+});
+
+// The end-to-end safety proof the coordinator asked for: a byte-length-preserving
+// edit in a sampler GAP that the FINGERPRINT alone false-hits is nonetheless
+// caught — by the mtime guard, and (if mtime is preserved) by the full-file hash
+// background revalidation. Neither guard depends on the fingerprint.
+describe('source-decoupled gap-edit safety (fingerprint false-hit is still caught)', () => {
+  it('mtime guard catches a gap edit the fingerprint misses', () => {
+    const a = fill(4_000_000, 303);
+    const b = a.slice(0);
+    new Uint8Array(b)[700_000] ^= 0xff;
+
+    // The fingerprint false-hits (same key) …
+    assert.equal(computeSourceFingerprint(a).hex, computeSourceFingerprint(b).hex);
+    // … but any real on-disk edit bumps mtime → the hit is a safe MISS.
+    assert.equal(
+      decideMeshOnlyCacheHit({ storedMtime: 1000, freshMtime: 1001, hasFullHash: true }),
+      'miss',
+    );
+  });
+
+  it('full-file hash catches a gap edit even with mtime PRESERVED (deliberate attack)', async () => {
+    const a = fill(4_000_000, 404);
+    const b = a.slice(0);
+    new Uint8Array(b)[700_000] ^= 0xff;
+
+    // Fingerprint false-hits AND the attacker preserved the mtime → mtime says
+    // "serve". The background full-hash revalidation is the last line of defense:
+    assert.equal(computeSourceFingerprint(a).hex, computeSourceFingerprint(b).hex);
+    assert.equal(
+      decideMeshOnlyCacheHit({ storedMtime: 1000, freshMtime: 1000, hasFullHash: true }),
+      'serve',
+    );
+    const storedHash = await computeFullSourceHash(a); // written at cache time
+    const freshHash = await computeFullSourceHash(b);   // recomputed on the fresh buffer
+    assert.notEqual(freshHash, storedHash, 'full-hash mismatch → purge + reload');
+  });
+});

--- a/apps/viewer/src/utils/sourceContentHash.ts
+++ b/apps/viewer/src/utils/sourceContentHash.ts
@@ -1,0 +1,60 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * TRUE full-file content hash of an IFC source, used to VALIDATE a mesh-only
+ * cache hit (distinct from the O(1) spread fingerprint in `sourceFingerprint.ts`,
+ * which only keys the entry and cannot see bytes between its sample windows).
+ *
+ * Uses the Web Crypto `crypto.subtle.digest('SHA-256', …)`, which is:
+ *   - asynchronous and implemented natively OFF the JS main thread (no worker
+ *     file, no message-passing), so hashing a 300MB+ source never janks the UI;
+ *   - zero-copy for a normal `ArrayBuffer` (the digest reads the buffer in
+ *     place). A `SharedArrayBuffer`-backed view is rejected by SubtleCrypto for
+ *     data-race safety, so it is copied to a plain buffer first — that only
+ *     happens for the ≥256MB SAB-streaming band, and only on the backgrounded
+ *     write / background revalidation, never on the interactive path.
+ *
+ * Returns `null` when Web Crypto is unavailable (e.g. an insecure-context / very
+ * old browser). Callers treat `null` as "cannot revalidate": combined with the
+ * mtime guard, a hit is only served when mtime confirms it OR a full hash is
+ * available to revalidate — never served fully unvalidated.
+ */
+export async function computeFullSourceHash(
+  source: ArrayBufferLike | ArrayBufferView,
+): Promise<string | null> {
+  const subtle = globalThis.crypto?.subtle;
+  if (!subtle?.digest) return null; // insecure context / unavailable
+
+  try {
+    // Normalize to a Uint8Array view over the source bytes (zero copy).
+    const u8: Uint8Array = ArrayBuffer.isView(source)
+      ? new Uint8Array(source.buffer, source.byteOffset, source.byteLength)
+      : new Uint8Array(source);
+    const raw = u8.buffer;
+
+    // SubtleCrypto only accepts ArrayBuffer-backed data (a SharedArrayBuffer view
+    // is rejected for data-race safety). A plain ArrayBuffer is hashed in place
+    // (zero copy); a SAB (only the ≥256MB SAB-streaming band) is copied first.
+    const bytes: Uint8Array<ArrayBuffer> = raw instanceof ArrayBuffer
+      ? new Uint8Array(raw, u8.byteOffset, u8.byteLength)
+      : Uint8Array.from(u8);
+
+    const digest = await subtle.digest('SHA-256', bytes);
+    return bytesToHex(new Uint8Array(digest));
+  } catch (err) {
+    // Never let a hashing failure break a load — treat as "cannot revalidate".
+    console.warn('[source-hash] full-file hash failed; skipping revalidation', err);
+    return null;
+  }
+}
+
+const HEX = '0123456789abcdef';
+function bytesToHex(bytes: Uint8Array): string {
+  let out = '';
+  for (let i = 0; i < bytes.length; i++) {
+    out += HEX[bytes[i] >> 4] + HEX[bytes[i] & 0x0f];
+  }
+  return out;
+}

--- a/packages/cache/README.md
+++ b/packages/cache/README.md
@@ -66,6 +66,25 @@ const rawKey = xxhash64(buffer);     // same hash as a bigint
 
 The cache keys models by the xxHash64 of the source IFC, and `reader.validate(cacheBuffer, sourceBuffer)` uses the same hash to detect when the source has changed.
 
+## Source-hash contract (and `omitSourceHash`)
+
+By default the header stores the full-file `xxhash64` of the source in `sourceHash`, and `reader.validate()` / `read({ sourceBuffer })` compare against it. Hashing a large source can be a multi-second main-thread cost, so a caller that validates the source **another way** (e.g. an application-layer content hash plus a file modified-time guard, as the viewer's source-decoupled cache tier does) can pass `omitSourceHash: true`:
+
+```typescript
+// Skip the full-file hash; validate the source at the application layer instead.
+const cacheBuffer = await writer.write(dataStore, geometry, ifcBuffer, {
+  includeGeometry: true,
+  omitSourceHash: true,
+});
+```
+
+Such an entry stores `sourceHash = 0n` and sets `HeaderFlags.SourceHashUnset`. Read it back via `CacheHeaderInfo.hasSourceHash`:
+
+- `hasSourceHash === true`  → `sourceHash` is a real full-file hash; `validate()` and `read({ sourceBuffer })` work as usual.
+- `hasSourceHash === false` → `sourceHash` is unset. `read({ sourceBuffer })` **skips** header validation (it does not fail-close on a valid cache), and `validate()` **throws** a clear error instead of returning a misleading `false`. Validate the source yourself (e.g. compare a stored content hash / mtime).
+
+This is backward compatible: entries written before the flag existed have it unset-as-in-absent, so their `sourceHash` remains a real hash and continues to validate normally.
+
 ## API
 
 See the [API Reference](https://ltplus-ag.github.io/ifc-lite/api/typescript/#ifc-litecache).

--- a/packages/cache/src/cache.test.ts
+++ b/packages/cache/src/cache.test.ts
@@ -313,6 +313,73 @@ describe('BinaryCacheWriter and BinaryCacheReader', () => {
     expect(header.sections.length).toBeGreaterThan(0);
   });
 
+  it('stores a precomputed sourceHash verbatim and skips the full-file hash', async () => {
+    // The mesh-only tier passes the cheap spread-sample hash so a 400MB source
+    // never pays a full-file main-thread hash on write. A value that is NOT the
+    // real xxhash64(sourceBuffer) proves the writer used ours, not the buffer.
+    const provided = 0x0123456789abcdefn;
+    expect(provided).not.toBe(xxhash64(sourceBuffer));
+
+    const writer = new BinaryCacheWriter();
+    const cacheBuffer = await writer.write(dataStore, undefined, sourceBuffer, {
+      includeGeometry: false,
+      sourceHash: provided,
+    });
+
+    const header = new BinaryCacheReader().readHeader(cacheBuffer);
+    expect(header.sourceHash).toBe(provided);
+  });
+
+  it('mesh-only write (provided hash, no persisted source) round-trips geometry byte-identical', async () => {
+    // Byte-identity of the restored geometry is what makes a mesh-only cache hit
+    // equal to a cold load. The write path is source-decoupled (the viewer does
+    // NOT persist the source for this tier), so exercise write→read with only a
+    // precomputed hash and assert the meshes come back bit-for-bit.
+    const positions = new Float32Array([0, 0, 0, 1, 0, 0, 1, 1, 0]);
+    const normals = new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]);
+    const indices = new Uint32Array([0, 1, 2]);
+    const geometry = {
+      meshes: [{ expressId: 4, positions, normals, indices, color: [0.2, 0.4, 0.6, 1] as [number, number, number, number] }],
+      totalVertices: 3,
+      totalTriangles: 1,
+      coordinateInfo: {
+        originShift: { x: 0, y: 0, z: 0 },
+        originalBounds: { min: { x: 0, y: 0, z: 0 }, max: { x: 1, y: 1, z: 0 } },
+        shiftedBounds: { min: { x: 0, y: 0, z: 0 }, max: { x: 1, y: 1, z: 0 } },
+        hasLargeCoordinates: false,
+      } as CoordinateInfo,
+    };
+
+    const writer = new BinaryCacheWriter();
+    const cacheBuffer = await writer.write(dataStore, geometry, sourceBuffer, { sourceHash: 42n });
+    const result = await new BinaryCacheReader().read(cacheBuffer);
+
+    const mesh = result.geometry!.meshes[0];
+    expect(mesh.expressId).toBe(4);
+    expect(Array.from(mesh.positions)).toEqual(Array.from(positions));
+    expect(Array.from(mesh.normals)).toEqual(Array.from(normals));
+    expect(Array.from(mesh.indices)).toEqual(Array.from(indices));
+    expect(result.geometry!.totalVertices).toBe(3);
+    expect(result.geometry!.totalTriangles).toBe(1);
+  });
+
+  it('rejects a truncated / corrupt cache buffer (graceful-miss path)', async () => {
+    // loadFromCache catches this, deletes the entry, and falls back to a normal
+    // parse — a validated miss, not a crash.
+    const writer = new BinaryCacheWriter();
+    const full = await writer.write(dataStore, undefined, sourceBuffer, { includeGeometry: false });
+    const reader = new BinaryCacheReader();
+
+    // Truncated mid-section: header parses but a section read runs off the end.
+    const truncated = full.slice(0, Math.floor(full.byteLength / 2));
+    await expect(reader.read(truncated)).rejects.toThrow();
+
+    // Garbage magic bytes: header validation fails immediately.
+    const garbage = new Uint8Array(full.byteLength);
+    garbage.fill(0xcd);
+    await expect(reader.read(garbage.buffer)).rejects.toThrow();
+  });
+
   it('should preserve entity data through round-trip', async () => {
     const writer = new BinaryCacheWriter();
     const cacheBuffer = await writer.write(dataStore, undefined, sourceBuffer, {

--- a/packages/cache/src/cache.test.ts
+++ b/packages/cache/src/cache.test.ts
@@ -313,28 +313,45 @@ describe('BinaryCacheWriter and BinaryCacheReader', () => {
     expect(header.sections.length).toBeGreaterThan(0);
   });
 
-  it('stores a precomputed sourceHash verbatim and skips the full-file hash', async () => {
-    // The mesh-only tier passes the cheap spread-sample hash so a 400MB source
-    // never pays a full-file main-thread hash on write. A value that is NOT the
-    // real xxhash64(sourceBuffer) proves the writer used ours, not the buffer.
-    const provided = 0x0123456789abcdefn;
-    expect(provided).not.toBe(xxhash64(sourceBuffer));
-
+  it('default write embeds a real full-file xxhash64 and validate() works', async () => {
     const writer = new BinaryCacheWriter();
     const cacheBuffer = await writer.write(dataStore, undefined, sourceBuffer, {
       includeGeometry: false,
-      sourceHash: provided,
     });
+    const reader = new BinaryCacheReader();
+    const header = reader.readHeader(cacheBuffer);
 
-    const header = new BinaryCacheReader().readHeader(cacheBuffer);
-    expect(header.sourceHash).toBe(provided);
+    expect(header.hasSourceHash).toBe(true);
+    expect(header.sourceHash).toBe(xxhash64(sourceBuffer));
+    expect(reader.validate(cacheBuffer, sourceBuffer)).toBe(true);
   });
 
-  it('mesh-only write (provided hash, no persisted source) round-trips geometry byte-identical', async () => {
+  it('omitSourceHash skips the full-file hash and flags the header (SourceHashUnset)', async () => {
+    // The mesh-only tier omits the header hash so a 400MB source pays no
+    // full-file main-thread hash on write; it validates the source another way
+    // (mtime + an app-layer content hash). The header must self-describe this so
+    // a future reader.validate() / read({sourceBuffer}) can't silently fail-close.
+    const writer = new BinaryCacheWriter();
+    const cacheBuffer = await writer.write(dataStore, undefined, sourceBuffer, {
+      includeGeometry: false,
+      omitSourceHash: true,
+    });
+    const reader = new BinaryCacheReader();
+    const header = reader.readHeader(cacheBuffer);
+
+    expect(header.hasSourceHash).toBe(false);
+    expect(header.sourceHash).toBe(0n);
+    // validate() refuses (throws) rather than returning a misleading false.
+    expect(() => reader.validate(cacheBuffer, sourceBuffer)).toThrow(/SourceHashUnset/);
+    // read({sourceBuffer}) does NOT fail-close on an unset hash — it just reads.
+    await expect(reader.read(cacheBuffer, { sourceBuffer })).resolves.toBeTruthy();
+  });
+
+  it('mesh-only write (omitSourceHash, no persisted source) round-trips geometry byte-identical', async () => {
     // Byte-identity of the restored geometry is what makes a mesh-only cache hit
     // equal to a cold load. The write path is source-decoupled (the viewer does
-    // NOT persist the source for this tier), so exercise write→read with only a
-    // precomputed hash and assert the meshes come back bit-for-bit.
+    // NOT persist the source for this tier), so exercise write→read with the hash
+    // omitted and assert the meshes come back bit-for-bit.
     const positions = new Float32Array([0, 0, 0, 1, 0, 0, 1, 1, 0]);
     const normals = new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]);
     const indices = new Uint32Array([0, 1, 2]);
@@ -351,7 +368,7 @@ describe('BinaryCacheWriter and BinaryCacheReader', () => {
     };
 
     const writer = new BinaryCacheWriter();
-    const cacheBuffer = await writer.write(dataStore, geometry, sourceBuffer, { sourceHash: 42n });
+    const cacheBuffer = await writer.write(dataStore, geometry, sourceBuffer, { omitSourceHash: true });
     const result = await new BinaryCacheReader().read(cacheBuffer);
 
     const mesh = result.geometry!.meshes[0];

--- a/packages/cache/src/reader.ts
+++ b/packages/cache/src/reader.ts
@@ -36,10 +36,20 @@ export class BinaryCacheReader {
   }
 
   /**
-   * Validate cache against source file
+   * Validate cache against source file.
+   *
+   * Throws when the entry was written with {@link HeaderFlags.SourceHashUnset}
+   * (its `sourceHash` is not a real full-file hash), so the caller cannot
+   * accidentally read this as a mismatch and silently discard a valid cache —
+   * it must validate the source another way (see the header note).
    */
   validate(cacheBuffer: ArrayBuffer, sourceBuffer: ArrayBuffer): boolean {
     const header = this.readHeader(cacheBuffer);
+    if (!header.hasSourceHash) {
+      throw new Error(
+        'Cache entry has no full-file source hash (SourceHashUnset); validate the source at the application layer instead of reader.validate().',
+      );
+    }
     const sourceHash = xxhash64(sourceBuffer);
     return header.sourceHash === sourceHash;
   }
@@ -56,8 +66,11 @@ export class BinaryCacheReader {
     const reader = new BufferReader(buffer);
     const header = readHeader(reader);
 
-    // Validate source if provided
-    if (sourceBuffer) {
+    // Validate source if provided AND this entry actually carries a full-file
+    // hash. Entries written with SourceHashUnset (their `sourceHash` is 0n)
+    // are validated by the application layer — skip here so a provided
+    // `sourceBuffer` can't spuriously fail-close a valid cache.
+    if (sourceBuffer && header.hasSourceHash) {
       const sourceHash = xxhash64(sourceBuffer);
       if (header.sourceHash !== sourceHash) {
         throw new Error('Cache validation failed: source file has changed');

--- a/packages/cache/src/sections/header.ts
+++ b/packages/cache/src/sections/header.ts
@@ -120,6 +120,7 @@ export function readHeader(reader: BufferReader): CacheHeaderInfo {
     version,
     schema,
     sourceHash,
+    hasSourceHash: (flags & HeaderFlags.SourceHashUnset) === 0,
     entityCount,
     totalVertices,
     totalTriangles,

--- a/packages/cache/src/types.ts
+++ b/packages/cache/src/types.ts
@@ -101,6 +101,15 @@ export enum HeaderFlags {
   Compressed = 1 << 0,
   HasGeometry = 1 << 1,
   HasSpatial = 1 << 2,
+  /**
+   * The `sourceHash` field is NOT a full-file `xxhash64` — it is unset (0) and
+   * must not be used to validate the source. Set by writers that validate the
+   * source by another means (see `omitSourceHash`), so `reader.validate()` /
+   * `read({ sourceBuffer })` can fail LOUD (or skip) instead of silently
+   * fail-closing on a real match. Backward-compatible: entries written before
+   * this flag existed have it unset, so their `sourceHash` stays a real hash.
+   */
+  SourceHashUnset = 1 << 3,
 }
 
 /** Section flags */
@@ -147,15 +156,16 @@ export interface CacheWriteOptions {
   /** Compress sections (default: false, future feature) */
   compress?: boolean;
   /**
-   * Precomputed value for the header's `sourceHash` field. When provided, the
-   * writer stores it verbatim and SKIPS the internal full-buffer `xxhash64` of
-   * `sourceBuffer`. Supply this when the caller already validates the source by
-   * another means (e.g. a strengthened cache key) so a large source doesn't pay
-   * a full-file main-thread hash on write. Omit it for the default behaviour
-   * (the writer hashes the whole `sourceBuffer`, and `reader.validate()` stays
-   * meaningful).
+   * Skip the header's full-file `xxhash64(sourceBuffer)`: store `sourceHash = 0n`
+   * and set {@link HeaderFlags.SourceHashUnset}. Use when the caller validates
+   * the source by another means (e.g. an application-layer content hash), so a
+   * large source pays NO full-file main-thread hash on write. Consumers that
+   * would validate against the header (`reader.validate()` / `read({
+   * sourceBuffer })`) can then detect the absence via {@link
+   * CacheHeaderInfo.hasSourceHash} instead of silently fail-closing. Default
+   * `false` (the writer hashes the whole `sourceBuffer`, unchanged).
    */
-  sourceHash?: bigint;
+  omitSourceHash?: boolean;
 }
 
 /**
@@ -176,7 +186,14 @@ export interface CacheReadOptions {
 export interface CacheHeaderInfo {
   version: number;
   schema: SchemaVersion;
+  /**
+   * Full-file `xxhash64` of the source — VALID only when {@link hasSourceHash}
+   * is true. When false it is `0n` and carries no meaning (see
+   * {@link HeaderFlags.SourceHashUnset}).
+   */
   sourceHash: bigint;
+  /** Is {@link sourceHash} a real full-file hash (vs. an unset `0n`)? */
+  hasSourceHash: boolean;
   entityCount: number;
   totalVertices: number;
   totalTriangles: number;

--- a/packages/cache/src/types.ts
+++ b/packages/cache/src/types.ts
@@ -146,6 +146,16 @@ export interface CacheWriteOptions {
   includeSpatialHierarchy?: boolean;
   /** Compress sections (default: false, future feature) */
   compress?: boolean;
+  /**
+   * Precomputed value for the header's `sourceHash` field. When provided, the
+   * writer stores it verbatim and SKIPS the internal full-buffer `xxhash64` of
+   * `sourceBuffer`. Supply this when the caller already validates the source by
+   * another means (e.g. a strengthened cache key) so a large source doesn't pay
+   * a full-file main-thread hash on write. Omit it for the default behaviour
+   * (the writer hashes the whole `sourceBuffer`, and `reader.validate()` stays
+   * meaningful).
+   */
+  sourceHash?: bigint;
 }
 
 /**

--- a/packages/cache/src/writer.ts
+++ b/packages/cache/src/writer.ts
@@ -60,12 +60,13 @@ export class BinaryCacheWriter {
     const {
       includeGeometry = true,
       includeSpatialHierarchy = true,
+      omitSourceHash = false,
     } = options;
 
-    // Source hash: use the caller's precomputed value when supplied (they
-    // validate the source another way), else hash the whole buffer. Supplying
-    // it skips a full-file main-thread hash on write for large sources.
-    const sourceHash = options.sourceHash ?? xxhash64(sourceBuffer);
+    // Source hash: `omitSourceHash` skips the full-file main-thread `xxhash64`
+    // for large sources (the caller validates the source another way and flags
+    // the header as unset); otherwise hash the whole buffer as before.
+    const sourceHash = omitSourceHash ? 0n : xxhash64(sourceBuffer);
 
     // Build sections
     const sectionBuffers: Array<{ type: SectionType; buffer: ArrayBuffer }> = [];
@@ -174,6 +175,9 @@ export class BinaryCacheWriter {
     }
     if (includeSpatialHierarchy && dataStore.spatialHierarchy) {
       headerFlags |= HeaderFlags.HasSpatial;
+    }
+    if (omitSourceHash) {
+      headerFlags |= HeaderFlags.SourceHashUnset;
     }
 
     const header: CacheHeader = {

--- a/packages/cache/src/writer.ts
+++ b/packages/cache/src/writer.ts
@@ -62,8 +62,10 @@ export class BinaryCacheWriter {
       includeSpatialHierarchy = true,
     } = options;
 
-    // Compute source hash
-    const sourceHash = xxhash64(sourceBuffer);
+    // Source hash: use the caller's precomputed value when supplied (they
+    // validate the source another way), else hash the whole buffer. Supplying
+    // it skips a full-file main-thread hash on write for large sources.
+    const sourceHash = options.sourceHash ?? xxhash64(sourceBuffer);
 
     // Build sections
     const sectionBuffers: Array<{ type: SectionType; buffer: ArrayBuffer }> = [];


### PR DESCRIPTION
## What (prototype, default-off behind `?meshCache=1`)

Repeat opens of large models drop from 10-90s to a few seconds. The 150MB cache cap is a *source-persistence* artifact (the cache persists the source buffer for lazy property/re-export accessors, and a >150MB source in IndexedDB is prohibitively large). But `loadFile` already reads the full file (for the fingerprint) and `loadFromCache` already accepts a `fallbackSourceBuffer` — so the **meshes** can be cached **without** the source for 150-400MB files, and the fresh read hydrates the accessors on re-open.

## Measured (Holter 169MB)

| | value |
|---|---|
| Cold open | 7.0s (writes the mesh-only entry) |
| **Repeat open** | **1.63s → 4.3×** |
| Cache entry | 108MB, `savedWithoutSource: true` |

## Correctness

- **Byte-identical restore** — the cached restore reported 60,432 meshes = the cold load's 60,432 exactly. Tier/fast-mode flags are in the cache key, so an `exact` reload never returns `fast` bytes.
- **`sourceHash` validation** — a sourceless hit is validated against the freshly-read buffer's full-source xxhash64 (upgrades the weak 4KB fingerprint to full-content); mismatch → delete + normal load.
- **No ≤150MB regression** — `classifyCacheTier` returns `source` for ≤150MB and never consults the flag. Viewer suite 1414/1416 pass; typecheck clean.
- Added quota/LRU eviction hardening to the cache service (there was none): per-entry ceiling, `storage.estimate()` guard, oldest-first eviction.

## Follow-ups before un-flagging (prototype scope)

1. Validation hash is pure-JS xxhash (~0.7-1.7s main-thread stall on repeat) — move to the wasm/Rust xxhash (GB/s).
2. Safari quota untested (may reject a 300MB+ IndexedDB blob).
3. Single-record blob; very large entries may want chunked storage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)