### PR TITLE
chore(geometry): drop unused direct num-bigint dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1527,7 +1527,6 @@ dependencies = [
  "jpeg-decoder",
  "memchr",
  "nalgebra",
- "num-bigint",
  "num-rational",
  "num-traits",
  "png",

--- a/rust/geometry/Cargo.toml
+++ b/rust/geometry/Cargo.toml
@@ -86,7 +86,6 @@ geometry-predicates = "0.3"
 # Exact BigRational oracle + the predicate cascade's exact fallback tier
 # (already transitive; promoted to direct).
 num-rational = { version = "0.4", default-features = false, features = ["num-bigint"] }
-num-bigint = { version = "0.4", default-features = false }
 num-traits = { version = "0.2", default-features = false }
 bnum = { version = "0.14.4", features = ["numtraits"] }
 


### PR DESCRIPTION
## What

Removes the direct `num-bigint` dependency from `rust/geometry/Cargo.toml`. It was declared but never used.

## Why

`num-bigint` is never referenced in the geometry crate (zero `num_bigint::` / `use num_bigint` sites, tests and benches included). The crate's exact-arithmetic tier uses `num-rational`'s `BigRational`, and `num-rational` already pulls `num-bigint` transitively via its `num-bigint` feature (pinned to 0.4).

Because the direct declaration existed, Dependabot kept proposing a semver-major `0.4 -> 0.5` bump (#1636). That bump unified nothing: `num-rational` holds `num-bigint` at 0.4, so 0.5 just landed a **second** copy of the crate in `Cargo.lock`. Closing #1636 and deleting the dead declaration is the correct fix and stops the bump from recurring.

## Verification

- `cargo tree -i num-bigint`: single `num-bigint v0.4.6` (via `num-rational`), no 0.5.x, no duplicate.
- Diff is 2 deletions only (`Cargo.toml` line + its `Cargo.lock` dependency entry); `num-bigint 0.4.6` remains in the lock for `num-rational`.
- `cargo check -p ifc-lite-geometry` clean.
- `cargo test -p ifc-lite-geometry --lib`: 401 passed, 0 failed (includes the exact BigRational predicate-cascade tests).

Behavior-neutral: an unused dependency declaration has no effect on compiled output.

Closes #1636 (already closed in favor of this).