### PR TITLE
fix(rust): harden malformed-input paths against panics and worker aborts

### DIFF
--- a/rust/core/src/project_units/mod.rs
+++ b/rust/core/src/project_units/mod.rs
@@ -139,6 +139,23 @@ pub fn resolve_unit_by_ref(
     decoder: &mut EntityDecoder,
     unit_ref: u32,
 ) -> Option<(Option<String>, ResolvedUnit, bool)> {
+    resolve_unit_by_ref_depth(decoder, unit_ref, 0)
+}
+
+/// Max depth for the IFCDERIVEDUNIT -> element -> unit recursion. Real derived
+/// units nest ~2 levels; a malformed file can form a reference cycle (an
+/// IFCDERIVEDUNIT whose element's Unit points back to it), so cap the recursion
+/// to keep it from overflowing the stack, which is an uncatchable abort.
+const MAX_UNIT_RESOLVE_DEPTH: u32 = 16;
+
+fn resolve_unit_by_ref_depth(
+    decoder: &mut EntityDecoder,
+    unit_ref: u32,
+    depth: u32,
+) -> Option<(Option<String>, ResolvedUnit, bool)> {
+    if depth > MAX_UNIT_RESOLVE_DEPTH {
+        return None;
+    }
     let entity = decoder.decode_by_id(unit_ref).ok()?;
     match entity.ifc_type.as_str() {
         "IFCSIUNIT" => {
@@ -174,7 +191,9 @@ pub fn resolve_unit_by_ref(
             let mut parts: Vec<(String, i32)> = Vec::new();
             let mut scale = 1.0f64;
             for er in elem_refs {
-                if let Some((sym, unit_scale, exponent)) = resolve_derived_element(decoder, er) {
+                if let Some((sym, unit_scale, exponent)) =
+                    resolve_derived_element(decoder, er, depth)
+                {
                     scale *= unit_scale.powi(exponent);
                     parts.push((sym, exponent));
                 }
@@ -201,6 +220,7 @@ pub fn resolve_unit_by_ref(
 fn resolve_derived_element(
     decoder: &mut EntityDecoder,
     elem_ref: u32,
+    depth: u32,
 ) -> Option<(String, f64, i32)> {
     let elem = decoder.decode_by_id(elem_ref).ok()?;
     if elem.ifc_type.as_str() != "IFCDERIVEDUNITELEMENT" {
@@ -209,7 +229,7 @@ fn resolve_derived_element(
     // [0]=Unit (IfcNamedUnit), [1]=Exponent
     let unit_ref = elem.get_ref(0)?;
     let exponent = elem.get(1).and_then(|a| a.as_int()).unwrap_or(1) as i32;
-    let (_ut, resolved, _mon) = resolve_unit_by_ref(decoder, unit_ref)?;
+    let (_ut, resolved, _mon) = resolve_unit_by_ref_depth(decoder, unit_ref, depth + 1)?;
     Some((resolved.symbol, resolved.si_scale, exponent))
 }
 

--- a/rust/core/src/project_units/tests.rs
+++ b/rust/core/src/project_units/tests.rs
@@ -159,3 +159,18 @@ END-ISO-10303-21;
     // Still yields SI defaults via unit_for_measure.
     assert_eq!(units.unit_for_measure("IfcAreaMeasure").unwrap().symbol, "m\u{00B2}");
 }
+
+/// A malformed IFCDERIVEDUNIT whose element's Unit points back to itself would
+/// recurse forever (an uncatchable stack-overflow abort). With the depth cap it
+/// terminates and resolves to None. NOTE: pre-fix this SIGABRTs the whole test
+/// binary, so the fail-before check is a one-time manual `--test` run with the
+/// fix reverted; checked in, it asserts only post-fix termination.
+#[test]
+fn cyclic_derived_unit_terminates_not_stack_overflow() {
+    let content = "\
+#10=IFCDERIVEDUNIT((#11),.USERDEFINED.);
+#11=IFCDERIVEDUNITELEMENT(#10,1);
+";
+    let mut decoder = EntityDecoder::new(content);
+    assert!(resolve_unit_by_ref(&mut decoder, 10).is_none());
+}

--- a/rust/geometry/src/kernel/rational.rs
+++ b/rust/geometry/src/kernel/rational.rs
@@ -8,7 +8,7 @@
 
 use super::{DropAxis, ImplicitPoint, Lpi, Sign, Tpi};
 use num_rational::BigRational;
-use num_traits::Signed;
+use num_traits::{Signed, Zero};
 
 #[inline]
 fn r(x: f64) -> BigRational {
@@ -31,6 +31,18 @@ type V3 = [BigRational; 3];
 #[inline]
 fn vec(p: [f64; 3]) -> V3 {
     [r(p[0]), r(p[1]), r(p[2])]
+}
+
+/// Exact average of explicit points. Finite fallback for a degenerate (d==0)
+/// implicit point whose λ/d is undefined (avoids a worker-aborting div-by-zero).
+fn average(pts: &[[f64; 3]]) -> V3 {
+    let n = BigRational::from_float(pts.len() as f64).unwrap();
+    let mut acc = [r(0.0), r(0.0), r(0.0)];
+    for p in pts {
+        let v = vec(*p);
+        acc = [&acc[0] + &v[0], &acc[1] + &v[1], &acc[2] + &v[2]];
+    }
+    [&acc[0] / &n, &acc[1] / &n, &acc[2] / &n]
 }
 
 #[inline]
@@ -103,6 +115,12 @@ pub fn lpi_lambda(l: &Lpi) -> (V3, BigRational) {
 /// independently checks the homogenised form in [`lpi_orient3d`].
 pub fn lpi_point(l: &Lpi) -> V3 {
     let (lambda, d) = lpi_lambda(l);
+    if d.is_zero() {
+        // Degenerate LPI (line parallel to plane): λ/d undefined. Return the
+        // segment midpoint instead of dividing by zero (which aborts the worker;
+        // reachable via classify::to_f64_pt / boolean::point_via_interner).
+        return average(&[l.p, l.q]);
+    }
     [&lambda[0] / &d, &lambda[1] / &d, &lambda[2] / &d]
 }
 
@@ -168,6 +186,11 @@ pub fn tpi_orient3d(t: &Tpi, p2: [f64; 3], p3: [f64; 3], p4: [f64; 3]) -> Sign {
 /// Materialised TPI point `λ/d` (exact) — for the oracle cross-check.
 pub fn tpi_point(t: &Tpi) -> V3 {
     let (lambda, d) = tpi_lambda(t);
+    if d.is_zero() {
+        // Degenerate TPI (planes not concurrent at a point): λ/d undefined. Fall
+        // back to the first plane's centroid instead of dividing by zero.
+        return average(&t.planes[0]);
+    }
     [&lambda[0] / &d, &lambda[1] / &d, &lambda[2] / &d]
 }
 
@@ -370,3 +393,7 @@ pub fn cmp_lex(a: &ImplicitPoint, b: &ImplicitPoint) -> Sign {
     }
     Sign::Zero
 }
+
+#[cfg(test)]
+#[path = "rational_tests.rs"]
+mod rational_tests;

--- a/rust/geometry/src/kernel/rational_tests.rs
+++ b/rust/geometry/src/kernel/rational_tests.rs
@@ -1,0 +1,38 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Degenerate-input tests for the exact BigRational tier. Split into a `_tests.rs`
+//! file so `rational.rs` stays under the module-size ratchet.
+
+use super::*;
+use num_traits::ToPrimitive;
+
+// Line pq lies in plane rst (d == 0): the exact λ/d is undefined. Pre-fix the
+// BigRational division panicked ("denominator == 0"); it must now return the
+// finite segment midpoint.
+#[test]
+fn lpi_point_parallel_line_plane_is_finite_not_panic() {
+    let l = Lpi {
+        p: [0.0, 0.0, 0.0],
+        q: [1.0, 0.0, 0.0],
+        r: [0.0, 0.0, 0.0],
+        s: [1.0, 0.0, 0.0],
+        t: [0.0, 1.0, 0.0],
+    };
+    let pt = lpi_point(&l);
+    assert_eq!(pt[0], BigRational::from_float(0.5).unwrap());
+    assert!(pt.iter().all(|c| c.to_f64().unwrap().is_finite()));
+}
+
+// Three parallel planes never meet at a point (d == 0): must fall back to a
+// finite centroid, not divide by zero.
+#[test]
+fn tpi_point_parallel_planes_is_finite_not_panic() {
+    let plane_at = |z: f64| [[0.0, 0.0, z], [1.0, 0.0, z], [0.0, 1.0, z]];
+    let t = Tpi {
+        planes: [plane_at(0.0), plane_at(1.0), plane_at(2.0)],
+    };
+    let pt = tpi_point(&t);
+    assert!(pt.iter().all(|c| c.to_f64().unwrap().is_finite()));
+}

--- a/rust/geometry/src/mesh.rs
+++ b/rust/geometry/src/mesh.rs
@@ -498,6 +498,16 @@ impl Mesh {
         let mut kept = Vec::with_capacity(self.indices.len());
         for tri in self.indices.chunks_exact(3) {
             let (ia, ib, ic) = (tri[0], tri[1], tri[2]);
+            // Drop any out-of-range triangle BEFORE the unchecked `bits()` closure
+            // indexes positions[] (unlike `vert()` below, `bits()` has no bounds
+            // check). Matches the drop-not-panic contract of vert()/validate_indices;
+            // sibling drop_thin_triangles guards the same way.
+            if ia as usize >= vertex_count
+                || ib as usize >= vertex_count
+                || ic as usize >= vertex_count
+            {
+                continue;
+            }
             // Bit-identical f32 vertex pair → exact zero-area collapse.
             let (ba, bb, bc) = (bits(ia), bits(ib), bits(ic));
             if ba == bb || bb == bc || ba == bc {
@@ -1410,6 +1420,28 @@ mod tests {
             origin: [0.0; 3],
         instance_meta: None, local_bounds: None, local_to_world: None };
         mesh.drop_thin_triangles(GRID);
+        assert_eq!(mesh.indices, vec![0, 1, 2]);
+    }
+
+    // Sibling of the above for drop_degenerate_triangles: the bits() closure
+    // indexed positions[] unchecked before vert()'s bounds check, so an OOB index
+    // panicked. It must now drop the bad triangle without panicking.
+    #[test]
+    fn drop_degenerate_skips_oob_index_without_panic() {
+        let mut mesh = Mesh {
+            positions: vec![0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0],
+            normals: vec![],
+            indices: vec![
+                0, 1, 2, // valid
+                0, 1, 9, // out-of-bounds index → would panic in bits() pre-fix
+            ],
+            rtc_applied: false,
+            origin: [0.0; 3],
+            instance_meta: None,
+            local_bounds: None,
+            local_to_world: None,
+        };
+        mesh.drop_degenerate_triangles();
         assert_eq!(mesh.indices, vec![0, 1, 2]);
     }
 

--- a/rust/geometry/src/processors/advanced_face/bspline.rs
+++ b/rust/geometry/src/processors/advanced_face/bspline.rs
@@ -10,6 +10,14 @@ use ifc_lite_core::{DecodedEntity, EntityDecoder};
 /// Evaluate a B-spline basis function (Cox-de Boor recursion)
 #[inline]
 fn bspline_basis(i: usize, p: usize, u: f64, knots: &[f64]) -> f64 {
+    // Malformed IfcBSplineSurface/CurveWithKnots can present a knot vector too
+    // short for the control-point grid (or a bailed-empty vector from
+    // expand_knots). The Cox-de Boor recursion indexes up to knots[i + p + 1];
+    // guard the largest access so an out-of-range basis contributes 0 rather
+    // than panicking the surface/curve tessellation.
+    if i + p + 1 >= knots.len() {
+        return 0.0;
+    }
     if p == 0 {
         if knots[i] <= u && u < knots[i + 1] {
             1.0
@@ -228,12 +236,30 @@ pub(super) fn parse_control_points(
     Ok(result)
 }
 
+/// Per-knot multiplicity ceiling. Real knot multiplicities are bounded by
+/// degree+1 (<= ~12 for any practical NURBS); this leaves ~100x headroom while
+/// stopping an attacker-controlled multiplicity (e.g. 500_000_000) from driving
+/// a multi-gigabyte allocation.
+const MAX_KNOT_MULTIPLICITY: i64 = 1024;
+/// Total expanded-knot ceiling. A legitimate knot vector is `n_control_points +
+/// degree + 1` entries (dozens); 1<<16 is unreachable for any real model. On a
+/// malformed file that exceeds it we return an EMPTY vector, so the caller's
+/// `knots.len() <= degree` guard rejects the curve/surface rather than sampling a
+/// silently-truncated (wrong) knot vector.
+const MAX_EXPANDED_KNOTS: usize = 1 << 16;
+
 /// Expand knot vector based on multiplicities
 pub(super) fn expand_knots(knot_values: &[f64], multiplicities: &[i64]) -> Vec<f64> {
     let mut expanded = Vec::new();
     for (knot, &mult) in knot_values.iter().zip(multiplicities.iter()) {
+        // Negative multiplicities are already inert (`0..mult` is an empty
+        // range); clamp the upper end so one entry cannot request a huge push.
+        let mult = mult.clamp(0, MAX_KNOT_MULTIPLICITY);
         for _ in 0..mult {
             expanded.push(*knot);
+            if expanded.len() > MAX_EXPANDED_KNOTS {
+                return Vec::new();
+            }
         }
     }
     expanded
@@ -323,4 +349,42 @@ pub(super) fn evaluate_bspline_curve(
         }
     }
     result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn expand_knots_caps_hostile_multiplicity() {
+        // A single attacker-controlled multiplicity is clamped, so it can never
+        // drive a multi-gigabyte allocation (pre-fix: 1_000_000 pushed entries).
+        let knots = expand_knots(&[0.0, 1.0], &[1_000_000, 1]);
+        assert!(
+            knots.len() <= MAX_KNOT_MULTIPLICITY as usize + 1,
+            "multiplicity not clamped: got {}",
+            knots.len()
+        );
+
+        // A knot vector whose total expansion exceeds the ceiling bails to EMPTY,
+        // so the caller's `len <= degree` guard rejects it rather than sampling a
+        // silently-truncated (wrong) knot vector.
+        let many: Vec<f64> = (0..100).map(|i| i as f64).collect();
+        let mults = vec![MAX_KNOT_MULTIPLICITY; 100]; // 100 * 1024 > MAX_EXPANDED_KNOTS
+        assert!(expand_knots(&many, &mults).is_empty());
+    }
+
+    #[test]
+    fn expand_knots_keeps_valid_vectors() {
+        assert_eq!(
+            expand_knots(&[0.0, 0.5, 1.0], &[2, 1, 2]),
+            vec![0.0, 0.0, 0.5, 1.0, 1.0]
+        );
+    }
+
+    #[test]
+    fn bspline_basis_out_of_range_returns_zero_not_panic() {
+        // Knot vector too short for (i, p): must contribute 0.0, not panic OOB.
+        assert_eq!(bspline_basis(5, 3, 0.5, &[0.0, 1.0]), 0.0);
+    }
 }

--- a/rust/geometry/src/processors/advanced_face/curves.rs
+++ b/rust/geometry/src/processors/advanced_face/curves.rs
@@ -73,6 +73,14 @@ pub(super) fn sample_bspline_edge_curve(
     }
 
     let knots = expand_knots(&knot_values, &mults);
+    // A malformed IfcBSplineCurveWithKnots can carry multiplicities summing to
+    // fewer than degree+1 knots (or expand_knots may have bailed to empty on an
+    // over-large multiplicity). Indexing knots[degree] / knots[len-degree-1]
+    // would then panic (OOB, or a usize underflow in len-degree-1). Mirror the
+    // sibling polyline.rs guard and treat the curve as unusable.
+    if knots.len() <= degree {
+        return vec![*start];
+    }
     let t_min = knots[degree];
     let t_max = knots[knots.len() - degree - 1];
 

--- a/rust/geometry/src/profiles/shapes.rs
+++ b/rust/geometry/src/profiles/shapes.rs
@@ -379,7 +379,7 @@ impl ProfileProcessor {
             .get_float(6)
             .unwrap_or(0.0)
             .clamp(0.0, (width - t).min(depth - t).max(0.0));
-        let re = profile.get_float(7).unwrap_or(0.0).clamp(0.0, t * 0.999);
+        let re = profile.get_float(7).unwrap_or(0.0).clamp(0.0, (t * 0.999).max(0.0));
         // Root-fillet segments per corner: 6 at Medium+, coarser below.
         let seg = self.quality().profile_arc_segments(6, 2);
         let half_pi = std::f64::consts::FRAC_PI_2;
@@ -437,7 +437,7 @@ impl ProfileProcessor {
             .get_float(7)
             .unwrap_or(0.0)
             .clamp(0.0, (flange_width - web_thickness).min(half_depth - ft).max(0.0));
-        let re = profile.get_float(8).unwrap_or(0.0).clamp(0.0, ft * 0.999);
+        let re = profile.get_float(8).unwrap_or(0.0).clamp(0.0, (ft * 0.999).max(0.0));
 
         // Sharp outline (counter-clockwise). 2,5 = flange toes; 3,4 = junctions.
         let sharp = [
@@ -483,8 +483,8 @@ impl ProfileProcessor {
             .get_float(7)
             .unwrap_or(0.0)
             .clamp(0.0, (half_flange - half_web).min(ftf).max(0.0));
-        let r_fl = profile.get_float(8).unwrap_or(0.0).clamp(0.0, ft * 0.999);
-        let r_web = profile.get_float(9).unwrap_or(0.0).clamp(0.0, half_web * 0.999);
+        let r_fl = profile.get_float(8).unwrap_or(0.0).clamp(0.0, (ft * 0.999).max(0.0));
+        let r_web = profile.get_float(9).unwrap_or(0.0).clamp(0.0, (half_web * 0.999).max(0.0));
 
         // Sharp outline (counter-clockwise). 1,6 = junctions; 2,5 = flange toes;
         // 0,7 = web free-end corners.

--- a/rust/geometry/src/profiles/tests.rs
+++ b/rust/geometry/src/profiles/tests.rs
@@ -701,3 +701,23 @@ use super::*;
         assert!(approx_eq_p3(pts[0], Point3::new(0.0, 10.0, 0.0), 1e-9));
         assert!(approx_eq_p3(pts[1], Point3::new(0.0, 7.0, 0.0), 1e-9));
     }
+
+    // A negative Thickness / WebThickness on a parametric L/U/T profile made the
+    // fillet-radius clamp bound negative and panicked f64::clamp (release too). The
+    // `.max(0.0)` on the bound must now keep it panic-free (the element renders or
+    // errors gracefully, but never aborts the worker).
+    #[test]
+    fn negative_profile_thickness_does_not_panic() {
+        let cases = [
+            "#1=IFCLSHAPEPROFILEDEF(.AREA.,$,$,100.,80.,-10.,$,$,$,$,$);\n",
+            "#1=IFCUSHAPEPROFILEDEF(.AREA.,$,$,100.,80.,-10.,12.,$,$,$);\n",
+            "#1=IFCTSHAPEPROFILEDEF(.AREA.,$,$,100.,80.,-10.,12.,$,$,$,$,$);\n",
+        ];
+        for content in cases {
+            let mut decoder = EntityDecoder::new(content);
+            let processor = ProfileProcessor::new(IfcSchema::new());
+            let entity = decoder.decode_by_id(1).unwrap();
+            // Reaching here for every case (any Result) proves the clamp is safe.
+            let _ = processor.process(&entity, &mut decoder, TessellationQuality::Medium);
+        }
+    }

--- a/rust/geometry/src/router/transforms/parsers.rs
+++ b/rust/geometry/src/router/transforms/parsers.rs
@@ -189,11 +189,11 @@ impl GeometryRouter {
             scale
         };
 
-        // Get Axis1 (X axis, attribute 0)
-        let x_axis = if let Some(axis1_attr) = entity.get(0) {
+        // Get Axis1 (raw local X, attribute 0), defaulting to +X when absent/null.
+        let x_axis_raw = if let Some(axis1_attr) = entity.get(0) {
             if !axis1_attr.is_null() {
                 if let Some(axis1_entity) = decoder.resolve_ref(axis1_attr)? {
-                    self.parse_direction(&axis1_entity)?.normalize()
+                    self.parse_direction(&axis1_entity)?
                 } else {
                     Vector3::new(1.0, 0.0, 0.0)
                 }
@@ -204,11 +204,11 @@ impl GeometryRouter {
             Vector3::new(1.0, 0.0, 0.0)
         };
 
-        // Get Axis3 (Z axis, attribute 4 for 3D)
-        let z_axis = if let Some(axis3_attr) = entity.get(4) {
+        // Get Axis3 (raw local Z, attribute 4 for 3D), defaulting to +Z.
+        let z_axis_raw = if let Some(axis3_attr) = entity.get(4) {
             if !axis3_attr.is_null() {
                 if let Some(axis3_entity) = decoder.resolve_ref(axis3_attr)? {
-                    self.parse_direction(&axis3_entity)?.normalize()
+                    self.parse_direction(&axis3_entity)?
                 } else {
                     Vector3::new(0.0, 0.0, 1.0)
                 }
@@ -219,9 +219,27 @@ impl GeometryRouter {
             Vector3::new(0.0, 0.0, 1.0)
         };
 
-        // Derive Y axis from Z and X (right-hand coordinate system)
+        // Orthonormalize (Gram-Schmidt), guarding every normalize so a malformed
+        // IfcDirection((0,0,0)) or an Axis1 parallel to Axis3 cannot produce a NaN
+        // transform that silently poisons bounds/RTC/instancing/export. A zero
+        // Axis3 falls back to +Z; a zero-or-parallel Axis1 keeps the valid Z and
+        // takes a deterministic perpendicular X (mirrors build_axis2_matrix). Only
+        // the truly degenerate operator reorients, and it always stays finite.
+        let z_axis = z_axis_raw
+            .try_normalize(1e-9)
+            .unwrap_or_else(|| Vector3::new(0.0, 0.0, 1.0));
+        let x_norm = x_axis_raw
+            .try_normalize(1e-9)
+            .unwrap_or_else(|| Vector3::new(1.0, 0.0, 0.0));
+        let x_ortho = x_norm - z_axis * x_norm.dot(&z_axis);
+        let x_axis = x_ortho.try_normalize(1e-6).unwrap_or_else(|| {
+            if z_axis.z.abs() < 0.9 {
+                Vector3::new(0.0, 0.0, 1.0).cross(&z_axis).normalize()
+            } else {
+                Vector3::new(1.0, 0.0, 0.0).cross(&z_axis).normalize()
+            }
+        });
         let y_axis = z_axis.cross(&x_axis).normalize();
-        let x_axis = y_axis.cross(&z_axis).normalize();
 
         // Build transformation matrix. Each axis is scaled by its
         // per-axis factor (Scale / Scale2 / Scale3) so non-uniform
@@ -241,5 +259,28 @@ impl GeometryRouter {
         transform[(2, 3)] = origin.z;
 
         Ok(transform)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // A zero IfcDirection((0,0,0)) as Axis1 made a bare normalize() emit NaN, and
+    // the operator matrix was returned Ok, silently poisoning every mapped vertex.
+    // The matrix must now be finite.
+    #[test]
+    fn cartesian_transformation_operator_zero_axis_stays_finite() {
+        let content = "\
+#1=IFCDIRECTION((0.,0.,0.));
+#3=IFCCARTESIANTRANSFORMATIONOPERATOR3D(#1,$,$,$,$);
+";
+        let mut decoder = EntityDecoder::new(content);
+        let router = GeometryRouter::new();
+        let entity = decoder.decode_by_id(3).unwrap();
+        let m = router
+            .parse_cartesian_transformation_operator(&entity, &mut decoder)
+            .expect("operator should still parse");
+        assert!(m.iter().all(|v| v.is_finite()), "NaN in transform matrix: {m:?}");
     }
 }

--- a/rust/geometry/src/router/voids/flap_clip_tests.rs
+++ b/rust/geometry/src/router/voids/flap_clip_tests.rs
@@ -355,3 +355,12 @@ fn budget_tripped_engulfing_cutter_skips_aabb_fallback() {
         "a non-engulfing opening under the tripped cap must still cut the host (#635 box-cut)"
     );
 }
+
+// A non-finite vertex (e.g. from a degenerate upstream transform) reaching the
+// malformed-opening OBB heuristic must not panic the partial_cmp sorts; the
+// cutter is not worth reshaping, so it bails to None.
+#[test]
+fn opening_obb_if_malformed_bails_on_nan_vertex_not_panic() {
+    let cutter = box_cutter_mesh([1.0, 1.0, 1.0], &[[f64::NAN, 0.0, 0.0]]);
+    assert!(opening_obb_if_malformed(&cutter).is_none());
+}

--- a/rust/geometry/src/router/voids/mod.rs
+++ b/rust/geometry/src/router/voids/mod.rs
@@ -313,9 +313,14 @@ fn opening_obb_if_malformed(m: &Mesh) -> Option<OpeningBox> {
     if all.len() < 8 {
         return None;
     }
+    // Bail on any non-finite vertex so the partial_cmp sorts below cannot panic;
+    // a garbage cutter is not worth reshaping (file filters non-finite elsewhere).
+    if all.iter().any(|v| v.iter().any(|c| !c.is_finite())) {
+        return None;
+    }
     let median_axis = |axis: usize| -> f64 {
         let mut vals: Vec<f64> = all.iter().map(|v| v[axis]).collect();
-        vals.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        vals.sort_by(f64::total_cmp);
         vals[vals.len() / 2]
     };
     let med = Vector3::new(median_axis(0), median_axis(1), median_axis(2));
@@ -324,7 +329,7 @@ fn opening_obb_if_malformed(m: &Mesh) -> Option<OpeningBox> {
         .enumerate()
         .map(|(i, v)| ((v - med).norm(), i))
         .collect();
-    dist.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
+    dist.sort_by(|a, b| a.0.total_cmp(&b.0));
     // The garbage "fins" of these broken cutters sit METRES from the opening
     // (≈9 m here), far beyond any legitimate opening vertex (even a big garage
     // door is ≲3 m). Detect malformity ONLY by an ABSOLUTE far cluster — a

--- a/rust/geometry/src/transform.rs
+++ b/rust/geometry/src/transform.rs
@@ -77,9 +77,17 @@ pub(crate) fn build_axis2_matrix(
     z_axis: Vector3<f64>,
     x_axis: Vector3<f64>,
 ) -> Matrix4<f64> {
-    // Normalize axes
-    let z_axis_final = z_axis.normalize();
-    let x_axis_normalized = x_axis.normalize();
+    // Normalize axes. A malformed IfcDirection((0,0,0)) as Axis/RefDirection would
+    // make a bare normalize() emit NaN (0/0) and poison the whole placement matrix
+    // (this helper is the shared home for every IfcAxis2Placement3D parser, so the
+    // guard lives here once). A zero Axis falls back to +Z; a zero RefDirection
+    // routes into the parallel-axis fallback below.
+    let z_axis_final = z_axis
+        .try_normalize(1e-9)
+        .unwrap_or_else(|| Vector3::new(0.0, 0.0, 1.0));
+    let x_axis_normalized = x_axis
+        .try_normalize(1e-9)
+        .unwrap_or_else(|| Vector3::new(1.0, 0.0, 0.0));
 
     // Ensure X is orthogonal to Z (project X onto plane perpendicular to Z)
     let dot_product = x_axis_normalized.dot(&z_axis_final);
@@ -489,5 +497,17 @@ mod tests {
 
         // Degenerate (zero-length) projected X-axis → None.
         assert!(rotation_angle_about_z(&[0.0f64; 16]).is_none());
+    }
+
+    // A malformed IfcDirection((0,0,0)) as Axis must not NaN-poison the matrix;
+    // build_axis2_matrix is the shared home for every IfcAxis2Placement3D parser.
+    #[test]
+    fn build_axis2_matrix_zero_axis_stays_finite() {
+        let m = build_axis2_matrix(
+            Point3::new(0.0, 0.0, 0.0),
+            Vector3::new(0.0, 0.0, 0.0),
+            Vector3::new(1.0, 0.0, 0.0),
+        );
+        assert!(m.iter().all(|v| v.is_finite()), "NaN in matrix: {m:?}");
     }
 }

--- a/rust/processing/src/processor/quick_metadata.rs
+++ b/rust/processing/src/processor/quick_metadata.rs
@@ -3,7 +3,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use crate::types::response::{QuickMetadataEntitySummary, QuickMetadataSpatialNode};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 #[derive(Clone)]
 pub(super) struct QuickSpatialNodeEntry {
@@ -132,17 +132,38 @@ pub(super) fn build_quick_spatial_tree_node(
     nodes: &HashMap<u32, QuickSpatialNodeEntry>,
     element_summaries: &HashMap<u32, QuickMetadataEntitySummary>,
 ) -> Result<QuickMetadataSpatialNode, String> {
+    let mut ancestors = HashSet::new();
+    build_quick_spatial_tree_node_inner(express_id, nodes, element_summaries, &mut ancestors)
+}
+
+/// A malformed IfcRelAggregates graph can make a spatial node its own
+/// descendant; the recursion would then overflow the stack, an uncatchable
+/// abort. `ancestors` holds the current root-to-node path, so a child already on
+/// it is a back-edge: skip just that child and keep building the rest of the tree.
+fn build_quick_spatial_tree_node_inner(
+    express_id: u32,
+    nodes: &HashMap<u32, QuickSpatialNodeEntry>,
+    element_summaries: &HashMap<u32, QuickMetadataEntitySummary>,
+    ancestors: &mut HashSet<u32>,
+) -> Result<QuickMetadataSpatialNode, String> {
     let node = nodes
         .get(&express_id)
         .ok_or_else(|| format!("Quick spatial node #{express_id} not found"))?;
+    ancestors.insert(express_id);
     let mut children = Vec::with_capacity(node.children.len());
     for child_id in &node.children {
-        children.push(build_quick_spatial_tree_node(
+        if ancestors.contains(child_id) {
+            // Cyclic aggregate edge: skip this back-edge child, keep the rest.
+            continue;
+        }
+        children.push(build_quick_spatial_tree_node_inner(
             *child_id,
             nodes,
             element_summaries,
+            ancestors,
         )?);
     }
+    ancestors.remove(&express_id);
     let elements = node
         .elements
         .iter()
@@ -176,4 +197,34 @@ pub(super) fn build_quick_spatial_tree_node(
         children,
         elements,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn node(id: u32, children: Vec<u32>) -> QuickSpatialNodeEntry {
+        QuickSpatialNodeEntry {
+            express_id: id,
+            type_name: "IfcSpace".to_string(),
+            name: format!("#{id}"),
+            elevation: None,
+            children,
+            elements: vec![],
+            parent: None,
+        }
+    }
+
+    // A malformed IfcRelAggregates graph making two nodes each other's child would
+    // recurse forever (stack-overflow abort). The back-edge child is skipped and
+    // the rest of the tree still builds.
+    #[test]
+    fn cyclic_aggregate_graph_does_not_stack_overflow() {
+        let mut nodes = HashMap::new();
+        nodes.insert(1, node(1, vec![2]));
+        nodes.insert(2, node(2, vec![1]));
+        let summaries = HashMap::new();
+        let tree = build_quick_spatial_tree_node(1, &nodes, &summaries);
+        assert!(tree.is_ok(), "cyclic tree should build (cycle pruned), got {tree:?}");
+    }
 }


### PR DESCRIPTION
## Summary

A full review of the Rust side surfaced several places where a few bytes of malformed STEP can panic — and under the wasm `panic=abort` profile, each panic kills the whole geometry worker (two are uncatchable stack overflows). This PR hardens the **Critical + High** findings. The dominant pattern: in nearly every case a **sibling function in the same file already guards the exact failure mode** and the flagged path missed it, so the fixes are small and low-risk.

Each fix ships with a **fail-before / pass-after** test (the pre-fix panics were reproduced against `origin/main` before writing the guard).

## Fixes

| # | Area | Root cause | Fix |
|---|------|-----------|-----|
| C1 | `profiles/shapes.rs` | negative Thickness made the L/U/T fillet clamp bound negative → `f64::clamp` asserts (release too) | `.max(0.0)` on the 4 bounds, matching the `rf`/I-shape siblings |
| C2 | `advanced_face/curves.rs`, `bspline.rs` | unvalidated knot vector: OOB index + unbounded alloc from attacker multiplicities | `len <= degree` guard, per-multiplicity + total caps (bail to empty), and a `bspline_basis` bounds guard covering the surface path |
| C3 | `core/project_units`, `processing/quick_metadata.rs` | recursion over file-defined reference graphs with no cycle/depth guard → stack-overflow abort | depth cap for derived units; ancestor-path skip for the spatial tree (prunes only the back-edge child) |
| H1 | `transform.rs::build_axis2_matrix`, `transforms/parsers.rs` | bare `.normalize()` on a zero/parallel `IfcDirection` → NaN transform, returned `Ok`, silently poisons bounds/RTC/instancing/export | `try_normalize` + deterministic fallback in the shared placement helper and the CTO parser |
| H2 | `router/voids/mod.rs` | `partial_cmp().unwrap()` on raw vertex f64s before the finiteness guard | bail on non-finite vertex + `total_cmp` in the sorts |
| H3 | `mesh.rs::drop_degenerate_triangles` | unchecked `bits()` closure indexes `positions[]` before the bounds-checked `vert()` | drop out-of-range triangles at the top of the loop (matches `drop_thin_triangles`) |
| H4 | `kernel/rational.rs` | `lpi_point`/`tpi_point` divide by an unchecked zero denominator on degenerate (parallel) inputs | finite `average` fallback on `d.is_zero()` (no signature change; covers both production callers) |

The adversarial review of the fix plan added two siblings the finders missed: **H1's `build_axis2_matrix`** (the shared home for every `IfcAxis2Placement3D` parser — more reachable than the CTO path) and **C2's `bspline_basis`** (the surface tessellation path).

## Not in this PR (fast-follow)

The 4 Medium (DoS caps / hangs on crafted files) and 1 Low (alignment NaN) findings, plus a fuller positivity-validation pass on the profile dimensions (which would need a `shapes.rs` split to fit the module-size ratchet).

## Testing

- 11 new fail-before/pass-after tests; full `ifc-lite-{geometry,core,processing}` suites green.
- Full workspace build (server, ffi, wasm, clash) clean.
- Module-size ratchet green; no new clippy warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability when opening or processing malformed files, including cyclic references, invalid geometry, and non-finite values.
  * Fixed several cases that could previously cause crashes or panics during unit resolution, profile handling, mesh cleanup, transformation parsing, and B-spline sampling.
  * Added safer fallbacks for degenerate inputs so affected operations now return valid results or skip bad data instead of failing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->