### PR TITLE
feat(viewer): GROUPS hierarchy tab for IfcSystem/IfcZone/IfcGroup browsing (#1622)

### DIFF
--- a/apps/viewer/src/components/viewer/HierarchyPanel.tsx
+++ b/apps/viewer/src/components/viewer/HierarchyPanel.tsx
@@ -12,7 +12,9 @@ import {
   FileBox,
   GripHorizontal,
   Palette,
+  Network,
 } from 'lucide-react';
+import { extractGroupMembersOnDemand, type IfcDataStore } from '@ifc-lite/parser';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
@@ -69,6 +71,13 @@ export function HierarchyPanel() {
   const clearAllFilters = useViewerStore((s) => s.clearAllFilters);
   const setHierarchyBasketSelection = useViewerStore((s) => s.setHierarchyBasketSelection);
 
+  // Group-isolation needs the camera + the hidden-by-default class toggles
+  // (spaces / spatial zones), mirroring the properties panel's Groups & Zones
+  // isolate action (#1622, pattern from #1075).
+  const cameraCallbacks = useViewerStore((s) => s.cameraCallbacks);
+  const typeVisibility = useViewerStore((s) => s.typeVisibility);
+  const toggleTypeVisibility = useViewerStore((s) => s.toggleTypeVisibility);
+
   const hiddenEntities = useViewerStore((s) => s.hiddenEntities);
   const hideEntities = useViewerStore((s) => s.hideEntities);
   const showEntities = useViewerStore((s) => s.showEntities);
@@ -112,6 +121,8 @@ export function HierarchyPanel() {
     setGroupingMode,
     sortMode,
     setSortMode,
+    groupFilter,
+    setGroupFilter,
     unifiedStoreys,
     filteredNodes: rawFilteredNodes,
     storeysNodes: rawStoreysNodes,
@@ -381,6 +392,78 @@ export function HierarchyPanel() {
       return;
     }
 
+    // Group rows (Groups tab, #1622) - isolate + fit the group's resolved member
+    // geometry and select the GROUP entity so its system-level psets show.
+    if (node.type === 'group') {
+      const modelId = node.modelIds[0] || 'legacy';
+      const groupExpressId = node.entityExpressId;
+      if (!groupExpressId) return;
+      const dataStore = (models.get(modelId)?.ifcDataStore ?? ifcDataStore) as IfcDataStore | null | undefined;
+      const groupGlobalId = modelId !== 'legacy'
+        ? toGlobalIdFromModels(models, modelId, groupExpressId)
+        : groupExpressId;
+
+      // Members can be hidden-by-default classes (IfcSpace / IfcSpatialZone in
+      // an IfcZone): flip only the toggles the group actually needs, or the
+      // isolated set would render nothing (lifted from PropertiesPanel's
+      // handleIsolateGroupMembers, #1075 / PR #1094 review).
+      if (dataStore) {
+        const members = extractGroupMembersOnDemand(dataStore, groupExpressId);
+        if (!typeVisibility.spaces && members.some((m) => m.type === 'IfcSpace')) {
+          toggleTypeVisibility('spaces');
+        }
+        if (!typeVisibility.spatialZones && members.some((m) => m.type === 'IfcSpatialZone')) {
+          toggleTypeVisibility('spatialZones');
+        }
+      }
+
+      // node.globalIds carry the RESOLVED member geometry (ports folded into
+      // their nesting host elements) - see buildGroupTree (#1622).
+      const memberGlobalIds = node.globalIds;
+      if (memberGlobalIds.length > 0) {
+        isolateEntities(memberGlobalIds);
+        // Highlight members + frame them; the group goes last so it becomes the
+        // primary selection and its row reads selected (same trick as
+        // decomposing assemblies, #1133).
+        setSelectedEntityIds([...memberGlobalIds, groupGlobalId]);
+      } else {
+        setSelectedEntityIds([]);
+        setSelectedEntityId(groupGlobalId);
+      }
+      // Model-aware ref so the properties panel shows the group's own psets
+      // (e.g. Pset_DistributionSystemTypeCommon).
+      setSelectedEntity({ modelId, expressId: groupExpressId });
+      if (modelId !== 'legacy') setActiveModel(modelId);
+      if (memberGlobalIds.length > 0 && cameraCallbacks.frameSelection) {
+        window.setTimeout(() => cameraCallbacks.frameSelection?.(), 50);
+      }
+      if (node.hasChildren) {
+        toggleExpand(node.id);
+      }
+      return;
+    }
+
+    // Group member rows (Groups tab, #1622) - select + focus, like picking the
+    // element in 3D plus a camera frame (no-op frame for geometry-less members).
+    if (node.type === 'group-member') {
+      const memberExpressId = node.expressIds[0];
+      const modelId = node.modelIds[0] || 'legacy';
+      const globalId = node.globalIds[0] ?? memberExpressId;
+
+      setSelectedEntityIds([]);
+      setSelectedEntityId(globalId);
+      if (modelId !== 'legacy') {
+        setSelectedEntity({ modelId, expressId: memberExpressId });
+        setActiveModel(modelId);
+      } else {
+        setSelectedEntity(resolveEntityRef(globalId));
+      }
+      if (cameraCallbacks.frameSelection) {
+        window.setTimeout(() => cameraCallbacks.frameSelection?.(), 50);
+      }
+      return;
+    }
+
     // IFC type entity nodes (e.g. IfcWallType/W01) - select type entity for property panel + isolate instances
     if (node.type === 'ifc-type') {
       const modelId = node.modelIds[0];
@@ -593,7 +676,7 @@ export function HierarchyPanel() {
         setSelectedEntity(resolveEntityRef(globalId));
       }
     }
-  }, [selectedStoreys, setStoreysSelection, clearStoreySelection, setActiveStorey, setLevelDisplayMode, setSelectedEntityId, setSelectedEntityIds, setSelectedEntity, setSelectedEntities, setActiveModel, toggleExpand, unifiedStoreys, models, isolateEntities, getNodeElements, setHierarchyBasketSelection, toGlobalId, groupingMode, setClassFilter, upsertSearchRule, onMultiSelect, setMultiSelectAnchor, selectableNodeItems, selectableNodeIndexById]);
+  }, [selectedStoreys, setStoreysSelection, clearStoreySelection, setActiveStorey, setLevelDisplayMode, setSelectedEntityId, setSelectedEntityIds, setSelectedEntity, setSelectedEntities, setActiveModel, toggleExpand, unifiedStoreys, models, ifcDataStore, isolateEntities, getNodeElements, setHierarchyBasketSelection, toGlobalId, groupingMode, setClassFilter, upsertSearchRule, onMultiSelect, setMultiSelectAnchor, selectableNodeItems, selectableNodeIndexById, cameraCallbacks, typeVisibility, toggleTypeVisibility]);
 
   // Compute selection and visibility state for a node
   const computeNodeState = useCallback((node: TreeNode): { isSelected: boolean; nodeHidden: boolean; modelVisible?: boolean } => {
@@ -603,14 +686,16 @@ export function HierarchyPanel() {
       ? node.expressIds.some(id => selectedStoreys.has(id))
       : node.type === 'IfcBuildingStorey'
         ? selectedStoreys.has(node.expressIds[0])
-        : node.type === 'IfcSpace' || node.type === 'element'
+        : node.type === 'IfcSpace' || node.type === 'element' || node.type === 'group-member'
           ? (() => {
               const gId = node.globalIds[0] ?? node.expressIds[0];
               // Honour the multi-selection set so Ctrl/Shift-selected rows all
               // read as highlighted in the tree, not just the primary. (#1463)
+              // group-member rows highlight by globalId, so the same element
+              // under two groups lights up in both rows (many-to-many, #1622).
               return selectedEntityId === gId || selectedEntityIds.has(gId);
             })()
-          : node.type === 'ifc-type' || node.type === 'material-group'
+          : node.type === 'ifc-type' || node.type === 'material-group' || node.type === 'group'
             ? (() => {
                 const entityExpressId = node.entityExpressId;
                 if (!entityExpressId) return false;
@@ -624,7 +709,7 @@ export function HierarchyPanel() {
 
     // Compute visibility inline - for elements check directly, for storeys use getNodeElements
     let nodeHidden = false;
-    if (node.type === 'element') {
+    if (node.type === 'element' || node.type === 'group-member') {
       const parts = node.assemblyChildGlobalIds;
       if (parts && parts.length > 0) {
         // An assembly reads as hidden only when every part it owns is hidden
@@ -635,6 +720,7 @@ export function HierarchyPanel() {
       }
     } else if (node.type === 'IfcBuildingStorey' || node.type === 'IfcSpace' || node.type === 'unified-storey' ||
                node.type === 'type-group' || node.type === 'ifc-type' || node.type === 'material-group' ||
+               node.type === 'group' ||
                (node.type === 'model-header' && node.id.startsWith('contrib-'))) {
       const elements = getNodeElements(node);
       nodeHidden = elements.length > 0 && elements.every(id => hiddenEntities.has(id));
@@ -759,8 +845,40 @@ export function HierarchyPanel() {
         <Palette className="h-3 w-3 shrink-0 panel-compact-icon" />
         <span className="panel-compact-text">Material</span>
       </Button>
+      <Button
+        variant={groupingMode === 'groups' ? 'default' : 'outline'}
+        size="sm"
+        className="h-6 text-[10px] flex-1 min-w-0 rounded-none uppercase tracking-wider"
+        onClick={() => setGroupingMode('groups')}
+        title="Groups, systems and zones"
+      >
+        <Network className="h-3 w-3 shrink-0 panel-compact-icon" />
+        <span className="panel-compact-text">Groups</span>
+      </Button>
     </div>
   );
+
+  // Sub-filter chips for the Groups tab (#1622). Session-only; not persisted.
+  const groupFilterChips = groupingMode === 'groups' ? (
+    <div className="flex gap-1 mt-2">
+      {([
+        ['all', 'All'],
+        ['systems', 'Systems'],
+        ['zones', 'Zones'],
+        ['other', 'Other'],
+      ] as const).map(([value, label]) => (
+        <Button
+          key={value}
+          variant={groupFilter === value ? 'default' : 'outline'}
+          size="sm"
+          className="h-5 text-[10px] flex-1 min-w-0 rounded-none uppercase tracking-wider px-1"
+          onClick={() => setGroupFilter(value)}
+        >
+          {label}
+        </Button>
+      ))}
+    </div>
+  ) : null;
 
   // In type/ifc-type grouping mode, always use flat tree layout (even for multi-model)
   if (isMultiModel && groupingMode === 'spatial') {
@@ -899,13 +1017,18 @@ export function HierarchyPanel() {
           className="h-9 text-sm rounded-none border-2 border-zinc-200 dark:border-zinc-800 focus:border-primary focus:ring-0 bg-white dark:bg-zinc-950 text-zinc-900 dark:text-zinc-100 placeholder:text-zinc-400 dark:placeholder:text-zinc-600"
         />
         {groupingToggle}
+        {groupFilterChips}
         {groupingMode === 'spatial' && (
           <HierarchySortControl value={sortMode} onChange={setSortMode} />
         )}
       </div>
 
       {/* Section Header */}
-      <SectionHeader icon={groupingMode === 'spatial' ? Building2 : groupingMode === 'type' ? Layers : groupingMode === 'material' ? Palette : FileBox} title={groupingMode === 'spatial' ? 'Hierarchy' : groupingMode === 'type' ? 'By Class' : groupingMode === 'material' ? 'By Material' : 'By Type'} count={filteredNodes.length} />
+      <SectionHeader
+        icon={groupingMode === 'spatial' ? Building2 : groupingMode === 'type' ? Layers : groupingMode === 'material' ? Palette : groupingMode === 'groups' ? Network : FileBox}
+        title={groupingMode === 'spatial' ? 'Hierarchy' : groupingMode === 'type' ? 'By Class' : groupingMode === 'material' ? 'By Material' : groupingMode === 'groups' ? 'By Group' : 'By Type'}
+        count={filteredNodes.length}
+      />
 
       {/* Level display (Stacked / Exploded / Solo) + floorplan — only in the
           spatial view where storeys are the organising concept. */}

--- a/apps/viewer/src/components/viewer/hierarchy/HierarchyNode.tsx
+++ b/apps/viewer/src/components/viewer/hierarchy/HierarchyNode.tsx
@@ -76,7 +76,8 @@ export function HierarchyNode({
     node.type === 'IfcSpatialZone' ||
     node.type === 'unified-storey' ||
     node.type === 'type-group' ||
-    node.type === 'material-group'
+    node.type === 'material-group' ||
+    node.type === 'group'
       ? 'font-medium text-zinc-900 dark:text-zinc-100'
       : 'text-zinc-700 dark:text-zinc-300';
   const strikeWhenHidden = nodeHidden && 'line-through decoration-zinc-400 dark:decoration-zinc-600';
@@ -306,7 +307,7 @@ export function HierarchyNode({
           </span>
         )}
 
-        {node.ifcType && node.type === 'element' && (
+        {node.ifcType && (node.type === 'element' || node.type === 'group-member') && (
           <span className="text-[10px] font-mono text-zinc-400 dark:text-zinc-500 truncate max-w-[90px]">
             {node.ifcType}
           </span>

--- a/apps/viewer/src/components/viewer/hierarchy/ifc-icons.ts
+++ b/apps/viewer/src/components/viewer/hierarchy/ifc-icons.ts
@@ -21,6 +21,16 @@ export const IFC_ICON_CODEPOINTS: Record<string, string> = {
   // space-like spatial element, distinguished from IfcSpace by name/colour (#1075).
   IfcSpatialZone: '\ueff4',
   IfcZone: '\ueb97', // "workspaces" \u2014 a grouping of spaces/zones
+
+  // Functional groupings (Groups hierarchy tab, #1622). Systems share the
+  // "account_tree" glyph (a network of members); the generic IfcGroup uses
+  // "group_work".
+  IfcGroup: '\ue886', // "group_work"
+  IfcSystem: '\ue97a', // "account_tree"
+  IfcDistributionSystem: '\ue97a',
+  IfcBuiltSystem: '\ue97a',
+  IfcBuildingSystem: '\ue97a',
+  IfcStructuralAnalysisModel: '\ue97a',
   // IFC4.3 facility containers \u2014 same family as IfcBuilding (multi-storey
   // spatial root) but `domain` carries the "campus / infrastructure
   // facility" reading; IfcFacilityPart follows the storey-line icon for

--- a/apps/viewer/src/components/viewer/hierarchy/treeDataBuilder.test.ts
+++ b/apps/viewer/src/components/viewer/hierarchy/treeDataBuilder.test.ts
@@ -7,7 +7,17 @@ import assert from 'node:assert';
 import { IfcTypeEnum, RelationshipType, type SpatialHierarchy, type SpatialNode } from '@ifc-lite/data';
 import type { IfcDataStore } from '@ifc-lite/parser';
 import { useViewerStore, type FederatedModel } from '@/store';
-import { buildTreeData, buildTypeTree, buildUnifiedStoreys, compareStoreyEntries, type AuthoredProduct } from './treeDataBuilder';
+import {
+  buildTreeData,
+  buildTypeTree,
+  buildUnifiedStoreys,
+  compareStoreyEntries,
+  buildGroupTree,
+  resolveMemberGeometry,
+  groupMatchesSubFilter,
+  GROUP_ENTITY_TYPES,
+  type AuthoredProduct,
+} from './treeDataBuilder';
 import type { HierarchySortMode } from './types';
 
 function createSpatialNode(
@@ -744,5 +754,202 @@ describe('storey sort order — IFC4.3 parts and non-level siblings (#1296)', ()
       .map((n) => n.expressIds[0]);
     // Storeys A(6)/B(4) reorder by name; the space (5) stays in the middle slot.
     assert.deepStrictEqual(order, [6, 5, 4]);
+  });
+});
+
+// ============================================================================
+// Groups tab — buildGroupTree / resolveMemberGeometry (#1622)
+// ============================================================================
+
+/**
+ * A minimal MEP-shaped store for the Groups tab. Legacy mode → globalId ===
+ * expressId, so `geometricIds` are plain express ids.
+ *
+ *  - IfcDistributionSystem #100 "HVAC System": ports #201/#203 (no geometry) +
+ *    duct #202 (geometry). Both ports NEST under #202 (IfcRelNests → the shared
+ *    Aggregates edge bucket, inverse direction).
+ *  - IfcZone #300 (unnamed, ObjectType "Fire Compartment"): spaces #301/#302.
+ *  - IfcGroup #400 "Misc": duct #202 again (many-to-many) + orphan port #999
+ *    (no geometry, no relatives → select-only row).
+ *  - IfcSystem #500 "Empty": no members → skipped.
+ *
+ * Note #100 is an IfcDistributionSystem, NOT an IfcSystem: an exact-match
+ * `byType.get('IFCSYSTEM')` returns only #500, so the tab must enumerate the
+ * subtype explicitly (the #1662 defect class).
+ */
+function createGroupDataStore(): IfcDataStore {
+  const names: Record<number, string> = {
+    100: 'HVAC System', 300: '', 400: 'Misc', 500: 'Empty',
+    201: 'Port A', 202: 'Main Duct', 203: 'Port B',
+    301: 'Room 1', 302: 'Room 2', 999: 'Orphan Port',
+  };
+  const types: Record<number, string> = {
+    100: 'IfcDistributionSystem', 300: 'IfcZone', 400: 'IfcGroup', 500: 'IfcSystem',
+    201: 'IfcDistributionPort', 202: 'IfcDuctSegment', 203: 'IfcDistributionPort',
+    301: 'IfcSpace', 302: 'IfcSpace', 999: 'IfcDistributionPort',
+  };
+  const objectTypes: Record<number, string> = { 300: 'Fire Compartment' };
+
+  const byType = new Map<string, number[]>([
+    ['IFCDISTRIBUTIONSYSTEM', [100]],
+    ['IFCZONE', [300]],
+    ['IFCGROUP', [400]],
+    ['IFCSYSTEM', [500]],
+  ]);
+  const byId = new Map<number, { type: string }>();
+  for (const id of Object.keys(types)) byId.set(Number(id), { type: types[Number(id)].toUpperCase() });
+
+  const members: Record<number, number[]> = {
+    100: [201, 202, 203],
+    300: [301, 302],
+    400: [202, 999],
+    500: [],
+  };
+  // IfcRelNests: ports #201/#203 nest under duct #202 (inverse → parent host).
+  const nestParent: Record<number, number[]> = { 201: [202], 203: [202] };
+
+  return {
+    entityIndex: { byType, byId },
+    entities: {
+      count: 0,
+      getName: (id: number) => names[id] ?? '',
+      getTypeName: (id: number) => types[id] ?? 'Unknown',
+      getObjectType: (id: number) => objectTypes[id] ?? '',
+    },
+    relationships: {
+      getRelated: (id: number, relType: RelationshipType, direction: 'forward' | 'inverse') => {
+        if (relType === RelationshipType.AssignsToGroup && direction === 'forward') {
+          return members[id] ?? [];
+        }
+        if (relType === RelationshipType.Aggregates && direction === 'inverse') {
+          return nestParent[id] ?? [];
+        }
+        return [];
+      },
+    },
+  } as unknown as IfcDataStore;
+}
+
+const GROUP_GEO_IDS = new Set<number>([202, 301, 302]);
+
+const toLegacyGlobal = (id: number) => id;
+
+describe('resolveMemberGeometry (#1622)', () => {
+  it('passes a geometry-bearing member through as itself', () => {
+    const ds = createGroupDataStore();
+    const resolved = resolveMemberGeometry(ds, 202, toLegacyGlobal, GROUP_GEO_IDS);
+    assert.deepStrictEqual(resolved, [{ expressId: 202, globalId: 202 }]);
+  });
+
+  it('resolves a geometry-less port to its nesting host element (IfcRelNests / Aggregates inverse)', () => {
+    const ds = createGroupDataStore();
+    const resolved = resolveMemberGeometry(ds, 201, toLegacyGlobal, GROUP_GEO_IDS);
+    assert.deepStrictEqual(resolved, [{ expressId: 202, globalId: 202 }]);
+  });
+
+  it('returns [] for a member with no geometry and no resolvable relatives', () => {
+    const ds = createGroupDataStore();
+    const resolved = resolveMemberGeometry(ds, 999, toLegacyGlobal, GROUP_GEO_IDS);
+    assert.deepStrictEqual(resolved, []);
+  });
+});
+
+describe('groupMatchesSubFilter (#1622)', () => {
+  it('buckets the IfcSystem family (incl. IfcStructuralAnalysisModel) as Systems', () => {
+    assert.strictEqual(groupMatchesSubFilter('IfcDistributionSystem', 'systems'), true);
+    assert.strictEqual(groupMatchesSubFilter('IfcStructuralAnalysisModel', 'systems'), true);
+    assert.strictEqual(groupMatchesSubFilter('IfcZone', 'systems'), false);
+  });
+
+  it('buckets IfcZone as Zones and IfcGroup as Other', () => {
+    assert.strictEqual(groupMatchesSubFilter('IfcZone', 'zones'), true);
+    assert.strictEqual(groupMatchesSubFilter('IfcGroup', 'other'), true);
+    assert.strictEqual(groupMatchesSubFilter('IfcDistributionSystem', 'other'), false);
+  });
+
+  it('passes everything under All', () => {
+    for (const t of GROUP_ENTITY_TYPES) {
+      assert.strictEqual(groupMatchesSubFilter(t, 'all'), true);
+    }
+  });
+});
+
+describe('buildGroupTree (#1622)', () => {
+  it('enumerates concrete subtypes an exact-match IfcSystem query would miss', () => {
+    const ds = createGroupDataStore();
+    // Guard: the exact-match index really does NOT fold subtypes.
+    assert.deepStrictEqual(ds.entityIndex!.byType!.get('IFCSYSTEM'), [500]);
+    assert.strictEqual(ds.entityIndex!.byType!.get('IFCDISTRIBUTIONSYSTEM')?.[0], 100);
+
+    const nodes = buildGroupTree(new Map(), ds, new Set(), false, GROUP_GEO_IDS);
+    const distSystem = nodes.find((n) => n.type === 'group' && n.ifcType === 'IfcDistributionSystem');
+    assert.ok(distSystem, 'the IfcDistributionSystem surfaces despite the exact-match index');
+    assert.strictEqual(distSystem.name, 'HVAC System');
+  });
+
+  it('skips a group with zero members', () => {
+    const ds = createGroupDataStore();
+    const nodes = buildGroupTree(new Map(), ds, new Set(), false, GROUP_GEO_IDS);
+    assert.ok(!nodes.some((n) => n.entityExpressId === 500), 'the empty IfcSystem #500 is dropped');
+  });
+
+  it('collapses ports into their host element and carries resolved geometry for isolation', () => {
+    const ds = createGroupDataStore();
+    const nodes = buildGroupTree(new Map(), ds, new Set(['group-legacy-100']), false, GROUP_GEO_IDS);
+    const groupNode = nodes.find((n) => n.type === 'group' && n.entityExpressId === 100)!;
+    // #100 has 3 members (2 ports + 1 duct) but they resolve to ONE geometry row.
+    assert.strictEqual(groupNode.elementCount, 1);
+    assert.deepStrictEqual(groupNode.globalIds, [202], 'isolation ids = resolved host geometry only');
+    const memberRows = nodes.filter((n) => n.type === 'group-member' && n.id.startsWith('groupmember-legacy-100-'));
+    assert.strictEqual(memberRows.length, 1);
+    assert.strictEqual(memberRows[0].expressIds[0], 202, 'the duct, not the ports');
+  });
+
+  it('keeps a select-only row for a member with no resolvable geometry', () => {
+    const ds = createGroupDataStore();
+    const nodes = buildGroupTree(new Map(), ds, new Set(['group-legacy-400']), false, GROUP_GEO_IDS);
+    const groupNode = nodes.find((n) => n.type === 'group' && n.entityExpressId === 400)!;
+    // Duct #202 (geometry) + orphan port #999 (select-only) = 2 rows, but only
+    // the duct contributes to isolation geometry.
+    assert.strictEqual(groupNode.elementCount, 2);
+    assert.deepStrictEqual(groupNode.globalIds, [202]);
+    const orphan = nodes.find((n) => n.type === 'group-member' && n.id === 'groupmember-legacy-400-999');
+    assert.ok(orphan, 'the geometry-less orphan port stays browsable');
+  });
+
+  it('renders the same member under two groups as distinct rows (many-to-many, no dedup)', () => {
+    const ds = createGroupDataStore();
+    const nodes = buildGroupTree(
+      new Map(), ds, new Set(['group-legacy-100', 'group-legacy-400']), false, GROUP_GEO_IDS,
+    );
+    // Duct #202 belongs to BOTH the HVAC system and the Misc group.
+    const rowsFor202 = nodes.filter((n) => n.type === 'group-member' && n.expressIds[0] === 202);
+    assert.strictEqual(rowsFor202.length, 2, 'one row per owning group');
+    const ids = new Set(rowsFor202.map((n) => n.id));
+    assert.strictEqual(ids.size, 2, 'composite ids keep the rows distinct');
+    assert.ok(ids.has('groupmember-legacy-100-202'));
+    assert.ok(ids.has('groupmember-legacy-400-202'));
+  });
+
+  it('falls back to ObjectType for an unnamed group (#1075 display parity)', () => {
+    const ds = createGroupDataStore();
+    const nodes = buildGroupTree(new Map(), ds, new Set(), false, GROUP_GEO_IDS);
+    const zone = nodes.find((n) => n.type === 'group' && n.entityExpressId === 300)!;
+    assert.strictEqual(zone.name, 'Fire Compartment');
+  });
+
+  it('honours the sub-filter, returning only zones', () => {
+    const ds = createGroupDataStore();
+    const nodes = buildGroupTree(new Map(), ds, new Set(), false, GROUP_GEO_IDS, 'zones');
+    const groups = nodes.filter((n) => n.type === 'group');
+    assert.strictEqual(groups.length, 1);
+    assert.strictEqual(groups[0].ifcType, 'IfcZone');
+  });
+
+  it('orders systems before zones before generic groups', () => {
+    const ds = createGroupDataStore();
+    const nodes = buildGroupTree(new Map(), ds, new Set(), false, GROUP_GEO_IDS);
+    const order = nodes.filter((n) => n.type === 'group').map((n) => n.ifcType);
+    assert.deepStrictEqual(order, ['IfcDistributionSystem', 'IfcZone', 'IfcGroup']);
   });
 });

--- a/apps/viewer/src/components/viewer/hierarchy/treeDataBuilder.test.ts
+++ b/apps/viewer/src/components/viewer/hierarchy/treeDataBuilder.test.ts
@@ -779,12 +779,13 @@ describe('storey sort order — IFC4.3 parts and non-level siblings (#1296)', ()
  */
 function createGroupDataStore(): IfcDataStore {
   const names: Record<number, string> = {
-    100: 'HVAC System', 300: '', 400: 'Misc', 500: 'Empty',
+    100: 'HVAC System', 300: '', 400: 'Misc', 500: 'Empty', 600: 'Lighting Circuit',
     201: 'Port A', 202: 'Main Duct', 203: 'Port B',
     301: 'Room 1', 302: 'Room 2', 999: 'Orphan Port',
   };
   const types: Record<number, string> = {
     100: 'IfcDistributionSystem', 300: 'IfcZone', 400: 'IfcGroup', 500: 'IfcSystem',
+    600: 'IfcDistributionCircuit',
     201: 'IfcDistributionPort', 202: 'IfcDuctSegment', 203: 'IfcDistributionPort',
     301: 'IfcSpace', 302: 'IfcSpace', 999: 'IfcDistributionPort',
   };
@@ -792,6 +793,7 @@ function createGroupDataStore(): IfcDataStore {
 
   const byType = new Map<string, number[]>([
     ['IFCDISTRIBUTIONSYSTEM', [100]],
+    ['IFCDISTRIBUTIONCIRCUIT', [600]],
     ['IFCZONE', [300]],
     ['IFCGROUP', [400]],
     ['IFCSYSTEM', [500]],
@@ -804,6 +806,7 @@ function createGroupDataStore(): IfcDataStore {
     300: [301, 302],
     400: [202, 999],
     500: [],
+    600: [202],
   };
   // IfcRelNests: ports #201/#203 nest under duct #202 (inverse → parent host).
   const nestParent: Record<number, number[]> = { 201: [202], 203: [202] };
@@ -855,15 +858,20 @@ describe('resolveMemberGeometry (#1622)', () => {
 });
 
 describe('groupMatchesSubFilter (#1622)', () => {
-  it('buckets the IfcSystem family (incl. IfcStructuralAnalysisModel) as Systems', () => {
+  it('buckets the IfcSystem family (incl. IfcDistributionCircuit, IfcStructuralAnalysisModel) as Systems', () => {
     assert.strictEqual(groupMatchesSubFilter('IfcDistributionSystem', 'systems'), true);
+    assert.strictEqual(groupMatchesSubFilter('IfcDistributionCircuit', 'systems'), true);
     assert.strictEqual(groupMatchesSubFilter('IfcStructuralAnalysisModel', 'systems'), true);
     assert.strictEqual(groupMatchesSubFilter('IfcZone', 'systems'), false);
   });
 
-  it('buckets IfcZone as Zones and IfcGroup as Other', () => {
+  it('buckets IfcZone as Zones and IfcGroup / IfcAsset / IfcInventory as Other', () => {
     assert.strictEqual(groupMatchesSubFilter('IfcZone', 'zones'), true);
     assert.strictEqual(groupMatchesSubFilter('IfcGroup', 'other'), true);
+    assert.strictEqual(groupMatchesSubFilter('IfcAsset', 'other'), true);
+    assert.strictEqual(groupMatchesSubFilter('IfcInventory', 'other'), true);
+    assert.strictEqual(groupMatchesSubFilter('IfcStructuralResultGroup', 'other'), true);
+    assert.strictEqual(groupMatchesSubFilter('IfcDistributionCircuit', 'other'), false);
     assert.strictEqual(groupMatchesSubFilter('IfcDistributionSystem', 'other'), false);
   });
 
@@ -885,6 +893,29 @@ describe('buildGroupTree (#1622)', () => {
     const distSystem = nodes.find((n) => n.type === 'group' && n.ifcType === 'IfcDistributionSystem');
     assert.ok(distSystem, 'the IfcDistributionSystem surfaces despite the exact-match index');
     assert.strictEqual(distSystem.name, 'HVAC System');
+  });
+
+  it('surfaces IfcDistributionCircuit and buckets it under the Systems sub-filter', () => {
+    const ds = createGroupDataStore();
+    // Guard: the circuit is a distinct exact-match bucket, not folded into IfcSystem.
+    assert.strictEqual(ds.entityIndex!.byType!.get('IFCDISTRIBUTIONCIRCUIT')?.[0], 600);
+
+    const all = buildGroupTree(new Map(), ds, new Set(), false, GROUP_GEO_IDS);
+    const circuit = all.find((n) => n.type === 'group' && n.ifcType === 'IfcDistributionCircuit');
+    assert.ok(circuit, 'the IfcDistributionCircuit surfaces despite the exact-match index');
+    assert.strictEqual(circuit.name, 'Lighting Circuit');
+
+    // It is a system, so the Systems sub-filter keeps it and Zones drops it.
+    const systems = buildGroupTree(new Map(), ds, new Set(), false, GROUP_GEO_IDS, 'systems');
+    assert.ok(
+      systems.some((n) => n.type === 'group' && n.ifcType === 'IfcDistributionCircuit'),
+      'IfcDistributionCircuit passes the Systems sub-filter',
+    );
+    const zones = buildGroupTree(new Map(), ds, new Set(), false, GROUP_GEO_IDS, 'zones');
+    assert.ok(
+      !zones.some((n) => n.type === 'group' && n.ifcType === 'IfcDistributionCircuit'),
+      'IfcDistributionCircuit is not a zone',
+    );
   });
 
   it('skips a group with zero members', () => {
@@ -950,6 +981,8 @@ describe('buildGroupTree (#1622)', () => {
     const ds = createGroupDataStore();
     const nodes = buildGroupTree(new Map(), ds, new Set(), false, GROUP_GEO_IDS);
     const order = nodes.filter((n) => n.type === 'group').map((n) => n.ifcType);
-    assert.deepStrictEqual(order, ['IfcDistributionSystem', 'IfcZone', 'IfcGroup']);
+    assert.deepStrictEqual(order, [
+      'IfcDistributionSystem', 'IfcDistributionCircuit', 'IfcZone', 'IfcGroup',
+    ]);
   });
 });

--- a/apps/viewer/src/components/viewer/hierarchy/treeDataBuilder.ts
+++ b/apps/viewer/src/components/viewer/hierarchy/treeDataBuilder.ts
@@ -992,16 +992,27 @@ export function buildMaterialTree(
  * index (`entityIndex.byType` / `getEntitiesByType`) is exact-match with no
  * subtype closure, so querying 'IfcSystem' alone would silently miss
  * IfcDistributionSystem / IfcBuiltSystem — exactly the classes MEP files use
- * (issue #1622; same defect class as #1662). Order = display order: systems,
- * then zones, then generic groups.
+ * (issue #1622; same defect class as #1662). This must list EVERY concrete
+ * IfcGroup descendant in the supported schemas (IFC4 / IFC4X3) or those classes
+ * never appear in the tab. Order = display order: systems, then zones, then
+ * generic groups.
  */
 export const GROUP_ENTITY_TYPES = [
+  // IfcSystem family (bucketed under Systems).
   'IfcDistributionSystem',
+  'IfcDistributionCircuit',
   'IfcBuiltSystem',
   'IfcBuildingSystem',
-  'IfcSystem',
   'IfcStructuralAnalysisModel',
+  'IfcSystem',
+  // IfcZone (its own bucket, though schema-wise a subtype of IfcSystem).
   'IfcZone',
+  // Remaining concrete IfcGroup descendants (bucketed under Other).
+  'IfcAsset',
+  'IfcInventory',
+  'IfcStructuralLoadGroup',
+  'IfcStructuralLoadCase',
+  'IfcStructuralResultGroup',
   'IfcGroup',
 ] as const;
 
@@ -1010,15 +1021,17 @@ export type GroupSubFilter = 'all' | 'systems' | 'zones' | 'other';
 
 const SYSTEM_GROUP_TYPES: ReadonlySet<string> = new Set([
   'IfcDistributionSystem',
+  'IfcDistributionCircuit',
   'IfcBuiltSystem',
   'IfcBuildingSystem',
-  'IfcSystem',
   'IfcStructuralAnalysisModel',
+  'IfcSystem',
 ]);
 
 /** Whether a group entity class passes the Groups-tab sub-filter.
- *  Systems = the IfcSystem family (incl. IfcStructuralAnalysisModel);
- *  Zones = IfcZone; Other = IfcGroup and any remaining class. */
+ *  Systems = the IfcSystem family (incl. IfcDistributionCircuit and
+ *  IfcStructuralAnalysisModel); Zones = IfcZone; Other = IfcGroup, IfcAsset,
+ *  IfcInventory, the structural load/result groups and any remaining class. */
 export function groupMatchesSubFilter(ifcType: string, filter: GroupSubFilter): boolean {
   switch (filter) {
     case 'all': return true;

--- a/apps/viewer/src/components/viewer/hierarchy/treeDataBuilder.ts
+++ b/apps/viewer/src/components/viewer/hierarchy/treeDataBuilder.ts
@@ -12,7 +12,7 @@ import {
   type SpatialNode,
 } from '@ifc-lite/data';
 import type { IfcDataStore } from '@ifc-lite/parser';
-import { buildMaterialUsageIndex } from '@ifc-lite/parser';
+import { buildMaterialUsageIndex, extractGroupMembersOnDemand } from '@ifc-lite/parser';
 import { useViewerStore, type FederatedModel } from '@/store';
 import { toGlobalIdFromModels } from '@/store/globalId';
 import {
@@ -982,6 +982,273 @@ export function buildMaterialTree(
       isVisible: true,
       elementCount: entry.elements.size,
     });
+  }
+
+  return nodes;
+}
+
+/**
+ * Concrete IfcGroup subtypes the Groups tab enumerates EXPLICITLY. The entity
+ * index (`entityIndex.byType` / `getEntitiesByType`) is exact-match with no
+ * subtype closure, so querying 'IfcSystem' alone would silently miss
+ * IfcDistributionSystem / IfcBuiltSystem — exactly the classes MEP files use
+ * (issue #1622; same defect class as #1662). Order = display order: systems,
+ * then zones, then generic groups.
+ */
+export const GROUP_ENTITY_TYPES = [
+  'IfcDistributionSystem',
+  'IfcBuiltSystem',
+  'IfcBuildingSystem',
+  'IfcSystem',
+  'IfcStructuralAnalysisModel',
+  'IfcZone',
+  'IfcGroup',
+] as const;
+
+/** Sub-filter chips for the Groups tab (#1622). */
+export type GroupSubFilter = 'all' | 'systems' | 'zones' | 'other';
+
+const SYSTEM_GROUP_TYPES: ReadonlySet<string> = new Set([
+  'IfcDistributionSystem',
+  'IfcBuiltSystem',
+  'IfcBuildingSystem',
+  'IfcSystem',
+  'IfcStructuralAnalysisModel',
+]);
+
+/** Whether a group entity class passes the Groups-tab sub-filter.
+ *  Systems = the IfcSystem family (incl. IfcStructuralAnalysisModel);
+ *  Zones = IfcZone; Other = IfcGroup and any remaining class. */
+export function groupMatchesSubFilter(ifcType: string, filter: GroupSubFilter): boolean {
+  switch (filter) {
+    case 'all': return true;
+    case 'systems': return SYSTEM_GROUP_TYPES.has(ifcType);
+    case 'zones': return ifcType === 'IfcZone';
+    case 'other': return !SYSTEM_GROUP_TYPES.has(ifcType) && ifcType !== 'IfcZone';
+  }
+}
+
+/** A geometry-bearing entity a group member resolves to. */
+export interface ResolvedMemberGeometry {
+  expressId: number;
+  globalId: number;
+}
+
+/**
+ * Resolve a group member to the geometry that should represent it (#1622).
+ * IfcRelAssignsToGroup members are frequently geometry-less: in HVAC exports
+ * roughly two thirds of an IfcDistributionSystem's members are
+ * IfcDistributionPorts, so raw isolation would render a perforated (or empty)
+ * network. If the member itself carries geometry, that's the answer; otherwise
+ * fold in its IfcRelNests/IfcRelAggregates relatives — IfcRelNests is mapped
+ * onto the shared Aggregates edge bucket (see columnar-parser-indexes), so
+ * `inverse` yields a port's nesting host element and `forward` yields nested /
+ * aggregated children — keeping only relatives that actually have geometry.
+ * Returns [] when nothing resolves (e.g. a nested IfcZone member).
+ */
+export function resolveMemberGeometry(
+  dataStore: IfcDataStore,
+  memberExpressId: number,
+  toGlobal: (expressId: number) => number,
+  geometricIds: Set<number>,
+): ResolvedMemberGeometry[] {
+  const ownGlobal = toGlobal(memberExpressId);
+  if (geometricIds.has(ownGlobal)) {
+    return [{ expressId: memberExpressId, globalId: ownGlobal }];
+  }
+  const relationships = dataStore.relationships;
+  if (!relationships) return [];
+  const out: ResolvedMemberGeometry[] = [];
+  const seen = new Set<number>();
+  for (const direction of ['inverse', 'forward'] as const) {
+    for (const relatedId of relationships.getRelated(memberExpressId, RelationshipType.Aggregates, direction)) {
+      if (relatedId === memberExpressId || seen.has(relatedId)) continue;
+      seen.add(relatedId);
+      const globalId = toGlobal(relatedId);
+      if (geometricIds.has(globalId)) {
+        out.push({ expressId: relatedId, globalId });
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * Build the flat "Groups" tree (#1622): one 'group' row per IfcGroup-family
+ * entity (enumerated via {@link GROUP_ENTITY_TYPES}), expanding to
+ * 'group-member' child rows. Mirrors {@link buildMaterialTree} structurally.
+ *
+ * Group membership is MANY-TO-MANY (an element may sit in several systems, a
+ * space in several zones) — the same entity legitimately appears under multiple
+ * group rows, distinguished by the composite node id. Members are deduped only
+ * WITHIN one group (a host element and its two ports must not yield three rows).
+ *
+ * Member rows: a geometry-bearing member appears as itself; a geometry-less
+ * member (IfcDistributionPort) is represented by the geometry-bearing relatives
+ * it resolves to via {@link resolveMemberGeometry}; a member with no resolvable
+ * geometry at all (e.g. a nested IfcZone) keeps a select-only row. The group
+ * row's `globalIds` carry the union of resolved geometry for O(1)
+ * isolate / eye-toggle / basket.
+ */
+export function buildGroupTree(
+  models: Map<string, FederatedModel>,
+  ifcDataStore: IfcDataStore | null | undefined,
+  expandedNodes: Set<string>,
+  isMultiModel: boolean,
+  geometricIds?: Set<number>,
+  subFilter: GroupSubFilter = 'all',
+): TreeNode[] {
+  interface MemberRow {
+    expressId: number;
+    globalId: number;
+    name: string;
+    ifcType: string;
+  }
+  interface GroupEntry {
+    modelId: string;
+    groupExpressId: number;
+    name: string;
+    ifcType: string;
+    typeRank: number;
+    memberRows: MemberRow[];
+    isolationGlobalIds: number[];
+  }
+
+  const geo = geometricIds ?? new Set<number>();
+  const entries: GroupEntry[] = [];
+
+  const processDataStore = (dataStore: IfcDataStore, modelId: string) => {
+    const byType = dataStore.entityIndex?.byType;
+    const entities = dataStore.entities;
+    if (!byType || !entities) return;
+    const toGlobal = (expressId: number) => resolveTreeGlobalId(modelId, expressId, models);
+
+    for (let rank = 0; rank < GROUP_ENTITY_TYPES.length; rank++) {
+      const typeName = GROUP_ENTITY_TYPES[rank];
+      if (!groupMatchesSubFilter(typeName, subFilter)) continue;
+      const groupIds = byType.get(typeName.toUpperCase());
+      if (!groupIds || groupIds.length === 0) continue;
+
+      for (const groupId of groupIds) {
+        const members = extractGroupMembersOnDemand(dataStore, groupId);
+        // Empty group: a dead click, skip (mirror the empty-material skip).
+        if (members.length === 0) continue;
+
+        const rowByGlobalId = new Map<number, MemberRow>();
+        const isolation = new Set<number>();
+        for (const member of members) {
+          const ownGlobal = toGlobal(member.id);
+          const resolved = resolveMemberGeometry(dataStore, member.id, toGlobal, geo);
+          for (const r of resolved) isolation.add(r.globalId);
+
+          if (resolved.length === 1 && resolved[0].expressId === member.id) {
+            // Member carries its own geometry — list it as itself.
+            if (!rowByGlobalId.has(ownGlobal)) {
+              rowByGlobalId.set(ownGlobal, {
+                expressId: member.id,
+                globalId: ownGlobal,
+                name: member.name || `${member.type} #${member.id}`,
+                ifcType: member.type,
+              });
+            }
+          } else if (resolved.length > 0) {
+            // Geometry-less member (port): list its geometry-bearing relatives
+            // instead of a dead row. The host element is often ALSO a direct
+            // member — the by-globalId map collapses those to one row.
+            for (const r of resolved) {
+              if (rowByGlobalId.has(r.globalId)) continue;
+              const relName = entities.getName(r.expressId);
+              const relType = entities.getTypeName(r.expressId) || 'Unknown';
+              rowByGlobalId.set(r.globalId, {
+                expressId: r.expressId,
+                globalId: r.globalId,
+                name: relName || `${relType} #${r.expressId}`,
+                ifcType: relType,
+              });
+            }
+          } else if (!rowByGlobalId.has(ownGlobal)) {
+            // No geometry anywhere (nested group/zone, proxy without shape):
+            // keep a select-only row so the membership stays browsable.
+            rowByGlobalId.set(ownGlobal, {
+              expressId: member.id,
+              globalId: ownGlobal,
+              name: member.name || `${member.type} #${member.id}`,
+              ifcType: member.type,
+            });
+          }
+        }
+
+        // Name with ObjectType fallback for unnamed systems — same display
+        // logic as the properties panel's Groups & Zones card (#1075).
+        const name = entities.getName(groupId);
+        const objectType = entities.getObjectType?.(groupId);
+        entries.push({
+          modelId,
+          groupExpressId: groupId,
+          name: name || objectType || `${typeName} #${groupId}`,
+          ifcType: typeName,
+          typeRank: rank,
+          memberRows: Array.from(rowByGlobalId.values()),
+          isolationGlobalIds: Array.from(isolation),
+        });
+      }
+    }
+  };
+
+  if (models.size > 0) {
+    for (const [modelId, model] of models) {
+      if (model.ifcDataStore) processDataStore(model.ifcDataStore, modelId);
+    }
+  } else if (ifcDataStore) {
+    processDataStore(ifcDataStore, 'legacy');
+  }
+
+  // Systems first, then zones, then generic groups; name order within a class.
+  entries.sort((a, b) => a.typeRank - b.typeRank || storeyNameCollator.compare(a.name, b.name));
+
+  const nodes: TreeNode[] = [];
+  for (const entry of entries) {
+    const nodeId = `group-${entry.modelId}-${entry.groupExpressId}`;
+    const hasChildren = entry.memberRows.length > 0;
+    const isExpanded = hasChildren && expandedNodes.has(nodeId);
+    const suffix = isMultiModel ? ` [${models.get(entry.modelId)?.name || entry.modelId}]` : '';
+
+    nodes.push({
+      id: nodeId,
+      expressIds: [entry.groupExpressId],
+      globalIds: entry.isolationGlobalIds,
+      entityExpressId: entry.groupExpressId,
+      modelIds: [entry.modelId],
+      name: entry.name + suffix,
+      type: 'group',
+      ifcType: entry.ifcType,
+      depth: 0,
+      hasChildren,
+      isExpanded,
+      isVisible: true,
+      elementCount: entry.memberRows.length,
+    });
+
+    if (isExpanded) {
+      const rows = [...entry.memberRows].sort((a, b) => storeyNameCollator.compare(a.name, b.name));
+      for (const row of rows) {
+        nodes.push({
+          // Composite id keyed by the OWNING group: the same member under N
+          // groups yields N distinct rows — spec-correct many-to-many (#1622).
+          id: `groupmember-${entry.modelId}-${entry.groupExpressId}-${row.expressId}`,
+          expressIds: [row.expressId],
+          globalIds: [row.globalId],
+          modelIds: [entry.modelId],
+          name: row.name,
+          type: 'group-member',
+          ifcType: row.ifcType,
+          depth: 1,
+          hasChildren: false,
+          isExpanded: false,
+          isVisible: true,
+        });
+      }
+    }
   }
 
   return nodes;

--- a/apps/viewer/src/components/viewer/hierarchy/types.ts
+++ b/apps/viewer/src/components/viewer/hierarchy/types.ts
@@ -24,6 +24,8 @@ export type NodeType =
   | 'type-group'          // IFC class grouping header (e.g., "IfcWall (47)")
   | 'ifc-type'            // IFC type entity node (e.g., "IfcWallType/W01")
   | 'material-group'      // Material grouping (e.g., "Concrete (47)") from the Materials tab
+  | 'group'               // IfcGroup/IfcSystem/IfcZone entity row from the Groups tab (#1622)
+  | 'group-member'        // Member row under an expanded group (#1622)
   | 'element';            // Individual element
 
 export interface TreeNode {

--- a/apps/viewer/src/components/viewer/hierarchy/useHierarchyTree.ts
+++ b/apps/viewer/src/components/viewer/hierarchy/useHierarchyTree.ts
@@ -15,12 +15,14 @@ import {
   buildTypeTree,
   buildIfcTypeTree,
   buildMaterialTree,
+  buildGroupTree,
   filterNodes,
   splitNodes,
   type AuthoredProduct,
+  type GroupSubFilter,
 } from './treeDataBuilder';
 
-export type GroupingMode = 'spatial' | 'type' | 'ifc-type' | 'material';
+export type GroupingMode = 'spatial' | 'type' | 'ifc-type' | 'material' | 'groups';
 
 const SORT_STORAGE_KEY = 'hierarchy-sort';
 
@@ -118,6 +120,9 @@ export function useHierarchyTree({ models, ifcDataStore, isMultiModel, geometryR
     (typeof window !== 'undefined' && localStorage.getItem('hierarchy-grouping') as GroupingMode) || 'spatial'
   );
   const [sortMode, setSortMode] = useState<HierarchySortMode>(readStoredSortMode);
+  // Groups-tab sub-filter (All / Systems / Zones / Other) — session-only state,
+  // deliberately not persisted (#1622).
+  const [groupFilter, setGroupFilter] = useState<GroupSubFilter>('all');
 
   // Build unified storey data for multi-model mode (moved before useEffect that depends on it)
   const unifiedStoreys = useMemo(
@@ -303,9 +308,12 @@ export function useHierarchyTree({ models, ifcDataStore, isMultiModel, geometryR
       if (groupingMode === 'material') {
         return buildMaterialTree(models, ifcDataStore, expandedNodes, isMultiModel, geometricIds);
       }
+      if (groupingMode === 'groups') {
+        return buildGroupTree(models, ifcDataStore, expandedNodes, isMultiModel, geometricIds, groupFilter);
+      }
       return buildTreeData(models, ifcDataStore, expandedNodes, isMultiModel, unifiedStoreys, sortMode);
     },
-    [models, ifcDataStore, expandedNodes, isMultiModel, unifiedStoreys, sortMode, groupingMode, geometricIds, classTreeIds, authoredProducts]
+    [models, ifcDataStore, expandedNodes, isMultiModel, unifiedStoreys, sortMode, groupingMode, geometricIds, classTreeIds, authoredProducts, groupFilter]
   );
 
   // Filter nodes based on search
@@ -334,8 +342,10 @@ export function useHierarchyTree({ models, ifcDataStore, isMultiModel, geometryR
 
   // Get all elements for a node (handles type groups, ifc-type, unified storeys, single storeys, model contributions, and elements)
   const getNodeElements = useCallback((node: TreeNode): number[] => {
-    if (node.type === 'type-group' || node.type === 'ifc-type' || node.type === 'material-group') {
-      // GlobalIds are pre-stored on the node during tree construction — O(1)
+    if (node.type === 'type-group' || node.type === 'ifc-type' || node.type === 'material-group' ||
+        node.type === 'group' || node.type === 'group-member') {
+      // GlobalIds are pre-stored on the node during tree construction — O(1).
+      // For 'group' rows these are the RESOLVED member geometry ids (#1622).
       return node.globalIds;
     }
     if (node.type === 'unified-storey') {
@@ -420,6 +430,8 @@ export function useHierarchyTree({ models, ifcDataStore, isMultiModel, geometryR
     setGroupingMode: handleSetGroupingMode,
     sortMode,
     setSortMode: handleSetSortMode,
+    groupFilter,
+    setGroupFilter,
     unifiedStoreys,
     treeData,
     filteredNodes,


### PR DESCRIPTION
## Problem

The hierarchy panel has four group-by projections (SPATIAL / CLASS / TYPE / MATERIAL) but no way to browse functional groupings. For MEP/HVAC and CAFM/digital-twin workflows the system node (not the individual duct) is the entity a facility manager reasons about, and it carries the system-level property sets. Today membership lives only in the reverse direction (an element's "Groups & Zones" card); there is no forward browser to enumerate IfcSystem / IfcDistributionSystem / IfcZone / IfcGroup, expand their members, or isolate a whole system. Selecting the group directly shows nothing because these are abstract groupings with no shape of their own.

## Approach

A 5th "Groups" projection, modelled structurally on the existing `buildMaterialTree`. TS/React only, no Rust/WASM changes.

- `buildGroupTree` enumerates **every concrete IfcGroup subtype explicitly** (IfcDistributionSystem, IfcBuiltSystem, IfcBuildingSystem, IfcSystem, IfcStructuralAnalysisModel, IfcZone, IfcGroup). `getEntitiesByType` is exact-match with no subtype closure, so a bare `IfcSystem` query silently misses the subtypes that MEP files actually use (VZT.ifc has 9 IfcDistributionSystems and **zero** IfcSystem).
- `resolveMemberGeometry` folds geometry-less members into their nesting host element via the IfcRelNests-on-Aggregates edge (inverse = the port's parent). In the reporter's file ~66% of members are geometry-less IfcDistributionPorts, so without this, isolating a system would render a perforated network. Ports collapse into their already-present host duct/fitting, deduped by globalId.
- **Many-to-many, not a partition:** composite node ids (`group-<model>-<gid>` / `groupmember-<model>-<gid>-<mid>`) keep the same element under N groups as N distinct rows; deduped only within a group. Highlight is by globalId so all copies of a member light up together.
- **Click a group:** isolate + fit its resolved geometry and select the group entity so its psets render; flips the hidden-by-default spaces/spatialZones toggles when the group needs them (lifted from PropertiesPanel `handleIsolateGroupMembers`). **Click a member:** select + focus.
- All / Systems / Zones / Other sub-filter chips (session-only state, not persisted).

## Tests

- Unit tests added to `treeDataBuilder.test.ts` (36 pass total): buildGroupTree subtype enumeration, empty-group skip, port-to-host collapse + isolation ids, select-only row for un-resolvable members, many-to-many distinct rows, ObjectType name fallback, sub-filter, ordering; resolveMemberGeometry passthrough / port-to-parent / no-geometry; groupMatchesSubFilter bucketing.
- Typecheck clean on all touched files (full viewer `tsc --noEmit` = 0 errors after staging built package dists).
- **Manual verification on localhost against the reporter's VZT.ifc** (IFC4X3, 9 IfcDistributionSystems): the tab lists all 9 with correct resolved member counts; clicking a system isolates a visually complete, non-perforated network and shows `Pset_DistributionSystemCommon` on the IfcDistributionSystem entity; members render as their host elements (IfcUnitaryEquipment / IfcDuctSegment / IfcDuctFitting, not ports); member click selects + focuses; ZONES filter is empty gracefully; the other four tabs and localStorage persistence are unchanged.

## Minor product decisions to confirm

- **5-button toggle row overflow:** five equal-width buttons are cramped at the default panel width (labels nearly touch). They already collapse to icon-only via the existing `panel-compact-text`/`panel-compact-icon` classes at min width, so it's functional but tight. Happy to switch the row to icon-only-with-tooltips or a dropdown if you prefer.
- **Sub-filter bucketing:** Systems = IfcDistributionSystem + IfcBuiltSystem + IfcBuildingSystem + IfcSystem + IfcStructuralAnalysisModel; Zones = IfcZone; Other = IfcGroup and anything else. The placement of IfcStructuralAnalysisModel and IfcBuildingSystem under "Systems" is a judgement call worth a sanity check.

Closes #1622