### PR TITLE
fix(geometry): graceful handling of models over the wasm 4GB ceiling

### DIFF
--- a/.changeset/huge-file-graceful-4gb.md
+++ b/.changeset/huge-file-graceful-4gb.md
@@ -1,0 +1,6 @@
+---
+"@ifc-lite/wasm": patch
+"@ifc-lite/geometry": patch
+---
+
+Fail gracefully on models that exceed the browser's WebAssembly memory ceiling instead of a bare `unreachable executed` crash. The streaming prepass copies the whole file into wasm linear memory and builds the entity index alongside it; on wasm32 (4GB address space) a ~3GB+ model can't fit, so the allocator aborted with an opaque trap. Two changes: (1) cap the entity-index up-front reservation (`content.len() / 50` reserved ~1GB of hash slots for a ~4GB file, on top of the resident file — that alone blew the budget before the scan; now capped, a rare huge model grows the map via rehash instead of aborting), which lifts the practical browser ceiling and lowers peak memory for every large model; (2) when the prepass still traps on a very large file, surface an actionable error ("This model is X GB, which exceeds the browser's ~3GB WebAssembly ceiling — open it in the desktop app") rather than the cryptic wasm trap. Ordinary (<2GB) models are unaffected (their reservation stays under the cap; the error helper never fires).

--- a/packages/geometry/src/geometry.worker.ts
+++ b/packages/geometry/src/geometry.worker.ts
@@ -4,6 +4,7 @@
 
 import init, { initSync, IfcAPI } from '@ifc-lite/wasm';
 import { initWasmWithRetry } from './wasm-init-retry.js';
+import { largeFilePrepassError } from './huge-file-error.js';
 import type { MeshData, TessellationQuality } from './types.js';
 import { mergeGeometryDiagnostics, type GeometryDiagnostics } from './diagnostics.js';
 import {
@@ -1160,22 +1161,23 @@ async function handleMessage(e: MessageEvent<GeometryWorkerRequest>): Promise<vo
       // them as the streaming-prepass protocol. SAB-decode fallback: try the
       // zero-copy view first, fall back to a materialised copy only if
       // wasm-bindgen rejects the view.
-      let view = viewSharedBytes(sharedBuffer);
-      let triedFallback = false;
       const onEvent = (event: unknown) => {
         (self as unknown as Worker).postMessage({ type: 'prepass-stream', event });
       };
+      const runPrepass = (bytes: Uint8Array) =>
+        ifcApi.buildPrePassStreaming(bytes, onEvent, chunkSize, disabledTypes, skipTypeGeometry);
       try {
-        ifcApi.buildPrePassStreaming(view, onEvent, chunkSize, disabledTypes, skipTypeGeometry);
+        // Zero-copy SAB view first; wasm-bindgen copies it into linear memory.
+        runPrepass(viewSharedBytes(sharedBuffer));
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
-        if (!triedFallback) {
-          triedFallback = true;
-          console.warn(`[Worker] Streaming prepass with SAB view failed (${msg}), retrying with copy`);
-          view = materialiseSharedBytes(sharedBuffer);
-          ifcApi.buildPrePassStreaming(view, onEvent, chunkSize, disabledTypes, skipTypeGeometry);
-        } else {
-          throw err;
+        console.warn(`[Worker] Streaming prepass with SAB view failed (${msg}), retrying with copy`);
+        try {
+          runPrepass(materialiseSharedBytes(sharedBuffer));
+        } catch (retryErr) {
+          // Both paths trapped — on a very large model this is the wasm32 4GB
+          // limit; surface an actionable error instead of `unreachable executed`.
+          throw largeFilePrepassError(retryErr, sharedBuffer.byteLength) ?? retryErr;
         }
       }
       return;

--- a/packages/geometry/src/huge-file-error.test.ts
+++ b/packages/geometry/src/huge-file-error.test.ts
@@ -12,6 +12,17 @@ describe('largeFilePrepassError', () => {
     expect(e!.message).toMatch(/4 ?GB|32-bit|WebAssembly/);
   });
 
+  it('PRESERVES the original trap so a genuine panic on a large file is never masked', () => {
+    // A Rust panic surfaces as the same `unreachable executed` as an OOM abort;
+    // the mapped error must keep the original verbatim (message tail + cause) so
+    // a real bug is still diagnosable, not silently relabelled "too large".
+    const original = new Error('unreachable executed');
+    const e = largeFilePrepassError(original, 3.9 * GB);
+    expect(e).not.toBeNull();
+    expect(e!.message).toContain('unreachable executed');
+    expect(e!.cause).toBe(original);
+  });
+
   it('recognises the OOM/abort signatures other engines emit', () => {
     for (const m of [
       'RuntimeError: unreachable',

--- a/packages/geometry/src/huge-file-error.test.ts
+++ b/packages/geometry/src/huge-file-error.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { largeFilePrepassError } from './huge-file-error.js';
+
+const GB = 1e9;
+
+describe('largeFilePrepassError', () => {
+  it('maps a wasm OOM trap on a large file to an actionable error', () => {
+    const e = largeFilePrepassError(new Error('unreachable executed'), 3.9 * GB);
+    expect(e).not.toBeNull();
+    expect(e!.message).toContain('3.9 GB');
+    expect(e!.message).toMatch(/desktop app/);
+    expect(e!.message).toMatch(/4 ?GB|32-bit|WebAssembly/);
+  });
+
+  it('recognises the OOM/abort signatures other engines emit', () => {
+    for (const m of [
+      'RuntimeError: unreachable',
+      'Out of memory',
+      'memory access out of bounds',
+      'WebAssembly.Memory(): could not allocate memory',
+      'cannot enlarge memory arrays',
+      'grow memory failed',
+    ]) {
+      expect(largeFilePrepassError(new Error(m), 3 * GB), m).not.toBeNull();
+    }
+  });
+
+  it('does NOT hijack a small-file failure (rethrow the original)', () => {
+    // A trap on a 0.5GB file is a real bug, not the size ceiling — must pass through.
+    expect(largeFilePrepassError(new Error('unreachable executed'), 0.5 * GB)).toBeNull();
+  });
+
+  it('does NOT hijack an unrelated error on a large file', () => {
+    expect(largeFilePrepassError(new Error('malformed STEP header'), 3.9 * GB)).toBeNull();
+  });
+
+  it('handles non-Error throwables', () => {
+    expect(largeFilePrepassError('unreachable', 3 * GB)).not.toBeNull();
+  });
+
+  it('is inclusive at the 2.5 GB threshold', () => {
+    expect(largeFilePrepassError(new Error('unreachable'), 2.5 * GB)).not.toBeNull();
+    expect(largeFilePrepassError(new Error('unreachable'), 2.4 * GB)).toBeNull();
+  });
+});

--- a/packages/geometry/src/huge-file-error.ts
+++ b/packages/geometry/src/huge-file-error.ts
@@ -19,14 +19,26 @@ const OOM_SIGNATURE =
 /**
  * Returns a clear error when `err` looks like a wasm OOM trap on a large file,
  * else `null` (the caller then rethrows the original error unchanged).
+ *
+ * IMPORTANT: a Rust panic and a wasm OOM abort BOTH surface to JS as the SAME
+ * `RuntimeError: unreachable executed` — `console_error_panic_hook` prints to
+ * the console but does not re-type the exception, so the message alone can't
+ * prove OOM. This is intentionally a heuristic (large file + an OOM-shaped
+ * trap, and the caller only invokes it AFTER both the SAB-view and the full
+ * in-memory copy attempts trapped — overwhelmingly the 4GB ceiling). To make
+ * sure it never SILENTLY masks a genuine panic/assert on a large model, the
+ * mapped error preserves the original trap: verbatim in the message tail and as
+ * `.cause` for programmatic inspection.
  */
 export function largeFilePrepassError(err: unknown, byteLength: number): Error | null {
   const sizeGB = byteLength / 1e9;
-  const msg = err instanceof Error ? err.message : String(err);
-  if (sizeGB >= HUGE_FILE_GB_THRESHOLD && OOM_SIGNATURE.test(msg)) {
+  const raw = err instanceof Error ? err.message : String(err);
+  if (sizeGB >= HUGE_FILE_GB_THRESHOLD && OOM_SIGNATURE.test(raw)) {
     return new Error(
       `This model is ${sizeGB.toFixed(1)} GB, which exceeds the browser's ~3 GB WebAssembly memory ` +
-        `ceiling (32-bit address space). Open it in the ifc-lite desktop app, which has no such limit.`,
+        `ceiling (32-bit address space). Open it in the ifc-lite desktop app, which has no such limit. ` +
+        `(underlying wasm trap: ${raw})`,
+      { cause: err },
     );
   }
   return null;

--- a/packages/geometry/src/huge-file-error.ts
+++ b/packages/geometry/src/huge-file-error.ts
@@ -1,0 +1,33 @@
+/**
+ * Turn the bare wasm trap a huge model triggers in the streaming prepass into an
+ * actionable, human-readable error.
+ *
+ * The streaming prepass (`buildPrePassStreaming`) copies the whole file into
+ * wasm linear memory AND builds the entity index alongside it. On wasm32 the
+ * address space is capped at 4GB, so a ~3GB+ file cannot fit — the allocator
+ * aborts with a bare `unreachable executed` / `RuntimeError`. This maps that to
+ * a clear message pointing at the desktop app (which is 64-bit, no such limit).
+ */
+
+/** Below this the failure is treated as unrelated to size (caller rethrows). */
+const HUGE_FILE_GB_THRESHOLD = 2.5;
+
+/** wasm OOM / abort signatures across engines (V8, SpiderMonkey, JSC). */
+const OOM_SIGNATURE =
+  /unreachable|out of memory|memory access|RuntimeError|allocat|enlarge memory|grow memory|could not allocate/i;
+
+/**
+ * Returns a clear error when `err` looks like a wasm OOM trap on a large file,
+ * else `null` (the caller then rethrows the original error unchanged).
+ */
+export function largeFilePrepassError(err: unknown, byteLength: number): Error | null {
+  const sizeGB = byteLength / 1e9;
+  const msg = err instanceof Error ? err.message : String(err);
+  if (sizeGB >= HUGE_FILE_GB_THRESHOLD && OOM_SIGNATURE.test(msg)) {
+    return new Error(
+      `This model is ${sizeGB.toFixed(1)} GB, which exceeds the browser's ~3 GB WebAssembly memory ` +
+        `ceiling (32-bit address space). Open it in the ifc-lite desktop app, which has no such limit.`,
+    );
+  }
+  return null;
+}

--- a/rust/processing/tests/module_size_allowlist.txt
+++ b/rust/processing/tests/module_size_allowlist.txt
@@ -111,7 +111,8 @@
      941 rust/wasm-bindings/src/api/gpu_meshes/batch.rs
 # +108: build the referenced-repmaps + instantiated-type-id sets and the material-layer index ONCE in the streaming pre-pass (from spans this scan already collected) and emit them as a `prepass-columns` event, so every geometry worker skips its own full-file walk on the first batch (perf/single-scan #957/#563).
 # +14: #1623 Phase 3 — tally the don't-bake MappedInstancePlan from the same IfcMappedItem spans and emit it on the prepass-columns event (mirrors the referenced-repmaps ship).
-     749 rust/wasm-bindings/src/api/gpu_meshes/prepass.rs
+# +9: cap the entity-index up-front reservation (PREPASS_INDEX_RESERVE_CAP) so a ~4GB file does not reserve ~1GB of slots on top of the resident file and abort the wasm32 4GB address space before the scan (huge-file graceful-4gb).
+     758 rust/wasm-bindings/src/api/gpu_meshes/prepass.rs
      436 rust/wasm-bindings/src/api/grid_lines.rs
 # +75: add the setReferencedRepmaps / setInstantiatedTypeIds / setMaterialLayerIndex wasm setters that install the pre-pass-computed per-content structures into the worker's IfcAPI (perf/single-scan #957/#563), mirroring setEntityIndex.
 # +23: add the cached_source_bytes session field (doc + init + clearPrePassCache drop) for cold-load lever 1c (setSourceBytes); the setter + FromSource batch variants live in the new sub-400 gpu_meshes/batch_from_source.rs, not here (perf/coldload-setsourcebytes).

--- a/rust/wasm-bindings/src/api/gpu_meshes/prepass.rs
+++ b/rust/wasm-bindings/src/api/gpu_meshes/prepass.rs
@@ -222,7 +222,16 @@ impl IfcAPI {
         // tag geometry-bearing rows so we can emit jobs incrementally.
         // Entity index is built from the same pass — no second walk.
         let mut scanner = EntityScanner::new(content);
-        let estimated = content.len() / 50;
+        // Cap the up-front index reservation. On wasm32 the whole `content` slice
+        // is already resident in the 4GB linear memory (wasm-bindgen copies the
+        // buffer in), so reserving `len/50` slots — ~82M entries (~1GB) for a
+        // ~4GB file — ON TOP of that exhausts the address space before the scan
+        // even starts, aborting with a bare `unreachable executed`. Reserve at
+        // most CAP entries; a rarer huge model grows the map via rehash (a
+        // one-time cost) instead of a fatal up-front OOM. Ordinary (<2GB) files
+        // are unaffected — their `len/50` estimate stays under the cap.
+        const PREPASS_INDEX_RESERVE_CAP: usize = 40_000_000; // ~0.5GB reserved
+        let estimated = (content.len() / 50).min(PREPASS_INDEX_RESERVE_CAP);
         let mut entity_index: rustc_hash::FxHashMap<u32, (usize, usize)> =
             rustc_hash::FxHashMap::with_capacity_and_hasher(estimated, Default::default());
 


### PR DESCRIPTION
## Problem (reported from prod on a 3.9GB model)

Loading a ~4GB IFC in the browser aborts the geometry worker with a bare `unreachable executed` trap and 0 geometry:

```
[stream] processParallel start, fileSizeMB=3899.1 workerCount=1 (bound=memory)
[Worker] Streaming prepass with SAB view failed (unreachable executed), retrying with copy
[useIfc] Error in processing: Error: unreachable executed
```

**Root cause:** the streaming prepass (`buildPrePassStreaming`) copies the whole file into wasm32 linear memory (4GB address space) **and** builds the entity index alongside it. Worse, the index is pre-reserved at `content.len() / 50` — **~82M slots (~1GB) for a ~4GB file**, on top of the resident file — so the reservation aborts *before the scan even starts*. Not a regression from recent perf work (the pre-alloc dates to #1389).

## Fixes

1. **Cap the index reservation** (`PREPASS_INDEX_RESERVE_CAP = 40M`). A rare huge model grows the map via rehash (one-time cost) instead of a fatal up-front OOM. Ordinary (<2GB) files keep their exact `len/50` estimate — unaffected. Lowers peak memory for every large model and lifts the practical browser ceiling (~3.2 → ~3.5GB).
2. **Actionable error** instead of the cryptic trap. When the prepass still traps on a very large file, `huge-file-error.ts` maps the wasm OOM/abort signatures to: *"This model is X GB, which exceeds the browser's ~3GB WebAssembly ceiling — open it in the desktop app."* Standalone import-safe module, unit-tested (6 cases incl. small-file/unrelated-error pass-through).

## Honest scope

A **true 4GB model still needs native/desktop** — the file + its entity index inherently exceed wasm32's 4GB, short of a streaming-prepass refactor or wasm64. This makes the failure *clear and actionable* and raises the ceiling for ~3–3.5GB models. The streaming-prepass refactor (never resident-copy the file) is the follow-up for real in-browser 4GB.

## Verify
- Rust build + clippy clean; `mesh_determinism` unaffected; module-size ratchet green (+9 justified).
- `huge-file-error.test.ts` 6/6; full `@ifc-lite/geometry` suite 134/134; typecheck clean.
- Changeset added (`@ifc-lite/wasm` + `@ifc-lite/geometry` patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling for very large models so scanning is less likely to fail due to memory limits.
  * Replaced cryptic WebAssembly failures with a clearer message that suggests using the desktop app.
  * Added a fallback path when zero-copy processing fails, making large-file imports more resilient.

* **Tests**
  * Added coverage for large-file error handling, including size thresholds and non-standard failure messages.

* **Chores**
  * Updated internal size tracking for the large-model handling change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->