### PR TITLE
perf(processing): build material-layer index from stashed spans, not a re-scan

### DIFF
--- a/.changeset/perf-material-layer-from-spans.md
+++ b/.changeset/perf-material-layer-from-spans.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/wasm": patch
+---
+
+Faster load: build the material-layer index from the `IfcRelAssociatesMaterial` spans the main scan already stashed, instead of re-walking the whole file. The native `process_geometry` path (CLI, server, glTF/GLB export) called `MaterialLayerIndex::from_content`, a redundant single-threaded full-file scan for the exact entities the scan loop already collects into `prepass_spans`. Switching to the existing byte-identical `from_spans` (the wasm streaming pre-pass already uses it for the same reason) removes that extra pass — measured -15% total load on a 47 MB architectural model, -9% on a 169 MB model, -6% on a 54 MB model, ~0 on geometry-bound (steel) models. Output is byte-identical (mesh/vertex/triangle counts unchanged across the fixture set; no mesh-determinism manifest change).

--- a/rust/processing/src/processor/mod.rs
+++ b/rust/processing/src/processor/mod.rs
@@ -1022,13 +1022,12 @@ pub fn process_geometry_streaming_filtered_with_options(
     );
     let mut router = GeometryRouter::with_scale(unit_scales.length_unit_scale);
     router.set_tessellation_quality(options.tessellation_quality);
-    // Slice single-solid walls/slabs with an IfcMaterialLayerSetUsage into one
-    // coloured sub-mesh per layer (#563); #874 dropped this wiring across every
-    // pipeline. The native pass processes the file once, so build the index
-    // directly here (the wasm batch path caches it on the IfcAPI). Cheap on
-    // files with no layer set (substring bail-out inside the builder).
+    // Build the #563 material-layer index from the IfcRelAssociatesMaterial spans
+    // the main scan already stashed (like the wasm pre-pass), not a redundant
+    // `from_content` re-walk of the whole file. Byte-identical; saves 6-15% load.
+    let material_spans = &prepass_spans.rel_associates_material;
     router.set_material_layer_index(Arc::new(
-        ifc_lite_geometry::MaterialLayerIndex::from_content(content, &mut decoder),
+        ifc_lite_geometry::MaterialLayerIndex::from_spans(material_spans, &mut decoder),
     ));
 
     // Resolve IfcSite and IfcBuilding placement transforms.


### PR DESCRIPTION
## Summary

The native `process_geometry` path (CLI, server, glTF/GLB export) built the material-layer index with `MaterialLayerIndex::from_content`, which **re-walks the entire file** looking for `IfcRelAssociatesMaterial` entities. But the main scan loop **already stashes every one of those spans** into `prepass_spans.rel_associates_material`. This swaps in the existing `from_spans` builder — the wasm streaming pre-pass already uses it for exactly this reason — so the redundant single-threaded pass is gone.

This is part of a theme: on multi-core machines geometry parallelizes away and the **single-threaded parse dominates** (73% of load on a 47 MB model at 8 cores). The parse makes several passes over the file; this removes one of them.

## Measured (`perf_probe`, RAYON=8)

| Model | size | total before → after |
|---|---|---|
| schependomlaan | 47 MB | 206 → 175 ms (**−15%**) |
| Holter Tower | 169 MB | 1104 → 1005 ms (−9%) |
| ARK NUS skolebygg | 54 MB | 565 → 533 ms (−6%) |
| rvt01 (steel) | 4 MB | ~0 (geometry-bound) |

## Byte-identical

`from_spans` feeds the same spans, in the same file order, through the same `insert_association` step as `from_content` (it exists precisely so the native and wasm paths can't drift). Verified: mesh / vertex / triangle counts unchanged across schependomlaan, dental_clinic, skolebygg, rvt01; all `ifc-lite-processing` tests green including `mesh_determinism` and `styling_parity`; no manifest change.

## Test plan

- [x] `perf_probe` A/B (numbers above)
- [x] mesh/vert/tri parity `from_content` vs `from_spans` on material-heavy models
- [x] `cargo test -p ifc-lite-processing`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved geometry loading speed for native builds by avoiding an extra full-file scan during material-layer processing.
  * Load times are reduced for larger models, while results remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->