### PR TITLE
perf(geometry): wire the browser (wasm) don't-bake instanced output (#1623 Phase 3)

### DIFF
--- a/packages/geometry/src/geometry-parallel.ts
+++ b/packages/geometry/src/geometry-parallel.ts
@@ -891,6 +891,9 @@ export async function* processParallel(
         // after `entity-index` and workers handle messages FIFO, so it holds.
         const referencedRepmaps = evt.referencedRepmaps as Uint32Array;
         const instantiatedTypeIds = evt.instantiatedTypeIds as Uint32Array;
+        // #1623 Phase 3 don't-bake plan (RepresentationMap ids repeated >= 2x).
+        // Absent on older pre-pass builds -> empty, so the batch never arms.
+        const mappedInstancePlan = (evt.mappedInstancePlan as Uint32Array | undefined) ?? new Uint32Array(0);
         const mliElementIds = evt.mliElementIds as Uint32Array;
         const mliAxis = evt.mliAxis as Uint32Array;
         const mliLayerCounts = evt.mliLayerCounts as Uint32Array;
@@ -904,6 +907,7 @@ export async function* processParallel(
           try {
             const rRepmaps = referencedRepmaps.slice();
             const rTypeIds = instantiatedTypeIds.slice();
+            const rMappedPlan = mappedInstancePlan.slice();
             const mIds = mliElementIds.slice();
             const mAxis = mliAxis.slice();
             const mCounts = mliLayerCounts.slice();
@@ -916,6 +920,7 @@ export async function* processParallel(
                 type: 'set-prepass-columns' as const,
                 referencedRepmaps: rRepmaps,
                 instantiatedTypeIds: rTypeIds,
+                mappedInstancePlan: rMappedPlan,
                 mliElementIds: mIds,
                 mliAxis: mAxis,
                 mliLayerCounts: mCounts,
@@ -925,7 +930,7 @@ export async function* processParallel(
                 mliLayerThicknesses: mThick,
               },
               [
-                rRepmaps.buffer, rTypeIds.buffer, mIds.buffer, mAxis.buffer, mCounts.buffer,
+                rRepmaps.buffer, rTypeIds.buffer, rMappedPlan.buffer, mIds.buffer, mAxis.buffer, mCounts.buffer,
                 mDir.buffer, mOff.buffer, mMatIds.buffer, mThick.buffer,
               ],
             );

--- a/packages/geometry/src/geometry.worker.ts
+++ b/packages/geometry/src/geometry.worker.ts
@@ -126,6 +126,10 @@ export interface GeometryWorkerSetPrepassColumnsMessage {
   type: 'set-prepass-columns';
   referencedRepmaps: Uint32Array;
   instantiatedTypeIds: Uint32Array;
+  /** #1623 Phase 3 don't-bake plan: RepresentationMap ids an IfcMappedItem
+   *  instantiates >= 2x. Installed via `setMappedInstancePlan`; absent/empty ⇒
+   *  the batch never arms the don't-bake path (materializes every occurrence). */
+  mappedInstancePlan?: Uint32Array;
   mliElementIds: Uint32Array;
   mliAxis: Uint32Array;
   mliLayerCounts: Uint32Array;
@@ -377,6 +381,9 @@ type IfcAPIWithMerge = IfcAPI & {
 type IfcAPIWithPrepassColumns = IfcAPI & {
   setReferencedRepmaps?: (ids: Uint32Array) => void;
   setInstantiatedTypeIds?: (ids: Uint32Array) => void;
+  /** #1623 Phase 3: install the don't-bake plan (RepresentationMap ids repeated
+   *  >= 2x). Optional so an older engine binary degrades to full materialize. */
+  setMappedInstancePlan?: (ids: Uint32Array) => void;
   setMaterialLayerIndex?: (
     elementIds: Uint32Array,
     axis: Uint32Array,
@@ -505,6 +512,11 @@ function applyPrepassColumnsToApi(): void {
   }
   if (typeof ifcApi.setInstantiatedTypeIds === 'function') {
     ifcApi.setInstantiatedTypeIds(c.instantiatedTypeIds);
+  }
+  // #1623 Phase 3: install the don't-bake plan so the partitioned batch can arm
+  // batch-local instancing. Empty/absent ⇒ the setter no-ops (nothing repeated).
+  if (typeof ifcApi.setMappedInstancePlan === 'function' && c.mappedInstancePlan) {
+    ifcApi.setMappedInstancePlan(c.mappedInstancePlan);
   }
   if (typeof ifcApi.setMaterialLayerIndex === 'function') {
     ifcApi.setMaterialLayerIndex(

--- a/packages/wasm/pkg/ifc-lite.d.ts
+++ b/packages/wasm/pkg/ifc-lite.d.ts
@@ -422,6 +422,22 @@ export class IfcAPI {
    */
   setReferencedRepmaps(ids: Uint32Array): void;
   /**
+   * Install the pre-computed #1623 Phase 3 don't-bake plan: the flat list of
+   * `IfcRepresentationMap` ids that an `IfcMappedItem` instantiates >= 2 times.
+   * The streaming pre-pass tallies it in the SAME scan that builds the referenced-
+   * repmap set (`styling::build_mapped_instance_plan_from_spans`) and ships the id
+   * list here. The batch path arms its router with it (batch-local template mode),
+   * so a repeated single-solid mapped source materializes ONCE per batch and the
+   * rest ride as instances in the IFNS shard.
+   *
+   * Same injection contract as [`Self::set_referenced_repmaps`]: installed after
+   * `setEntityIndex` (which clears it on content swap), and a no-op absence leaves
+   * the batch path materializing every occurrence (byte-identical). Each id is
+   * stored as `(2, id)` — the batch-local router only needs the eligibility set
+   * (count >= 2); the min-id template slot is unused in batch-local mode.
+   */
+  setMappedInstancePlan(source_ids: Uint32Array): void;
+  /**
    * Install the pre-computed [`ifc_lite_geometry::MaterialLayerIndex`] (#563)
    * from its flat SoA encoding, so the worker's first batch skips the
    * per-worker [`Self::get_or_build_material_layer_index`] full-file decode
@@ -1231,6 +1247,7 @@ export interface InitOutput {
   readonly ifcapi_setComputeGeometryHashes: (a: number, b: number, c: number) => void;
   readonly ifcapi_setEntityIndex: (a: number, b: number, c: number, d: number, e: number, f: number, g: number) => void;
   readonly ifcapi_setInstantiatedTypeIds: (a: number, b: number, c: number) => void;
+  readonly ifcapi_setMappedInstancePlan: (a: number, b: number, c: number) => void;
   readonly ifcapi_setMaterialLayerIndex: (a: number, b: number, c: number, d: number, e: number, f: number, g: number, h: number, i: number, j: number, k: number, l: number, m: number, n: number, o: number) => void;
   readonly ifcapi_setMergeLayers: (a: number, b: number) => void;
   readonly ifcapi_setRectParamFastPath: (a: number, b: number) => void;

--- a/rust/geometry/src/instancing/collate.rs
+++ b/rust/geometry/src/instancing/collate.rs
@@ -141,12 +141,12 @@ pub fn collate_refs(meshes: &[InstanceMeshRef], min_group: usize, rtc: [f64; 3])
     // they're routed to flat_indices and emitted as flat singleton templates.
     // Dropping them here would silently lose geometry now that capture is always-on
     // and real models feed the collator — the unit fixtures were all instanceable,
-    // which hid this. Empty meshes carry nothing to draw and are the only skip.
+    // which hid this. A non-empty non-instanceable mesh goes flat; an EMPTY mesh
+    // carries nothing to draw UNLESS it is a #1623 Phase 3 don't-bake occurrence
+    // placeholder (empty geometry + instanceable InstanceMeta) — the shared template
+    // supplies its geometry, so it joins its rep group like a materialized member.
     let mut flat: Vec<usize> = Vec::new();
     for (i, m) in meshes.iter().enumerate() {
-        if m.positions.is_empty() {
-            continue;
-        }
         match m.instance_meta {
             Some(im) if im.instanceable => {
                 groups
@@ -157,9 +157,25 @@ pub fn collate_refs(meshes: &[InstanceMeshRef], min_group: usize, rtc: [f64; 3])
                     })
                     .push(i);
             }
-            _ => flat.push(i),
+            // Empty + non-instanceable = nothing to draw (skip); non-empty +
+            // non-instanceable = flat singleton.
+            _ if !m.positions.is_empty() => flat.push(i),
+            _ => {}
         }
     }
+
+    // Route only DRAWABLE members flat: an empty don't-bake placeholder carries no
+    // geometry, so it can never render flat — the caller (the wasm don't-bake
+    // finalize) recovers such occurrences flat itself before collation, so a group
+    // it feeds here always has a materialized template and passes the count gate.
+    // Filtering defends against ever silently emitting an empty flat singleton.
+    let drawable = |members: &[usize]| -> Vec<usize> {
+        members
+            .iter()
+            .copied()
+            .filter(|&i| !meshes[i].positions.is_empty())
+            .collect::<Vec<_>>()
+    };
 
     let mut out = Collated {
         flat_indices: flat,
@@ -168,16 +184,27 @@ pub fn collate_refs(meshes: &[InstanceMeshRef], min_group: usize, rtc: [f64; 3])
     for rep in order {
         let members = &groups[&rep];
         if members.len() < min_group.max(1) {
-            out.flat_indices.extend_from_slice(members);
+            out.flat_indices.extend(drawable(members));
             continue;
         }
-        let t_idx = members[0];
+        // Template = the first NON-EMPTY (materialized) member. Empty members are
+        // don't-bake placeholders whose geometry IS this template.
+        let Some(t_idx) = members
+            .iter()
+            .copied()
+            .find(|&i| !meshes[i].positions.is_empty())
+        else {
+            // All-empty group: no template geometry to draw against. Unreachable by
+            // the caller contract (a materialized template always accompanies its
+            // occurrences); drop rather than emit empty singletons that draw nothing.
+            continue;
+        };
         let template = &meshes[t_idx];
         // Compose in the post-RTC frame so the georeferenced offset cancels
         // exactly regardless of each occurrence's rotation (see fn docs).
         let m_ref = to_post_rtc(compose_world(template.instance_meta.unwrap()), rtc);
         let Some(m_ref_inv) = m_ref.try_inverse() else {
-            out.flat_indices.extend_from_slice(members);
+            out.flat_indices.extend(drawable(members));
             continue;
         };
 
@@ -194,14 +221,20 @@ pub fn collate_refs(meshes: &[InstanceMeshRef], min_group: usize, rtc: [f64; 3])
         let mut shapes_match = true;
         for &i in members {
             let mesh = &meshes[i];
-            // Exact-tier occurrences share the SAME local geometry (so same counts),
-            // differing only by placement — we can't byte-compare their BAKED
-            // positions (those legitimately differ). Content-equality is instead
-            // guaranteed upstream: rep_identity is a FULL 128-bit content hash
-            // (compute_mesh_hash_full | tag), so a same-counts/different-content
-            // collision is ~2^-127. The count check stays as a cheap guard.
-            // Rigid-tier occurrences are intentionally non-identical (verified).
-            if !is_rigid && (mesh.positions.len() != vlen || mesh.indices.len() != ilen) {
+            // A #1623 Phase 3 don't-bake placeholder (empty geometry) is pose-only:
+            // its geometry IS the template, so skip the same-shape guard (like the
+            // rigid tier). Exact-tier materialized occurrences share the SAME local
+            // geometry (so same counts), differing only by placement — we can't
+            // byte-compare their BAKED positions (those legitimately differ).
+            // Content-equality is guaranteed upstream: rep_identity is a FULL 128-bit
+            // content hash (or the RepresentationMap id), so a same-counts/
+            // different-content collision is ~2^-127. The count check stays a cheap
+            // guard. Rigid-tier occurrences are intentionally non-identical (verified).
+            let pose_only = mesh.positions.is_empty();
+            if !pose_only
+                && !is_rigid
+                && (mesh.positions.len() != vlen || mesh.indices.len() != ilen)
+            {
                 shapes_match = false;
                 break;
             }
@@ -220,7 +253,7 @@ pub fn collate_refs(meshes: &[InstanceMeshRef], min_group: usize, rtc: [f64; 3])
                 occurrences,
             });
         } else {
-            out.flat_indices.extend_from_slice(members);
+            out.flat_indices.extend(drawable(members));
         }
     }
     out

--- a/rust/geometry/src/instancing/tests.rs
+++ b/rust/geometry/src/instancing/tests.rs
@@ -385,6 +385,108 @@ fn collate_and_encode_matches_mesh_path() {
 }
 
 #[test]
+fn dont_bake_empty_occurrence_refs_recompose_like_materialized() {
+    // #1623 Phase 3: the browser don't-bake path feeds `collate_refs` a single
+    // MATERIALIZED template plus EMPTY-geometry occurrence placeholders (each
+    // carrying only the pre-RTC world transform, id, and colour). The resulting
+    // shard must recompose to the EXACT same world triangles as if every
+    // occurrence had been materialized flat — the byte-identity gate.
+    use std::f64::consts::FRAC_PI_4;
+    let placements = [
+        Matrix4::new_translation(&nalgebra::Vector3::new(2.0, 0.0, 0.0)),
+        Matrix4::from_euler_angles(0.0, 0.0, FRAC_PI_4)
+            * Matrix4::new_translation(&nalgebra::Vector3::new(-6.0, 4.0, 1.0)),
+        Matrix4::from_euler_angles(FRAC_PI_4, 0.0, 0.0)
+            * Matrix4::new_translation(&nalgebra::Vector3::new(30.0, -12.0, 5.0)),
+    ];
+    let meta_for = |m: &Matrix4<f64>| InstanceMeta {
+        transform: mat_rm(m),
+        local_transform: None,
+        canonical_transform: None,
+        rep_identity: 314,
+        instanceable: true,
+    };
+
+    // A: the FLAT baseline — every occurrence materialized (baked verts + meta).
+    let materialized: Vec<Mesh> = placements
+        .iter()
+        .map(|m| mesh_from(baked(&CANON, m), meta_for(m)))
+        .collect();
+    let flat_shard = {
+        let refs: Vec<InstanceMeshRef> = materialized
+            .iter()
+            .enumerate()
+            .map(|(i, m)| {
+                let mut r = InstanceMeshRef::from_mesh(m);
+                r.entity_id = 1000 + i as u32;
+                r.color = [0.2, 0.4, 0.6, 1.0];
+                r
+            })
+            .collect();
+        collate_and_encode(&refs, 2, [0.0, 0.0, 0.0])
+    };
+
+    // B: the don't-bake path — occurrence 0 materialized as the template, 1 & 2 as
+    // EMPTY placeholders carrying only their world transform (no baked geometry).
+    let template = &materialized[0];
+    let metas: Vec<InstanceMeta> = placements[1..].iter().map(meta_for).collect();
+    let mut refs_db: Vec<InstanceMeshRef> = Vec::new();
+    let mut tmpl_ref = InstanceMeshRef::from_mesh(template);
+    tmpl_ref.entity_id = 1000;
+    tmpl_ref.color = [0.2, 0.4, 0.6, 1.0];
+    refs_db.push(tmpl_ref);
+    for (k, meta) in metas.iter().enumerate() {
+        refs_db.push(InstanceMeshRef {
+            positions: &[],
+            normals: &[],
+            indices: &[],
+            origin: [0.0; 3],
+            instance_meta: Some(meta),
+            entity_id: 1000 + (k as u32 + 1),
+            color: [0.2, 0.4, 0.6, 1.0],
+        });
+    }
+    let db_shard = collate_and_encode(&refs_db, 2, [0.0, 0.0, 0.0]);
+
+    // Both shards must be byte-identical: same one template geometry (occurrence 0),
+    // same three instances, same ids/colours/transforms. The don't-bake path never
+    // materialized occurrences 1 & 2, yet produces the identical wire shard.
+    assert_eq!(
+        flat_shard, db_shard,
+        "don't-bake empty-occurrence shard must equal the fully-materialized shard byte-for-byte"
+    );
+
+    // And it recomposes to the flat baked world verts within a micrometre.
+    let dec = decode_instanced(&db_shard).expect("decodes");
+    assert_eq!(dec.templates.len(), 1, "one shared template");
+    assert_eq!(dec.instances.len(), 3, "template + two don't-bake occurrences");
+    for inst in &dec.instances {
+        let tmpl = &dec.templates[inst.template_index as usize];
+        let rel = Matrix4::from_row_slice(&inst.transform.map(|v| v as f64));
+        let orig_idx = (inst.entity_id - 1000) as usize;
+        let orig = &materialized[orig_idx];
+        let n = tmpl.positions.len() / 3;
+        for v in 0..n {
+            let w = rel
+                * nalgebra::Vector4::new(
+                    tmpl.origin[0] + tmpl.positions[v * 3] as f64,
+                    tmpl.origin[1] + tmpl.positions[v * 3 + 1] as f64,
+                    tmpl.origin[2] + tmpl.positions[v * 3 + 2] as f64,
+                    1.0,
+                );
+            let gx = orig.origin[0] + orig.positions[v * 3] as f64;
+            let gy = orig.origin[1] + orig.positions[v * 3 + 1] as f64;
+            let gz = orig.origin[2] + orig.positions[v * 3 + 2] as f64;
+            let err = ((w.x / w.w - gx).powi(2)
+                + (w.y / w.w - gy).powi(2)
+                + (w.z / w.w - gz).powi(2))
+            .sqrt();
+            assert!(err < 1e-4, "don't-bake recompose vertex error {err}");
+        }
+    }
+}
+
+#[test]
 fn decode_rejects_bad_magic() {
     assert!(decode_instanced(&[0u8; 32]).is_none());
     assert!(decode_instanced(&[]).is_none());

--- a/rust/geometry/src/router/mod.rs
+++ b/rust/geometry/src/router/mod.rs
@@ -230,6 +230,23 @@ pub struct GeometryRouter {
     /// single-solid id is in this set the router routes it to the normal flat
     /// materialize (byte-identical to instancing-off). `None`/empty ⇒ no exclusion.
     indexed_colour_split_ids: Option<Arc<FxHashSet<u32>>>,
+    /// #1623 Phase 3 template-selection mode for the don't-bake path. `false`
+    /// (default, NATIVE): the deterministic global template is the plan's min-id
+    /// occurrence (`item.id == template_item_id`), so every occurrence resolves
+    /// against ONE model-wide template across the rayon pool. `true` (the WASM
+    /// per-BATCH path): this router meshes ONE batch onto ONE thread serially, so
+    /// the FIRST occurrence of each source THIS router sees is the template (tracked
+    /// in [`Self::instanced_sources_materialized`]) and the rest don't-bake — each
+    /// per-batch shard is then self-contained (its occurrences' template is in the
+    /// same shard), so a batch never depends on a template materialized in another
+    /// batch. Both modes emit geometrically identical world triangles.
+    instancing_batch_local: bool,
+    /// #1623 Phase 3 (batch-local mode only): the `IfcRepresentationMap` source ids
+    /// this router has already materialized as a batch-local template. The first
+    /// occurrence of a source inserts its id (materializes); later occurrences see
+    /// the id present and don't-bake. Reset implicitly per batch — a fresh router is
+    /// built per `produce_batch`. Unused (stays empty) in the native global mode.
+    instanced_sources_materialized: RefCell<FxHashSet<u32>>,
 }
 
 /// Whether an `IfcShapeRepresentation.RepresentationType` names a meshable
@@ -296,6 +313,8 @@ impl GeometryRouter {
             skip_small_cuts: false,
             output_instancing_plan: None, // armed by `enable_output_instancing`
             indexed_colour_split_ids: None, // armed by `enable_indexed_colour_split_guard`
+            instancing_batch_local: false, // native global-template mode by default
+            instanced_sources_materialized: RefCell::new(FxHashSet::default()),
         };
 
         // Register default P0 processors
@@ -461,6 +480,29 @@ impl GeometryRouter {
         self.indexed_colour_split_ids
             .as_ref()
             .is_some_and(|ids| ids.contains(&geometry_id))
+    }
+
+    /// Select the #1623 Phase 3 batch-local template mode (see
+    /// [`Self::instancing_batch_local`]). The WASM per-batch path sets this so each
+    /// batch materializes its OWN first-seen template per source and stays a
+    /// self-contained shard; the native path leaves it off (global min-id template).
+    pub fn set_instancing_batch_local(&mut self, on: bool) {
+        self.instancing_batch_local = on;
+    }
+
+    /// Whether batch-local template selection is active (see the field doc).
+    #[inline]
+    pub(super) fn instancing_batch_local(&self) -> bool {
+        self.instancing_batch_local
+    }
+
+    /// Batch-local don't-bake template decision: returns `true` (materialize as the
+    /// batch-local template) the FIRST time this router sees `source_id`, `false`
+    /// (don't-bake) every time after. Idempotent per source within one router/batch.
+    pub(super) fn mark_source_materialized_if_first(&self, source_id: u32) -> bool {
+        self.instanced_sources_materialized
+            .borrow_mut()
+            .insert(source_id)
     }
 
     /// Disable content-dedup (drops the cache reference so `item_dedup_key`

--- a/rust/geometry/src/router/processing.rs
+++ b/rust/geometry/src/router/processing.rs
@@ -414,25 +414,26 @@ impl GeometryRouter {
                 None
             };
 
-            // #1623 Phase 2 "don't-bake": if this top-level mapped item's source is a
-            // REPEATED (count >= 2) single-solid `IfcRepresentationMap` and the armed
-            // plan says so, only the deterministic template occurrence
-            // (min IfcMappedItem id) materializes its geometry; every OTHER occurrence
-            // skips the per-occurrence vertex clone / MappingTarget bake / weld and
-            // emits an instance-only placeholder (empty geometry carrying the mapping
-            // transform + rep_identity in `InstanceMeta`). `apply_submesh_placement`
-            // folds the world placement into `im.transform`; the streaming finalize
-            // turns the placeholder into an `InstanceRecord` against the template.
+            // #1623 Phase 2/3 "don't-bake": if this top-level mapped item's source is
+            // a REPEATED (count >= 2) single-solid `IfcRepresentationMap` the armed
+            // plan lists, exactly ONE occurrence (the "template") materializes its
+            // geometry; every OTHER occurrence skips the per-occurrence vertex clone /
+            // MappingTarget bake / weld and emits an instance-only placeholder (empty
+            // geometry carrying the mapping transform + rep_identity in `InstanceMeta`).
+            // `apply_submesh_placement` folds the world placement into `im.transform`;
+            // the finalize turns the placeholder into an occurrence against the template.
             //
+            // `instance_solid_id` is the nested SOLID's id (used as the placeholder's
+            // geometry_id so colour resolves EXACTLY as the flat/template sub-mesh).
             // Only fires at the TOP level (`depth == 0`) — a mapped item nested inside
             // another map is part of its parent's shared geometry, not an independent
             // occurrence — and only when `allow_instancing` (the non-void path). With
             // no armed plan this is skipped entirely, so the flat output is unchanged.
-            let dont_bake = if allow_instancing && depth == 0 {
+            let instance_solid_id: Option<u32> = if allow_instancing && depth == 0 {
                 self.output_instancing_plan()
                     .and_then(|plan| plan.get(&source_id).copied())
                     .filter(|&(count, _)| count >= 2)
-                    .and_then(|(count, template_item_id)| {
+                    .and_then(|_| {
                         self.mapped_source_single_item(&mapped_repr, decoder)
                             // #858: a source whose single solid carries an
                             // IfcIndexedColourMap must materialize flat so
@@ -441,13 +442,32 @@ impl GeometryRouter {
                             // collapsing the palette (WRONG vs the flat path); route
                             // to flat instead (byte-identical to instancing-off).
                             .filter(|&item_id| !self.is_indexed_colour_split_source(item_id))
-                            .map(|item_id| (count, template_item_id, item_id))
                     })
             } else {
                 None
             };
-            if let Some((_, template_item_id, solid_item_id)) = dont_bake {
-                if item.id != template_item_id {
+            // Which occurrence MATERIALIZES the template. Native (global) mode: the
+            // plan's deterministic min-id occurrence, so all occurrences resolve
+            // against ONE model-wide template across the rayon pool. WASM batch-local
+            // mode: the FIRST occurrence of this source seen by this router/batch (the
+            // rest don't-bake), so each per-batch shard is self-contained. Both emit
+            // geometrically identical world triangles.
+            let is_template = match instance_solid_id {
+                None => true, // not eligible ⇒ materialize flat as usual
+                Some(_) if self.instancing_batch_local() => {
+                    self.mark_source_materialized_if_first(source_id)
+                }
+                Some(_) => {
+                    let template_item_id = self
+                        .output_instancing_plan()
+                        .and_then(|plan| plan.get(&source_id))
+                        .map(|&(_, t)| t)
+                        .unwrap_or(item.id);
+                    item.id == template_item_id
+                }
+            };
+            if let Some(solid_item_id) = instance_solid_id {
+                if !is_template {
                     // NON-template occurrence: don't-bake. Ensure the shared registry
                     // holds the source geometry (meshed once model-wide) so the
                     // finalize can recover geometry even in the (effectively
@@ -546,7 +566,7 @@ impl GeometryRouter {
                 }
             }
 
-            // #1623 Phase 2: this is the don't-bake TEMPLATE occurrence (min-id). It
+            // #1623 Phase 2/3: this is the don't-bake TEMPLATE occurrence. It
             // materialized normally above (byte-identical to a flat occurrence — a
             // single-solid source ⇒ exactly one sub-mesh). Re-tag its `rep_identity`
             // to the source id and record the (scaled) MappingTarget as
@@ -556,17 +576,15 @@ impl GeometryRouter {
             // `local_transform`, which is consistent (the template's world geometry is
             // `transform · local_transform · source`, so `m_ref` recovers the same
             // `source` the placeholders reference). See the finalize in processor/mod.rs.
-            if let Some((_, template_item_id, _)) = dont_bake {
-                if item.id == template_item_id {
-                    let local_rm = mapping_transform.map(|mut t| {
-                        self.scale_transform(&mut t);
-                        mat4_to_row_major(&t)
-                    });
-                    for sub in &mut sub_meshes.sub_meshes[mapped_items_start..] {
-                        if let Some(im) = sub.mesh.instance_meta.as_mut() {
-                            im.rep_identity = source_id as u128;
-                            im.local_transform = local_rm;
-                        }
+            if instance_solid_id.is_some() && is_template {
+                let local_rm = mapping_transform.map(|mut t| {
+                    self.scale_transform(&mut t);
+                    mat4_to_row_major(&t)
+                });
+                for sub in &mut sub_meshes.sub_meshes[mapped_items_start..] {
+                    if let Some(im) = sub.mesh.instance_meta.as_mut() {
+                        im.rep_identity = source_id as u128;
+                        im.local_transform = local_rm;
                     }
                 }
             }

--- a/rust/processing/tests/instancing_batch_local.rs
+++ b/rust/processing/tests/instancing_batch_local.rs
@@ -1,0 +1,262 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! #1623 Phase 3 BROWSER "don't-bake" byte-identity gate (batch-local mode).
+//!
+//! Phase 2 proved the NATIVE global-template don't-bake path. Phase 3 wires the
+//! browser (wasm) partitioned path, which selects the template PER BATCH (the
+//! first occurrence a batch sees) instead of a model-wide min-id, and emits the
+//! non-template occurrences into the IFNS shard via `collate_refs` fed
+//! EMPTY-geometry occurrence refs. This test exercises that exact browser path on
+//! real fixture geometry WITHOUT wasm:
+//!
+//!   * flat run   — a router with no plan; every occurrence materializes.
+//!   * batch-local run — ONE router (as a wasm batch has) armed in BATCH-LOCAL
+//!     don't-bake mode; the first occurrence of the shared source materializes as
+//!     the template, the rest emit `RawInstanceOccurrence`s. Those are collated the
+//!     same way `process_geometry_batch_partitioned` does (empty-geometry
+//!     `InstanceMeshRef`s → `collate_refs`).
+//!
+//! It then proves the collated shard recomposes to the flat run's WORLD TRIANGLES
+//! within a micrometre, and that far fewer occurrences materialized.
+
+use ifc_lite_core::{build_entity_index, has_geometry_by_name, EntityDecoder, EntityScanner};
+use ifc_lite_geometry::{collate_refs, GeometryRouter, InstanceMeshRef, InstanceMeta};
+use ifc_lite_processing::element::{
+    produce_element_meshes, ElementJobKind, ElementMeshJob, MeshProductionContext,
+    MeshProductionOptions,
+};
+use ifc_lite_processing::MeshData;
+use rustc_hash::FxHashMap;
+use std::sync::Arc;
+
+/// A geometry element job: `(express_id, byte_start, byte_end)`.
+type Job = (u32, usize, usize);
+/// The #1623 don't-bake plan: RepresentationMap id ⇒ `(occurrence_count, min-id)`.
+type Plan = FxHashMap<u32, (u32, u32)>;
+
+fn synthetic_bytes() -> Vec<u8> {
+    let path = format!(
+        "{}/../geometry/tests/fixtures/mapped_instances_synthetic.ifc",
+        env!("CARGO_MANIFEST_DIR")
+    );
+    std::fs::read(&path).unwrap_or_else(|e| panic!("read {path}: {e}"))
+}
+
+/// Scan the file for (a) geometry element jobs and (b) the #1623 don't-bake plan
+/// (RepresentationMap source ids an IfcMappedItem instantiates >= 2x) — the exact
+/// data the wasm pre-pass ships to workers, computed here inline via the decoder
+/// (IfcMappedItem.MappingSource = attribute 0), exactly as the pre-pass does.
+fn scan(
+    content: &[u8],
+    index: &Arc<ifc_lite_core::EntityIndex>,
+) -> (Vec<Job>, Plan) {
+    let mut jobs: Vec<(u32, usize, usize)> = Vec::new();
+    let mut counts: FxHashMap<u32, (u32, u32)> = FxHashMap::default();
+    let mut decoder = EntityDecoder::with_arc_index(content, index.clone());
+    let mut scanner = EntityScanner::new(content);
+    while let Some((id, type_name, start, end)) = scanner.next_entity() {
+        if type_name == "IFCMAPPEDITEM" {
+            if let Ok(ent) = decoder.decode_at_with_id(id, start, end) {
+                if let Some(src) = ent.get_ref(0) {
+                    counts
+                        .entry(src)
+                        .and_modify(|(c, t)| {
+                            *c += 1;
+                            if id < *t {
+                                *t = id;
+                            }
+                        })
+                        .or_insert((1, id));
+                }
+            }
+        } else if has_geometry_by_name(type_name) {
+            jobs.push((id, start, end));
+        }
+    }
+    let plan: FxHashMap<u32, (u32, u32)> =
+        counts.into_iter().filter(|(_, (c, _))| *c >= 2).collect();
+    (jobs, plan)
+}
+
+fn world_vertices(m: &MeshData) -> Vec<[f64; 3]> {
+    let n = m.positions.len() / 3;
+    (0..n)
+        .map(|v| {
+            [
+                m.origin[0] + m.positions[v * 3] as f64,
+                m.origin[1] + m.positions[v * 3 + 1] as f64,
+                m.origin[2] + m.positions[v * 3 + 2] as f64,
+            ]
+        })
+        .collect()
+}
+
+fn apply(t: &[f32; 16], p: [f64; 3]) -> [f64; 3] {
+    let (x, y, z) = (p[0], p[1], p[2]);
+    let wx = t[0] as f64 * x + t[1] as f64 * y + t[2] as f64 * z + t[3] as f64;
+    let wy = t[4] as f64 * x + t[5] as f64 * y + t[6] as f64 * z + t[7] as f64;
+    let wz = t[8] as f64 * x + t[9] as f64 * y + t[10] as f64 * z + t[11] as f64;
+    let ww = t[12] as f64 * x + t[13] as f64 * y + t[14] as f64 * z + t[15] as f64;
+    [wx / ww, wy / ww, wz / ww]
+}
+
+fn max_err(a: &[[f64; 3]], b: &[[f64; 3]]) -> f64 {
+    assert_eq!(a.len(), b.len(), "vertex count mismatch ({} vs {})", a.len(), b.len());
+    a.iter()
+        .zip(b)
+        .map(|(p, q)| ((p[0] - q[0]).powi(2) + (p[1] - q[1]).powi(2) + (p[2] - q[2]).powi(2)).sqrt())
+        .fold(0.0f64, f64::max)
+}
+
+/// Run every job through the canonical producer with the given router, returning
+/// (materialized meshes, collected don't-bake occurrences).
+fn produce(
+    content: &[u8],
+    index: &Arc<ifc_lite_core::EntityIndex>,
+    jobs: &[Job],
+    router: &GeometryRouter,
+) -> (Vec<MeshData>, Vec<ifc_lite_processing::RawInstanceOccurrence>) {
+    let mut decoder = EntityDecoder::with_arc_index(content, index.clone());
+    decoder.seed_unit_scales(router.unit_scale(), 1.0);
+    let void_index = FxHashMap::default();
+    let geometry_style_index = FxHashMap::default();
+    let indexed_colour_full = FxHashMap::default();
+    let element_material_colors = FxHashMap::default();
+    let texture_index = FxHashMap::default();
+    let ctx = MeshProductionContext {
+        void_index: &void_index,
+        geometry_style_index: &geometry_style_index,
+        indexed_colour_full: &indexed_colour_full,
+        element_material_colors: &element_material_colors,
+        texture_index: &texture_index,
+        site_local_rotation: None,
+    };
+    let opts = MeshProductionOptions::default();
+    let mut meshes = Vec::new();
+    let mut occ = Vec::new();
+    for &(id, start, end) in jobs {
+        let Ok(entity) = decoder.decode_at_with_id(id, start, end) else {
+            continue;
+        };
+        let ifc_type = entity.ifc_type;
+        let produced = produce_element_meshes(
+            &ElementMeshJob {
+                id,
+                ifc_type,
+                entity: &entity,
+                kind: ElementJobKind::Product,
+                element_color: None,
+                metadata: None,
+            },
+            &ctx,
+            &opts,
+            &mut decoder,
+            router,
+        );
+        meshes.extend(produced.meshes);
+        occ.extend(produced.instance_occurrences);
+    }
+    (meshes, occ)
+}
+
+#[test]
+fn browser_batch_local_instanced_equals_flat_synthetic() {
+    let content = synthetic_bytes();
+    let index = Arc::new(build_entity_index(&content));
+    let (jobs, plan) = scan(&content, &index);
+    assert!(!plan.is_empty(), "fixture has no repeated mapped source");
+
+    // Flat baseline: no plan ⇒ every occurrence materializes.
+    let flat_router = GeometryRouter::with_scale(1.0);
+    let (flat_meshes, flat_occ) = produce(&content, &index, &jobs, &flat_router);
+    assert!(flat_occ.is_empty(), "flat run must not emit don't-bake occurrences");
+    let mut flat_by_id: FxHashMap<u32, Vec<[f64; 3]>> = FxHashMap::default();
+    for m in &flat_meshes {
+        if m.geometry_class == 0 && !m.positions.is_empty() {
+            flat_by_id.entry(m.express_id).or_insert_with(|| world_vertices(m));
+        }
+    }
+
+    // Browser batch-local run: ONE router (as a wasm batch has), armed batch-local.
+    let mut bl_router = GeometryRouter::with_scale(1.0);
+    bl_router.enable_shared_mapped_item_cache(GeometryRouter::new_mapped_item_cache());
+    bl_router.enable_output_instancing(Arc::new(plan));
+    bl_router.set_instancing_batch_local(true);
+    let (bl_meshes, bl_occ) = produce(&content, &index, &jobs, &bl_router);
+    assert!(!bl_occ.is_empty(), "batch-local run emitted no don't-bake occurrences");
+
+    // Collate EXACTLY as process_geometry_batch_partitioned does: materialized
+    // instanceable meshes as real refs + occurrences as empty-geometry refs.
+    let occ_metas: Vec<InstanceMeta> = bl_occ
+        .iter()
+        .map(|o| InstanceMeta {
+            transform: o.world_transform,
+            local_transform: None,
+            canonical_transform: None,
+            rep_identity: o.rep_identity,
+            instanceable: true,
+        })
+        .collect();
+    let mut refs: Vec<InstanceMeshRef> = bl_meshes
+        .iter()
+        .map(|m| InstanceMeshRef {
+            positions: &m.positions,
+            normals: &m.normals,
+            indices: &m.indices,
+            origin: m.origin,
+            instance_meta: m.instance.as_ref(),
+            entity_id: m.express_id,
+            color: m.color,
+        })
+        .collect();
+    for (o, meta) in bl_occ.iter().zip(occ_metas.iter()) {
+        refs.push(InstanceMeshRef {
+            positions: &[],
+            normals: &[],
+            indices: &[],
+            origin: [0.0, 0.0, 0.0],
+            instance_meta: Some(meta),
+            entity_id: o.express_id,
+            color: o.color,
+        });
+    }
+    let collated = collate_refs(&refs, 2, [0.0, 0.0, 0.0]);
+    assert!(!collated.templates.is_empty(), "no instanced template formed");
+
+    // Every occurrence (incl. the template's own) recomposes to its flat world verts.
+    let tol = 1e-6;
+    let mut checked = 0usize;
+    for tmpl in &collated.templates {
+        let template_world = world_vertices(&bl_meshes[tmpl.template_index]);
+        for o in &tmpl.occurrences {
+            let entity_id = refs[o.mesh_index].entity_id;
+            let flat_world = flat_by_id
+                .get(&entity_id)
+                .unwrap_or_else(|| panic!("occurrence {entity_id} has no flat counterpart"));
+            let recomposed: Vec<[f64; 3]> =
+                template_world.iter().map(|&p| apply(&o.transform, p)).collect();
+            let err = max_err(&recomposed, flat_world);
+            assert!(err < tol, "occurrence {entity_id}: world-vertex error {err:.3e} m exceeds 1um");
+            checked += 1;
+        }
+    }
+
+    // Materialize reduction: batch-local materialized far fewer meshes than flat,
+    // and templates + occurrences account for every flat occurrence.
+    let flat_n = flat_by_id.len();
+    let bl_n = bl_meshes.iter().filter(|m| m.geometry_class == 0 && !m.positions.is_empty()).count();
+    let bl_verts: usize = bl_meshes.iter().map(|m| m.positions.len() / 3).sum();
+    let flat_verts: usize = flat_meshes.iter().map(|m| m.positions.len() / 3).sum();
+    assert!(bl_n < flat_n, "batch-local materialized ({bl_n}) not fewer than flat ({flat_n})");
+    assert_eq!(checked, flat_n, "collated occurrences must cover every flat occurrence");
+    eprintln!(
+        "[#1623 P3] synthetic batch-local: flat = {flat_n} meshes / {flat_verts} verts; \
+         batch-local = {bl_n} materialized + {} shard occurrences / {bl_verts} materialized verts \
+         (reduction: {} meshes, {} verts)",
+        bl_occ.len(),
+        flat_n - bl_n,
+        flat_verts.saturating_sub(bl_verts),
+    );
+}

--- a/rust/processing/tests/module_size_allowlist.txt
+++ b/rust/processing/tests/module_size_allowlist.txt
@@ -66,10 +66,12 @@
 # +65: promote the per-router IfcMappedItem source cache to a model-wide SharedMappedItemCache (type alias + field + new_/enable_ setters + unique-count diagnostic), meshing each source once model-wide (#1623).
 # +38: #1623 Phase 2 don't-bake — MappedInstancePlan type alias + output_instancing_plan field + enable_/getter + `mod instancing` decl.
 # +28: #858 palette guard — indexed_colour_split_ids field + enable_indexed_colour_split_guard setter + is_indexed_colour_split_source accessor (routes an indexed-colour mapped source to the flat per-palette split instead of a colour-collapsing instance placeholder).
-     704 rust/geometry/src/router/mod.rs
+# +42: #1623 Phase 3 batch-local template mode — instancing_batch_local flag + instanced_sources_materialized tracker fields + set_/getter/mark_source_materialized_if_first methods (browser per-batch don't-bake).
+     746 rust/geometry/src/router/mod.rs
 # +65: #1623 Phase 2 don't-bake — the top-level mapped-item intercept (template retag + instance placeholder) + the public/impl process_element_with_submeshes split; the two eligibility/ensure helpers were extracted to router/instancing.rs (new, 92 lines) to hold the net down.
 # +7: #858 palette guard — exclude an indexed-colour single-solid source from the don't-bake decision (one .filter on the resolved solid id + explanatory comment) so its per-triangle palette survives the flat split.
-    1144 rust/geometry/src/router/processing.rs
+# +16: #1623 Phase 3 — thread the batch-local vs global template decision through the mapped-item intercept (is_template match arm + retag guard).
+    1162 rust/geometry/src/router/processing.rs
 # +26: is_rtc_votable_representation predicate + doc — Surface3D is meshable but must NOT cast RTC votes (#1526 pollution via absolute-coord surfaces).
      472 rust/geometry/src/router/rtc_offset.rs
 # +1: reveal-quads comment expanded to 2 lines (dead-symbol reference fix, no code change).
@@ -105,14 +107,17 @@
      440 rust/processing/src/symbolic/items.rs
 # +6: wire per-batch point-cache hit/miss stats into record_pipeline_batch (perf/brep-point-cache-instrumentation).
 # +13: attach the per-worker shared IfcMappedItem source cache to each batch router, mirroring the item-dedup attach (#1623).
-     786 rust/wasm-bindings/src/api/gpu_meshes/batch.rs
+# +155: #1623 Phase 3 browser don't-bake — produce_batch gains arm_instancing (batch-local plan arm + occurrence collection + finalize call/return-tuple change) and the partitioned path folds the kept occurrences into the IFNS shard as empty-geometry refs; the finalize + recovery bodies were extracted to gpu_meshes/instancing.rs (new, ~165 lines) to hold the net down.
+     941 rust/wasm-bindings/src/api/gpu_meshes/batch.rs
 # +108: build the referenced-repmaps + instantiated-type-id sets and the material-layer index ONCE in the streaming pre-pass (from spans this scan already collected) and emit them as a `prepass-columns` event, so every geometry worker skips its own full-file walk on the first batch (perf/single-scan #957/#563).
-     735 rust/wasm-bindings/src/api/gpu_meshes/prepass.rs
+# +14: #1623 Phase 3 — tally the don't-bake MappedInstancePlan from the same IfcMappedItem spans and emit it on the prepass-columns event (mirrors the referenced-repmaps ship).
+     749 rust/wasm-bindings/src/api/gpu_meshes/prepass.rs
      436 rust/wasm-bindings/src/api/grid_lines.rs
 # +75: add the setReferencedRepmaps / setInstantiatedTypeIds / setMaterialLayerIndex wasm setters that install the pre-pass-computed per-content structures into the worker's IfcAPI (perf/single-scan #957/#563), mirroring setEntityIndex.
 # +23: add the cached_source_bytes session field (doc + init + clearPrePassCache drop) for cold-load lever 1c (setSourceBytes); the setter + FromSource batch variants live in the new sub-400 gpu_meshes/batch_from_source.rs, not here (perf/coldload-setsourcebytes).
 # +37: hold the per-worker shared IfcMappedItem source cache field + drop it on content swap / setEntityIndex / setTessellationQuality, mirroring cached_item_dedup (#1623).
 # +10: drop the shared mapped-item cache in set_skip_small_cuts too (boolean-processor swap; #1623 P1 settings-hole fix).
-     1023 rust/wasm-bindings/src/api/mod.rs
+# +65: #1623 Phase 3 — cached_mapped_instance_plan field (doc + init + clear on clearPrePassCache/setEntityIndex) + setMappedInstancePlan wasm setter + mapped_instance_plan accessor (mirrors setReferencedRepmaps).
+     1088 rust/wasm-bindings/src/api/mod.rs
      692 rust/wasm-bindings/src/zero_copy/mesh.rs
      743 rust/wasm-bindings/src/zero_copy/symbolic.rs

--- a/rust/wasm-bindings/src/api/gpu_meshes/batch.rs
+++ b/rust/wasm-bindings/src/api/gpu_meshes/batch.rs
@@ -55,7 +55,19 @@ impl IfcAPI {
         material_element_ids: Option<Vec<u32>>,
         material_color_counts: Option<Vec<u32>>,
         material_colors_rgba: Option<Vec<u8>>,
-    ) -> (Vec<ElementMeshOutput>, ifc_lite_geometry::GeometryDiagnostics) {
+        // #1623 Phase 3: when `true` AND a mapped-instance plan is installed AND the
+        // model is unshifted AND geometry hashing is off, arm the batch router in
+        // BATCH-LOCAL don't-bake mode so a repeated single-solid mapped source
+        // materializes once per batch and the rest ride the IFNS shard. Only the
+        // partitioned entry point (which holds a flat MeshCollection for the
+        // sub-threshold recovery) passes `true`; the flat / instanced-only entry
+        // points pass `false`, keeping their output byte-identical.
+        arm_instancing: bool,
+    ) -> (
+        Vec<ElementMeshOutput>,
+        ifc_lite_geometry::GeometryDiagnostics,
+        Vec<super::instancing::ShardOccurrence>,
+    ) {
         use crate::api::styling::resolve_element_color;
         use ifc_lite_core::EntityDecoder;
         use ifc_lite_geometry::GeometryRouter;
@@ -151,8 +163,10 @@ impl IfcAPI {
         // Arm the shared IfcMappedItem source cache (#1623) against the per-worker
         // cache so a RepresentationMap source shared across owning elements is
         // meshed ONCE across batches, not once per batch. Held on the IfcApi like
-        // the item-dedup cache above (one per worker session).
-        {
+        // the item-dedup cache above (one per worker session). Keep a clone for the
+        // Phase 3 don't-bake finalize below (sub-threshold occurrences recover flat
+        // from this registry).
+        let mapped_item_cache = {
             let mut slot = self
                 .cached_mapped_item
                 .lock()
@@ -160,7 +174,32 @@ impl IfcAPI {
             let cache = slot
                 .get_or_insert_with(GeometryRouter::new_mapped_item_cache)
                 .clone();
-            router.enable_shared_mapped_item_cache(cache);
+            router.enable_shared_mapped_item_cache(cache.clone());
+            cache
+        };
+
+        // #1623 Phase 3 "don't-bake": arm the batch router in BATCH-LOCAL mode when
+        // the partitioned path asked for it AND a plan is installed. Gated on
+        // `!needs_shift` (unshifted models only): the browser shard math is
+        // coordinate-space-agnostic (collate reduces to the post-RTC frame and the
+        // renderer applies any site rotation uniformly), but georef/site-local
+        // byte-identity needs a headed-browser check, so — mirroring the native
+        // `coord_space != site_local` guard — georef routes to flat here for now
+        // (loosen this predicate once the coord space is verified in-browser). Also
+        // gated on hashing being OFF: the #924 per-element geometry-diff fingerprint
+        // is computed during the per-occurrence materialize, which the don't-bake
+        // path skips — so when the diff feature needs those hashes, every occurrence
+        // materializes exactly as before. `None` ⇒ router unarmed ⇒ every occurrence
+        // materializes (byte-identical to the pre-Phase-3 partitioned path).
+        let instancing_armed = arm_instancing && !needs_shift && hash_tolerance.is_none();
+        let instance_plan = if instancing_armed {
+            self.mapped_instance_plan()
+        } else {
+            None
+        };
+        if let Some(plan) = instance_plan.as_ref() {
+            router.enable_output_instancing(plan.clone());
+            router.set_instancing_batch_local(true);
         }
 
         // Attach the per-content material-layer index so single-solid walls and
@@ -319,6 +358,11 @@ impl IfcAPI {
         let mut batch_elements: u64 = 0;
         let mut batch_backstop: u64 = 0;
 
+        // #1623 Phase 3: don't-bake occurrences collected across the batch's
+        // elements (empty when the router is unarmed). Resolved after the loop into
+        // shard instances (kept) + recovered flat meshes (sub-threshold).
+        let mut all_occurrences: Vec<ifc_lite_processing::RawInstanceOccurrence> = Vec::new();
+
         // Process only the entities specified in jobs_flat — every job runs
         // THE canonical per-element producer (`ifc_lite_processing::element`),
         // the same code the native pipeline runs.
@@ -404,6 +448,9 @@ impl IfcAPI {
             }
             batch_elements += 1;
             batch_backstop += produced.degenerate_triangles_dropped;
+            if !produced.instance_occurrences.is_empty() {
+                all_occurrences.extend(produced.instance_occurrences);
+            }
             outputs.push(ElementMeshOutput {
                 id,
                 meshes: produced.meshes,
@@ -449,6 +496,63 @@ impl IfcAPI {
             }
         }
 
+        // #1623 Phase 3: resolve the batch's don't-bake occurrences into shard
+        // instances (kept) + recovered flat meshes (sub-threshold / ineligible
+        // template). Build the per-rep template facts from the retained instanceable
+        // meshes (batch-local mode materialized one template per source), then split.
+        // Empty (unarmed / no occurrences) ⇒ nothing changes, byte-identical output.
+        let shard_occurrences = if all_occurrences.is_empty() {
+            Vec::new()
+        } else {
+            let mut template_by_rep: rustc_hash::FxHashMap<u128, super::instancing::TemplateInfo> =
+                rustc_hash::FxHashMap::default();
+            for out in &outputs {
+                for m in &out.meshes {
+                    if m.positions.is_empty() {
+                        continue;
+                    }
+                    if let Some(im) = m.instance.as_ref() {
+                        if im.instanceable {
+                            // Shard-eligible = the partition's candidate gate: opaque,
+                            // untextured, ordinary-occurrence (class 0) geometry.
+                            let eligible = m.color[3] >= INSTANCED_ALPHA_CUTOFF
+                                && m.texture.is_none()
+                                && m.geometry_class == 0;
+                            template_by_rep
+                                .entry(im.rep_identity)
+                                .or_insert(super::instancing::TemplateInfo { eligible });
+                        }
+                    }
+                }
+            }
+            let rtc = if needs_shift {
+                [rtc_x, rtc_y, rtc_z]
+            } else {
+                [0.0, 0.0, 0.0]
+            };
+            let mut recovered_flats: Vec<ifc_lite_processing::MeshData> = Vec::new();
+            let shard = super::instancing::resolve_batch_occurrences(
+                std::mem::take(&mut all_occurrences),
+                &template_by_rep,
+                &mapped_item_cache,
+                rtc,
+                INSTANCE_MIN_OCCURRENCES as usize,
+                &mut recovered_flats,
+            );
+            // Recovered occurrences ride as their own single-mesh outputs; the
+            // partition routes them to the flat MeshCollection (instance meta is None
+            // ⇒ never instanced), byte-identical to the flat baseline for that element.
+            for m in recovered_flats {
+                let id = m.express_id;
+                outputs.push(ElementMeshOutput {
+                    id,
+                    meshes: vec![m],
+                    geometry_hash: None,
+                });
+            }
+            shard
+        };
+
         // Fold this batch into the per-worker PipelineDiagnostics accumulator
         // (read by JS via getPipelineDiagnostics). Counts + two Date.now()
         // reads — cheap enough to stay on the normal load path unconditionally.
@@ -474,7 +578,7 @@ impl IfcAPI {
             &csg_diag,
         );
 
-        (outputs, csg_diag)
+        (outputs, csg_diag, shard_occurrences)
     }
 }
 
@@ -507,10 +611,12 @@ impl IfcAPI {
         material_colors_rgba: Option<Vec<u8>>,
     ) -> MeshCollection {
         let num_jobs = jobs_flat.len() / 3;
-        let (outputs, csg_diag) = self.produce_batch(
+        // arm_instancing = false: the flat path has no IFNS shard to hold don't-bake
+        // occurrences, so every occurrence must materialize (byte-identical output).
+        let (outputs, csg_diag, _shard_occurrences) = self.produce_batch(
             data, jobs_flat, unit_scale, rtc_x, rtc_y, rtc_z, needs_shift, void_keys,
             void_counts, void_values, style_ids, style_colors, plane_angle_to_radians,
-            material_element_ids, material_color_counts, material_colors_rgba,
+            material_element_ids, material_color_counts, material_colors_rgba, false,
         );
         let mut mesh_collection = MeshCollection::with_capacity(num_jobs);
         if needs_shift {
@@ -562,10 +668,14 @@ impl IfcAPI {
         // NB: this instanced-only export returns raw shard bytes with no
         // MeshCollection carrier, so CSG diagnostics are intentionally dropped. It
         // is not the worker's default path (partitioned/flat carry the counts).
-        let (outputs, _) = self.produce_batch(
+        // arm_instancing = false: with no flat carrier there is nowhere to route the
+        // don't-bake sub-threshold recovery, so every occurrence materializes here
+        // and this export stays byte-identical (it collates the baked meshes as
+        // before). Only `process_geometry_batch_partitioned` arms the don't-bake path.
+        let (outputs, _, _shard_occurrences) = self.produce_batch(
             data, jobs_flat, unit_scale, rtc_x, rtc_y, rtc_z, needs_shift, void_keys,
             void_counts, void_values, style_ids, style_colors, plane_angle_to_radians,
-            material_element_ids, material_color_counts, material_colors_rgba,
+            material_element_ids, material_color_counts, material_colors_rgba, false,
         );
         let meshes: Vec<ifc_lite_processing::MeshData> =
             outputs.into_iter().flat_map(|o| o.meshes).collect();
@@ -637,10 +747,16 @@ impl IfcAPI {
         material_colors_rgba: Option<Vec<u8>>,
     ) -> PartitionedBatch {
         let num_jobs = jobs_flat.len() / 3;
-        let (outputs, csg_diag) = self.produce_batch(
+        // arm_instancing = true (#1623 Phase 3): the partitioned path holds a flat
+        // MeshCollection, so it CAN route the don't-bake sub-threshold recovery to
+        // flat — the only entry point that arms it. `shard_occurrences` are the kept
+        // don't-bake occurrences (pose-only, no baked vertices); their template
+        // materialized once in `outputs`, and any recovered flats are already
+        // appended to `outputs`.
+        let (outputs, csg_diag, shard_occurrences) = self.produce_batch(
             data, jobs_flat, unit_scale, rtc_x, rtc_y, rtc_z, needs_shift, void_keys,
             void_counts, void_values, style_ids, style_colors, plane_angle_to_radians,
-            material_element_ids, material_color_counts, material_colors_rgba,
+            material_element_ids, material_color_counts, material_colors_rgba, true,
         );
         let mut mesh_collection = MeshCollection::with_capacity(num_jobs);
         if needs_shift {
@@ -688,6 +804,15 @@ impl IfcAPI {
                 mesh_collection.push_geometry_hash(out.id, hash);
             }
         }
+        // #1623 Phase 3: fold the kept don't-bake occurrence counts into the per-rep
+        // tally so a batch-local template (materialized ONCE, so count 1 among the
+        // candidates) plus its N shard occurrences clears INSTANCE_MIN_OCCURRENCES
+        // and routes to the instanced shard (the finalize already applied that gate,
+        // so this only confirms it). The template's geometry rides the shard once;
+        // the occurrences ride as pose-only instances against it.
+        for occ in &shard_occurrences {
+            *counts.entry(occ.rep_identity).or_insert(0) += 1;
+        }
         let mut instanced: Vec<ifc_lite_processing::MeshData> = Vec::new();
         for mesh_data in candidates {
             let instance_it = mesh_data.instance.as_ref().is_some_and(|im| {
@@ -701,8 +826,27 @@ impl IfcAPI {
                 mesh_collection.add(MeshDataJs::from_mesh_data(mesh_data));
             }
         }
-        let instanced_occurrences = instanced.len();
-        let refs: Vec<ifc_lite_geometry::InstanceMeshRef> = instanced
+        // Each materialized instanced mesh is one shard instance; each kept don't-bake
+        // occurrence adds one more. Report the sum so the viewer's mesh total reflects
+        // ALL rendered geometry (flat + instanced), not just the flat MeshCollection.
+        let instanced_occurrences = instanced.len() + shard_occurrences.len();
+        // #1623 Phase 3: back the kept don't-bake occurrences with InstanceMeta storage
+        // that outlives `refs` — `collate_refs` reads each placeholder's PRE-RTC world
+        // transform (local/canonical identity) to derive its `rel_k` against the
+        // batch-local template, exactly as a materialized occurrence would. Building
+        // these EMPTY-geometry refs is the whole Phase 3 win: the occurrence vertices
+        // were never materialized.
+        let occ_metas: Vec<ifc_lite_geometry::InstanceMeta> = shard_occurrences
+            .iter()
+            .map(|o| ifc_lite_geometry::InstanceMeta {
+                transform: o.world_transform,
+                local_transform: None,
+                canonical_transform: None,
+                rep_identity: o.rep_identity,
+                instanceable: true,
+            })
+            .collect();
+        let mut refs: Vec<ifc_lite_geometry::InstanceMeshRef> = instanced
             .iter()
             .map(|m| ifc_lite_geometry::InstanceMeshRef {
                 positions: &m.positions,
@@ -714,6 +858,17 @@ impl IfcAPI {
                 color: m.color,
             })
             .collect();
+        for (o, meta) in shard_occurrences.iter().zip(occ_metas.iter()) {
+            refs.push(ifc_lite_geometry::InstanceMeshRef {
+                positions: &[],
+                normals: &[],
+                indices: &[],
+                origin: [0.0, 0.0, 0.0],
+                instance_meta: Some(meta),
+                entity_id: o.entity_id,
+                color: o.color,
+            });
+        }
         // min_group == the routing threshold so collate_refs never re-flattens a group
         // that already passed the count gate; only its own try_inverse / shape-mismatch
         // safety net can still drop a (rare, degenerate) group to a singleton template.

--- a/rust/wasm-bindings/src/api/gpu_meshes/instancing.rs
+++ b/rust/wasm-bindings/src/api/gpu_meshes/instancing.rs
@@ -1,0 +1,148 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! #1623 Phase 3 browser don't-bake finalize.
+//!
+//! The batch router (armed in BATCH-LOCAL mode) materializes ONE template per
+//! repeated single-solid `IfcRepresentationMap` source per batch and emits every
+//! OTHER occurrence as a lightweight [`RawInstanceOccurrence`] (no per-occurrence
+//! vertex bake). This module turns those raw occurrences into the two outputs the
+//! partitioned batch needs:
+//!
+//! - [`ShardOccurrence`]s: occurrences whose (in-batch) template is shard-eligible
+//!   AND whose group clears the instancing threshold. They ride the IFNS shard as
+//!   pose-only instances (empty-geometry `InstanceMeshRef`s → `collate_refs`), so
+//!   their vertices are never materialized — the Phase 3 CPU win.
+//! - recovered flat [`MeshData`]s: every other occurrence, baked from the shared
+//!   mapped-item source registry (`bake_source_at_world`) so no geometry is lost.
+//!   These render flat exactly as if instancing had never fired (byte-identical
+//!   world triangles to the flat baseline, mirroring the native orphan recovery).
+
+use ifc_lite_geometry::{bake_source_at_world, SharedMappedItemCache};
+use ifc_lite_processing::{MeshData, RawInstanceOccurrence};
+use rustc_hash::FxHashMap;
+
+/// A batch-local template's shard-relevant facts: its PRE-RTC composed world
+/// transform and whether it is shard-eligible (opaque, untextured, ordinary
+/// occurrence geometry — the exact criteria the partition routes a candidate to
+/// the instanced shard by). Built by the batch from each retained instanceable
+/// mesh; consumed here to decide keep-as-shard vs recover-flat per rep group.
+pub(super) struct TemplateInfo {
+    pub eligible: bool,
+}
+
+/// One resolved don't-bake occurrence, ready to ride the IFNS shard as a pose-only
+/// instance. Carries no geometry (the batch-local template supplies it) — only the
+/// per-occurrence id, colour, and PRE-RTC composed world transform. The partition
+/// wraps each as an empty-geometry `InstanceMeshRef` so `collate_refs` derives its
+/// `rel_k` against the template, exactly as a materialized occurrence would.
+pub(super) struct ShardOccurrence {
+    pub entity_id: u32,
+    pub color: [f32; 4],
+    pub rep_identity: u128,
+    /// PRE-RTC composed world transform (row-major) — `RawInstanceOccurrence::world_transform`.
+    pub world_transform: [f64; 16],
+}
+
+/// Resolve the batch's collected don't-bake occurrences (#1623 Phase 3). For each
+/// rep group with a SHARD-ELIGIBLE in-batch template whose total occurrence count
+/// (template + placeholders) clears `min_occurrences`, the occurrences become
+/// [`ShardOccurrence`]s; every other occurrence is RECOVERED FLAT (baked from the
+/// shared source registry) and pushed to `recovered_flats` so nothing is lost.
+/// Deterministic: groups are visited in rep-id order and the shard output is sorted.
+pub(super) fn resolve_batch_occurrences(
+    raw: Vec<RawInstanceOccurrence>,
+    template_by_rep: &FxHashMap<u128, TemplateInfo>,
+    mapped_item_cache: &SharedMappedItemCache,
+    rtc: [f64; 3],
+    min_occurrences: usize,
+    recovered_flats: &mut Vec<MeshData>,
+) -> Vec<ShardOccurrence> {
+    if raw.is_empty() {
+        return Vec::new();
+    }
+    let mut by_rep: FxHashMap<u128, Vec<RawInstanceOccurrence>> = FxHashMap::default();
+    for occ in raw {
+        by_rep.entry(occ.rep_identity).or_default().push(occ);
+    }
+    let mut groups: Vec<(u128, Vec<RawInstanceOccurrence>)> = by_rep.into_iter().collect();
+    groups.sort_by_key(|(rep, _)| *rep);
+
+    let mut shard: Vec<ShardOccurrence> = Vec::new();
+    for (rep, occs) in groups {
+        // Keep as shard instances only when a shard-eligible in-batch template exists
+        // (batch-local mode materializes one per source, so it normally does) AND the
+        // group (template + occurrences) clears the instancing gate — matching the
+        // partition's `INSTANCE_MIN_OCCURRENCES` routing. Otherwise recover flat: the
+        // template renders flat and these occurrences must too.
+        let keep = template_by_rep
+            .get(&rep)
+            .is_some_and(|t| t.eligible)
+            && (occs.len() + 1) >= min_occurrences;
+        if keep {
+            for occ in occs {
+                shard.push(ShardOccurrence {
+                    entity_id: occ.express_id,
+                    color: occ.color,
+                    rep_identity: rep,
+                    world_transform: occ.world_transform,
+                });
+            }
+        } else {
+            recover_flat(rep, &occs, mapped_item_cache, rtc, recovered_flats);
+        }
+    }
+    // Deterministic shard-instance order (occurrences arrive in job order, already
+    // deterministic, but sort defensively so the wire bytes are stable run to run).
+    shard.sort_by_key(|o| (o.entity_id, o.rep_identity));
+    shard
+}
+
+/// Rebuild each occurrence of `rep` as a standalone flat [`MeshData`] from the
+/// shared source registry (source-coords geometry placed at the occurrence's world
+/// transform, post-RTC) — geometrically equal to the flat baked occurrence (same
+/// world triangles). The source is registered by `ensure_shared_mapped_source` on
+/// the don't-bake path, so it is present here; a missing/degenerate source (empty
+/// mesh or a per-element CSG-budget trip that skipped the cache insert) is the only
+/// drop, mirroring the native orphan recovery.
+fn recover_flat(
+    rep: u128,
+    occs: &[RawInstanceOccurrence],
+    mapped_item_cache: &SharedMappedItemCache,
+    rtc: [f64; 3],
+    out: &mut Vec<MeshData>,
+) {
+    // Mapped rep_identity is the RepresentationMap source id (always < 2^32).
+    let source_id = rep as u32;
+    let source = mapped_item_cache
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .get(&source_id)
+        .cloned();
+    let Some(source) = source else {
+        return;
+    };
+    for occ in occs {
+        let (positions, normals, indices) =
+            bake_source_at_world(&source, &occ.world_transform, rtc);
+        if positions.is_empty() || indices.is_empty() {
+            continue;
+        }
+        out.push(
+            MeshData::new(
+                occ.express_id,
+                occ.ifc_type.clone(),
+                positions,
+                normals,
+                indices,
+                occ.color,
+            )
+            .with_element_metadata(
+                occ.global_id.clone(),
+                occ.name.clone(),
+                occ.presentation_layer.clone(),
+            ),
+        );
+    }
+}

--- a/rust/wasm-bindings/src/api/gpu_meshes/mod.rs
+++ b/rust/wasm-bindings/src/api/gpu_meshes/mod.rs
@@ -9,4 +9,5 @@
 
 mod batch;
 mod batch_from_source;
+mod instancing;
 mod prepass;

--- a/rust/wasm-bindings/src/api/gpu_meshes/prepass.rs
+++ b/rust/wasm-bindings/src/api/gpu_meshes/prepass.rs
@@ -568,6 +568,15 @@ impl IfcAPI {
                 &rel_defines_by_type_spans,
                 &mut decoder,
             );
+        // #1623 Phase 3 don't-bake plan: the RepresentationMap ids an IfcMappedItem
+        // instantiates >= 2 times, tallied from the SAME spans (no extra scan). The
+        // batch path arms its router with these so a repeated single-solid mapped
+        // source materializes once per batch and the rest ride as shard instances.
+        let mapped_instance_plan =
+            crate::api::styling::build_mapped_instance_plan_from_spans(
+                &mapped_item_spans,
+                &mut decoder,
+            );
         // Gate on `has_layer_set` to stay bit-identical to
         // `get_or_build_material_layer_index`, which ships an EMPTY index when the
         // file authors no layer set (its substring bail-out). from_spans reuses
@@ -595,6 +604,11 @@ impl IfcAPI {
             &columns_event,
             "instantiatedTypeIds",
             &js_sys::Uint32Array::from(type_ids_arr.as_slice()),
+        );
+        crate::api::set_js_prop(
+            &columns_event,
+            "mappedInstancePlan",
+            &js_sys::Uint32Array::from(mapped_instance_plan.as_slice()),
         );
         crate::api::set_js_prop(
             &columns_event,

--- a/rust/wasm-bindings/src/api/mod.rs
+++ b/rust/wasm-bindings/src/api/mod.rs
@@ -142,6 +142,19 @@ pub struct IfcAPI {
     cached_instantiated_type_ids:
         std::sync::Mutex<Option<std::sync::Arc<rustc_hash::FxHashSet<u32>>>>,
 
+    /// #1623 Phase 3 don't-bake plan: `IfcRepresentationMap` id ⇒ `(count, min-id)`
+    /// for every source an `IfcMappedItem` instantiates >= 2 times (the streaming
+    /// pre-pass tallies it in the same scan that builds `cached_referenced_repmaps`).
+    /// When present AND the instanced/partitioned batch path runs, the batch router
+    /// is armed with it in BATCH-LOCAL mode so a repeated single-solid mapped source
+    /// meshes ONCE per batch (the first-seen occurrence) and the rest ride as
+    /// per-occurrence instances in the IFNS shard — killing the per-occurrence
+    /// vertex materialize. `None` (never installed) ⇒ the batch path materializes
+    /// every occurrence exactly as before (byte-identical). Cleared on content swap
+    /// (`setEntityIndex`) and `clearPrePassCache`, like the other pre-pass columns.
+    cached_mapped_instance_plan:
+        std::sync::Mutex<Option<ifc_lite_geometry::MappedInstancePlan>>,
+
     /// Lazily-built surface-texture index keyed by face-set id (issue #961):
     /// decoded RGBA images + per-triangle UV maps from
     /// `IfcIndexedTriangleTextureMap`. Built once per worker (cheap substring
@@ -255,6 +268,7 @@ impl IfcAPI {
             cached_material_layer_index: std::sync::Mutex::new(None),
             cached_referenced_repmaps: std::sync::Mutex::new(None),
             cached_instantiated_type_ids: std::sync::Mutex::new(None),
+            cached_mapped_instance_plan: std::sync::Mutex::new(None),
             cached_texture_index: std::sync::Mutex::new(None),
             cached_indexed_colour_maps: std::sync::Mutex::new(None),
             compute_geometry_hashes: std::sync::atomic::AtomicBool::new(false),
@@ -315,6 +329,12 @@ impl IfcAPI {
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         inst_slot.take();
+        // The don't-bake mapped-instance plan is keyed off the previous load's
+        // IfcMappedItem scan (#1623 Phase 3); drop it so the next file rebuilds it.
+        self.cached_mapped_instance_plan
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .take();
         // The texture index is keyed off the previous load's content; drop it.
         let mut texture_slot = self
             .cached_texture_index
@@ -430,6 +450,10 @@ impl IfcAPI {
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
             .take();
+        self.cached_mapped_instance_plan
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .take();
         self.cached_texture_index
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
@@ -502,6 +526,34 @@ impl IfcAPI {
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         *slot = Some(std::sync::Arc::new(set));
+    }
+
+    /// Install the pre-computed #1623 Phase 3 don't-bake plan: the flat list of
+    /// `IfcRepresentationMap` ids that an `IfcMappedItem` instantiates >= 2 times.
+    /// The streaming pre-pass tallies it in the SAME scan that builds the referenced-
+    /// repmap set (`styling::build_mapped_instance_plan_from_spans`) and ships the id
+    /// list here. The batch path arms its router with it (batch-local template mode),
+    /// so a repeated single-solid mapped source materializes ONCE per batch and the
+    /// rest ride as instances in the IFNS shard.
+    ///
+    /// Same injection contract as [`Self::set_referenced_repmaps`]: installed after
+    /// `setEntityIndex` (which clears it on content swap), and a no-op absence leaves
+    /// the batch path materializing every occurrence (byte-identical). Each id is
+    /// stored as `(2, id)` — the batch-local router only needs the eligibility set
+    /// (count >= 2); the min-id template slot is unused in batch-local mode.
+    #[wasm_bindgen(js_name = setMappedInstancePlan)]
+    pub fn set_mapped_instance_plan(&self, source_ids: &[u32]) {
+        if source_ids.is_empty() {
+            // Nothing repeated ⇒ leave the plan unset so the router never arms.
+            return;
+        }
+        let plan: rustc_hash::FxHashMap<u32, (u32, u32)> =
+            source_ids.iter().map(|&id| (id, (2u32, id))).collect();
+        let mut slot = self
+            .cached_mapped_instance_plan
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        *slot = Some(std::sync::Arc::new(plan));
     }
 
     /// Install the pre-computed [`ifc_lite_geometry::MaterialLayerIndex`] (#563)
@@ -821,6 +873,19 @@ impl IfcAPI {
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         *slot = Some(std::sync::Arc::clone(&arc));
         arc
+    }
+
+    /// The installed #1623 Phase 3 don't-bake plan (see [`Self::set_mapped_instance_plan`]),
+    /// or `None` when the pre-pass shipped no repeated mapped sources. UNLIKE the
+    /// referenced-repmap set there is NO lazy full-file fallback: the plan is a pure
+    /// optimization, so absence just means "materialize every occurrence" (the
+    /// byte-identical default), never a correctness gap.
+    pub(crate) fn mapped_instance_plan(&self) -> Option<ifc_lite_geometry::MappedInstancePlan> {
+        self.cached_mapped_instance_plan
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .as_ref()
+            .map(std::sync::Arc::clone)
     }
 
     /// Get or lazily build the set of `IfcRepresentationMap` ids instantiated by

--- a/rust/wasm-bindings/src/api/styling/mod.rs
+++ b/rust/wasm-bindings/src/api/styling/mod.rs
@@ -10,6 +10,6 @@ mod prepass;
 pub(crate) use color::resolve_element_color;
 pub(crate) use prepass::{
     build_instantiated_type_ids, build_instantiated_type_ids_from_spans,
-    build_referenced_representation_maps, build_referenced_representation_maps_from_spans,
-    collect_type_geometry_jobs, combined_pre_pass,
+    build_mapped_instance_plan_from_spans, build_referenced_representation_maps,
+    build_referenced_representation_maps_from_spans, collect_type_geometry_jobs, combined_pre_pass,
 };

--- a/rust/wasm-bindings/src/api/styling/prepass.rs
+++ b/rust/wasm-bindings/src/api/styling/prepass.rs
@@ -224,6 +224,36 @@ pub(crate) fn build_referenced_representation_maps_from_spans(
     referenced
 }
 
+/// #1623 Phase 3 don't-bake plan: the `IfcRepresentationMap` ids that an
+/// `IfcMappedItem` instantiates >= 2 times, tallied from the SAME `IfcMappedItem`
+/// spans the streaming pre-pass already stashes for
+/// [`build_referenced_representation_maps_from_spans`]. The batch path arms its
+/// router with these (batch-local template mode) so a repeated single-solid mapped
+/// source materializes ONCE per batch and the rest ride as IFNS-shard instances.
+/// Returns the eligible source ids sorted (a deterministic wire list); a source
+/// referenced by only ONE mapped item is omitted (nothing to instance).
+pub(crate) fn build_mapped_instance_plan_from_spans(
+    spans: &[(u32, usize, usize)],
+    decoder: &mut ifc_lite_core::EntityDecoder,
+) -> Vec<u32> {
+    let mut counts: rustc_hash::FxHashMap<u32, u32> = rustc_hash::FxHashMap::default();
+    for &(id, start, end) in spans {
+        if let Ok(entity) = decoder.decode_at_with_id(id, start, end) {
+            // IfcMappedItem.MappingSource = attr 0 (the IfcRepresentationMap).
+            if let Some(source_id) = entity.get_ref(0) {
+                *counts.entry(source_id).or_insert(0) += 1;
+            }
+        }
+    }
+    let mut eligible: Vec<u32> = counts
+        .into_iter()
+        .filter(|&(_, count)| count >= 2)
+        .map(|(source_id, _)| source_id)
+        .collect();
+    eligible.sort_unstable();
+    eligible
+}
+
 /// #957 follow-up: the set of type ids that an `IfcRelDefinesByType` instantiates
 /// (i.e. the type has at least one occurrence). `processGeometryBatch` uses it to
 /// suppress type-only geometry for such types — their geometry is already drawn


### PR DESCRIPTION
## What (#1623 Phase 3 — the browser half of the materialize kill)

Phase 2 shipped don't-bake on native (server/SDK/FFI). This wires the **browser wasm** partitioned path so the browser also stops materializing every IfcMappedItem occurrence:
- Pre-pass computes the `MappedInstancePlan` (`build_mapped_instance_plan_from_spans`, emitted as a `mappedInstancePlan` prepass column).
- `setMappedInstancePlan` wasm setter installs it per worker (mirrors `setReferencedRepmaps`).
- `produce_batch` arms a **batch-local** template mode: each batch materializes its own first-seen occurrence per source as the template and the rest don't-bake, so each per-batch IFNS shard is self-contained (no cross-batch template dependency in the streaming model).
- `collate_refs` consumes empty-geometry occurrence refs → the same IFNS shard shape the renderer already draws instanced (#1238). Sub-threshold occurrences are recovered flat from the shared registry (nothing lost).

## Byte-identical (Rust-level, proven)

- `instancing_batch_local`: browser A/B — flat `64 meshes/1536 verts → 1 template + 63 shard occurrences/24 verts` (98.4% fewer materialized), every occurrence recomposes to the flat world triangles **< 1µm**.
- `dont_bake_empty_occurrence_refs_recompose_like_materialized`: empty-occurrence shard byte-identical to the materialized shard.
- Default-off inert (`process_geometry_batch` passes `arm_instancing=false`); `mesh_determinism` no re-pin; `wasm32` clippy clean.
- Conservative gate: armed only on `!needs_shift` (georef/site-local routes to flat, matching #1238 + Phase 2's site-local guard). Georef win is a one-line loosening once verified in-browser.

## ⚠️ Gated on in-browser verification

Headless proves the shard math; the renderer path (instanced draw, per-occurrence colour, picking) needs a real browser. **Do not merge until the in-browser A/B (instancing on vs off, pixel-identical world triangles + correct per-occurrence colours + picking) passes on an instance-heavy near-origin model.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)