### PR TITLE
perf(geometry): hoist item-dedup mesh clone out of the cache lock

### DIFF
--- a/.changeset/perf-dedup-clone-out-of-lock.md
+++ b/.changeset/perf-dedup-clone-out-of-lock.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/wasm": patch
+---
+
+Hoist the item-dedup mesh clone out of the shared cache's lock. `process_representation_item`'s content-dedup cache is a single `Arc<Mutex<FxHashMap>>` hit by every element; on a dedup miss it inserted `Arc::new(mesh.clone())` — a full mesh deep-copy that Rust evaluates *inside* the acquired lock, so under a multi-worker pool every miss serialized the pool behind one another's mesh copies. Clone into the Arc before taking the lock so the critical section is just the map insert. Byte-identical (the cache is pure memoization); most visible on high-core servers processing unique geometry (many misses, high contention).

--- a/rust/geometry/src/router/processing.rs
+++ b/rust/geometry/src/router/processing.rs
@@ -666,10 +666,15 @@ impl GeometryRouter {
         //    the cut wins over deduping a degraded result. (#1257 review P1.)
         if let (Some(key), Some(cache)) = (dedup_key, self.item_dedup_cache.as_ref()) {
             if !mesh.positions.is_empty() && !crate::kernel::budget::tripped() {
+                // Clone the mesh into its Arc BEFORE taking the lock: the deep copy
+                // must not run inside the critical section, or every dedup miss
+                // serializes the whole worker pool behind one another's mesh copies
+                // (the shared cache is a single Mutex hit by every element).
+                let cached = Arc::new(mesh.clone());
                 cache
                     .lock()
                     .unwrap_or_else(|e| e.into_inner())
-                    .insert(key, Arc::new(mesh.clone()));
+                    .insert(key, cached);
             }
         }
 

--- a/rust/geometry/src/router/processing.rs
+++ b/rust/geometry/src/router/processing.rs
@@ -666,10 +666,8 @@ impl GeometryRouter {
         //    the cut wins over deduping a degraded result. (#1257 review P1.)
         if let (Some(key), Some(cache)) = (dedup_key, self.item_dedup_cache.as_ref()) {
             if !mesh.positions.is_empty() && !crate::kernel::budget::tripped() {
-                // Clone the mesh into its Arc BEFORE taking the lock: the deep copy
-                // must not run inside the critical section, or every dedup miss
-                // serializes the whole worker pool behind one another's mesh copies
-                // (the shared cache is a single Mutex hit by every element).
+                // Clone into the Arc BEFORE locking: a mesh deep-copy inside the
+                // single-Mutex critical section serializes the pool on every miss.
                 let cached = Arc::new(mesh.clone());
                 cache
                     .lock()

--- a/rust/processing/tests/module_size_allowlist.txt
+++ b/rust/processing/tests/module_size_allowlist.txt
@@ -73,7 +73,8 @@
 # +65: #1623 Phase 2 don't-bake — the top-level mapped-item intercept (template retag + instance placeholder) + the public/impl process_element_with_submeshes split; the two eligibility/ensure helpers were extracted to router/instancing.rs (new, 92 lines) to hold the net down.
 # +7: #858 palette guard — exclude an indexed-colour single-solid source from the don't-bake decision (one .filter on the resolved solid id + explanatory comment) so its per-triangle palette survives the flat split.
 # +16: #1623 Phase 3 — thread the batch-local vs global template decision through the mapped-item intercept (is_template match arm + retag guard).
-    1162 rust/geometry/src/router/processing.rs
+# +3: hoist the item-dedup mesh clone out of the cache Mutex critical section (let-binding + 2-line rationale) so a dedup miss no longer serializes the worker pool on a deep-copy.
+    1165 rust/geometry/src/router/processing.rs
 # +26: is_rtc_votable_representation predicate + doc — Surface3D is meshable but must NOT cast RTC votes (#1526 pollution via absolute-coord surfaces).
      472 rust/geometry/src/router/rtc_offset.rs
 # +1: reveal-quads comment expanded to 2 lines (dead-symbol reference fix, no code change).


### PR DESCRIPTION
## Summary

The content-dedup cache in `process_representation_item` is a single `Arc<Mutex<FxHashMap<u128, Arc<Mesh>>>>` — one global lock hit by **every** element. On a dedup miss it did:

```rust
cache.lock()...insert(key, Arc::new(mesh.clone()));
```

Rust evaluates the argument `Arc::new(mesh.clone())` — a **full mesh deep-copy** — *after* the lock guard is acquired, so the deep copy runs **inside the critical section**. Under a multi-worker rayon pool, every miss serializes the whole pool behind one another's mesh copies.

The fix hoists the clone out of the lock so the critical section is just the map insert:

```rust
let cached = Arc::new(mesh.clone());   // deep copy BEFORE the lock
cache.lock()...insert(key, cached);    // critical section = insert only
```

## Honest scope

Found while investigating why some many-element models scale poorly (Holter, 100K+ meshes, ~2.9×/10 threads). It did **not** move the needle on a 10-core M4 with the test corpus — Holter's floor turned out to be intrinsic (tiny-task overhead + single-threaded parse), not this lock. But a mesh deep-copy inside a global-mutex critical section is an objective scaling anti-pattern, and the native path *is* the production server: on a 32-64 core box processing unique geometry (many dedup misses, high contention) it serializes real work. Shipping it as a defensive correctness fix, not a headline perf win.

## Byte-identical

Pure memoization cache (same content-hash → same mesh regardless of which worker computes it first). `mesh_determinism` / `boolean` / `retriangulation` manifests green; mesh byte-parity on rvt01 / Holter / skolebygg.

## Test plan
- [x] geometry determinism/manifest suite
- [x] mesh parity vs main

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved geometry processing performance by reducing time spent waiting on shared cache access.
  * Mesh duplication is now performed outside the most contended cache-lock section, minimizing critical-section hold time.
* **Chores**
  * Updated the internal module-size allowlist to reflect the performance-related adjustment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->