### PR TITLE
perf(native): pin mimalloc as the global allocator for ffi + server (#1623)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1508,6 +1508,7 @@ name = "ifc-lite-ffi"
 version = "4.1.0"
 dependencies = [
  "ifc-lite-processing",
+ "mimalloc",
  "rayon",
  "serde_json",
 ]
@@ -1573,6 +1574,7 @@ dependencies = [
  "ifc-lite-core",
  "ifc-lite-geometry",
  "ifc-lite-processing",
+ "mimalloc",
  "num_cpus",
  "parquet",
  "rayon",
@@ -1781,6 +1783,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a45a52f43e1c16f667ccfe4dd8c85b7f7c204fd5e3bf46c5b0db9a5c3c0b8e9"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1874,6 +1885,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d4139bb28d14ad1facf21d5eb8825051b326e172d216b39f6d31df53cc97862"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]

--- a/apps/server/Cargo.toml
+++ b/apps/server/Cargo.toml
@@ -13,7 +13,19 @@ description = "High-performance IFC processing server for Railway deployment"
 keywords = ["ifc", "bim", "server", "aec", "api"]
 categories = ["web-programming", "parsing"]
 
+[features]
+# `mimalloc` (default): route the server's Rust allocations through mimalloc.
+# The platform system heap's global lock dominated native geometry self-time
+# (~70%) and capped rayon scaling to ~1.8x on IfcMappedItem-heavy models (#1623);
+# mimalloc's per-thread heaps remove the lock. `--no-default-features` ⇒ platform
+# allocator, unchanged.
+default = ["mimalloc"]
+mimalloc = ["dep:mimalloc"]
+
 [dependencies]
+# Native global allocator (see the `mimalloc` feature).
+mimalloc = { version = "0.1", optional = true }
+
 # Web framework
 axum = { version = "0.8", features = ["multipart", "tokio"] }
 tower = "0.5"

--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -18,8 +18,11 @@ FROM chef AS builder
 ARG CARGO_BUILD_JOBS=2
 ENV CARGO_BUILD_JOBS=${CARGO_BUILD_JOBS}
 
-# Install build dependencies
+# Install build dependencies. `build-essential` provides the C toolchain
+# `mimalloc` (via `libmimalloc-sys` -> `cc`) needs to compile its C sources, so
+# the build never depends on the base image implicitly shipping a compiler.
 RUN apt-get update && apt-get install -y \
+    build-essential \
     pkg-config \
     libssl-dev \
     && rm -rf /var/lib/apt/lists/*

--- a/apps/server/src/main.rs
+++ b/apps/server/src/main.rs
@@ -25,7 +25,8 @@
 // Native global allocator (#1623): the platform system heap's global lock was
 // ~70% of native geometry self-time and capped rayon scaling to ~1.8x on
 // IfcMappedItem-heavy models; mimalloc's per-thread heaps lifted an all-cores
-// СИКН geometry pass 35s -> 16.7s (2.1x). See the `mimalloc` feature.
+// geometry pass on a 462MB metering-station model 35s -> 16.7s (2.1x). See the
+// `mimalloc` feature.
 #[cfg(feature = "mimalloc")]
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;

--- a/apps/server/src/main.rs
+++ b/apps/server/src/main.rs
@@ -22,6 +22,14 @@
 //! - `GET /api/v1/parse/symbolic/:cache_key` - 2D symbol stream (IfcAnnotation + IfcGrid) as JSON
 //! - `GET /api/v1/cache/:key` - Retrieve cached result
 
+// Native global allocator (#1623): the platform system heap's global lock was
+// ~70% of native geometry self-time and capped rayon scaling to ~1.8x on
+// IfcMappedItem-heavy models; mimalloc's per-thread heaps lifted an all-cores
+// СИКН geometry pass 35s -> 16.7s (2.1x). See the `mimalloc` feature.
+#[cfg(feature = "mimalloc")]
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 use anyhow::Context;
 use axum::http::{header, HeaderValue, Method};
 use axum::{

--- a/rust/ffi/Cargo.toml
+++ b/rust/ffi/Cargo.toml
@@ -14,7 +14,20 @@ description = "C FFI bindings for ifc-lite — native DLL for in-process IFC par
 [lib]
 crate-type = ["cdylib"]
 
+[features]
+# `mimalloc` (default): route this native DLL's Rust allocations through mimalloc
+# instead of the platform system heap. The Windows system heap (`ntdll` RtlHeap)
+# has a global lock that dominated native geometry self-time (~70%) and capped
+# rayon scaling to ~1.8x on IfcMappedItem-heavy models (#1623); mimalloc's
+# per-thread heaps remove the lock. Off ⇒ the platform allocator, unchanged.
+default = ["mimalloc"]
+mimalloc = ["dep:mimalloc"]
+
 [dependencies]
+# Native global allocator (see the `mimalloc` feature). Optional so a consumer
+# can opt back out with `--no-default-features`. Never reaches wasm (this crate
+# is a native cdylib only).
+mimalloc = { version = "0.1", optional = true }
 # Carry an explicit `version` alongside `path` so the crate is publishable to
 # crates.io: `cargo publish` strips the path and keeps the version requirement.
 # A path-only dep fails publish ("dependency does not specify a version").

--- a/rust/ffi/src/lib.rs
+++ b/rust/ffi/src/lib.rs
@@ -18,6 +18,15 @@
 //! aborts the entire host CAD process instead of returning error code `3`.
 //! `server-release` inherits `release` but restores `panic = "unwind"`.
 
+// Native global allocator (#1623): the platform system heap's global lock was
+// ~70% of native geometry self-time and capped rayon scaling to ~1.8x on
+// IfcMappedItem-heavy models; mimalloc's per-thread heaps lifted an all-cores
+// СИКН geometry pass 35s -> 16.7s (2.1x). Rust-only — the DLL's Rust allocations
+// route through mimalloc; the host process's own malloc/free are untouched.
+#[cfg(feature = "mimalloc")]
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 use ifc_lite_processing::{
     process_geometry_filtered, OpeningFilterMode, ParseResponse, ProcessingResult,
 };

--- a/rust/ffi/src/lib.rs
+++ b/rust/ffi/src/lib.rs
@@ -21,8 +21,9 @@
 // Native global allocator (#1623): the platform system heap's global lock was
 // ~70% of native geometry self-time and capped rayon scaling to ~1.8x on
 // IfcMappedItem-heavy models; mimalloc's per-thread heaps lifted an all-cores
-// СИКН geometry pass 35s -> 16.7s (2.1x). Rust-only — the DLL's Rust allocations
-// route through mimalloc; the host process's own malloc/free are untouched.
+// geometry pass on a 462MB metering-station model 35s -> 16.7s (2.1x). Rust-only
+// — the DLL's Rust allocations route through mimalloc; the host process's own
+// malloc/free are untouched.
 #[cfg(feature = "mimalloc")]
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;

--- a/rust/ffi/src/tests.rs
+++ b/rust/ffi/src/tests.rs
@@ -281,3 +281,35 @@ fn free_tolerates_null_and_zero_len() {
         ifc_lite_free(ptr::null_mut(), 16);
     }
 }
+
+/// This crate pins `mimalloc` as the global allocator by default (#1623): the
+/// platform system heap's global lock dominated native geometry self-time (~70%)
+/// and capped rayon scaling. Guard that the geometry pipeline stays SOUND and
+/// run-to-run DETERMINISTIC under the swapped allocator — a corrupt or racy
+/// allocator would surface as empty/garbled meshes, or as two runs of the same
+/// input disagreeing. The whole test binary runs under the crate's global
+/// allocator (mimalloc unless built `--no-default-features`), so this doubles as
+/// the guard that the allocator swap never alters geometry output.
+#[test]
+fn geometry_is_sound_and_deterministic_under_the_global_allocator() {
+    let fixture = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../geometry/tests/fixtures/bath_csg_solid.ifc"
+    );
+    // Fixtures can be absent in a packaged checkout — skip rather than fail.
+    let Ok(ifc) = std::fs::read_to_string(fixture) else {
+        eprintln!("fixture absent, skipping: {fixture}");
+        return;
+    };
+
+    let a = ifc_lite_processing::process_geometry(&ifc);
+    let b = ifc_lite_processing::process_geometry(&ifc);
+
+    let tris: usize = a.meshes.iter().map(|m| m.indices.len() / 3).sum();
+    assert!(tris > 0, "fixture must produce geometry under the global allocator");
+    assert_eq!(a.meshes.len(), b.meshes.len(), "mesh count must be stable run-to-run");
+    for (x, y) in a.meshes.iter().zip(&b.meshes) {
+        assert_eq!(x.positions, y.positions, "positions must be deterministic");
+        assert_eq!(x.indices, y.indices, "indices must be deterministic");
+    }
+}

--- a/rust/ffi/src/tests.rs
+++ b/rust/ffi/src/tests.rs
@@ -296,11 +296,12 @@ fn geometry_is_sound_and_deterministic_under_the_global_allocator() {
         env!("CARGO_MANIFEST_DIR"),
         "/../geometry/tests/fixtures/bath_csg_solid.ifc"
     );
-    // Fixtures can be absent in a packaged checkout — skip rather than fail.
-    let Ok(ifc) = std::fs::read_to_string(fixture) else {
-        eprintln!("fixture absent, skipping: {fixture}");
-        return;
-    };
+    // Committed in-tree fixture (not a fetched `tests/models/` model), so it is
+    // always present in a normal checkout — a read failure is a real error, not a
+    // skip. Silently skipping would let this guard "pass" without exercising the
+    // allocator at all.
+    let ifc = std::fs::read_to_string(fixture)
+        .unwrap_or_else(|e| panic!("read committed fixture {fixture}: {e}"));
 
     let a = ifc_lite_processing::process_geometry(&ifc);
     let b = ifc_lite_processing::process_geometry(&ifc);


### PR DESCRIPTION
## What

Swap the native crates' global allocator to **mimalloc** (`ifc-lite-ffi` cdylib + `ifc-lite-server` bin), behind a default `mimalloc` feature.

## Why — native profiling of #1623

Profiled the 462 MB IfcMappedItem-heavy metering-station model (all `IfcTriangulatedFaceSet`, zero CSG) single-threaded, release, with `samply`:

| module | self-time |
|---|---|
| **`ntdll.dll`** | **69.7%** |
| `bench_load.exe` (our code) | 22.8% |
| `ucrtbase.dll` | 5.0% |

**~70% of native geometry time is in the Windows system heap (`ntdll` RtlHeap), not geometry compute.** The per-occurrence materialize churns tens of thousands of `Vec`/`MeshData` allocations, and RtlHeap's **global lock** both slows each allocation and serializes rayon — multithreading scaled only ~1.8x because workers contend on that one lock.

## Result

mimalloc's per-thread heaps remove the lock:

| geometry pass | system heap | **mimalloc** |
|---|---|---|
| all cores | 35.0 s | **16.7 s** (2.1×) |
| 1 thread | 64.1 s | 57.5 s |
| rayon scaling | ×1.8 | **×3.4** |

At 16.7 s the native all-cores pass now **beats web-ifc's single-thread geometry (19.8 s)** on this model — a larger lever than the instancing/don't-bake work.

## Scope & safety

- Default feature on the two **native** artifact crates only; `--no-default-features` restores the platform allocator. **Never reaches wasm** (both crates are native-only), so the browser path and `mesh_determinism` are untouched.
- The FFI `#[global_allocator]` is **Rust-only**: the DLL's Rust allocations route through mimalloc; the host process's `malloc`/`free` are unaffected.
- Test `geometry_is_sound_and_deterministic_under_the_global_allocator`: runs the pipeline on a committed fixture under the active allocator, asserts non-empty + run-to-run byte-identical meshes.

## Validated locally

- `cargo test -p ifc-lite-ffi` — 10 passed (incl. the new test, under mimalloc).
- `cargo build` for `ifc-lite-server` (default) and both crates with `--no-default-features` — all green.

## Follow-ups (not in this PR)

- **Browser/WASM** doesn't get mimalloc (separate per-worker heaps, no easy wasm allocator swap). Its slowness is a separate issue (worker-pool scaling / don't-bake arming).
- **Structural churn**: welding vertices (this model emits ~100 M verts for 43 M tris ≈ 2.3 v/tri) would cut allocations for both native and wasm.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled an optional, faster global memory allocator for the server and Rust FFI components, controlled via build feature flags (enabled by default).
* **Tests**
  * Added a geometry regression test to ensure repeated geometry processing produces deterministic, non-empty results.
* **Bug Fixes**
  * Improves memory allocation behavior for heap-intensive workloads, helping reduce runtime variability.
* **Chores**
  * Updated server container build dependencies to ensure a native toolchain is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->