### PR TITLE
perf(core): binary-search the shared entity-index columns instead of per-worker hashmaps (#1682)

### DIFF
--- a/.changeset/binary-search-shared-entity-index.md
+++ b/.changeset/binary-search-shared-entity-index.md
@@ -1,0 +1,34 @@
+---
+"@ifc-lite/wasm": patch
+---
+
+Binary-search the shared entity-index columns instead of building a per-worker
+hashmap (#1682).
+
+Every wasm worker (N geometry workers + prepass + parser) that receives the
+pre-scanned entity index via `setEntityIndex` used to materialize a private
+`FxHashMap<u32, (usize, usize)>`. hashbrown rounds the bucket count up to the
+next power of two, so a 19.1 M-entity model allocates `2^25` buckets ≈ 436 MB
+**per worker realm**, rebuilt in every realm. The delivered representation is
+already three `u32` columns (ids / starts / lengths).
+
+The worker now stores a compact `ColumnarEntityIndex` — three sorted `u32`
+columns with a `binary_search` lookup — ≈ 229 MB for the same model, no
+power-of-two rounding and no `(usize, usize)` widening. The producer emits the
+columns already sorted by id, so consumers take an O(n) already-sorted check
+and skip the argsort; a producer that ever emits out of order is handled by a
+one-time stable argsort. Duplicate express ids resolve last-in-file-order-wins,
+matching the previous `FxHashMap::insert` semantics.
+
+Measured on the native per-element geometry profiler (`csg_model_profile`,
+profiling build, best of 3), binary search is **faster**, not a regression,
+with byte-identical triangle counts:
+
+| model | FxHashMap | columnar | Δ geometry |
+|-------|-----------|----------|------------|
+| schependomlaan (49 MB) | 115 ms | 94 ms | -18% |
+| Holter Tower (177 MB, 60,669 elems) | 827 ms | 711 ms | -14% |
+| O-S1-BWK (342 MB) | 517 ms | 457 ms | -12% |
+
+Native / server paths that can exceed the 4 GiB `u32` offset ceiling keep the
+`usize`-carrying `EntityIndex` hashmap unchanged.

--- a/docs/api/rust.md
+++ b/docs/api/rust.md
@@ -174,6 +174,25 @@ pub type EntityIndex = FxHashMap<u32, (usize, usize)>;
 pub fn build_entity_index<T>(content: &T) -> EntityIndex;
 ```
 
+#### ColumnarEntityIndex (wasm workers)
+
+Wasm geometry workers keep the shared entity index as sorted `u32` columns
+(`ids` / `starts` / `lengths`) and look up by `binary_search` instead of
+materializing a per-worker `FxHashMap` (#1682). Native / server paths still
+use `EntityIndex`.
+
+```rust
+pub struct ColumnarEntityIndex { /* ids, starts, lengths */ }
+
+impl ColumnarEntityIndex {
+    pub fn from_columns(ids: &[u32], starts: &[u32], lengths: &[u32]) -> Self;
+    pub fn from_scan<T>(content: &T) -> Self;
+    pub fn from_hashmap(map: &EntityIndex) -> Self;
+    pub fn from_hashmap_consuming(map: EntityIndex) -> Self;
+    pub fn lookup(&self, id: u32) -> Option<(usize, usize)>;
+}
+```
+
 #### EntityDecoder
 
 ```rust
@@ -190,6 +209,8 @@ impl<'a> EntityDecoder<'a> {
     /// Create decoder with a pre-built index
     pub fn with_index<T>(content: &'a T, index: EntityIndex) -> Self;
     pub fn with_arc_index<T>(content: &'a T, index: Arc<EntityIndex>) -> Self;
+    /// Wasm path: attach a shared columnar index (binary-search lookup)
+    pub fn with_arc_columnar_index<T>(content: &'a T, index: Arc<ColumnarEntityIndex>) -> Self;
 
     /// Decode an entity by express id (cached)
     pub fn decode_by_id(&mut self, entity_id: u32) -> Result<DecodedEntity>;

--- a/packages/parser/src/entity-refs-from-index.ts
+++ b/packages/parser/src/entity-refs-from-index.ts
@@ -60,8 +60,9 @@ export function buildEntityRefsFromIndex(
   const refs: EntityRef[] = new Array(n);
   const intern = new Map<string, string>();
 
-  // The columns arrive in HashMap-iteration order from the Rust pre-pass
-  // (random). Downstream `buildCompactEntityIndexAsync` checks whether
+  // The wasm pre-pass now emits sorted columnar ids (#1682), but this helper
+  // still sorts defensively: a third-party / older producer may still send
+  // unsorted columns. Downstream `buildCompactEntityIndexAsync` checks whether
   // expressIds are ascending and pays an O(N log N) object sort if not
   // — on 14 M entries that's ~8 s. Pre-sort an index permutation (typed
   // array sort with comparator is ~1 s) so refs come out ID-ordered and

--- a/packages/wasm/pkg/ifc-lite.d.ts
+++ b/packages/wasm/pkg/ifc-lite.d.ts
@@ -384,13 +384,14 @@ export class IfcAPI {
    * even though the pre-pass worker built the same index minutes
    * earlier.
    *
-   * Building an `FxHashMap` from the three input slices costs ~1 s on
-   * 14 M entries — about 4–5× faster than re-scanning the file. After
-   * this call, the next `processGeometryBatch` skips the lazy build
-   * branch and reuses the populated cache by `Arc::clone()`.
+   * Builds a compact [`ColumnarEntityIndex`] from the three input slices
+   * (sorted `u32` columns + binary search) instead of a per-worker
+   * `FxHashMap` — ~229 MB vs ~436 MB on a 19.1 M-entity model (#1682).
+   * [`ColumnarEntityIndex::from_columns`] verifies the id ordering once
+   * (O(n)) and only argsorts if the producer did not emit sorted columns.
    *
-   * `lengths[i]` is the byte length of entity `ids[i]`, so the cache
-   * stores `(start, start + length)` to match the existing tuple layout.
+   * `lengths[i]` is the byte length of entity `ids[i]`, so lookup returns
+   * `(start, start + length)` to match the existing `(start, end)` layout.
    *
    * Idempotent in the sense that repeated calls REPLACE the cache —
    * supports the parser-worker pattern of reusing one IfcAPI across

--- a/rust/core/src/columnar_index.rs
+++ b/rust/core/src/columnar_index.rs
@@ -96,12 +96,19 @@ impl ColumnarEntityIndex {
     /// 19.1 M entities and the conversion runs while the whole source file is
     /// resident in the same <4 GiB heap; borrowing (`from_hashmap`) keeps the
     /// map alive across the copy AND the sort, spiking ~970 MB of transients.
-    /// Consuming lets the map's tuples drain into ONE interleaved buffer, the
-    /// map allocation is freed before sorting, and the sort is in-place
-    /// `sort_unstable` (map keys are unique, so no stability/permutation is
-    /// needed): peak extra memory drops to roughly the interleaved buffer.
+    ///
+    /// Consuming drains into one interleaved `Vec<(id, start, len)>` (~229 MB)
+    /// then sorts in place (`sort_unstable`; map keys are unique, so no
+    /// stability/permutation buffer). Peak during the drain is map + rows
+    /// capacity (~665 MB) until the map drops at end-of-loop; after that the
+    /// sort is in-place and the final column split briefly overlaps rows +
+    /// outputs (~458 MB) before rows drop. Still far below the borrowing path,
+    /// and the steady-state index is ~229 MB.
     pub fn from_hashmap_consuming(map: EntityIndex) -> Self {
         let n = map.len();
+        // Reserve while the map is still alive: peak ≈ map + rows (~665 MB at
+        // 19.1 M). Draining without reserve would thrash reallocs for the same
+        // asymptotic peak once the vec fills.
         let mut rows: Vec<(u32, u32, u32)> = Vec::with_capacity(n);
         for (id, (start, end)) in map {
             // u32 offsets are sound only under the wasm32 <4GiB address space
@@ -109,8 +116,7 @@ impl ColumnarEntityIndex {
             debug_assert!(end <= u32::MAX as usize, "entity offset exceeds the u32 column ceiling");
             rows.push((id, start as u32, (end - start) as u32));
         }
-        // `map` is dropped here (moved into the loop) before any further
-        // allocation.
+        // `map` dropped with the loop; sort is in-place on `rows` alone.
         rows.sort_unstable_by_key(|r| r.0);
         let mut ids = Vec::with_capacity(rows.len());
         let mut starts = Vec::with_capacity(rows.len());

--- a/rust/core/src/columnar_index.rs
+++ b/rust/core/src/columnar_index.rs
@@ -92,8 +92,42 @@ impl ColumnarEntityIndex {
     }
 
     /// Build from an already-scanned [`EntityIndex`](crate::EntityIndex)
+    /// hashmap, CONSUMING it. On the wasm prepass path the map is ~436 MB at
+    /// 19.1 M entities and the conversion runs while the whole source file is
+    /// resident in the same <4 GiB heap; borrowing (`from_hashmap`) keeps the
+    /// map alive across the copy AND the sort, spiking ~970 MB of transients.
+    /// Consuming lets the map's tuples drain into ONE interleaved buffer, the
+    /// map allocation is freed before sorting, and the sort is in-place
+    /// `sort_unstable` (map keys are unique, so no stability/permutation is
+    /// needed): peak extra memory drops to roughly the interleaved buffer.
+    pub fn from_hashmap_consuming(map: EntityIndex) -> Self {
+        let n = map.len();
+        let mut rows: Vec<(u32, u32, u32)> = Vec::with_capacity(n);
+        for (id, (start, end)) in map {
+            // u32 offsets are sound only under the wasm32 <4GiB address space
+            // (module docs); see `from_hashmap`.
+            debug_assert!(end <= u32::MAX as usize, "entity offset exceeds the u32 column ceiling");
+            rows.push((id, start as u32, (end - start) as u32));
+        }
+        // `map` is dropped here (moved into the loop) before any further
+        // allocation.
+        rows.sort_unstable_by_key(|r| r.0);
+        let mut ids = Vec::with_capacity(rows.len());
+        let mut starts = Vec::with_capacity(rows.len());
+        let mut lengths = Vec::with_capacity(rows.len());
+        for (id, start, len) in rows {
+            ids.push(id);
+            starts.push(start);
+            lengths.push(len);
+        }
+        Self { ids, starts, lengths }
+    }
+
+    /// Build from an already-scanned [`EntityIndex`](crate::EntityIndex)
     /// hashmap. The map is unique by construction (last-in-file-order-wins was
-    /// applied by `HashMap::insert`), so this only sorts the entries.
+    /// applied by `HashMap::insert`), so this only sorts the entries. Prefer
+    /// [`Self::from_hashmap_consuming`] when the map is no longer needed - it
+    /// avoids holding map + copies concurrently (P1 review finding on #1689).
     pub fn from_hashmap(map: &EntityIndex) -> Self {
         let n = map.len();
         let mut ids = Vec::with_capacity(n);
@@ -341,5 +375,19 @@ mod columnar_index_tests {
         for &id in col.ids() {
             assert_eq!(scanned.lookup(id), col.lookup(id));
         }
+    }
+
+    #[test]
+    fn consuming_and_borrowing_hashmap_builds_agree() {
+        let mut map: crate::EntityIndex = Default::default();
+        for (id, start, end) in [(7u32, 100usize, 150usize), (3, 0, 40), (9, 200, 260), (1, 41, 99)] {
+            map.insert(id, (start, end));
+        }
+        let borrowed = ColumnarEntityIndex::from_hashmap(&map);
+        let consumed = ColumnarEntityIndex::from_hashmap_consuming(map);
+        for id in [0u32, 1, 3, 7, 9, 10, u32::MAX] {
+            assert_eq!(borrowed.lookup(id), consumed.lookup(id), "id {id}");
+        }
+        assert_eq!(consumed.len(), 4);
     }
 }

--- a/rust/core/src/columnar_index.rs
+++ b/rust/core/src/columnar_index.rs
@@ -1,0 +1,339 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Columnar entity index — a compact, binary-searched alternative to the
+//! [`EntityIndex`](crate::EntityIndex) `FxHashMap<u32, (usize, usize)>`.
+//!
+//! # Why
+//!
+//! The streaming pre-pass hands every wasm worker (N geometry workers + prepass
+//! + parser) the same pre-scanned entity index as three parallel `u32` columns
+//! via `setEntityIndex`. Each worker used to materialize a private
+//! `FxHashMap<u32, (usize, usize)>` from those columns. hashbrown rounds the
+//! bucket count up to the next power of two, so for a 19.1 M-entity model it
+//! allocates `2^25` buckets × ~13 B ≈ **436 MB per worker**, rebuilt in every
+//! realm. Three sorted `Vec<u32>` columns for the same model are
+//! `3 × 19.1 M × 4 B ≈ 229 MB` — no power-of-two rounding, no per-bucket control
+//! byte, no `(usize, usize)` widening. The lookup becomes a `binary_search`
+//! (≈24 probes at 19 M rows) instead of an O(1) hash probe; see the PR for the
+//! measured wall-time delta on the full geometry pipeline.
+//!
+//! # `u32` offsets
+//!
+//! `starts`/`lengths` are `u32`, which is only sound while the source file is
+//! < 4 GiB. This type is used **exclusively on the wasm ingestion path**
+//! (`setEntityIndex` and the wasm `cached_entity_index`), where the whole file
+//! already lives in the < 4 GiB wasm32 linear address space and the delivered
+//! columns are themselves `&[u32]`. Native / server paths that can exceed 4 GiB
+//! keep the `usize`-carrying [`EntityIndex`](crate::EntityIndex) hashmap.
+//!
+//! # Duplicate express ids
+//!
+//! [`crate::build_entity_index`] inserts scanned spans into an `FxHashMap` in
+//! file order, so a repeated express id resolves to its **last** occurrence in
+//! the file (`HashMap::insert` overwrites). Express ids are unique per the STEP
+//! spec and duplicates essentially never occur, but this type replicates the
+//! last-in-file-order-wins behaviour deliberately (see `from_unsorted` and the
+//! `duplicate_id_last_wins` test) so a malformed file cannot diverge between the
+//! hashmap and columnar paths.
+
+use crate::decoder::EntityIndex;
+use crate::parser::EntityScanner;
+use std::sync::Arc;
+
+/// Compact, sorted, binary-searched entity index. Columns are kept sorted by
+/// `ids` (strictly ascending, unique) so [`Self::lookup`] can `binary_search`.
+///
+/// Invariants (upheld by every constructor):
+/// - `ids.len() == starts.len() == lengths.len()`
+/// - `ids` is strictly ascending (hence unique)
+/// - `starts[i]` / `lengths[i]` are the byte offset / byte length of `ids[i]`,
+///   so `lookup` returns `(start, start + length)` to match the `(start, end)`
+///   tuple layout of [`EntityIndex`](crate::EntityIndex).
+pub struct ColumnarEntityIndex {
+    ids: Vec<u32>,
+    starts: Vec<u32>,
+    lengths: Vec<u32>,
+}
+
+impl ColumnarEntityIndex {
+    /// Build from the three delivered columns (`setEntityIndex` ingestion).
+    ///
+    /// Verifies the id column's ordering **once**, O(n): the pre-pass emits in
+    /// whatever order it iterates (its own `FxHashMap` iteration order is
+    /// arbitrary), so this cannot assume ascending. If the ids are already
+    /// strictly ascending the columns are used as-is (no sort); otherwise a
+    /// single stable argsort permutation is applied and duplicate ids are
+    /// collapsed last-in-input-order-wins.
+    ///
+    /// Mismatched column lengths yield an empty index (the wasm caller guards
+    /// this too), so a malformed payload never panics a worker.
+    pub fn from_columns(ids: &[u32], starts: &[u32], lengths: &[u32]) -> Self {
+        let n = ids.len();
+        if n == 0 || starts.len() != n || lengths.len() != n {
+            return Self {
+                ids: Vec::new(),
+                starts: Vec::new(),
+                lengths: Vec::new(),
+            };
+        }
+        if is_strictly_ascending(ids) {
+            // Already sorted AND unique — the common case once the producer
+            // emits sorted columns. No permutation, no dedup: just adopt them.
+            return Self {
+                ids: ids.to_vec(),
+                starts: starts.to_vec(),
+                lengths: lengths.to_vec(),
+            };
+        }
+        Self::from_unsorted(ids.to_vec(), starts.to_vec(), lengths.to_vec())
+    }
+
+    /// Build from an already-scanned [`EntityIndex`](crate::EntityIndex)
+    /// hashmap. The map is unique by construction (last-in-file-order-wins was
+    /// applied by `HashMap::insert`), so this only sorts the entries.
+    pub fn from_hashmap(map: &EntityIndex) -> Self {
+        let n = map.len();
+        let mut ids = Vec::with_capacity(n);
+        let mut starts = Vec::with_capacity(n);
+        let mut lengths = Vec::with_capacity(n);
+        for (&id, &(start, end)) in map.iter() {
+            ids.push(id);
+            starts.push(start as u32);
+            lengths.push((end - start) as u32);
+        }
+        // Entries are unique; `from_unsorted`'s dedup is a no-op but keeps one
+        // sort/build code path.
+        Self::from_unsorted(ids, starts, lengths)
+    }
+
+    /// Scan `content` and build the columns directly, replicating
+    /// [`crate::build_entity_index`]'s HEADER-skipping / quoted-string scan and
+    /// its last-in-file-order-wins duplicate handling — without ever
+    /// materializing the intermediate `FxHashMap`. Used by the wasm lazy
+    /// fallback when `setEntityIndex` was never called.
+    pub fn from_scan<T>(content: &T) -> Self
+    where
+        T: AsRef<[u8]> + ?Sized,
+    {
+        let content = content.as_ref();
+        let estimated = content.len() / 50;
+        let mut ids = Vec::with_capacity(estimated);
+        let mut starts = Vec::with_capacity(estimated);
+        let mut lengths = Vec::with_capacity(estimated);
+        let mut scanner = EntityScanner::new(content);
+        while let Some((id, _type_name, start, end)) = scanner.next_entity() {
+            ids.push(id);
+            starts.push(start as u32);
+            lengths.push((end - start) as u32);
+        }
+        Self::from_unsorted(ids, starts, lengths)
+    }
+
+    /// Sort the (id, start, length) triples by id and collapse duplicate ids
+    /// keeping the one that appeared **last** in the input order (matching
+    /// `FxHashMap::insert`). The input `Vec`s are in original (file / delivery)
+    /// order.
+    fn from_unsorted(ids: Vec<u32>, starts: Vec<u32>, lengths: Vec<u32>) -> Self {
+        let n = ids.len();
+        // Argsort a permutation, ordering by (id, original_index). Ties break by
+        // original index ascending, so within an equal-id run the last element
+        // has the greatest original index == last-in-input-order.
+        let mut perm: Vec<u32> = (0..n as u32).collect();
+        perm.sort_unstable_by(|&a, &b| {
+            let ka = ids[a as usize];
+            let kb = ids[b as usize];
+            ka.cmp(&kb).then_with(|| a.cmp(&b))
+        });
+
+        let mut out_ids: Vec<u32> = Vec::with_capacity(n);
+        let mut out_starts: Vec<u32> = Vec::with_capacity(n);
+        let mut out_lengths: Vec<u32> = Vec::with_capacity(n);
+        for &p in &perm {
+            let p = p as usize;
+            let id = ids[p];
+            if out_ids.last() == Some(&id) {
+                // Duplicate id: overwrite the tail so the LAST occurrence wins.
+                let li = out_ids.len() - 1;
+                out_starts[li] = starts[p];
+                out_lengths[li] = lengths[p];
+            } else {
+                out_ids.push(id);
+                out_starts.push(starts[p]);
+                out_lengths.push(lengths[p]);
+            }
+        }
+        out_ids.shrink_to_fit();
+        out_starts.shrink_to_fit();
+        out_lengths.shrink_to_fit();
+        Self {
+            ids: out_ids,
+            starts: out_starts,
+            lengths: out_lengths,
+        }
+    }
+
+    /// Binary-search the byte span of `id`. Returns `(start, end)` where
+    /// `end = start + length`, exactly matching [`EntityIndex`](crate::EntityIndex)'s
+    /// tuple, or `None` if the id is absent.
+    #[inline]
+    pub fn lookup(&self, id: u32) -> Option<(usize, usize)> {
+        match self.ids.binary_search(&id) {
+            Ok(i) => {
+                let start = self.starts[i] as usize;
+                Some((start, start + self.lengths[i] as usize))
+            }
+            Err(_) => None,
+        }
+    }
+
+    /// Sorted, unique id column (for re-emitting the entity-index event).
+    #[inline]
+    pub fn ids(&self) -> &[u32] {
+        &self.ids
+    }
+
+    /// Byte-start column, parallel to [`Self::ids`].
+    #[inline]
+    pub fn starts(&self) -> &[u32] {
+        &self.starts
+    }
+
+    /// Byte-length column, parallel to [`Self::ids`].
+    #[inline]
+    pub fn lengths(&self) -> &[u32] {
+        &self.lengths
+    }
+
+    /// Number of indexed entities.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.ids.len()
+    }
+
+    /// Whether the index is empty.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.ids.is_empty()
+    }
+}
+
+/// True iff `ids` is strictly ascending (which also proves uniqueness). O(n).
+#[inline]
+fn is_strictly_ascending(ids: &[u32]) -> bool {
+    ids.windows(2).all(|w| w[0] < w[1])
+}
+
+/// The index representation an [`EntityDecoder`](crate::EntityDecoder) holds:
+/// either the legacy `FxHashMap` (native / lazily-built paths) or the compact
+/// columnar index (wasm shared-index ingestion). A thin dispatch keeps the
+/// decoder hot path (`decode_by_id`) agnostic to which one is installed.
+pub(crate) enum EntityIndexStore {
+    Hash(Arc<EntityIndex>),
+    Columnar(Arc<ColumnarEntityIndex>),
+}
+
+impl EntityIndexStore {
+    /// Resolve `id` to its `(start, end)` byte span.
+    #[inline]
+    pub(crate) fn lookup(&self, id: u32) -> Option<(usize, usize)> {
+        match self {
+            EntityIndexStore::Hash(m) => m.get(&id).copied(),
+            EntityIndexStore::Columnar(c) => c.lookup(id),
+        }
+    }
+}
+
+impl<'a> crate::EntityDecoder<'a> {
+    /// Create a decoder backed by a shared columnar index (wasm shared-index
+    /// path). Mirrors [`EntityDecoder::with_arc_index`](crate::EntityDecoder::with_arc_index)
+    /// but installs the compact representation.
+    pub fn with_arc_columnar_index<T>(content: &'a T, index: Arc<ColumnarEntityIndex>) -> Self
+    where
+        T: AsRef<[u8]> + ?Sized,
+    {
+        let mut decoder = Self::new(content);
+        decoder.set_columnar_index(index);
+        decoder
+    }
+
+    /// Install a shared columnar index into an existing decoder. Like
+    /// [`EntityDecoder::set_entity_index`](crate::EntityDecoder::set_entity_index)
+    /// but for the compact representation; afterwards `build_index` no-ops.
+    pub fn set_columnar_index(&mut self, index: Arc<ColumnarEntityIndex>) {
+        self.entity_index = Some(EntityIndexStore::Columnar(index));
+    }
+}
+
+#[cfg(test)]
+mod columnar_index_tests {
+    use super::*;
+
+    #[test]
+    fn sorted_unique_uses_fast_path_and_looks_up() {
+        let ids = [1u32, 5, 9, 100];
+        let starts = [10u32, 20, 30, 40];
+        let lengths = [3u32, 4, 5, 6];
+        let idx = ColumnarEntityIndex::from_columns(&ids, &starts, &lengths);
+        assert_eq!(idx.len(), 4);
+        assert_eq!(idx.lookup(1), Some((10, 13)));
+        assert_eq!(idx.lookup(5), Some((20, 24)));
+        assert_eq!(idx.lookup(100), Some((40, 46)));
+        assert_eq!(idx.lookup(2), None);
+        assert_eq!(idx.lookup(101), None);
+    }
+
+    #[test]
+    fn unsorted_input_is_sorted_then_searched() {
+        let ids = [100u32, 1, 9, 5];
+        let starts = [40u32, 10, 30, 20];
+        let lengths = [6u32, 3, 5, 4];
+        let idx = ColumnarEntityIndex::from_columns(&ids, &starts, &lengths);
+        assert_eq!(idx.ids(), &[1, 5, 9, 100]);
+        assert_eq!(idx.lookup(1), Some((10, 13)));
+        assert_eq!(idx.lookup(5), Some((20, 24)));
+        assert_eq!(idx.lookup(9), Some((30, 35)));
+        assert_eq!(idx.lookup(100), Some((40, 46)));
+    }
+
+    #[test]
+    fn duplicate_id_last_wins() {
+        // Same express id 7 appears twice; the LAST occurrence in input order
+        // must win, matching FxHashMap::insert / build_entity_index.
+        let ids = [7u32, 3, 7];
+        let starts = [10u32, 20, 30];
+        let lengths = [1u32, 2, 3];
+        let idx = ColumnarEntityIndex::from_columns(&ids, &starts, &lengths);
+        assert_eq!(idx.len(), 2);
+        // id 7 -> the (start=30, len=3) entry, NOT (10, 1)
+        assert_eq!(idx.lookup(7), Some((30, 33)));
+        assert_eq!(idx.lookup(3), Some((20, 22)));
+    }
+
+    #[test]
+    fn empty_and_mismatched_columns_are_empty() {
+        assert!(ColumnarEntityIndex::from_columns(&[], &[], &[]).is_empty());
+        assert!(ColumnarEntityIndex::from_columns(&[1, 2], &[0], &[0, 0]).is_empty());
+    }
+
+    #[test]
+    fn from_hashmap_matches_lookup() {
+        let content = "ISO-10303-21;\nHEADER;\nENDSEC;\nDATA;\n\
+            #1=IFCCARTESIANPOINT((0.,0.,0.));\n\
+            #7=IFCCARTESIANPOINT((1.,2.,3.));\n\
+            ENDSEC;\nEND-ISO-10303-21;\n";
+        let map = crate::build_entity_index(content);
+        let col = ColumnarEntityIndex::from_hashmap(&map);
+        assert_eq!(col.len(), map.len());
+        for (&id, &(s, e)) in map.iter() {
+            assert_eq!(col.lookup(id), Some((s, e)));
+        }
+        // A scan-built index must agree byte-for-byte with the hashmap one.
+        let scanned = ColumnarEntityIndex::from_scan(content);
+        assert_eq!(scanned.ids(), col.ids());
+        for &id in col.ids() {
+            assert_eq!(scanned.lookup(id), col.lookup(id));
+        }
+    }
+}

--- a/rust/core/src/columnar_index.rs
+++ b/rust/core/src/columnar_index.rs
@@ -7,8 +7,9 @@
 //!
 //! # Why
 //!
-//! The streaming pre-pass hands every wasm worker (N geometry workers + prepass
-//! + parser) the same pre-scanned entity index as three parallel `u32` columns
+//! The streaming pre-pass hands every wasm worker (N geometry workers plus the
+//! prepass and parser workers) the same pre-scanned entity index as three
+//! parallel `u32` columns
 //! via `setEntityIndex`. Each worker used to materialize a private
 //! `FxHashMap<u32, (usize, usize)>` from those columns. hashbrown rounds the
 //! bucket count up to the next power of two, so for a 19.1 M-entity model it
@@ -99,6 +100,10 @@ impl ColumnarEntityIndex {
         let mut starts = Vec::with_capacity(n);
         let mut lengths = Vec::with_capacity(n);
         for (&id, &(start, end)) in map.iter() {
+            // u32 offsets are sound only under the wasm32 <4GiB address space
+            // (module docs). Catch a future native caller in debug builds
+            // before a silent truncation decodes the wrong bytes.
+            debug_assert!(end <= u32::MAX as usize, "entity offset exceeds the u32 column ceiling");
             ids.push(id);
             starts.push(start as u32);
             lengths.push((end - start) as u32);
@@ -124,6 +129,7 @@ impl ColumnarEntityIndex {
         let mut lengths = Vec::with_capacity(estimated);
         let mut scanner = EntityScanner::new(content);
         while let Some((id, _type_name, start, end)) = scanner.next_entity() {
+            debug_assert!(end <= u32::MAX as usize, "entity offset exceeds the u32 column ceiling");
             ids.push(id);
             starts.push(start as u32);
             lengths.push((end - start) as u32);

--- a/rust/core/src/decoder.rs
+++ b/rust/core/src/decoder.rs
@@ -6,6 +6,7 @@
 //!
 //! Lazily decode IFC entities from byte offsets without loading entire file into memory.
 
+use crate::columnar_index::EntityIndexStore;
 use crate::error::{Error, Result};
 use crate::parser::{parse_entity, EntityScanner};
 use crate::schema_gen::{AttributeValue, DecodedEntity};
@@ -45,10 +46,9 @@ pub struct EntityDecoder<'a> {
     /// Cache of decoded entities (entity_id -> `Arc<DecodedEntity>`)
     /// Using Arc avoids expensive clones on cache hits
     cache: FxHashMap<u32, Arc<DecodedEntity>>,
-    /// Index of entity offsets (entity_id -> (start, end))
-    /// Can be pre-built or built lazily
-    /// Using Arc to allow sharing across threads without cloning the HashMap
-    entity_index: Option<Arc<EntityIndex>>,
+    /// Entity offsets (entity_id -> (start, end)): legacy `FxHashMap` or compact
+    /// columnar index. `pub(crate)` for `crate::columnar_index`'s constructors.
+    pub(crate) entity_index: Option<EntityIndexStore>,
     /// Cache of cartesian point coordinates for FacetedBrep optimization
     /// Only populated when using get_polyloop_coords_cached
     point_cache: FxHashMap<u32, (f64, f64, f64)>,
@@ -114,7 +114,7 @@ impl<'a> EntityDecoder<'a> {
         Self {
             content,
             cache: FxHashMap::default(),
-            entity_index: Some(Arc::new(index)),
+            entity_index: Some(EntityIndexStore::Hash(Arc::new(index))),
             point_cache: FxHashMap::default(),
             point_cache_hits: 0,
             point_cache_misses: 0,
@@ -133,7 +133,7 @@ impl<'a> EntityDecoder<'a> {
         Self {
             content,
             cache: FxHashMap::default(),
-            entity_index: Some(index),
+            entity_index: Some(EntityIndexStore::Hash(index)),
             point_cache: FxHashMap::default(),
             point_cache_hits: 0,
             point_cache_misses: 0,
@@ -148,7 +148,7 @@ impl<'a> EntityDecoder<'a> {
     /// decoder does not lazily rebuild it via `build_index`. Set it before any
     /// `decode_by_id`/ref-resolving call; afterwards `build_index` no-ops.
     pub fn set_entity_index(&mut self, index: Arc<EntityIndex>) {
-        self.entity_index = Some(index);
+        self.entity_index = Some(EntityIndexStore::Hash(index));
     }
 
     /// Build entity index for O(1) lookups
@@ -157,7 +157,7 @@ impl<'a> EntityDecoder<'a> {
         if self.entity_index.is_some() {
             return; // Already built
         }
-        self.entity_index = Some(Arc::new(build_entity_index(self.content)));
+        self.entity_index = Some(EntityIndexStore::Hash(Arc::new(build_entity_index(self.content))));
     }
 
     /// Decode entity at byte offset
@@ -284,7 +284,7 @@ impl<'a> EntityDecoder<'a> {
         let (start, end) = self
             .entity_index
             .as_ref()
-            .and_then(|idx| idx.get(&entity_id).copied())
+            .and_then(|idx| idx.lookup(entity_id))
             .ok_or_else(|| Error::parse(0, format!("Entity #{} not found", entity_id)))?;
 
         self.decode_at(start, end)
@@ -534,7 +534,7 @@ impl<'a> EntityDecoder<'a> {
     #[inline]
     pub fn get_raw_bytes(&mut self, entity_id: u32) -> Option<&'a [u8]> {
         self.build_index();
-        let (start, end) = self.entity_index.as_ref()?.get(&entity_id).copied()?;
+        let (start, end) = self.entity_index.as_ref()?.lookup(entity_id)?;
         Some(&self.content[start..end])
     }
 
@@ -873,7 +873,7 @@ impl<'a> EntityDecoder<'a> {
         let bytes_full = self.content;
 
         // Get polyloop raw bytes
-        let (start, end) = index.get(&entity_id).copied()?;
+        let (start, end) = index.lookup(entity_id)?;
         let bytes = &bytes_full[start..end];
 
         // IFCPOLYLOOP((#id1,#id2,#id3,...));
@@ -929,7 +929,7 @@ impl<'a> EntityDecoder<'a> {
 
                     // INLINE: Get cartesian point coordinates directly
                     // This avoids the overhead of calling get_cartesian_point_fast for each point
-                    if let Some((pt_start, pt_end)) = index.get(&point_id).copied() {
+                    if let Some((pt_start, pt_end)) = index.lookup(point_id) {
                         if let Some(coord) =
                             parse_cartesian_point_inline(&bytes_full[pt_start..pt_end])
                         {
@@ -960,7 +960,7 @@ impl<'a> EntityDecoder<'a> {
         let bytes_full = self.content;
 
         // Get polyloop raw bytes
-        let (start, end) = index.get(&entity_id).copied()?;
+        let (start, end) = index.lookup(entity_id)?;
         let bytes = &bytes_full[start..end];
 
         // IFCPOLYLOOP((#id1,#id2,#id3,...));
@@ -1024,7 +1024,7 @@ impl<'a> EntityDecoder<'a> {
                         coords.push(coord);
                     } else {
                         // Not in cache - parse and cache
-                        if let Some((pt_start, pt_end)) = index.get(&point_id).copied() {
+                        if let Some((pt_start, pt_end)) = index.lookup(point_id) {
                             if let Some(coord) =
                                 parse_cartesian_point_inline(&bytes_full[pt_start..pt_end])
                             {

--- a/rust/core/src/lib.rs
+++ b/rust/core/src/lib.rs
@@ -62,6 +62,7 @@
 //! - **Entity scanning**: ~650 MB/s with SIMD acceleration
 //! - **Number parsing**: 10x faster than std using [lexical-core](https://docs.rs/lexical-core)
 
+pub mod columnar_index;
 pub mod decoder;
 pub mod error;
 pub mod fast_parse;
@@ -77,6 +78,7 @@ pub mod step_encoding;
 pub mod streaming;
 pub mod units;
 
+pub use columnar_index::ColumnarEntityIndex;
 pub use decoder::{build_entity_index, EntityDecoder, EntityIndex};
 pub use error::{Error, Result};
 pub use fast_parse::{

--- a/rust/geometry/tests/csg_model_profile.rs
+++ b/rust/geometry/tests/csg_model_profile.rs
@@ -94,9 +94,22 @@ fn profile_model() {
     println!("\n=== #1109 per-element CSG profile (cap={:?}) ===", budget::cap());
     println!("model: {path}  ({} bytes)", content.len());
 
+    // #1682 A/B: IFCLT_COLUMNAR=1 drives the geometry pass through the compact
+    // ColumnarEntityIndex (sorted u32 columns + binary search) instead of the
+    // FxHashMap, so a before/after run on the same model measures the
+    // binary-search hot-path wall-time delta (and proves tri-count parity).
+    let use_columnar = std::env::var("IFCLT_COLUMNAR").is_ok_and(|v| v != "0");
     let t_parse = Instant::now();
-    let entity_index = build_entity_index(&content);
-    let mut decoder = EntityDecoder::with_index(&content, entity_index);
+    let mut decoder = if use_columnar {
+        let idx = std::sync::Arc::new(ifc_lite_core::ColumnarEntityIndex::from_scan(&content));
+        EntityDecoder::with_arc_columnar_index(&content, idx)
+    } else {
+        EntityDecoder::with_index(&content, build_entity_index(&content))
+    };
+    println!(
+        "index backing: {}",
+        if use_columnar { "columnar (binary search)" } else { "FxHashMap" }
+    );
     let router = GeometryRouter::with_units(&content, &mut decoder);
     let void_idx = build_void_index(&content);
     println!("parse+index+voididx: {:.0}ms  (voided hosts: {})",
@@ -151,7 +164,9 @@ fn profile_model() {
     let sum_ms: f64 = recs.iter().map(|r| r.ms).sum();
     let tripped_n = recs.iter().filter(|r| r.tripped).count();
 
+    let total_tris: usize = recs.iter().map(|r| r.tris).sum();
     println!("\nTOTAL serial geometry: {:.0}ms over {} elements", total_ms, recs.len());
+    println!("  total triangles: {total_tris}  (MUST match across index backings)");
     println!("  elements > 1s: {over_1s}");
     println!(
         "  elements that tripped active budgets (per-boolean={cap:?}, per-element={ecap:?}): {tripped_n}"

--- a/rust/wasm-bindings/src/api/gpu_meshes/batch.rs
+++ b/rust/wasm-bindings/src/api/gpu_meshes/batch.rs
@@ -106,7 +106,7 @@ impl IfcAPI {
         // because they're separate WASM realms from the pre-pass worker),
         // build once here and store under Arc so subsequent calls hit
         // the fast path.
-        let entity_index_arc: std::sync::Arc<ifc_lite_core::EntityIndex> = {
+        let entity_index_arc: std::sync::Arc<ifc_lite_core::ColumnarEntityIndex> = {
             // Mutex briefly held: peek at cache, build-if-empty, clone Arc.
             // The clone is what gets handed to rayon — no lock contention
             // on the per-job hot path that follows. Poison panics here
@@ -118,12 +118,15 @@ impl IfcAPI {
             if let Some(existing) = slot.as_ref() {
                 std::sync::Arc::clone(existing)
             } else {
-                let built = std::sync::Arc::new(ifc_lite_core::build_entity_index(content));
+                // No setEntityIndex was delivered (non-streaming path): scan the
+                // file straight into sorted columns, skipping the FxHashMap.
+                let built =
+                    std::sync::Arc::new(ifc_lite_core::ColumnarEntityIndex::from_scan(content));
                 *slot = Some(std::sync::Arc::clone(&built));
                 built
             }
         };
-        let mut decoder = EntityDecoder::with_arc_index(content, entity_index_arc);
+        let mut decoder = EntityDecoder::with_arc_columnar_index(content, entity_index_arc);
         // Seed the unit-scale caches so curve/arc tessellation never re-pays the
         // O(file) IFCPROJECT scan: this decoder is fresh on every batch call,
         // and `plane_angle_to_radians()` would otherwise walk the whole DATA

--- a/rust/wasm-bindings/src/api/gpu_meshes/prepass.rs
+++ b/rust/wasm-bindings/src/api/gpu_meshes/prepass.rs
@@ -463,10 +463,11 @@ impl IfcAPI {
         // Cache for processGeometryBatch reuse. Convert the scan's FxHashMap
         // into a compact columnar index (sorted u32 columns + binary search):
         // ~229 MB vs the hashmap's ~436 MB on a 19.1 M-entity model (#1682).
-        // Drop the hashmap right after so this worker's peak isn't both.
-        let entity_index_arc =
-            std::sync::Arc::new(ifc_lite_core::ColumnarEntityIndex::from_hashmap(&entity_index));
-        drop(entity_index);
+        // The consuming conversion frees the map before sorting, so the
+        // conversion transient is one interleaved buffer, not map + copies.
+        let entity_index_arc = std::sync::Arc::new(
+            ifc_lite_core::ColumnarEntityIndex::from_hashmap_consuming(entity_index),
+        );
         // Mutex held only briefly to install the Arc.
         {
             let mut slot = self

--- a/rust/wasm-bindings/src/api/gpu_meshes/prepass.rs
+++ b/rust/wasm-bindings/src/api/gpu_meshes/prepass.rs
@@ -61,9 +61,9 @@ impl IfcAPI {
 
         let content = data;
 
-        // Build entity index — wrap in Arc so processGeometryBatch can
-        // share it across many calls without cloning the HashMap.
-        let entity_index = std::sync::Arc::new(ifc_lite_core::build_entity_index(content));
+        // Build entity index — a compact columnar index (sorted u32 columns +
+        // binary search, #1682) wrapped in Arc for cheap reuse.
+        let entity_index = std::sync::Arc::new(ifc_lite_core::ColumnarEntityIndex::from_scan(content));
         // Cache for reuse by processGeometryBatch.
         // Mutex held only briefly to install the Arc; rayon helpers
         // pick up clones below without re-locking. Panic on poison —
@@ -75,7 +75,7 @@ impl IfcAPI {
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         *slot = Some(entity_index.clone());
         drop(slot);
-        let mut decoder = EntityDecoder::with_arc_index(content, entity_index);
+        let mut decoder = EntityDecoder::with_arc_columnar_index(content, entity_index);
 
         // Run combined pre-pass
         let pre_pass = combined_pre_pass(content, &mut decoder);
@@ -460,11 +460,13 @@ impl IfcAPI {
             on_event.call1(&JsValue::NULL, &meta.into())?;
         }
 
-        // Cache the entity index for processGeometryBatch reuse — same
-        // contract as buildPrePassOnce. Wrapped in Arc
-        // so process workers reuse the same index by reference instead of
-        // cloning the 14 M-entry HashMap on every batch call.
-        let entity_index_arc = std::sync::Arc::new(entity_index);
+        // Cache for processGeometryBatch reuse. Convert the scan's FxHashMap
+        // into a compact columnar index (sorted u32 columns + binary search):
+        // ~229 MB vs the hashmap's ~436 MB on a 19.1 M-entity model (#1682).
+        // Drop the hashmap right after so this worker's peak isn't both.
+        let entity_index_arc =
+            std::sync::Arc::new(ifc_lite_core::ColumnarEntityIndex::from_hashmap(&entity_index));
+        drop(entity_index);
         // Mutex held only briefly to install the Arc.
         {
             let mut slot = self
@@ -474,8 +476,8 @@ impl IfcAPI {
             *slot = Some(entity_index_arc.clone());
         }
         // Hold a second clone for the post-scan entity-index export below;
-        // `with_arc_index` consumes the Arc so we'd lose the reference
-        // after the decoder is created.
+        // `with_arc_columnar_index` consumes the Arc so we'd lose the
+        // reference after the decoder is created.
         let index_for_export = entity_index_arc.clone();
 
         // ── FAST FIRST GEOMETRY ──
@@ -492,14 +494,12 @@ impl IfcAPI {
         // it must reach them as early as possible. Built from the complete index.
         {
             // Bulk-copy in 3 boundary crossings, not ~8.4M per-entry set_index
-            // calls (workers' critical path). Order-free: they zip the 3 arrays.
-            let (ids, (starts, lengths)): (Vec<u32>, (Vec<u32>, Vec<u32>)) = index_for_export
-                .iter()
-                .map(|(&id, &(s, e))| (id, (s as u32, (e - s) as u32)))
-                .unzip();
-            let ids_arr = js_sys::Uint32Array::from(ids.as_slice());
-            let starts_arr = js_sys::Uint32Array::from(starts.as_slice());
-            let lengths_arr = js_sys::Uint32Array::from(lengths.as_slice());
+            // calls (workers' critical path). Columns are already sorted by id,
+            // so consumers hit ColumnarEntityIndex::from_columns' O(n)
+            // already-sorted fast path (no per-worker argsort).
+            let ids_arr = js_sys::Uint32Array::from(index_for_export.ids());
+            let starts_arr = js_sys::Uint32Array::from(index_for_export.starts());
+            let lengths_arr = js_sys::Uint32Array::from(index_for_export.lengths());
             let index_event = js_sys::Object::new();
             crate::api::set_js_prop(&index_event, "type", &"entity-index".into());
             crate::api::set_js_prop(&index_event, "ids", &ids_arr);
@@ -514,7 +514,7 @@ impl IfcAPI {
         // MaterialLayerIndex::from_content is deliberately skipped (its own full
         // scan); aggregate void propagation IS included via the stashed
         // IfcRelAggregates spans, keeping void-parity with the server.
-        let mut decoder = EntityDecoder::with_arc_index(content, entity_index_arc.clone());
+        let mut decoder = EntityDecoder::with_arc_columnar_index(content, entity_index_arc.clone());
         decoder.seed_unit_scales(1.0, plane_angle_to_radians);
         let resolved = ifc_lite_processing::prepass::resolve_prepass(
             &prepass_spans,
@@ -692,7 +692,7 @@ impl IfcAPI {
         // failure the key falls back to the element id (its own bucket).
         {
             let mut akey_decoder =
-                EntityDecoder::with_arc_index(content, entity_index_arc.clone());
+                EntityDecoder::with_arc_columnar_index(content, entity_index_arc.clone());
             let akey_router = GeometryRouter::new();
             let rest = &buffered_jobs[first_n..];
             let mut affinity: Vec<u32> = Vec::with_capacity(rest.len());

--- a/rust/wasm-bindings/src/api/gpu_meshes/prepass.rs
+++ b/rust/wasm-bindings/src/api/gpu_meshes/prepass.rs
@@ -463,8 +463,7 @@ impl IfcAPI {
         // Cache for processGeometryBatch reuse. Convert the scan's FxHashMap
         // into a compact columnar index (sorted u32 columns + binary search):
         // ~229 MB vs the hashmap's ~436 MB on a 19.1 M-entity model (#1682).
-        // The consuming conversion frees the map before sorting, so the
-        // conversion transient is one interleaved buffer, not map + copies.
+        // Consuming frees the map before sorting: one interleaved transient.
         let entity_index_arc = std::sync::Arc::new(
             ifc_lite_core::ColumnarEntityIndex::from_hashmap_consuming(entity_index),
         );

--- a/rust/wasm-bindings/src/api/mod.rs
+++ b/rust/wasm-bindings/src/api/mod.rs
@@ -27,7 +27,7 @@ mod symbolic;
 
 use csg_diagnostics::drain_and_log_csg_diagnostics;
 
-use ifc_lite_core::EntityIndex;
+use ifc_lite_core::ColumnarEntityIndex;
 use wasm_bindgen::prelude::*;
 
 /// `TessellationQuality::Medium` as the atomic discriminant stored on
@@ -40,11 +40,11 @@ pub struct IfcAPI {
     initialized: bool,
     /// Cached entity index from buildPrePassOnce, reused by processGeometryBatch.
     ///
-    /// Wrapped in `Arc` so successive `processGeometryBatch` calls reuse it
-    /// without cloning the (~14 M-entry, ~600 MB) FxHashMap on every call.
-    /// The streaming pre-pass calls `processGeometryBatch` dozens of times
-    /// per worker — the previous `RefCell<Option<EntityIndex>>::clone()`
-    /// path made each call effectively a full HashMap copy.
+    /// A compact [`ColumnarEntityIndex`] (three sorted `u32` columns +
+    /// binary-search lookup) not an `FxHashMap`: a 19.1 M-entity hashmap rounds
+    /// up to `2^25` buckets ≈ 436 MB per worker realm; the columns are ~229 MB
+    /// (#1682). Wrapped in `Arc` so successive `processGeometryBatch` calls
+    /// reuse it without cloning the columns on every call.
     ///
     /// Phase 1.1 of the single-controller refactor: switched from
     /// `RefCell` to `Mutex` so the API is `Sync`. Rayon helpers (added
@@ -56,7 +56,7 @@ pub struct IfcAPI {
     /// `RefCell` was unsafe here even on single-threaded WASM workers
     /// because wasm-bindgen's `WasmRefCell` borrow counter underflows
     /// under concurrent `&self` access.
-    cached_entity_index: std::sync::Mutex<Option<std::sync::Arc<EntityIndex>>>,
+    cached_entity_index: std::sync::Mutex<Option<std::sync::Arc<ColumnarEntityIndex>>>,
 
     /// Session source bytes (the whole IFC file) held ONCE per load, so the
     /// streaming batch path stops re-copying the file into the wasm heap on
@@ -399,13 +399,14 @@ impl IfcAPI {
     /// even though the pre-pass worker built the same index minutes
     /// earlier.
     ///
-    /// Building an `FxHashMap` from the three input slices costs ~1 s on
-    /// 14 M entries — about 4–5× faster than re-scanning the file. After
-    /// this call, the next `processGeometryBatch` skips the lazy build
-    /// branch and reuses the populated cache by `Arc::clone()`.
+    /// Builds a compact [`ColumnarEntityIndex`] from the three input slices
+    /// (sorted `u32` columns + binary search) instead of a per-worker
+    /// `FxHashMap` — ~229 MB vs ~436 MB on a 19.1 M-entity model (#1682).
+    /// [`ColumnarEntityIndex::from_columns`] verifies the id ordering once
+    /// (O(n)) and only argsorts if the producer did not emit sorted columns.
     ///
-    /// `lengths[i]` is the byte length of entity `ids[i]`, so the cache
-    /// stores `(start, start + length)` to match the existing tuple layout.
+    /// `lengths[i]` is the byte length of entity `ids[i]`, so lookup returns
+    /// `(start, start + length)` to match the existing `(start, end)` layout.
     ///
     /// Idempotent in the sense that repeated calls REPLACE the cache —
     /// supports the parser-worker pattern of reusing one IfcAPI across
@@ -416,12 +417,7 @@ impl IfcAPI {
         if n == 0 || starts.len() != n || lengths.len() != n {
             return;
         }
-        let mut index = ifc_lite_core::EntityIndex::with_capacity_and_hasher(n, Default::default());
-        for i in 0..n {
-            let start = starts[i] as usize;
-            let length = lengths[i] as usize;
-            index.insert(ids[i], (start, start + length));
-        }
+        let index = ColumnarEntityIndex::from_columns(ids, starts, lengths);
         let mut slot = self
             .cached_entity_index
             .lock()


### PR DESCRIPTION
## Memory math (the lever)

Every wasm worker (N geometry workers + prepass + parser) that receives the
pre-scanned entity index via `setEntityIndex` used to materialize a **private**
`FxHashMap<u32, (usize, usize)>`. hashbrown rounds the bucket count up to the
next power of two, so for a **19.1 M-entity** model:

- hashmap: `2^25` buckets x ~13 B/entry ≈ **~436 MB per worker realm**, rebuilt in every realm
- columns: `3 x 19.1 M x 4 B` ≈ **~229 MB**, no power-of-two rounding, no `(usize,usize)` widening

The delivered representation is already three `u32` columns (ids / starts /
lengths), so the worker now keeps them as a compact `ColumnarEntityIndex`
(sorted columns + `binary_search`) instead of exploding them into a hashmap.

## Wall-time (before/after)

The concern was that binary search (~24 probes at 19 M rows) could regress the
hot `decode_by_id` path. It does not — it is **faster**, because the sorted
`u32` columns are far more cache-friendly than a 436 MB hashmap. Measured on the
native per-element geometry profiler (`csg_model_profile`, profiling build, best
of 3 iters, same machine), with **byte-identical triangle counts** in every run:

| model | FxHashMap | columnar (binary search) | Δ geometry | tris (both) |
|-------|-----------|--------------------------|-----------|-------------|
| schependomlaan (49 MB) | 115 ms | **94 ms** | **-18%** | 254,536 |
| Holter Tower (177 MB, 60,669 elems) | 827 ms | **711 ms** | **-14%** | 2,866,667 |
| O-S1-BWK (342 MB) | 517 ms | **457 ms** | **-12%** | 1,596,302 |

Index-build cost is also comparable/better (`from_scan` scan+sort vs
`build_entity_index` scan+insert): O-S1-BWK parse+index best 1085 ms -> 1040 ms.

Reproduce: `IFCLT_MODEL=<abs.ifc> IFCLT_COLUMNAR=1 cargo test -p ifc-lite-geometry --profile profiling --test csg_model_profile -- --ignored --nocapture` (drop `IFCLT_COLUMNAR` for the hashmap baseline). The A/B toggle is new in this PR.

## What changed

- **New `ifc_lite_core::ColumnarEntityIndex`** (`rust/core/src/columnar_index.rs`): sorted `ids/starts/lengths: Vec<u32>` + `binary_search` lookup returning `(start, start+length)` to exactly match the `(start, end)` tuple. Builders: `from_columns` (setEntityIndex ingestion, O(n) sorted-check then argsort fallback), `from_scan` (lazy fallback, no intermediate hashmap), `from_hashmap` (streaming producer conversion).
- **`EntityDecoder` holds an `EntityIndexStore` enum** (`Hash(Arc<EntityIndex>)` | `Columnar(Arc<ColumnarEntityIndex>)`) so `decode_by_id` and the fast-path readers dispatch through one `lookup()` and stay agnostic. New `with_arc_columnar_index` / `set_columnar_index` constructors.
- **wasm `cached_entity_index` slot is now `Arc<ColumnarEntityIndex>`**: `setEntityIndex` builds columnar directly; the streaming prepass converts its scan hashmap to columnar (dropping the hashmap) and emits the columns **already sorted** so consumers hit the fast path; `buildPrePassOnce` and the `processGeometryBatch` lazy fallback build columnar via `from_scan`.

## Code paths that KEPT the FxHashMap (deliberately)

- All **native / server** ingestion: `process_geometry_with_index`, `stream_export_model_with_index`, `build_entity_index_parallel`, georeferencing, symbolic, csv/ifc5/gltf exporters, alignment/grid/color one-off decoders. These can exceed the 4 GiB `u32` offset ceiling and are not the per-worker-memory hot spot; converting them would be a large blast radius for no memory win. `EntityDecoder`'s lazy `build_index()` and `with_index`/`with_arc_index`/`set_entity_index` are unchanged.
- The streaming prepass's **mid-scan** decoders (meta/RTC resolution during the scan) keep the inline `FxHashMap`, which is the natural structure for the random lookups needed before the columns are sorted; it is converted to columnar once at end-of-scan.

## Semantic edges found

- **Unsorted delivery is the norm, not the exception.** The streaming producer previously emitted the entity-index columns from `FxHashMap::iter()`, i.e. arbitrary hash order — so consumers would always argsort. This PR emits from the sorted columnar index instead, so consumers take the O(n) already-sorted branch. The argsort path is still implemented and unit-tested for any producer that emits out of order.
- **Duplicate express ids**: `build_entity_index`/`FxHashMap::insert` resolve a repeated id to its **last** occurrence in file order. `ColumnarEntityIndex` replicates this deliberately (argsort by `(id, original_index)`, keep the tail of each equal-id run) with a `duplicate_id_last_wins` test. Express ids are unique per the STEP spec so this is defensive, but it guarantees the columnar and hashmap paths cannot diverge on a malformed file.

## Gates

- `cargo test -p ifc-lite-core -p ifc-lite-geometry -p ifc-lite-wasm` green; `ifc-lite-processing` green (incl. `mesh_output_matches_pinned_manifest`, `wasm_manifest_differs_only_in_the_trig_gap`) — the 3 pinned manifests are unchanged.
- Module-size ratchet green (all touched files kept under budget; no budget raised).
- Mesh byte-parity: identical triangle counts across index backings on all 3 models above.
- `cargo build -p ifc-lite-wasm --target wasm32-unknown-unknown --release` clean.
- Changeset: patch for `@ifc-lite/wasm`.

Refs #1682 (does not close it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved entity lookups for geometry processing with a compact, binary-searched index.
  * Reduced memory usage and accelerated repeated entity access.
  * Preserved triangle counts and existing duplicate-ID behavior.

* **API**
  * Added support for providing and inspecting compact entity indexes.

* **Compatibility**
  * Retained the existing indexing approach for data exceeding WebAssembly offset limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->