### PR TITLE
fix(lists): offer all model classes (incl. MEP) in New List scope (#1662)

### DIFF
--- a/apps/viewer/src/components/viewer/lists/ListBuilder.tsx
+++ b/apps/viewer/src/components/viewer/lists/ListBuilder.tsx
@@ -37,6 +37,7 @@ import type {
   ConditionOperator,
 } from '@ifc-lite/lists';
 import { discoverColumns, ENTITY_ATTRIBUTES, isNamePattern } from '@ifc-lite/lists';
+import { collectScopeTypes } from '@/lib/lists/scope-types';
 
 const NO_OPTIONS: readonly string[] = [];
 
@@ -77,33 +78,6 @@ function discoverConditionValues(stores: IfcDataStore[]): ListConditionValues {
   for (const [k, s] of propertyValues) pv.set(k, sort(s));
   return { materials: sort(materials), classifications: sort(classifications), propertyValues: pv };
 }
-
-// Building element types available for selection
-const SELECTABLE_TYPES: { type: IfcTypeEnum; label: string }[] = [
-  { type: IfcTypeEnum.IfcWall, label: 'Walls' },
-  { type: IfcTypeEnum.IfcWallStandardCase, label: 'Walls (Standard)' },
-  { type: IfcTypeEnum.IfcDoor, label: 'Doors' },
-  { type: IfcTypeEnum.IfcWindow, label: 'Windows' },
-  { type: IfcTypeEnum.IfcSlab, label: 'Slabs' },
-  { type: IfcTypeEnum.IfcColumn, label: 'Columns' },
-  { type: IfcTypeEnum.IfcBeam, label: 'Beams' },
-  { type: IfcTypeEnum.IfcStair, label: 'Stairs' },
-  { type: IfcTypeEnum.IfcRamp, label: 'Ramps' },
-  { type: IfcTypeEnum.IfcRoof, label: 'Roofs' },
-  { type: IfcTypeEnum.IfcCovering, label: 'Coverings' },
-  { type: IfcTypeEnum.IfcCurtainWall, label: 'Curtain Walls' },
-  { type: IfcTypeEnum.IfcRailing, label: 'Railings' },
-  { type: IfcTypeEnum.IfcSpace, label: 'Spaces' },
-  { type: IfcTypeEnum.IfcSpatialZone, label: 'Spatial Zones' },
-  { type: IfcTypeEnum.IfcZone, label: 'Zones' },
-  { type: IfcTypeEnum.IfcSystem, label: 'Systems' },
-  { type: IfcTypeEnum.IfcDistributionSystem, label: 'Distribution Systems' },
-  { type: IfcTypeEnum.IfcBuildingStorey, label: 'Storeys' },
-  { type: IfcTypeEnum.IfcDistributionElement, label: 'MEP Distribution' },
-  { type: IfcTypeEnum.IfcFlowTerminal, label: 'MEP Terminals' },
-  { type: IfcTypeEnum.IfcFlowSegment, label: 'MEP Segments' },
-  { type: IfcTypeEnum.IfcFlowFitting, label: 'MEP Fittings' },
-];
 
 /** Column descriptor shared by the quick-add grid. */
 interface CommonColumn { id: string; source: ColumnDefinition['source']; propertyName: string; label: string }
@@ -229,18 +203,16 @@ export function ListBuilder({ providers, stores, initial, onSave, onCancel, onEx
     new Set(initial?.grouping?.sumColumnIds ?? [])
   );
 
-  // Count entities per type across all providers
+  // Scope classes offered as chips: every element class actually present in
+  // the loaded model(s), with instance counts. Derived from the models rather
+  // than a curated allowlist, so a present class the curator never listed —
+  // e.g. IfcDuctSegment / IfcPipeSegment — is still selectable (#1662).
+  const scopeTypes = useMemo(() => collectScopeTypes(stores), [stores]);
   const typeCounts = useMemo(() => {
     const counts = new Map<IfcTypeEnum, number>();
-    for (const { type } of SELECTABLE_TYPES) {
-      let total = 0;
-      for (const p of providers) {
-        total += p.getEntitiesByType(type).length;
-      }
-      if (total > 0) counts.set(type, total);
-    }
+    for (const { type, count } of scopeTypes) counts.set(type, count);
     return counts;
-  }, [providers]);
+  }, [scopeTypes]);
 
   // Available columns. Prefer COMPLETE, type-independent discovery (every
   // property set / quantity set in the model) so all properties/quantities
@@ -392,20 +364,16 @@ export function ListBuilder({ providers, stores, initial, onSave, onCancel, onEx
             ) : (
               <>
                 <div className="flex flex-wrap gap-1.5">
-                  {SELECTABLE_TYPES.map(({ type, label }) => {
-                    const count = typeCounts.get(type);
-                    if (!count) return null;
-                    return (
-                      <Chip
-                        key={type}
-                        selected={selectedTypes.has(type)}
-                        onClick={() => toggleType(type)}
-                        trailing={count.toLocaleString()}
-                      >
-                        {label}
-                      </Chip>
-                    );
-                  })}
+                  {scopeTypes.map(({ type, label, count }) => (
+                    <Chip
+                      key={type}
+                      selected={selectedTypes.has(type)}
+                      onClick={() => toggleType(type)}
+                      trailing={count.toLocaleString()}
+                    >
+                      {label}
+                    </Chip>
+                  ))}
                 </div>
                 {selectedTypes.size === 0 && (
                   <p className="mt-2 text-[11px] leading-relaxed text-muted-foreground">

--- a/apps/viewer/src/lib/lists/scope-types.test.ts
+++ b/apps/viewer/src/lib/lists/scope-types.test.ts
@@ -1,0 +1,110 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Regression for #1662: the New List scope selector omitted element classes
+ * present in the model (IfcDuctSegment, IfcPipeSegment) because it drove its
+ * chips from a hardcoded curated list. `collectScopeTypes` now derives the
+ * offered classes from the model, so every present element class appears.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { EntityTableBuilder, StringTable, IfcTypeEnum, type EntityTable } from '@ifc-lite/data';
+import { collectScopeTypes, isScopeTargetType, type ScopeTypeStore } from './scope-types.js';
+
+/** [expressId, STEP type name, hasGeometry, isType] */
+type Row = [number, string, boolean?, boolean?];
+
+/** Build a minimal store (entity table + byType index) from a row list. */
+function makeStore(rows: Row[]): ScopeTypeStore {
+  const strings = new StringTable();
+  const builder = new EntityTableBuilder(rows.length, strings);
+  const byType = new Map<string, number[]>();
+  for (const [id, type, hasGeometry = false, isType = false] of rows) {
+    builder.add(id, type, `guid-${id}`, `${type}-${id}`, '', '', hasGeometry, isType);
+    const upper = type.toUpperCase();
+    const bucket = byType.get(upper) ?? [];
+    bucket.push(id);
+    byType.set(upper, bucket);
+  }
+  const entities: EntityTable = builder.build();
+  return { entities, entityIndex: { byType } };
+}
+
+describe('collectScopeTypes (#1662)', () => {
+  it('offers MEP classes present in the model (IfcDuctSegment / IfcPipeSegment)', () => {
+    const store = makeStore([
+      [1, 'IFCWALL', true],
+      [2, 'IFCSLAB', true],
+      [3, 'IFCDUCTSEGMENT', true],
+      [4, 'IFCPIPESEGMENT', true],
+    ]);
+
+    const offered = collectScopeTypes([store]);
+    const types = new Set(offered.map((o) => o.type));
+
+    // The bug: these two were never offered even though present.
+    assert.ok(types.has(IfcTypeEnum.IfcDuctSegment), 'IfcDuctSegment must be offered');
+    assert.ok(types.has(IfcTypeEnum.IfcPipeSegment), 'IfcPipeSegment must be offered');
+    assert.ok(types.has(IfcTypeEnum.IfcWall));
+    assert.ok(types.has(IfcTypeEnum.IfcSlab));
+
+    // Unknown-to-the-curator classes fall back to their IFC class name.
+    const duct = offered.find((o) => o.type === IfcTypeEnum.IfcDuctSegment);
+    assert.strictEqual(duct?.label, 'IfcDuctSegment');
+    assert.strictEqual(duct?.count, 1);
+    // Curated classes keep their friendly plural label.
+    assert.strictEqual(offered.find((o) => o.type === IfcTypeEnum.IfcWall)?.label, 'Walls');
+  });
+
+  it('excludes non-element records: type objects, relationships, and unmapped classes', () => {
+    const store = makeStore([
+      [1, 'IFCWALL', true],
+      [2, 'IFCWALLTYPE', false, true],   // type object → excluded
+      [3, 'IFCRELAGGREGATES'],           // relationship → excluded
+      [4, 'IFCSANITARYTERMINAL', true],  // no distinct enum (Unknown) → excluded
+      [5, 'IFCSITE'],                    // spatial structure → offered
+    ]);
+
+    const types = new Set(collectScopeTypes([store]).map((o) => o.type));
+    assert.ok(types.has(IfcTypeEnum.IfcWall));
+    assert.ok(types.has(IfcTypeEnum.IfcSite));
+    assert.ok(!types.has(IfcTypeEnum.IfcWallType), 'type objects are not list-able');
+    assert.ok(!types.has(IfcTypeEnum.IfcRelAggregates), 'relationships are not list-able');
+    assert.ok(!types.has(IfcTypeEnum.Unknown), 'unmapped classes are never offered');
+    // Exactly the two list-able classes, nothing leaked in.
+    assert.strictEqual(types.size, 2);
+  });
+
+  it('counts one entry per enum even when several STEP names share it', () => {
+    // IfcDoor and IfcDoorStandardCase both map to the IfcDoor enum.
+    const store = makeStore([
+      [1, 'IFCDOOR', true],
+      [2, 'IFCDOORSTANDARDCASE', true],
+    ]);
+    const offered = collectScopeTypes([store]);
+    const doors = offered.filter((o) => o.type === IfcTypeEnum.IfcDoor);
+    assert.strictEqual(doors.length, 1, 'a shared enum yields one chip');
+    assert.strictEqual(doors[0].count, 2, 'both STEP-name instances counted, once each');
+  });
+
+  it('sums instance counts across federated models', () => {
+    const a = makeStore([[1, 'IFCWALL', true], [2, 'IFCWALL', true]]);
+    const b = makeStore([[10, 'IFCWALL', true]]);
+    const offered = collectScopeTypes([a, b]);
+    const wall = offered.find((o) => o.type === IfcTypeEnum.IfcWall);
+    assert.strictEqual(wall?.count, 3);
+  });
+
+  it('predicate rejects the non-element categories directly', () => {
+    assert.strictEqual(isScopeTargetType(IfcTypeEnum.IfcDuctSegment, 'IfcDuctSegment'), true);
+    assert.strictEqual(isScopeTargetType(IfcTypeEnum.IfcWall, 'IfcWall'), true);
+    assert.strictEqual(isScopeTargetType(IfcTypeEnum.Unknown, 'IfcSanitaryTerminal'), false);
+    assert.strictEqual(isScopeTargetType(IfcTypeEnum.IfcWallType, 'IfcWallType'), false);
+    assert.strictEqual(isScopeTargetType(IfcTypeEnum.IfcRelAggregates, 'IfcRelAggregates'), false);
+    assert.strictEqual(isScopeTargetType(IfcTypeEnum.IfcPropertySet, 'IfcPropertySet'), false);
+    assert.strictEqual(isScopeTargetType(IfcTypeEnum.IfcElementQuantity, 'IfcElementQuantity'), false);
+  });
+});

--- a/apps/viewer/src/lib/lists/scope-types.ts
+++ b/apps/viewer/src/lib/lists/scope-types.ts
@@ -1,0 +1,165 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * List-scope class enumeration.
+ *
+ * The New List scope selector offers one chip per element class present in
+ * the loaded model(s). The previous implementation drove the chips from a
+ * hardcoded curated list of IfcTypeEnum members, so any present class that
+ * wasn't on that list (IfcDuctSegment, IfcPipeSegment, and every other
+ * class the curator forgot) was silently unlistable (#1662). This derives
+ * the offered classes from what the model actually contains instead, so a
+ * newly-present class appears automatically without editing a taxonomy.
+ *
+ * Only classes that map to a distinct IfcTypeEnum are offered — the scope is
+ * targeted by enum (`getEntitiesByType`), and classes with no dedicated enum
+ * all collapse into the `Unknown` bucket, which can't be selected without
+ * over-selecting. Those are still reachable through the "All elements"
+ * (no-type) scope. Relationships, property/quantity definitions and type
+ * objects are excluded: they are not list-able elements.
+ */
+
+import { IfcTypeEnum } from '@ifc-lite/data';
+import type { EntityTable } from '@ifc-lite/data';
+
+/** One selectable scope class: an IFC type present in the model, with count. */
+export interface ScopeTypeOption {
+  type: IfcTypeEnum;
+  /** Friendly label (curated plural where known, else the IFC class name). */
+  label: string;
+  /** Total instances across all provided stores. */
+  count: number;
+}
+
+/**
+ * Friendly plural labels for the common classes, so familiar chips still read
+ * "Walls" / "MEP Segments" rather than the raw IFC class name. Classes absent
+ * from this map fall back to their canonical `IfcClassName` (e.g.
+ * "IfcDuctSegment") — unknown to the curator, but never hidden.
+ */
+const SCOPE_TYPE_LABELS: Partial<Record<IfcTypeEnum, string>> = {
+  [IfcTypeEnum.IfcWall]: 'Walls',
+  [IfcTypeEnum.IfcWallStandardCase]: 'Walls (Standard)',
+  [IfcTypeEnum.IfcDoor]: 'Doors',
+  [IfcTypeEnum.IfcWindow]: 'Windows',
+  [IfcTypeEnum.IfcSlab]: 'Slabs',
+  [IfcTypeEnum.IfcColumn]: 'Columns',
+  [IfcTypeEnum.IfcBeam]: 'Beams',
+  [IfcTypeEnum.IfcStair]: 'Stairs',
+  [IfcTypeEnum.IfcRamp]: 'Ramps',
+  [IfcTypeEnum.IfcRoof]: 'Roofs',
+  [IfcTypeEnum.IfcCovering]: 'Coverings',
+  [IfcTypeEnum.IfcCurtainWall]: 'Curtain Walls',
+  [IfcTypeEnum.IfcRailing]: 'Railings',
+  [IfcTypeEnum.IfcSpace]: 'Spaces',
+  [IfcTypeEnum.IfcSpatialZone]: 'Spatial Zones',
+  [IfcTypeEnum.IfcZone]: 'Zones',
+  [IfcTypeEnum.IfcSystem]: 'Systems',
+  [IfcTypeEnum.IfcDistributionSystem]: 'Distribution Systems',
+  [IfcTypeEnum.IfcBuildingStorey]: 'Storeys',
+  [IfcTypeEnum.IfcDistributionElement]: 'MEP Distribution',
+  [IfcTypeEnum.IfcFlowTerminal]: 'MEP Terminals',
+  [IfcTypeEnum.IfcFlowSegment]: 'MEP Segments',
+  [IfcTypeEnum.IfcFlowFitting]: 'MEP Fittings',
+};
+
+/**
+ * Preferred ordering for the familiar classes, so the common chips keep their
+ * established layout. Present classes not listed here sort after, by label.
+ */
+const SCOPE_TYPE_ORDER: IfcTypeEnum[] = [
+  IfcTypeEnum.IfcWall,
+  IfcTypeEnum.IfcWallStandardCase,
+  IfcTypeEnum.IfcDoor,
+  IfcTypeEnum.IfcWindow,
+  IfcTypeEnum.IfcSlab,
+  IfcTypeEnum.IfcColumn,
+  IfcTypeEnum.IfcBeam,
+  IfcTypeEnum.IfcStair,
+  IfcTypeEnum.IfcRamp,
+  IfcTypeEnum.IfcRoof,
+  IfcTypeEnum.IfcCovering,
+  IfcTypeEnum.IfcCurtainWall,
+  IfcTypeEnum.IfcRailing,
+  IfcTypeEnum.IfcSpace,
+  IfcTypeEnum.IfcSpatialZone,
+  IfcTypeEnum.IfcZone,
+  IfcTypeEnum.IfcSystem,
+  IfcTypeEnum.IfcDistributionSystem,
+  IfcTypeEnum.IfcBuildingStorey,
+  IfcTypeEnum.IfcDistributionElement,
+  IfcTypeEnum.IfcFlowTerminal,
+  IfcTypeEnum.IfcFlowSegment,
+  IfcTypeEnum.IfcFlowFitting,
+];
+
+/**
+ * Whether a present class is a valid list-scope target. Products, spatial
+ * structure and groupings qualify; relationships, property/quantity
+ * definitions and type objects do not. `Unknown` never qualifies — a class
+ * with no distinct enum can't be targeted without pulling in every other
+ * unmapped class.
+ *
+ * @param type canonical IfcTypeEnum for the class
+ * @param name canonical `IfcClassName` (from `getTypeName`)
+ */
+export function isScopeTargetType(type: IfcTypeEnum, name: string): boolean {
+  if (type === IfcTypeEnum.Unknown) return false;
+  // Type objects (IfcWallType, IfcSurfaceStyle, …) — templates, not elements.
+  if (name.endsWith('Type') || name.endsWith('Style')) return false;
+  // Relationships (IfcRelAggregates, …).
+  if (name.startsWith('IfcRel')) return false;
+  // Property / quantity definitions (IfcPropertySet, IfcQuantityArea,
+  // IfcElementQuantity, …) — data records, not elements.
+  if (name.startsWith('IfcProperty') || name.startsWith('IfcQuantity')) return false;
+  if (name === 'IfcElementQuantity') return false;
+  return true;
+}
+
+/** The narrow store surface `collectScopeTypes` reads (full IfcDataStore assignable). */
+export interface ScopeTypeStore {
+  entities: Pick<EntityTable, 'getByType' | 'getTypeEnum' | 'getTypeName'>;
+  entityIndex: { byType: Map<string, number[]> };
+}
+
+/**
+ * Enumerate the element classes present across the given stores, with total
+ * instance counts, ready to render as scope chips. Sorted by the curated
+ * order first, then alphabetically by label for any remaining classes.
+ */
+export function collectScopeTypes(stores: ScopeTypeStore[]): ScopeTypeOption[] {
+  const byEnum = new Map<IfcTypeEnum, { label: string; count: number }>();
+
+  for (const store of stores) {
+    // Dedupe per store: several STEP names can share one enum (IfcDoor +
+    // IfcDoorStandardCase), and getByType already merges them, so count once.
+    const counted = new Set<IfcTypeEnum>();
+    for (const ids of store.entityIndex.byType.values()) {
+      if (ids.length === 0) continue;
+      const sample = ids[0];
+      const type = store.entities.getTypeEnum(sample);
+      if (type === IfcTypeEnum.Unknown || counted.has(type)) continue;
+      counted.add(type);
+      const name = store.entities.getTypeName(sample);
+      if (!isScopeTargetType(type, name)) continue;
+      const count = store.entities.getByType(type).length;
+      if (count === 0) continue;
+      const label = SCOPE_TYPE_LABELS[type] ?? name;
+      const entry = byEnum.get(type);
+      if (entry) entry.count += count;
+      else byEnum.set(type, { label, count });
+    }
+  }
+
+  const orderIndex = new Map<IfcTypeEnum, number>();
+  SCOPE_TYPE_ORDER.forEach((t, i) => orderIndex.set(t, i));
+
+  return Array.from(byEnum, ([type, { label, count }]) => ({ type, label, count })).sort((a, b) => {
+    const ai = orderIndex.get(a.type) ?? Number.MAX_SAFE_INTEGER;
+    const bi = orderIndex.get(b.type) ?? Number.MAX_SAFE_INTEGER;
+    if (ai !== bi) return ai - bi;
+    return a.label.localeCompare(b.label);
+  });
+}


### PR DESCRIPTION
## The bug (#1662)

Creating a **New List** in the viewer, the class-scope selector omitted classes that were actually present in the loaded model. The reported case: `IfcDuctSegment` and `IfcPipeSegment` never appeared, so an MEP model could not be scoped to them.

## Root cause

`ListBuilder` built its scope chips from a hardcoded, curated array (`SELECTABLE_TYPES`) and counted instances only for those types:

```ts
for (const { type } of SELECTABLE_TYPES) { total += provider.getEntitiesByType(type).length; ... }
```

`IfcDuctSegment` (enum 49) and `IfcPipeSegment` (enum 50) are stored under their **own** `IfcTypeEnum`; `getByType` does not re-bucket them under `IfcFlowSegment` (42), which *was* on the curated list. So the file had duct/pipe segments, but the only MEP chips offered (`IfcFlowSegment`, …) matched nothing. Any present class the curator forgot was unreachable — the same curated-taxonomy trap that has bitten distribution/MEP classes before.

## The fix

Drive the scope chips from **what the model actually contains** instead of an allowlist. New viewer helper `collectScopeTypes(stores)`:

- walks each store's present classes,
- keeps the list-able ones (products, spatial structure, groupings),
- drops relationships, property/quantity definitions, type objects, and classes with no distinct enum (those stay reachable via the existing "All elements" scope),
- sums counts across federated models and dedupes classes whose several STEP names share one enum (`IfcDoor` + `IfcDoorStandardCase`).

Curated plural labels (`Walls`, `MEP Segments`, …) are preserved for the familiar classes; anything else falls back to its IFC class name (e.g. `IfcDuctSegment`). A newly-present class now appears automatically — no taxonomy edit required.

## Files changed

- `apps/viewer/src/lib/lists/scope-types.ts` — new: `collectScopeTypes`, `isScopeTargetType`, label/order tables.
- `apps/viewer/src/components/viewer/lists/ListBuilder.tsx` — replace `SELECTABLE_TYPES` enumeration with `collectScopeTypes(stores)`.
- `apps/viewer/src/lib/lists/scope-types.test.ts` — new focused unit tests.

No published `packages/*` changed (viewer is a private app), so no changeset.

## Verification

- `pnpm --filter viewer typecheck` — clean.
- Viewer lists tests (`tsx --test --test-concurrency=1`): 27/27 pass, including the 5 new `scope-types` cases.
- End-to-end against the reported repro file (parsed through the real parser): the scope now offers `IfcDuctSegment` and `IfcPipeSegment` (plus Walls, Slabs, and the spatial containers), with type objects and relationships excluded.

Closes #1662


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Scope filter chips now appear automatically based on the IFC types present in the loaded models.
  * Type chips show clearer labels and accurate counts, including across multiple federated models.

* **Bug Fixes**
  * Improved the set of selectable scope types so valid element and spatial structure types are included, while non-relevant types are excluded.
  * Fixed total selected-entity counts to stay in sync with the updated scope selection data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->