### PR TITLE
fix(geometry): bound void-cut flap-clip pad so large hosts don't leak reveal overhang (#1633)

### DIFF
--- a/rust/geometry/src/mesh.rs
+++ b/rust/geometry/src/mesh.rs
@@ -797,9 +797,12 @@ impl Mesh {
     /// `1e-3 * diag` for hosts ≤ 10 m diagonal (`1e-3 * diag ≤ 1e-2`), trimming
     /// on every larger one. Returns the count dropped.
     pub fn clip_triangles_to_host_aabb(&mut self, min: [f32; 3], max: [f32; 3]) -> usize {
-        let diag = (((max[0] - min[0]) as f64).powi(2)
-            + ((max[1] - min[1]) as f64).powi(2)
-            + ((max[2] - min[2]) as f64).powi(2))
+        // Widen to f64 BEFORE subtracting (not `(max - min) as f64`) so `diag`,
+        // and thus `pad`, is bit-for-bit what the former inline `wall_max.x -
+        // wall_min.x` (f64) computed — the clamp is the only intended change.
+        let diag = ((max[0] as f64 - min[0] as f64).powi(2)
+            + (max[1] as f64 - min[1] as f64).powi(2)
+            + (max[2] as f64 - min[2] as f64).powi(2))
         .sqrt();
         let pad = (1.0e-3 * diag).clamp(5.0e-3, 1.0e-2) as f32;
         self.clip_triangles_to_aabb(min, max, pad)

--- a/rust/geometry/src/mesh.rs
+++ b/rust/geometry/src/mesh.rs
@@ -784,6 +784,26 @@ impl Mesh {
         self.indices = new_idx;
         dropped
     }
+
+    /// Clip a void-cut result to the host's pre-cut AABB `[min, max]`, dropping
+    /// any triangle poking beyond it (see [`Mesh::clip_triangles_to_aabb`]). A
+    /// subtract can only remove material, so anything past the host AABB is a cut
+    /// artifact. The tolerance absorbs f64→f32 round-trip jitter (sub-mm), so it
+    /// is a small ABSOLUTE band, NOT a fraction of host size: an unbounded
+    /// `1e-3 * diag` reaches 0.13 m on a 130 m floor slab — wider than the
+    /// ~0.105 m flush-cap reveal overhang it must trap, which is why only large
+    /// slabs/roofs leaked it (a 5 m wall's 5 mm pad already trims the identical
+    /// overhang, #1633). Clamped to [5 mm, 10 mm]: byte-identical to the former
+    /// `1e-3 * diag` for hosts ≤ 10 m diagonal (`1e-3 * diag ≤ 1e-2`), trimming
+    /// on every larger one. Returns the count dropped.
+    pub fn clip_triangles_to_host_aabb(&mut self, min: [f32; 3], max: [f32; 3]) -> usize {
+        let diag = (((max[0] - min[0]) as f64).powi(2)
+            + ((max[1] - min[1]) as f64).powi(2)
+            + ((max[2] - min[2]) as f64).powi(2))
+        .sqrt();
+        let pad = (1.0e-3 * diag).clamp(5.0e-3, 1.0e-2) as f32;
+        self.clip_triangles_to_aabb(min, max, pad)
+    }
 }
 
 impl Default for Mesh {
@@ -986,6 +1006,46 @@ mod tests {
         let dropped = m.clip_triangles_to_aabb([0.0, 0.0, 0.0], [1.0, 1.0, 0.0], 0.01);
         assert_eq!(dropped, 0);
         assert_eq!(m.triangle_count(), 1, "mesh preserved, not emptied");
+    }
+
+    #[test]
+    fn clip_to_host_aabb_trims_reveal_overhang_on_a_large_slab_1633() {
+        // #1633: a flush-capped through-opening's reveal is extended ~0.3·depth
+        // past the host cap for a clean transversal cut, so the exact subtract
+        // leaves a reveal triangle ~0.105 m past a 0.35 m floor slab. The auto pad
+        // MUST trim it regardless of host size — the bug was that `1e-3 · diag`
+        // grew to 0.13 m on this ~130 m-diagonal slab (wider than the overhang) and
+        // let it through, while a 5 m wall's 5 mm pad trimmed the identical overhang.
+        let big = 92.0_f32; // 92 × 92 × 0.35 slab ⇒ diag ≈ 130 m ⇒ old pad ≈ 0.13 m
+        let mut m = mesh_from_tris(&[
+            // two in-bounds cap triangles (host top face at z = 0.35)
+            [[0.0, 0.0, 0.35], [big, 0.0, 0.35], [big, big, 0.35]],
+            [[0.0, 0.0, 0.35], [big, big, 0.35], [0.0, big, 0.35]],
+            // reveal-overhang sliver: apex 0.105 m above the slab top cap
+            [[40.0, 40.0, 0.35], [41.0, 40.0, 0.35], [40.5, 40.5, 0.455]],
+        ]);
+        let dropped = m.clip_triangles_to_host_aabb([0.0, 0.0, 0.0], [big, big, 0.35]);
+        assert_eq!(dropped, 1, "the 0.105 m reveal overhang must be trimmed on a large host");
+        let (_lo, hi) = m.bounds();
+        assert!(hi.z <= 0.36, "no vertex may remain above the slab top cap: hi.z = {}", hi.z);
+    }
+
+    #[test]
+    fn clip_to_host_aabb_is_byte_identical_to_1e3_diag_for_small_hosts() {
+        // The bound only changes behaviour above a 10 m diagonal; a normal wall
+        // (~5 m diag ⇒ pad = 5 mm) is untouched, so the frozen corpus is safe.
+        let tris = [
+            [[0.0, 0.0, 0.0], [3.0, 0.0, 0.0], [3.0, 4.0, 0.0]],
+            [[0.0, 0.0, 0.0], [3.0, 4.0, 0.0], [0.0, 4.0, 0.0]],
+        ];
+        let mut auto = mesh_from_tris(&tris);
+        let mut manual = mesh_from_tris(&tris);
+        let diag = (3.0_f64 * 3.0 + 4.0 * 4.0).sqrt(); // 5 m
+        let old_pad = (1.0e-3 * diag).max(5.0e-3) as f32;
+        auto.clip_triangles_to_host_aabb([0.0, 0.0, 0.0], [3.0, 4.0, 0.0]);
+        manual.clip_triangles_to_aabb([0.0, 0.0, 0.0], [3.0, 4.0, 0.0], old_pad);
+        assert_eq!(auto.positions, manual.positions);
+        assert_eq!(auto.indices, manual.indices);
     }
 
     #[test]

--- a/rust/geometry/src/router/voids/mod.rs
+++ b/rust/geometry/src/router/voids/mod.rs
@@ -1836,24 +1836,19 @@ impl GeometryRouter {
         recut_malformed_openings(&mut result, &ctx.malformed_opening_boxes());
 
         // SPURIOUS-FLAP CLIP: a subtract can only remove material, so the cut is
-        // mathematically contained in the host's pre-cut AABB (`wall_min/max`).
-        // A malformed cutter (self-intersecting, or with garbage vertices metres
-        // from the real opening — the multi-body / tessellated-void case) can
-        // make the exact arrangement leak a far-flung flap triangle that pokes
-        // out of the wall, but only once a SECOND cutter perturbs the
-        // arrangement (so it slips past the per-cutter admission guards). Drop
-        // any triangle with a vertex beyond the host AABB; `pad` absorbs kernel
-        // snap / f64→f32 round-trip jitter (legit cut vertices land sub-mm
-        // inside). A no-op on clean cuts.
-        let diag = ((wall_max.x - wall_min.x).powi(2)
-            + (wall_max.y - wall_min.y).powi(2)
-            + (wall_max.z - wall_min.z).powi(2))
-        .sqrt();
-        let pad = (1.0e-3 * diag).max(5.0e-3) as f32;
-        result.clip_triangles_to_aabb(
+        // mathematically contained in the host's pre-cut AABB (`wall_min/max`);
+        // any triangle poking past it is provably an artifact — a malformed
+        // cutter's far-flung leaked flap (self-intersecting / tessellated void,
+        // surfacing once a SECOND cutter perturbs the arrangement), OR the
+        // flush-cap through-extension reveal overhang (`extend_opening_mesh_
+        // through_host` pushes a flush cap ~0.3·depth past the host for a clean
+        // transversal cut, so the subtract emits the reveal out to it — 0.105 m
+        // past a 0.35 m floor slab, #1633). `clip_triangles_to_host_aabb` bounds
+        // its jitter tolerance so a large host cannot leak the overhang. A no-op
+        // on clean cuts.
+        result.clip_triangles_to_host_aabb(
             [wall_min.x as f32, wall_min.y as f32, wall_min.z as f32],
             [wall_max.x as f32, wall_max.y as f32, wall_max.z as f32],
-            pad,
         );
 
         // Per-host cut-effect snapshot: tris_before / tris_after lets the


### PR DESCRIPTION
Fixes #1633.

## Root cause

Void reveal walls extended **±0.105 m past the host caps** on large floor slabs/roofs, inflating their Z bounds vs IfcOpenShell — but only on elements with openings, and only on large hosts.

The chain:

1. `extend_opening_mesh_through_host` pushes a **flush** opening cap `~0.30 · opening-depth` past the host face to turn a coplanar cap into a clean transversal cut (#1007 heuristic). On a 0.35 m slab whose opening is flush with both faces that is `0.105 m` each way, and the exact subtract emits the reveal wall out to that pushed extent.
2. The **spurious-flap clip** at the end of the void path is meant to trim any triangle that pokes past the host's pre-cut AABB (a subtract can only *remove* material, so anything beyond the host AABB is provably a cut artifact). Its tolerance was `pad = (1e-3 · diag).max(5e-3)` — a sub-mm **absolute** jitter tolerance mistakenly written as an **unbounded fraction of host size**.
3. On a 5 m wall the pad is 5 mm and trims the overhang. On a ~130 m-diagonal floor slab it balloons to **0.13 m** — wider than the 0.105 m overhang — so the overhang survives. That's exactly why the defect only appeared on large slabs/roofs with openings.

## Fix

Move the clip into `Mesh::clip_triangles_to_host_aabb` (co-located with `clip_triangles_to_aabb`, single-sourcing the tolerance) and clamp the pad to **[5 mm, 10 mm]**:

- **Byte-identical** to the former `1e-3 · diag` for every host ≤ 10 m diagonal (`1e-3 · diag ≤ 1e-2`), so walls and normal elements — and the frozen mesh-determinism corpus — are untouched.
- Trims the overhang on every larger host.

## Verification

Ran the issue's attached repro model (`ifclite_repro_minimal.ifc`) through the exact PyO3 path (`process_geometry` → `build_geometry_data_export`):

- **Before:** 9/20 flagged elements out of tolerance, residual ±0.105 m (headline slab already down from the reported 5.66 m via earlier fixes).
- **After:** **0/20** out of tolerance — every element matches IfcOpenShell within 0.011 m. On the worst element the fix also drops 20 spurious sliver triangles and takes non-manifold edges 2 → 0.

Tests:
- New `clip_to_host_aabb_trims_reveal_overhang_on_a_large_slab_1633` (fails on the old unbounded pad, passes with the fix) and `clip_to_host_aabb_is_byte_identical_to_1e3_diag_for_small_hosts`.
- `cargo test -p ifc-lite-geometry -p ifc-lite-processing` green (incl. `geometry_correctness_harness`, `mesh_output_matches_pinned_manifest` — no re-pin needed — and the module-size ratchet).

No wasm boundary / published-TS-API change (Rust-internal `Mesh` method), so no changeset or `pkg/*.d.ts` regen.