### PR TITLE
perf: SIMD schema detection + skip the no-op sliver-refine pass

### DIFF
--- a/.changeset/perf-schema-memmem-sliver-fastpath.md
+++ b/.changeset/perf-schema-memmem-sliver-fastpath.md
@@ -1,0 +1,10 @@
+---
+"@ifc-lite/wasm": patch
+---
+
+Two byte-identical cold-load micro-optimizations found by profiling the post-parse-optimization pipeline:
+
+- **SIMD schema detection.** Schema-version detection walked the whole file with a naive per-position `content.windows(n).any(|w| w == b"IFC4X3")` (then again for `IFC4`) — for an IFC2X3 file both scans traverse every byte and fail. Swapped to `memchr::memmem::find`, the same predicate with a SIMD scan. This sat in an untimed gap between phase counters, so it hid from the per-phase profile; measured **-14% total load on a 47 MB IFC2X3 model**, less on IFC4.
+- **Skip the no-op sliver-refine pass.** `refine_high_aspect_slivers` runs after every voided host; on a clean cut (no high-aspect slivers, the common case) it still built a per-round edge→triangle `BTreeMap` and scanned it only to discover there was nothing to split. It now does one O(T) aspect scan first and returns the mesh unchanged when no triangle exceeds the sliver threshold — byte-identical to the former `changed_any == false` return — and uses an `FxHashMap` for the vertex-canonicalization lookup (ids are insertion-ordered, map never iterated). A few percent on void-heavy architectural models.
+
+Output is byte-identical (mesh/vertex/triangle counts unchanged across the fixture set; no mesh-determinism manifest change).

--- a/rust/geometry/src/facet_weld.rs
+++ b/rust/geometry/src/facet_weld.rs
@@ -454,7 +454,10 @@ pub fn refine_high_aspect_slivers(mesh: &Mesh) -> Mesh {
     let mut canon_of: Vec<usize> = vec![0; vertex_count];
     let mut cpos: Vec<[f64; 3]> = Vec::new();
     {
-        let mut seen: BTreeMap<(i64, i64, i64), usize> = BTreeMap::new();
+        // FxHashMap (canonical ids are insertion-ordered via `cpos.len()`, the
+        // map is only queried by key — output identical, no tree-balance cost).
+        let mut seen: rustc_hash::FxHashMap<(i64, i64, i64), usize> =
+            rustc_hash::FxHashMap::default();
         for i in 0..vertex_count {
             let p = pos(i);
             let key = (dedup_key(p[0]), dedup_key(p[1]), dedup_key(p[2]));
@@ -488,6 +491,17 @@ pub fn refine_high_aspect_slivers(mesh: &Mesh) -> Mesh {
             (v, u)
         }
     };
+
+    // Fast path (common case: a clean cut leaves no slivers). A split only fires
+    // for a triangle whose aspect exceeds SLIVER_ASPECT; if none does, the round
+    // loop would build its edge map, find nothing, and return the mesh unchanged.
+    // One O(T) scan detects that and skips it — byte-identical to that no-op.
+    if !tris
+        .iter()
+        .any(|t| aspect(cpos[t[0]], cpos[t[1]], cpos[t[2]]) > SLIVER_ASPECT)
+    {
+        return mesh.clone();
+    }
 
     let mut changed_any = false;
     for _round in 0..MAX_BISECT_ROUNDS {

--- a/rust/processing/src/processor/mod.rs
+++ b/rust/processing/src/processor/mod.rs
@@ -890,16 +890,12 @@ pub fn process_geometry_streaming_filtered_with_options(
         opening_filter,
     );
 
-    // Detect schema version
-    if content
-        .windows(b"IFC4X3".len())
-        .any(|window| window == b"IFC4X3")
-    {
+    // Detect schema version. SIMD substring search (memmem) instead of the naive
+    // per-position `windows().any()`, which walked the WHOLE file — twice for an
+    // IFC2X3 file where both matches fail. Same predicate, byte-identical result.
+    if memchr::memmem::find(content, b"IFC4X3").is_some() {
         schema_version = "IFC4X3".into();
-    } else if content
-        .windows(b"IFC4".len())
-        .any(|window| window == b"IFC4")
-    {
+    } else if memchr::memmem::find(content, b"IFC4").is_some() {
         schema_version = "IFC4".into();
     }
 

--- a/rust/processing/tests/module_size_allowlist.txt
+++ b/rust/processing/tests/module_size_allowlist.txt
@@ -35,7 +35,7 @@
      998 rust/geometry/src/extrusion.rs
 # +4: refine_high_aspect_slivers routes its rebuild through Mesh::rebuilt_like so a slivered host keeps its local-frame origin + #1474 placement capture (B7 metadata-loss fix).
 # +1: SNAP_GRID/NORMAL_QUANT single-homed to kernel::mesh_bridge / crate::grid (import replaces local const; doc rewrap costs a line).
-     764 rust/geometry/src/facet_weld.rs
+          778 rust/geometry/src/facet_weld.rs
 # +2: mix64 made pub(crate); doc-comment noting the shared use by router::content_hash.
      410 rust/geometry/src/geom_hash.rs
      633 rust/geometry/src/kernel/arrangement/classify.rs


### PR DESCRIPTION
## Summary

Round-2 profiling (after the parse-side wins landed, geometry now dominates cold-load) surfaced two **byte-identical** micro-optimizations.

### 1. SIMD schema detection
Schema-version detection walked the whole file with a naive per-position `content.windows(n).any(|w| w == b"IFC4X3")`, then again for `IFC4` — for an **IFC2X3** file both scans traverse every byte and fail. It sits in an *untimed gap* between the phase counters, so it hid from the per-phase profile. Swapped to `memchr::memmem::find` (the same predicate, SIMD).

**Measured: −14% total load on schependomlaan (47 MB IFC2X3)**, less on IFC4.

### 2. Skip the no-op sliver-refine pass
`refine_high_aspect_slivers` runs after every voided host. On a clean cut (no high-aspect slivers — the common case) it still built a per-round edge→triangle `BTreeMap` and scanned it only to find nothing to split, then returned the mesh unchanged. It now does one O(T) aspect pre-scan and returns the mesh unchanged when no triangle exceeds `SLIVER_ASPECT` — byte-identical to the former `changed_any == false` return — and uses `FxHashMap` for the vertex-canonicalization lookup (ids are insertion-ordered, the map is never iterated).

## Byte-identical

Mesh / vertex / triangle counts unchanged across schependomlaan, skolebygg, dental_clinic, rvt01, Holter, HouseZ. `cargo test -p ifc-lite-processing -p ifc-lite-geometry` green (incl. `mesh_determinism`, `styling_parity`, the sliver-weld tests). No manifest change.

## Test plan
- [x] `perf_probe` A/B (numbers above), interleaved
- [x] mesh/vert/tri byte-parity vs main across fixtures
- [x] `cargo test -p ifc-lite-processing -p ifc-lite-geometry`