### PR TITLE
chore(python): bump ifclite-geom to 4.2.1 to ship #1633 geometry fix (#1665)

### DIFF
--- a/rust/python/Cargo.lock
+++ b/rust/python/Cargo.lock
@@ -293,7 +293,7 @@ dependencies = [
 
 [[package]]
 name = "ifc-lite-python"
-version = "4.2.0"
+version = "4.2.1"
 dependencies = [
  "ifc-lite-processing",
  "pyo3",

--- a/rust/python/Cargo.toml
+++ b/rust/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ifc-lite-python"
-version = "4.2.0"
+version = "4.2.1"
 edition = "2021"
 license = "MPL-2.0"
 repository = "https://github.com/LTplus-AG/ifc-lite"


### PR DESCRIPTION
## Why

The `ifclite-geom` PyPI package is stuck at **4.2.0**, which predates the #1633 fix (void-reveal Z over-inclusion, shipped to `main` in PR #1643). PyPI users are running geometry that lacks that fix.

The published wheel version is driven entirely by `rust/python/Cargo.toml` `[package] version` (maturin reads it; `pyproject.toml` declares `dynamic = ["version"]`). Version `4.2.0` is already tagged and published, so re-publishing it would collide on PyPI. The only change needed to ship the current `main` (which already contains the #1633 fix) is a patch bump so the next release tag builds a fresh wheel.

## What

- Bump `rust/python/Cargo.toml` `[package] version` `4.2.0` → `4.2.1`.
- Refresh the matching entry in the crate's own `rust/python/Cargo.lock` (this crate is excluded from the root workspace and keeps its own lockfile). No other lock entries touched.

No JS/npm workspace versions are affected. No `.pyi` / `README.md` version strings exist to sync (verified).

`cargo check -p ifc-lite-python` compiles cleanly at 4.2.1 (built standalone, as the wheel CI does; the crate is workspace-excluded).

## Release step (maintainer, after merge)

Publishing is gated on a git tag. After this merges, a maintainer pushes:

```
git tag ifclite-geom-v4.2.1 && git push origin ifclite-geom-v4.2.1
```

which triggers `.github/workflows/python-wheels.yml` to build and publish the wheels to PyPI via OIDC trusted publishing.

Closes #1665


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Python package version to the latest patch release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->