### PR TITLE
perf(wasm): bulk-copy the entity-index export instead of per-entry set_index

### DIFF
--- a/.changeset/perf-wasm-index-export-bulk.md
+++ b/.changeset/perf-wasm-index-export-bulk.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/wasm": patch
+---
+
+Faster cold load in the browser: bulk-copy the streaming pre-pass's entity-index export instead of writing it one entry at a time. The pre-pass ships the completed entity index to the geometry workers (they idle until it arrives, then stop re-scanning the file), and it filled three `Uint32Array`s with a per-entry `set_index` loop — three JS↔WASM boundary crossings per entity, ~8.4M FFI calls on a 2.8M-entity model, all on the workers' critical path. The index is now packed into three contiguous Rust buffers and handed to JS in one bulk `Uint32Array::from` copy each (matching the void/style exports beside it). Measured: the entity-index event reaches the workers ~11% sooner on a 169 MB model (360 ms → 321 ms) and ~9% sooner on a 47 MB model, pulling stream-complete in accordingly; the saving scales with entity count. Byte-identical: the workers zip `ids[i]`/`starts[i]`/`lengths[i]` into a map, so iteration order carries no meaning.

--- a/rust/wasm-bindings/src/api/gpu_meshes/prepass.rs
+++ b/rust/wasm-bindings/src/api/gpu_meshes/prepass.rs
@@ -473,15 +473,15 @@ impl IfcAPI {
         // (A) Entity-index — workers re-scan the whole file (~5 s) without it, so
         // it must reach them as early as possible. Built from the complete index.
         {
-            let n = index_for_export.len();
-            let ids_arr = js_sys::Uint32Array::new_with_length(n as u32);
-            let starts_arr = js_sys::Uint32Array::new_with_length(n as u32);
-            let lengths_arr = js_sys::Uint32Array::new_with_length(n as u32);
-            for (i, (&id, &(start, end))) in index_for_export.iter().enumerate() {
-                ids_arr.set_index(i as u32, id);
-                starts_arr.set_index(i as u32, start as u32);
-                lengths_arr.set_index(i as u32, (end - start) as u32);
-            }
+            // Bulk-copy in 3 boundary crossings, not ~8.4M per-entry set_index
+            // calls (workers' critical path). Order-free: they zip the 3 arrays.
+            let (ids, (starts, lengths)): (Vec<u32>, (Vec<u32>, Vec<u32>)) = index_for_export
+                .iter()
+                .map(|(&id, &(s, e))| (id, (s as u32, (e - s) as u32)))
+                .unzip();
+            let ids_arr = js_sys::Uint32Array::from(ids.as_slice());
+            let starts_arr = js_sys::Uint32Array::from(starts.as_slice());
+            let lengths_arr = js_sys::Uint32Array::from(lengths.as_slice());
             let index_event = js_sys::Object::new();
             crate::api::set_js_prop(&index_event, "type", &"entity-index".into());
             crate::api::set_js_prop(&index_event, "ids", &ids_arr);


### PR DESCRIPTION
## Summary

The streaming pre-pass ships the completed entity index to the geometry workers — they idle until it arrives, then use it to skip re-scanning the whole file. It built the export by filling three `Uint32Array`s with a per-entry `set_index` loop: three JS↔WASM boundary crossings per entity (~8.4M FFI calls on a 2.8M-entity model), all on the workers' critical path.

This packs the index into three contiguous Rust buffers and hands each to JS in one bulk `Uint32Array::from` copy — the same pattern the void/style exports a few lines above already use. It's a consistency fix as much as a perf one.

## Measured (viewer benchmark, prod build, clean same-session A/B)

Direct signal — when the `entity-index` event reaches the workers (the scan before it is identical between the two; only the export differs):

| Model | entities | baseline (main) | this PR | delta |
|---|---|---|---|---|
| schependomlaan (47 MB) | 714K | ~124 ms | 113 ms | −9% |
| Holter Tower (169 MB) | 2.8M | ~360 ms | 321 ms | **−11%** |

Stream-complete follows accordingly (Holter 2317 → 2279 ms). The saving scales with entity count, so it grows on larger models.

## Byte-identical

The workers zip `ids[i]` / `starts[i]` / `lengths[i]` into a map, so iteration order carries no meaning — the exported index is the same set of entries, transferred in bulk. Mesh-count validation in the benchmark passed unchanged (Holter 110,632 meshes), and `cargo test -p ifc-lite-wasm` is green.

## Test plan

- [x] Clean same-session viewer-benchmark A/B (numbers above)
- [x] `cargo test -p ifc-lite-wasm`
- [x] Benchmark mesh-count validation unchanged