### PR TITLE
feat(viewer): async lat/lon readout for the geo XYZ measure (#1657 follow-up)

### DIFF
--- a/apps/viewer/src/components/viewer/tools/MeasurePanel.tsx
+++ b/apps/viewer/src/components/viewer/tools/MeasurePanel.tsx
@@ -16,6 +16,11 @@ import { useDraggablePanel } from '@/hooks/useDraggablePanel';
 import { useAnchorGeoreference, type AnchorGeoreference } from '@/lib/geo/useAnchorGeoreference';
 import { viewerPointToProjected } from '@/lib/geo/pick-to-geo';
 import { mapUnitsToMeters } from '@/lib/geo/cesium-placement';
+import {
+  reprojectPointToLatLon,
+  reprojectionInputKey,
+  type LatLon,
+} from '@/lib/geo/reproject';
 
 interface Vec3Like { x: number; y: number; z: number }
 interface Enh { e: string; n: string; h: string }
@@ -47,6 +52,57 @@ function EnhLine({ label, enh }: { label?: string; enh: Enh }) {
       <span>H {enh.h}</span>
     </div>
   );
+}
+
+/**
+ * Resolve a picked viewer point to WGS84 lat/lon asynchronously (proj4). The
+ * synchronous E/N/H readout never blocks on this; lat/lon appears once the
+ * projection resolves and is `null` for a CRS proj4 can't resolve (the line is
+ * simply absent). The effect is keyed by a primitive derived from *all* inputs
+ * the reprojection consumes (CRS name + projection metadata + unit scales +
+ * quantised E/N) so it recomputes on any georef edit but not on unrelated
+ * re-renders — see {@link reprojectionInputKey}.
+ */
+function useProjectedLatLon(
+  point: Vec3Like | null,
+  anchor: AnchorGeoreference | null,
+): LatLon | null {
+  const [latLon, setLatLon] = useState<LatLon | null>(null);
+  const projected = point && anchor
+    ? viewerPointToProjected(point, anchor.eff, anchor.originViewer)
+    : null;
+  const key = projected && anchor
+    ? reprojectionInputKey(
+        projected.eastings,
+        projected.northings,
+        anchor.eff.projectedCRS,
+        anchor.eff.lengthUnitScale,
+      )
+    : '';
+
+  useEffect(() => {
+    if (!projected || !anchor) {
+      setLatLon(null);
+      return;
+    }
+    let cancelled = false;
+    void reprojectPointToLatLon(
+      projected.eastings,
+      projected.northings,
+      anchor.eff.projectedCRS,
+      anchor.eff.lengthUnitScale,
+    ).then((r) => {
+      if (!cancelled) setLatLon(r);
+    });
+    return () => {
+      cancelled = true;
+    };
+    // Keyed by the primitive `key` so unrelated re-renders don't refetch and a
+    // georef change that alters the projection always does.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [key]);
+
+  return latLon;
 }
 
 export function MeasureOverlay() {
@@ -133,6 +189,9 @@ export function MeasureOverlay() {
   const livePoint: Vec3Like | null = activeMeasurement?.current
     ?? (measurements.length > 0 ? measurements[measurements.length - 1].end : null);
   const liveEnh = showGeo && anchor && livePoint ? projectedEnh(livePoint, anchor) : null;
+  // Async WGS84 lat/lon for the live point. Non-blocking: null until proj4
+  // resolves (and stays null for an unresolvable CRS), so E/N/H is unaffected.
+  const liveLatLon = useProjectedLatLon(showGeo ? livePoint : null, showGeo ? anchor : null);
 
   const panelRef = React.useRef<HTMLDivElement>(null);
   const drag = useDraggablePanel(panelRef);
@@ -244,6 +303,11 @@ export function MeasureOverlay() {
           <div className="font-mono text-[9px] text-muted-foreground/80 mt-0.5 pl-5">
             {anchor.eff.projectedCRS.name}
           </div>
+          {liveLatLon && (
+            <div className="font-mono text-[10px] tabular-nums whitespace-nowrap text-muted-foreground mt-0.5 pl-5">
+              Lat {liveLatLon.lat.toFixed(6)} / Lon {liveLatLon.lon.toFixed(6)}
+            </div>
+          )}
         </div>
       )}
 

--- a/apps/viewer/src/lib/geo/reproject.adversarial.test.ts
+++ b/apps/viewer/src/lib/geo/reproject.adversarial.test.ts
@@ -74,7 +74,7 @@ describe('ADVERSARIAL: reprojectionInputKey collisions', () => {
   });
 
   it('PROBE_empty_vs_undefined_name: undefined and empty-string name share a key', () => {
-    const a = reprojectionInputKey(1, 2, { id: 1, name: undefined } as ProjectedCRS, 1);
+    const a = reprojectionInputKey(1, 2, { id: 1, name: undefined } as unknown as ProjectedCRS, 1);
     const b = reprojectionInputKey(1, 2, { id: 1, name: '' } as ProjectedCRS, 1);
     assert.strictEqual(a, b, 'name ?? "" collapses undefined and "" (benign: same resolveProjection path)');
   });

--- a/apps/viewer/src/lib/geo/reproject.adversarial.test.ts
+++ b/apps/viewer/src/lib/geo/reproject.adversarial.test.ts
@@ -1,0 +1,184 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * ADVERSARIAL probes for PR #1679 (async lat/lon readout for the geo measure).
+ *
+ * Targets:
+ *   reprojectPointToLatLon(), reprojectionInputKey() in reproject.ts
+ * Goal: BREAK them. Each test is named CONFIRMED_* (proves a defect) or
+ * REFUTED_* (proves a guard holds).
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+
+import {
+  reprojectPointToLatLon,
+  reprojectionInputKey,
+} from './reproject.js';
+import type { ProjectedCRS } from '@ifc-lite/parser';
+
+const utmCrs: ProjectedCRS = {
+  id: 18,
+  name: 'EPSG:32760',
+  mapUnit: 'METRE',
+  mapUnitScale: 1,
+};
+
+// ---------------------------------------------------------------------------
+// ATTACK 2: KEY COLLISIONS (delimiter injection, empty/undefined, -0)
+// ---------------------------------------------------------------------------
+describe('ADVERSARIAL: reprojectionInputKey collisions', () => {
+  it('delimiter injection cannot collide two different CRS configs', () => {
+    // Free-text fields (description, mapProjection) can contain the '|'
+    // character; a join('|') key let content shift across field boundaries
+    // and collide. The JSON-encoded key must keep such configs distinct.
+    const crsA: ProjectedCRS = {
+      id: 1, name: 'EPSG:32760', mapUnitScale: 1,
+      description: 'c', mapProjection: 'd|e',
+    };
+    const crsB: ProjectedCRS = {
+      id: 1, name: 'EPSG:32760', mapUnitScale: 1,
+      description: 'c|d', mapProjection: 'e',
+    };
+    const keyA = reprojectionInputKey(500000, 5000000, crsA, 1);
+    const keyB = reprojectionInputKey(500000, 5000000, crsB, 1);
+    assert.notStrictEqual(keyA, keyB,
+      'distinct configs must yield distinct keys (JSON-encoded key is injective)');
+  });
+
+  it('zone shifted across field boundaries yields distinct keys', async () => {
+    // mapZone is read FIRST by resolveProjection. Shifting a valid zone across
+    // the mapZone/description boundary changes reprojection resolvability, so
+    // the keys MUST differ or the async effect would freeze on a stale value.
+    const resolves: ProjectedCRS = {
+      id: 1, name: '', mapZone: '60S', description: 'A|B', mapUnitScale: 1,
+    };
+    const doesNot: ProjectedCRS = {
+      id: 1, name: '', mapZone: '60S|A', description: 'B', mapUnitScale: 1,
+    };
+    const kR = reprojectionInputKey(500000, 5000000, resolves, 1);
+    const kD = reprojectionInputKey(500000, 5000000, doesNot, 1);
+    assert.notStrictEqual(kR, kD, 'distinct zone/description splits must yield distinct keys');
+
+    // The two genuinely reproject differently: '60S' -> valid UTM,
+    // '60S|A' -> not a zone -> null. Distinct keys make the effect refetch.
+    const rr = await reprojectPointToLatLon(500000, 5000000, resolves, 1);
+    const rd = await reprojectPointToLatLon(500000, 5000000, doesNot, 1);
+    assert.ok(rr, "'60S' should resolve to a lat/lon");
+    assert.strictEqual(rd, null, "'60S|A' should be unresolvable");
+    // Same key yet different truth: a live georef edit between these is invisible
+    // to the effect -> stale lat/lon retained.
+  });
+
+  it('PROBE_empty_vs_undefined_name: undefined and empty-string name share a key', () => {
+    const a = reprojectionInputKey(1, 2, { id: 1, name: undefined } as ProjectedCRS, 1);
+    const b = reprojectionInputKey(1, 2, { id: 1, name: '' } as ProjectedCRS, 1);
+    assert.strictEqual(a, b, 'name ?? "" collapses undefined and "" (benign: same resolveProjection path)');
+  });
+
+  it('REFUTED_negative_zero: -0 easting and +0 easting produce the same key (join coerces -0 -> "0")', () => {
+    const a = reprojectionInputKey(-0, 0, utmCrs, 1);
+    const b = reprojectionInputKey(0, 0, utmCrs, 1);
+    assert.strictEqual(a, b, 'no -0 vs 0 key drift');
+    assert.ok(!a.includes('-0'), 'key must not contain a literal -0 token');
+  });
+
+  it('PROBE_quantisation_rounding_boundary: values 0.5mm either side of a bucket edge', () => {
+    // metre CRS: eMm = round(E*1000). E=0.0015 -> 2 (round half up), E=0.0025 -> 3 (round half to even? no, JS Math.round is half-up)
+    const a = reprojectionInputKey(0.00149, 0, utmCrs, 1); // *1000=1.49 -> 1
+    const b = reprojectionInputKey(0.00151, 0, utmCrs, 1); // *1000=1.51 -> 2
+    assert.notStrictEqual(a, b, 'a >0.5mm move across a bucket edge changes the key (expected)');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ATTACK 3: HOSTILE INPUTS to reprojectPointToLatLon (must return null, never throw / never NaN)
+// ---------------------------------------------------------------------------
+describe('ADVERSARIAL: reprojectPointToLatLon hostile inputs', () => {
+  it('REFUTED_NaN_input: NaN easting/northing returns null (not NaN, not throw)', async () => {
+    const r = await reprojectPointToLatLon(NaN, NaN, utmCrs, 1);
+    assert.strictEqual(r, null);
+  });
+
+  it('REFUTED_Infinity_input: +/-Infinity returns null', async () => {
+    const rp = await reprojectPointToLatLon(Infinity, Infinity, utmCrs, 1);
+    const rn = await reprojectPointToLatLon(-Infinity, -Infinity, utmCrs, 1);
+    assert.strictEqual(rp, null);
+    assert.strictEqual(rn, null);
+  });
+
+  it('REFUTED_wild_out_of_zone: easting/northing light-years outside the zone returns null (not garbage lat/lon)', async () => {
+    const r = await reprojectPointToLatLon(1e18, 1e18, utmCrs, 1);
+    if (r) {
+      assert.ok(Number.isFinite(r.lat) && Number.isFinite(r.lon), 'if non-null, must be finite');
+      assert.ok(r.lat >= -90 && r.lat <= 90, 'lat within range');
+      assert.ok(r.lon >= -180 && r.lon <= 180, 'lon within range');
+    } else {
+      assert.strictEqual(r, null);
+    }
+  });
+
+  it('PROBE_mapUnitScale_zero: mapUnitScale=0 is silently reinterpreted as 1 (no crash)', async () => {
+    const zeroScale: ProjectedCRS = { id: 1, name: 'EPSG:32760', mapUnitScale: 0 };
+    // With mapUnitScale=0, resolveMapUnitToMetreScale returns 1 -> treated as metres.
+    const r = await reprojectPointToLatLon(500000, 5000000, zeroScale, 1);
+    // Should behave identically to a metre CRS, not zero-collapse the coordinates.
+    const ref = await reprojectPointToLatLon(500000, 5000000, utmCrs, 1);
+    assert.deepStrictEqual(r, ref, 'mapUnitScale=0 falls back to 1 (metre) rather than collapsing to origin');
+  });
+
+  it('PROBE_negative_mapUnitScale: negative mapUnitScale also falls back to 1', async () => {
+    const neg: ProjectedCRS = { id: 1, name: 'EPSG:32760', mapUnitScale: -0.001 };
+    const r = await reprojectPointToLatLon(500000, 5000000, neg, 1);
+    const ref = await reprojectPointToLatLon(500000, 5000000, utmCrs, 1);
+    assert.deepStrictEqual(r, ref, 'negative mapUnitScale falls back to 1, not a mirrored/negative coordinate');
+  });
+
+  it('REFUTED_geographic_out_of_range: geographic CRS with lat>90 returns null', async () => {
+    const geo: ProjectedCRS = { id: 1, name: 'EPSG:4326' };
+    // eastings=lon, northings=lat. Feed an impossible latitude.
+    const r = await reprojectPointToLatLon(200, 999, geo, 1);
+    assert.strictEqual(r, null, 'lat 999 must be rejected, not rendered as 999.000000');
+  });
+
+  it('PROBE_geographic_ignores_mapUnitScale: geographic CRS does NOT scale eastings by mapUnitScale', async () => {
+    // A mm-declared geographic CRS: the geographic branch treats eastings as lon
+    // degrees verbatim (no *mapScale). If a file mislabels a lon/lat CRS as
+    // MILLIMETRE, a valid lon like 5 is used as-is (fine), but this asymmetry
+    // vs the projected branch is worth noting.
+    const geoMm: ProjectedCRS = { id: 1, name: 'EPSG:4326', mapUnit: 'MILLIMETRE', mapUnitScale: 0.001 };
+    const r = await reprojectPointToLatLon(5, 52, geoMm, 1);
+    assert.ok(r, 'lon 5 / lat 52 accepted verbatim');
+    assert.strictEqual(r!.lon, 5, 'lon not scaled by mapUnitScale in the geographic branch');
+    assert.strictEqual(r!.lat, 52);
+  });
+
+  it('REFUTED_never_throws_on_garbage_crs_name: bogus EPSG code returns null', async () => {
+    const bogus: ProjectedCRS = { id: 1, name: 'EPSG:0' };
+    const r = await reprojectPointToLatLon(500000, 5000000, bogus, 1);
+    assert.strictEqual(r, null);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ATTACK 1 (partial, unit-testable slice): out-of-order microtask resolution.
+// The React latest-wins guard lives in the hook (cannot mount here), but we can
+// at least confirm reprojectPointToLatLon is deterministic and its resolution
+// order for interleaved calls is FIFO for a cached CRS (so the hook's cancelled
+// flag is the only thing that must guard order).
+// ---------------------------------------------------------------------------
+describe('ADVERSARIAL: async ordering sanity (hook guard reasoned separately)', () => {
+  it('PROBE_interleaved_resolution_order: two overlapping calls both resolve, order observed', async () => {
+    const order: string[] = [];
+    const p1 = reprojectPointToLatLon(500000, 5000000, utmCrs, 1).then((r) => { order.push('A'); return r; });
+    const p2 = reprojectPointToLatLon(600000, 5000000, utmCrs, 1).then((r) => { order.push('B'); return r; });
+    const [a, b] = await Promise.all([p1, p2]);
+    assert.ok(a && b);
+    // Document the observed order; the hook must NOT rely on it (it uses a
+    // per-effect `cancelled` flag instead).
+    assert.deepStrictEqual(order, ['A', 'B'], 'FIFO for cached CRS in this run (informational)');
+  });
+});

--- a/apps/viewer/src/lib/geo/reproject.test.ts
+++ b/apps/viewer/src/lib/geo/reproject.test.ts
@@ -10,6 +10,8 @@ import {
   computeFootprintGeoJSON,
   computeModelCenterInIfcMeters,
   reprojectFromLatLon,
+  reprojectionInputKey,
+  reprojectPointToLatLon,
   reprojectToLatLon,
   resolveProjection,
   sanitizeProj4,
@@ -244,5 +246,106 @@ describe('reproject helpers', () => {
     assert.ok(footprint);
     assert.strictEqual(footprint!.length, 5);
     assert.deepStrictEqual(footprint![0], footprint![4]);
+  });
+});
+
+describe('reprojectPointToLatLon (#1657 measure geo lat/lon)', () => {
+  // building-architecture.ifc constants (EPSG:32760, UTM zone 60S), offsets in
+  // millimetres (mapUnitScale 0.001) — mirrors pick-to-geo.test.ts.
+  const BUILDING_ARCH_EASTINGS_MM = 729013348.8297004;
+  const BUILDING_ARCH_NORTHINGS_MM = 9063992684.697363;
+  const mmCrs: ProjectedCRS = {
+    id: 18,
+    name: 'EPSG:32760',
+    mapUnit: 'MILLIMETRE',
+    mapUnitScale: 0.001,
+  };
+  const metreCrs: ProjectedCRS = {
+    id: 18,
+    name: 'EPSG:32760',
+    mapUnit: 'METRE',
+    mapUnitScale: 1,
+  };
+
+  it('reprojects a picked E/N (mm CRS) to WGS84 in the expected UTM-60S region', async () => {
+    const latLon = await reprojectPointToLatLon(
+      BUILDING_ARCH_EASTINGS_MM,
+      BUILDING_ARCH_NORTHINGS_MM,
+      mmCrs,
+      0.001,
+    );
+    assert.ok(latLon, 'should resolve for a bundled UTM code');
+    // Zone 60S, central meridian 177E: this E/N lands just east of the antimeridian
+    // in the southern hemisphere.
+    assert.ok(latLon!.lat < 0 && latLon!.lat > -20, `lat = ${latLon!.lat} (expected southern)`);
+    assert.ok(latLon!.lon > 170 && latLon!.lon <= 180, `lon = ${latLon!.lon} (expected ~zone 60)`);
+  });
+
+  it('honours the map-unit scale: mm offsets and equivalent metre offsets agree', async () => {
+    const fromMm = await reprojectPointToLatLon(
+      BUILDING_ARCH_EASTINGS_MM,
+      BUILDING_ARCH_NORTHINGS_MM,
+      mmCrs,
+      0.001,
+    );
+    const fromMetres = await reprojectPointToLatLon(
+      BUILDING_ARCH_EASTINGS_MM * 0.001,
+      BUILDING_ARCH_NORTHINGS_MM * 0.001,
+      metreCrs,
+      1,
+    );
+    assert.ok(fromMm && fromMetres);
+    assert.ok(Math.abs(fromMm!.lat - fromMetres!.lat) < 1e-9, 'lat must match across unit scaling');
+    assert.ok(Math.abs(fromMm!.lon - fromMetres!.lon) < 1e-9, 'lon must match across unit scaling');
+  });
+
+  it('returns null (never throws) for an unresolvable CRS', async () => {
+    const unknown: ProjectedCRS = { id: 1, name: 'TOTALLY_UNKNOWN_CRS' };
+    const latLon = await reprojectPointToLatLon(500000, 5000000, unknown, 1);
+    assert.strictEqual(latLon, null);
+  });
+});
+
+describe('reprojectionInputKey (effect dependency correctness)', () => {
+  const crs: ProjectedCRS = {
+    id: 1,
+    name: 'EPSG:32760',
+    mapUnit: 'MILLIMETRE',
+    mapUnitScale: 0.001,
+    mapZone: '60S',
+    description: 'WGS 84 / UTM zone 60S',
+    mapProjection: 'UTM',
+  };
+
+  it('quantises sub-millimetre E/N jitter to the same key', () => {
+    // mm CRS: eastings are millimetres, so nudges within the same millimetre
+    // bucket round identically (both 729013348.x -> 729013348).
+    const a = reprojectionInputKey(729013348.1, 9063992684.1, crs, 0.001);
+    const b = reprojectionInputKey(729013348.4, 9063992684.4, crs, 0.001);
+    assert.strictEqual(a, b, 'sub-mm changes must not change the key');
+  });
+
+  it('changes the key when E/N moves by more than a millimetre', () => {
+    const a = reprojectionInputKey(729013348.1, 9063992684.1, crs, 0.001);
+    const b = reprojectionInputKey(729013350.1, 9063992684.1, crs, 0.001);
+    assert.notStrictEqual(a, b, 'a >1 mm move must change the key');
+  });
+
+  it('folds every reprojection input (codex #1671 P2): a projection-metadata edit changes the key even when name + E/N are unchanged', () => {
+    const base = reprojectionInputKey(729013348.1, 9063992684.1, crs, 0.001);
+    // Each field resolveProjection / reprojectPointToLatLon reads must move the key.
+    const edits: Array<Partial<ProjectedCRS>> = [
+      { mapZone: '59S' },
+      { description: 'something else' },
+      { mapProjection: 'TM' },
+      { mapUnitScale: 1 },
+    ];
+    for (const edit of edits) {
+      const mutated = reprojectionInputKey(729013348.1, 9063992684.1, { ...crs, ...edit }, 0.001);
+      assert.notStrictEqual(mutated, base, `editing ${Object.keys(edit)[0]} must change the key`);
+    }
+    // lengthUnitScale is a non-CRS input the reprojection reads too.
+    const diffLength = reprojectionInputKey(729013348.1, 9063992684.1, crs, 0.01);
+    assert.notStrictEqual(diffLength, base, 'a lengthUnitScale change must change the key');
   });
 });

--- a/apps/viewer/src/lib/geo/reproject.ts
+++ b/apps/viewer/src/lib/geo/reproject.ts
@@ -456,6 +456,88 @@ export async function reprojectToLatLon(
 }
 
 /**
+ * Reproject an explicit projected point (eastings/northings in the CRS map
+ * unit) to WGS84 lat/lon. Unlike {@link reprojectToLatLon}, which derives the
+ * model centre, this takes coordinates already resolved in the map CRS — e.g.
+ * a picked point's E/N from the measure geo readout (issue #1657).
+ *
+ * @param eastings        Easting in the CRS map unit.
+ * @param northings       Northing in the CRS map unit.
+ * @param crs             IfcProjectedCRS (EPSG code, mapUnitScale).
+ * @param lengthUnitScale IFC project length unit to metres (fallback when
+ *                        crs.mapUnitScale is absent).
+ */
+export async function reprojectPointToLatLon(
+  eastings: number,
+  northings: number,
+  crs: ProjectedCRS,
+  lengthUnitScale = 1,
+): Promise<LatLon | null> {
+  const projDef = await resolveProjection(crs);
+  if (!projDef) return null;
+
+  // Geographic CRS (e.g. EPSG:4326) — eastings/northings are already lon/lat.
+  if (isGeographicProj4(projDef)) {
+    const lon = eastings;
+    const lat = northings;
+    if (!Number.isFinite(lat) || !Number.isFinite(lon)) return null;
+    if (lat < -90 || lat > 90 || lon < -180 || lon > 180) return null;
+    return { lat, lon };
+  }
+
+  const mapScale = resolveMapUnitToMetreScale(crs.mapUnitScale, lengthUnitScale);
+  const eastingM = eastings * mapScale;
+  const northingM = northings * mapScale;
+  try {
+    const [lon, lat] = proj4(projDef, 'WGS84', [eastingM, northingM]);
+    if (!Number.isFinite(lat) || !Number.isFinite(lon)) return null;
+    if (lat < -90 || lat > 90 || lon < -180 || lon > 180) return null;
+    return { lat, lon };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Derive a primitive cache key for a {@link reprojectPointToLatLon} call.
+ *
+ * The key must fold **every** input the reprojection reads, or an effect keyed
+ * by it would leave a rendered lat/lon stale when a georef edit changes the
+ * projection while the CRS name and rounded E/N stay put. `resolveProjection`
+ * reads `name`, `mapZone`, `description` and `mapProjection`;
+ * `reprojectPointToLatLon` additionally reads `mapUnitScale` and
+ * `lengthUnitScale`. The E/N are quantised to ~millimetre in metre-space (unit
+ * independent — the raw offsets may be millimetres or metres) so sub-mm hover
+ * jitter does not spam proj4. Keeping this a pure function makes the
+ * correctness-critical key derivation directly testable.
+ *
+ * @param eastings        Easting in the CRS map unit (as fed to reprojectPointToLatLon).
+ * @param northings       Northing in the CRS map unit.
+ * @param crs             IfcProjectedCRS.
+ * @param lengthUnitScale IFC project length unit to metres.
+ */
+export function reprojectionInputKey(
+  eastings: number,
+  northings: number,
+  crs: ProjectedCRS,
+  lengthUnitScale = 1,
+): string {
+  const mapScale = resolveMapUnitToMetreScale(crs.mapUnitScale, lengthUnitScale);
+  const eMm = Math.round(eastings * mapScale * 1000);
+  const nMm = Math.round(northings * mapScale * 1000);
+  return [
+    crs.name ?? '',
+    crs.mapZone ?? '',
+    crs.description ?? '',
+    crs.mapProjection ?? '',
+    crs.mapUnitScale ?? '',
+    lengthUnitScale,
+    eMm,
+    nMm,
+  ].join('|');
+}
+
+/**
  * Compute the model's center in IFC Z-up metres from coordinate info.
  * This is the geometry center before MapConversion is applied.
  */

--- a/apps/viewer/src/lib/geo/reproject.ts
+++ b/apps/viewer/src/lib/geo/reproject.ts
@@ -525,7 +525,12 @@ export function reprojectionInputKey(
   const mapScale = resolveMapUnitToMetreScale(crs.mapUnitScale, lengthUnitScale);
   const eMm = Math.round(eastings * mapScale * 1000);
   const nMm = Math.round(northings * mapScale * 1000);
-  return [
+  // JSON-encode rather than join with a delimiter: the free-text CRS fields
+  // (name, mapZone, description, mapProjection) can legally contain any
+  // character, and a delimiter that also appears in a field lets two different
+  // georefs collide to one key, freezing the async lat/lon effect on a stale
+  // value. JSON escaping keeps the key injective.
+  return JSON.stringify([
     crs.name ?? '',
     crs.mapZone ?? '',
     crs.description ?? '',
@@ -534,7 +539,7 @@ export function reprojectionInputKey(
     lengthUnitScale,
     eMm,
     nMm,
-  ].join('|');
+  ]);
 }
 
 /**


### PR DESCRIPTION
## What

Adds an asynchronous WGS84 **lat/lon** readout to the Geo XYZ measure. When the georef anchor has a usable IfcMapConversion, the live measure readout now shows a compact `Lat 47.376190 / Lon 8.541710` line under the existing Eastings/Northings/Height.

## Why

Follow-up to #1674, which shipped the georef-aware Geo XYZ measure (projected E/N/H via `viewerPointToProjected` + the `hasUsableMapGeoref` gate). The closed parallel PR #1671 additionally implemented an async lat/lon readout — the one piece main lacked. This ports that delta onto main's #1674 structure (main's `MeasurePanel` / `useAnchorGeoreference` shape, not #1671's).

## Changes

- **`lib/geo/reproject.ts`** — `reprojectPointToLatLon(eastings, northings, crs, lengthUnitScale)`: point-level WGS84 reprojection built on the existing proj4 machinery (`resolveProjection`). Map-unit-scale aware, handles geographic CRS (EPSG:4326) identity, and returns `null` rather than throwing for an unresolvable CRS.
- **`lib/geo/reproject.ts`** — `reprojectionInputKey(...)`: a **pure, exported** key-derivation function so the correctness-critical part is directly testable.
- **`components/viewer/tools/MeasurePanel.tsx`** — `useProjectedLatLon` hook resolves lat/lon asynchronously off that primitive key and renders a compact, labelled line under the E/N/H box. Non-blocking: E/N/H stays synchronous; the lat/lon line is simply absent when proj4 can't resolve the CRS.

## Dependency-key correctness (codex P2 on #1671)

The async effect must be keyed by a primitive derived from **all** inputs the reprojection consumes — not just CRS name + E/N, and not object identities (which would refetch every render). `resolveProjection` reads `crs.name`, `crs.mapZone`, `crs.description`, `crs.mapProjection`; `reprojectPointToLatLon` additionally reads `crs.mapUnitScale` and `lengthUnitScale`. `reprojectionInputKey` folds all of these plus the E/N quantised to ~millimetre in metre-space (unit-independent), so a georef edit that changes the projection while leaving the CRS name and rounded E/N unchanged still refreshes the readout, and sub-mm hover jitter does not spam proj4.

## Test coverage (`lib/geo/reproject.test.ts`)

- `reprojectPointToLatLon` round-trip sanity in EPSG:32760 (the mm-scaled building-architecture.ifc CRS used by `pick-to-geo.test.ts`) — result lands in the expected UTM-60S region.
- Map-unit-scale invariance: mm offsets (`mapUnitScale 0.001`) and the equivalent metre offsets (`mapUnitScale 1`) agree to 1e-9.
- Unknown CRS yields `null` (never throws).
- `reprojectionInputKey`: sub-mm jitter collapses to one key; a >1 mm move changes it; and a projection-metadata edit (`mapZone`/`description`/`mapProjection`/`mapUnitScale`) or a `lengthUnitScale` change all change the key even when name + E/N are unchanged.

## Verification

- Viewer `tsc --noEmit`: clean.
- `lib/geo` suite (`tsx --test`): 126/126 pass.