### PR TITLE
fix(viewer): widen export modals for comfortable use (#1644)

### DIFF
--- a/apps/viewer/src/components/viewer/ExportDialog.tsx
+++ b/apps/viewer/src/components/viewer/ExportDialog.tsx
@@ -614,7 +614,7 @@ export function ExportDialog({ trigger }: ExportDialogProps) {
           </Button>
         )}
       </DialogTrigger>
-      <DialogContent className="sm:max-w-md overflow-hidden">
+      <DialogContent className="sm:max-w-lg overflow-hidden">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <Download className="h-5 w-5" />
@@ -625,7 +625,7 @@ export function ExportDialog({ trigger }: ExportDialogProps) {
           </DialogDescription>
         </DialogHeader>
 
-        <div ref={scrollAreaRef} className="grid gap-4 py-4 max-h-[60vh] overflow-y-auto">
+        <div ref={scrollAreaRef} className="grid gap-4 py-4 max-h-[70vh] overflow-y-auto">
           {/* Scope selector (only for STEP schemas with multiple models) */}
           {!isIfc5 && !changesOnly && modelList.length > 1 && (
             <div className="flex items-center gap-4">
@@ -669,7 +669,7 @@ export function ExportDialog({ trigger }: ExportDialogProps) {
               </SelectTrigger>
               <SelectContent>
                 {modelList.map((m) => {
-                  const maxLen = 24;
+                  const maxLen = 32;
                   const displayName = m.name.length > maxLen ? m.name.slice(0, maxLen) + '\u2026' : m.name;
                   return (
                   <SelectItem key={m.id} value={m.id} title={m.name}>

--- a/apps/viewer/src/components/viewer/GLBExportDialog.tsx
+++ b/apps/viewer/src/components/viewer/GLBExportDialog.tsx
@@ -342,7 +342,7 @@ export function GLBExportDialog({ trigger }: GLBExportDialogProps) {
           </Button>
         )}
       </DialogTrigger>
-      <DialogContent className="sm:max-w-md overflow-hidden">
+      <DialogContent className="sm:max-w-lg overflow-hidden">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <Download className="h-5 w-5" />
@@ -353,7 +353,7 @@ export function GLBExportDialog({ trigger }: GLBExportDialogProps) {
           </DialogDescription>
         </DialogHeader>
 
-        <div className="grid gap-4 py-4 max-h-[60vh] overflow-y-auto">
+        <div className="grid gap-4 py-4 max-h-[70vh] overflow-y-auto">
           {/* Model selector — only shown when multiple are loaded */}
           {modelList.length > 1 && (
             <div className="flex items-center gap-4">
@@ -364,7 +364,7 @@ export function GLBExportDialog({ trigger }: GLBExportDialogProps) {
                 </SelectTrigger>
                 <SelectContent>
                   {modelList.map((m) => {
-                    const maxLen = 24;
+                    const maxLen = 32;
                     const displayName =
                       m.name.length > maxLen ? m.name.slice(0, maxLen) + '…' : m.name;
                     return (

--- a/apps/viewer/src/components/viewer/HbjsonExportDialog.tsx
+++ b/apps/viewer/src/components/viewer/HbjsonExportDialog.tsx
@@ -123,7 +123,7 @@ export function HbjsonExportDialog({ trigger }: HbjsonExportDialogProps) {
           </Button>
         )}
       </DialogTrigger>
-      <DialogContent className="sm:max-w-md overflow-hidden">
+      <DialogContent className="sm:max-w-lg overflow-hidden">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <Download className="h-5 w-5" />
@@ -134,7 +134,7 @@ export function HbjsonExportDialog({ trigger }: HbjsonExportDialogProps) {
           </DialogDescription>
         </DialogHeader>
 
-        <div className="grid gap-4 py-4 max-h-[60vh] overflow-y-auto">
+        <div className="grid gap-4 py-4 max-h-[70vh] overflow-y-auto">
           {/* Model selector — only shown when multiple are loaded */}
           {modelList.length > 1 && (
             <div className="flex items-center gap-4">
@@ -145,7 +145,7 @@ export function HbjsonExportDialog({ trigger }: HbjsonExportDialogProps) {
                 </SelectTrigger>
                 <SelectContent>
                   {modelList.map((m) => {
-                    const maxLen = 24;
+                    const maxLen = 32;
                     const displayName =
                       m.name.length > maxLen ? m.name.slice(0, maxLen) + '…' : m.name;
                     return (


### PR DESCRIPTION
## Issue
The export modal was reported as wrong-sized (issue title: "export dialog window size"). The "export visible" capability already exists as a toggle; the real complaint was the modal being cramped and undersized.

## Change
- `ExportDialog`, `GLBExportDialog`, `HbjsonExportDialog`: `sm:max-w-md` (448px) -> `sm:max-w-lg` (512px)
- content scroll area `max-h-[60vh]` -> `max-h-[70vh]` so it does not scroll needlessly
- model-name truncation `24` -> `32` chars

Applied consistently across the three export dialogs so they match.

## Verification
Reproduced and checked on localhost (before/after screenshots captured). Change is pure className/constant, fully responsive (`w-full` base preserved). Local viewer typecheck is clean for the touched files; the only local errors are pre-existing stale-dist mismatches in unrelated clash files (`modelNameOf` exists in `packages/clash/src` on main but not in the local built dist) and are green on CI's fresh build.

Closes #1644

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved export dialog layouts with wider panels and more vertical space for scrolling.
  * Model selectors now display longer model names before truncating them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->