### PR TITLE
feat(viewer): live match preview for regex pset/qto columns (#1591)

### DIFF
--- a/apps/viewer/src/components/viewer/lists/ListBuilder.tsx
+++ b/apps/viewer/src/components/viewer/lists/ListBuilder.tsx
@@ -36,8 +36,9 @@ import type {
   PropertyCondition,
   ConditionOperator,
 } from '@ifc-lite/lists';
-import { discoverColumns, ENTITY_ATTRIBUTES, isNamePattern } from '@ifc-lite/lists';
+import { discoverColumns, ENTITY_ATTRIBUTES } from '@ifc-lite/lists';
 import { collectScopeTypes } from '@/lib/lists/scope-types';
+import { previewSetPattern, formatMatchHint } from './pattern-preview';
 
 const NO_OPTIONS: readonly string[] = [];
 
@@ -721,12 +722,15 @@ function CustomColumnEntry({
 
   const set = setName.trim();
   const prop = propName.trim();
-  const isPattern = isNamePattern(set);
+  // Live preview: which discovered sets a `/regex/` set field matches, so a
+  // power user sees "matches 2 sets: ..." before adding, and a malformed pattern
+  // is flagged rather than silently added as a dead literal (issue #1591).
+  const preview = useMemo(() => previewSetPattern(set, setOptions), [set, setOptions]);
   // Slugify like the discovered-column ids (collapse whitespace) but keep the
   // original case: regex patterns are case-sensitive, so `/A/` and `/a/` are
   // distinct sets and must not collapse to one id.
   const columnId = `custom-${source}-${set}-${prop}`.replace(/\s+/g, '-');
-  const canAdd = set.length > 0 && prop.length > 0 && !selectedIds.has(columnId);
+  const canAdd = set.length > 0 && prop.length > 0 && !selectedIds.has(columnId) && !preview.isInvalid;
 
   const add = () => {
     if (!canAdd) return;
@@ -753,7 +757,7 @@ function CustomColumnEntry({
       <div className="flex items-center gap-1.5">
         <Chip selected={source === 'property'} onClick={() => setSource('property')}>Property</Chip>
         <Chip selected={source === 'quantity'} onClick={() => setSource('quantity')}>Quantity</Chip>
-        {isPattern && (
+        {preview.isPattern && (
           <span className="rounded bg-primary/10 px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-wide text-primary">
             regex
           </span>
@@ -791,11 +795,21 @@ function CustomColumnEntry({
           <Plus className="h-3.5 w-3.5" />
         </Button>
       </div>
-      <p className="text-[11px] leading-relaxed text-muted-foreground">
-        Type an exact set name, or wrap a pattern in{' '}
-        <code className="rounded bg-muted px-1 font-mono text-[10px]">/…/</code> to pull one value across every
-        matching set, e.g. <code className="rounded bg-muted px-1 font-mono text-[10px]">/Qto_.*BaseQuantities/</code>.
-      </p>
+      {preview.isInvalid ? (
+        <p className="text-[11px] leading-relaxed text-destructive">
+          Invalid pattern. It would be matched as a literal name, so it likely hits nothing.
+        </p>
+      ) : preview.isPattern ? (
+        <p className="text-[11px] leading-relaxed text-muted-foreground">
+          {formatMatchHint(preview.matches)}
+        </p>
+      ) : (
+        <p className="text-[11px] leading-relaxed text-muted-foreground">
+          Type an exact set name, or wrap a pattern in{' '}
+          <code className="rounded bg-muted px-1 font-mono text-[10px]">/…/</code> to pull one value across every
+          matching set, e.g. <code className="rounded bg-muted px-1 font-mono text-[10px]">/Qto_.*BaseQuantities/</code>.
+        </p>
+      )}
     </div>
   );
 }

--- a/apps/viewer/src/components/viewer/lists/pattern-preview.test.ts
+++ b/apps/viewer/src/components/viewer/lists/pattern-preview.test.ts
@@ -1,0 +1,83 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { previewSetPattern, formatMatchHint } from './pattern-preview';
+
+const SETS = [
+  'Qto_WallBaseQuantities',
+  'Qto_SlabBaseQuantities',
+  'Qto_ColumnBaseQuantities',
+  'Pset_WallCommon',
+];
+
+describe('previewSetPattern', () => {
+  it('lists every discovered set a valid /regex/ matches (the issue #1591 example)', () => {
+    const p = previewSetPattern('/Qto_.*BaseQuantities/', SETS);
+    assert.equal(p.isPattern, true);
+    assert.equal(p.isInvalid, false);
+    assert.deepEqual(p.matches, [
+      'Qto_WallBaseQuantities',
+      'Qto_SlabBaseQuantities',
+      'Qto_ColumnBaseQuantities',
+    ]);
+  });
+
+  it('trims surrounding whitespace before classifying', () => {
+    const p = previewSetPattern('  /Pset_.*/  ', SETS);
+    assert.equal(p.isPattern, true);
+    assert.deepEqual(p.matches, ['Pset_WallCommon']);
+  });
+
+  it('is case-sensitive by default, case-insensitive with /i', () => {
+    assert.deepEqual(previewSetPattern('/qto_.*/', SETS).matches, []);
+    assert.deepEqual(previewSetPattern('/qto_.*/i', SETS).matches, [
+      'Qto_WallBaseQuantities',
+      'Qto_SlabBaseQuantities',
+      'Qto_ColumnBaseQuantities',
+    ]);
+  });
+
+  it('returns a valid pattern with zero matches (not invalid)', () => {
+    const p = previewSetPattern('/Nope_.*/', SETS);
+    assert.equal(p.isPattern, true);
+    assert.equal(p.isInvalid, false);
+    assert.deepEqual(p.matches, []);
+  });
+
+  it('treats a plain exact name as neither pattern nor invalid', () => {
+    const p = previewSetPattern('Qto_WallBaseQuantities', SETS);
+    assert.equal(p.isPattern, false);
+    assert.equal(p.isInvalid, false);
+    assert.deepEqual(p.matches, []);
+  });
+
+  it('flags a slash-shaped literal that does not compile as invalid', () => {
+    const p = previewSetPattern('/[unclosed/', SETS);
+    assert.equal(p.isPattern, false);
+    assert.equal(p.isInvalid, true);
+    assert.deepEqual(p.matches, []);
+  });
+
+  it('treats an empty / whitespace field as blank (no preview)', () => {
+    assert.deepEqual(previewSetPattern('', SETS), { isPattern: false, isInvalid: false, matches: [] });
+    assert.deepEqual(previewSetPattern('   ', SETS), { isPattern: false, isInvalid: false, matches: [] });
+  });
+});
+
+describe('formatMatchHint', () => {
+  it('reads "matches 0 sets in loaded models" for no matches', () => {
+    assert.equal(formatMatchHint([]), 'matches 0 sets in loaded models');
+  });
+
+  it('singularises one match', () => {
+    assert.equal(formatMatchHint(['Qto_WallBaseQuantities']), 'matches 1 set: Qto_WallBaseQuantities');
+  });
+
+  it('lists up to the cap then " +N more"', () => {
+    assert.equal(formatMatchHint(['A', 'B']), 'matches 2 sets: A, B');
+    assert.equal(formatMatchHint(['A', 'B', 'C', 'D', 'E']), 'matches 5 sets: A, B, C +2 more');
+  });
+});

--- a/apps/viewer/src/components/viewer/lists/pattern-preview.ts
+++ b/apps/viewer/src/components/viewer/lists/pattern-preview.ts
@@ -1,0 +1,68 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Live preview for the custom / pattern column entry (issue #1591 follow-up).
+ *
+ * The set-name field accepts a Bonsai-style `/regex/` pattern that pulls one
+ * value across every matching property / quantity set. Before the column is
+ * added, this resolves the pattern against the set names already discovered in
+ * the loaded models so the builder can show "matches N sets: A, B", turning a
+ * blind regex into an immediate confirmation. It reuses the SAME
+ * `compileNameMatcher` the engine uses, so the preview and the executed column
+ * can never disagree.
+ */
+
+import { compileNameMatcher, isNamePattern } from '@ifc-lite/lists';
+
+/** Shape of a slash literal `/body/` or `/body/flags` (valid OR malformed body). */
+const LOOKS_LIKE_PATTERN = /^\/.+\/[a-z]*$/;
+
+export interface SetPatternPreview {
+  /** The field is a valid `/regex/` slash literal. */
+  isPattern: boolean;
+  /** The field looks like a slash literal but the regex does not compile. The
+   *  engine then falls back to an exact-literal match, which almost never hits a
+   *  real set, so the builder disables Add and warns. */
+  isInvalid: boolean;
+  /** Discovered set names the pattern matches (only populated when `isPattern`). */
+  matches: string[];
+}
+
+/**
+ * Classify the set-name field and, for a valid pattern, list the discovered set
+ * names it matches. A plain (non-slash) name is neither a pattern nor invalid:
+ * it stays an exact match and needs no preview.
+ */
+export function previewSetPattern(setField: string, setNames: Iterable<string>): SetPatternPreview {
+  const set = setField.trim();
+  if (set.length === 0) return { isPattern: false, isInvalid: false, matches: [] };
+
+  if (!isNamePattern(set)) {
+    // A slash-shaped string that failed to compile is flagged so the UI can
+    // warn; a plain name is just an exact match.
+    return { isPattern: false, isInvalid: LOOKS_LIKE_PATTERN.test(set), matches: [] };
+  }
+
+  const match = compileNameMatcher(set);
+  const matches: string[] = [];
+  for (const name of setNames) {
+    if (match(name)) matches.push(name);
+  }
+  return { isPattern: true, isInvalid: false, matches };
+}
+
+/**
+ * Human hint for a pattern's matches: `matches 2 sets: A, B`, capping the named
+ * sets at `cap` then appending ` +N more`. Zero matches reads
+ * `matches 0 sets in loaded models` (the pattern is valid, just unmatched).
+ */
+export function formatMatchHint(matches: string[], cap = 3): string {
+  const n = matches.length;
+  if (n === 0) return 'matches 0 sets in loaded models';
+  const shown = matches.slice(0, cap).join(', ');
+  const extra = n - Math.min(cap, n);
+  const suffix = extra > 0 ? ` +${extra} more` : '';
+  return `matches ${n} ${n === 1 ? 'set' : 'sets'}: ${shown}${suffix}`;
+}


### PR DESCRIPTION
## Context
Issue #1591 asked for (Q1) regex pset/property matching and (Q2) a project/site source column. Both already shipped on main:
- #1626 - Bonsai-style `/regex/` set & property name matching (engine + SDK)
- #1614 - federation-identity columns (Model + leveled Storey/Building/Site/Project)

## This PR
Completes the authoring UX for the regex feature in the List column builder:
- Live hint when a set field is a `/pattern/`: "matches N sets: ..." (capped at 3, then "+N more"), or "matches 0 sets in loaded models"
- Flags a malformed pattern (`Invalid pattern...`) instead of silently adding a dead literal column
- Disables Add while the pattern is invalid
- New pure helpers `previewSetPattern` / `formatMatchHint` in `pattern-preview.ts` with a 10-case unit test

## Verification
`pattern-preview` unit test 10/10; viewer typecheck clean. Viewer-only, no changeset.

Closes #1591

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added live previews for set-name patterns, including matching set counts and sample names.
  * Added clear validation feedback for malformed patterns.
  * Added support for case-insensitive regex patterns using the `/i` flag.
  * Prevented invalid patterns from being added to custom columns.

* **Bug Fixes**
  * Improved handling of whitespace, empty inputs, exact names, and patterns with no matches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->