### PR TITLE
perf(geometry): clamp the 16-core worker tier for huge files (#1682)

### DIFF
--- a/.changeset/worker-count-huge-file-clamp.md
+++ b/.changeset/worker-count-huge-file-clamp.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/geometry": patch
+---
+
+Clamp the 16-core worker tier for huge files (issue #1682). The `cores >= 16` tier was the only one without the `>512MB` file-size clamp, so a 16-core desktop spawned `cores/2 = 8` geometry workers on an 883MB model - each a private wasm realm holding a full source copy plus its own entity index (~1.3GB per worker, ~10.6GB total), producing 16GB memory peaks. Huge-file geometry is memory-bandwidth bound (a 5th/6th worker gives no measured speedup), so the tier now caps at 4 workers above 512MB, matching the 12-core tier. `?geomWorkers=N` still overrides per host.

--- a/packages/geometry/src/worker-count.test.ts
+++ b/packages/geometry/src/worker-count.test.ts
@@ -223,15 +223,27 @@ describe('computeWorkerCount', () => {
     expect(r.count).toBe(8);
   });
 
-  it('Desktop tower, 2 GB file → memory-capped well below 8', () => {
+  it('Desktop tower, 2 GB file → huge-file bandwidth clamp wins (4 workers)', () => {
     const r = computeWorkerCount({
       fileSizeMB: 2048, cores: 16, deviceMemoryGB: 32, totalJobs: 30000,
     });
-    // 32 GB RAM, 8 GB reserved, 5 GB main-thread budget → 19 GB / (3 GB per
-    // worker) ≈ 6 workers, capped by cores at 8 → memory wins.
-    expect(r.count).toBeGreaterThanOrEqual(2);
-    expect(r.count).toBeLessThanOrEqual(8);
-    expect(r.reason).toBe('memory');
+    // The >512 MB clamp (4) is tighter than the memory budget (~6 here), so
+    // cores is the binding constraint (#1682).
+    expect(r.count).toBe(4);
+    expect(r.reason).toBe('cores');
+  });
+
+  it('16-core desktop, 883 MB model → clamped to 4 workers, not cores/2 = 8 (#1682)', () => {
+    // Each worker is a private MVP-wasm realm holding a full source copy plus
+    // its own entity index (~fileSize x 1.5 ~= 1.3 GB on this model). The
+    // unclamped 16-core tier spawned 8 workers = ~10.6 GB of redundant worker
+    // heap, the reported 16 GB peak. Huge files are memory-bandwidth bound;
+    // the 4-worker ceiling matches the 12-core tier's measured plateau.
+    const r = computeWorkerCount({
+      fileSizeMB: 883, cores: 16, deviceMemoryGB: 32, totalJobs: 59_018,
+    });
+    expect(r.count).toBe(4);
+    expect(r.reason).toBe('cores');
   });
 
   it('huge file on big desktop never returns 0', () => {

--- a/packages/geometry/src/worker-count.ts
+++ b/packages/geometry/src/worker-count.ts
@@ -120,7 +120,16 @@ export function computeWorkerCount(inputs: WorkerCountInputs): WorkerCountResult
   if (fileSizeMB >= MIN_PARALLEL_MB && fileSizeMB <= SMALL_FILE_MB && cores >= 10) {
     coresCap = Math.min(maxWorkers, cores - 2);
   } else if (cores >= 16 && deviceMemoryGB >= 16) {
-    coresCap = Math.min(maxWorkers, Math.floor(cores / 2));
+    // Same >512 MB bandwidth ceiling as the 12-core tier below. This was the
+    // ONLY tier without the huge-file clamp, so a 16-core desktop spawned
+    // cores/2 = 8 workers on an 883 MB model - each a private MVP-wasm realm
+    // holding a full source copy plus its own entity index (~fileSize x 1.5
+    // ~= 1.3 GB each, ~10.6 GB total), producing the 16 GB peaks reported in
+    // #1682. Geometry wall-time on huge files is memory-bandwidth bound, not
+    // core bound (the 12-core A/B sweep showed a 5th/6th grinder yields no
+    // speedup), so the extra workers bought nothing but memory. Users can
+    // still override per-host via `?geomWorkers=N`.
+    coresCap = fileSizeMB > 512 ? 4 : Math.min(maxWorkers, Math.floor(cores / 2));
   } else if (cores >= 12 && deviceMemoryGB >= 8) {
     // 12+ cores indicates M-series Pro 12-core or M-series Max with active
     // cooling. The >512 MB cap stays 4: a `?geomWorkers` A/B sweep on a large


### PR DESCRIPTION
## Problem

Issue #1682 (reporter follow-up on #1661): loading the 883MB CatiaA1 model peaks at ~16GB (avg 9.8GB) vs BIMVision's 4GB peak.

Profiling the actual model attributed the swing to the worker multiplier, not the geometry (which is only ~1.31GB per full copy: 46.7M verts / 23.5M tris / zero CSG):

- Each geometry worker is a private MVP-wasm realm that receives a **full 883MB source copy** per batch call (wasm-bindgen copies the SAB view into linear memory; the high-water sticks) and rebuilds its **own ~436MB entity-index hashmap** - ~1.3GB per worker, matching the codebase's own `fileSize x 1.5` heuristic.
- `computeWorkerCount`'s **`cores >= 16` tier was the only tier without the `>512MB` huge-file clamp** (10-core caps at 3, 12-core at 4), so a 16-core desktop spawned `cores/2 = 8` workers: **~10.6GB of redundant worker heap** - the 16GB peak. The 3-4 worker tiers produce the reported 9.8GB 'average'.

## Fix

Apply the same `>512MB` bandwidth ceiling as the 12-core tier: cap at 4. Rationale: huge-file geometry wall-time is memory-bandwidth bound, not core bound - the 12-core `?geomWorkers` A/B sweep showed a 5th/6th worker gives no speedup and starves the co-running parser; this model additionally has zero CSG (pure tessellation, parse-bound at 62%). `?geomWorkers=N` still overrides per host (and stays memory-budget-clamped).

Expected effect on the reporter's model: peak drops by ~5GB (8 -> 4 workers x ~1.3GB) on high-core machines, with no wall-time cost.

## Not in this PR (tracked in #1682, ranked)

- Per-worker index hashmap -> binary search over the already-shared sorted columns (~0.4GB x N)
- Threaded/shared-memory wasm (removes source duplication entirely; #1429 prior art)
- Gate `releaseGeometryAfterFinalize` on the 500MB threshold (~1.3GB CPU retention)
- Oct-encoded normals (~0.9GB)

## Tests

29/29 worker-count tests: new case pinning 16-core/883MB -> 4 workers ('cores'), the 2GB desktop case updated (clamp now binds before the memory budget), 400MB desktop case unchanged (still 8 - the clamp only bites >512MB). Full geometry suite 123/123, tsc clean.

Closes nothing (top lever of #1682; the issue stays open for the deeper levers).