### PR TITLE
perf(wasm): collect orphan type-geometry from stashed spans, not a re-scan

### DIFF
--- a/.changeset/perf-wasm-orphan-type-from-spans.md
+++ b/.changeset/perf-wasm-orphan-type-from-spans.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/wasm": patch
+---
+
+Faster browser cold load on RepresentationMap models: the streaming pre-pass's orphan-type-geometry collection (#957) ran a SECOND full `EntityScanner` walk over the whole file — a flagged `#962` TODO — whenever the model contained an `IfcRepresentationMap` (every Revit/Tekla mapped-item export, where the fast-path substring bail-out does not fire). The main scan already stashes the `IfcMappedItem` spans; it now also stashes the `IfcTypeProduct` candidate spans (with their `IfcType` resolved from the scanner's type name), and `collect_type_geometry_jobs_from_spans` builds the orphan-type jobs from those spans instead of re-walking the file — the same span-reuse pattern as the material-layer and referenced-map builders. Byte-identical: same referenced set, same candidates in file order, same unreferenced-map filter (verified on the fixture corpus plus orphan/referenced synthetic cases). Removes one whole-file scan from time-to-first-geometry on affected models.

--- a/rust/processing/tests/module_size_allowlist.txt
+++ b/rust/processing/tests/module_size_allowlist.txt
@@ -114,7 +114,7 @@
 # +108: build the referenced-repmaps + instantiated-type-id sets and the material-layer index ONCE in the streaming pre-pass (from spans this scan already collected) and emit them as a `prepass-columns` event, so every geometry worker skips its own full-file walk on the first batch (perf/single-scan #957/#563).
 # +14: #1623 Phase 3 — tally the don't-bake MappedInstancePlan from the same IfcMappedItem spans and emit it on the prepass-columns event (mirrors the referenced-repmaps ship).
 # +9: cap the entity-index up-front reservation (PREPASS_INDEX_RESERVE_CAP) so a ~4GB file does not reserve ~1GB of slots on top of the resident file and abort the wasm32 4GB address space before the scan (huge-file graceful-4gb).
-     758 rust/wasm-bindings/src/api/gpu_meshes/prepass.rs
+     780 rust/wasm-bindings/src/api/gpu_meshes/prepass.rs
      436 rust/wasm-bindings/src/api/grid_lines.rs
 # +75: add the setReferencedRepmaps / setInstantiatedTypeIds / setMaterialLayerIndex wasm setters that install the pre-pass-computed per-content structures into the worker's IfcAPI (perf/single-scan #957/#563), mirroring setEntityIndex.
 # +23: add the cached_source_bytes session field (doc + init + clearPrePassCache drop) for cold-load lever 1c (setSourceBytes); the setter + FromSource batch variants live in the new sub-400 gpu_meshes/batch_from_source.rs, not here (perf/coldload-setsourcebytes).
@@ -124,3 +124,4 @@
      1088 rust/wasm-bindings/src/api/mod.rs
      692 rust/wasm-bindings/src/zero_copy/mesh.rs
      743 rust/wasm-bindings/src/zero_copy/symbolic.rs
+     440 rust/wasm-bindings/src/api/styling/prepass.rs

--- a/rust/wasm-bindings/src/api/gpu_meshes/prepass.rs
+++ b/rust/wasm-bindings/src/api/gpu_meshes/prepass.rs
@@ -250,6 +250,12 @@ impl IfcAPI {
         // already stashed in `prepass_spans`.
         let mut mapped_item_spans: Vec<(u32, usize, usize)> = Vec::new();
         let mut rel_defines_by_type_spans: Vec<(u32, usize, usize)> = Vec::new();
+        // #957/#962: IfcTypeProduct candidates (id, span, resolved type), stashed
+        // here so the orphan-type-geometry pass reuses THIS scan instead of a
+        // second full EntityScanner walk over the file. `IfcType` is captured
+        // from the scanner's `type_name` so it matches `collect_type_geometry_jobs`
+        // byte-for-byte.
+        let mut type_candidate_spans: Vec<(u32, usize, usize, IfcType)> = Vec::new();
         // Mirror `get_or_build_material_layer_index`'s `IFCMATERIALLAYERSET`
         // substring gate exactly, but detect it from the scan (a layer-set
         // keyword only appears as an entity type) so we never re-scan the file:
@@ -355,6 +361,18 @@ impl IfcAPI {
                     has_layer_set = true;
                 }
                 _ => {
+                    // #957/#962: an IfcTypeProduct subtype (its geometry is
+                    // authored on RepresentationMaps, not the type itself, so it
+                    // never matches `has_geometry_by_name`). Stash it for the
+                    // orphan-type pass; the RepresentationMaps attr-6 decode +
+                    // referenced-filter happens later in
+                    // `collect_type_geometry_jobs_from_spans`.
+                    if type_name.ends_with("TYPE") || type_name.ends_with("STYLE") {
+                        let type_ty = IfcType::from_str(type_name);
+                        if type_ty.is_subtype_of(IfcType::IfcTypeProduct) {
+                            type_candidate_spans.push((id, start, end, type_ty));
+                        }
+                    }
                     if has_geometry_by_name(type_name) && !disabled_types.contains(type_name) {
                         let ifc_type = IfcType::from_str(type_name);
                         // We don't bucket by simple/complex here — the host
@@ -718,7 +736,11 @@ impl IfcAPI {
         // type-library (#957) geometry, so skip producing it at load when the
         // caller asks (the Types view re-loads on demand).
         if !skip_type_geometry {
-            let type_jobs = crate::api::styling::collect_type_geometry_jobs(content, &mut decoder);
+            let type_jobs = crate::api::styling::collect_type_geometry_jobs_from_spans(
+                &mapped_item_spans,
+                &type_candidate_spans,
+                &mut decoder,
+            );
             if !type_jobs.is_empty() {
                 total_jobs += type_jobs.len() as u32;
                 // Type-library geometry is a small, usually-suppressed tail; route

--- a/rust/wasm-bindings/src/api/gpu_meshes/prepass.rs
+++ b/rust/wasm-bindings/src/api/gpu_meshes/prepass.rs
@@ -261,15 +261,6 @@ impl IfcAPI {
         // keyword only appears as an entity type) so we never re-scan the file:
         // an `IfcMaterialLayerSet`/`...Usage` entity is present iff the gate fires.
         let mut has_layer_set = false;
-        // #957 orphan-type gate. `collect_type_geometry_jobs` used to bail on a
-        // whole-file `IFCREPRESENTATIONMAP` substring check; we detect the same
-        // condition from the scan (a RepresentationMap keyword only appears as an
-        // entity type) and skip the span collector entirely when absent. This
-        // keeps the no-type-geometry common case free AND stays byte-identical to
-        // the old bail-out: with no RepresentationMap entity there is nothing a
-        // type's attr-6 can validly reference, so the job list is empty either
-        // way (and a dangling attr-6 ref no longer fabricates a phantom job).
-        let mut has_representation_map = false;
         // Plane-angle scale, resolved with the meta by the shared resolver and
         // carried on the meta event so workers seed their batch decoders.
         let mut plane_angle_to_radians = 1.0f64;
@@ -368,9 +359,6 @@ impl IfcAPI {
                 }
                 "IFCMATERIALLAYERSET" | "IFCMATERIALLAYERSETUSAGE" => {
                     has_layer_set = true;
-                }
-                "IFCREPRESENTATIONMAP" => {
-                    has_representation_map = true;
                 }
                 _ => {
                     // #957/#962: an IfcTypeProduct subtype (its geometry is
@@ -738,16 +726,16 @@ impl IfcAPI {
         //
         // #962 done: the mapped-item source + type-candidate spans were collected
         // by the streaming scan above, so this resolves orphans from those stashes
-        // with NO second EntityScanner pass. `has_representation_map` reproduces
-        // the old whole-file `IFCREPRESENTATIONMAP` substring bail-out: with no
-        // RepresentationMap entity there can be no orphan type geometry, so skip
-        // the collector entirely — free on the ~all-files-without-type-geometry
-        // common case, and byte-identical to the old guard (no phantom job from a
-        // dangling type attr-6 ref).
+        // with NO second EntityScanner pass. The gate is the SAME predicate the old
+        // `collect_type_geometry_jobs` bailed on — an `IFCREPRESENTATIONMAP`
+        // substring (a SIMD memmem, not a full scan) — so behaviour stays byte-
+        // identical to the old path and `combined_pre_pass`, free on the no-type case.
         // #1097 perf: the viewer's default Model view does not render the
         // type-library (#957) geometry, so skip producing it at load when the
         // caller asks (the Types view re-loads on demand).
-        if !skip_type_geometry && has_representation_map {
+        if !skip_type_geometry
+            && memchr::memmem::find(content, b"IFCREPRESENTATIONMAP").is_some()
+        {
             let type_jobs = crate::api::styling::collect_type_geometry_jobs_from_spans(
                 &mapped_item_spans,
                 &type_candidate_spans,

--- a/rust/wasm-bindings/src/api/gpu_meshes/prepass.rs
+++ b/rust/wasm-bindings/src/api/gpu_meshes/prepass.rs
@@ -261,6 +261,15 @@ impl IfcAPI {
         // keyword only appears as an entity type) so we never re-scan the file:
         // an `IfcMaterialLayerSet`/`...Usage` entity is present iff the gate fires.
         let mut has_layer_set = false;
+        // #957 orphan-type gate. `collect_type_geometry_jobs` used to bail on a
+        // whole-file `IFCREPRESENTATIONMAP` substring check; we detect the same
+        // condition from the scan (a RepresentationMap keyword only appears as an
+        // entity type) and skip the span collector entirely when absent. This
+        // keeps the no-type-geometry common case free AND stays byte-identical to
+        // the old bail-out: with no RepresentationMap entity there is nothing a
+        // type's attr-6 can validly reference, so the job list is empty either
+        // way (and a dangling attr-6 ref no longer fabricates a phantom job).
+        let mut has_representation_map = false;
         // Plane-angle scale, resolved with the meta by the shared resolver and
         // carried on the meta event so workers seed their batch decoders.
         let mut plane_angle_to_radians = 1.0f64;
@@ -359,6 +368,9 @@ impl IfcAPI {
                 }
                 "IFCMATERIALLAYERSET" | "IFCMATERIALLAYERSETUSAGE" => {
                     has_layer_set = true;
+                }
+                "IFCREPRESENTATIONMAP" => {
+                    has_representation_map = true;
                 }
                 _ => {
                     // #957/#962: an IfcTypeProduct subtype (its geometry is
@@ -724,18 +736,18 @@ impl IfcAPI {
         // (geometry on the type via RepresentationMaps, no occurrence). The
         // entity index is complete here, so this resolves cleanly.
         //
-        // PERF (flagged, #962 review): for files WITH representation maps this is
-        // a second linear EntityScanner pass over `content` on top of the
-        // streaming scan above. A `IFCREPRESENTATIONMAP` substring guard inside
-        // the helper makes the ~all-files-without-type-geometry case free (just a
-        // SIMD memmem). The remaining instanced-file cost is a tracked follow-up:
-        // fold the mapped-item-source + type-candidate collection into the
-        // streaming scan loop so orphans resolve with no extra pass. Kept as a
-        // separate pass for now to avoid destabilising the streaming hot path.
+        // #962 done: the mapped-item source + type-candidate spans were collected
+        // by the streaming scan above, so this resolves orphans from those stashes
+        // with NO second EntityScanner pass. `has_representation_map` reproduces
+        // the old whole-file `IFCREPRESENTATIONMAP` substring bail-out: with no
+        // RepresentationMap entity there can be no orphan type geometry, so skip
+        // the collector entirely — free on the ~all-files-without-type-geometry
+        // common case, and byte-identical to the old guard (no phantom job from a
+        // dangling type attr-6 ref).
         // #1097 perf: the viewer's default Model view does not render the
         // type-library (#957) geometry, so skip producing it at load when the
         // caller asks (the Types view re-loads on demand).
-        if !skip_type_geometry {
+        if !skip_type_geometry && has_representation_map {
             let type_jobs = crate::api::styling::collect_type_geometry_jobs_from_spans(
                 &mapped_item_spans,
                 &type_candidate_spans,

--- a/rust/wasm-bindings/src/api/styling/mod.rs
+++ b/rust/wasm-bindings/src/api/styling/mod.rs
@@ -11,5 +11,5 @@ pub(crate) use color::resolve_element_color;
 pub(crate) use prepass::{
     build_instantiated_type_ids, build_instantiated_type_ids_from_spans,
     build_mapped_instance_plan_from_spans, build_referenced_representation_maps,
-    build_referenced_representation_maps_from_spans, collect_type_geometry_jobs, collect_type_geometry_jobs_from_spans, combined_pre_pass,
+    build_referenced_representation_maps_from_spans, collect_type_geometry_jobs_from_spans, combined_pre_pass,
 };

--- a/rust/wasm-bindings/src/api/styling/mod.rs
+++ b/rust/wasm-bindings/src/api/styling/mod.rs
@@ -11,5 +11,5 @@ pub(crate) use color::resolve_element_color;
 pub(crate) use prepass::{
     build_instantiated_type_ids, build_instantiated_type_ids_from_spans,
     build_mapped_instance_plan_from_spans, build_referenced_representation_maps,
-    build_referenced_representation_maps_from_spans, collect_type_geometry_jobs, combined_pre_pass,
+    build_referenced_representation_maps_from_spans, collect_type_geometry_jobs, collect_type_geometry_jobs_from_spans, combined_pre_pass,
 };

--- a/rust/wasm-bindings/src/api/styling/prepass.rs
+++ b/rust/wasm-bindings/src/api/styling/prepass.rs
@@ -183,6 +183,49 @@ pub(crate) fn collect_type_geometry_jobs(
         .collect()
 }
 
+/// Span-based twin of [`collect_type_geometry_jobs`]. The streaming pre-pass
+/// stashes both the `IfcMappedItem` spans and the `IfcTypeProduct` candidate
+/// spans (with their resolved `IfcType`, computed from the scanner's `type_name`)
+/// during its single scan, so this reuses them instead of re-walking the whole
+/// file — the #957/#962 second `EntityScanner` pass. Byte-identical: same
+/// referenced set (same mapped-item spans, file order), same candidates (same
+/// type spans in file order, same attr-6 RepresentationMaps decode), same
+/// unreferenced-map filter, same output order.
+pub(crate) fn collect_type_geometry_jobs_from_spans(
+    mapped_item_spans: &[(u32, usize, usize)],
+    type_candidate_spans: &[(u32, usize, usize, ifc_lite_core::IfcType)],
+    decoder: &mut ifc_lite_core::EntityDecoder,
+) -> Vec<(u32, usize, usize, ifc_lite_core::IfcType)> {
+    let mut referenced: rustc_hash::FxHashSet<u32> = rustc_hash::FxHashSet::default();
+    for &(id, start, end) in mapped_item_spans {
+        if let Ok(entity) = decoder.decode_at_with_id(id, start, end) {
+            if let Some(source_id) = entity.get_ref(0) {
+                referenced.insert(source_id);
+            }
+        }
+    }
+
+    let mut candidates: Vec<(u32, usize, usize, ifc_lite_core::IfcType, Vec<u32>)> = Vec::new();
+    for &(id, start, end, ifc_type) in type_candidate_spans {
+        if let Ok(entity) = decoder.decode_at_with_id(id, start, end) {
+            let rep_maps: Vec<u32> = entity
+                .get(6)
+                .and_then(|a| a.as_list())
+                .map(|list| list.iter().filter_map(|v| v.as_entity_ref()).collect())
+                .unwrap_or_default();
+            if !rep_maps.is_empty() {
+                candidates.push((id, start, end, ifc_type, rep_maps));
+            }
+        }
+    }
+
+    candidates
+        .into_iter()
+        .filter(|(_, _, _, _, maps)| maps.iter().any(|rm| !referenced.contains(rm)))
+        .map(|(id, start, end, ifc_type, _)| (id, start, end, ifc_type))
+        .collect()
+}
+
 /// #957: the set of `RepresentationMap`s instantiated by an `IfcMappedItem`, so
 /// `processGeometryBatch` can tell which of a type's RepresentationMaps are
 /// orphan (rendered directly) vs already drawn through an occurrence.
@@ -300,3 +343,98 @@ pub(crate) fn build_instantiated_type_ids_from_spans(
 // longer drift between them. (It is still derived from the canonical resolved
 // placement matrix `GeometryRouter::resolve_scaled_placement` + the shared
 // `ifc_lite_geometry::rotation_angle_about_z`.)
+
+#[cfg(test)]
+mod orphan_type_from_spans_tests {
+    use super::{collect_type_geometry_jobs, collect_type_geometry_jobs_from_spans};
+    use ifc_lite_core::{build_entity_index, EntityDecoder, EntityScanner, IfcType};
+
+    /// Build the mapped-item + type-candidate spans exactly as the streaming
+    /// pre-pass scan does, then assert the span-based orphan-type collector
+    /// matches the full-scan one byte-for-byte.
+    fn assert_match(content: &[u8]) -> usize {
+        let index = std::sync::Arc::new(build_entity_index(content));
+        let mut d1 = EntityDecoder::with_arc_index(content, index.clone());
+        let old = collect_type_geometry_jobs(content, &mut d1);
+        let mut mapped: Vec<(u32, usize, usize)> = Vec::new();
+        let mut cands: Vec<(u32, usize, usize, IfcType)> = Vec::new();
+        let mut sc = EntityScanner::new(content);
+        while let Some((id, tn, st, en)) = sc.next_entity() {
+            if tn == "IFCMAPPEDITEM" {
+                mapped.push((id, st, en));
+            } else if tn.ends_with("TYPE") || tn.ends_with("STYLE") {
+                let t = IfcType::from_str(tn);
+                if t.is_subtype_of(IfcType::IfcTypeProduct) {
+                    cands.push((id, st, en, t));
+                }
+            }
+        }
+        let mut d2 = EntityDecoder::with_arc_index(content, index);
+        let new = collect_type_geometry_jobs_from_spans(&mapped, &cands, &mut d2);
+        assert_eq!(old, new, "orphan type jobs diverged");
+        old.len()
+    }
+
+    // An IfcColumnType carrying a RepresentationMap that NO IfcMappedItem
+    // references — the #957 orphan-type-geometry case (renders the type's map
+    // directly). RepresentationMaps is IfcTypeProduct attr 6.
+    const ORPHAN: &str = r#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''),'2;1');
+FILE_NAME('t.ifc','',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('0Project0000000000000A',$,'P',$,$,$,$,(#2),#3);
+#2=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.0E-5,#5,$);
+#3=IFCUNITASSIGNMENT((#6));
+#4=IFCCARTESIANPOINT((0.,0.,0.));
+#5=IFCAXIS2PLACEMENT3D(#4,$,$);
+#6=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+#8=IFCCARTESIANPOINTLIST3D(((0.,0.,0.),(1.,0.,0.),(0.,1.,0.),(0.,0.,1.)));
+#10=IFCREPRESENTATIONMAP(#5,#12);
+#12=IFCSHAPEREPRESENTATION(#2,'Body','Tessellation',(#13));
+#13=IFCTRIANGULATEDFACESET(#8,$,.T.,((1,2,3),(1,2,4),(1,4,3),(2,3,4)),$);
+#20=IFCCOLUMNTYPE('0ColType00000000000A',$,'ColType',$,$,$,(#10),$,$,.COLUMN.);
+ENDSEC;
+END-ISO-10303-21;
+"#;
+
+    // Same, but an IfcMappedItem references the map — the map is drawn through
+    // the occurrence, so the type yields NO orphan job (filtered out).
+    const REFERENCED: &str = r#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''),'2;1');
+FILE_NAME('t.ifc','',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('0Project0000000000000A',$,'P',$,$,$,$,(#2),#3);
+#2=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.0E-5,#5,$);
+#3=IFCUNITASSIGNMENT((#6));
+#4=IFCCARTESIANPOINT((0.,0.,0.));
+#5=IFCAXIS2PLACEMENT3D(#4,$,$);
+#6=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+#8=IFCCARTESIANPOINTLIST3D(((0.,0.,0.),(1.,0.,0.),(0.,1.,0.),(0.,0.,1.)));
+#10=IFCREPRESENTATIONMAP(#5,#12);
+#12=IFCSHAPEREPRESENTATION(#2,'Body','Tessellation',(#13));
+#13=IFCTRIANGULATEDFACESET(#8,$,.T.,((1,2,3),(1,2,4),(1,4,3),(2,3,4)),$);
+#20=IFCCOLUMNTYPE('0ColType00000000000A',$,'ColType',$,$,$,(#10),$,$,.COLUMN.);
+#30=IFCMAPPEDITEM(#10,#31);
+#31=IFCCARTESIANTRANSFORMATIONOPERATOR3D($,$,#4,$,$);
+ENDSEC;
+END-ISO-10303-21;
+"#;
+
+    #[test]
+    fn from_spans_matches_full_scan_orphan_case() {
+        let n = assert_match(ORPHAN.as_bytes());
+        assert_eq!(n, 1, "the orphan IfcColumnType should yield one type job");
+    }
+
+    #[test]
+    fn from_spans_matches_full_scan_referenced_case() {
+        let n = assert_match(REFERENCED.as_bytes());
+        assert_eq!(n, 0, "a referenced RepresentationMap yields no orphan type job");
+    }
+}


### PR DESCRIPTION
## Summary

The streaming pre-pass's orphan-type-geometry collection (#957) ran a **second full `EntityScanner` walk** over the whole file whenever the model carried an `IfcRepresentationMap` — every Revit/Tekla mapped-item export (the fast-path substring bail-out only skips it on files with *no* representation maps). This was a flagged in-code TODO (#962: "fold the mapped-item-source + type-candidate collection into the streaming scan loop").

The main scan already stashes the `IfcMappedItem` spans. It now also stashes the `IfcTypeProduct` candidate spans — `(id, span, IfcType)`, with the `IfcType` resolved from the scanner's `type_name` so it matches the full-scan path exactly — and `collect_type_geometry_jobs_from_spans` builds the orphan-type jobs from those spans instead of re-walking the file. Same span-reuse pattern as the already-shipped material-layer (#1648) and referenced-representation-map builders.

Removes one whole-file scan from time-to-first-geometry on RepresentationMap-heavy models.

## Byte-identical

Same referenced set (same `IfcMappedItem` spans, file order), same candidates (same type spans in file order, same attr-6 `RepresentationMaps` decode), same unreferenced-map filter, same output order. Verified:
- `collect_type_geometry_jobs` vs `collect_type_geometry_jobs_from_spans` agree across the fixture corpus (schependomlaan, Holter, rvt01, annex-E, ifcopenshell columns, …).
- Synthetic **orphan** case (an `IfcColumnType` whose `RepresentationMap` no `IfcMappedItem` references → **1** job) and **referenced** case (a mapped item references it → **0** jobs) both match.
- `cargo test -p ifc-lite-wasm` green.

## Test plan
- [x] old-vs-new equality across corpus + orphan/referenced synthetic cases
- [x] `cargo test -p ifc-lite-wasm`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved browser cold-load performance for certain model types by reducing redundant processing.
  * Streamlined how geometry-related data is handled so previously gathered information can be reused instead of scanning content again.
* **Tests**
  * Added coverage to confirm the new approach matches existing behavior and correctly skips already-referenced data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->