### PR TITLE
perf(geometry): register-resident FixedInt in exact predicates (#1655)

### DIFF
--- a/rust/geometry/src/kernel/fixed.rs
+++ b/rust/geometry/src/kernel/fixed.rs
@@ -249,25 +249,25 @@ const FINE: f64 = 68_719_476_736.0;
 const FINE_OVER_COARSE: i64 = 1 << 20;
 
 mod w256 {
-    fixed_impl!(bnum::types::I256, super::COARSE);
+    fixed_impl!(crate::kernel::fixed_int::FixedInt<4>, super::COARSE);
 }
 mod w512 {
-    fixed_impl!(bnum::types::I512, super::COARSE);
+    fixed_impl!(crate::kernel::fixed_int::FixedInt<8>, super::COARSE);
 }
 mod w1024 {
-    fixed_impl!(bnum::types::I1024, super::COARSE);
+    fixed_impl!(crate::kernel::fixed_int::FixedInt<16>, super::COARSE);
 }
 mod f256 {
-    fixed_impl!(bnum::types::I256, super::FINE);
+    fixed_impl!(crate::kernel::fixed_int::FixedInt<4>, super::FINE);
 }
 mod f512 {
-    fixed_impl!(bnum::types::I512, super::FINE);
+    fixed_impl!(crate::kernel::fixed_int::FixedInt<8>, super::FINE);
 }
 mod f1024 {
-    fixed_impl!(bnum::types::I1024, super::FINE);
+    fixed_impl!(crate::kernel::fixed_int::FixedInt<16>, super::FINE);
 }
 mod f2048 {
-    fixed_impl!(bnum::types::I2048, super::FINE);
+    fixed_impl!(crate::kernel::fixed_int::FixedInt<32>, super::FINE);
 }
 
 // Tiered dispatch: narrowest width first, escalate on overflow; the coarse-scale
@@ -311,7 +311,7 @@ cascade!(indirect_orient3d(p: &ImplicitPoint, p2: [f64; 3], p3: [f64; 3], p4: [f
 // ~2^742 for fine LPI pairs) overflow I512 and fall to the dual-scale cascade —
 // a deliberate trade that keeps the cache at I512 width for the coarse-grid
 // majority (an I1024 cache measured +35% on the 841 corpus).
-type Big = bnum::types::I512;
+type Big = crate::kernel::fixed_int::FixedInt<8>;
 pub type Lam = ([Big; 3], Big);
 
 #[inline]

--- a/rust/geometry/src/kernel/fixed_int/mod.rs
+++ b/rust/geometry/src/kernel/fixed_int/mod.rs
@@ -1,0 +1,630 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! `FixedInt<const K: usize>` — a register-resident fixed-width signed big
+//! integer used as the arithmetic backing of the exact predicate tier
+//! (`kernel/fixed.rs`).
+//!
+//! ## Why a local newtype instead of `bnum`
+//! The fixed-width predicate cascade (`fixed_impl!`) is the FAST exact tier
+//! between the interval filter and the BigRational fallback; every LPI/TPI
+//! lambda and determinant runs its inner limb math here. `bnum` 0.14 backs its
+//! `Integer` with a `[u8; N]` byte array, so the hot add / sub / mul / neg on
+//! the narrow widths pay byte-granular work. `FixedInt` stores `[u64; K]`
+//! little-endian two's-complement limbs and hand-rolls the HOT ops as native
+//! 64-bit limb arithmetic (carry chains, a conservative-precheck schoolbook
+//! multiply, i64/i128 conversions, sign tests) so they stay in registers.
+//!
+//! ## Correctness contract (this is the whole game)
+//! Every operation the cascade relies on is **bit-identical** to the `bnum`
+//! type it replaces:
+//! - HOT ops are native but validated by an exhaustive differential fuzz
+//!   (`mod tests`) against `bnum` across all four widths (K = 4, 8, 16, 32),
+//!   every boundary value, and a deterministic LCG stream. `checked_mul` in
+//!   particular must agree with `bnum` on BOTH the value AND the `Some`/`None`
+//!   overflow verdict — a truncated product escaping as `Some` would silently
+//!   flip a predicate sign and corrupt CSG, so its precheck is deliberately
+//!   CONSERVATIVE (fast-accept only when the product provably fits, fast-reject
+//!   only when it provably overflows, exact wide check in the ambiguous band).
+//! - COLD ops (`Div`, `Rem`, `to_f64`, `from_str_radix`) delegate to `bnum`
+//!   through a little-endian two's-complement byte round-trip. `FixedInt<K>`'s
+//!   `K` u64 limbs are exactly `K*8` bytes, and `bnum::types::I{K*64}` stores
+//!   `K*8` bytes in the same little-endian two's-complement layout, so
+//!   `to_le_bytes`/`from_le_slice` is a lossless reinterpretation.
+//!
+//! The newtype is invisible to `fixed.rs`: the `fixed_impl!` macro names the
+//! width only through its `$T` type argument (`FixedInt<4/8/16/32>`), so no
+//! caller and no macro-body line changes.
+
+use core::cmp::Ordering;
+use core::ops::{Add, Div, Mul, Neg, Rem, Sub};
+use num_traits::{
+    CheckedAdd, CheckedMul, CheckedSub, FromPrimitive, Num, One, Signed, ToPrimitive, Zero,
+};
+
+/// Little-endian, two's-complement fixed-width signed integer with `K` u64
+/// limbs (`self.0[0]` is the least-significant limb; the sign bit is bit 63 of
+/// `self.0[K-1]`). Instantiated at K ∈ {4, 8, 16, 32} = I256/I512/I1024/I2048.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct FixedInt<const K: usize>([u64; K]);
+
+// ── Inherent surface ────────────────────────────────────────────────────────
+// `is_zero` / `is_one` / `is_negative` / `is_positive` are provided as INHERENT
+// methods (not only via the `Zero`/`One`/`Signed` traits) because `bnum`
+// exposes them inherently and `fixed.rs` calls e.g. `x.is_zero()` /
+// `d.is_negative()` in scopes that import `Signed` but not `Zero`, or import no
+// predicate trait at all (`lambda1024`). Inherent methods take resolution
+// priority over trait methods, so these satisfy the macro calls and never
+// conflict with the trait impls below (which carry identical semantics).
+impl<const K: usize> FixedInt<K> {
+    /// Construct directly from little-endian limbs (test-only constructor).
+    #[cfg(test)]
+    #[inline]
+    pub(crate) const fn from_limbs(limbs: [u64; K]) -> Self {
+        FixedInt(limbs)
+    }
+
+    #[inline]
+    pub fn is_zero(&self) -> bool {
+        self.0.iter().all(|&l| l == 0)
+    }
+
+    #[inline]
+    pub fn is_one(&self) -> bool {
+        self.0[0] == 1 && self.0[1..].iter().all(|&l| l == 0)
+    }
+
+    /// Sign test. Takes `self` by value (mirroring `bnum`'s inherent
+    /// `Int::is_negative(self)`): a call on a `&FixedInt` receiver — as in the
+    /// `fixed_impl!` macro's `sign_of` — then binds the `Signed` *trait* method
+    /// instead, keeping the macro's `use num_traits::Signed` genuinely used,
+    /// while calls on an owned value (`lambda1024`) bind this inherent one.
+    #[inline]
+    pub fn is_negative(self) -> bool {
+        self.0[K - 1] >> 63 == 1
+    }
+}
+
+// ── Native limb helpers (the hot path) ──────────────────────────────────────
+
+#[inline]
+fn is_neg<const K: usize>(a: &[u64; K]) -> bool {
+    a[K - 1] >> 63 == 1
+}
+
+/// Two's-complement negation of the limb array (`!a + 1`). Wraps on `MIN`
+/// exactly like `bnum`'s `wrapping_neg`.
+#[inline]
+fn negate<const K: usize>(a: &[u64; K]) -> [u64; K] {
+    let mut out = [0u64; K];
+    let mut carry = 1u64;
+    for i in 0..K {
+        let (v, c) = (!a[i]).overflowing_add(carry);
+        out[i] = v;
+        carry = c as u64;
+    }
+    out
+}
+
+/// Bit length of an UNSIGNED magnitude limb array (0 for all-zero).
+#[inline]
+fn bit_length<const K: usize>(a: &[u64; K]) -> usize {
+    for i in (0..K).rev() {
+        if a[i] != 0 {
+            return i * 64 + (64 - a[i].leading_zeros() as usize);
+        }
+    }
+    0
+}
+
+/// `(|a|, a<0)`. For `a == MIN`, `negate` returns the `MIN` bit pattern which
+/// reads as the correct unsigned magnitude `2^(K*64-1)`.
+#[inline]
+fn magnitude<const K: usize>(a: &FixedInt<K>) -> ([u64; K], bool) {
+    if is_neg(&a.0) {
+        (negate(&a.0), true)
+    } else {
+        (a.0, false)
+    }
+}
+
+/// Low `K` limbs of the unsigned product `a * b` (mod 2^(K*64)). Exact for the
+/// low limbs because a partial product `a[i]*b[j]` with `i+j >= K` is a multiple
+/// of `2^(K*64)` and any carry off limb `K-1` lands at bit `>= K*64`, so both
+/// are `0 mod 2^(K*64)` and may be dropped.
+#[inline]
+fn mul_low<const K: usize>(a: &[u64; K], b: &[u64; K]) -> [u64; K] {
+    let mut out = [0u64; K];
+    for i in 0..K {
+        let mut carry: u128 = 0;
+        let mut j = 0;
+        while i + j < K {
+            let idx = i + j;
+            let t = (a[i] as u128) * (b[j] as u128) + (out[idx] as u128) + carry;
+            out[idx] = t as u64;
+            carry = t >> 64;
+            j += 1;
+        }
+    }
+    out
+}
+
+/// Wrapping two's-complement limb addition (drops the final carry). Kept a free
+/// function so the carry-combine `|` stays out of the `Add` trait impl, where
+/// clippy's `suspicious_arithmetic_impl` would (wrongly) flag it.
+#[inline]
+fn wrapping_add<const K: usize>(a: &[u64; K], b: &[u64; K]) -> [u64; K] {
+    let mut out = [0u64; K];
+    let mut carry = 0u64;
+    for i in 0..K {
+        let (s1, c1) = a[i].overflowing_add(b[i]);
+        let (s2, c2) = s1.overflowing_add(carry);
+        out[i] = s2;
+        // At most one of c1, c2 can be set, so `|` == the true 0/1 carry.
+        carry = (c1 as u64) | (c2 as u64);
+    }
+    out
+}
+
+/// Wrapping two's-complement limb subtraction (drops the final borrow).
+#[inline]
+fn wrapping_sub<const K: usize>(a: &[u64; K], b: &[u64; K]) -> [u64; K] {
+    let mut out = [0u64; K];
+    let mut borrow = 0u64;
+    for i in 0..K {
+        let (d1, b1) = a[i].overflowing_sub(b[i]);
+        let (d2, b2) = d1.overflowing_sub(borrow);
+        out[i] = d2;
+        borrow = (b1 as u64) | (b2 as u64);
+    }
+    out
+}
+
+/// Native two's-complement addition with signed-overflow detection.
+#[inline]
+fn checked_add_limbs<const K: usize>(a: &FixedInt<K>, b: &FixedInt<K>) -> Option<FixedInt<K>> {
+    let out = wrapping_add(&a.0, &b.0);
+    let sa = a.0[K - 1] >> 63;
+    let sb = b.0[K - 1] >> 63;
+    let sr = out[K - 1] >> 63;
+    // Overflow iff the operands share a sign and the result flips it.
+    if sa == sb && sr != sa {
+        None
+    } else {
+        Some(FixedInt(out))
+    }
+}
+
+/// Native two's-complement subtraction with signed-overflow detection.
+#[inline]
+fn checked_sub_limbs<const K: usize>(a: &FixedInt<K>, b: &FixedInt<K>) -> Option<FixedInt<K>> {
+    let out = wrapping_sub(&a.0, &b.0);
+    let sa = a.0[K - 1] >> 63;
+    let sb = b.0[K - 1] >> 63;
+    let sr = out[K - 1] >> 63;
+    // Overflow iff the operands differ in sign and the result flips the minuend.
+    if sa != sb && sr != sa {
+        None
+    } else {
+        Some(FixedInt(out))
+    }
+}
+
+/// Native checked multiply with a CONSERVATIVE bit-length precheck.
+///
+/// The signed range of a K-limb value is `[-2^(w-1), 2^(w-1)-1]` with
+/// `w = K*64`. Let `la = bitlen(|a|)`, `lb = bitlen(|b|)`.
+/// - `la + lb <= w-1` ⇒ `|a*b| < 2^(w-1)` ⇒ fits both signs ⇒ fast low-K product.
+/// - `la + lb >= w+2` ⇒ `|a*b| >= 2^w > 2^(w-1)` ⇒ overflows both signs ⇒ `None`.
+/// - `la + lb ∈ {w, w+1}` (ambiguous, straddles `MIN`): compute the full 2K-limb
+///   two's-complement product and narrow it exactly (fits iff the high K limbs
+///   are the sign extension of limb `K-1`, which correctly admits exactly `MIN`).
+///
+/// Both prechecks are one-sided/conservative, so a wrong `Some` is impossible;
+/// the differential fuzz pins agreement with `bnum` on value and verdict.
+#[inline]
+fn checked_mul_limbs<const K: usize>(a: &FixedInt<K>, b: &FixedInt<K>) -> Option<FixedInt<K>> {
+    let (ma, sa) = magnitude(a);
+    let (mb, sb) = magnitude(b);
+    let la = bit_length(&ma);
+    let lb = bit_length(&mb);
+    if la == 0 || lb == 0 {
+        return Some(FixedInt([0u64; K]));
+    }
+    let neg = sa ^ sb;
+    let w = K * 64;
+
+    if la + lb <= w - 1 {
+        // Fast-accept: provably fits.
+        let lo = mul_low(&ma, &mb);
+        let out = if neg { negate(&lo) } else { lo };
+        return Some(FixedInt(out));
+    }
+    if la + lb >= w + 2 {
+        // Fast-reject: provably overflows.
+        return None;
+    }
+
+    // Ambiguous band: full 2K-limb magnitude product, then exact narrowing.
+    debug_assert!(K <= 32, "FixedInt checked_mul scratch supports only K <= 32");
+    let n2 = 2 * K;
+    let mut full = [0u64; 64];
+    for i in 0..K {
+        let mut carry: u128 = 0;
+        for j in 0..K {
+            let idx = i + j;
+            let t = (ma[i] as u128) * (mb[j] as u128) + (full[idx] as u128) + carry;
+            full[idx] = t as u64;
+            carry = t >> 64;
+        }
+        full[i + K] = carry as u64;
+    }
+    if neg {
+        // Two's-complement negate over the low n2 limbs in place.
+        let mut c = 1u64;
+        for slot in full.iter_mut().take(n2) {
+            let (v, cc) = (!*slot).overflowing_add(c);
+            *slot = v;
+            c = cc as u64;
+        }
+    }
+    // Fits in K limbs iff the upper half is the sign extension of the low half.
+    let ext = if full[K - 1] >> 63 == 1 { u64::MAX } else { 0 };
+    for &limb in &full[K..n2] {
+        if limb != ext {
+            return None;
+        }
+    }
+    let mut out = [0u64; K];
+    out.copy_from_slice(&full[..K]);
+    Some(FixedInt(out))
+}
+
+// ── bnum byte-bridge (the cold path) ────────────────────────────────────────
+
+/// Parse error placeholder for [`Num::from_str_radix`]; the predicate cascade
+/// never calls it, the impl exists only to satisfy the `Num` trait bound.
+#[derive(Debug, PartialEq, Eq)]
+pub struct ParseFixedIntError;
+
+/// Serialize the limbs into a fixed 256-byte little-endian scratch buffer
+/// (32 limbs = the widest supported width, I2048). Only the first `K*8` bytes
+/// are meaningful.
+#[inline]
+fn to_le_scratch<const K: usize>(x: &FixedInt<K>) -> [u8; 256] {
+    debug_assert!(K <= 32, "FixedInt bnum bridge supports only K <= 32");
+    let mut buf = [0u8; 256];
+    for i in 0..K {
+        buf[i * 8..i * 8 + 8].copy_from_slice(&x.0[i].to_le_bytes());
+    }
+    buf
+}
+
+/// Rebuild a `FixedInt<K>` from the first `K*8` little-endian bytes of `buf`.
+#[inline]
+fn from_le_scratch<const K: usize>(buf: &[u8]) -> FixedInt<K> {
+    let mut limbs = [0u64; K];
+    for i in 0..K {
+        let mut b = [0u8; 8];
+        b.copy_from_slice(&buf[i * 8..i * 8 + 8]);
+        limbs[i] = u64::from_le_bytes(b);
+    }
+    FixedInt(limbs)
+}
+
+/// Dispatch a binary op on the `bnum` signed type matching the width `K`,
+/// round-tripping both operands and the result through little-endian bytes.
+/// The `from_le_slice`/`to_le_bytes` layout is bit-identical to `FixedInt`, so
+/// the round-trip is lossless; the `unwrap` cannot fail because every canonical
+/// `K*8`-byte value is representable in `I{K*64}` (byte-aligned width, no pad).
+macro_rules! bnum_binary {
+    ($K:expr, $ab:expr, $bb:expr, |$x:ident, $y:ident| $op:expr) => {{
+        let nb = $K * 8;
+        match $K {
+            4 => {
+                let $x = bnum::types::I256::from_le_slice(&$ab[..nb]).unwrap();
+                let $y = bnum::types::I256::from_le_slice(&$bb[..nb]).unwrap();
+                from_le_scratch::<$K>(&($op).to_le_bytes())
+            }
+            8 => {
+                let $x = bnum::types::I512::from_le_slice(&$ab[..nb]).unwrap();
+                let $y = bnum::types::I512::from_le_slice(&$bb[..nb]).unwrap();
+                from_le_scratch::<$K>(&($op).to_le_bytes())
+            }
+            16 => {
+                let $x = bnum::types::I1024::from_le_slice(&$ab[..nb]).unwrap();
+                let $y = bnum::types::I1024::from_le_slice(&$bb[..nb]).unwrap();
+                from_le_scratch::<$K>(&($op).to_le_bytes())
+            }
+            32 => {
+                let $x = bnum::types::I2048::from_le_slice(&$ab[..nb]).unwrap();
+                let $y = bnum::types::I2048::from_le_slice(&$bb[..nb]).unwrap();
+                from_le_scratch::<$K>(&($op).to_le_bytes())
+            }
+            _ => panic!("FixedInt<{}>: bnum bridge supports only K in {{4,8,16,32}}", $K),
+        }
+    }};
+}
+
+#[inline]
+fn bnum_to_f64<const K: usize>(buf: &[u8]) -> Option<f64> {
+    let nb = K * 8;
+    match K {
+        4 => bnum::types::I256::from_le_slice(&buf[..nb]).unwrap().to_f64(),
+        8 => bnum::types::I512::from_le_slice(&buf[..nb]).unwrap().to_f64(),
+        16 => bnum::types::I1024::from_le_slice(&buf[..nb]).unwrap().to_f64(),
+        32 => bnum::types::I2048::from_le_slice(&buf[..nb]).unwrap().to_f64(),
+        _ => panic!("FixedInt<{K}>: bnum bridge supports only K in {{4,8,16,32}}"),
+    }
+}
+
+#[inline]
+fn bnum_from_str_radix<const K: usize>(
+    s: &str,
+    radix: u32,
+) -> Result<FixedInt<K>, ParseFixedIntError> {
+    match K {
+        4 => bnum::types::I256::from_str_radix(s, radix)
+            .map(|v| from_le_scratch::<K>(&v.to_le_bytes()))
+            .map_err(|_| ParseFixedIntError),
+        8 => bnum::types::I512::from_str_radix(s, radix)
+            .map(|v| from_le_scratch::<K>(&v.to_le_bytes()))
+            .map_err(|_| ParseFixedIntError),
+        16 => bnum::types::I1024::from_str_radix(s, radix)
+            .map(|v| from_le_scratch::<K>(&v.to_le_bytes()))
+            .map_err(|_| ParseFixedIntError),
+        32 => bnum::types::I2048::from_str_radix(s, radix)
+            .map(|v| from_le_scratch::<K>(&v.to_le_bytes()))
+            .map_err(|_| ParseFixedIntError),
+        _ => panic!("FixedInt<{K}>: bnum bridge supports only K in {{4,8,16,32}}"),
+    }
+}
+
+// ── std::ops ────────────────────────────────────────────────────────────────
+// Bare `Add`/`Sub`/`Mul` exist to satisfy the `CheckedAdd`/`CheckedSub`/
+// `CheckedMul`/`Num`/`One` supertrait bounds; the macro never calls them hot.
+// They wrap on overflow (two's complement), matching `bnum`'s `wrapping_*`.
+
+impl<const K: usize> Add for FixedInt<K> {
+    type Output = Self;
+    #[inline]
+    fn add(self, rhs: Self) -> Self {
+        FixedInt(wrapping_add(&self.0, &rhs.0))
+    }
+}
+
+impl<const K: usize> Sub for FixedInt<K> {
+    type Output = Self;
+    #[inline]
+    fn sub(self, rhs: Self) -> Self {
+        FixedInt(wrapping_sub(&self.0, &rhs.0))
+    }
+}
+
+impl<const K: usize> Mul for FixedInt<K> {
+    type Output = Self;
+    #[inline]
+    fn mul(self, rhs: Self) -> Self {
+        // Low-K limbs of the product agree for the signed and unsigned
+        // interpretations, so this is the wrapping signed product.
+        FixedInt(mul_low(&self.0, &rhs.0))
+    }
+}
+
+impl<const K: usize> Neg for FixedInt<K> {
+    type Output = Self;
+    #[inline]
+    fn neg(self) -> Self {
+        FixedInt(negate(&self.0))
+    }
+}
+
+impl<const K: usize> Div for FixedInt<K> {
+    type Output = Self;
+    #[inline]
+    fn div(self, rhs: Self) -> Self {
+        let ab = to_le_scratch(&self);
+        let bb = to_le_scratch(&rhs);
+        bnum_binary!(K, ab, bb, |x, y| x / y)
+    }
+}
+
+impl<const K: usize> Rem for FixedInt<K> {
+    type Output = Self;
+    #[inline]
+    fn rem(self, rhs: Self) -> Self {
+        let ab = to_le_scratch(&self);
+        let bb = to_le_scratch(&rhs);
+        bnum_binary!(K, ab, bb, |x, y| x % y)
+    }
+}
+
+// ── num_traits ──────────────────────────────────────────────────────────────
+
+impl<const K: usize> Zero for FixedInt<K> {
+    #[inline]
+    fn zero() -> Self {
+        FixedInt([0u64; K])
+    }
+    #[inline]
+    fn is_zero(&self) -> bool {
+        self.0.iter().all(|&l| l == 0)
+    }
+}
+
+impl<const K: usize> One for FixedInt<K> {
+    #[inline]
+    fn one() -> Self {
+        let mut limbs = [0u64; K];
+        limbs[0] = 1;
+        FixedInt(limbs)
+    }
+    #[inline]
+    fn is_one(&self) -> bool {
+        self.0[0] == 1 && self.0[1..].iter().all(|&l| l == 0)
+    }
+}
+
+impl<const K: usize> Num for FixedInt<K> {
+    type FromStrRadixErr = ParseFixedIntError;
+    #[inline]
+    fn from_str_radix(s: &str, radix: u32) -> Result<Self, Self::FromStrRadixErr> {
+        bnum_from_str_radix::<K>(s, radix)
+    }
+}
+
+impl<const K: usize> Signed for FixedInt<K> {
+    #[inline]
+    fn abs(&self) -> Self {
+        if is_neg(&self.0) {
+            FixedInt(negate(&self.0))
+        } else {
+            *self
+        }
+    }
+    #[inline]
+    fn abs_sub(&self, other: &Self) -> Self {
+        if self <= other {
+            FixedInt([0u64; K])
+        } else {
+            *self - *other
+        }
+    }
+    #[inline]
+    fn signum(&self) -> Self {
+        if is_neg(&self.0) {
+            FixedInt([u64::MAX; K]) // -1
+        } else if self.is_zero() {
+            FixedInt([0u64; K])
+        } else {
+            <Self as One>::one()
+        }
+    }
+    #[inline]
+    fn is_positive(&self) -> bool {
+        !is_neg(&self.0) && !self.is_zero()
+    }
+    #[inline]
+    fn is_negative(&self) -> bool {
+        is_neg(&self.0)
+    }
+}
+
+impl<const K: usize> FromPrimitive for FixedInt<K> {
+    #[inline]
+    fn from_i64(n: i64) -> Option<Self> {
+        let mut limbs = if n < 0 { [u64::MAX; K] } else { [0u64; K] };
+        limbs[0] = n as u64;
+        Some(FixedInt(limbs))
+    }
+    #[inline]
+    fn from_u64(n: u64) -> Option<Self> {
+        let mut limbs = [0u64; K];
+        limbs[0] = n;
+        Some(FixedInt(limbs))
+    }
+}
+
+impl<const K: usize> ToPrimitive for FixedInt<K> {
+    #[inline]
+    fn to_i64(&self) -> Option<i64> {
+        if is_neg(&self.0) {
+            for i in 1..K {
+                if self.0[i] != u64::MAX {
+                    return None;
+                }
+            }
+            let v = self.0[0];
+            if v >> 63 == 1 {
+                Some(v as i64)
+            } else {
+                None
+            }
+        } else {
+            for i in 1..K {
+                if self.0[i] != 0 {
+                    return None;
+                }
+            }
+            let v = self.0[0];
+            if v >> 63 == 0 {
+                Some(v as i64)
+            } else {
+                None
+            }
+        }
+    }
+    #[inline]
+    fn to_u64(&self) -> Option<u64> {
+        if is_neg(&self.0) {
+            return None;
+        }
+        for i in 1..K {
+            if self.0[i] != 0 {
+                return None;
+            }
+        }
+        Some(self.0[0])
+    }
+    #[inline]
+    fn to_f64(&self) -> Option<f64> {
+        // Delegate to bnum: the default `to_f64` routes through `to_i64` and
+        // would return `None` for the wide lambda values `point_to_f64` feeds it.
+        let buf = to_le_scratch(self);
+        bnum_to_f64::<K>(&buf)
+    }
+}
+
+impl<const K: usize> CheckedAdd for FixedInt<K> {
+    #[inline]
+    fn checked_add(&self, v: &Self) -> Option<Self> {
+        checked_add_limbs(self, v)
+    }
+}
+
+impl<const K: usize> CheckedSub for FixedInt<K> {
+    #[inline]
+    fn checked_sub(&self, v: &Self) -> Option<Self> {
+        checked_sub_limbs(self, v)
+    }
+}
+
+impl<const K: usize> CheckedMul for FixedInt<K> {
+    #[inline]
+    fn checked_mul(&self, v: &Self) -> Option<Self> {
+        checked_mul_limbs(self, v)
+    }
+}
+
+impl<const K: usize> Ord for FixedInt<K> {
+    #[inline]
+    fn cmp(&self, other: &Self) -> Ordering {
+        match (is_neg(&self.0), is_neg(&other.0)) {
+            (true, false) => Ordering::Less,
+            (false, true) => Ordering::Greater,
+            // Same sign: unsigned high-to-low limb compare gives signed order.
+            _ => {
+                for i in (0..K).rev() {
+                    match self.0[i].cmp(&other.0[i]) {
+                        Ordering::Equal => {}
+                        o => return o,
+                    }
+                }
+                Ordering::Equal
+            }
+        }
+    }
+}
+
+impl<const K: usize> PartialOrd for FixedInt<K> {
+    #[inline]
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+// The differential fuzz vs bnum (the correctness oracle) lives in the sibling
+// `tests.rs`; it is a child module so it keeps access to the private limbs.
+#[cfg(test)]
+mod tests;

--- a/rust/geometry/src/kernel/fixed_int/tests.rs
+++ b/rust/geometry/src/kernel/fixed_int/tests.rs
@@ -1,0 +1,280 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Differential fuzz for [`super::FixedInt`] against `bnum`: every hot op
+//! (native) and cold op (bnum bridge) is pinned to agree on value AND the
+//! `Some`/`None` overflow verdict across all four widths, boundary values, and
+//! a deterministic LCG stream. See the module doc in `mod.rs` for why.
+
+use super::*;
+use num_traits::{CheckedAdd, CheckedMul, CheckedSub, FromPrimitive, One, ToPrimitive};
+
+/// Deterministic LCG (no `rand` crate; fixed seed for reproducibility).
+/// Constants are Knuth's MMIX multiplier / increment, matching the LCG in
+/// `kernel/predicates.rs`.
+struct Lcg(u64);
+impl Lcg {
+    #[inline]
+    fn u(&mut self) -> u64 {
+        self.0 = self
+            .0
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        self.0
+    }
+}
+
+/// Generate a random `FixedInt<K>` whose magnitude has at most `maxbits`
+/// bits, then a random sign. Concentrating mass near a target bit length
+/// stresses the `checked_mul` overflow boundary where a truncated product
+/// could escape.
+macro_rules! rand_fixed {
+    ($rng:expr, $K:literal, $maxbits:expr) => {{
+        let bits = ($rng.u() as usize) % ($maxbits + 1); // 0..=maxbits
+        let mut limbs = [0u64; $K];
+        for l in limbs.iter_mut() {
+            *l = $rng.u();
+        }
+        for i in 0..$K {
+            let lo = i * 64;
+            if lo >= bits {
+                limbs[i] = 0;
+            } else if lo + 64 > bits {
+                let keep = bits - lo; // 1..=63 in this branch
+                limbs[i] &= (1u64 << keep) - 1;
+            }
+        }
+        let mut v = FixedInt::<$K>::from_limbs(limbs);
+        if $rng.u() & 1 == 1 {
+            v = -v;
+        }
+        v
+    }};
+}
+
+/// Stamp out a per-width differential fuzz test. `$K` is the limb count and
+/// `$BT` the matching `bnum` signed type (I256/I512/I1024/I2048).
+macro_rules! diff_fuzz {
+    ($name:ident, $K:literal, $BT:path) => {
+        #[test]
+        fn $name() {
+            const W: usize = $K * 64; // total bit width
+
+            // FixedInt<K> -> bnum, built independently from the limbs so the
+            // hot-op comparisons are genuinely differential (native vs bnum).
+            let to_bnum = |x: &FixedInt<$K>| -> $BT {
+                let mut buf = [0u8; $K * 8];
+                for i in 0..$K {
+                    buf[i * 8..i * 8 + 8].copy_from_slice(&x.0[i].to_le_bytes());
+                }
+                <$BT>::from_le_slice(&buf).unwrap()
+            };
+
+            // Boundary set: 0, ±1, MIN, MAX, MIN+1, MAX-1, i64/u64 edges,
+            // half-width powers of two (mul overflow straddles).
+            let mut min_limbs = [0u64; $K];
+            min_limbs[$K - 1] = 1u64 << 63;
+            let mut max_limbs = [u64::MAX; $K];
+            max_limbs[$K - 1] = i64::MAX as u64; // 0x7FFF...
+            let mut half_limbs = [0u64; $K]; // 2^(W/2)
+            half_limbs[$K / 2] = 1;
+            let zero = FixedInt::<$K>::from_limbs([0u64; $K]);
+            let one = <FixedInt<$K> as One>::one();
+            let min = FixedInt::<$K>::from_limbs(min_limbs);
+            let max = FixedInt::<$K>::from_limbs(max_limbs);
+            let half = FixedInt::<$K>::from_limbs(half_limbs);
+            let mut boundaries: Vec<FixedInt<$K>> = vec![
+                zero,
+                one,
+                -one,
+                min,
+                max,
+                min + one,          // MIN+1
+                max - one,          // MAX-1
+                half,
+                -half,
+                half - one,         // 2^(W/2) - 1
+                -(half - one),
+                <FixedInt<$K> as FromPrimitive>::from_i64(i64::MAX).unwrap(),
+                <FixedInt<$K> as FromPrimitive>::from_i64(i64::MIN).unwrap(),
+                <FixedInt<$K> as FromPrimitive>::from_u64(u64::MAX).unwrap(),
+                <FixedInt<$K> as FromPrimitive>::from_i64(-1).unwrap(),
+            ];
+
+            // Assert a single pair agrees across every op vs bnum.
+            let check_pair = |a: &FixedInt<$K>, b: &FixedInt<$K>| {
+                let (ba, bb) = (to_bnum(a), to_bnum(b));
+
+                // checked_add / sub / mul: value AND Some/None verdict.
+                assert_eq!(
+                    CheckedAdd::checked_add(a, b).map(|r| to_bnum(&r)),
+                    CheckedAdd::checked_add(&ba, &bb),
+                    "checked_add mismatch a={:?} b={:?}",
+                    a.0,
+                    b.0
+                );
+                assert_eq!(
+                    CheckedSub::checked_sub(a, b).map(|r| to_bnum(&r)),
+                    CheckedSub::checked_sub(&ba, &bb),
+                    "checked_sub mismatch a={:?} b={:?}",
+                    a.0,
+                    b.0
+                );
+                assert_eq!(
+                    CheckedMul::checked_mul(a, b).map(|r| to_bnum(&r)),
+                    CheckedMul::checked_mul(&ba, &bb),
+                    "checked_mul mismatch a={:?} b={:?}",
+                    a.0,
+                    b.0
+                );
+
+                // Ordering.
+                assert_eq!(
+                    a.cmp(b),
+                    ba.cmp(&bb),
+                    "cmp mismatch a={:?} b={:?}",
+                    a.0,
+                    b.0
+                );
+
+                // Div / Rem: bnum panics on zero divisor and on MIN / -1
+                // (both guarded away in production; d is canonically > 0).
+                let is_min = *b == min;
+                let is_neg_one = *b == -one;
+                if !b.is_zero() && !(*a == min && is_neg_one) && !is_min {
+                    assert_eq!(
+                        to_bnum(&(*a / *b)),
+                        ba / bb,
+                        "div mismatch a={:?} b={:?}",
+                        a.0,
+                        b.0
+                    );
+                    assert_eq!(
+                        to_bnum(&(*a % *b)),
+                        ba % bb,
+                        "rem mismatch a={:?} b={:?}",
+                        a.0,
+                        b.0
+                    );
+                }
+            };
+
+            // Unary invariants vs bnum for a single value.
+            let check_unary = |a: &FixedInt<$K>| {
+                let ba = to_bnum(a);
+                assert_eq!(to_bnum(&(-*a)), ba.wrapping_neg(), "neg mismatch {:?}", a.0);
+                assert_eq!(a.to_i64(), ba.to_i64(), "to_i64 mismatch {:?}", a.0);
+                assert_eq!(a.to_u64(), ba.to_u64(), "to_u64 mismatch {:?}", a.0);
+                assert_eq!(a.to_f64(), ba.to_f64(), "to_f64 mismatch {:?}", a.0);
+                assert_eq!(a.is_zero(), ba.is_zero(), "is_zero mismatch {:?}", a.0);
+                assert_eq!(a.is_one(), ba.is_one(), "is_one mismatch {:?}", a.0);
+                assert_eq!(a.is_negative(), ba.is_negative(), "is_neg mismatch {:?}", a.0);
+                // is_positive is fully determined by is_negative + is_zero,
+                // both pinned above; verify the composite matches bnum.
+                assert_eq!(
+                    !a.is_negative() && !a.is_zero(),
+                    ba.is_positive(),
+                    "is_pos mismatch {:?}",
+                    a.0
+                );
+            };
+
+            // Seed the boundary set with a handful of near-boundary randoms.
+            let mut seed = Lcg(0x1234_5678_9abc_def0 ^ (W as u64));
+            for _ in 0..8 {
+                boundaries.push(rand_fixed!(seed, $K, W - 1));
+            }
+
+            // All boundary pairs (exact edge coverage).
+            for a in &boundaries {
+                check_unary(a);
+                for b in &boundaries {
+                    check_pair(a, b);
+                }
+            }
+
+            // Random stream, heavy on the multiply overflow boundary: draw
+            // magnitudes across the whole width so products straddle W bits.
+            let mut rng = Lcg(0xdead_beef_0000_0000 ^ (W as u64));
+            for _ in 0..40_000 {
+                let a = rand_fixed!(rng, $K, W - 1);
+                let b = rand_fixed!(rng, $K, W - 1);
+                check_unary(&a);
+                check_pair(&a, &b);
+
+                // from_i64 / from_u64 exactness.
+                let n = rng.u() as i64;
+                assert_eq!(
+                    to_bnum(&<FixedInt<$K> as FromPrimitive>::from_i64(n).unwrap()),
+                    <$BT as FromPrimitive>::from_i64(n).unwrap(),
+                    "from_i64 mismatch n={n}"
+                );
+                let m = rng.u();
+                assert_eq!(
+                    to_bnum(&<FixedInt<$K> as FromPrimitive>::from_u64(m).unwrap()),
+                    <$BT as FromPrimitive>::from_u64(m).unwrap(),
+                    "from_u64 mismatch m={m}"
+                );
+            }
+
+            // Extra multiply-boundary sweep: pin bit-length sums around W so
+            // both the fast-accept edge (W-1) and the ambiguous band (W, W+1)
+            // are exercised densely.
+            let mut rng2 = Lcg(0x0f0f_0f0f_f0f0_f0f0 ^ (W as u64));
+            for _ in 0..40_000 {
+                let ba_bits = (rng2.u() as usize) % (W / 2 + 2) + (W / 2 - 1);
+                let bb_bits = W - (ba_bits.min(W)); // partner so sum ~ W
+                let a = rand_fixed!(rng2, $K, ba_bits.min(W - 1));
+                let b = rand_fixed!(rng2, $K, (bb_bits + 2).min(W - 1));
+                let ta = to_bnum(&a);
+                let tb = to_bnum(&b);
+                assert_eq!(
+                    CheckedMul::checked_mul(&a, &b).map(|r| to_bnum(&r)),
+                    CheckedMul::checked_mul(&ta, &tb),
+                    "checked_mul boundary mismatch a={:?} b={:?}",
+                    a.0,
+                    b.0
+                );
+            }
+        }
+    };
+}
+
+diff_fuzz!(fuzz_i256, 4, bnum::types::I256);
+diff_fuzz!(fuzz_i512, 8, bnum::types::I512);
+diff_fuzz!(fuzz_i1024, 16, bnum::types::I1024);
+diff_fuzz!(fuzz_i2048, 32, bnum::types::I2048);
+
+/// Targeted MIN-boundary check: `MIN * 1`, `MIN * -1` (overflow), `(-half) *
+/// (-half)` at the exact `MIN` product for even widths.
+#[test]
+fn checked_mul_min_boundary() {
+    // I256: MIN = -2^255. MIN * 1 = MIN (fits). MIN * -1 = 2^255 (overflow).
+    let mut min_limbs = [0u64; 4];
+    min_limbs[3] = 1u64 << 63;
+    let min = FixedInt::<4>::from_limbs(min_limbs);
+    let one = <FixedInt<4> as One>::one();
+    let neg_one = -one;
+    assert_eq!(CheckedMul::checked_mul(&min, &one), Some(min));
+    assert_eq!(CheckedMul::checked_mul(&min, &neg_one), None);
+
+    // (-2^127) * (-2^127) = 2^254 (fits, positive, top bit clear).
+    let mut h = [0u64; 4];
+    h[1] = 1u64 << 63; // 2^127
+    let two127 = FixedInt::<4>::from_limbs(h);
+    let neg = -two127;
+    let prod = CheckedMul::checked_mul(&neg, &neg).expect("2^254 fits I256");
+    let mut expect = [0u64; 4];
+    expect[3] = 1u64 << 62; // 2^254
+    assert_eq!(prod, FixedInt::<4>::from_limbs(expect));
+
+    // (-2^128) * (2^127) = -2^255 = MIN exactly (fits ONLY because negative).
+    let mut a = [0u64; 4];
+    a[2] = 1; // 2^128
+    let two128 = FixedInt::<4>::from_limbs(a);
+    let prod2 = CheckedMul::checked_mul(&(-two128), &two127).expect("-2^255 = MIN fits");
+    assert_eq!(prod2, min);
+    // Positive 2^255 must overflow.
+    assert_eq!(CheckedMul::checked_mul(&two128, &two127), None);
+}

--- a/rust/geometry/src/kernel/mod.rs
+++ b/rust/geometry/src/kernel/mod.rs
@@ -19,6 +19,10 @@ pub mod broadphase;
 pub mod budget;
 pub mod coplanar;
 pub mod fixed;
+// Public because `fixed::Lam` (a `pub type`) and the `pub` cached-lambda
+// predicates expose `FixedInt` exactly as they previously exposed the external
+// `bnum::types::I512`; a narrower visibility would trip `private_interfaces`.
+pub mod fixed_int;
 pub mod interner;
 pub mod interval;
 pub mod manifest;

--- a/rust/processing/tests/module_size_allowlist.txt
+++ b/rust/processing/tests/module_size_allowlist.txt
@@ -40,6 +40,8 @@
      410 rust/geometry/src/geom_hash.rs
      633 rust/geometry/src/kernel/arrangement/classify.rs
      566 rust/geometry/src/kernel/fixed.rs
+# NEW (#1655): register-resident FixedInt<K> newtype backing the exact predicate cascade; large because it is a drop-in for bnum's I512 and must carry the full num_traits + std::ops trait surface (16 impls) the fixed_impl! macro binds. Its differential fuzz is split into the sibling tests.rs, kept under budget.
+     630 rust/geometry/src/kernel/fixed_int/mod.rs
 # +39: begin()/tripped() budget-guard added to the union & intersection kernel entries (#1109 parity with subtract).
 # +7: union_many threads/documents union_all's new (union, conforming) signal (B8 arrange-many parity).
 # +12: near_band_from_extent (the snap-scatter band formula) single-homed here, next to canonical SNAP_GRID; tritri/classify import it instead of mirroring the expression.


### PR DESCRIPTION
## What

Replace the `bnum` `I256`/`I512`/`I1024`/`I2048` backing of the fixed-width exact predicate cascade (`rust/geometry/src/kernel/fixed.rs`) with a new local `FixedInt<const K: usize>` newtype over `[u64; K]` little-endian two's-complement limbs.

`bnum` 0.14 backs its `Integer` with a `[u8; N]` byte array, so the hot `add`/`sub`/`mul`/`neg`/`sign` ops that dominate every LPI/TPI lambda and determinant paid byte-granular work. `FixedInt` hand-rolls those hot ops as native 64-bit limb arithmetic and stays register-resident.

## Approach

New module `rust/geometry/src/kernel/fixed_int/` (`mod.rs` + `tests.rs`):

- `pub struct FixedInt<const K: usize>([u64; K])`, LE two's-complement, `Copy`/`Clone`/`Debug`/`PartialEq`/`Eq`. It is a **newtype**, not the bare `[u64; K]` alias the issue text suggested: the orphan rule forbids implementing foreign `num_traits` traits on a foreign array type.
- HOT ops are native: `checked_add`/`checked_sub`/`checked_neg` via limb carry chains with signed-overflow detection; `checked_mul` via a **conservative** bit-length precheck (fast-accept only when the product provably fits in `K*64-1` magnitude bits, fast-reject only when it provably overflows, and an exact full-width 2K-limb narrowing check in the ambiguous band that correctly admits exactly `MIN`); `Signed`/`Zero`/`One`, `FromPrimitive::from_i64`, `ToPrimitive::to_i64`, and `Ord`.
- COLD ops (`Div`, `Rem`, `to_f64`, `from_str_radix`) delegate to `bnum` through a bit-exact little-endian byte round-trip. `FixedInt<K>`'s `K` u64 limbs are `K*8` bytes and `bnum::types::I{K*64}` stores `K*8` bytes in the same LE two's-complement layout (byte-aligned, no pad bits), so `to_le_bytes`/`from_le_slice` is lossless.
- The inherent `is_negative` takes `self` by value (mirroring `bnum`'s `Int::is_negative(self)`), so the macro's `sign_of(x: &I)` still binds the `Signed` trait method and its `use num_traits::Signed` stays genuinely used, while `lambda1024`'s owned `d.is_negative()` binds the inherent one.

In `fixed.rs`, only the 7 `fixed_impl!` type args and the cached-lambda `type Big` alias change (16 lines). The `fixed_impl!` macro body and every caller are untouched; `bnum` stays a dependency. `FixedInt` is `pub` in a `pub mod` because `fixed::Lam` (a `pub type`) and the `pub` cached-lambda predicates expose it exactly as they previously exposed the external `bnum::types::I512`; a narrower visibility would trip `private_interfaces` under CI's `clippy -D warnings`.

## Verification ladder

1. **Differential fuzz vs bnum** (`fixed_int/tests.rs`, written before wiring `fixed.rs`): all four widths K = 4/8/16/32, an enumerated boundary set (0, +/-1, MIN, MAX, MIN+1, MAX-1, i64/u64 edges, half-width powers of two), all boundary pairs, and ~80k deterministic-LCG random pairs per width (no `rand` crate), plus a dense multiply-overflow-boundary sweep. Every op agrees with `bnum` on **value AND the `Some`/`None` overflow verdict**. Passes.
2. **Three pinned manifests byte-identical**: `indirect_sign 0xdd1d_d6b0_0013_0af5`, `boolean 0x0465_b83a_5fdb_8b2b`, `retriangulation 0xef5b_32fd_d838_4776`. Unchanged.
3. **wasm32 manifest cross-check**: `wasm-pack test --node rust/wasm-bindings --test mesh_determinism` passes against the pinned `mesh_determinism.wasm32.json` (byte-identical). The exact predicate arithmetic is pure integer limb math, so it is platform-deterministic by construction.
4. **Mesh byte-parity on real models**: the native `mesh_determinism` manifest (voids, multi-material, curved-profile battery) is byte-identical; the `wall_opening_cut_regression` real-model CSG cuts (ara3d `advanced_model.ifc`) pass; the full geometry suite (569) and processing suite (120) pass. The one exception, `production_smiley_all_host_walls_have_holes`, fails **identically on the bnum baseline and on FixedInt** (3/190 walls, a pre-existing fixture-version artifact for a dev-local fixture that is not in the fetch manifest and skips on CI), confirming no behavioural change.
5. **Measured perf**: native `scripts/perf/probe.sh` (the same Rust CSG code that runs in wasm), best-of-10, A/B on the same machine by toggling only the kernel backing. On the CSG-heavy `ara3d/advanced_model.ifc` (55 subtracts, geometry = 88.8% of load) the **geometry phase drops from ~643-654 ms (bnum) to ~534-556 ms (FixedInt), roughly a 15-17% speedup** (total load ~720 ms to ~640 ms, ~11%). On the low-CSG `schependomlaan.ifc` control the geometry phase is flat (48 vs 50 ms, noise), as expected. This is below the issue's 15-28% upper estimate; wasm end-to-end may differ further since CSG there is also memory-bandwidth and worker-throttle bound.

No changeset (rust internals compiled into wasm; no `packages/wasm/pkg/package.json` change). `clippy --all-targets -- -D warnings` is clean and the module-size ratchet is satisfied (the impl file carries one allowlist row with justification; the fuzz is split into a sibling `tests.rs` kept under budget).

Closes #1655
