### PR TITLE
feat(viewer): measure real-world XYZ at a picked point (#1657)

### DIFF
--- a/apps/viewer/src/components/viewer/BasepointOverlay.tsx
+++ b/apps/viewer/src/components/viewer/BasepointOverlay.tsx
@@ -28,6 +28,7 @@ import {
   type ModelGeorefInput,
 } from '@/lib/geo/ifc-origin';
 import { getEffectiveGeoreference } from '@/lib/geo/effective-georef';
+import { selectAnchorGeoref } from '@/lib/geo/useAnchorGeoreference';
 import type { FederatedModel } from '@/store/types';
 import type { IfcDataStore } from '@ifc-lite/parser';
 import type { Renderer } from '@ifc-lite/renderer';
@@ -70,43 +71,23 @@ export function BasepointOverlay() {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const rafRef = useRef<number | null>(null);
 
-  // Compute the anchor's georef input once per dependency change.
+  // Compute the anchor's georef input once per dependency change. Shares the
+  // "user-pinned anchor, else earliest-loaded model with a usable map-conversion
+  // georef" selection with the measure-tool readout and findReferenceGeorefModel.
   const anchorInput = useMemo((): { id: string | null; input: ModelGeorefInput | null } => {
-    if (models.size === 0) return { id: null, input: null };
-    // Honour the user-pinned anchor first; fall back to earliest-loaded model
-    // with a valid georef. Matches findReferenceGeorefModel in useIfcFederation.
-    const buildInput = (model: FederatedModel): ModelGeorefInput | null => {
-      const ds = model.ifcDataStore;
-      if (!ds) return null;
-      const eff = getEffectiveGeoreference(
-        ds as IfcDataStore,
-        model.geometryResult?.coordinateInfo,
-        georefMutations.get(model.id),
-      );
-      if (!eff?.mapConversion || !eff.projectedCRS?.name) return null;
-      return {
-        coordinateInfo: model.geometryResult?.coordinateInfo,
-        mapConversion: eff.mapConversion,
-        projectedCRS: eff.projectedCRS,
-        lengthUnitScale: eff.lengthUnitScale,
-        preAlignmentCoordinateInfo: model.preAlignmentCoordinateInfo,
-      };
+    const selection = selectAnchorGeoref({ models, anchorModelIdOverride, georefMutations });
+    if (!selection) return { id: null, input: null };
+    const model = models.get(selection.modelId);
+    return {
+      id: selection.modelId,
+      input: {
+        coordinateInfo: selection.coordinateInfo,
+        mapConversion: selection.eff.mapConversion,
+        projectedCRS: selection.eff.projectedCRS,
+        lengthUnitScale: selection.eff.lengthUnitScale,
+        preAlignmentCoordinateInfo: model?.preAlignmentCoordinateInfo,
+      },
     };
-
-    if (anchorModelIdOverride) {
-      const m = models.get(anchorModelIdOverride);
-      if (m) {
-        const input = buildInput(m);
-        if (input) return { id: anchorModelIdOverride, input };
-      }
-    }
-    const sorted = Array.from(models.values()).sort((a, b) => (a.loadedAt ?? 0) - (b.loadedAt ?? 0));
-    for (const m of sorted) {
-      const input = buildInput(m);
-      if (input) return { id: m.id, input };
-    }
-    return { id: null, input: null };
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [models, anchorModelIdOverride, georefMutations]);
 
   // Recompute every model's IFC-origin viewer position when the inputs change.

--- a/apps/viewer/src/components/viewer/ViewportContainer.tsx
+++ b/apps/viewer/src/components/viewer/ViewportContainer.tsx
@@ -324,6 +324,13 @@ export function ViewportContainer() {
     // Check federated models, preferring the user-pinned anchor when present.
     // Matches findReferenceGeorefModel() in useIfcFederation so the Cesium bridge
     // and the parse-time alignment agree on which model drives the world frame.
+    //
+    // The ungated `selectAnchorGeoref` (lib/geo/useAnchorGeoreference) shares this
+    // "pinned anchor, else first model with a usable map-conversion georef"
+    // selection for the basepoint overlay and the measure-tool XYZ readout. This
+    // memo stays bespoke on purpose: it is gated on Cesium/solar, iterates in the
+    // store's insertion order (not loadedAt), and layers the placement-draft
+    // preview + storey elevations that only the Cesium bridge consumes.
     const orderedModels = (() => {
       if (!anchorModelIdOverride) return Array.from(storeModels);
       const entries = Array.from(storeModels);

--- a/apps/viewer/src/components/viewer/tools/MeasurePanel.tsx
+++ b/apps/viewer/src/components/viewer/tools/MeasurePanel.tsx
@@ -7,12 +7,47 @@
  */
 
 import React, { useCallback, useState, useEffect } from 'react';
-import { X, Trash2, Ruler, ChevronDown, GripVertical } from 'lucide-react';
+import { X, Trash2, Ruler, ChevronDown, GripVertical, Globe } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { useViewerStore, type Measurement } from '@/store';
 import { MeasurementOverlays } from './MeasurementVisuals';
 import { formatDistance } from './formatDistance';
 import { useDraggablePanel } from '@/hooks/useDraggablePanel';
+import { useAnchorGeoreference, type AnchorGeoreference } from '@/lib/geo/useAnchorGeoreference';
+import { viewerPointToProjected } from '@/lib/geo/pick-to-geo';
+import { mapUnitsToMeters } from '@/lib/geo/cesium-placement';
+
+interface Vec3Like { x: number; y: number; z: number }
+interface Enh { e: string; n: string; h: string }
+
+/**
+ * Project a picked viewer point to real-world Eastings/Northings/Height and
+ * format it in the CRS's metre unit to millimetre precision. The stored
+ * MapConversion offsets are in the authored map unit (millimetres for the
+ * bundled sample), so we convert to metres with the anchor's map-unit scale —
+ * the raw offsets would read ~1000x too large for a metre CRS.
+ */
+function projectedEnh(point: Vec3Like, anchor: AnchorGeoreference): Enh {
+  const proj = viewerPointToProjected(point, anchor.eff, anchor.originViewer);
+  const { projectedCRS, lengthUnitScale } = anchor.eff;
+  return {
+    e: mapUnitsToMeters(proj.eastings, projectedCRS, lengthUnitScale).toFixed(3),
+    n: mapUnitsToMeters(proj.northings, projectedCRS, lengthUnitScale).toFixed(3),
+    h: mapUnitsToMeters(proj.height, projectedCRS, lengthUnitScale).toFixed(3),
+  };
+}
+
+/** One compact monospace E/N/H line, optionally labelled (A/B endpoints). */
+function EnhLine({ label, enh }: { label?: string; enh: Enh }) {
+  return (
+    <div className="flex items-center gap-2 font-mono text-[10px] leading-tight text-muted-foreground whitespace-nowrap">
+      {label && <span className="text-muted-foreground/60 w-3 shrink-0">{label}</span>}
+      <span>E {enh.e}</span>
+      <span>N {enh.n}</span>
+      <span>H {enh.h}</span>
+    </div>
+  );
+}
 
 export function MeasureOverlay() {
   const measurements = useViewerStore((s) => s.measurements);
@@ -21,6 +56,8 @@ export function MeasureOverlay() {
   const snapTarget = useViewerStore((s) => s.snapTarget);
   const snapVisualization = useViewerStore((s) => s.snapVisualization);
   const snapEnabled = useViewerStore((s) => s.snapEnabled);
+  const geoReadoutEnabled = useViewerStore((s) => s.geoReadoutEnabled);
+  const toggleGeoReadout = useViewerStore((s) => s.toggleGeoReadout);
   const measurementConstraintEdge = useViewerStore((s) => s.measurementConstraintEdge);
   const toggleSnap = useViewerStore((s) => s.toggleSnap);
   const deleteMeasurement = useViewerStore((s) => s.deleteMeasurement);
@@ -86,6 +123,17 @@ export function MeasureOverlay() {
   // Calculate total distance
   const totalDistance = measurements.reduce((sum, m) => sum + m.distance, 0);
 
+  // Real-world XYZ readout. `anchor` is non-null only when the georef anchor
+  // model carries a usable IfcMapConversion (projected CRS + offsets, not a
+  // bare IfcSite lat/lon), which gates the toggle and the readout.
+  const anchor = useAnchorGeoreference();
+  const showGeo = geoReadoutEnabled && anchor !== null;
+  // Live point: the current drag endpoint while measuring, else the most
+  // recently finalized endpoint. Drives the standalone readout box.
+  const livePoint: Vec3Like | null = activeMeasurement?.current
+    ?? (measurements.length > 0 ? measurements[measurements.length - 1].end : null);
+  const liveEnh = showGeo && anchor && livePoint ? projectedEnh(livePoint, anchor) : null;
+
   const panelRef = React.useRef<HTMLDivElement>(null);
   const drag = useDraggablePanel(panelRef);
 
@@ -141,6 +189,7 @@ export function MeasureOverlay() {
                     measurement={m}
                     index={i}
                     onDelete={handleDeleteMeasurement}
+                    geoAnchor={showGeo ? anchor : null}
                   />
                 ))}
                 {measurements.length > 1 && (
@@ -177,8 +226,29 @@ export function MeasureOverlay() {
         </span>
       </div>
 
-      {/* Snap toggle - brutalist style */}
-      <div className="pointer-events-auto absolute bottom-4 left-1/2 -translate-x-1/2 z-30">
+      {/* Live real-world XYZ readout for the active / last point */}
+      {liveEnh && anchor && (
+        <div className="pointer-events-none absolute bottom-28 left-1/2 -translate-x-1/2 z-30 bg-background/95 backdrop-blur-sm border-2 border-primary/60 px-3 py-1.5 shadow-lg max-w-[92vw] overflow-x-auto">
+          <div className="flex items-baseline gap-2">
+            <Globe className="h-3 w-3 text-primary shrink-0 self-center" />
+            <span className="font-mono text-[10px] uppercase tracking-wider text-primary shrink-0">
+              {activeMeasurement ? 'Live' : 'Last'}
+            </span>
+            <div className="font-mono text-[11px] tabular-nums whitespace-nowrap">
+              <span>E {liveEnh.e}</span>
+              <span className="ml-2">N {liveEnh.n}</span>
+              <span className="ml-2">H {liveEnh.h}</span>
+              <span className="ml-2 text-muted-foreground">m</span>
+            </div>
+          </div>
+          <div className="font-mono text-[9px] text-muted-foreground/80 mt-0.5 pl-5">
+            {anchor.eff.projectedCRS.name}
+          </div>
+        </div>
+      )}
+
+      {/* Snap + Geo toggles - brutalist style */}
+      <div className="pointer-events-auto absolute bottom-4 left-1/2 -translate-x-1/2 z-30 flex items-center gap-2">
         <button
           onClick={toggleSnap}
           className={`px-2 py-1 font-mono text-[10px] uppercase tracking-wider border-2 transition-colors ${
@@ -190,6 +260,20 @@ export function MeasureOverlay() {
         >
           Snap {snapEnabled ? 'On' : 'Off'}
         </button>
+        {anchor && (
+          <button
+            onClick={toggleGeoReadout}
+            className={`flex items-center gap-1 px-2 py-1 font-mono text-[10px] uppercase tracking-wider border-2 transition-colors ${
+              geoReadoutEnabled
+                ? 'bg-primary text-primary-foreground border-primary'
+                : 'bg-zinc-100 dark:bg-zinc-900 text-zinc-500 border-zinc-300 dark:border-zinc-700'
+            }`}
+            title="Toggle real-world XYZ (Eastings / Northings / Height)"
+          >
+            <Globe className="h-3 w-3" />
+            Geo XYZ {geoReadoutEnabled ? 'On' : 'Off'}
+          </button>
+        )}
       </div>
 
       {/* Render measurement lines, labels, and snap indicators */}
@@ -211,21 +295,31 @@ interface MeasurementItemProps {
   measurement: Measurement;
   index: number;
   onDelete: (id: string) => void;
+  /** When set, show real-world E/N/H for the measurement's two endpoints. */
+  geoAnchor: AnchorGeoreference | null;
 }
 
-function MeasurementItem({ measurement, index, onDelete }: MeasurementItemProps) {
+function MeasurementItem({ measurement, index, onDelete, geoAnchor }: MeasurementItemProps) {
   return (
-    <div className="flex items-center justify-between bg-muted/50 rounded px-2 py-0.5 text-xs">
-      <span className="text-muted-foreground text-xs">#{index + 1}</span>
-      <span className="font-mono font-medium">{formatDistance(measurement.distance)}</span>
-      <Button
-        variant="ghost"
-        size="icon-sm"
-        className="h-4 w-4 hover:bg-destructive/20"
-        onClick={() => onDelete(measurement.id)}
-      >
-        <X className="h-2.5 w-2.5" />
-      </Button>
+    <div className="bg-muted/50 rounded px-2 py-0.5 text-xs">
+      <div className="flex items-center justify-between">
+        <span className="text-muted-foreground text-xs">#{index + 1}</span>
+        <span className="font-mono font-medium">{formatDistance(measurement.distance)}</span>
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          className="h-4 w-4 hover:bg-destructive/20"
+          onClick={() => onDelete(measurement.id)}
+        >
+          <X className="h-2.5 w-2.5" />
+        </Button>
+      </div>
+      {geoAnchor && (
+        <div className="mt-0.5 overflow-x-auto">
+          <EnhLine label="A" enh={projectedEnh(measurement.start, geoAnchor)} />
+          <EnhLine label="B" enh={projectedEnh(measurement.end, geoAnchor)} />
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/viewer/src/lib/geo/ifc-origin.ts
+++ b/apps/viewer/src/lib/geo/ifc-origin.ts
@@ -51,7 +51,15 @@ export interface ModelGeorefInput {
   preAlignmentCoordinateInfo?: CoordinateInfo;
 }
 
-function totalYupOffset(info?: CoordinateInfo): { x: number; y: number; z: number } {
+/**
+ * Total Y-up (viewer-space) offset applied to a model's IFC (0,0,0) point:
+ * `originShift` plus the wasm RTC offset re-expressed in the viewer's Y-up
+ * frame. A model's IFC origin sits at `-totalYupOffset` in viewer space, so for
+ * a standalone load or the federation anchor this yields the origin
+ * synchronously (no proj4 hop). Exported so the measure-tool XYZ readout can
+ * derive the anchor origin without awaiting {@link computeIfcOriginViewerPosition}.
+ */
+export function totalYupOffset(info?: CoordinateInfo): { x: number; y: number; z: number } {
   const shift = info?.originShift ?? { x: 0, y: 0, z: 0 };
   const rtc = info?.wasmRtcOffset;
   const rtcYup = rtc ? { x: rtc.x, y: rtc.z, z: -rtc.y } : { x: 0, y: 0, z: 0 };

--- a/apps/viewer/src/lib/geo/pick-to-geo.test.ts
+++ b/apps/viewer/src/lib/geo/pick-to-geo.test.ts
@@ -1,0 +1,181 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+
+import {
+  hasUsableMapGeoref,
+  viewerPointToProjected,
+  type MapGeoreference,
+} from './pick-to-geo.js';
+import type { EffectiveGeoreference } from './effective-georef.js';
+
+/**
+ * Ground truth from the bundled `apps/viewer/public/samples/building-architecture.ifc`:
+ *   #19 = IFCMAPCONVERSION(#11, #18, 729013348.8297004, 9063992684.697363,
+ *                          1300.0000000000011, 0.4999999999999999,
+ *                          0.8660254037844387, 1.);
+ *   #18 = IFCPROJECTEDCRS('EPSG:32760', ..., MapUnit = #15 = MILLIMETRE);
+ *   project length unit = MILLIMETRE.
+ *
+ * XAxisAbscissa 0.5 / XAxisOrdinate 0.866 encode a 60 deg grid rotation, and
+ * BOTH the offsets and the project geometry are millimetre-scaled
+ * (mapUnitScale = lengthUnitScale = 0.001). The readout must therefore honour
+ * the map-unit scale: the offsets are stored in millimetres even though
+ * EPSG:32760 is a metre CRS. Using the parser's `transformToWorld` (which
+ * assumes map units) here would be ~1000x wrong.
+ */
+const BUILDING_ARCH_EASTINGS = 729013348.8297004;
+const BUILDING_ARCH_NORTHINGS = 9063992684.697363;
+const BUILDING_ARCH_ORTHO_HEIGHT = 1300.0000000000011;
+const BUILDING_ARCH_ABSCISSA = 0.4999999999999999; // cos 60 deg
+const BUILDING_ARCH_ORDINATE = 0.8660254037844387; // sin 60 deg
+
+function buildingArchGeoref(): MapGeoreference {
+  return {
+    hasGeoreference: true,
+    source: 'mapConversion',
+    projectedCRS: { id: 18, name: 'EPSG:32760', mapUnit: 'MILLIMETRE', mapUnitScale: 0.001 },
+    mapConversion: {
+      id: 19,
+      sourceCRS: 11,
+      targetCRS: 18,
+      eastings: BUILDING_ARCH_EASTINGS,
+      northings: BUILDING_ARCH_NORTHINGS,
+      orthogonalHeight: BUILDING_ARCH_ORTHO_HEIGHT,
+      xAxisAbscissa: BUILDING_ARCH_ABSCISSA,
+      xAxisOrdinate: BUILDING_ARCH_ORDINATE,
+      scale: 1,
+    },
+    lengthUnitScale: 0.001,
+  };
+}
+
+/** A no-rotation georef in a genuine metre CRS (offsets already in metres). */
+function metreCrsGeoref(): MapGeoreference {
+  return {
+    hasGeoreference: true,
+    source: 'mapConversion',
+    projectedCRS: { id: 1, name: 'EPSG:32631', mapUnit: 'METRE', mapUnitScale: 1 },
+    mapConversion: {
+      id: 2,
+      sourceCRS: 10,
+      targetCRS: 1,
+      eastings: 500000,
+      northings: 5000000,
+      orthogonalHeight: 100,
+      xAxisAbscissa: 1,
+      xAxisOrdinate: 0,
+      scale: 1,
+    },
+    lengthUnitScale: 1,
+  };
+}
+
+describe('viewerPointToProjected', () => {
+  it('maps the IFC origin exactly to the authored MapConversion values (mm-scaled sample)', () => {
+    const eff = buildingArchGeoref();
+    // Origin can sit anywhere in viewer-local space; picking it back yields a
+    // zero delta and thus the raw authored offsets, mm and all.
+    const originViewer = { x: 12.5, y: -4, z: 7 };
+    const out = viewerPointToProjected(originViewer, eff, originViewer);
+
+    assert.strictEqual(out.eastings, BUILDING_ARCH_EASTINGS);
+    assert.strictEqual(out.northings, BUILDING_ARCH_NORTHINGS);
+    assert.strictEqual(out.height, BUILDING_ARCH_ORTHO_HEIGHT);
+    assert.strictEqual(out.crsName, 'EPSG:32760');
+  });
+
+  it('rotates a 1 m viewer-X step by the 60 deg grid and scales it to millimetres', () => {
+    const eff = buildingArchGeoref();
+    const originViewer = { x: 12.5, y: -4, z: 7 };
+    // 1 metre along viewer +X.
+    const point = { x: originViewer.x + 1, y: originViewer.y, z: originViewer.z };
+    const out = viewerPointToProjected(point, eff, originViewer);
+
+    // 1 m along viewer-X projects onto (cos60, sin60) = (0.5 m, 0.866 m) in the
+    // grid, i.e. +500 mm easting / +866.025 mm northing in the mm map unit.
+    assert.ok(
+      Math.abs(out.eastings - (BUILDING_ARCH_EASTINGS + 500)) < 1e-3,
+      `eastings = ${out.eastings}`,
+    );
+    assert.ok(
+      Math.abs(out.northings - (BUILDING_ARCH_NORTHINGS + 866.0254037844387)) < 1e-3,
+      `northings = ${out.northings}`,
+    );
+    // No vertical move.
+    assert.ok(Math.abs(out.height - BUILDING_ARCH_ORTHO_HEIGHT) < 1e-6, `height = ${out.height}`);
+  });
+
+  it('adds a 1 m viewer-Y rise as +1000 mm orthogonal height (map-unit scaled)', () => {
+    const eff = buildingArchGeoref();
+    const originViewer = { x: 0, y: 0, z: 0 };
+    const out = viewerPointToProjected({ x: 0, y: 1, z: 0 }, eff, originViewer);
+    // Height is the authored orthogonal height + the metre rise in map units.
+    assert.ok(
+      Math.abs(out.height - (BUILDING_ARCH_ORTHO_HEIGHT + 1000)) < 1e-6,
+      `height = ${out.height}`,
+    );
+    // Purely vertical: E/N unchanged.
+    assert.ok(Math.abs(out.eastings - BUILDING_ARCH_EASTINGS) < 1e-6);
+    assert.ok(Math.abs(out.northings - BUILDING_ARCH_NORTHINGS) < 1e-6);
+  });
+
+  it('handles a no-rotation metre CRS with the local_to_map sign convention', () => {
+    const eff = metreCrsGeoref();
+    const originViewer = { x: 0, y: 0, z: 0 };
+    // Viewer +X -> +Easting; viewer -Z -> +Northing (viewer Z = -ifcY); +Y -> +H.
+    const out = viewerPointToProjected({ x: 3, y: 2, z: -4 }, eff, originViewer);
+    assert.strictEqual(out.eastings, 500003);
+    assert.strictEqual(out.northings, 5000004);
+    assert.strictEqual(out.height, 102);
+    assert.strictEqual(out.crsName, 'EPSG:32631');
+  });
+
+  it('offsets from a non-zero anchor origin (federated frame)', () => {
+    const eff = metreCrsGeoref();
+    const originViewer = { x: 10, y: 5, z: -20 };
+    const out = viewerPointToProjected({ x: 13, y: 7, z: -24 }, eff, originViewer);
+    // Delta = (3, 2, -4), identical to the previous case.
+    assert.strictEqual(out.eastings, 500003);
+    assert.strictEqual(out.northings, 5000004);
+    assert.strictEqual(out.height, 102);
+  });
+});
+
+describe('hasUsableMapGeoref', () => {
+  it('accepts a projected-CRS map conversion', () => {
+    assert.strictEqual(hasUsableMapGeoref(buildingArchGeoref()), true);
+  });
+
+  it('rejects null / undefined', () => {
+    assert.strictEqual(hasUsableMapGeoref(null), false);
+    assert.strictEqual(hasUsableMapGeoref(undefined), false);
+  });
+
+  it('rejects a bare IfcSite lat/lon (source === siteLocation)', () => {
+    const siteOnly: EffectiveGeoreference = {
+      ...buildingArchGeoref(),
+      source: 'siteLocation',
+    };
+    assert.strictEqual(hasUsableMapGeoref(siteOnly), false);
+  });
+
+  it('rejects a georef missing the projected CRS name', () => {
+    const noCrsName: EffectiveGeoreference = {
+      ...buildingArchGeoref(),
+      projectedCRS: { id: 0, name: '', mapUnit: 'METRE', mapUnitScale: 1 },
+    };
+    assert.strictEqual(hasUsableMapGeoref(noCrsName), false);
+  });
+
+  it('rejects a georef missing the map conversion', () => {
+    const noConversion: EffectiveGeoreference = {
+      ...buildingArchGeoref(),
+      mapConversion: undefined,
+    };
+    assert.strictEqual(hasUsableMapGeoref(noConversion), false);
+  });
+});

--- a/apps/viewer/src/lib/geo/pick-to-geo.ts
+++ b/apps/viewer/src/lib/geo/pick-to-geo.ts
@@ -1,0 +1,111 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Convert a picked viewer-space point (Y-up, metres) into projected
+ * Eastings / Northings / Height using a model's effective IfcMapConversion.
+ *
+ * This is the inverse of the placement math the Cesium editor already uses: it
+ * reuses {@link viewerDeltaToProjectedDelta} and {@link metersToMapUnits} so the
+ * XYZ readout, the basepoint overlay, and the Cesium bridge all agree on the
+ * unit- and rotation-aware transform (XAxisAbscissa/Ordinate rotation, Scale,
+ * and — critically — the millimetre-vs-metre map-unit scaling that sample
+ * models rely on; see #595 and the `resolveMapUnitToMetreScale` heuristic).
+ *
+ * Given the viewer position of the model's IFC (0,0,0) (`originViewer`), a
+ * point P relates to the projected frame as:
+ *
+ *   d          = P - originViewer                     (viewer-space metres)
+ *   (ΔE, ΔN)   = viewerDeltaToProjectedDelta(d.x, d.z) (map units, rotated/scaled)
+ *   E          = MapConversion.Eastings  + ΔE
+ *   N          = MapConversion.Northings + ΔN
+ *   H          = MapConversion.OrthogonalHeight + metersToMapUnits(d.y)
+ *
+ * Values are returned in the projected CRS's authored MAP UNIT (the same unit
+ * as the stored MapConversion offsets — millimetres for the bundled sample),
+ * so `E/N/H` for the origin equal the file's MapConversion values exactly. The
+ * height is the authored orthogonal height above the CRS vertical datum; there
+ * is no in-browser vertical-datum transform (matches ifc-origin.ts).
+ *
+ * The rotation sign convention matches rust/core/src/georef.rs `local_to_map`.
+ */
+
+import type { MapConversion, ProjectedCRS } from '@ifc-lite/parser';
+import { hasStandardGeoreferencing, type EffectiveGeoreference } from './effective-georef';
+import { metersToMapUnits, viewerDeltaToProjectedDelta } from './cesium-placement';
+
+export interface Vec3 {
+  x: number;
+  y: number;
+  z: number;
+}
+
+/**
+ * An {@link EffectiveGeoreference} narrowed to one that carries a usable
+ * map-conversion georeference (a projected CRS name plus a MapConversion, and
+ * not a bare IfcSite lat/lon).
+ */
+export type MapGeoreference = EffectiveGeoreference & {
+  mapConversion: MapConversion;
+  projectedCRS: ProjectedCRS;
+};
+
+/**
+ * Projected coordinate of a picked point, in the CRS's authored map unit.
+ */
+export interface ProjectedPoint {
+  /** Easting offset from the CRS origin, in the map unit (as authored). */
+  eastings: number;
+  /** Northing offset from the CRS origin, in the map unit (as authored). */
+  northings: number;
+  /** Orthogonal height above the vertical datum, in the map unit. */
+  height: number;
+  /** Projected CRS identifier, e.g. `"EPSG:32760"`. */
+  crsName: string;
+}
+
+/**
+ * True when `eff` carries a map-conversion georeference the XYZ readout can use:
+ * a projected CRS name plus a MapConversion, and NOT a bare IfcSite lat/lon
+ * (`source === 'siteLocation'`), which has no projected frame to place a point
+ * in. Delegates to {@link hasStandardGeoreferencing} so the guard never drifts
+ * from the rest of the georef stack.
+ */
+export function hasUsableMapGeoref(
+  eff: EffectiveGeoreference | null | undefined,
+): eff is MapGeoreference {
+  return hasStandardGeoreferencing(eff ?? null);
+}
+
+/**
+ * Project a picked viewer point into the CRS of `eff`. `originViewer` is the
+ * viewer-space position of `eff`'s model IFC (0,0,0) — for the federation
+ * anchor (or a standalone model) that is `-totalYupOffset(coordinateInfo)`,
+ * computable synchronously (no proj4 hop).
+ */
+export function viewerPointToProjected(
+  point: Vec3,
+  eff: MapGeoreference,
+  originViewer: Vec3,
+): ProjectedPoint {
+  const { mapConversion, projectedCRS, lengthUnitScale } = eff;
+  const dx = point.x - originViewer.x;
+  const dy = point.y - originViewer.y;
+  const dz = point.z - originViewer.z;
+
+  const delta = viewerDeltaToProjectedDelta(
+    dx,
+    dz,
+    mapConversion,
+    projectedCRS,
+    lengthUnitScale,
+  );
+
+  return {
+    eastings: mapConversion.eastings + delta.eastings,
+    northings: mapConversion.northings + delta.northings,
+    height: mapConversion.orthogonalHeight + metersToMapUnits(dy, projectedCRS, lengthUnitScale),
+    crsName: projectedCRS.name,
+  };
+}

--- a/apps/viewer/src/lib/geo/useAnchorGeoreference.ts
+++ b/apps/viewer/src/lib/geo/useAnchorGeoreference.ts
@@ -1,0 +1,149 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Resolve the federation *anchor* model's effective georeference — the model
+ * whose projected CRS + IfcMapConversion define the world frame every other
+ * model's vertices were baked into.
+ *
+ * The selection order (user-pinned anchor, else earliest-loaded model with a
+ * usable map-conversion georef, else the legacy single-model store fields)
+ * matches `findReferenceGeorefModel` in useIfcFederation, the Cesium georef
+ * memo in ViewportContainer, and the basepoint overlay's anchor input, so the
+ * measure-tool XYZ readout places points in exactly the frame the geometry was
+ * placed in.
+ *
+ * Unlike the Cesium/solar georef memo, this hook is NOT gated on
+ * `cesiumEnabled` / `solarEnabled`: the measure readout must work with Cesium
+ * and the solar study both off. It also exposes the anchor's IFC-origin viewer
+ * position synchronously (`-totalYupOffset`, valid because the anchor is always
+ * its own frame), so callers never await a proj4 hop.
+ */
+
+import { useMemo } from 'react';
+import type { CoordinateInfo } from '@ifc-lite/geometry';
+import type { IfcDataStore } from '@ifc-lite/parser';
+import { useViewerStore } from '@/store';
+import type { FederatedModel } from '@/store/types';
+import {
+  getEffectiveGeoreference,
+  type GeorefMutationDataLike,
+} from './effective-georef';
+import { totalYupOffset } from './ifc-origin';
+import { hasUsableMapGeoref, type MapGeoreference, type Vec3 } from './pick-to-geo';
+
+/** The store field set when a single model loads without going through federation. */
+const LEGACY_MODEL_ID = '__legacy__';
+
+export interface AnchorGeorefSelection {
+  /** Model id, or `'__legacy__'` for the single-model fallback store fields. */
+  modelId: string;
+  /** Effective georef, guaranteed to carry a usable map conversion + CRS name. */
+  eff: MapGeoreference;
+  /** The anchor model's coordinate info (drives the IFC-origin viewer position). */
+  coordinateInfo?: CoordinateInfo;
+}
+
+export interface SelectAnchorGeorefParams {
+  models: Map<string, FederatedModel>;
+  legacyDataStore?: IfcDataStore | null;
+  legacyCoordinateInfo?: CoordinateInfo;
+  anchorModelIdOverride?: string | null;
+  georefMutations: Map<string, GeorefMutationDataLike>;
+}
+
+/**
+ * Pure anchor-selection shared by the measure readout, the basepoint overlay,
+ * and (for its selection step) the Cesium georef memo.
+ */
+export function selectAnchorGeoref({
+  models,
+  legacyDataStore,
+  legacyCoordinateInfo,
+  anchorModelIdOverride,
+  georefMutations,
+}: SelectAnchorGeorefParams): AnchorGeorefSelection | null {
+  const build = (
+    modelId: string,
+    dataStore: IfcDataStore,
+    coordinateInfo: CoordinateInfo | undefined,
+  ): AnchorGeorefSelection | null => {
+    const eff = getEffectiveGeoreference(dataStore, coordinateInfo, georefMutations.get(modelId));
+    if (!hasUsableMapGeoref(eff)) return null;
+    return { modelId, eff, coordinateInfo };
+  };
+
+  if (models.size > 0) {
+    if (anchorModelIdOverride) {
+      const pinned = models.get(anchorModelIdOverride);
+      if (pinned?.ifcDataStore) {
+        const got = build(
+          anchorModelIdOverride,
+          pinned.ifcDataStore as IfcDataStore,
+          pinned.geometryResult?.coordinateInfo,
+        );
+        if (got) return got;
+      }
+    }
+    // Earliest-loaded model with a usable georef wins (stable across reloads).
+    const ordered = Array.from(models.values()).sort(
+      (a, b) => (a.loadedAt ?? 0) - (b.loadedAt ?? 0),
+    );
+    for (const model of ordered) {
+      if (!model.ifcDataStore) continue;
+      const got = build(
+        model.id,
+        model.ifcDataStore as IfcDataStore,
+        model.geometryResult?.coordinateInfo,
+      );
+      if (got) return got;
+    }
+  }
+
+  if (legacyDataStore) {
+    const got = build(LEGACY_MODEL_ID, legacyDataStore, legacyCoordinateInfo);
+    if (got) return got;
+  }
+
+  return null;
+}
+
+export interface AnchorGeoreference extends AnchorGeorefSelection {
+  /** Viewer-space (Y-up) position of the anchor model's IFC (0,0,0). */
+  originViewer: Vec3;
+}
+
+/**
+ * React hook wrapping {@link selectAnchorGeoref} with the store subscriptions
+ * the measure readout needs. Recomputes only when the georef inputs change
+ * (model load/removal, anchor override, or a georef field edit via
+ * `mutationVersion`), never per camera frame or per measurement.
+ */
+export function useAnchorGeoreference(): AnchorGeoreference | null {
+  const models = useViewerStore((s) => s.models);
+  const ifcDataStore = useViewerStore((s) => s.ifcDataStore);
+  const geometryResult = useViewerStore((s) => s.geometryResult);
+  const anchorModelIdOverride = useViewerStore((s) => s.anchorModelIdOverride);
+  const georefMutations = useViewerStore((s) => s.georefMutations);
+  // Re-derive when any georef edit lands (mutations map is replaced, but this
+  // makes the dependency explicit and matches BasepointOverlay).
+  const mutationVersion = useViewerStore((s) => s.mutationVersion);
+
+  return useMemo(() => {
+    const selection = selectAnchorGeoref({
+      models,
+      legacyDataStore: ifcDataStore as IfcDataStore | null,
+      legacyCoordinateInfo: geometryResult?.coordinateInfo,
+      anchorModelIdOverride,
+      georefMutations,
+    });
+    if (!selection) return null;
+    const off = totalYupOffset(selection.coordinateInfo);
+    return {
+      ...selection,
+      originViewer: { x: -off.x, y: -off.y, z: -off.z },
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [models, ifcDataStore, geometryResult, anchorModelIdOverride, georefMutations, mutationVersion]);
+}

--- a/apps/viewer/src/store/slices/measurementSlice.ts
+++ b/apps/viewer/src/store/slices/measurementSlice.ts
@@ -29,6 +29,13 @@ export interface MeasurementSlice {
   activeMeasurement: ActiveMeasurement | null;
   snapTarget: SnapTarget | null;
   snapEnabled: boolean;
+  /**
+   * When on, the Measure tool shows real-world projected coordinates
+   * (Eastings / Northings / Height) for picked points, derived from the
+   * anchor model's IfcMapConversion. Only meaningful for georeferenced models
+   * (the toggle is hidden otherwise). Mirrors {@link snapEnabled}.
+   */
+  geoReadoutEnabled: boolean;
   snapVisualization: SnapVisualization | null;
   edgeLockState: EdgeLockState;
   /** Edge constraint for perpendicular measurements (when shift is held) */
@@ -53,6 +60,9 @@ export interface MeasurementSlice {
   setSnapTarget: (target: SnapTarget | null) => void;
   setSnapVisualization: (viz: SnapVisualization | null) => void;
   toggleSnap: () => void;
+
+  // Geo readout actions
+  toggleGeoReadout: () => void;
 
   // Edge lock actions
   setEdgeLock: (edge: EdgeLockState['edge'], meshExpressId: number | null, edgeT?: number) => void;
@@ -82,6 +92,7 @@ export const createMeasurementSlice: StateCreator<MeasurementSlice, [], [], Meas
   activeMeasurement: null,
   snapTarget: null,
   snapEnabled: true,
+  geoReadoutEnabled: false,
   snapVisualization: null,
   edgeLockState: getDefaultEdgeLockState(),
   measurementConstraintEdge: null,
@@ -244,6 +255,9 @@ export const createMeasurementSlice: StateCreator<MeasurementSlice, [], [], Meas
   setSnapTarget: (snapTarget) => set({ snapTarget }),
   setSnapVisualization: (snapVisualization) => set({ snapVisualization }),
   toggleSnap: () => set((state) => ({ snapEnabled: !state.snapEnabled })),
+
+  // Geo readout actions
+  toggleGeoReadout: () => set((state) => ({ geoReadoutEnabled: !state.geoReadoutEnabled })),
 
   // Edge lock actions
   setEdgeLock: (edge, meshExpressId, edgeT = EDGE_LOCK_DEFAULTS.INITIAL_T) => set({


### PR DESCRIPTION
## What

Adds a georef-aware XYZ readout to the Measure tool. A picked viewer point (Y-up metres) is converted to projected **Eastings / Northings / Height** using the anchor model's effective `IfcMapConversion`. Pure client-side TS, no Rust/WASM.

## The transform

For a picked point `P` and the anchor model's IFC-origin viewer position `originViewer`:

```
d        = P - originViewer                       (viewer-space metres)
(ΔE, ΔN) = viewerDeltaToProjectedDelta(d.x, d.z)  (map units; rotation + Scale aware)
E        = MapConversion.Eastings  + ΔE
N        = MapConversion.Northings + ΔN
H        = MapConversion.OrthogonalHeight + metersToMapUnits(d.y)
```

`originViewer` is `-totalYupOffset(coordinateInfo)` — synchronous, since the anchor is always its own frame (no proj4 hop). The rotation sign matches `rust/core/src/georef.rs` `local_to_map`.

## Reused helpers (no new georef math)

- `getEffectiveGeoreference` / `hasStandardGeoreferencing` (effective-georef.ts) — anchor georef + the guard.
- `viewerDeltaToProjectedDelta` + `metersToMapUnits` (cesium-placement.ts) — the unit/Scale/rotation-aware transforms (same ones the Cesium placement editor uses).
- `computeIfcOriginViewerPosition`'s `self` branch, via the newly exported `totalYupOffset` (ifc-origin.ts).

## The unit trap

Sample models store `IfcMapConversion` offsets in **millimetres** (building-architecture.ifc: `MapUnit = MILLIMETRE`, eastings `729013348.83`), even though EPSG:32760 is a metre CRS. The readout goes through `viewerDeltaToProjectedDelta` / `metersToMapUnits` (map-unit + Scale aware) and never touches the parser's `transformToWorld`/`transformToLocal` (which assume map units and would be ~1000x off). Coordinates convert with the **anchor** model's georef (federated vertices are baked into the anchor frame), display in the CRS metre unit to mm precision, and label `H` as the authored orthogonal height (no in-browser vertical-datum transform).

## Files

- **new** `lib/geo/pick-to-geo.ts` (+ `pick-to-geo.test.ts`): `viewerPointToProjected` + `hasUsableMapGeoref`.
- **new** `lib/geo/useAnchorGeoreference.ts`: shared, ungated `selectAnchorGeoref` selector + hook. `BasepointOverlay` now reuses the selector. `ViewportContainer`'s Cesium/solar memo stays bespoke on purpose (it is gated, uses insertion order, and layers the placement-draft preview + storey elevations) — a pointer comment documents the shared path.
- `lib/geo/ifc-origin.ts`: export `totalYupOffset`.
- `components/viewer/tools/MeasurePanel.tsx`: "Geo XYZ" toggle mirroring the Snap toggle, shown **only** when a usable map-conversion georef exists; live E/N/H (+ EPSG) for the active point and finalized endpoints.
- `store/slices/measurementSlice.ts`: `geoReadoutEnabled` flag + `toggleGeoReadout` (mirrors `snapEnabled`).

## UX decisions

- Toggle inside MeasurePanel, not a separate toolbar Tool (avoids threading a new Tool through the whole toolbar/viewport union).
- Anchor CRS for federated sets; projected E/N/H + EPSG; mm precision. Toggle hidden for non-georeferenced and `siteLocation`-only sources.

## Verification

- `pick-to-geo` unit tests (10/10) against the building-architecture.ifc constants: origin maps exactly to the authored MapConversion; a 1 m viewer-X step lands rotated 60° and mm-scaled; a no-rotation metre-CRS case; the guard rejects null / `siteLocation` / missing CRS / missing conversion.
- Viewer typecheck clean on all touched files (only the pre-existing unrelated `ClashBcfOptions.modelNameOf` stale-dist errors remain).
- Headless (Playwright) live check on the real viewer:
  - **building-architecture.ifc**: IFC origin reads `E 729013.349 m, N 9063992.685 m, H 1.300 m` (exactly the authored MapConversion, mm→m); a 1 m viewer-X step reads `E 729013.849, N 9063993.551, H 1.300` (+0.5 m E / +0.866 m N — the authored 60° grid rotation); toggle + `EPSG:32760` render.
  - **hello-wall.ifc** (no georef): Measure panel present, Geo XYZ toggle hidden, no readout.

apps/viewer only, so no changeset.

Closes #1657