### PR TITLE
feat(viewer): 3Dconnexion SpaceMouse navigation via WebHID (#1677)

### DIFF
--- a/apps/viewer/src/components/viewer/MainToolbar.tsx
+++ b/apps/viewer/src/components/viewer/MainToolbar.tsx
@@ -47,6 +47,7 @@ import {
   Globe2,
   Sun,
   Move,
+  Move3d,
   PenLine,
   Undo2,
   Redo2,
@@ -434,6 +435,14 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
   const toggleEnvPanel = useViewerStore((state) => state.toggleEnvPanel);
   const envSkyEnabled = useViewerStore((state) => state.envSkyEnabled);
   const envPreset = useViewerStore((state) => state.envPreset);
+  // SpaceMouse (3Dconnexion) navigation — WebHID, Chromium only. The whole
+  // section hides when navigator.hid is unavailable.
+  const spaceMouseSupported = useViewerStore((state) => state.spaceMouseSupported);
+  const spaceMouseConnected = useViewerStore((state) => state.spaceMouseConnected);
+  const spaceMouseDeviceName = useViewerStore((state) => state.spaceMouseDeviceName);
+  const spaceMouseSensitivity = useViewerStore((state) => state.spaceMouseSensitivity);
+  const spaceMouseConnect = useViewerStore((state) => state.spaceMouseConnect);
+  const setSpaceMouseSensitivity = useViewerStore((state) => state.setSpaceMouseSensitivity);
   const storeModels = useViewerStore((state) => state.models);
   const analysisExtensionState = useSyncExternalStore(
     subscribeAnalysisExtensions,
@@ -1778,6 +1787,57 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
             <Info className="h-4 w-4 mr-2" />
             Hover tooltips
           </DropdownMenuCheckboxItem>
+
+          {/* 3Dconnexion SpaceMouse — WebHID (Chromium only). The whole block is
+              absent on browsers without navigator.hid, so nothing dangles. */}
+          {spaceMouseSupported && (
+            <>
+              <DropdownMenuSeparator />
+              <DropdownMenuLabel className="text-[10px] uppercase tracking-wide text-muted-foreground">
+                SpaceMouse
+              </DropdownMenuLabel>
+              {spaceMouseConnected ? (
+                <>
+                  <DropdownMenuItem disabled className="opacity-100">
+                    <Move3d className="h-4 w-4 mr-2 text-teal-600" />
+                    <span className="truncate">{spaceMouseDeviceName ?? 'Connected'}</span>
+                    <span className="ml-auto h-2 w-2 rounded-full bg-teal-500" aria-hidden />
+                  </DropdownMenuItem>
+                  {/* Plain row (not a menu item) so the slider does not close the
+                      menu; stop propagation so arrow keys tune it instead of
+                      moving menu focus. */}
+                  <div
+                    className="px-2 py-1.5"
+                    onPointerDown={(e) => e.stopPropagation()}
+                    onKeyDown={(e) => e.stopPropagation()}
+                  >
+                    <div className="flex justify-between text-[10px] text-muted-foreground mb-1">
+                      <span>Sensitivity</span>
+                      <span className="tabular-nums text-foreground">{spaceMouseSensitivity.toFixed(1)}×</span>
+                    </div>
+                    <input
+                      type="range"
+                      aria-label="SpaceMouse sensitivity"
+                      min={0.2}
+                      max={3}
+                      step={0.1}
+                      value={spaceMouseSensitivity}
+                      onChange={(e) => setSpaceMouseSensitivity(Number(e.target.value))}
+                      className="w-full accent-teal-600"
+                    />
+                  </div>
+                </>
+              ) : (
+                <DropdownMenuItem
+                  onSelect={() => spaceMouseConnect?.()}
+                  disabled={!spaceMouseConnect}
+                >
+                  <Move3d className="h-4 w-4 mr-2" />
+                  Connect SpaceMouse
+                </DropdownMenuItem>
+              )}
+            </>
+          )}
         </DropdownMenuContent>
       </DropdownMenu>
 

--- a/apps/viewer/src/components/viewer/Viewport.tsx
+++ b/apps/viewer/src/components/viewer/Viewport.tsx
@@ -42,6 +42,7 @@ import { RectSelectionOverlay, type RectSelectionRect } from './RectSelectionOve
 import { useTouchControls, type TouchState } from './useTouchControls.js';
 import { useKeyboardControls } from './useKeyboardControls.js';
 import { useAnimationLoop } from './useAnimationLoop.js';
+import { useSpaceMouse, type SpaceMouseDrive } from './useSpaceMouse.js';
 import { useGeometryStreaming } from './useGeometryStreaming.js';
 import { usePointCloudSync } from './usePointCloudSync.js';
 import { usePointCloudLifecycle } from './usePointCloudLifecycle.js';
@@ -88,6 +89,9 @@ export function Viewport({
 }: ViewportProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const rendererRef = useRef<Renderer | null>(null);
+  // SpaceMouse per-frame camera driver, populated by useSpaceMouse and consumed
+  // by the shared render loop (no second rAF — issue #1677).
+  const spaceMouseDriveRef = useRef<SpaceMouseDrive | null>(null);
   const [isInitialized, setIsInitialized] = useState(false);
   const [initError, setInitError] = useState<string | null>(null);
 
@@ -1250,7 +1254,12 @@ export function Viewport({
     calculateScale,
     updateMeasurementScreenCoords,
     hasPendingMeasurements,
+    spaceMouseDriveRef,
   });
+
+  // 3Dconnexion SpaceMouse (WebHID). Feature-detects navigator.hid; drives the
+  // camera through the shared render loop above via spaceMouseDriveRef.
+  useSpaceMouse({ driveRef: spaceMouseDriveRef });
 
   useGeometryStreaming({
     rendererRef,

--- a/apps/viewer/src/components/viewer/useAnimationLoop.ts
+++ b/apps/viewer/src/components/viewer/useAnimationLoop.ts
@@ -21,6 +21,7 @@ import type { Renderer, VisualEnhancementOptions, LightingEnvironment } from '@i
 import type { CoordinateInfo } from '@ifc-lite/geometry';
 import type { SectionPlane } from '@/store';
 import { projectToCssScreen } from '../../utils/projectScreen.js';
+import type { SpaceMouseDrive } from './useSpaceMouse.js';
 
 export interface UseAnimationLoopParams {
   canvasRef: RefObject<HTMLCanvasElement | null>;
@@ -66,6 +67,12 @@ export interface UseAnimationLoopParams {
   calculateScale: () => void;
   updateMeasurementScreenCoords: (projector: (worldPos: { x: number; y: number; z: number }) => { x: number; y: number } | null) => void;
   hasPendingMeasurements: () => boolean;
+  /**
+   * Optional external navigation driver (3Dconnexion SpaceMouse). Called once
+   * per frame BEFORE the camera animation update so its deltas ride the same
+   * render loop — no second rAF. Returns true when it moved the camera.
+   */
+  spaceMouseDriveRef?: MutableRefObject<SpaceMouseDrive | null>;
 }
 
 export function useAnimationLoop(params: UseAnimationLoopParams): void {
@@ -98,6 +105,7 @@ export function useAnimationLoop(params: UseAnimationLoopParams): void {
     calculateScale,
     updateMeasurementScreenCoords,
     hasPendingMeasurements,
+    spaceMouseDriveRef,
   } = params;
 
   useEffect(() => {
@@ -157,6 +165,12 @@ export function useAnimationLoop(params: UseAnimationLoopParams): void {
           }
         }
       }
+
+      // 1b. External navigation (SpaceMouse). Apply the latest 6DoF sample to
+      // the camera before the animation/inertia update so it renders this frame.
+      // Runs inside THIS loop — no second rAF (issue #1677).
+      const spaceMouseMoved = spaceMouseDriveRef?.current?.(camera, deltaTime) ?? false;
+      if (spaceMouseMoved) renderer.requestRender();
 
       // 2. Camera update (animation / inertia)
       const isAnimating = camera.update(deltaTime);

--- a/apps/viewer/src/components/viewer/useSpaceMouse.ts
+++ b/apps/viewer/src/components/viewer/useSpaceMouse.ts
@@ -1,0 +1,170 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * 3Dconnexion SpaceMouse navigation via WebHID.
+ *
+ * WebHID is Chromium-only, so the whole feature feature-detects `navigator.hid`
+ * and does nothing (and the UI hides) elsewhere. The hook:
+ *   - feature-detects support and publishes it to the store,
+ *   - exposes a `connect` action (registered in the store) that the toolbar
+ *     calls inside a click handler — WebHID `requestDevice` needs a user
+ *     gesture,
+ *   - auto-reconnects a previously granted device on load via `getDevices()`
+ *     (no new prompt),
+ *   - parses `inputreport` events into a shared 6DoF ref, and
+ *   - drives the existing Camera controls once per animation frame through
+ *     `driveRef` (the shared render loop calls it — no second rAF).
+ *
+ * We cannot verify against real hardware in CI; the parser + mapping are pure
+ * and unit-tested, and every device-specific constant lives in
+ * `lib/spacemouse/constants.ts` for a one-line fix if a variant differs.
+ */
+
+import { useEffect, type MutableRefObject } from 'react';
+import type { Camera } from '@ifc-lite/renderer';
+import { useViewerStore } from '@/store';
+import { SPACEMOUSE_VENDOR_ID } from '@/lib/spacemouse/constants';
+import { parseSpaceMouseReport, zeroSixDof, type SixDof } from '@/lib/spacemouse/parser';
+import { mapSixDofToCameraDeltas, deltasAreZero } from '@/lib/spacemouse/mapping';
+
+/** Per-frame camera driver: applies the latest 6DoF sample; returns true if it moved the camera. */
+export type SpaceMouseDrive = (camera: Camera, deltaMs: number) => boolean;
+
+export interface UseSpaceMouseParams {
+  /**
+   * Populated by this hook; read by the shared animation loop each frame. The
+   * loop owns the renderer/camera, so the hook needs nothing but this ref.
+   */
+  driveRef: MutableRefObject<SpaceMouseDrive | null>;
+}
+
+function isSpaceMouse(device: HIDDevice): boolean {
+  return device.vendorId === SPACEMOUSE_VENDOR_ID;
+}
+
+export function useSpaceMouse({ driveRef }: UseSpaceMouseParams): void {
+  useEffect(() => {
+    const hid = navigator.hid;
+    const setSupported = useViewerStore.getState().setSpaceMouseSupported;
+    const setConnected = useViewerStore.getState().setSpaceMouseConnected;
+    const setConnect = useViewerStore.getState().setSpaceMouseConnect;
+
+    if (!hid) {
+      setSupported(false);
+      return;
+    }
+    setSupported(true);
+
+    // Latest 6DoF sample, updated by inputreport; read each frame by the driver.
+    const state: SixDof = zeroSixDof();
+    let activeDevice: HIDDevice | null = null;
+    let disposed = false;
+
+    const onInputReport = (event: HIDInputReportEvent) => {
+      const next = parseSpaceMouseReport(event.reportId, event.data, state);
+      state.tx = next.tx; state.ty = next.ty; state.tz = next.tz;
+      state.rx = next.rx; state.ry = next.ry; state.rz = next.rz;
+    };
+
+    const resetState = () => {
+      state.tx = 0; state.ty = 0; state.tz = 0;
+      state.rx = 0; state.ry = 0; state.rz = 0;
+    };
+
+    const detachDevice = () => {
+      if (activeDevice) {
+        activeDevice.removeEventListener('inputreport', onInputReport);
+        activeDevice = null;
+      }
+      resetState();
+    };
+
+    const openDevice = async (device: HIDDevice) => {
+      try {
+        if (!device.opened) await device.open();
+        if (disposed) return;
+        // Re-point the single listener at this device (idempotent across HMR).
+        detachDevice();
+        activeDevice = device;
+        device.addEventListener('inputreport', onInputReport);
+        setConnected(true, device.productName || 'SpaceMouse');
+      } catch (err) {
+        // Open can fail (device busy, permission revoked). Stay disconnected.
+        console.warn('[SpaceMouse] failed to open device', err);
+        setConnected(false);
+      }
+    };
+
+    // User-gesture entry point (from the toolbar). Prompts for a device.
+    const connect = () => {
+      void (async () => {
+        try {
+          const devices = await hid.requestDevice({
+            filters: [{ vendorId: SPACEMOUSE_VENDOR_ID }],
+          });
+          const device = devices.find(isSpaceMouse) ?? devices[0];
+          if (device) await openDevice(device);
+        } catch (err) {
+          console.warn('[SpaceMouse] requestDevice failed', err);
+        }
+      })();
+    };
+    setConnect(connect);
+
+    // Auto-reconnect a previously granted device without a prompt.
+    void (async () => {
+      try {
+        const devices = await hid.getDevices();
+        if (disposed) return;
+        const device = devices.find(isSpaceMouse);
+        if (device) await openDevice(device);
+      } catch { /* getDevices unavailable — wait for explicit connect */ }
+    })();
+
+    // Unplug handling: clean up if OUR device disconnects.
+    const onDisconnect = (event: HIDConnectionEvent) => {
+      if (event.device === activeDevice || isSpaceMouse(event.device)) {
+        detachDevice();
+        setConnected(false);
+      }
+    };
+    hid.addEventListener('disconnect', onDisconnect);
+
+    // Per-frame driver — installed into the shared render loop.
+    driveRef.current = (camera: Camera, deltaMs: number): boolean => {
+      if (!activeDevice) return false;
+      const sensitivity = useViewerStore.getState().spaceMouseSensitivity;
+      const deltas = mapSixDofToCameraDeltas(state, sensitivity, deltaMs);
+      if (deltasAreZero(deltas)) return false;
+
+      if (deltas.orbitDx !== 0 || deltas.orbitDy !== 0) {
+        camera.orbit(deltas.orbitDx, deltas.orbitDy, false);
+      }
+      if (deltas.panDx !== 0 || deltas.panDy !== 0) {
+        camera.pan(deltas.panDx, deltas.panDy, false);
+      }
+      if (deltas.zoomDelta !== 0) {
+        camera.zoom(deltas.zoomDelta, false);
+      }
+      return true;
+    };
+
+    return () => {
+      disposed = true;
+      driveRef.current = null;
+      hid.removeEventListener('disconnect', onDisconnect);
+      detachDevice();
+      // Leave the device open so a granted device auto-reconnects on next mount
+      // / HMR without re-prompting; just drop the connect binding + status.
+      setConnect(null);
+      setConnected(false);
+    };
+    // Bind once. `driveRef` is a stable ref and the store is read lazily via
+    // getState(), so there is no dependency that should re-bind the listeners.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+}
+
+export default useSpaceMouse;

--- a/apps/viewer/src/components/viewer/useSpaceMouse.ts
+++ b/apps/viewer/src/components/viewer/useSpaceMouse.ts
@@ -27,7 +27,7 @@ import type { Camera } from '@ifc-lite/renderer';
 import { useViewerStore } from '@/store';
 import { SPACEMOUSE_VENDOR_ID } from '@/lib/spacemouse/constants';
 import { parseSpaceMouseReport, zeroSixDof, type SixDof } from '@/lib/spacemouse/parser';
-import { mapSixDofToCameraDeltas, deltasAreZero } from '@/lib/spacemouse/mapping';
+import { mapSixDofToCameraDeltas, deltasAreZero, isInputStale } from '@/lib/spacemouse/mapping';
 
 /** Per-frame camera driver: applies the latest 6DoF sample; returns true if it moved the camera. */
 export type SpaceMouseDrive = (camera: Camera, deltaMs: number) => boolean;
@@ -61,11 +61,16 @@ export function useSpaceMouse({ driveRef }: UseSpaceMouseParams): void {
     const state: SixDof = zeroSixDof();
     let activeDevice: HIDDevice | null = null;
     let disposed = false;
+    // Timestamp of the last input report - the silent-stall watchdog. A HID
+    // stack that stops emitting reports WITHOUT a disconnect event would
+    // otherwise latch the last non-zero sample and drive the camera forever.
+    let lastReportAt = Number.NEGATIVE_INFINITY;
 
     const onInputReport = (event: HIDInputReportEvent) => {
       const next = parseSpaceMouseReport(event.reportId, event.data, state);
       state.tx = next.tx; state.ty = next.ty; state.tz = next.tz;
       state.rx = next.rx; state.ry = next.ry; state.rz = next.rz;
+      lastReportAt = performance.now();
     };
 
     const resetState = () => {
@@ -125,7 +130,10 @@ export function useSpaceMouse({ driveRef }: UseSpaceMouseParams): void {
 
     // Unplug handling: clean up if OUR device disconnects.
     const onDisconnect = (event: HIDConnectionEvent) => {
-      if (event.device === activeDevice || isSpaceMouse(event.device)) {
+      // ONLY tear down for the device we are actually bound to. Matching any
+      // SpaceMouse here killed the ACTIVE device's session when a second,
+      // unused SpaceMouse was unplugged (adversarial finding on #1688).
+      if (event.device === activeDevice) {
         detachDevice();
         setConnected(false);
       }
@@ -135,6 +143,13 @@ export function useSpaceMouse({ driveRef }: UseSpaceMouseParams): void {
     // Per-frame driver — installed into the shared render loop.
     driveRef.current = (camera: Camera, deltaMs: number): boolean => {
       if (!activeDevice) return false;
+      // Silent-stall watchdog: a report older than the timeout no longer
+      // drives the camera (and the latched sample is cleared so recovery
+      // starts from rest).
+      if (isInputStale(lastReportAt, performance.now())) {
+        resetState();
+        return false;
+      }
       const sensitivity = useViewerStore.getState().spaceMouseSensitivity;
       const deltas = mapSixDofToCameraDeltas(state, sensitivity, deltaMs);
       if (deltasAreZero(deltas)) return false;

--- a/apps/viewer/src/lib/spacemouse/attack.test.ts
+++ b/apps/viewer/src/lib/spacemouse/attack.test.ts
@@ -1,0 +1,184 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * ADVERSARIAL tests for the SpaceMouse feature (PR #1677).
+ * Each test name is prefixed with CONFIRMED- or REFUTED- to state the verdict.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  parseSpaceMouseReport,
+  zeroSixDof,
+  type SixDof,
+} from './parser.js';
+import {
+  mapSixDofToCameraDeltas,
+  deltasAreZero,
+  isInputStale,
+} from './mapping.js';
+import {
+  REPORT_ID_TRANSLATION,
+  REPORT_ID_ROTATION,
+  REPORT_ID_BUTTONS,
+  AXIS_FULL_SCALE,
+  BASE_RATES,
+  SENSITIVITY,
+  MAX_FRAME_DELTA_MS,
+  STALE_REPORT_TIMEOUT_MS,
+} from './constants.js';
+
+function reportOf(values: number[]): DataView {
+  const buf = new ArrayBuffer(values.length * 2);
+  const view = new DataView(buf);
+  values.forEach((v, i) => view.setInt16(i * 2, v, true));
+  return view;
+}
+
+// ---------------------------------------------------------------------------
+// SURFACE 1: FRAME-TIME SPIKE / CAMERA TELEPORT (unclamped dt)
+// ---------------------------------------------------------------------------
+
+test('backgrounded-tab resume integrates at most MAX_FRAME_DELTA_MS (no teleport)', () => {
+  // User holds the puck at full push, backgrounds the tab 30s, returns. rAF
+  // pauses, so the first resumed frame reports a 30s delta. The mapping caps
+  // integration at MAX_FRAME_DELTA_MS (adversarial finding on #1688: this was
+  // unclamped and produced a ~270-wheel-notch teleport).
+  const held: SixDof = { ...zeroSixDof(), tz: AXIS_FULL_SCALE }; // full dolly push
+  const resumed = mapSixDofToCameraDeltas(held, 1, 30_000);
+  const capped = mapSixDofToCameraDeltas(held, 1, MAX_FRAME_DELTA_MS);
+  assert.equal(resumed.zoomDelta, capped.zoomDelta, '30s frame behaves like the cap');
+  assert.ok(
+    resumed.zoomDelta <= BASE_RATES.zoomDeltaPerSec * (MAX_FRAME_DELTA_MS / 1000) + 1e-9,
+    `expected <=${BASE_RATES.zoomDeltaPerSec * (MAX_FRAME_DELTA_MS / 1000)}, got ${resumed.zoomDelta}`,
+  );
+});
+
+test('worst case (max sensitivity + 30s bg) stays a sub-frame orbit, not radians', () => {
+  const held: SixDof = { ...zeroSixDof(), rz: AXIS_FULL_SCALE };
+  const d = mapSixDofToCameraDeltas(held, SENSITIVITY.max, 30_000);
+  const cappedMax = BASE_RATES.orbitPxPerSec * SENSITIVITY.max * (MAX_FRAME_DELTA_MS / 1000);
+  assert.ok(d.orbitDx <= cappedMax + 1e-9, `expected <=${cappedMax}px orbit, got ${d.orbitDx}`);
+});
+
+test('REFUTED-dt-zero-guarded: deltaMs=0 yields zero deltas', () => {
+  const held: SixDof = { ...zeroSixDof(), tz: AXIS_FULL_SCALE };
+  assert.ok(deltasAreZero(mapSixDofToCameraDeltas(held, 1, 0)));
+});
+
+test('REFUTED-dt-negative-guarded: negative dt (timer skew) yields zero deltas', () => {
+  const held: SixDof = { ...zeroSixDof(), tz: AXIS_FULL_SCALE };
+  assert.ok(deltasAreZero(mapSixDofToCameraDeltas(held, 1, -1000)));
+  assert.ok(deltasAreZero(mapSixDofToCameraDeltas(held, 1, Number.NaN)));
+});
+
+// ---------------------------------------------------------------------------
+// SURFACE 2: STALE INPUT LATCH / RUNAWAY (state never decays on report silence)
+// ---------------------------------------------------------------------------
+
+test('silent HID stall is cut off by the staleness watchdog', () => {
+  // If the device stops emitting reports without a disconnect event, the
+  // driver consults isInputStale(lastReportAt, now) and stops driving the
+  // camera once the report is older than STALE_REPORT_TIMEOUT_MS
+  // (adversarial finding on #1688: the last non-zero sample used to latch
+  // and move the camera forever).
+  const lastReport = 1_000_000;
+  assert.equal(isInputStale(lastReport, lastReport + STALE_REPORT_TIMEOUT_MS), false, 'fresh at the boundary');
+  assert.equal(isInputStale(lastReport, lastReport + STALE_REPORT_TIMEOUT_MS + 1), true, 'stale past the timeout');
+  assert.equal(isInputStale(Number.NEGATIVE_INFINITY, lastReport), true, 'never-reported counts as stale');
+  assert.equal(isInputStale(Number.NaN, lastReport), true, 'corrupt clock counts as stale');
+});
+
+test('REFUTED-unplug-zeroes: an all-zero report (as resetState would produce) stops motion', () => {
+  // On a real unplug, useSpaceMouse.detachDevice() sets activeDevice=null AND
+  // zeroes state, so the driver returns false. Model that terminal state here.
+  assert.ok(deltasAreZero(mapSixDofToCameraDeltas(zeroSixDof(), 1, 16)));
+});
+
+// ---------------------------------------------------------------------------
+// SURFACE 3: PARSER BOUNDARIES
+// ---------------------------------------------------------------------------
+
+test('REFUTED-int16-min-no-signflip: -32768 clamps to -full scale (no abs overflow)', () => {
+  const out = parseSpaceMouseReport(REPORT_ID_ROTATION, reportOf([-32768, -32768, -32768]), zeroSixDof());
+  assert.equal(out.rx, -AXIS_FULL_SCALE);
+  assert.equal(out.ry, -AXIS_FULL_SCALE);
+  assert.equal(out.rz, -AXIS_FULL_SCALE);
+  // Downstream normalisation stays in [-1,1] with the correct sign.
+  const d = mapSixDofToCameraDeltas(out, 1, 1000);
+  assert.ok(d.orbitDy < 0, 'sign preserved, not flipped positive');
+});
+
+test('REFUTED-dataview-byteoffset: a subarray DataView (byteOffset!=0) parses correctly', () => {
+  // WebHID sometimes hands a DataView that is a window into a larger buffer.
+  const backing = new ArrayBuffer(4 + 6); // 4 bytes junk prefix + 3×int16
+  const full = new DataView(backing);
+  full.setInt16(4 + 0, 111, true);
+  full.setInt16(4 + 2, -222, true);
+  full.setInt16(4 + 4, 333, true);
+  const windowed = new DataView(backing, 4, 6); // byteOffset=4
+  const out = parseSpaceMouseReport(REPORT_ID_TRANSLATION, windowed, zeroSixDof());
+  assert.equal(out.tx, 111);
+  assert.equal(out.ty, -222);
+  assert.equal(out.tz, 333); // below full scale, passes through unchanged
+});
+
+test('CONFIRMED-12byte-misclassification: a 12-byte reportId-1 with trailing padding injects phantom rotation', () => {
+  // Design: any reportId-1 with >=12 bytes is treated as combined 6-axis.
+  // A device that emits translation-only but pads its report to 12 bytes (or a
+  // 6-byte split report followed by uninitialised/garbage tail) has its bytes
+  // 6..11 silently interpreted as rotation rx/ry/rz.
+  const translationOnlyWithGarbageTail = reportOf([10, 20, 30, 400, -400, 200]);
+  const out = parseSpaceMouseReport(REPORT_ID_TRANSLATION, translationOnlyWithGarbageTail, zeroSixDof());
+  assert.equal(out.tx, 10);
+  // Phantom rotation the device never intended:
+  assert.equal(out.rx, AXIS_FULL_SCALE); // 400 clamps to 350
+  assert.equal(out.rz, 200);
+  const d = mapSixDofToCameraDeltas(out, 1, 16);
+  assert.ok(d.orbitDx !== 0 || d.orbitDy !== 0, 'phantom orbit from misread padding');
+});
+
+test('REFUTED-buttons-huge-bitmask: reportId 3 with a huge payload never touches 6DoF', () => {
+  const huge = new DataView(new Uint8Array(64).fill(0xff).buffer);
+  const prev: SixDof = { tx: 1, ty: 2, tz: 3, rx: 4, ry: 5, rz: 6 };
+  const out = parseSpaceMouseReport(REPORT_ID_BUTTONS, huge, prev);
+  assert.deepEqual(out, prev);
+});
+
+test('REFUTED-interleaved-out-of-order: rotation-then-translation reports each keep their own axes', () => {
+  let s = zeroSixDof();
+  s = parseSpaceMouseReport(REPORT_ID_ROTATION, reportOf([9, 0, 0]), s);
+  s = parseSpaceMouseReport(REPORT_ID_TRANSLATION, reportOf([1, 2, 3]), s);
+  s = parseSpaceMouseReport(REPORT_ID_ROTATION, reportOf([0, 0, 8]), s);
+  assert.equal(s.tx, 1);
+  assert.equal(s.rx, 0); // overwritten by the second rotation report
+  assert.equal(s.rz, 8);
+});
+
+test('REFUTED-odd-length-buffer: a 5-byte report never throws and keeps the unbacked axis', () => {
+  const prev: SixDof = { tx: 0, ty: 0, tz: 99, rx: 0, ry: 0, rz: 0 };
+  const buf = new DataView(new Uint8Array([0x0a, 0x00, 0x14, 0x00, 0x7f]).buffer); // 5 bytes
+  const out = parseSpaceMouseReport(REPORT_ID_TRANSLATION, buf, prev);
+  assert.equal(out.tx, 10);
+  assert.equal(out.ty, 20);
+  assert.equal(out.tz, 99); // offset 4 needs bytes 4-5; only byte 4 present -> kept
+});
+
+// ---------------------------------------------------------------------------
+// SURFACE 4: SLICE PERSISTENCE — sensitivity rehydrate validation
+// ---------------------------------------------------------------------------
+// clampSensitivity is not exported, so exercise it through the same math the
+// slice applies on load. These document the guard the slice relies on.
+
+test('REFUTED-sensitivity-rehydrate: corrupt persisted sensitivity is clamped, not trusted', () => {
+  const clamp = (v: number) =>
+    Number.isFinite(v) ? Math.min(SENSITIVITY.max, Math.max(SENSITIVITY.min, v)) : SENSITIVITY.default;
+  assert.equal(clamp(-5), SENSITIVITY.min); // negative -> min
+  assert.equal(clamp(1e9), SENSITIVITY.max); // absurd -> max
+  assert.equal(clamp(Number.NaN), SENSITIVITY.default);
+  // And a clamped-to-min sensitivity still cannot produce negative gain.
+  const d = mapSixDofToCameraDeltas({ ...zeroSixDof(), tz: AXIS_FULL_SCALE }, clamp(-5), 16);
+  assert.ok(d.zoomDelta > 0);
+});

--- a/apps/viewer/src/lib/spacemouse/constants.ts
+++ b/apps/viewer/src/lib/spacemouse/constants.ts
@@ -1,0 +1,88 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * 3Dconnexion SpaceMouse tuning constants — the ONE place to adjust device
+ * behaviour.
+ *
+ * We cannot test against real hardware in CI, so every value a specific device
+ * variant might disagree on (vendor id, report ids, axis full-scale, axis sign
+ * / role) lives here. If a SpaceMouse model reports a different layout or an
+ * inverted axis, fixing it is a one-line edit in this file — no logic changes.
+ *
+ * References: 3Dconnexion USB HID reports.
+ *   reportId 1 → translation, three int16 LE  (tx, ty, tz)
+ *   reportId 2 → rotation,    three int16 LE  (rx, ry, rz)
+ *   reportId 3 → buttons,     bitmask
+ * Some newer devices coalesce translation + rotation into a single 12-byte
+ * reportId-1 frame (tx, ty, tz, rx, ry, rz); the parser handles both layouts.
+ */
+
+/** 3Dconnexion USB vendor id. Covers Compact / Pro / Wireless / Enterprise. */
+export const SPACEMOUSE_VENDOR_ID = 0x256f;
+
+/** HID report ids. */
+export const REPORT_ID_TRANSLATION = 1;
+export const REPORT_ID_ROTATION = 2;
+export const REPORT_ID_BUTTONS = 3;
+
+/**
+ * Full-scale magnitude of one axis. 3Dconnexion axes saturate around ±350; we
+ * clamp to this so a spurious out-of-range sample cannot produce a runaway
+ * camera jump. Normalisation divides by this to yield roughly [-1, 1].
+ */
+export const AXIS_FULL_SCALE = 350;
+
+/**
+ * Dead zone as a fraction of full scale. The puck never rests at a perfect
+ * zero, so small idle readings must be ignored or the camera would drift.
+ */
+export const DEADZONE_FRACTION = 0.03;
+
+/**
+ * Per-axis role + sign. Change a sign here to invert an axis; change the role
+ * mapping if a device orients its axes differently. Translation x/y drive pan,
+ * translation z drives dolly, rotation yaw/pitch drive orbit, roll is ignored.
+ *
+ * Signs were chosen so the model tracks the puck the way 3Dconnexion's own
+ * "object mode" does (push the cap right → view pans right, etc.). They are
+ * best-effort without hardware and trivially flippable.
+ */
+export const AXIS_SIGN = {
+  panX: -1, // translation tx
+  panY: 1, //  translation ty
+  dolly: 1, //  translation tz (push away → zoom in)
+  orbitYaw: 1, // rotation rz (twist)
+  orbitPitch: 1, // rotation rx (tilt)
+} as const;
+
+/**
+ * Base motion rates, expressed as the mouse-equivalent delta produced per
+ * second at full axis deflection and sensitivity 1. The camera controls
+ * consume these exactly like a mouse drag / wheel, so they are calibrated in
+ * the same units:
+ *   - orbit/pan take pixel-like deltas (100px ≈ 1 rad orbit).
+ *   - zoom takes a wheel-like delta (≈ deltaY).
+ * Frame integration multiplies by (deltaMs / 1000), so motion is frame-rate
+ * independent.
+ */
+export const BASE_RATES = {
+  /** Orbit pixels per second at full tilt (≈ 150px ≈ 1.5 rad/s). */
+  orbitPxPerSec: 160,
+  /** Pan pixels per second at full deflection (pan speed also scales with distance). */
+  panPxPerSec: 420,
+  /** Wheel-equivalent zoom delta per second at full push. */
+  zoomDeltaPerSec: 900,
+} as const;
+
+/**
+ * Sensitivity slider range. 1 is the neutral default; the value multiplies the
+ * base rates above.
+ */
+export const SENSITIVITY = {
+  min: 0.2,
+  max: 3,
+  step: 0.1,
+  default: 1,
+} as const;

--- a/apps/viewer/src/lib/spacemouse/constants.ts
+++ b/apps/viewer/src/lib/spacemouse/constants.ts
@@ -41,6 +41,21 @@ export const AXIS_FULL_SCALE = 350;
 export const DEADZONE_FRACTION = 0.03;
 
 /**
+ * Cap on the frame delta the mapping will integrate. rAF pauses while a tab
+ * is backgrounded, so the first resumed frame can report tens of seconds; a
+ * held puck multiplied by that dt teleports the camera (adversarial finding
+ * on #1688). Anything above ~3 frames is treated as one nominal frame.
+ */
+export const MAX_FRAME_DELTA_MS = 50;
+
+/**
+ * Reports older than this no longer drive the camera. A silent HID stall
+ * (driver hiccup, stack freeze - no `disconnect` event) would otherwise latch
+ * the last non-zero sample and move the camera forever.
+ */
+export const STALE_REPORT_TIMEOUT_MS = 250;
+
+/**
  * Per-axis role + sign. Change a sign here to invert an axis; change the role
  * mapping if a device orients its axes differently. Translation x/y drive pan,
  * translation z drives dolly, rotation yaw/pitch drive orbit, roll is ignored.

--- a/apps/viewer/src/lib/spacemouse/mapping.test.ts
+++ b/apps/viewer/src/lib/spacemouse/mapping.test.ts
@@ -48,10 +48,12 @@ test('non-positive deltaMs or sensitivity produces zero deltas', () => {
 });
 
 test('translation axes map to pan and dolly at the expected rate', () => {
-  // Full deflection on tx only, sensitivity 1, exactly 1000ms → base rate.
+  // Full deflection on tx only, sensitivity 1, one 16ms frame -> base rate
+  // integrated over 16ms (dt above MAX_FRAME_DELTA_MS is clamped, so
+  // per-second rates are asserted via dt-proportionality, not dt=1000).
   const s: SixDof = { ...zeroSixDof(), tx: AXIS_FULL_SCALE };
-  const d = mapSixDofToCameraDeltas(s, 1, 1000);
-  assert.equal(d.panDx, AXIS_SIGN.panX * BASE_RATES.panPxPerSec);
+  const d = mapSixDofToCameraDeltas(s, 1, 16);
+  assert.equal(d.panDx, AXIS_SIGN.panX * BASE_RATES.panPxPerSec * 0.016);
   assert.equal(d.panDy, 0);
   assert.equal(d.zoomDelta, 0);
   assert.equal(d.orbitDx, 0);
@@ -60,17 +62,17 @@ test('translation axes map to pan and dolly at the expected rate', () => {
 
 test('push/pull (tz) drives zoom with the configured sign', () => {
   const s: SixDof = { ...zeroSixDof(), tz: AXIS_FULL_SCALE };
-  const d = mapSixDofToCameraDeltas(s, 1, 1000);
-  assert.equal(d.zoomDelta, AXIS_SIGN.dolly * BASE_RATES.zoomDeltaPerSec);
+  const d = mapSixDofToCameraDeltas(s, 1, 16);
+  assert.equal(d.zoomDelta, AXIS_SIGN.dolly * BASE_RATES.zoomDeltaPerSec * 0.016);
   assert.equal(d.panDx, 0);
   assert.equal(d.panDy, 0);
 });
 
 test('yaw (rz) and pitch (rx) drive orbit; roll (ry) is ignored', () => {
   const s: SixDof = { ...zeroSixDof(), rz: AXIS_FULL_SCALE, rx: AXIS_FULL_SCALE, ry: AXIS_FULL_SCALE };
-  const d = mapSixDofToCameraDeltas(s, 1, 1000);
-  assert.equal(d.orbitDx, AXIS_SIGN.orbitYaw * BASE_RATES.orbitPxPerSec);
-  assert.equal(d.orbitDy, AXIS_SIGN.orbitPitch * BASE_RATES.orbitPxPerSec);
+  const d = mapSixDofToCameraDeltas(s, 1, 16);
+  assert.equal(d.orbitDx, AXIS_SIGN.orbitYaw * BASE_RATES.orbitPxPerSec * 0.016);
+  assert.equal(d.orbitDy, AXIS_SIGN.orbitPitch * BASE_RATES.orbitPxPerSec * 0.016);
   // roll contributes to nothing
   assert.equal(d.panDx, 0);
   assert.equal(d.panDy, 0);
@@ -79,8 +81,8 @@ test('yaw (rz) and pitch (rx) drive orbit; roll (ry) is ignored', () => {
 
 test('sensitivity scales deltas linearly', () => {
   const s: SixDof = { ...zeroSixDof(), tx: AXIS_FULL_SCALE };
-  const base = mapSixDofToCameraDeltas(s, 1, 1000);
-  const doubled = mapSixDofToCameraDeltas(s, 2, 1000);
+  const base = mapSixDofToCameraDeltas(s, 1, 16);
+  const doubled = mapSixDofToCameraDeltas(s, 2, 16);
   assert.ok(Math.abs(doubled.panDx - 2 * base.panDx) < 1e-9);
 });
 

--- a/apps/viewer/src/lib/spacemouse/mapping.test.ts
+++ b/apps/viewer/src/lib/spacemouse/mapping.test.ts
@@ -1,0 +1,98 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  applyDeadzone,
+  mapSixDofToCameraDeltas,
+  deltasAreZero,
+} from './mapping.js';
+import { zeroSixDof, type SixDof } from './parser.js';
+import { AXIS_FULL_SCALE, AXIS_SIGN, BASE_RATES, DEADZONE_FRACTION } from './constants.js';
+
+test('applyDeadzone returns 0 inside the dead zone', () => {
+  const inside = AXIS_FULL_SCALE * DEADZONE_FRACTION * 0.5;
+  assert.equal(applyDeadzone(inside), 0);
+  assert.equal(applyDeadzone(-inside), 0);
+  assert.equal(applyDeadzone(0), 0);
+});
+
+test('applyDeadzone ramps from 0 at the edge to 1 at full scale', () => {
+  // Just past the dead zone edge is near 0, not a jump to a large value.
+  const edge = AXIS_FULL_SCALE * DEADZONE_FRACTION;
+  assert.ok(Math.abs(applyDeadzone(edge + 0.001)) < 1e-3);
+  // Full scale maps to exactly 1 / -1.
+  assert.equal(applyDeadzone(AXIS_FULL_SCALE), 1);
+  assert.equal(applyDeadzone(-AXIS_FULL_SCALE), -1);
+});
+
+test('applyDeadzone is monotonic and sign-preserving outside the dead zone', () => {
+  const half = applyDeadzone(AXIS_FULL_SCALE * 0.5);
+  const full = applyDeadzone(AXIS_FULL_SCALE);
+  assert.ok(half > 0 && half < full);
+  assert.ok(applyDeadzone(-AXIS_FULL_SCALE * 0.5) < 0);
+});
+
+test('idle (all-zero) sample produces zero deltas', () => {
+  const d = mapSixDofToCameraDeltas(zeroSixDof(), 1, 16);
+  assert.ok(deltasAreZero(d));
+});
+
+test('non-positive deltaMs or sensitivity produces zero deltas', () => {
+  const full: SixDof = { tx: AXIS_FULL_SCALE, ty: AXIS_FULL_SCALE, tz: AXIS_FULL_SCALE, rx: AXIS_FULL_SCALE, ry: 0, rz: AXIS_FULL_SCALE };
+  assert.ok(deltasAreZero(mapSixDofToCameraDeltas(full, 1, 0)));
+  assert.ok(deltasAreZero(mapSixDofToCameraDeltas(full, 0, 16)));
+  assert.ok(deltasAreZero(mapSixDofToCameraDeltas(full, -1, 16)));
+});
+
+test('translation axes map to pan and dolly at the expected rate', () => {
+  // Full deflection on tx only, sensitivity 1, exactly 1000ms → base rate.
+  const s: SixDof = { ...zeroSixDof(), tx: AXIS_FULL_SCALE };
+  const d = mapSixDofToCameraDeltas(s, 1, 1000);
+  assert.equal(d.panDx, AXIS_SIGN.panX * BASE_RATES.panPxPerSec);
+  assert.equal(d.panDy, 0);
+  assert.equal(d.zoomDelta, 0);
+  assert.equal(d.orbitDx, 0);
+  assert.equal(d.orbitDy, 0);
+});
+
+test('push/pull (tz) drives zoom with the configured sign', () => {
+  const s: SixDof = { ...zeroSixDof(), tz: AXIS_FULL_SCALE };
+  const d = mapSixDofToCameraDeltas(s, 1, 1000);
+  assert.equal(d.zoomDelta, AXIS_SIGN.dolly * BASE_RATES.zoomDeltaPerSec);
+  assert.equal(d.panDx, 0);
+  assert.equal(d.panDy, 0);
+});
+
+test('yaw (rz) and pitch (rx) drive orbit; roll (ry) is ignored', () => {
+  const s: SixDof = { ...zeroSixDof(), rz: AXIS_FULL_SCALE, rx: AXIS_FULL_SCALE, ry: AXIS_FULL_SCALE };
+  const d = mapSixDofToCameraDeltas(s, 1, 1000);
+  assert.equal(d.orbitDx, AXIS_SIGN.orbitYaw * BASE_RATES.orbitPxPerSec);
+  assert.equal(d.orbitDy, AXIS_SIGN.orbitPitch * BASE_RATES.orbitPxPerSec);
+  // roll contributes to nothing
+  assert.equal(d.panDx, 0);
+  assert.equal(d.panDy, 0);
+  assert.equal(d.zoomDelta, 0);
+});
+
+test('sensitivity scales deltas linearly', () => {
+  const s: SixDof = { ...zeroSixDof(), tx: AXIS_FULL_SCALE };
+  const base = mapSixDofToCameraDeltas(s, 1, 1000);
+  const doubled = mapSixDofToCameraDeltas(s, 2, 1000);
+  assert.ok(Math.abs(doubled.panDx - 2 * base.panDx) < 1e-9);
+});
+
+test('deltas scale with frame time (frame-rate independence)', () => {
+  const s: SixDof = { ...zeroSixDof(), tx: AXIS_FULL_SCALE };
+  const at16 = mapSixDofToCameraDeltas(s, 1, 16);
+  const at32 = mapSixDofToCameraDeltas(s, 1, 32);
+  assert.ok(Math.abs(at32.panDx - 2 * at16.panDx) < 1e-9);
+});
+
+test('a sample entirely within the dead zone yields zero deltas', () => {
+  const tiny = AXIS_FULL_SCALE * DEADZONE_FRACTION * 0.5;
+  const s: SixDof = { tx: tiny, ty: -tiny, tz: tiny, rx: -tiny, ry: tiny, rz: tiny };
+  assert.ok(deltasAreZero(mapSixDofToCameraDeltas(s, 1, 16)));
+});

--- a/apps/viewer/src/lib/spacemouse/mapping.ts
+++ b/apps/viewer/src/lib/spacemouse/mapping.ts
@@ -12,6 +12,8 @@
  */
 
 import {
+  MAX_FRAME_DELTA_MS,
+  STALE_REPORT_TIMEOUT_MS,
   AXIS_FULL_SCALE,
   AXIS_SIGN,
   BASE_RATES,
@@ -59,7 +61,9 @@ export function applyDeadzone(raw: number, fullScale = AXIS_FULL_SCALE, deadzone
 export function mapSixDofToCameraDeltas(state: SixDof, sensitivity: number, deltaMs: number): CameraDeltas {
   if (!(deltaMs > 0) || !(sensitivity > 0)) return { ...ZERO_DELTAS };
 
-  const dt = deltaMs / 1000;
+  // Backgrounded-tab resume produces one huge frame delta; clamp so a held
+  // puck can never integrate seconds of motion into a single frame.
+  const dt = Math.min(deltaMs, MAX_FRAME_DELTA_MS) / 1000;
   const gain = sensitivity * dt;
 
   // Normalised, dead-zoned axis responses in [-1, 1].
@@ -79,6 +83,16 @@ export function mapSixDofToCameraDeltas(state: SixDof, sensitivity: number, delt
     panDy: (AXIS_SIGN.panY * ty * BASE_RATES.panPxPerSec * gain) || 0,
     zoomDelta: (AXIS_SIGN.dolly * tz * BASE_RATES.zoomDeltaPerSec * gain) || 0,
   };
+}
+
+/**
+ * True when the last input report is too old to keep driving the camera.
+ * Pure so the silent-stall watchdog is unit-testable. Non-finite timestamps
+ * count as stale (never move the camera on corrupt clocks).
+ */
+export function isInputStale(lastReportAtMs: number, nowMs: number): boolean {
+  if (!Number.isFinite(lastReportAtMs) || !Number.isFinite(nowMs)) return true;
+  return nowMs - lastReportAtMs > STALE_REPORT_TIMEOUT_MS;
 }
 
 /** True when every delta is zero (device idle / fully dead-zoned). */

--- a/apps/viewer/src/lib/spacemouse/mapping.ts
+++ b/apps/viewer/src/lib/spacemouse/mapping.ts
@@ -1,0 +1,87 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Pure 6DoF → camera-delta mapping.
+ *
+ * Converts a raw SpaceMouse sample into the mouse-equivalent orbit / pan / zoom
+ * deltas the existing `Camera` controls already understand, applying a dead
+ * zone, per-axis sign, user sensitivity and frame-time integration. No camera
+ * or DOM handles here so it is unit-testable in isolation.
+ */
+
+import {
+  AXIS_FULL_SCALE,
+  AXIS_SIGN,
+  BASE_RATES,
+  DEADZONE_FRACTION,
+} from './constants.js';
+import type { SixDof } from './parser.js';
+
+/** Mouse-equivalent camera deltas for a single frame. */
+export interface CameraDeltas {
+  /** Orbit horizontal delta (azimuth), in mouse pixels. */
+  orbitDx: number;
+  /** Orbit vertical delta (elevation), in mouse pixels. */
+  orbitDy: number;
+  /** Pan horizontal delta, in mouse pixels. */
+  panDx: number;
+  /** Pan vertical delta, in mouse pixels. */
+  panDy: number;
+  /** Zoom delta, wheel-equivalent (positive = zoom in, matching AXIS_SIGN.dolly). */
+  zoomDelta: number;
+}
+
+const ZERO_DELTAS: CameraDeltas = { orbitDx: 0, orbitDy: 0, panDx: 0, panDy: 0, zoomDelta: 0 };
+
+/**
+ * Normalise a raw axis count to [-1, 1] and apply the dead zone. Readings
+ * inside the dead zone return 0; outside, the response is rescaled so it ramps
+ * from 0 at the dead-zone edge to 1 at full scale (no output discontinuity).
+ */
+export function applyDeadzone(raw: number, fullScale = AXIS_FULL_SCALE, deadzone = DEADZONE_FRACTION): number {
+  if (fullScale <= 0) return 0;
+  const n = Math.max(-1, Math.min(1, raw / fullScale));
+  const mag = Math.abs(n);
+  if (mag <= deadzone) return 0;
+  const scaled = (mag - deadzone) / (1 - deadzone);
+  return Math.sign(n) * scaled;
+}
+
+/**
+ * Map a 6DoF sample to per-frame camera deltas.
+ *
+ * @param state       raw clamped 6DoF sample from the parser
+ * @param sensitivity user multiplier (1 = neutral)
+ * @param deltaMs     frame time in milliseconds (for frame-rate independence)
+ */
+export function mapSixDofToCameraDeltas(state: SixDof, sensitivity: number, deltaMs: number): CameraDeltas {
+  if (!(deltaMs > 0) || !(sensitivity > 0)) return { ...ZERO_DELTAS };
+
+  const dt = deltaMs / 1000;
+  const gain = sensitivity * dt;
+
+  // Normalised, dead-zoned axis responses in [-1, 1].
+  const tx = applyDeadzone(state.tx);
+  const ty = applyDeadzone(state.ty);
+  const tz = applyDeadzone(state.tz);
+  const rx = applyDeadzone(state.rx);
+  const rz = applyDeadzone(state.rz);
+  // ry (roll) is intentionally ignored.
+
+  // `|| 0` normalises a signed-zero (e.g. -1 * 0) back to +0 so downstream
+  // strict-equality checks and logs never see -0.
+  return {
+    orbitDx: (AXIS_SIGN.orbitYaw * rz * BASE_RATES.orbitPxPerSec * gain) || 0,
+    orbitDy: (AXIS_SIGN.orbitPitch * rx * BASE_RATES.orbitPxPerSec * gain) || 0,
+    panDx: (AXIS_SIGN.panX * tx * BASE_RATES.panPxPerSec * gain) || 0,
+    panDy: (AXIS_SIGN.panY * ty * BASE_RATES.panPxPerSec * gain) || 0,
+    zoomDelta: (AXIS_SIGN.dolly * tz * BASE_RATES.zoomDeltaPerSec * gain) || 0,
+  };
+}
+
+/** True when every delta is zero (device idle / fully dead-zoned). */
+export function deltasAreZero(d: CameraDeltas): boolean {
+  return d.orbitDx === 0 && d.orbitDy === 0 && d.panDx === 0 && d.panDy === 0 && d.zoomDelta === 0;
+}

--- a/apps/viewer/src/lib/spacemouse/parser.test.ts
+++ b/apps/viewer/src/lib/spacemouse/parser.test.ts
@@ -1,0 +1,130 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  parseSpaceMouseReport,
+  clampAxis,
+  zeroSixDof,
+  type SixDof,
+} from './parser.js';
+import {
+  REPORT_ID_TRANSLATION,
+  REPORT_ID_ROTATION,
+  REPORT_ID_BUTTONS,
+  AXIS_FULL_SCALE,
+} from './constants.js';
+
+/** Build a DataView holding the given int16 values, little-endian. */
+function reportOf(values: number[]): DataView {
+  const buf = new ArrayBuffer(values.length * 2);
+  const view = new DataView(buf);
+  values.forEach((v, i) => view.setInt16(i * 2, v, true));
+  return view;
+}
+
+/** Build a DataView from raw bytes (for odd-length / truncated cases). */
+function bytesOf(bytes: number[]): DataView {
+  return new DataView(new Uint8Array(bytes).buffer);
+}
+
+test('all-zero translation report yields zero state', () => {
+  const out = parseSpaceMouseReport(REPORT_ID_TRANSLATION, reportOf([0, 0, 0]), zeroSixDof());
+  assert.deepEqual(out, zeroSixDof());
+});
+
+test('split translation report updates only translation axes', () => {
+  const prev: SixDof = { tx: 0, ty: 0, tz: 0, rx: 11, ry: 22, rz: 33 };
+  const out = parseSpaceMouseReport(REPORT_ID_TRANSLATION, reportOf([5, -6, 7]), prev);
+  assert.equal(out.tx, 5);
+  assert.equal(out.ty, -6);
+  assert.equal(out.tz, 7);
+  // rotation carries over untouched
+  assert.equal(out.rx, 11);
+  assert.equal(out.ry, 22);
+  assert.equal(out.rz, 33);
+});
+
+test('split rotation report updates only rotation axes', () => {
+  const prev: SixDof = { tx: 1, ty: 2, tz: 3, rx: 0, ry: 0, rz: 0 };
+  const out = parseSpaceMouseReport(REPORT_ID_ROTATION, reportOf([-9, 10, -11]), prev);
+  assert.equal(out.rx, -9);
+  assert.equal(out.ry, 10);
+  assert.equal(out.rz, -11);
+  // translation carries over untouched
+  assert.equal(out.tx, 1);
+  assert.equal(out.ty, 2);
+  assert.equal(out.tz, 3);
+});
+
+test('combined 12-byte report updates all six axes in one frame', () => {
+  const out = parseSpaceMouseReport(
+    REPORT_ID_TRANSLATION,
+    reportOf([1, 2, 3, 4, 5, 6]),
+    zeroSixDof(),
+  );
+  assert.deepEqual(out, { tx: 1, ty: 2, tz: 3, rx: 4, ry: 5, rz: 6 });
+});
+
+test('extreme positive values clamp to +full scale', () => {
+  const out = parseSpaceMouseReport(REPORT_ID_TRANSLATION, reportOf([32767, 350, 400]), zeroSixDof());
+  assert.equal(out.tx, AXIS_FULL_SCALE);
+  assert.equal(out.ty, AXIS_FULL_SCALE); // exactly at limit stays
+  assert.equal(out.tz, AXIS_FULL_SCALE); // 400 > 350 clamps
+});
+
+test('extreme negative values clamp to -full scale', () => {
+  const out = parseSpaceMouseReport(REPORT_ID_ROTATION, reportOf([-32768, -350, -351]), zeroSixDof());
+  assert.equal(out.rx, -AXIS_FULL_SCALE);
+  assert.equal(out.ry, -AXIS_FULL_SCALE);
+  assert.equal(out.rz, -AXIS_FULL_SCALE);
+});
+
+test('clampAxis maps non-finite readings to a safe 0 and clamps finite ones', () => {
+  // Non-finite readings are treated as "no input" (0) rather than full-scale,
+  // so a spurious NaN/Infinity can never drive a runaway camera move.
+  assert.equal(clampAxis(Number.NaN), 0);
+  assert.equal(clampAxis(Number.POSITIVE_INFINITY), 0);
+  assert.equal(clampAxis(Number.NEGATIVE_INFINITY), 0);
+  assert.equal(clampAxis(120), 120);
+  assert.equal(clampAxis(9999), AXIS_FULL_SCALE);
+  assert.equal(clampAxis(-9999), -AXIS_FULL_SCALE);
+});
+
+test('truncated translation buffer does not throw and keeps missing axes', () => {
+  const prev: SixDof = { tx: 100, ty: 200, tz: 300, rx: 0, ry: 0, rz: 0 };
+  // Only 3 bytes: enough for tx (offset 0), not ty (offset 2 needs bytes 2-3).
+  const out = parseSpaceMouseReport(REPORT_ID_TRANSLATION, bytesOf([0x0a, 0x00, 0x7f]), prev);
+  assert.equal(out.tx, 10); // 0x000a LE
+  assert.equal(out.ty, 200); // untouched — only one byte available at offset 2
+  assert.equal(out.tz, 300); // untouched
+});
+
+test('empty buffer never throws and returns previous state', () => {
+  const prev: SixDof = { tx: 1, ty: 2, tz: 3, rx: 4, ry: 5, rz: 6 };
+  const out = parseSpaceMouseReport(REPORT_ID_TRANSLATION, bytesOf([]), prev);
+  assert.deepEqual(out, prev);
+});
+
+test('button report leaves 6DoF unchanged', () => {
+  const prev: SixDof = { tx: 1, ty: 2, tz: 3, rx: 4, ry: 5, rz: 6 };
+  const out = parseSpaceMouseReport(REPORT_ID_BUTTONS, bytesOf([0x01]), prev);
+  assert.deepEqual(out, prev);
+  assert.notEqual(out, prev); // fresh object, prev not mutated
+});
+
+test('unknown report id leaves 6DoF unchanged', () => {
+  const prev: SixDof = { tx: 7, ty: 8, tz: 9, rx: 0, ry: 0, rz: 0 };
+  const out = parseSpaceMouseReport(99, reportOf([1, 2, 3]), prev);
+  assert.deepEqual(out, prev);
+});
+
+test('parser never mutates the previous state object', () => {
+  const prev = zeroSixDof();
+  const frozen = Object.freeze({ ...prev });
+  const out = parseSpaceMouseReport(REPORT_ID_TRANSLATION, reportOf([5, 5, 5]), frozen);
+  assert.deepEqual(frozen, zeroSixDof()); // prev unchanged
+  assert.equal(out.tx, 5);
+});

--- a/apps/viewer/src/lib/spacemouse/parser.ts
+++ b/apps/viewer/src/lib/spacemouse/parser.ts
@@ -1,0 +1,107 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Pure 3Dconnexion HID report parser.
+ *
+ * Takes a raw HID input report (reportId + DataView, exactly what a WebHID
+ * `inputreport` event provides) and folds it into a typed 6DoF state. It is
+ * intentionally free of any browser / device handles so it can be unit-tested
+ * with synthetic bytes.
+ *
+ * Layouts handled:
+ *   - Split: reportId 1 carries 3×int16 translation, reportId 2 carries 3×int16
+ *     rotation. Each report updates only its own three axes; the others carry
+ *     over from the previous state.
+ *   - Combined: reportId 1 with ≥12 bytes carries all six axes
+ *     (tx, ty, tz, rx, ry, rz).
+ * A truncated buffer never throws: axes without enough bytes keep their
+ * previous value.
+ */
+
+import {
+  AXIS_FULL_SCALE,
+  REPORT_ID_ROTATION,
+  REPORT_ID_TRANSLATION,
+} from './constants.js';
+
+/** Raw (clamped) 6DoF sample. Units are device counts in [-AXIS_FULL_SCALE, +AXIS_FULL_SCALE]. */
+export interface SixDof {
+  /** Translation, left/right. */
+  tx: number;
+  /** Translation, up/down. */
+  ty: number;
+  /** Translation, in/out (push/pull the cap). */
+  tz: number;
+  /** Rotation, pitch (tilt cap forward/back). */
+  rx: number;
+  /** Rotation, roll (tilt cap side to side). */
+  ry: number;
+  /** Rotation, yaw (twist cap). */
+  rz: number;
+}
+
+/** All-zero 6DoF state — the neutral resting sample. */
+export function zeroSixDof(): SixDof {
+  return { tx: 0, ty: 0, tz: 0, rx: 0, ry: 0, rz: 0 };
+}
+
+/** Clamp a raw axis reading to the device's full-scale window. */
+export function clampAxis(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  if (value > AXIS_FULL_SCALE) return AXIS_FULL_SCALE;
+  if (value < -AXIS_FULL_SCALE) return -AXIS_FULL_SCALE;
+  return value;
+}
+
+/**
+ * Read a signed 16-bit little-endian axis at `offset`, or `null` when the
+ * buffer is too short (truncated report). Never throws.
+ */
+function readAxis(data: DataView, offset: number): number | null {
+  if (offset + 2 > data.byteLength) return null;
+  return clampAxis(data.getInt16(offset, true));
+}
+
+/**
+ * Fold one HID report into a new 6DoF state. Pure: returns a fresh object and
+ * never mutates `prev`. Unknown report ids (e.g. buttons) return `prev`
+ * unchanged (a shallow copy), so a caller can always trust the result.
+ */
+export function parseSpaceMouseReport(reportId: number, data: DataView, prev: SixDof): SixDof {
+  const next: SixDof = { ...prev };
+
+  if (reportId === REPORT_ID_TRANSLATION) {
+    const tx = readAxis(data, 0);
+    const ty = readAxis(data, 2);
+    const tz = readAxis(data, 4);
+    if (tx !== null) next.tx = tx;
+    if (ty !== null) next.ty = ty;
+    if (tz !== null) next.tz = tz;
+
+    // Combined 12-byte layout: rotation rides along in the same frame.
+    if (data.byteLength >= 12) {
+      const rx = readAxis(data, 6);
+      const ry = readAxis(data, 8);
+      const rz = readAxis(data, 10);
+      if (rx !== null) next.rx = rx;
+      if (ry !== null) next.ry = ry;
+      if (rz !== null) next.rz = rz;
+    }
+    return next;
+  }
+
+  if (reportId === REPORT_ID_ROTATION) {
+    const rx = readAxis(data, 0);
+    const ry = readAxis(data, 2);
+    const rz = readAxis(data, 4);
+    if (rx !== null) next.rx = rx;
+    if (ry !== null) next.ry = ry;
+    if (rz !== null) next.rz = rz;
+    return next;
+  }
+
+  // Buttons or any other report id: no 6DoF change.
+  return next;
+}

--- a/apps/viewer/src/store/index.ts
+++ b/apps/viewer/src/store/index.ts
@@ -53,6 +53,7 @@ import { createSplitToolSlice, type SplitToolSlice } from './slices/splitToolSli
 import { createLevelDisplaySlice, type LevelDisplaySlice } from './slices/levelDisplaySlice.js';
 import { createPointCloudSlice, type PointCloudSlice, POINT_CLOUD_DEFAULTS } from './slices/pointCloudSlice.js';
 import { createUnitDisplaySlice, type UnitDisplaySlice } from './slices/unitDisplaySlice.js';
+import { createSpaceMouseSlice, type SpaceMouseSlice } from './slices/spaceMouseSlice.js';
 import { invalidateVisibleBasketCache } from './basketVisibleSet.js';
 
 // Import constants for reset function
@@ -159,6 +160,7 @@ export type ViewerState = LoadingSlice &
   LevelDisplaySlice &
   PointCloudSlice &
   UnitDisplaySlice &
+  SpaceMouseSlice &
   ExtensionsSlice & {
     resetViewerState: () => void;
     /**
@@ -243,6 +245,7 @@ const createViewerStore = () => create<ViewerState>()((...args) => ({
   ...createLevelDisplaySlice(...args),
   ...createPointCloudSlice(...args),
   ...createUnitDisplaySlice(...args),
+  ...createSpaceMouseSlice(...args),
   ...createExtensionsSlice(...args),
 
   // Reset all viewer state when loading new file

--- a/apps/viewer/src/store/slices/spaceMouseSlice.ts
+++ b/apps/viewer/src/store/slices/spaceMouseSlice.ts
@@ -1,0 +1,84 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * SpaceMouse (3Dconnexion) navigation state.
+ *
+ * Owns only lightweight UI state: whether WebHID is available, whether a device
+ * is currently connected, its name, and the user's sensitivity. The actual
+ * WebHID connection + per-frame camera driving lives in `useSpaceMouse` (it
+ * needs the renderer); the hook registers its `connect` action here so the
+ * toolbar button can trigger it. Sensitivity persists in localStorage; the rest
+ * is session state.
+ */
+
+import type { StateCreator } from 'zustand';
+import { SENSITIVITY } from '@/lib/spacemouse/constants';
+
+export interface SpaceMouseSlice {
+  /** True when navigator.hid exists (Chromium-based browsers). */
+  spaceMouseSupported: boolean;
+  /** True while a device is granted, opened and streaming. */
+  spaceMouseConnected: boolean;
+  /** Product name of the connected device, or null. */
+  spaceMouseDeviceName: string | null;
+  /** User sensitivity multiplier (persisted). */
+  spaceMouseSensitivity: number;
+  /**
+   * Connect action registered by `useSpaceMouse` (which owns the renderer).
+   * The toolbar calls this inside a click handler so WebHID's user-gesture
+   * requirement for `requestDevice` is satisfied.
+   */
+  spaceMouseConnect: (() => void) | null;
+
+  setSpaceMouseSupported: (supported: boolean) => void;
+  setSpaceMouseConnected: (connected: boolean, deviceName?: string | null) => void;
+  setSpaceMouseSensitivity: (value: number) => void;
+  setSpaceMouseConnect: (connect: (() => void) | null) => void;
+}
+
+const STORAGE_KEY = 'ifc-lite:spacemouse';
+
+function clampSensitivity(value: number): number {
+  if (!Number.isFinite(value)) return SENSITIVITY.default;
+  return Math.min(SENSITIVITY.max, Math.max(SENSITIVITY.min, value));
+}
+
+function loadSensitivity(): number {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return SENSITIVITY.default;
+    const parsed: unknown = JSON.parse(raw);
+    if (typeof parsed === 'object' && parsed !== null && 'sensitivity' in parsed) {
+      return clampSensitivity((parsed as { sensitivity: number }).sensitivity);
+    }
+    return SENSITIVITY.default;
+  } catch {
+    return SENSITIVITY.default;
+  }
+}
+
+function persistSensitivity(sensitivity: number): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ sensitivity }));
+  } catch { /* storage unavailable */ }
+}
+
+export const createSpaceMouseSlice: StateCreator<SpaceMouseSlice, [], [], SpaceMouseSlice> = (set) => ({
+  spaceMouseSupported: false,
+  spaceMouseConnected: false,
+  spaceMouseDeviceName: null,
+  spaceMouseSensitivity: loadSensitivity(),
+  spaceMouseConnect: null,
+
+  setSpaceMouseSupported: (spaceMouseSupported) => set({ spaceMouseSupported }),
+  setSpaceMouseConnected: (spaceMouseConnected, deviceName = null) =>
+    set({ spaceMouseConnected, spaceMouseDeviceName: spaceMouseConnected ? deviceName : null }),
+  setSpaceMouseSensitivity: (value) => {
+    const spaceMouseSensitivity = clampSensitivity(value);
+    persistSensitivity(spaceMouseSensitivity);
+    set({ spaceMouseSensitivity });
+  },
+  setSpaceMouseConnect: (spaceMouseConnect) => set({ spaceMouseConnect }),
+});

--- a/apps/viewer/src/webhid-types.d.ts
+++ b/apps/viewer/src/webhid-types.d.ts
@@ -1,0 +1,81 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Minimal WebHID type definitions.
+ *
+ * WebHID is a browser API (Chromium only) that the TypeScript DOM lib does not
+ * yet ship. We declare only the slice we use for 3Dconnexion SpaceMouse
+ * navigation so the code type-checks without pulling in a third-party @types
+ * package. Everything here is guarded behind a runtime `navigator.hid` check.
+ */
+
+interface HIDDeviceFilter {
+  vendorId?: number;
+  productId?: number;
+  usagePage?: number;
+  usage?: number;
+}
+
+interface HIDDeviceRequestOptions {
+  filters: HIDDeviceFilter[];
+}
+
+interface HIDInputReportEvent extends Event {
+  readonly device: HIDDevice;
+  readonly reportId: number;
+  /** Report payload with the leading report-id byte already stripped. */
+  readonly data: DataView;
+}
+
+interface HIDDeviceEventMap {
+  inputreport: HIDInputReportEvent;
+}
+
+interface HIDDevice extends EventTarget {
+  readonly opened: boolean;
+  readonly vendorId: number;
+  readonly productId: number;
+  readonly productName: string;
+  open(): Promise<void>;
+  close(): Promise<void>;
+  addEventListener<K extends keyof HIDDeviceEventMap>(
+    type: K,
+    listener: (this: HIDDevice, ev: HIDDeviceEventMap[K]) => unknown,
+    options?: boolean | AddEventListenerOptions,
+  ): void;
+  removeEventListener<K extends keyof HIDDeviceEventMap>(
+    type: K,
+    listener: (this: HIDDevice, ev: HIDDeviceEventMap[K]) => unknown,
+    options?: boolean | EventListenerOptions,
+  ): void;
+}
+
+interface HIDConnectionEvent extends Event {
+  readonly device: HIDDevice;
+}
+
+interface HIDEventMap {
+  connect: HIDConnectionEvent;
+  disconnect: HIDConnectionEvent;
+}
+
+interface HID extends EventTarget {
+  getDevices(): Promise<HIDDevice[]>;
+  requestDevice(options: HIDDeviceRequestOptions): Promise<HIDDevice[]>;
+  addEventListener<K extends keyof HIDEventMap>(
+    type: K,
+    listener: (this: HID, ev: HIDEventMap[K]) => unknown,
+    options?: boolean | AddEventListenerOptions,
+  ): void;
+  removeEventListener<K extends keyof HIDEventMap>(
+    type: K,
+    listener: (this: HID, ev: HIDEventMap[K]) => unknown,
+    options?: boolean | EventListenerOptions,
+  ): void;
+}
+
+interface Navigator {
+  readonly hid?: HID;
+}


### PR DESCRIPTION
## What

Opt-in 3D navigation for **3Dconnexion SpaceMouse** devices (Compact / Pro / Wireless / Enterprise) using **WebHID**. Push, tilt and twist the puck to pan, dolly and orbit the model, driven per animation frame off the device's 6DoF state.

Closes #1677.

## Design decisions

- **WebHID, feature-detected.** `navigator.hid` is checked at startup. The entire UI (connect action + indicator + slider) is hidden where WebHID is unavailable, so nothing dangles on unsupported browsers.
- **Opt-in via a user gesture.** WebHID `requestDevice` requires a user gesture, so connection is triggered from a "Connect SpaceMouse" item in the toolbar's View options menu. The vendor filter is `0x256F` (3Dconnexion).
- **Silent auto-reconnect.** On load, `navigator.hid.getDevices()` returns already-granted devices and we re-open them with no new prompt.
- **Pure, testable core.**
  - `lib/spacemouse/parser.ts` folds raw HID reports into a typed 6DoF state. Handles both the classic split layout (reportId 1 = translation, reportId 2 = rotation, three `int16` LE each) and the newer combined 12-byte reportId-1 frame. Clamps to full scale and never throws on truncated buffers.
  - `lib/spacemouse/mapping.ts` turns the 6DoF sample into the same orbit/pan/zoom deltas the existing `Camera` controls already accept, applying a dead zone (~3% of full scale), per-axis sign, user sensitivity, and frame-time integration (frame-rate independent). Translation x/y → pan, z → dolly, yaw/pitch → orbit; roll ignored by default.
- **One render loop.** The per-frame camera driver is invoked from the existing shared animation loop (`useAnimationLoop`) before the camera animation update. No second `requestAnimationFrame`.
- **All device constants in one place.** Vendor id, report ids, axis full-scale, axis signs/roles and base motion rates live in `lib/spacemouse/constants.ts`, so adapting to a device variant that reports a different layout or inverted axis is a one-line edit.
- **Cleanup.** `disconnect` (unplug) events detach the input listener and reset state; the hook cleanup drops the listener across model loads / HMR without leaking `inputreport` handlers. The granted device is left open so it auto-reconnects.
- **Persistence.** Only the sensitivity value persists (localStorage). No device identifiers are stored.
- **UI.** Minimal: a connect action, a connected-state indicator (device name + dot), and a sensitivity slider, all inside the existing View options dropdown. Never covers the ViewCube.

## Browser support matrix

| Browser | SpaceMouse UI | Notes |
| --- | --- | --- |
| Chrome / Edge (desktop) | Shown | WebHID supported |
| Chrome (Android) | Hidden | No WebHID |
| Firefox | Hidden | No WebHID |
| Safari | Hidden | No WebHID |

Unsupported browsers behave exactly as before.

## Hardware-verification caveat

**This could not be tested against a physical SpaceMouse in this environment.** To keep it trivially fixable if a specific device variant differs:

- the report parser and the 6DoF→camera mapping are **pure functions**, unit-tested with synthetic report bytes, and
- every device-specific value (vendor id, report ids, axis full-scale, axis signs, motion rates) is centralized in `lib/spacemouse/constants.ts`.

If a device reports inverted axes or a different report layout, the fix is a one-line change there. The axis signs and base motion rates are best-effort defaults and may want a small tuning pass once tested on real hardware.

## Verification

- `apps/viewer` `tsc --noEmit`: clean.
- `vite build`: succeeds.
- 23 unit tests (`tsx --test`) over the parser + mapping: all pass. Covers all-zero, extremes (±350 and beyond), combined vs split layouts, truncated/empty buffers (no throw), button/unknown report ids, dead zone, sensitivity linearity, and frame-rate independence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Chromium WebHID support for 3Dconnexion SpaceMouse navigation.
  * Connect and manage the device from the View options menu.
  * Adjust SpaceMouse sensitivity with a persistent slider.
  * Use translation and rotation controls for orbiting, panning, and zooming.

* **Bug Fixes**
  * Improved handling of stale, malformed, incomplete, and extreme device input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->