### PR TITLE
chore: package metadata hygiene across published packages

### DIFF
--- a/.changeset/package-metadata-hygiene.md
+++ b/.changeset/package-metadata-hygiene.md
@@ -1,0 +1,9 @@
+---
+'@ifc-lite/codegen': patch
+'@ifc-lite/embed-protocol': patch
+'@ifc-lite/embed-sdk': patch
+'@ifc-lite/wasm': patch
+'create-ifc-lite': patch
+---
+
+Package metadata hygiene: correct the @ifc-lite/codegen license field to MPL-2.0 (the source has always carried MPL headers; the MIT value was a scaffolding accident) and give it a files allowlist so the npm tarball ships dist, schemas, and README instead of the whole package directory. Add the missing publishConfig, homepage, and bugs fields to codegen, embed-protocol, embed-sdk, and wasm, and homepage/bugs to create-ifc-lite, matching the rest of the workspace.

--- a/packages/codegen/package.json
+++ b/packages/codegen/package.json
@@ -24,8 +24,8 @@
     "codegen",
     "typescript"
   ],
-  "author": "",
-  "license": "MIT",
+  "author": "Louis True",
+  "license": "MPL-2.0",
   "dependencies": {
     "@ifc-lite/data": "workspace:^",
     "commander": "^15.0.0"
@@ -34,5 +34,15 @@
     "@types/node": "^26.1.0",
     "typescript": "^6.0.3",
     "vitest": "^4.1.9"
-  }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://ltplus-ag.github.io/ifc-lite/",
+  "bugs": "https://github.com/LTplus-AG/ifc-lite/issues",
+  "files": [
+    "dist",
+    "schemas",
+    "README.md"
+  ]
 }

--- a/packages/create-ifc-lite/package.json
+++ b/packages/create-ifc-lite/package.json
@@ -37,5 +37,7 @@
   "devDependencies": {
     "@types/node": "^26.1.0",
     "typescript": "^5.3.0"
-  }
+  },
+  "homepage": "https://ltplus-ag.github.io/ifc-lite/",
+  "bugs": "https://github.com/LTplus-AG/ifc-lite/issues"
 }

--- a/packages/embed-protocol/package.json
+++ b/packages/embed-protocol/package.json
@@ -27,5 +27,11 @@
   },
   "files": [
     "dist"
-  ]
+  ],
+  "author": "Louis True",
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://ltplus-ag.github.io/ifc-lite/",
+  "bugs": "https://github.com/LTplus-AG/ifc-lite/issues"
 }

--- a/packages/embed-sdk/package.json
+++ b/packages/embed-sdk/package.json
@@ -40,5 +40,11 @@
   ],
   "files": [
     "dist"
-  ]
+  ],
+  "author": "Louis True",
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://ltplus-ag.github.io/ifc-lite/",
+  "bugs": "https://github.com/LTplus-AG/ifc-lite/issues"
 }

--- a/packages/wasm/package.json
+++ b/packages/wasm/package.json
@@ -38,5 +38,11 @@
     "wasm",
     "webassembly",
     "aec"
-  ]
+  ],
+  "author": "Louis True",
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://ltplus-ag.github.io/ifc-lite/",
+  "bugs": "https://github.com/LTplus-AG/ifc-lite/issues"
 }


### PR DESCRIPTION
Follow-up to #1676 (flagged in its review).

## What

- **@ifc-lite/codegen**: `license` corrected MIT -> MPL-2.0. Every source file in the package carries the MPL header and the repo license is MPL-2.0; the MIT value was a scaffolding accident. Also adds `files: ["dist", "schemas", "README.md"]` so the tarball stops shipping src/test/generated, and fills in the empty `author`.
- **@ifc-lite/embed-protocol, @ifc-lite/embed-sdk, @ifc-lite/wasm**: add the `publishConfig`, `homepage`, `bugs`, and `author` fields the other 31 published packages already have.
- **create-ifc-lite**: add `homepage` and `bugs`.
- One changeset patch-bumps the five packages.

## Verification

Audited all 36 published packages for `license`/`publishConfig`/`homepage`/`bugs`/`repository`/`files`; these five were the only outliers. JSON formatting (2-space indent, trailing newline) preserved; diff contains only the intended fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)