### PR TITLE
feat(cli): extract-entities — isolate a suspect element with its voids

### DIFF
--- a/.changeset/extract-entities-command.md
+++ b/.changeset/extract-entities-command.md
@@ -1,0 +1,11 @@
+---
+"@ifc-lite/cli": minor
+---
+
+Add `ifc-lite extract-entities` — isolate a handful of entities from a large IFC into a small, valid, viewable standalone model, the "reproduce a suspect element" step of a geometry-triage loop.
+
+Selectors (unioned): `--product <GUID|expressId>` (repeatable / comma-list), `--type <IfcType>`, `--storey <GUID|name|expressId>` (every product placed under a storey via its placement chain), and `--detect [--top N]` (the meshes a geometry-triage pass ranks most unusual). The output carries each selected product's full forward reference closure plus the shared context roots (IfcProject, unit assignment, geometric contexts, and the site/building/storey spatial skeleton) and every spatial-containment relation whose members are all kept — so the result parses and renders on its own with zero dangling references. Add `--view` to open it in the viewer.
+
+Crucially, a selected element also carries its openings and their fillers: every `IfcRelVoidsElement` whose host is kept (plus the `IfcOpeningElement` cutter) and every `IfcRelFillsElement` whose opening is kept (plus the window/door). These relations point *backward* to the host, so forward closure alone never reaches them — without this an isolated wall extracts as an uncut box, hiding the very void-cut geometry a triage loop needs to reproduce.
+
+`extract-entities <file> --detect --report [--json]` prints a triage report without extracting, separating HARD defects (non-finite or `|coord|>1e4` vertices after the per-element local-frame/RTC recentre — genuine corruption) from REVIEW heuristics (oversized AABB) that are frequently legitimate for thin or large elements and must be eyeballed, not trusted.

--- a/packages/cli/src/commands/extract-entities.test.ts
+++ b/packages/cli/src/commands/extract-entities.test.ts
@@ -74,6 +74,10 @@ describe('resolveToId', () => {
   it('throws on an unknown GlobalId', () => {
     expect(() => resolveToId('NOPE00000000000000000X', p)).toThrow(/not found/);
   });
+  it('throws on a non-existent express id / #id (not silently selecting nothing)', () => {
+    expect(() => resolveToId('999999', p)).toThrow(/expressId not found/);
+    expect(() => resolveToId('#999999', p)).toThrow(/expressId not found/);
+  });
 });
 
 describe('forwardClosure', () => {

--- a/packages/cli/src/commands/extract-entities.test.ts
+++ b/packages/cli/src/commands/extract-entities.test.ts
@@ -1,0 +1,198 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, expect, it } from 'vitest';
+import {
+  parseStep,
+  resolveToId,
+  forwardClosure,
+  buildSubset,
+  serializeSubset,
+  scoreTriage,
+} from './extract-entities.js';
+
+// A tiny but representative model: project + units + geometric context + a
+// storey, one wall placed under the storey (with a placement chain and a
+// rectangle-extrusion body), a containment relation, and — critically — a Name
+// literal carrying both `;` and `#` to exercise the string-aware tokenizer.
+const MODEL = `ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''),'2;1');
+FILE_NAME('m','2024',(''),(''),'','','');
+FILE_SCHEMA(('IFC2X3'));
+ENDSEC;
+DATA;
+#1= IFCPROJECT('PROJ00000000000000000X',$,'Proj',$,$,$,$,(#20),#30);
+#20= IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.E-5,#21,$);
+#21= IFCAXIS2PLACEMENT3D(#22,$,$);
+#22= IFCCARTESIANPOINT((0.,0.,0.));
+#30= IFCUNITASSIGNMENT((#31));
+#31= IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+#40= IFCLOCALPLACEMENT($,#21);
+#41= IFCBUILDINGSTOREY('STOR00000000000000000X',$,'L01',$,$,#40,$,$,.ELEMENT.,0.);
+#50= IFCLOCALPLACEMENT(#40,#21);
+#60= IFCRECTANGLEPROFILEDEF(.AREA.,$,#21,2.,0.2);
+#61= IFCEXTRUDEDAREASOLID(#60,#21,#62,3.);
+#62= IFCDIRECTION((0.,0.,1.));
+#63= IFCSHAPEREPRESENTATION(#20,'Body','SweptSolid',(#61));
+#64= IFCPRODUCTDEFINITIONSHAPE($,$,(#63));
+#70= IFCWALLSTANDARDCASE('WALL00000000000000000X',$,'Basic Wall:type;01 #north',$,$,#50,#64,'tag');
+#80= IFCRELCONTAINEDINSPATIALSTRUCTURE('REL000000000000000000X',$,$,$,(#70),#41);
+#90= IFCWALLSTANDARDCASE('WALO00000000000000000X',$,'Other',$,$,#40,#64,'tag2');
+#91= IFCRELCONTAINEDINSPATIALSTRUCTURE('RELO00000000000000000X',$,$,$,(#70,#90),#41);
+ENDSEC;
+END-ISO-10303-21;
+`;
+
+describe('parseStep', () => {
+  it('tokenizes instances despite ; and # inside a string literal', () => {
+    const p = parseStep(MODEL);
+    const wall = p.instances.get(70);
+    expect(wall?.type).toBe('IFCWALLSTANDARDCASE');
+    // The Name "Basic Wall:type;01 #north" must NOT split the instance.
+    expect(wall?.full).toContain("'Basic Wall:type;01 #north'");
+    // 18 data instances parsed; the `#north` inside the Name string must NOT be
+    // mistaken for a 19th instance definition.
+    expect(p.instances.size).toBe(18);
+  });
+
+  it('indexes GlobalIds of rooted entities', () => {
+    const p = parseStep(MODEL);
+    expect(p.guidToId.get('WALL00000000000000000X')).toBe(70);
+    expect(p.guidToId.get('PROJ00000000000000000X')).toBe(1);
+  });
+});
+
+describe('resolveToId', () => {
+  const p = parseStep(MODEL);
+  it('resolves #id, bare id, and GlobalId', () => {
+    expect(resolveToId('#70', p)).toBe(70);
+    expect(resolveToId('70', p)).toBe(70);
+    expect(resolveToId('WALL00000000000000000X', p)).toBe(70);
+  });
+  it('throws on an unknown GlobalId', () => {
+    expect(() => resolveToId('NOPE00000000000000000X', p)).toThrow(/not found/);
+  });
+});
+
+describe('forwardClosure', () => {
+  it('pulls the whole reference subtree of a product', () => {
+    const p = parseStep(MODEL);
+    const keep = new Set<number>();
+    forwardClosure([70], p, keep);
+    // wall → placement chain (#50→#40→#21→#22), shape (#64→#63→#61→#60,#62), ctx (#20)
+    for (const id of [70, 50, 40, 21, 22, 64, 63, 61, 60, 62, 20]) {
+      expect(keep.has(id)).toBe(true);
+    }
+    // it must NOT drag in the unrelated wall #90
+    expect(keep.has(90)).toBe(false);
+  });
+});
+
+describe('buildSubset + serializeSubset', () => {
+  const p = parseStep(MODEL);
+  const keep = buildSubset(new Set([70]), p);
+
+  it('includes the project + spatial context roots', () => {
+    for (const id of [1, 20, 30, 31, 41]) expect(keep.has(id)).toBe(true);
+  });
+
+  it('keeps a containment relation whose members are ALL kept, drops one that references an unkept product', () => {
+    // #80 references only #70 (kept) → included; #91 references #70 AND #90
+    // (#90 not selected) → excluded to avoid a dangling reference.
+    expect(keep.has(80)).toBe(true);
+    expect(keep.has(91)).toBe(false);
+    expect(keep.has(90)).toBe(false);
+  });
+
+  it('serializes a valid, self-contained STEP file with zero dangling references', () => {
+    const out = serializeSubset(keep, p);
+    expect(out).toContain('FILE_SCHEMA');
+    expect(out.trimEnd().endsWith('END-ISO-10303-21;')).toBe(true);
+    const defined = new Set<number>();
+    for (const m of out.matchAll(/^#(\d+)=/gm)) defined.add(Number(m[1]));
+    const data = out.slice(out.indexOf('DATA;'));
+    for (const m of data.matchAll(/#(\d+)/g)) {
+      expect(defined.has(Number(m[1]))).toBe(true);
+    }
+  });
+});
+
+// A wall with a window opening: IfcRelVoidsElement (rel → wall) points BACKWARD
+// to the wall, and IfcRelFillsElement (rel → opening) to the filler window. The
+// opening carries its own faceted-brep cutter body. Forward closure from the
+// wall alone never reaches any of these.
+const VOID_MODEL = `ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''),'2;1');
+FILE_NAME('m','2024',(''),(''),'','','');
+FILE_SCHEMA(('IFC2X3'));
+ENDSEC;
+DATA;
+#1= IFCPROJECT('PROJ00000000000000000X',$,'Proj',$,$,$,$,(#20),#30);
+#20= IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.E-5,#21,$);
+#21= IFCAXIS2PLACEMENT3D(#22,$,$);
+#22= IFCCARTESIANPOINT((0.,0.,0.));
+#30= IFCUNITASSIGNMENT((#31));
+#31= IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+#40= IFCLOCALPLACEMENT($,#21);
+#41= IFCBUILDINGSTOREY('STOR00000000000000000X',$,'L01',$,$,#40,$,$,.ELEMENT.,0.);
+#50= IFCLOCALPLACEMENT(#40,#21);
+#60= IFCRECTANGLEPROFILEDEF(.AREA.,$,#21,2.,0.2);
+#61= IFCEXTRUDEDAREASOLID(#60,#21,#62,3.);
+#62= IFCDIRECTION((0.,0.,1.));
+#63= IFCSHAPEREPRESENTATION(#20,'Body','SweptSolid',(#61));
+#64= IFCPRODUCTDEFINITIONSHAPE($,$,(#63));
+#70= IFCWALLSTANDARDCASE('WALL00000000000000000X',$,'Wall',$,$,#50,#64,'tag');
+#100= IFCEXTRUDEDAREASOLID(#60,#21,#62,3.);
+#101= IFCSHAPEREPRESENTATION(#20,'Body','SweptSolid',(#100));
+#102= IFCPRODUCTDEFINITIONSHAPE($,$,(#101));
+#103= IFCOPENINGELEMENT('OPEN00000000000000000X',$,'Opening',$,$,#50,#102,'op');
+#104= IFCRELVOIDSELEMENT('VOID00000000000000000X',$,$,$,#70,#103);
+#110= IFCSHAPEREPRESENTATION(#20,'Body','SweptSolid',(#100));
+#111= IFCPRODUCTDEFINITIONSHAPE($,$,(#110));
+#112= IFCWINDOW('WIN000000000000000000X',$,'Window',$,$,#50,#111,'w',1.,1.);
+#113= IFCRELFILLSELEMENT('FILL00000000000000000X',$,$,$,#103,#112);
+ENDSEC;
+END-ISO-10303-21;
+`;
+
+describe('buildSubset — voids and fills', () => {
+  const p = parseStep(VOID_MODEL);
+  const keep = buildSubset(new Set([70]), p);
+
+  it('pulls the backward IfcRelVoidsElement + its opening into a wall-only selection', () => {
+    // The wall's forward closure never reaches these (the relation references
+    // the wall, not vice-versa); without void inclusion the wall extracts as an
+    // uncut box, hiding any void-cut defect.
+    expect(keep.has(104)).toBe(true); // IfcRelVoidsElement
+    expect(keep.has(103)).toBe(true); // IfcOpeningElement
+    expect(keep.has(102)).toBe(true); // opening's shape (its cutter body)
+    expect(keep.has(100)).toBe(true); // opening's extrusion
+  });
+
+  it('pulls the IfcRelFillsElement + its filler window once the opening is kept', () => {
+    expect(keep.has(113)).toBe(true); // IfcRelFillsElement
+    expect(keep.has(112)).toBe(true); // IfcWindow
+    expect(keep.has(110)).toBe(true); // window shape
+  });
+
+  it('serializes with zero dangling references', () => {
+    const out = serializeSubset(keep, p);
+    const defined = new Set<number>();
+    for (const m of out.matchAll(/^#(\d+)=/gm)) defined.add(Number(m[1]));
+    const data = out.slice(out.indexOf('DATA;'));
+    for (const m of data.matchAll(/#(\d+)/g)) expect(defined.has(Number(m[1]))).toBe(true);
+  });
+});
+
+describe('scoreTriage', () => {
+  it('always ranks a hard defect (non-finite, then huge) above any AABB heuristic', () => {
+    const nan = scoreTriage({ expressId: 1, ifcType: 'IfcWall', tris: 2, nonFinite: 1, huge: 0, aabbBlowout: 1 });
+    const huge = scoreTriage({ expressId: 2, ifcType: 'IfcWall', tris: 2, nonFinite: 0, huge: 5, aabbBlowout: 999 });
+    const heuristic = scoreTriage({ expressId: 3, ifcType: 'IfcSlab', tris: 2, nonFinite: 0, huge: 0, aabbBlowout: 50 });
+    expect(nan).toBeGreaterThan(huge);
+    expect(huge).toBeGreaterThan(heuristic);
+  });
+});

--- a/packages/cli/src/commands/extract-entities.ts
+++ b/packages/cli/src/commands/extract-entities.ts
@@ -1,0 +1,493 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * `ifc-lite extract-entities <file.ifc> [selectors] --out sub.ifc [--view]`
+ *
+ * Pull a handful of entities out of a large IFC into a small, VALID, viewable
+ * standalone model — the isolate step of a "reproduce a suspect element" loop.
+ * Selectors (unioned):
+ *   --product <GUID|expressId>  explicit product(s); repeatable or comma-list
+ *   --type <IfcType>            every product of a type
+ *   --storey <GUID|name|id>     every product placed under a storey (placement chain)
+ *   --detect [--top N]          the N meshes a geometry-triage pass ranks most unusual
+ *
+ * The output carries each selected product's full forward reference closure PLUS
+ * the shared context roots (IfcProject, unit assignment, geometric contexts, the
+ * spatial site/building/storey skeleton) and every spatial-containment relation
+ * whose members are all kept — so the result parses and renders on its own.
+ *
+ * `--detect --report [--json]` prints the triage report WITHOUT extracting. The
+ * report separates HARD defects (non-finite or |coord|>1e4 vertices after the
+ * per-element local-frame/RTC recentre — genuine corruption) from REVIEW
+ * heuristics (oversized AABB, needle/burst triangulation) that are frequently
+ * legitimate for thin or large elements and must be eyeballed, not trusted.
+ */
+import { readFile, writeFile } from 'node:fs/promises';
+import { basename } from 'node:path';
+import { fatal, getFlag, getAllFlags, hasFlag } from '../output.js';
+import { logger } from '../logger.js';
+
+/** One parsed STEP instance: `#id = TYPE(<body>);`. */
+interface Instance {
+  id: number;
+  type: string;
+  /** Argument text between the outermost parentheses (references + literals). */
+  body: string;
+  /** The verbatim `#id= TYPE(...);` text, re-emitted unchanged into the subset. */
+  full: string;
+}
+
+interface ParsedStep {
+  header: string;
+  instances: Map<number, Instance>;
+  /** 22-char GlobalId → expressId, for rooted entities. */
+  guidToId: Map<string, number>;
+}
+
+/**
+ * String-aware STEP DATA tokenizer. Splits the data section into instances at
+ * the `;` that terminates each `#id = TYPE(...)`, ignoring `;`/`#`/`(` inside
+ * STEP string literals (`'...'`, where `''` is an escaped quote). A regex split
+ * mis-fires on names containing `;` or `#` (common in Revit exports), so this
+ * scans character by character instead.
+ */
+export function parseStep(text: string): ParsedStep {
+  const dataStart = text.indexOf('DATA;');
+  if (dataStart < 0) throw new Error('Not a STEP file: no DATA; section');
+  const headerEnd = text.indexOf('\n', dataStart) + 1;
+  const header = text.slice(0, headerEnd);
+  const data = text;
+
+  const instances = new Map<number, Instance>();
+  const guidToId = new Map<string, number>();
+
+  let i = headerEnd;
+  const n = data.length;
+  while (i < n) {
+    // Seek the next `#`
+    while (i < n && data[i] !== '#') {
+      // Stop at ENDSEC to avoid scanning the footer.
+      if (data.startsWith('ENDSEC', i)) {
+        i = n;
+        break;
+      }
+      i++;
+    }
+    if (i >= n) break;
+    const hashStart = i;
+    i++; // past '#'
+    let idStr = '';
+    while (i < n && data[i] >= '0' && data[i] <= '9') idStr += data[i++];
+    if (idStr === '') continue; // a `#` inside something odd; skip
+    // expect optional spaces then '='
+    let j = i;
+    while (j < n && (data[j] === ' ' || data[j] === '\t')) j++;
+    if (data[j] !== '=') continue; // `#42` as a REFERENCE, not a definition
+    j++;
+    while (j < n && (data[j] === ' ' || data[j] === '\t' || data[j] === '\n' || data[j] === '\r')) j++;
+    // read TYPE
+    let type = '';
+    while (j < n && /[A-Za-z0-9_]/.test(data[j])) type += data[j++];
+    // now consume the balanced `( ... )` respecting strings, then the ';'
+    while (j < n && data[j] !== '(') j++;
+    const bodyStart = j + 1;
+    let depth = 0;
+    let inStr = false;
+    for (; j < n; j++) {
+      const ch = data[j];
+      if (inStr) {
+        if (ch === "'") {
+          if (data[j + 1] === "'") j++; // escaped quote
+          else inStr = false;
+        }
+        continue;
+      }
+      if (ch === "'") inStr = true;
+      else if (ch === '(') depth++;
+      else if (ch === ')') {
+        depth--;
+        if (depth === 0) {
+          j++;
+          break;
+        }
+      }
+    }
+    const bodyEnd = j - 1; // index of the matching ')'
+    // consume up to and including the terminating ';'
+    while (j < n && data[j] !== ';') j++;
+    const semi = j;
+    const id = parseInt(idStr, 10);
+    const body = data.slice(bodyStart, bodyEnd);
+    const full = data.slice(hashStart, semi + 1).trim();
+    instances.set(id, { id, type: type.toUpperCase(), body, full });
+    // First quoted 22-char token is the GlobalId of a rooted entity.
+    const gm = /^\s*'([^']{22})'/.exec(body);
+    if (gm) guidToId.set(gm[1], id);
+    i = semi + 1;
+  }
+  return { header, instances, guidToId };
+}
+
+/** Resolve one selector token to an expressId (`#42`, `42`, or a GlobalId). */
+export function resolveToId(token: string, parsed: ParsedStep): number {
+  const t = token.trim();
+  if (t.startsWith('#')) return parseInt(t.slice(1), 10);
+  if (/^\d+$/.test(t)) return parseInt(t, 10);
+  const id = parsed.guidToId.get(t);
+  if (id === undefined) throw new Error(`GlobalId not found in model: ${t}`);
+  return id;
+}
+
+const REF_RE = /#(\d+)/g;
+
+/** Forward reference closure: every instance transitively referenced by `seeds`. */
+export function forwardClosure(seeds: Iterable<number>, parsed: ParsedStep, into: Set<number>): void {
+  const stack = [...seeds];
+  while (stack.length) {
+    const id = stack.pop()!;
+    if (into.has(id)) continue;
+    into.add(id);
+    const rec = parsed.instances.get(id);
+    if (!rec) continue;
+    REF_RE.lastIndex = 0;
+    let m: RegExpExecArray | null;
+    while ((m = REF_RE.exec(rec.body)) !== null) {
+      const ref = parseInt(m[1], 10);
+      if (!into.has(ref)) stack.push(ref);
+    }
+  }
+}
+
+/** Map each IfcLocalPlacement to its parent placement (or null when top-level). */
+function placementParents(parsed: ParsedStep): Map<number, number | null> {
+  const parents = new Map<number, number | null>();
+  for (const inst of parsed.instances.values()) {
+    if (inst.type !== 'IFCLOCALPLACEMENT') continue;
+    const pm = /^\s*(#\d+|\$)/.exec(inst.body);
+    parents.set(inst.id, pm && pm[1].startsWith('#') ? parseInt(pm[1].slice(1), 10) : null);
+  }
+  return parents;
+}
+
+/** Every product whose ObjectPlacement chains up through `storeyPlacementId`. */
+function productsUnderPlacement(storeyPlacementId: number, parsed: ParsedStep): Set<number> {
+  const parents = placementParents(parsed);
+  const under = new Set<number>();
+  for (const pid of parents.keys()) {
+    let cur: number | null = pid;
+    let guard = 0;
+    while (cur != null && guard++ < 128) {
+      if (cur === storeyPlacementId) {
+        under.add(pid);
+        break;
+      }
+      cur = parents.get(cur) ?? null;
+    }
+  }
+  // Products referencing a selected placement.
+  const seeds = new Set<number>();
+  for (const inst of parsed.instances.values()) {
+    REF_RE.lastIndex = 0;
+    let m: RegExpExecArray | null;
+    while ((m = REF_RE.exec(inst.body)) !== null) {
+      if (under.has(parseInt(m[1], 10))) {
+        seeds.add(inst.id);
+        break;
+      }
+    }
+  }
+  return seeds;
+}
+
+/** Resolve a --storey selector (GUID / name / expressId) to its placement id. */
+function resolveStoreyPlacement(token: string, parsed: ParsedStep): number {
+  let storeyId: number | undefined;
+  const t = token.trim();
+  if (/^#?\d+$/.test(t)) {
+    storeyId = parseInt(t.replace('#', ''), 10);
+  } else if (parsed.guidToId.has(t)) {
+    storeyId = parsed.guidToId.get(t);
+  } else {
+    // match by name (2nd-to-last-ish quoted arg); scan storeys for a Name match
+    for (const inst of parsed.instances.values()) {
+      if (inst.type !== 'IFCBUILDINGSTOREY') continue;
+      if (inst.body.includes(`'${t}'`)) {
+        storeyId = inst.id;
+        break;
+      }
+    }
+  }
+  if (storeyId === undefined) throw new Error(`Storey not found: ${token}`);
+  const storey = parsed.instances.get(storeyId);
+  if (!storey || storey.type !== 'IFCBUILDINGSTOREY') {
+    throw new Error(`#${storeyId} is ${storey?.type ?? 'missing'}, not an IfcBuildingStorey`);
+  }
+  // IfcBuildingStorey ObjectPlacement is attribute 6 (after Guid, Owner, Name,
+  // Description, ObjectType) — the last #ref before LongName/Elevation. Grab the
+  // placement ref: the storey references exactly one IfcLocalPlacement.
+  const refs = [...storey.body.matchAll(REF_RE)].map((m) => parseInt(m[1], 10));
+  const placementId = refs.find((r) => parsed.instances.get(r)?.type === 'IFCLOCALPLACEMENT');
+  if (placementId === undefined) throw new Error(`Storey #${storeyId} has no IfcLocalPlacement`);
+  return placementId;
+}
+
+/**
+ * Assemble the kept-id set: the closure of `seedProducts` + context roots
+ * (project/units/contexts + spatial skeleton) + spatial-containment relations
+ * whose every member is kept (so no dangling references).
+ */
+export function buildSubset(seedProducts: Set<number>, parsed: ParsedStep): Set<number> {
+  const keep = new Set<number>();
+  forwardClosure(seedProducts, parsed, keep);
+
+  // Context roots: the project + spatial skeleton, closed forward for units,
+  // geometric contexts, and placement chains.
+  const rootSeeds: number[] = [];
+  for (const inst of parsed.instances.values()) {
+    if (
+      inst.type === 'IFCPROJECT' ||
+      inst.type === 'IFCSITE' ||
+      inst.type === 'IFCBUILDING' ||
+      inst.type === 'IFCBUILDINGSTOREY'
+    ) {
+      rootSeeds.push(inst.id);
+    }
+  }
+  forwardClosure(rootSeeds, parsed, keep);
+
+  // Opening (void) + filler relations. These point FROM the relation TO the host
+  // wall (RelatingBuildingElement), so walking only the wall's forward closure
+  // never reaches its openings — the isolated wall would lose every window/door
+  // cut and render as an uncut box, hiding the very void-cut defect the isolate
+  // step exists to reproduce. Pull each IfcRelVoidsElement whose host is kept
+  // (+ the IfcOpeningElement's forward closure), then each IfcRelFillsElement
+  // whose opening is now kept (+ the filler window/door). The fixpoint loop lets
+  // a fill relation see an opening that a voids relation added in an earlier pass.
+  let grew = true;
+  while (grew) {
+    grew = false;
+    for (const inst of parsed.instances.values()) {
+      if (keep.has(inst.id)) continue;
+      const refs = [...inst.body.matchAll(REF_RE)].map((m) => parseInt(m[1], 10));
+      if (inst.type === 'IFCRELVOIDSELEMENT') {
+        // refs: [OwnerHistory, RelatingBuildingElement, RelatedOpeningElement].
+        const host = refs[refs.length - 2];
+        const opening = refs[refs.length - 1];
+        if (host !== undefined && opening !== undefined && keep.has(host)) {
+          keep.add(inst.id);
+          forwardClosure([opening], parsed, keep);
+          grew = true;
+        }
+      } else if (inst.type === 'IFCRELFILLSELEMENT') {
+        // refs: [OwnerHistory, RelatingOpeningElement, RelatedBuildingElement(filler)].
+        const opening = refs[refs.length - 2];
+        const filler = refs[refs.length - 1];
+        if (opening !== undefined && filler !== undefined && keep.has(opening)) {
+          keep.add(inst.id);
+          forwardClosure([filler], parsed, keep);
+          grew = true;
+        }
+      }
+    }
+  }
+
+  // Spatial relationships that connect kept products into the tree — but only
+  // when EVERY referenced element is already kept, else we'd emit dangling refs.
+  for (const inst of parsed.instances.values()) {
+    if (
+      inst.type === 'IFCRELCONTAINEDINSPATIALSTRUCTURE' ||
+      inst.type === 'IFCRELAGGREGATES'
+    ) {
+      const refs = [...inst.body.matchAll(REF_RE)].map((m) => parseInt(m[1], 10));
+      if (refs.length > 0 && refs.every((r) => keep.has(r))) keep.add(inst.id);
+    }
+  }
+  return keep;
+}
+
+/** Serialize the kept ids back into a valid STEP file (sorted, header preserved). */
+export function serializeSubset(keep: Set<number>, parsed: ParsedStep): string {
+  const kept = [...keep].filter((id) => parsed.instances.has(id)).sort((a, b) => a - b);
+  const lines = kept.map((id) => parsed.instances.get(id)!.full);
+  return parsed.header + lines.join('\n') + '\nENDSEC;\nEND-ISO-10303-21;\n';
+}
+
+// ── Geometry triage ─────────────────────────────────────────────────────────
+
+interface TriageRow {
+  expressId: number;
+  ifcType: string;
+  tris: number;
+  /** Non-finite vertices (NaN/Inf) — a HARD defect. */
+  nonFinite: number;
+  /** Vertices with |coord|>1e4 after recentre — HARD (RTC/local-frame miss). */
+  huge: number;
+  /** full-AABB / 2-98 percentile-AABB diagonal ratio — REVIEW heuristic. */
+  aabbBlowout: number;
+}
+
+/**
+ * Score meshes for triage. Pure so it is unit-testable without a wasm round-trip.
+ * A HARD defect (non-finite/huge) always sorts above any REVIEW heuristic.
+ */
+export function scoreTriage(row: TriageRow): number {
+  if (row.nonFinite > 0) return 1e12 + row.nonFinite;
+  if (row.huge > 0) return 1e11 + row.huge;
+  return row.aabbBlowout;
+}
+
+function pct(sorted: Float64Array, p: number): number {
+  if (sorted.length === 0) return 0;
+  const idx = Math.min(sorted.length - 1, Math.max(0, Math.floor((p / 100) * (sorted.length - 1))));
+  return sorted[idx];
+}
+
+async function triage(bytes: Uint8Array): Promise<TriageRow[]> {
+  const { GeometryProcessor } = await import('@ifc-lite/geometry');
+  const gp = new GeometryProcessor();
+  await gp.init();
+  const res = await gp.process(bytes);
+  const rows: TriageRow[] = [];
+  for (const m of res.meshes) {
+    const p = m.positions;
+    const nv = p.length / 3;
+    if (nv === 0) continue;
+    const xs = new Float64Array(nv);
+    const ys = new Float64Array(nv);
+    const zs = new Float64Array(nv);
+    let nonFinite = 0;
+    let huge = 0;
+    for (let i = 0, k = 0; i < p.length; i += 3, k++) {
+      const x = p[i];
+      const y = p[i + 1];
+      const z = p[i + 2];
+      if (!Number.isFinite(x) || !Number.isFinite(y) || !Number.isFinite(z)) nonFinite++;
+      if (Math.abs(x) > 1e4 || Math.abs(y) > 1e4 || Math.abs(z) > 1e4) huge++;
+      xs[k] = x;
+      ys[k] = y;
+      zs[k] = z;
+    }
+    xs.sort();
+    ys.sort();
+    zs.sort();
+    const full = Math.hypot(xs[nv - 1] - xs[0], ys[nv - 1] - ys[0], zs[nv - 1] - zs[0]);
+    const trim = Math.hypot(pct(xs, 98) - pct(xs, 2), pct(ys, 98) - pct(ys, 2), pct(zs, 98) - pct(zs, 2));
+    const aabbBlowout = trim > 0.01 ? full / trim : full > 0.01 ? 999 : 1;
+    rows.push({
+      expressId: m.expressId,
+      ifcType: m.ifcType ?? '',
+      tris: m.indices.length / 3,
+      nonFinite,
+      huge,
+      aabbBlowout: +aabbBlowout.toFixed(2),
+    });
+  }
+  rows.sort((a, b) => scoreTriage(b) - scoreTriage(a));
+  return rows;
+}
+
+// ── Command ─────────────────────────────────────────────────────────────────
+
+export async function extractEntitiesCommand(args: string[]): Promise<void> {
+  const filePath = args.find((a) => !a.startsWith('-') && !isFlagValue(args, a));
+  if (!filePath) {
+    fatal(
+      'Usage: ifc-lite extract-entities <file.ifc> [--product ID|GUID] [--type T] ' +
+        '[--storey ID|GUID|name] [--detect [--top N]] --out sub.ifc [--view] [--port N]\n' +
+        '       ifc-lite extract-entities <file.ifc> --detect --report [--json]',
+    );
+    return;
+  }
+
+  const buf = await readFile(filePath);
+  const text = buf.toString('utf8');
+  const parsed = parseStep(text);
+  logger.info(`Parsed ${parsed.instances.size} STEP instances from ${basename(filePath)}`);
+
+  const detect = hasFlag(args, '--detect');
+  const report = hasFlag(args, '--report');
+  const asJson = hasFlag(args, '--json');
+  const topN = parseInt(getFlag(args, '--top') ?? '20', 10);
+
+  // ── Detect-only report path ──
+  if (detect && report) {
+    const bytes = new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength);
+    const rows = await triage(bytes);
+    const hard = rows.filter((r) => r.nonFinite > 0 || r.huge > 0);
+    if (asJson) {
+      process.stdout.write(JSON.stringify({ total: rows.length, hardDefects: hard, top: rows.slice(0, topN) }, null, 2) + '\n');
+      return;
+    }
+    process.stdout.write(`Geometry triage — ${rows.length} meshes\n\n`);
+    process.stdout.write(
+      hard.length > 0
+        ? `HARD defects (non-finite or |coord|>1e4 vertices — genuine corruption): ${hard.length}\n`
+        : `HARD defects: none (no NaN/Inf, no coordinate collapse)\n`,
+    );
+    for (const r of hard.slice(0, topN)) {
+      process.stdout.write(`  #${r.expressId} ${r.ifcType} nonFinite=${r.nonFinite} huge=${r.huge}\n`);
+    }
+    process.stdout.write(
+      `\nREVIEW heuristics (top ${topN} by AABB blowout — OFTEN LEGITIMATE for thin/large elements; eyeball, do not trust):\n`,
+    );
+    for (const r of rows.slice(0, topN)) {
+      process.stdout.write(`  #${r.expressId} ${r.ifcType} tris=${r.tris} aabbBlowout=${r.aabbBlowout}x\n`);
+    }
+    return;
+  }
+
+  // ── Extraction path — collect seed products from all selectors ──
+  const outPath = getFlag(args, '--out');
+  const seeds = new Set<number>();
+
+  for (const token of getAllFlags(args, '--product').flatMap((v) => v.split(','))) {
+    if (token) seeds.add(resolveToId(token, parsed));
+  }
+  for (const t of getAllFlags(args, '--type').flatMap((v) => v.split(','))) {
+    const want = t.trim().toUpperCase();
+    if (!want) continue;
+    for (const inst of parsed.instances.values()) if (inst.type === want) seeds.add(inst.id);
+  }
+  for (const t of getAllFlags(args, '--storey').flatMap((v) => v.split(','))) {
+    if (!t) continue;
+    const placementId = resolveStoreyPlacement(t, parsed);
+    for (const id of productsUnderPlacement(placementId, parsed)) seeds.add(id);
+  }
+  if (detect) {
+    const bytes = new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength);
+    const rows = await triage(bytes);
+    for (const r of rows.slice(0, topN)) seeds.add(r.expressId);
+  }
+
+  if (seeds.size === 0) {
+    fatal('No entities selected. Use --product, --type, --storey, or --detect.');
+    return;
+  }
+  if (!outPath) {
+    fatal('Missing --out <sub.ifc> for extraction (or use --detect --report for a report).');
+    return;
+  }
+
+  const keep = buildSubset(seeds, parsed);
+  const out = serializeSubset(keep, parsed);
+  await writeFile(outPath, out);
+  process.stdout.write(
+    `Extracted ${seeds.size} product(s) → ${keep.size} instances → ${outPath}\n`,
+  );
+
+  if (hasFlag(args, '--view')) {
+    const { viewCommand } = await import('./view.js');
+    const viewArgs = [outPath];
+    const port = getFlag(args, '--port');
+    if (port) viewArgs.push('--port', port);
+    await viewCommand(viewArgs);
+  }
+}
+
+/** True when `a` is the VALUE of a preceding option flag (so it isn't the file). */
+function isFlagValue(args: string[], a: string): boolean {
+  const idx = args.indexOf(a);
+  return idx > 0 && args[idx - 1].startsWith('--') && args[idx - 1] !== '--detect' && args[idx - 1] !== '--report' && args[idx - 1] !== '--view' && args[idx - 1] !== '--json';
+}

--- a/packages/cli/src/commands/extract-entities.ts
+++ b/packages/cli/src/commands/extract-entities.ts
@@ -130,11 +130,16 @@ export function parseStep(text: string): ParsedStep {
   return { header, instances, guidToId };
 }
 
-/** Resolve one selector token to an expressId (`#42`, `42`, or a GlobalId). */
+/** Resolve one selector token to an expressId (`#42`, `42`, or a GlobalId).
+ * An `#id` / bare id is validated against the model too, so a typo'd or stale
+ * id fails loudly instead of silently selecting nothing. */
 export function resolveToId(token: string, parsed: ParsedStep): number {
   const t = token.trim();
-  if (t.startsWith('#')) return parseInt(t.slice(1), 10);
-  if (/^\d+$/.test(t)) return parseInt(t, 10);
+  if (t.startsWith('#') || /^\d+$/.test(t)) {
+    const id = parseInt(t.startsWith('#') ? t.slice(1) : t, 10);
+    if (!parsed.instances.has(id)) throw new Error(`expressId not found in model: #${id}`);
+    return id;
+  }
   const id = parsed.guidToId.get(t);
   if (id === undefined) throw new Error(`GlobalId not found in model: ${t}`);
   return id;
@@ -409,7 +414,10 @@ export async function extractEntitiesCommand(args: string[]): Promise<void> {
   const detect = hasFlag(args, '--detect');
   const report = hasFlag(args, '--report');
   const asJson = hasFlag(args, '--json');
-  const topN = parseInt(getFlag(args, '--top') ?? '20', 10);
+  // Fall back to 20 on a missing or non-numeric `--top` (a `NaN` would make
+  // every `slice(0, topN)` return nothing).
+  const topRaw = Number.parseInt(getFlag(args, '--top') ?? '20', 10);
+  const topN = Number.isNaN(topRaw) ? 20 : topRaw;
 
   // ── Detect-only report path ──
   if (detect && report) {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -16,6 +16,7 @@ import { queryCommand } from './commands/query.js';
 import { propsCommand } from './commands/props.js';
 import { exportCommand } from './commands/export.js';
 import { diagnoseGeometryCommand } from './commands/diagnose-geometry.js';
+import { extractEntitiesCommand } from './commands/extract-entities.js';
 import { idsCommand } from './commands/ids.js';
 import { bcfCommand } from './commands/bcf.js';
 import { clashCommand } from './commands/clash.js';
@@ -69,6 +70,8 @@ const HELP = `
     export    <file.ifc> --format csv|json|ifc|hbjson  Export data / Honeybee energy model
     diagnose-geometry <file.ifc> [--json]        CSG / opening diagnostics (failures, classification)
                       [--product ID|GUID] [--type T]  Filter worst-hosts detail to one product/type
+    extract-entities <file.ifc> --out F          Isolate entities into a small, viewable standalone IFC
+                      [--product ID|GUID] [--storey S] [--detect] [--view]  by GUID/type/storey or auto-triage
     ids       <file.ifc> <rules.ids>              Validate against IDS rules
     bcf       <create|list|add-comment>           Work with BCF collaboration files
     clash     <file.ifc> [--matrix] [--bcf F]      Detect geometric clashes between elements
@@ -218,6 +221,9 @@ async function main(): Promise<void> {
       break;
     case 'diagnose-geometry':
       await diagnoseGeometryCommand(commandArgs);
+      break;
+    case 'extract-entities':
+      await extractEntitiesCommand(commandArgs);
       break;
     case 'ids':
       await idsCommand(commandArgs);


### PR DESCRIPTION
## What

Adds `ifc-lite extract-entities <file.ifc> [selectors] --out sub.ifc` — the "reproduce a suspect element" step of a geometry-triage loop. It isolates a handful of entities from a large IFC into a small, valid, viewable standalone model.

Selectors (unioned): `--product <GUID|expressId>`, `--type <IfcType>`, `--storey <GUID|name|id>`, `--detect [--top N]`. The subset carries each product's full forward reference closure, the shared context roots (project / units / geometric contexts / spatial skeleton), and every spatial-containment relation whose members are all kept — so it parses and renders on its own with zero dangling references. `--view` opens it in the viewer; `--detect --report [--json]` prints a triage report.

## Why the voids matter

A selected element now also carries its **openings and fillers**: every `IfcRelVoidsElement` whose host is kept (plus the `IfcOpeningElement` cutter) and every `IfcRelFillsElement` whose opening is kept (plus the window/door).

These relations point **backward** to the host, so forward closure alone never reaches them. Without this, isolating a wall produced an **uncut box** — the void-cut geometry (which is exactly what a triage loop is trying to reproduce) was silently stripped. This was the concrete blocker while investigating the ISSUE_098 model: isolating the reported wall kept showing "no defect" because the windows were gone.

## Tests

New `extract-entities.test.ts` covers the tokenizer, selectors, subset assembly, serialization (zero dangling refs), triage scoring, and the new voids/fills inclusion. Full CLI suite: 152/152 green; typecheck clean.

## Notes

- Pure additive CLI command; no changes to geometry/kernel.
- Changeset included (`@ifc-lite/cli` minor).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `extract-entities` CLI command to create a smaller IFC file from selected products, types, or storeys.
  * Added optional detection and report output to help highlight unusual geometry, with support for plain text or JSON.
  * Added a view option to open the extracted model after generation.

* **Bug Fixes**
  * Improved extraction so related openings, fills, spatial structure, and required references are preserved in the output.
  * Reduced the risk of broken IFC files by ensuring extracted models remain self-contained.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->