### PR TITLE
feat(viewer): georef-aware XYZ measure readout (#1657)

### DIFF
--- a/apps/viewer/src/components/viewer/tools/MeasurePanel.tsx
+++ b/apps/viewer/src/components/viewer/tools/MeasurePanel.tsx
@@ -40,10 +40,26 @@ function useProjectedLatLon(
   effective: UsableEffectiveGeoref | null,
 ): LatLon | null {
   const [latLon, setLatLon] = useState<LatLon | null>(null);
-  const key = projected
+  const pointKey = projected
     ? `${Math.round(projected.eastings * 1000)}:${Math.round(projected.northings * 1000)}`
     : '';
-  const crsName = effective?.projectedCRS.name ?? '';
+  // Every input reprojectPointToLatLon reads must key the effect, or editing a
+  // georef field that changes the projection while leaving the CRS name and
+  // rounded E/N unchanged (MapUnit, MapZone, projection metadata, length unit)
+  // would leave lat/lon stale against a live E/N/H readout (issue #1657 review).
+  // resolveProjection reads name/mapZone/description/mapProjection;
+  // reprojectPointToLatLon also reads mapUnitScale + lengthUnitScale.
+  const crs = effective?.projectedCRS;
+  const georefKey = crs
+    ? [
+        crs.name,
+        crs.mapZone ?? '',
+        crs.description ?? '',
+        crs.mapProjection ?? '',
+        crs.mapUnitScale ?? '',
+        effective?.lengthUnitScale ?? '',
+      ].join('|')
+    : '';
   useEffect(() => {
     if (!projected || !effective) {
       setLatLon(null);
@@ -61,8 +77,10 @@ function useProjectedLatLon(
     return () => {
       cancelled = true;
     };
+    // Effect keyed by primitive georefKey/pointKey so it recomputes when any
+    // reprojection input changes without refetching on unrelated re-renders.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [key, crsName]);
+  }, [pointKey, georefKey]);
   return latLon;
 }
 

--- a/apps/viewer/src/components/viewer/tools/MeasurePanel.tsx
+++ b/apps/viewer/src/components/viewer/tools/MeasurePanel.tsx
@@ -6,13 +6,65 @@
  * Measure tool panel UI (measurement list, controls)
  */
 
-import React, { useCallback, useState, useEffect } from 'react';
+import React, { useCallback, useState, useEffect, useMemo } from 'react';
 import { X, Trash2, Ruler, ChevronDown, GripVertical } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { useViewerStore, type Measurement } from '@/store';
 import { MeasurementOverlays } from './MeasurementVisuals';
 import { formatDistance } from './formatDistance';
 import { useDraggablePanel } from '@/hooks/useDraggablePanel';
+import { useAnchorGeoreference } from '@/lib/geo/useAnchorGeoreference';
+import {
+  ifcOriginViewerPoint,
+  mapCoordinateDecimals,
+  viewerPointToProjected,
+  type ProjectedPoint,
+  type UsableEffectiveGeoref,
+} from '@/lib/geo/pick-to-geo';
+import { reprojectPointToLatLon, type LatLon } from '@/lib/geo/reproject';
+
+/** Live E/N/H readout bound to one anchor georef (issue #1657). */
+interface GeoReadout {
+  effective: UsableEffectiveGeoref;
+  toProjected: (p: { x: number; y: number; z: number }) => ProjectedPoint;
+  format: (v: number) => string;
+}
+
+/**
+ * Reproject a picked point's E/N to WGS84 lat/lon asynchronously (proj4).
+ * Returns null until the projection resolves; the E/N/H readout never blocks
+ * on it. Quantised to ~mm so hover jitter doesn't spam proj4.
+ */
+function useProjectedLatLon(
+  projected: ProjectedPoint | null,
+  effective: UsableEffectiveGeoref | null,
+): LatLon | null {
+  const [latLon, setLatLon] = useState<LatLon | null>(null);
+  const key = projected
+    ? `${Math.round(projected.eastings * 1000)}:${Math.round(projected.northings * 1000)}`
+    : '';
+  const crsName = effective?.projectedCRS.name ?? '';
+  useEffect(() => {
+    if (!projected || !effective) {
+      setLatLon(null);
+      return;
+    }
+    let cancelled = false;
+    void reprojectPointToLatLon(
+      projected.eastings,
+      projected.northings,
+      effective.projectedCRS,
+      effective.lengthUnitScale,
+    ).then((r) => {
+      if (!cancelled) setLatLon(r);
+    });
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [key, crsName]);
+  return latLon;
+}
 
 export function MeasureOverlay() {
   const measurements = useViewerStore((s) => s.measurements);
@@ -23,6 +75,8 @@ export function MeasureOverlay() {
   const snapEnabled = useViewerStore((s) => s.snapEnabled);
   const measurementConstraintEdge = useViewerStore((s) => s.measurementConstraintEdge);
   const toggleSnap = useViewerStore((s) => s.toggleSnap);
+  const measureGeoEnabled = useViewerStore((s) => s.measureGeoEnabled);
+  const toggleMeasureGeo = useViewerStore((s) => s.toggleMeasureGeo);
   const deleteMeasurement = useViewerStore((s) => s.deleteMeasurement);
   const clearMeasurements = useViewerStore((s) => s.clearMeasurements);
   const setActiveTool = useViewerStore((s) => s.setActiveTool);
@@ -86,6 +140,29 @@ export function MeasureOverlay() {
   // Calculate total distance
   const totalDistance = measurements.reduce((sum, m) => sum + m.distance, 0);
 
+  // Georef-aware XYZ readout (issue #1657): convert picked viewer points to
+  // projected E/N/H via the ANCHOR model's effective IfcMapConversion.
+  // Hidden entirely when no loaded model carries a usable map georef.
+  const anchorGeoref = useAnchorGeoreference();
+  const geo = useMemo<GeoReadout | null>(() => {
+    if (!anchorGeoref) return null;
+    const { effective } = anchorGeoref;
+    const origin = ifcOriginViewerPoint(effective.coordinateInfo);
+    const decimals = mapCoordinateDecimals(effective.projectedCRS, effective.lengthUnitScale);
+    return {
+      effective,
+      toProjected: (p: { x: number; y: number; z: number }): ProjectedPoint =>
+        viewerPointToProjected(p, effective, origin),
+      format: (v: number) => v.toFixed(decimals),
+    };
+  }, [anchorGeoref]);
+  const geoActive = measureGeoEnabled && geo !== null;
+
+  // Live point priority: drag current > hover snap > legacy pending point.
+  const livePoint = activeMeasurement?.current ?? snapTarget?.position ?? pendingMeasurePoint;
+  const liveProjected = geoActive && geo && livePoint ? geo.toProjected(livePoint) : null;
+  const liveLatLon = useProjectedLatLon(liveProjected, geoActive && geo ? geo.effective : null);
+
   const panelRef = React.useRef<HTMLDivElement>(null);
   const drag = useDraggablePanel(panelRef);
 
@@ -141,6 +218,7 @@ export function MeasureOverlay() {
                     measurement={m}
                     index={i}
                     onDelete={handleDeleteMeasurement}
+                    geo={geoActive ? geo : null}
                   />
                 ))}
                 {measurements.length > 1 && (
@@ -177,8 +255,21 @@ export function MeasureOverlay() {
         </span>
       </div>
 
-      {/* Snap toggle - brutalist style */}
-      <div className="pointer-events-auto absolute bottom-4 left-1/2 -translate-x-1/2 z-30">
+      {/* Live geo readout for the current point - brutalist style */}
+      {geo && liveProjected && (
+        <div className="pointer-events-none absolute bottom-28 left-1/2 -translate-x-1/2 z-30 bg-zinc-900 dark:bg-zinc-100 text-zinc-100 dark:text-zinc-900 px-3 py-1 border-2 border-zinc-900 dark:border-zinc-100 font-mono text-[10px] leading-tight whitespace-nowrap text-center">
+          <div>
+            E {geo.format(liveProjected.eastings)} N {geo.format(liveProjected.northings)} H {geo.format(liveProjected.height)}
+          </div>
+          <div className="opacity-60">
+            {liveProjected.crsName}
+            {liveLatLon ? ` | lat ${liveLatLon.lat.toFixed(6)} lon ${liveLatLon.lon.toFixed(6)}` : ''}
+          </div>
+        </div>
+      )}
+
+      {/* Snap + XYZ Geo toggles - brutalist style */}
+      <div className="pointer-events-auto absolute bottom-4 left-1/2 -translate-x-1/2 z-30 flex gap-1">
         <button
           onClick={toggleSnap}
           className={`px-2 py-1 font-mono text-[10px] uppercase tracking-wider border-2 transition-colors ${
@@ -190,6 +281,19 @@ export function MeasureOverlay() {
         >
           Snap {snapEnabled ? 'On' : 'Off'}
         </button>
+        {geo && (
+          <button
+            onClick={toggleMeasureGeo}
+            className={`px-2 py-1 font-mono text-[10px] uppercase tracking-wider border-2 transition-colors ${
+              measureGeoEnabled
+                ? 'bg-primary text-primary-foreground border-primary'
+                : 'bg-zinc-100 dark:bg-zinc-900 text-zinc-500 border-zinc-300 dark:border-zinc-700'
+            }`}
+            title="Show map coordinates (Eastings/Northings/orthogonal Height)"
+          >
+            XYZ Geo {measureGeoEnabled ? 'On' : 'Off'}
+          </button>
+        )}
       </div>
 
       {/* Render measurement lines, labels, and snap indicators */}
@@ -211,21 +315,48 @@ interface MeasurementItemProps {
   measurement: Measurement;
   index: number;
   onDelete: (id: string) => void;
+  geo: GeoReadout | null;
 }
 
-function MeasurementItem({ measurement, index, onDelete }: MeasurementItemProps) {
+function MeasurementItem({ measurement, index, onDelete, geo }: MeasurementItemProps) {
   return (
-    <div className="flex items-center justify-between bg-muted/50 rounded px-2 py-0.5 text-xs">
-      <span className="text-muted-foreground text-xs">#{index + 1}</span>
-      <span className="font-mono font-medium">{formatDistance(measurement.distance)}</span>
-      <Button
-        variant="ghost"
-        size="icon-sm"
-        className="h-4 w-4 hover:bg-destructive/20"
-        onClick={() => onDelete(measurement.id)}
-      >
-        <X className="h-2.5 w-2.5" />
-      </Button>
+    <div className="bg-muted/50 rounded px-2 py-0.5 text-xs">
+      <div className="flex items-center justify-between">
+        <span className="text-muted-foreground text-xs">#{index + 1}</span>
+        <span className="font-mono font-medium">{formatDistance(measurement.distance)}</span>
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          className="h-4 w-4 hover:bg-destructive/20"
+          onClick={() => onDelete(measurement.id)}
+        >
+          <X className="h-2.5 w-2.5" />
+        </Button>
+      </div>
+      {geo && (
+        <div className="mt-0.5 font-mono text-[10px] text-muted-foreground leading-tight overflow-x-auto">
+          <GeoEndpoint label="A" point={measurement.start} geo={geo} />
+          <GeoEndpoint label="B" point={measurement.end} geo={geo} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** One measurement endpoint's E/N/H in the anchor CRS map unit. */
+function GeoEndpoint({
+  label,
+  point,
+  geo,
+}: {
+  label: string;
+  point: { x: number; y: number; z: number };
+  geo: GeoReadout;
+}) {
+  const p = geo.toProjected(point);
+  return (
+    <div className="whitespace-nowrap">
+      {label} E {geo.format(p.eastings)} N {geo.format(p.northings)} H {geo.format(p.height)}
     </div>
   );
 }

--- a/apps/viewer/src/lib/geo/ifc-origin.ts
+++ b/apps/viewer/src/lib/geo/ifc-origin.ts
@@ -51,7 +51,12 @@ export interface ModelGeorefInput {
   preAlignmentCoordinateInfo?: CoordinateInfo;
 }
 
-function totalYupOffset(info?: CoordinateInfo): { x: number; y: number; z: number } {
+/**
+ * Total viewer Y-up offset applied to a model's geometry (origin shift +
+ * WASM RTC offset, the latter converted from IFC Z-up). The model's IFC
+ * (0,0,0) sits at the NEGATION of this offset in viewer space.
+ */
+export function totalYupOffset(info?: CoordinateInfo): { x: number; y: number; z: number } {
   const shift = info?.originShift ?? { x: 0, y: 0, z: 0 };
   const rtc = info?.wasmRtcOffset;
   const rtcYup = rtc ? { x: rtc.x, y: rtc.z, z: -rtc.y } : { x: 0, y: 0, z: 0 };

--- a/apps/viewer/src/lib/geo/pick-to-geo.test.ts
+++ b/apps/viewer/src/lib/geo/pick-to-geo.test.ts
@@ -1,0 +1,194 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+
+import {
+  hasUsableMapGeoref,
+  ifcOriginViewerPoint,
+  mapCoordinateDecimals,
+  viewerPointToProjected,
+  type UsableEffectiveGeoref,
+} from './pick-to-geo.js';
+
+const ORIGIN0 = { x: 0, y: 0, z: 0 };
+
+function approx(actual: number, expected: number, eps = 1e-6): void {
+  assert.ok(
+    Math.abs(actual - expected) <= eps,
+    `expected ${actual} to be within ${eps} of ${expected}`,
+  );
+}
+
+/**
+ * Effective georef for apps/viewer/public/samples/building-architecture.ifc:
+ *   IFCSIUNIT LENGTHUNIT MILLI METRE            -> lengthUnitScale 0.001
+ *   IFCPROJECTEDCRS 'EPSG:32760', MapUnit MILLI -> mapUnitScale 0.001
+ *   IFCMAPCONVERSION eastings 729013348.8297004,
+ *     northings 9063992684.697363, orthogonalHeight 1300.0000000000011,
+ *     xAxisAbscissa 0.4999999999999999 (cos 60deg),
+ *     xAxisOrdinate 0.8660254037844387 (sin 60deg), scale 1.0
+ */
+const BUILDING_ARCH: UsableEffectiveGeoref = {
+  hasGeoreference: true,
+  source: 'mapConversion',
+  lengthUnitScale: 0.001,
+  projectedCRS: {
+    id: 18,
+    name: 'EPSG:32760',
+    mapUnit: 'MILLIMETRE',
+    mapUnitScale: 0.001,
+  },
+  mapConversion: {
+    id: 19,
+    sourceCRS: 11,
+    targetCRS: 18,
+    eastings: 729013348.8297004,
+    northings: 9063992684.697363,
+    orthogonalHeight: 1300.0000000000011,
+    xAxisAbscissa: 0.4999999999999999,
+    xAxisOrdinate: 0.8660254037844387,
+    scale: 1,
+  },
+} as UsableEffectiveGeoref;
+
+const ABSCISSA = 0.4999999999999999;
+const ORDINATE = 0.8660254037844387;
+
+describe('viewerPointToProjected', () => {
+  it('maps the anchor IFC origin to the authored MapConversion offsets', () => {
+    const p = viewerPointToProjected(ORIGIN0, BUILDING_ARCH, ORIGIN0);
+    // mm map units: origin lands exactly on the authored eastings/northings/height.
+    approx(p.eastings, 729013348.8297004, 1e-3);
+    approx(p.northings, 9063992684.697363, 1e-3);
+    approx(p.height, 1300.0000000000011, 1e-6);
+    assert.strictEqual(p.crsName, 'EPSG:32760');
+  });
+
+  it('rotates a +1m viewer-X offset by the 60deg grid rotation and scales to mm', () => {
+    // +1m along viewer X. E delta = cos60 * 1m = 0.5m -> 500 mm map units;
+    // N delta = sin60 * 1m = 0.866m -> 866 mm. Magnitude stays 1000 mm (1m).
+    const p = viewerPointToProjected({ x: 1, y: 0, z: 0 }, BUILDING_ARCH, ORIGIN0);
+    approx(p.eastings - 729013348.8297004, ABSCISSA * 1000, 1e-6);
+    approx(p.northings - 9063992684.697363, ORDINATE * 1000, 1e-6);
+    const de = p.eastings - 729013348.8297004;
+    const dn = p.northings - 9063992684.697363;
+    approx(Math.hypot(de, dn), 1000, 1e-6);
+  });
+
+  it('maps +1m viewer-Z per the local_to_map sign convention (rust/core/src/georef.rs)', () => {
+    // Viewer Z-up mapping: ifcX = viewerX, ifcY = -viewerZ. With
+    // local_to_map east = absc*ifcX - ordi*ifcY, north = ordi*ifcX + absc*ifcY,
+    // a +1m viewer Z gives ifcY = -1 -> E += ordi*1000, N += -absc*1000.
+    const p = viewerPointToProjected({ x: 0, y: 0, z: 1 }, BUILDING_ARCH, ORIGIN0);
+    approx(p.eastings - 729013348.8297004, ORDINATE * 1000, 1e-6);
+    approx(p.northings - 9063992684.697363, -ABSCISSA * 1000, 1e-6);
+  });
+
+  it('converts orthogonal height in mm map units (1m up = +1000)', () => {
+    const p = viewerPointToProjected({ x: 0, y: 1, z: 0 }, BUILDING_ARCH, ORIGIN0);
+    approx(p.height - 1300.0000000000011, 1000, 1e-6);
+  });
+
+  it('honours the origin offset (federated anchor frame)', () => {
+    // A picked point equal to the origin viewer position resolves to the pivot.
+    const originViewer = { x: 12, y: 3, z: -7 };
+    const p = viewerPointToProjected(originViewer, BUILDING_ARCH, originViewer);
+    approx(p.eastings, 729013348.8297004, 1e-3);
+    approx(p.northings, 9063992684.697363, 1e-3);
+    approx(p.height, 1300.0000000000011, 1e-6);
+  });
+
+  it('does not inflate a metre CRS with no rotation (unit trap guard)', () => {
+    // metre project + metre map units, identity rotation: +1m viewer X is
+    // exactly +1 easting map unit, NOT 1000 (the transformToWorld trap).
+    const metreGeoref: UsableEffectiveGeoref = {
+      hasGeoreference: true,
+      source: 'mapConversion',
+      lengthUnitScale: 1,
+      projectedCRS: { id: 1, name: 'EPSG:2056', mapUnit: 'METRE', mapUnitScale: 1 },
+      mapConversion: {
+        id: 2,
+        sourceCRS: 0,
+        targetCRS: 1,
+        eastings: 2600000,
+        northings: 1200000,
+        orthogonalHeight: 400,
+        xAxisAbscissa: 1,
+        xAxisOrdinate: 0,
+        scale: 1,
+      },
+    } as UsableEffectiveGeoref;
+    const p = viewerPointToProjected({ x: 1, y: 2, z: -3 }, metreGeoref, ORIGIN0);
+    approx(p.eastings, 2600001, 1e-6);
+    approx(p.northings, 1200003, 1e-6); // ifcY = -viewerZ = 3 -> +3 north
+    approx(p.height, 402, 1e-6);
+  });
+});
+
+describe('hasUsableMapGeoref', () => {
+  it('accepts a real map conversion + named projected CRS', () => {
+    assert.strictEqual(hasUsableMapGeoref(BUILDING_ARCH), true);
+  });
+
+  it('rejects null/undefined', () => {
+    assert.strictEqual(hasUsableMapGeoref(null), false);
+    assert.strictEqual(hasUsableMapGeoref(undefined), false);
+  });
+
+  it('rejects a georef missing the map conversion', () => {
+    const noConversion = {
+      hasGeoreference: true,
+      source: 'mapConversion',
+      lengthUnitScale: 1,
+      projectedCRS: { id: 1, name: 'EPSG:32760', mapUnitScale: 1 },
+      mapConversion: undefined,
+    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    assert.strictEqual(hasUsableMapGeoref(noConversion as any), false);
+  });
+
+  it('rejects the siteLocation source (legacy EPSG:4326 lat/lon)', () => {
+    const siteLocation = {
+      ...BUILDING_ARCH,
+      source: 'siteLocation',
+    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    assert.strictEqual(hasUsableMapGeoref(siteLocation as any), false);
+  });
+});
+
+describe('mapCoordinateDecimals', () => {
+  it('uses 0 decimals for a millimetre CRS', () => {
+    assert.strictEqual(mapCoordinateDecimals({ mapUnitScale: 0.001 }, 0.001), 0);
+  });
+
+  it('uses 3 decimals for a metre CRS', () => {
+    assert.strictEqual(mapCoordinateDecimals({ mapUnitScale: 1 }, 1), 3);
+    assert.strictEqual(mapCoordinateDecimals(undefined, 1), 3);
+  });
+
+  it('clamps to [0, 3]', () => {
+    // Coarse (kilometre) map units cap at 3 decimals; sub-mm units floor at 0.
+    assert.strictEqual(mapCoordinateDecimals({ mapUnitScale: 1000 }, 1), 3);
+    assert.strictEqual(mapCoordinateDecimals({ mapUnitScale: 0.0001 }, 1), 0);
+  });
+});
+
+describe('ifcOriginViewerPoint', () => {
+  it('returns the negated total Y-up offset (origin shift + RTC)', () => {
+    const zero = ifcOriginViewerPoint(undefined);
+    // Use == against 0 so the harmless -0 from negating 0 still passes.
+    assert.ok(zero.x === 0 && zero.y === 0 && zero.z === 0);
+    const p = ifcOriginViewerPoint({
+      originShift: { x: 10, y: 5, z: -2 },
+      // RTC is IFC Z-up; viewer maps {x, z, -y}.
+      wasmRtcOffset: { x: 1, y: 2, z: 3 },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+    // total = shift + {rtc.x, rtc.z, -rtc.y} = {11, 8, -4}; negated:
+    assert.deepStrictEqual(p, { x: -11, y: -8, z: 4 });
+  });
+});

--- a/apps/viewer/src/lib/geo/pick-to-geo.ts
+++ b/apps/viewer/src/lib/geo/pick-to-geo.ts
@@ -1,0 +1,118 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Convert a picked viewer-space point (Y-up metres) into projected map
+ * coordinates (Eastings / Northings / orthogonal Height, in the CRS map
+ * unit) using the anchor model's effective IfcMapConversion +
+ * IfcProjectedCRS.
+ *
+ * All conversions go through `viewerDeltaToProjectedDelta` /
+ * `metersToMapUnits`, which are unit- and IfcMapConversion.Scale-aware.
+ * Do NOT swap in the parser's `transformToWorld`: it assumes local coords
+ * in map units and is ~1000x off for mm-unit projects whose geometry the
+ * viewer already converted to metres.
+ *
+ * Height is the authored orthogonal height in the map CRS — no vertical
+ * datum transform is applied in the browser.
+ */
+
+import type { CoordinateInfo } from '@ifc-lite/geometry';
+import type { MapConversion, ProjectedCRS } from '@ifc-lite/parser';
+import {
+  getMapUnitScale,
+  metersToMapUnits,
+  viewerDeltaToProjectedDelta,
+} from './cesium-placement';
+import {
+  hasStandardGeoreferencing,
+  type EffectiveGeoreference,
+} from './effective-georef';
+import { totalYupOffset } from './ifc-origin';
+
+/** Effective georef narrowed to the fields the projection math requires. */
+export type UsableEffectiveGeoref = EffectiveGeoreference & {
+  mapConversion: MapConversion;
+  projectedCRS: ProjectedCRS;
+};
+
+/**
+ * True when the georef can meaningfully place a picked point in a projected
+ * CRS: a real IfcMapConversion + named IfcProjectedCRS. Excludes the
+ * synthesised `siteLocation` source (legacy EPSG:4326 lat/lon from IfcSite),
+ * whose degree-based offsets would produce misleading E/N/H output.
+ */
+export function hasUsableMapGeoref(
+  georef: EffectiveGeoreference | null | undefined,
+): georef is UsableEffectiveGeoref {
+  return Boolean(georef && hasStandardGeoreferencing(georef));
+}
+
+export interface ProjectedPoint {
+  /** Eastings in the CRS map unit (e.g. mm when MapUnit is MILLIMETRE). */
+  eastings: number;
+  /** Northings in the CRS map unit. */
+  northings: number;
+  /** Authored orthogonal height in the CRS map unit (no datum transform). */
+  height: number;
+  /** CRS identifier, e.g. "EPSG:32760". */
+  crsName: string;
+}
+
+/**
+ * Viewer-space (Y-up) position where the model's IFC (0,0,0) sits.
+ * Synchronous equivalent of `computeIfcOriginViewerPosition`'s `'self'`
+ * branch — valid for a standalone model or the federation ANCHOR model
+ * (federated vertices are re-baked into the anchor frame, so picked points
+ * must always be converted through the anchor's georef and origin).
+ */
+export function ifcOriginViewerPoint(
+  coordinateInfo?: CoordinateInfo,
+): { x: number; y: number; z: number } {
+  const off = totalYupOffset(coordinateInfo);
+  return { x: -off.x, y: -off.y, z: -off.z };
+}
+
+/**
+ * Project a picked viewer point (Y-up metres) into the map CRS.
+ *
+ * @param point        Picked position in viewer space (Y-up metres).
+ * @param georef       Anchor model's effective georef (map conversion + CRS).
+ * @param originViewer Viewer position of the anchor's IFC (0,0,0) — see
+ *                     {@link ifcOriginViewerPoint}.
+ */
+export function viewerPointToProjected(
+  point: { x: number; y: number; z: number },
+  georef: UsableEffectiveGeoref,
+  originViewer: { x: number; y: number; z: number },
+): ProjectedPoint {
+  const { mapConversion, projectedCRS, lengthUnitScale } = georef;
+  const delta = viewerDeltaToProjectedDelta(
+    point.x - originViewer.x,
+    point.z - originViewer.z,
+    mapConversion,
+    projectedCRS,
+    lengthUnitScale,
+  );
+  return {
+    eastings: mapConversion.eastings + delta.eastings,
+    northings: mapConversion.northings + delta.northings,
+    height: mapConversion.orthogonalHeight
+      + metersToMapUnits(point.y - originViewer.y, projectedCRS, lengthUnitScale),
+    crsName: projectedCRS.name,
+  };
+}
+
+/**
+ * Decimal places giving roughly millimetre resolution in the CRS map unit:
+ * 3 decimals for a metre CRS, 0 for a millimetre CRS, clamped to [0, 3].
+ */
+export function mapCoordinateDecimals(
+  projectedCRS: Pick<ProjectedCRS, 'mapUnitScale'> | undefined,
+  lengthUnitScale: number,
+): number {
+  const metresPerMapUnit = getMapUnitScale(projectedCRS, lengthUnitScale);
+  const decimals = Math.ceil(Math.log10(metresPerMapUnit * 1000));
+  return Math.min(3, Math.max(0, decimals));
+}

--- a/apps/viewer/src/lib/geo/reproject.ts
+++ b/apps/viewer/src/lib/geo/reproject.ts
@@ -456,6 +456,49 @@ export async function reprojectToLatLon(
 }
 
 /**
+ * Reproject an explicit projected point (eastings/northings in the CRS map
+ * unit) to WGS84 lat/lon. Unlike {@link reprojectToLatLon}, which derives the
+ * model centre, this takes coordinates already resolved in the map CRS — e.g.
+ * a picked point's E/N from the measure geo readout (issue #1657).
+ *
+ * @param eastings        Easting in the CRS map unit.
+ * @param northings       Northing in the CRS map unit.
+ * @param crs             IfcProjectedCRS (EPSG code, mapUnitScale).
+ * @param lengthUnitScale IFC project length unit to metres (fallback when
+ *                        crs.mapUnitScale is absent).
+ */
+export async function reprojectPointToLatLon(
+  eastings: number,
+  northings: number,
+  crs: ProjectedCRS,
+  lengthUnitScale = 1,
+): Promise<LatLon | null> {
+  const projDef = await resolveProjection(crs);
+  if (!projDef) return null;
+
+  // Geographic CRS (e.g. EPSG:4326) — eastings/northings are already lon/lat.
+  if (isGeographicProj4(projDef)) {
+    const lon = eastings;
+    const lat = northings;
+    if (!Number.isFinite(lat) || !Number.isFinite(lon)) return null;
+    if (lat < -90 || lat > 90 || lon < -180 || lon > 180) return null;
+    return { lat, lon };
+  }
+
+  const mapScale = resolveMapUnitToMetreScale(crs.mapUnitScale, lengthUnitScale);
+  const eastingM = eastings * mapScale;
+  const northingM = northings * mapScale;
+  try {
+    const [lon, lat] = proj4(projDef, 'WGS84', [eastingM, northingM]);
+    if (!Number.isFinite(lat) || !Number.isFinite(lon)) return null;
+    if (lat < -90 || lat > 90 || lon < -180 || lon > 180) return null;
+    return { lat, lon };
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Compute the model's center in IFC Z-up metres from coordinate info.
  * This is the geometry center before MapConversion is applied.
  */

--- a/apps/viewer/src/lib/geo/useAnchorGeoreference.ts
+++ b/apps/viewer/src/lib/geo/useAnchorGeoreference.ts
@@ -1,0 +1,129 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Shared resolution of the ANCHOR model's effective georeference — the
+ * georef that drives the displayed world frame. Federated vertices are
+ * re-baked into the anchor frame, so every viewer-space-to-map conversion
+ * (Cesium bridge, basepoint overlay, measure geo readout) must use the
+ * anchor's MapConversion, never a per-picked-element one.
+ *
+ * Selection matches `findReferenceGeorefModel` in useIfcFederation: the
+ * user-pinned anchor first (falling through when it no longer resolves),
+ * then the earliest-loaded model with a usable map georef, then the legacy
+ * single-model data store. Unlike the Cesium overlay's memo, this is NOT
+ * gated on Cesium/solar being enabled.
+ */
+
+import { useMemo } from 'react';
+import type { CoordinateInfo } from '@ifc-lite/geometry';
+import type { IfcDataStore } from '@ifc-lite/parser';
+import { useViewerStore } from '@/store';
+import type { FederatedModel } from '@/store/types';
+import {
+  getEffectiveGeoreference,
+  type GeorefMutationDataLike,
+} from './effective-georef';
+import { hasUsableMapGeoref, type UsableEffectiveGeoref } from './pick-to-geo';
+
+export interface AnchorGeoreference {
+  /** Model driving the world frame ('__legacy__' for the single-model path). */
+  modelId: string;
+  effective: UsableEffectiveGeoref;
+  storeyElevations?: Map<number, number>;
+}
+
+export interface ResolveAnchorGeoreferenceArgs {
+  models: Map<string, FederatedModel>;
+  anchorModelIdOverride?: string | null;
+  georefMutations: Map<string, GeorefMutationDataLike>;
+  /** Legacy single-model fallback (mutations keyed '__legacy__'). */
+  legacyDataStore?: IfcDataStore | null;
+  legacyCoordinateInfo?: CoordinateInfo;
+}
+
+export function resolveAnchorGeoreference({
+  models,
+  anchorModelIdOverride,
+  georefMutations,
+  legacyDataStore,
+  legacyCoordinateInfo,
+}: ResolveAnchorGeoreferenceArgs): AnchorGeoreference | null {
+  const tryModel = (modelId: string, model: FederatedModel): AnchorGeoreference | null => {
+    const ds = model.ifcDataStore;
+    if (!ds) return null;
+    const effective = getEffectiveGeoreference(
+      ds as IfcDataStore,
+      model.geometryResult?.coordinateInfo,
+      georefMutations.get(modelId),
+    );
+    if (!hasUsableMapGeoref(effective)) return null;
+    return {
+      modelId,
+      effective,
+      storeyElevations: ds.spatialHierarchy?.storeyElevations,
+    };
+  };
+
+  // User-pinned anchor first; fall through if it no longer resolves so loads
+  // stay recoverable when the pinned anchor was removed or lost its georef.
+  if (anchorModelIdOverride) {
+    const pinned = models.get(anchorModelIdOverride);
+    if (pinned) {
+      const resolved = tryModel(anchorModelIdOverride, pinned);
+      if (resolved) return resolved;
+    }
+  }
+
+  const sorted = Array.from(models.entries())
+    .sort(([, a], [, b]) => (a.loadedAt ?? 0) - (b.loadedAt ?? 0));
+  for (const [modelId, model] of sorted) {
+    if (modelId === anchorModelIdOverride) continue;
+    const resolved = tryModel(modelId, model);
+    if (resolved) return resolved;
+  }
+
+  if (legacyDataStore) {
+    const effective = getEffectiveGeoreference(
+      legacyDataStore,
+      legacyCoordinateInfo,
+      georefMutations.get('__legacy__'),
+    );
+    if (hasUsableMapGeoref(effective)) {
+      return {
+        modelId: '__legacy__',
+        effective,
+        storeyElevations: legacyDataStore.spatialHierarchy?.storeyElevations,
+      };
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Reactive anchor georef. Returns null when no loaded model carries a usable
+ * map georef (callers should hide geo UI in that case).
+ */
+export function useAnchorGeoreference(): AnchorGeoreference | null {
+  const models = useViewerStore((s) => s.models);
+  const ifcDataStore = useViewerStore((s) => s.ifcDataStore);
+  const legacyCoordinateInfo = useViewerStore((s) => s.geometryResult?.coordinateInfo);
+  const anchorModelIdOverride = useViewerStore((s) => s.anchorModelIdOverride);
+  const georefMutations = useViewerStore((s) => s.georefMutations);
+  // Georef edits mutate in place; the version counter invalidates the memo.
+  const mutationVersion = useViewerStore((s) => s.mutationVersion);
+
+  return useMemo(
+    () => resolveAnchorGeoreference({
+      models,
+      anchorModelIdOverride,
+      georefMutations,
+      legacyDataStore: ifcDataStore ?? undefined,
+      legacyCoordinateInfo,
+    }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [models, anchorModelIdOverride, georefMutations, ifcDataStore, legacyCoordinateInfo, mutationVersion],
+  );
+}

--- a/apps/viewer/src/store/slices/measurementSlice.ts
+++ b/apps/viewer/src/store/slices/measurementSlice.ts
@@ -29,6 +29,8 @@ export interface MeasurementSlice {
   activeMeasurement: ActiveMeasurement | null;
   snapTarget: SnapTarget | null;
   snapEnabled: boolean;
+  /** Show projected map coordinates (E/N/H) for measure points (issue #1657). */
+  measureGeoEnabled: boolean;
   snapVisualization: SnapVisualization | null;
   edgeLockState: EdgeLockState;
   /** Edge constraint for perpendicular measurements (when shift is held) */
@@ -53,6 +55,7 @@ export interface MeasurementSlice {
   setSnapTarget: (target: SnapTarget | null) => void;
   setSnapVisualization: (viz: SnapVisualization | null) => void;
   toggleSnap: () => void;
+  toggleMeasureGeo: () => void;
 
   // Edge lock actions
   setEdgeLock: (edge: EdgeLockState['edge'], meshExpressId: number | null, edgeT?: number) => void;
@@ -82,6 +85,7 @@ export const createMeasurementSlice: StateCreator<MeasurementSlice, [], [], Meas
   activeMeasurement: null,
   snapTarget: null,
   snapEnabled: true,
+  measureGeoEnabled: false,
   snapVisualization: null,
   edgeLockState: getDefaultEdgeLockState(),
   measurementConstraintEdge: null,
@@ -244,6 +248,7 @@ export const createMeasurementSlice: StateCreator<MeasurementSlice, [], [], Meas
   setSnapTarget: (snapTarget) => set({ snapTarget }),
   setSnapVisualization: (snapVisualization) => set({ snapVisualization }),
   toggleSnap: () => set((state) => ({ snapEnabled: !state.snapEnabled })),
+  toggleMeasureGeo: () => set((state) => ({ measureGeoEnabled: !state.measureGeoEnabled })),
 
   // Edge lock actions
   setEdgeLock: (edge, meshExpressId, edgeT = EDGE_LOCK_DEFAULTS.INITIAL_T) => set({


### PR DESCRIPTION
## Problem

The Measure tool reports only local model space (viewer Y-up metres). Users with georeferenced models (IfcMapConversion / IfcProjectedCRS) want the true surveyed coordinate of a picked point (Eastings / Northings / Height in the project CRS). Nothing in the codebase computed that, even though picking, effective-georef resolution, and unit/rotation/scale-aware local-to-map transforms already exist and are tested via the Cesium placement editor.

## Approach

Pure client-side TS, no Rust/WASM changes. Compose the already tested helpers into one new pure function plus UI wiring.

- `apps/viewer/src/lib/geo/pick-to-geo.ts` (new): `viewerPointToProjected(point, georef, originViewer)` converts a picked viewer point to projected E/N/H. It goes through the unit- and `IfcMapConversion.Scale`-aware `viewerDeltaToProjectedDelta` / `metersToMapUnits` (cesium-placement.ts), so mm-unit projects, `XAxisAbscissa/Ordinate` rotation, and mm-vs-m bridging are all handled. It deliberately does NOT use the parser's `transformToWorld` (which assumes map units and is ~1000x off on metre-scaled viewer geometry). `hasUsableMapGeoref()` requires a real MapConversion + named ProjectedCRS and rejects the legacy `siteLocation` (EPSG:4326) source. Height is the authored orthogonal height, no vertical datum transform.
- `apps/viewer/src/lib/geo/useAnchorGeoreference.ts` (new): shared resolution of the anchor model's effective georef, matching `findReferenceGeorefModel` (pinned anchor first, then earliest-loaded with a usable map georef, then legacy single model). Federated vertices are re-baked into the anchor frame, so conversion always uses the anchor's MapConversion. Not gated on Cesium/solar being enabled.
- `apps/viewer/src/lib/geo/ifc-origin.ts`: export `totalYupOffset` so the IFC origin's viewer position resolves synchronously per frame.
- `apps/viewer/src/lib/geo/reproject.ts`: add `reprojectPointToLatLon()` for an explicit picked point (async proj4; never blocks the E/N/H readout).
- `apps/viewer/src/components/viewer/tools/MeasurePanel.tsx`: an "XYZ Geo" toggle next to Snap, shown only when a usable map georef exists; a live E/N/H (+ CRS, + async lat/lon) readout for the active/hover point; and per-endpoint E/N/H on finalized measurements.
- `apps/viewer/src/store/slices/measurementSlice.ts`: persist the `measureGeoEnabled` flag (mirrors the snap flag).

## Product decisions (recommended defaults, per the issue's open questions)

- **Toggle in MeasurePanel** rather than a separate toolbar Tool (keeps the Tool union untouched, minimal UI).
- **Anchor CRS** for federated models (not per-picked-element) since federated geometry is baked into the anchor frame.
- **Projected E/N/H + EPSG label**, with **lat/lon appended asynchronously** when proj4 resolves.
- **Precision** is roughly millimetre: 0 decimals for a millimetre CRS, 3 for a metre CRS (clamped to [0, 3]).
- Toggle is **hidden** for non-georeferenced models and siteLocation-only sources to avoid misleading output.

## Tests

- New `pick-to-geo.test.ts` (14 cases) pins the math to `building-architecture.ifc`'s `IFCMAPCONVERSION` (EPSG:32760, mm units, `xAxisAbscissa` 0.5 / `xAxisOrdinate` 0.866 = 60deg): IFC origin maps exactly to the authored offsets; a 1m viewer offset lands rotated 60deg and scaled to 1000 map units; a metre-CRS no-rotation case guards the unit trap; the viewer Z sign matches `rust/core/src/georef.rs` `local_to_map`; guard rejects missing MapConversion and siteLocation.
- Full `lib/geo` suite: 81/81 pass. Viewer `tsc --noEmit` clean. `vite build` succeeds.

## Deviations

- Did NOT refactor the existing `ViewportContainer` / `BasepointOverlay` georef call sites onto the shared hook. Their outputs differ materially (placement-draft preview merge; `ModelGeorefInput` with `preAlignmentCoordinateInfo`), so folding them in risked regressing the two most delicate, hard-to-auto-test georef paths for little gain. The new hook uses the same selection logic and the same `hasStandardGeoreferencing` guard, so behaviour is consistent.
- Automated on-localhost visual verification was blocked by an already-running Chrome profile that chrome-devtools MCP could not attach to; recommend a manual pass (load `building-architecture.ifc`, toggle XYZ Geo, confirm E/N/H against the authored offsets; confirm the toggle is hidden on a non-georeferenced model).

Closes #1657

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added georeferenced measurement readouts with projected eastings, northings, and height.
  * Added optional WGS84 latitude/longitude display for the active measurement point.
  * Added an “XYZ Geo” toggle to show or hide geospatial measurement details.
  * Measurement endpoints now display projected coordinate values when georeferencing is available.

* **Bug Fixes**
  * Improved coordinate conversion accuracy across map units, rotations, offsets, and model origins.

* **Tests**
  * Added coverage for georeferencing, coordinate conversion, precision, and origin calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->