### PR TITLE
fix: recover from worker-script 404s after a redeploy; skip wasm scan over the 4GB ceiling

### DIFF
--- a/.changeset/worker-script-skew-recovery.md
+++ b/.changeset/worker-script-skew-recovery.md
@@ -1,0 +1,6 @@
+---
+"@ifc-lite/geometry": patch
+"@ifc-lite/parser": patch
+---
+
+Harden huge-file loads against stale deployments and the wasm32 ceiling. (1) A geometry or pre-pass worker whose SCRIPT fails to load (a redeploy rotated the hashed asset; the 404 is served as text/plain and the browser blocks the worker with an empty-message onerror) now dispatches the existing version-skew recovery event so the viewer reloads once onto the current deployment, instead of dying with "Pre-pass worker failed: undefined". (2) The parser skips the byte-level WASM entity scan for sources over 2.5GB: the buffer copy plus entity index cannot fit in wasm32's 4GB address space, so the scan always trapped with `unreachable executed` before the JS tokeniser fallback ran anyway.

--- a/apps/viewer/src/lib/wasm-version-skew.test.ts
+++ b/apps/viewer/src/lib/wasm-version-skew.test.ts
@@ -6,6 +6,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import {
   recoverFromWasmVersionSkew,
+  recoverFromWorkerScriptSkew,
   installWasmVersionSkewRecovery,
   __resetWasmVersionSkewForTests,
   type VersionSkewDeps,
@@ -17,6 +18,8 @@ const MIME_SKEW =
 /** A controllable clock + in-memory reload bookkeeping for the recovery deps. */
 class Harness {
   reloads = 0;
+  /** Simulates sessionStorage being blocked (private mode / sandboxed embed). */
+  storageBlocked = false;
   private now: number;
   private lastReloadAt: number | null = null;
   readonly deps: VersionSkewDeps;
@@ -30,7 +33,9 @@ class Harness {
       },
       hasRecentReload: (n) => this.lastReloadAt != null && n - this.lastReloadAt < 60_000,
       rememberReload: (n) => {
+        if (this.storageBlocked) return false;
         this.lastReloadAt = n;
+        return true;
       },
     };
   }
@@ -77,6 +82,44 @@ describe('recoverFromWasmVersionSkew', () => {
     const h = makeDeps();
     assert.equal(recoverFromWasmVersionSkew(new TypeError(MIME_SKEW), h.deps), true);
     assert.equal(h.reloads, 1);
+  });
+});
+
+describe('recoverFromWorkerScriptSkew (pre-classified by the geometry library)', () => {
+  it('reloads once without re-running the message matcher', () => {
+    // The worker-script 404 signature has NO message (the MIME detail goes
+    // only to the console), so the strict matcher can never accept it; the
+    // library's classification must be trusted (adversarial finding on #1680).
+    const h = makeDeps();
+    assert.equal(recoverFromWorkerScriptSkew(h.deps), true);
+    assert.equal(h.reloads, 1);
+  });
+
+  it('debounces a second worker-script skew within the window', () => {
+    const h = makeDeps(1_000_000);
+    assert.equal(recoverFromWorkerScriptSkew(h.deps), true);
+    h.setNow(1_030_000);
+    assert.equal(recoverFromWorkerScriptSkew(h.deps), false);
+    assert.equal(h.reloads, 1);
+  });
+
+  it('REFUSES to reload when the attempt cannot be recorded (storage blocked)', () => {
+    // A permanent condition (CSP-blocked worker spawn, proxy rewriting
+    // assets) in a storage-partitioned embed would otherwise reload on every
+    // occurrence with no debounce at all - a reload loop.
+    const h = makeDeps();
+    h.storageBlocked = true;
+    assert.equal(recoverFromWorkerScriptSkew(h.deps), false);
+    assert.equal(h.reloads, 0);
+  });
+});
+
+describe('storage-veto applies to the message-matched path too', () => {
+  it('does not reload a matching wasm-MIME error when the attempt cannot be recorded', () => {
+    const h = makeDeps();
+    h.storageBlocked = true;
+    assert.equal(recoverFromWasmVersionSkew(MIME_SKEW, h.deps), false);
+    assert.equal(h.reloads, 0);
   });
 });
 

--- a/apps/viewer/src/lib/wasm-version-skew.ts
+++ b/apps/viewer/src/lib/wasm-version-skew.ts
@@ -48,11 +48,17 @@ function recentlyReloaded(now: number): boolean {
   }
 }
 
-function markReloaded(now: number): void {
+function markReloaded(now: number): boolean {
   try {
     sessionStorage.setItem(RELOAD_TS_KEY, String(now));
+    return true;
   } catch {
-    /* sessionStorage blocked (private mode / disabled) — still reload once */
+    // sessionStorage blocked (private mode / sandboxed embed without
+    // allow-same-origin / "block all cookies"). If we cannot RECORD a reload
+    // we must not PERFORM one: a permanent failure (CSP-blocked worker, proxy
+    // rewriting assets) would otherwise reload on every occurrence with no
+    // debounce at all. Mirrors the vite:preloadError policy in main.tsx.
+    return false;
   }
 }
 
@@ -60,7 +66,8 @@ export interface VersionSkewDeps {
   now: () => number;
   reload: () => void;
   hasRecentReload: (now: number) => boolean;
-  rememberReload: (now: number) => void;
+  /** Persist the reload attempt. Returning false VETOES the reload (storage unavailable). */
+  rememberReload: (now: number) => boolean;
 }
 
 const defaultDeps: VersionSkewDeps = {
@@ -80,9 +87,27 @@ export function recoverFromWasmVersionSkew(
   deps: VersionSkewDeps = defaultDeps,
 ): boolean {
   if (!isWasmAssetUnavailableError(err)) return false;
+  return attemptBoundedReload(deps);
+}
+
+/**
+ * Reload for an event the geometry library ALREADY classified as version skew
+ * (`detail.kind === 'worker-script'`): a worker script that failed to load
+ * fires `onerror` with an EMPTY message, so re-running the message matcher
+ * here would reject exactly the case the event exists for. The classification
+ * is trusted; safety comes from the bounded reload policy instead — at most
+ * one reload per debounce window, and none at all when the attempt cannot be
+ * recorded. A rare false positive (a worker OOM-killed before its first post,
+ * a CSP-blocked spawn) therefore costs one debounced reload, not a loop.
+ */
+export function recoverFromWorkerScriptSkew(deps: VersionSkewDeps = defaultDeps): boolean {
+  return attemptBoundedReload(deps);
+}
+
+function attemptBoundedReload(deps: VersionSkewDeps): boolean {
   const now = deps.now();
   if (deps.hasRecentReload(now)) return false;
-  deps.rememberReload(now);
+  if (!deps.rememberReload(now)) return false;
   deps.reload();
   return true;
 }
@@ -101,7 +126,11 @@ export function installWasmVersionSkewRecovery(): void {
   // the common case where the app caught + reported the failure rather than
   // letting it bubble to the global handlers below.
   window.addEventListener(WASM_ASSET_UNAVAILABLE_EVENT, (event) => {
-    const detail = (event as CustomEvent<{ message?: string }>).detail;
+    const detail = (event as CustomEvent<{ message?: string; kind?: string }>).detail;
+    if (detail?.kind === 'worker-script') {
+      recoverFromWorkerScriptSkew();
+      return;
+    }
     recoverFromWasmVersionSkew(detail?.message ?? '');
   });
 

--- a/packages/geometry/src/adversarial-skew.test.ts
+++ b/packages/geometry/src/adversarial-skew.test.ts
@@ -1,0 +1,99 @@
+/* Adversarial probes for PR #1680 (worker-script skew recovery).
+ * Originally written to break the feature; they CONFIRMED the dispatched
+ * event died in the viewer's message re-validation (the synthetic
+ * worker-script message carries no wasm token). The fix routes on the
+ * event's `kind` discriminator instead; these tests now pin that contract. */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  isWasmAssetUnavailableError,
+  notifyIfWorkerScriptUnavailable,
+} from './wasm-asset-error.js';
+import { largeFilePrepassError } from './huge-file-error.js';
+
+/**
+ * Capture the `detail.message` of the CustomEvent that
+ * notifyIfWorkerScriptUnavailable dispatches, exactly as the viewer host would
+ * receive it on `window`.
+ */
+function captureDispatchedDetail(
+  err: unknown,
+  spoke: boolean,
+): { message?: string; kind?: string } | null {
+  let captured: { message?: string; kind?: string } | null = null;
+  const dispatchEvent = vi.fn((event: unknown) => {
+    captured = (event as { detail?: { message?: string; kind?: string } }).detail ?? null;
+    return true;
+  });
+  vi.stubGlobal('dispatchEvent', dispatchEvent);
+  notifyIfWorkerScriptUnavailable(err, spoke);
+  return captured;
+}
+
+describe('worker-script skew event carries a kind the host can trust', () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('the synthetic worker-script message still fails the strict matcher (why kind exists)', () => {
+    // The synthetic message deliberately carries no wasm token, so a host that
+    // re-ran the message matcher would drop it - the original adversarial
+    // finding. The event's kind discriminator is the supported contract.
+    const detail = captureDispatchedDetail({ message: undefined }, false);
+    expect(detail?.message).toMatch(/worker script/i);
+    expect(isWasmAssetUnavailableError(detail?.message)).toBe(false);
+    expect(detail?.kind).toBe('worker-script');
+  });
+
+  it('end-to-end: the worker-script-404 path is routed by kind, not by message', () => {
+    const detail = captureDispatchedDetail(undefined, false);
+    // The viewer listener (apps/viewer/src/lib/wasm-version-skew.ts) reloads
+    // via recoverFromWorkerScriptSkew when kind === 'worker-script', without
+    // re-running the message matcher.
+    expect(detail?.kind).toBe('worker-script');
+  });
+
+  it('a real wasm-MIME message from the SAME helper dispatches with kind wasm-asset', () => {
+    const msg =
+      "Response has unsupported MIME type 'text/plain; charset=utf-8' expected 'application/wasm'";
+    const detail = captureDispatchedDetail({ message: msg }, false);
+    expect(isWasmAssetUnavailableError(detail?.message ?? '')).toBe(true);
+    expect(detail?.kind).toBe('wasm-asset');
+  });
+});
+
+describe('ADVERSARIAL: false-positive classification of empty-message spawn errors', () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('an empty-message error from a worker that never posted is always treated as skew', () => {
+    // Known, accepted over-breadth: notifyIfWorkerScriptUnavailable cannot
+    // distinguish a stale-deploy 404 from other empty-message-before-first-post
+    // causes (wasm compile OOM at startup, browser killing the worker during
+    // init, CSP spawn block). The viewer bounds the cost: at most one reload
+    // per debounce window, and none when the attempt cannot be recorded
+    // (storage-blocked embeds) - see recoverFromWorkerScriptSkew.
+    const dispatch = vi.fn(() => true);
+    vi.stubGlobal('dispatchEvent', dispatch);
+
+    // Shapes that a non-deploy startup failure could plausibly present as:
+    for (const errShape of [
+      { message: '' }, // ErrorEvent with blank message
+      { message: undefined }, // ErrorEvent with absent message
+      {}, // bare object, no message field
+      null, // some engines pass null
+      undefined,
+    ]) {
+      expect(notifyIfWorkerScriptUnavailable(errShape, false)).toBe(true);
+    }
+    expect(dispatch).toHaveBeenCalledTimes(5);
+  });
+});
+
+describe('ADVERSARIAL: 2.5GB boundary consistency parser<->geometry', () => {
+  it('geometry huge-file heuristic fires at EXACTLY 2.5e9 bytes (decimal GB, not GiB)', () => {
+    // largeFilePrepassError uses byteLength / 1e9 >= 2.5  => >= 2_500_000_000.
+    expect(largeFilePrepassError(new Error('unreachable executed'), 2_500_000_000)).not.toBeNull();
+    // Just under the boundary: rethrow (null).
+    expect(largeFilePrepassError(new Error('unreachable executed'), 2_499_999_999)).toBeNull();
+    // The parser gate refuses at exactly 2.5e9 (strict <) so the two ceilings
+    // agree at the boundary.
+  });
+});

--- a/packages/geometry/src/geometry-parallel.ts
+++ b/packages/geometry/src/geometry-parallel.ts
@@ -30,7 +30,7 @@ import type { StreamingGeometryEvent } from './index.js';
 import { mergeGeometryDiagnostics, type GeometryDiagnostics } from './diagnostics.js';
 import { computeWorkerCount } from './worker-count.js';
 import type { BatchSizingConfig } from './batch-sizing.js';
-import { notifyIfWasmAssetUnavailable } from './wasm-asset-error.js';
+import { notifyIfWasmAssetUnavailable, notifyIfWorkerScriptUnavailable } from './wasm-asset-error.js';
 
 /**
  * Plan content-affinity routing for one chunk: assign each job (by index) to a
@@ -292,7 +292,11 @@ export async function* processParallel(
   // workerCount at this point). The closure indexes by workerIndex.
   const firstBatchByWorker: number[] = [];
   const installWorkerHandlers = (worker: Worker, workerIndex: number) => {
+    // True once the worker delivers ANY message — distinguishes an in-worker
+    // crash from the worker SCRIPT failing to load (stale-deploy 404, #1251).
+    let workerSpoke = false;
     worker.onmessage = (e: MessageEvent) => {
+      workerSpoke = true;
       const msg = e.data;
       if (msg.type === 'ready') {
         console.log(`[stream] worker[${workerIndex}] WASM ready @ ${elapsed()}ms`);
@@ -444,8 +448,12 @@ export async function* processParallel(
       const detail =
         (err?.message && String(err.message)) ||
         (err?.filename ? `at ${err.filename}:${err.lineno ?? 0}` : '') ||
-        'worker terminated unexpectedly';
-      notifyIfWasmAssetUnavailable(detail);
+        (workerSpoke
+          ? 'worker terminated unexpectedly'
+          : 'worker script failed to load (possibly a stale deployment)');
+      // Covers both the wasm-binary 404 (message present, #1363) and the
+      // worker SCRIPT 404 after a redeploy (empty message, never spoke).
+      notifyIfWorkerScriptUnavailable(err, workerSpoke);
       workerError = new Error(`Geometry worker failed: ${detail}`);
       workersCompleted++;
       worker.terminate();
@@ -715,7 +723,13 @@ export async function* processParallel(
   let chunkArrivals = 0;
   let totalDispatchedJobs = 0;
   let firstChunkAt = -1;
+  // True once the pre-pass worker delivers ANY message — distinguishes an
+  // in-worker failure from the worker SCRIPT failing to load (a stale-deploy
+  // 404 is served as text/plain; the browser blocks the worker and fires
+  // onerror with an EMPTY message, so the wasm matcher alone never fires).
+  let prepassSpoke = false;
   prepassWorker.onmessage = (e: MessageEvent) => {
+    prepassSpoke = true;
     const data = e.data;
     if (data.type === 'prepass-progress') {
       eventQueue.push({ type: 'progress', phase: 'prepass' });
@@ -974,8 +988,16 @@ export async function* processParallel(
     // `buildPrePassStreaming`. We treat unknown messages as no-ops.
   };
   prepassWorker.onerror = (e) => {
-    notifyIfWasmAssetUnavailable(e.message);
-    prepassError = new Error(`Pre-pass worker failed: ${e.message}`);
+    const detail =
+      (e?.message && String(e.message)) ||
+      (prepassSpoke
+        ? 'worker terminated unexpectedly'
+        : 'worker script failed to load (possibly a stale deployment)');
+    // Covers both the wasm-binary 404 (message present, #1363) and the worker
+    // SCRIPT 404 after a redeploy (empty message, never spoke) — either way
+    // the host reloads once onto the current deployment.
+    notifyIfWorkerScriptUnavailable(e, prepassSpoke);
+    prepassError = new Error(`Pre-pass worker failed: ${detail}`);
     prepassDone = true;
     prepassWorker.terminate();
     wake();

--- a/packages/geometry/src/wasm-asset-error.test.ts
+++ b/packages/geometry/src/wasm-asset-error.test.ts
@@ -5,6 +5,7 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import {
   isWasmAssetUnavailableError,
+  notifyIfWorkerScriptUnavailable,
   notifyIfWasmAssetUnavailable,
   WASM_ASSET_UNAVAILABLE_EVENT,
 } from './wasm-asset-error.js';
@@ -103,5 +104,58 @@ describe('notifyIfWasmAssetUnavailable', () => {
     vi.stubGlobal('dispatchEvent', dispatchEvent);
     expect(notifyIfWasmAssetUnavailable('some unrelated failure')).toBe(false);
     expect(dispatchEvent).not.toHaveBeenCalled();
+  });
+});
+
+describe('notifyIfWorkerScriptUnavailable', () => {
+  it('treats an empty-message error from a worker that never spoke as version skew', () => {
+    // The stale-deploy signature: the worker SCRIPT 404s (served text/plain),
+    // the browser blocks it and fires onerror with NO message - the MIME
+    // detail goes only to the console.
+    const dispatchEvent = vi.fn();
+    vi.stubGlobal('dispatchEvent', dispatchEvent);
+    expect(notifyIfWorkerScriptUnavailable({ message: undefined }, false)).toBe(true);
+    if (typeof CustomEvent === 'function') {
+      expect(dispatchEvent).toHaveBeenCalledTimes(1);
+      const event = dispatchEvent.mock.calls[0][0] as CustomEvent;
+      expect(event.type).toBe(WASM_ASSET_UNAVAILABLE_EVENT);
+      expect(String(event.detail.message)).toMatch(/worker script/i);
+    }
+  });
+
+  it('does NOT fire for an empty-message error after the worker already spoke', () => {
+    // A hard in-worker crash (e.g. the wasm thread aborting under memory
+    // pressure) can also produce an empty message - but the script
+    // demonstrably loaded, so a reload would loop without fixing anything.
+    const dispatchEvent = vi.fn();
+    vi.stubGlobal('dispatchEvent', dispatchEvent);
+    expect(notifyIfWorkerScriptUnavailable({ message: '' }, true)).toBe(false);
+    expect(dispatchEvent).not.toHaveBeenCalled();
+  });
+
+  it('does NOT fire for a real in-worker error message that is not the wasm signature', () => {
+    const dispatchEvent = vi.fn();
+    vi.stubGlobal('dispatchEvent', dispatchEvent);
+    expect(
+      notifyIfWorkerScriptUnavailable({ message: 'TypeError: x is not a function' }, false),
+    ).toBe(false);
+    expect(dispatchEvent).not.toHaveBeenCalled();
+  });
+
+  it('still fires for the wasm-MIME signature carried in the message, even after speaking', () => {
+    const dispatchEvent = vi.fn();
+    vi.stubGlobal('dispatchEvent', dispatchEvent);
+    const msg =
+      "Response has unsupported MIME type 'text/plain; charset=utf-8' expected 'application/wasm'";
+    expect(notifyIfWorkerScriptUnavailable({ message: msg }, true)).toBe(true);
+    if (typeof CustomEvent === 'function') {
+      expect(dispatchEvent).toHaveBeenCalledTimes(1);
+    }
+  });
+
+  it('null/undefined error from a silent spawn failure counts as empty-message', () => {
+    const dispatchEvent = vi.fn();
+    vi.stubGlobal('dispatchEvent', dispatchEvent);
+    expect(notifyIfWorkerScriptUnavailable(undefined, false)).toBe(true);
   });
 });

--- a/packages/geometry/src/wasm-asset-error.ts
+++ b/packages/geometry/src/wasm-asset-error.ts
@@ -119,15 +119,59 @@ function domDispatcher(): DomDispatcher | null {
  */
 export function notifyIfWasmAssetUnavailable(err: unknown): boolean {
   if (!isWasmAssetUnavailableError(err)) return false;
+  dispatchAssetUnavailable(messageOf(err));
+  return true;
+}
+
+function dispatchAssetUnavailable(message: string): void {
   const target = domDispatcher();
-  if (target) {
-    try {
-      target.dispatchEvent(
-        new CustomEvent(WASM_ASSET_UNAVAILABLE_EVENT, { detail: { message: messageOf(err) } }),
-      );
-    } catch {
-      /* CustomEvent unavailable — best effort, nothing more to do */
-    }
+  if (!target) return;
+  try {
+    target.dispatchEvent(
+      new CustomEvent(WASM_ASSET_UNAVAILABLE_EVENT, { detail: { message } }),
+    );
+  } catch {
+    /* CustomEvent unavailable — best effort, nothing more to do */
   }
+}
+
+/**
+ * Classify a Worker `onerror` that fired on a worker and broadcast
+ * {@link WASM_ASSET_UNAVAILABLE_EVENT} when it is the version-skew signature.
+ *
+ * When a deploy rotates hashed assets under an open tab, the worker SCRIPT
+ * itself can 404 — the host serves the 404 body as `text/plain`, the browser
+ * blocks the load ("disallowed MIME type"), and fires `onerror` with an
+ * EMPTY/undefined `message` (the MIME detail goes only to the console). The
+ * strict wasm matcher above never sees a signature there, so such a load used
+ * to die with "Pre-pass worker failed: undefined" instead of recovering.
+ *
+ * Rules:
+ * - the error carries a message → strict wasm matcher only (a genuine
+ *   in-worker crash must not trigger a reload; the host reload policy is
+ *   additionally sessionStorage-bounded as defence in depth).
+ * - empty message AND `receivedAnyMessage` is true → NOT a spawn failure (the
+ *   script demonstrably ran); no dispatch.
+ * - empty message AND the worker never spoke → the script failed to load;
+ *   treat as version skew.
+ */
+export function notifyIfWorkerScriptUnavailable(
+  err: unknown,
+  receivedAnyMessage: boolean,
+): boolean {
+  // Strict string-only extraction: `messageOf`'s `String(err)` fallback would
+  // turn an ErrorEvent whose `.message` is undefined into "[object Object]",
+  // which would mask exactly the empty-message spawn failure this exists for.
+  const msg =
+    typeof err === 'string'
+      ? err
+      : err != null && typeof (err as { message?: unknown }).message === 'string'
+        ? ((err as { message: string }).message)
+        : '';
+  if (msg) return notifyIfWasmAssetUnavailable(msg);
+  if (receivedAnyMessage) return false;
+  dispatchAssetUnavailable(
+    'worker script failed to load (no error message; likely a rotated asset after a redeploy)',
+  );
   return true;
 }

--- a/packages/geometry/src/wasm-asset-error.ts
+++ b/packages/geometry/src/wasm-asset-error.ts
@@ -34,6 +34,18 @@
  */
 export const WASM_ASSET_UNAVAILABLE_EVENT = 'ifclite:wasm-asset-unavailable';
 
+/**
+ * Discriminates WHY the event fired, so the host does not have to re-derive
+ * the classification from the message text (a synthetic worker-script message
+ * carries none of the wasm-MIME tokens the strict matcher looks for - re-running
+ * the matcher host-side would silently drop exactly the case this exists for).
+ *
+ * - `wasm-asset`:    the engine binary fetch hit the #1363 MIME/404 signature.
+ * - `worker-script`: a Worker script failed to load (empty-message onerror
+ *                    from a worker that never posted; stale-deploy 404).
+ */
+export type WasmAssetUnavailableKind = 'wasm-asset' | 'worker-script';
+
 function messageOf(err: unknown): string {
   if (err == null) return '';
   if (typeof err === 'string') return err;
@@ -119,16 +131,16 @@ function domDispatcher(): DomDispatcher | null {
  */
 export function notifyIfWasmAssetUnavailable(err: unknown): boolean {
   if (!isWasmAssetUnavailableError(err)) return false;
-  dispatchAssetUnavailable(messageOf(err));
+  dispatchAssetUnavailable(messageOf(err), 'wasm-asset');
   return true;
 }
 
-function dispatchAssetUnavailable(message: string): void {
+function dispatchAssetUnavailable(message: string, kind: WasmAssetUnavailableKind): void {
   const target = domDispatcher();
   if (!target) return;
   try {
     target.dispatchEvent(
-      new CustomEvent(WASM_ASSET_UNAVAILABLE_EVENT, { detail: { message } }),
+      new CustomEvent(WASM_ASSET_UNAVAILABLE_EVENT, { detail: { message, kind } }),
     );
   } catch {
     /* CustomEvent unavailable — best effort, nothing more to do */
@@ -172,6 +184,7 @@ export function notifyIfWorkerScriptUnavailable(
   if (receivedAnyMessage) return false;
   dispatchAssetUnavailable(
     'worker script failed to load (no error message; likely a rotated asset after a redeploy)',
+    'worker-script',
   );
   return true;
 }

--- a/packages/parser/src/adversarial-gate.test.ts
+++ b/packages/parser/src/adversarial-gate.test.ts
@@ -1,0 +1,66 @@
+/* Adversarial probes for PR #1680 parser gate (wasmBytesScanAllowed).
+ * Written to break the feature; safe to delete. */
+
+import { describe, expect, it, vi } from 'vitest';
+import { scanIfcEntities, wasmBytesScanAllowed } from './entity-scanner.js';
+
+const SMALL_IFC = [
+  'ISO-10303-21;',
+  'HEADER;',
+  "FILE_DESCRIPTION((''),'2;1');",
+  "FILE_NAME('t','',(''),(''),'','','');",
+  "FILE_SCHEMA(('IFC4'));",
+  'ENDSEC;',
+  'DATA;',
+  "#1=IFCPROJECT('0000000000000000000001',$,'P',$,$,$,$,$,$);",
+  "#2=IFCWALL('0000000000000000000002',$,$,$,$,$,$,$,$);",
+  "#3=IFCWALL('0000000000000000000003',$,$,$,$,$,$,$,$);",
+  'ENDSEC;',
+  'END-ISO-10303-21;',
+  '',
+].join('\n');
+
+function ifcBuffer(): ArrayBuffer {
+  return new TextEncoder().encode(SMALL_IFC).buffer;
+}
+
+describe('ADVERSARIAL: wasmBytesScanAllowed boundary', () => {
+  it('gate is decimal 2.5e9 (matches geometry huge-file 1e9 GB, NOT GiB)', () => {
+    // If it were GiB the threshold would be 2.5 * 1024^3 = 2_684_354_560.
+    expect(wasmBytesScanAllowed(2_500_000_000)).toBe(false); // strict <: agrees with geometry >= at the boundary
+    expect(wasmBytesScanAllowed(2_500_000_001)).toBe(false);
+    // A GiB-based reader would wrongly allow this; assert we do NOT.
+    expect(wasmBytesScanAllowed(2_684_354_560)).toBe(false);
+  });
+});
+
+describe('ADVERSARIAL: null selectWasmScanFunction reaches the JS tokeniser', () => {
+  it('when scanEntitiesFastBytes throws, the scan falls through to the tokeniser', async () => {
+    // Positive control for the whole fallback chain: even a broken wasm API must
+    // not strand the parse — the JS tokeniser recovers. (The >2.5GB gate returns
+    // null the same way, taking the identical fall-through path.)
+    const scanEntitiesFastBytes = vi.fn(() => {
+      throw new Error('unreachable executed'); // simulate the wasm32 OOM trap
+    });
+    const res = await scanIfcEntities(ifcBuffer(), {
+      disableWorkerScan: true,
+      wasmApi: { scanEntitiesFastBytes },
+    });
+    expect(scanEntitiesFastBytes).toHaveBeenCalledTimes(1);
+    expect(res.scanPath).toBe('tokenizer');
+    // The tokeniser still finds both walls + the project.
+    expect(res.entityRefs.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('a supplied wasm byte API IS used for an in-budget buffer (proves it is wired, so the gate matters)', async () => {
+    const scanEntitiesFastBytes = vi.fn(() => [
+      { expressId: 1, type: 'IFCPROJECT', byteOffset: 0, byteLength: 10, lineNumber: 1 },
+    ]);
+    const res = await scanIfcEntities(ifcBuffer(), {
+      disableWorkerScan: true,
+      wasmApi: { scanEntitiesFastBytes },
+    });
+    expect(scanEntitiesFastBytes).toHaveBeenCalledTimes(1);
+    expect(res.scanPath).toBe('wasm');
+  });
+});

--- a/packages/parser/src/entity-scanner.gate.test.ts
+++ b/packages/parser/src/entity-scanner.gate.test.ts
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, expect, it } from 'vitest';
+import { wasmBytesScanAllowed } from './entity-scanner.js';
+
+describe('wasmBytesScanAllowed', () => {
+  it('allows typical large models', () => {
+    expect(wasmBytesScanAllowed(883 * 1024 * 1024)).toBe(true);
+    expect(wasmBytesScanAllowed(2_400_000_000)).toBe(true);
+  });
+
+  it('refuses sources beyond the wasm32 ceiling instead of trapping', () => {
+    // A 3.9GB source cannot be copied into wasm32 linear memory alongside its
+    // entity index; attempting it aborts with a bare `unreachable executed`
+    // before the JS tokeniser fallback runs anyway (observed on a 3899MB IFC).
+    expect(wasmBytesScanAllowed(3_899_000_000)).toBe(false);
+    expect(wasmBytesScanAllowed(2_500_000_001)).toBe(false);
+  });
+});

--- a/packages/parser/src/entity-scanner.gate.test.ts
+++ b/packages/parser/src/entity-scanner.gate.test.ts
@@ -16,6 +16,8 @@ describe('wasmBytesScanAllowed', () => {
     // entity index; attempting it aborts with a bare `unreachable executed`
     // before the JS tokeniser fallback runs anyway (observed on a 3899MB IFC).
     expect(wasmBytesScanAllowed(3_899_000_000)).toBe(false);
-    expect(wasmBytesScanAllowed(2_500_000_001)).toBe(false);
+    // Exactly 2.5e9 is refused, matching the geometry huge-file heuristic's
+    // `>=` so the two ceilings agree at the boundary.
+    expect(wasmBytesScanAllowed(2_500_000_000)).toBe(false);
   });
 });

--- a/packages/parser/src/entity-scanner.ts
+++ b/packages/parser/src/entity-scanner.ts
@@ -129,7 +129,7 @@ export async function scanIfcEntities(
  * the copy alone leaves no headroom.
  */
 export function wasmBytesScanAllowed(byteLength: number): boolean {
-  return byteLength <= 2_500_000_000;
+  return byteLength < 2_500_000_000;
 }
 
 function selectWasmScanFunction(api: WasmScanApi | undefined, uint8Buffer: Uint8Array): WasmScanFunction | null {

--- a/packages/parser/src/entity-scanner.ts
+++ b/packages/parser/src/entity-scanner.ts
@@ -116,10 +116,33 @@ export async function scanIfcEntities(
   return { entityRefs, processed, elapsedMs, scanPath };
 }
 
+/**
+ * Whether the byte-level WASM scan may run for a source of this size.
+ *
+ * `scanEntitiesFastBytes` copies the whole buffer into wasm32 linear memory
+ * and builds the entity index alongside it, inside a 4GB address space. Above
+ * this ceiling the allocator aborts with a bare `unreachable executed` trap —
+ * the scan can never succeed, so attempting it only burns seconds and logs a
+ * frightening wasm panic before the JS tokeniser fallback runs anyway.
+ * Mirrors the geometry prepass's 2.5GB huge-file heuristic (#1630): the file
+ * copy plus the index for a 2.5GB source stays under the ceiling; beyond it
+ * the copy alone leaves no headroom.
+ */
+export function wasmBytesScanAllowed(byteLength: number): boolean {
+  return byteLength <= 2_500_000_000;
+}
+
 function selectWasmScanFunction(api: WasmScanApi | undefined, uint8Buffer: Uint8Array): WasmScanFunction | null {
   if (!api) return null;
 
   if (typeof api.scanEntitiesFastBytes === 'function') {
+    if (!wasmBytesScanAllowed(uint8Buffer.byteLength)) {
+      console.warn(
+        '[parser] scanEntitiesFastBytes skipped: source is %d MB, exceeds the wasm32 memory ceiling - falling back to JS tokeniser.',
+        Math.round(uint8Buffer.byteLength / (1024 * 1024)),
+      );
+      return null;
+    }
     return () => api.scanEntitiesFastBytes?.(uint8Buffer);
   }
 


### PR DESCRIPTION
## Problem (observed live on ifclite.com)

A user's open tab failed to load a model with `Pre-pass worker failed: undefined` plus
`Loading Worker ... geometry.worker-<hash>.js was blocked because of a disallowed MIME type ('text/plain')`.

Today's merges rotated asset hashes under the open tab. The lazily-spawned pre-pass worker script 404'd - Vercel serves the 404 body as `text/plain` (with `cache-control: immutable`!), the browser blocks the worker, and `onerror` fires with an EMPTY message (the MIME detail goes only to the console). The existing recovery paths never trigger:

- `vite:preloadError` covers lazy CHUNK imports, not worker spawns.
- The wasm-MIME matcher (#1363) needs a message signature; there is no message.

The dead pre-pass then starved the parser of its shared entity index; after the 60s timeout it attempted a byte-level WASM scan of the 3.9GB source - a guaranteed wasm32 OOM trap (`unreachable executed`) - before finally reaching the JS tokeniser.

## Fix

1. **`notifyIfWorkerScriptUnavailable(err, receivedAnyMessage)`** (geometry pkg): an `onerror` with NO message from a worker that NEVER delivered a message is classified as the spawn-failure signature and dispatches the existing `ifclite:wasm-asset-unavailable` event - the viewer's subscriber reloads once (sessionStorage-bounded) onto the current deployment. Guard rails: message-bearing errors keep the strict wasm matcher (an in-worker crash never causes a reload), and an empty-message crash AFTER the worker spoke stays local. Message extraction is strict string-only - `String(err)` would stringify an ErrorEvent with an undefined message to `[object Object]` and defeat the classifier.
2. Pre-pass + pool worker `onerror` handlers track a `spoke` flag and synthesize actionable error text instead of the literal `undefined`.
3. **`wasmBytesScanAllowed`** (parser pkg): skip `scanEntitiesFastBytes` above 2.5GB - the buffer copy plus entity index cannot fit in wasm32's 4GB address space (mirrors the geometry prepass heuristic from #1630) - and fall straight to the JS tokeniser with a clear one-line warn instead of a wasm panic.

## Tests

- 5 new cases for the spawn classifier (empty-message/never-spoke fires; empty-message/spoke does not; real crash message does not; wasm-MIME message still fires; null error counts as empty) + existing matcher regressions: geometry 140/140.
- `wasmBytesScanAllowed` boundary tests: parser 244/244.
- tsc clean on both packages.

Changeset included (patch: @ifc-lite/geometry, @ifc-lite/parser).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery when worker scripts fail to load after a deployment update, automatically reloading the current version when safe.
  * Prevented repeated reload loops when browser storage is unavailable.
  * Large files over 2.5 billion bytes now avoid unsafe WASM scanning and use the tokenizer fallback instead.
  * Improved handling and classification of worker and WASM loading failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->