### PR TITLE
fix(telemetry): surface rect-fast defer_too_many_openings in diagnostics

### DIFF
--- a/.changeset/rect-fast-defer-too-many-telemetry.md
+++ b/.changeset/rect-fast-defer-too-many-telemetry.md
@@ -1,0 +1,7 @@
+---
+"@ifc-lite/geometry": patch
+"@ifc-lite/server-client": patch
+"@ifc-lite/cli": patch
+---
+
+Surface the rect-fast `deferTooManyOpenings` counter in the geometry diagnostics. The Rust `RectFastSummary` already emits it (the opening-count DoS cap, #1649); the `GeometryDiagnostics.rectFast` and server-client types now include it (optional, defaulted to 0 when absent so older payloads merge cleanly), `mergeGeometryDiagnostics` sums it, and the CLI geometry report renders it in the rect_fast defer breakdown.

--- a/packages/cli/src/geometry-report.test.ts
+++ b/packages/cli/src/geometry-report.test.ts
@@ -17,7 +17,7 @@ function makeDiagnostics(partial: Partial<GeometryDiagnostics> = {}): GeometryDi
     silentNoOps: 0,
     rectFast: {
       fired: 0, openingsCut: 0, deferHostNotBox: 0, deferNotThrough: 0,
-      deferOffFace: 0, deferNearEdge: 0, deferNoOpenings: 0,
+      deferOffFace: 0, deferNearEdge: 0, deferNoOpenings: 0, deferTooManyOpenings: 0,
     },
     worstHosts: [],
     ...partial,
@@ -66,11 +66,12 @@ describe('formatGeometryReport', () => {
     const report = formatGeometryReport(makeDiagnostics({
       rectFast: {
         fired: 10, openingsCut: 8, deferHostNotBox: 1, deferNotThrough: 2,
-        deferOffFace: 0, deferNearEdge: 1, deferNoOpenings: 0,
+        deferOffFace: 0, deferNearEdge: 1, deferNoOpenings: 0, deferTooManyOpenings: 3,
       },
     }));
     expect(report).toContain('rect_fast: fired 10, openings cut 8');
     expect(report).toContain('host-not-box 1');
+    expect(report).toContain('too-many 3');
   });
 
   it('lists worst-failing hosts with productId, ifcType, failures, openings', () => {

--- a/packages/cli/src/geometry-report.ts
+++ b/packages/cli/src/geometry-report.ts
@@ -41,7 +41,8 @@ export function formatGeometryReport(d: GeometryDiagnostics): string {
   lines.push(
     `rect_fast: fired ${rf.fired}, openings cut ${rf.openingsCut} ` +
       `(defer: host-not-box ${rf.deferHostNotBox}, not-through ${rf.deferNotThrough}, ` +
-      `off-face ${rf.deferOffFace}, near-edge ${rf.deferNearEdge}, no-openings ${rf.deferNoOpenings})`,
+      `off-face ${rf.deferOffFace}, near-edge ${rf.deferNearEdge}, no-openings ${rf.deferNoOpenings}, ` +
+      `too-many ${rf.deferTooManyOpenings ?? 0})`,
   );
 
   if (d.worstHosts.length > 0) {

--- a/packages/geometry/src/diagnostics.test.ts
+++ b/packages/geometry/src/diagnostics.test.ts
@@ -15,7 +15,7 @@ function make(partial: Partial<GeometryDiagnostics> = {}): GeometryDiagnostics {
     silentNoOps: 0,
     rectFast: {
       fired: 0, openingsCut: 0, deferHostNotBox: 0, deferNotThrough: 0,
-      deferOffFace: 0, deferNearEdge: 0, deferNoOpenings: 0,
+      deferOffFace: 0, deferNearEdge: 0, deferNoOpenings: 0, deferTooManyOpenings: 0,
     },
     worstHosts: [],
     ...partial,
@@ -35,12 +35,12 @@ describe('mergeGeometryDiagnostics', () => {
     const a = make({
       totalCsgFailures: 2, productsWithFailures: 1, hostsWithOpenings: 4, silentNoOps: 1,
       classification: { rectangular: 5, diagonal: 1, nonRectangular: 2, total: 8 },
-      rectFast: { fired: 3, openingsCut: 6, deferHostNotBox: 1, deferNotThrough: 0, deferOffFace: 0, deferNearEdge: 2, deferNoOpenings: 0 },
+      rectFast: { fired: 3, openingsCut: 6, deferHostNotBox: 1, deferNotThrough: 0, deferOffFace: 0, deferNearEdge: 2, deferNoOpenings: 0, deferTooManyOpenings: 2 },
     });
     const b = make({
       totalCsgFailures: 3, productsWithFailures: 2, hostsWithOpenings: 1, silentNoOps: 2,
       classification: { rectangular: 1, diagonal: 0, nonRectangular: 1, total: 2 },
-      rectFast: { fired: 1, openingsCut: 1, deferHostNotBox: 0, deferNotThrough: 4, deferOffFace: 1, deferNearEdge: 0, deferNoOpenings: 3 },
+      rectFast: { fired: 1, openingsCut: 1, deferHostNotBox: 0, deferNotThrough: 4, deferOffFace: 1, deferNearEdge: 0, deferNoOpenings: 3, deferTooManyOpenings: 5 },
     });
     const m = mergeGeometryDiagnostics(a, b)!;
     expect(m.totalCsgFailures).toBe(5);
@@ -48,7 +48,7 @@ describe('mergeGeometryDiagnostics', () => {
     expect(m.hostsWithOpenings).toBe(5);
     expect(m.silentNoOps).toBe(3);
     expect(m.classification).toEqual({ rectangular: 6, diagonal: 1, nonRectangular: 3, total: 10 });
-    expect(m.rectFast).toEqual({ fired: 4, openingsCut: 7, deferHostNotBox: 1, deferNotThrough: 4, deferOffFace: 1, deferNearEdge: 2, deferNoOpenings: 3 });
+    expect(m.rectFast).toEqual({ fired: 4, openingsCut: 7, deferHostNotBox: 1, deferNotThrough: 4, deferOffFace: 1, deferNearEdge: 2, deferNoOpenings: 3, deferTooManyOpenings: 7 });
   });
 
   it('merges failuresByReason by reason and re-sorts desc by count', () => {

--- a/packages/geometry/src/diagnostics.ts
+++ b/packages/geometry/src/diagnostics.ts
@@ -56,6 +56,8 @@ export interface GeometryDiagnostics {
     deferOffFace: number;
     deferNearEdge: number;
     deferNoOpenings: number;
+    /** Optional: absent on payloads produced before this counter existed (#1649). */
+    deferTooManyOpenings?: number;
   };
   /** Bounded top-N worst-failing hosts (opt-in per-product detail). */
   worstHosts: Array<{
@@ -143,6 +145,7 @@ export function mergeGeometryDiagnostics(
       deferOffFace: a.rectFast.deferOffFace + b.rectFast.deferOffFace,
       deferNearEdge: a.rectFast.deferNearEdge + b.rectFast.deferNearEdge,
       deferNoOpenings: a.rectFast.deferNoOpenings + b.rectFast.deferNoOpenings,
+      deferTooManyOpenings: (a.rectFast.deferTooManyOpenings ?? 0) + (b.rectFast.deferTooManyOpenings ?? 0),
     },
     worstHosts,
   };

--- a/packages/server-client/src/types.ts
+++ b/packages/server-client/src/types.ts
@@ -194,6 +194,7 @@ export interface GeometryDiagnostics {
     deferOffFace: number;
     deferNearEdge: number;
     deferNoOpenings: number;
+    deferTooManyOpenings?: number;
   };
   worstHosts: Array<{
     productId: number;


### PR DESCRIPTION
## Summary

Follow-up to #1649. The rect-fast opening-count DoS cap added a new `deferTooManyOpenings` counter, and the Rust side (#1649) already emits it in the `RectFastSummary` JSON — but the TS diagnostics types, the merge function, and the CLI geometry report never surfaced it, so the new defer reason was invisible in observability. This wires it end-to-end.

## Changes
- `@ifc-lite/geometry` `GeometryDiagnostics.rectFast` type + `mergeGeometryDiagnostics` (sums the new field).
- `@ifc-lite/server-client` mirror type.
- CLI geometry report renders `too-many N` in the rect_fast defer breakdown.
- Tests: the merge test now exercises the new field's sum (2 + 5 = 7); the CLI report test asserts the rendered `too-many 3`.

## Verification
Verified locally (deps installed this time): `turbo build` typechecks the cli/geometry/server-client chain clean, and `turbo test` passes — 135 geometry + 140 CLI tests. Rust already carries the field (merged in #1649), so this is TS-only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Geometry reports now include an additional `too-many` count in the `rect_fast` summary, so all defer-related metrics are shown more completely.
  * Diagnostic merging now preserves this new count correctly, keeping combined results accurate across runs.
  * Updated related tests to cover the new output and ensure the reported totals stay consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->