### PR TITLE
feat(viewer): 3D SpaceMouse navigation over WebHID (#1677)

### DIFF
--- a/apps/viewer/src/components/viewer/MainToolbar.tsx
+++ b/apps/viewer/src/components/viewer/MainToolbar.tsx
@@ -47,6 +47,7 @@ import {
   Globe2,
   Sun,
   Move,
+  Move3d,
   PenLine,
   Undo2,
   Redo2,
@@ -434,6 +435,10 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
   const toggleEnvPanel = useViewerStore((state) => state.toggleEnvPanel);
   const envSkyEnabled = useViewerStore((state) => state.envSkyEnabled);
   const envPreset = useViewerStore((state) => state.envPreset);
+  // SpaceMouse panel state (3D mouse navigation, #1677)
+  const spaceMousePanelOpen = useViewerStore((state) => state.spaceMousePanelOpen);
+  const toggleSpaceMousePanel = useViewerStore((state) => state.toggleSpaceMousePanel);
+  const spaceMouseConnected = useViewerStore((state) => state.spaceMouseConnected);
   const storeModels = useViewerStore((state) => state.models);
   const analysisExtensionState = useSyncExternalStore(
     subscribeAnalysisExtensions,
@@ -1705,6 +1710,30 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
           </Button>
         </TooltipTrigger>
         <TooltipContent>Sun &amp; sky</TooltipContent>
+      </Tooltip>
+
+      {/* SpaceMouse panel — connect a 3Dconnexion 3D mouse over WebHID and
+          tune its sensitivity (#1677). */}
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            variant={spaceMousePanelOpen ? 'default' : 'ghost'}
+            size="icon-sm"
+            aria-label={spaceMousePanelOpen ? 'Close SpaceMouse panel' : 'Open SpaceMouse panel'}
+            aria-pressed={spaceMousePanelOpen}
+            onClick={(e) => {
+              (e.currentTarget as HTMLButtonElement).blur();
+              toggleSpaceMousePanel();
+            }}
+            className={cn(
+              (spaceMousePanelOpen || spaceMouseConnected)
+                && 'bg-teal-600 text-white hover:bg-teal-500',
+            )}
+          >
+            <Move3d className="h-4 w-4" />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>SpaceMouse</TooltipContent>
       </Tooltip>
 
       {/*

--- a/apps/viewer/src/components/viewer/SpaceMousePanel.tsx
+++ b/apps/viewer/src/components/viewer/SpaceMousePanel.tsx
@@ -1,0 +1,149 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * SpaceMouse panel (#1677): connect a 3Dconnexion device over WebHID and tune
+ * its sensitivity. The connect button must stay a plain click handler, WebHID
+ * only shows its device chooser from a user gesture. Everything device-side
+ * lives in useSpaceMouseControls; this panel is a thin view over the
+ * spaceMouse store slice.
+ */
+
+import { useRef, useState } from 'react';
+import { ChevronDown, ChevronUp, GripVertical, Unplug } from 'lucide-react';
+import { useViewerStore } from '@/store';
+import { useDraggablePanel } from '@/hooks/useDraggablePanel';
+import { cn } from '@/lib/utils';
+import { SENSITIVITY } from '@/lib/spacemouse/constants';
+
+export function SpaceMousePanel() {
+  const open = useViewerStore((s) => s.spaceMousePanelOpen);
+
+  const supported = useViewerStore((s) => s.spaceMouseSupported);
+  const connected = useViewerStore((s) => s.spaceMouseConnected);
+  const deviceName = useViewerStore((s) => s.spaceMouseDeviceName);
+  const error = useViewerStore((s) => s.spaceMouseError);
+  const sensitivity = useViewerStore((s) => s.spaceMouseSensitivity);
+  const setSensitivity = useViewerStore((s) => s.setSpaceMouseSensitivity);
+  const connect = useViewerStore((s) => s.spaceMouseConnect);
+  const disconnect = useViewerStore((s) => s.spaceMouseDisconnect);
+
+  const [collapsed, setCollapsed] = useState(false);
+  // Hooks must run unconditionally — keep these ABOVE the `!open` early return
+  // (a conditional hook is React error #310).
+  const panelRef = useRef<HTMLDivElement>(null);
+  const drag = useDraggablePanel(panelRef);
+
+  if (!open) return null;
+
+  return (
+    <div
+      ref={panelRef}
+      style={drag.style}
+      className="pointer-events-auto absolute top-56 right-4 z-10 w-60 bg-background/90 backdrop-blur-sm rounded-lg border shadow-lg p-2 flex flex-col gap-2 text-xs"
+    >
+      {/* Header: the grip drags; the rest toggles collapse (same split of
+          affordances as SunSkyPanel). */}
+      <div className="flex items-center gap-1.5">
+        <span
+          onMouseDown={drag.onDragStart}
+          title="Drag to move"
+          className="shrink-0 cursor-grab active:cursor-grabbing text-muted-foreground/50 hover:text-muted-foreground"
+        >
+          <GripVertical className="h-3.5 w-3.5" />
+        </span>
+        <button
+          type="button"
+          onClick={() => setCollapsed(!collapsed)}
+          aria-expanded={!collapsed}
+          className="flex-1 flex items-center justify-between gap-2 text-left"
+        >
+          <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+            SpaceMouse
+          </span>
+          <span className="text-muted-foreground">
+            {collapsed ? <ChevronDown className="h-3 w-3" /> : <ChevronUp className="h-3 w-3" />}
+          </span>
+        </button>
+      </div>
+
+      {!collapsed && (
+        <>
+          {!supported ? (
+            <p className="text-[9px] leading-snug text-muted-foreground">
+              This browser has no WebHID support. Use a Chromium-based browser
+              (Chrome or Edge) to navigate with a 3D mouse.
+            </p>
+          ) : connected ? (
+            <div className="flex items-center justify-between gap-2">
+              <span className="min-w-0 truncate text-[10px] text-foreground" title={deviceName ?? undefined}>
+                <span className="mr-1.5 inline-block h-1.5 w-1.5 rounded-full bg-teal-500 align-middle" />
+                {deviceName ?? 'SpaceMouse'}
+              </span>
+              <button
+                type="button"
+                onClick={() => disconnect?.()}
+                title="Disconnect the device"
+                className="flex shrink-0 items-center gap-1 rounded px-1.5 py-0.5 text-[10px] text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+              >
+                <Unplug className="h-3 w-3" />
+                Disconnect
+              </button>
+            </div>
+          ) : (
+            <button
+              type="button"
+              onClick={() => connect?.()}
+              disabled={!connect}
+              className="w-full rounded bg-teal-600 px-2 py-1.5 text-[10px] font-semibold uppercase tracking-wider text-white transition-colors hover:bg-teal-500 disabled:opacity-50"
+            >
+              Connect SpaceMouse
+            </button>
+          )}
+
+          {error && !connected && (
+            <p className="text-[9px] leading-snug text-amber-600 dark:text-amber-500">{error}</p>
+          )}
+
+          {supported && (
+            <>
+              <label className="flex flex-col gap-0.5">
+                <span className="flex justify-between text-[9px] uppercase tracking-wider text-muted-foreground">
+                  <span>Sensitivity</span>
+                  <button
+                    type="button"
+                    onClick={() => setSensitivity(SENSITIVITY.default)}
+                    title="Reset sensitivity"
+                    className={cn(
+                      'tabular-nums transition-colors',
+                      sensitivity !== SENSITIVITY.default && 'text-foreground hover:text-teal-600',
+                    )}
+                  >
+                    {sensitivity.toFixed(1)}x
+                  </button>
+                </span>
+                <input
+                  type="range"
+                  min={SENSITIVITY.min}
+                  max={SENSITIVITY.max}
+                  step={SENSITIVITY.step}
+                  value={sensitivity}
+                  onChange={(e) => setSensitivity(Number(e.target.value))}
+                  className="w-full accent-teal-600"
+                />
+              </label>
+
+              <p className="text-[9px] leading-snug text-muted-foreground">
+                Slide the cap to pan, push or pull it to zoom, twist and tilt
+                to orbit. The device buttons fit the view. If the 3Dconnexion
+                driver is running it may hold the device; quit it before
+                connecting here.
+              </p>
+            </>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/viewer/src/components/viewer/Viewport.tsx
+++ b/apps/viewer/src/components/viewer/Viewport.tsx
@@ -41,6 +41,7 @@ import { useMouseControls, type MouseState } from './useMouseControls.js';
 import { RectSelectionOverlay, type RectSelectionRect } from './RectSelectionOverlay.js';
 import { useTouchControls, type TouchState } from './useTouchControls.js';
 import { useKeyboardControls } from './useKeyboardControls.js';
+import { useSpaceMouseControls } from './useSpaceMouseControls.js';
 import { useAnimationLoop } from './useAnimationLoop.js';
 import { useGeometryStreaming } from './useGeometryStreaming.js';
 import { usePointCloudSync } from './usePointCloudSync.js';
@@ -1218,6 +1219,15 @@ export function Viewport({
     sectionPlaneRef,
     sectionRangeRef,
     updateCameraRotationRealtime,
+    calculateScale,
+  });
+
+  useSpaceMouseControls({
+    rendererRef,
+    isInitialized,
+    geometryBoundsRef,
+    geometryRef,
+    selectedEntityIdRef,
     calculateScale,
   });
 

--- a/apps/viewer/src/components/viewer/ViewportContainer.tsx
+++ b/apps/viewer/src/components/viewer/ViewportContainer.tsx
@@ -23,6 +23,7 @@ import { BCFOverlay } from './bcf/BCFOverlay';
 import { CesiumOverlay } from './CesiumOverlay';
 import { CesiumPlacementEditor } from './CesiumPlacementEditor';
 import { SunSkyPanel } from './SunSkyPanel';
+import { SpaceMousePanel } from './SpaceMousePanel';
 import { useSolarEnvironment } from '@/hooks/useSolarEnvironment';
 import { useSolarSweep } from '@/hooks/useSolarSweep';
 import { getViewerStoreApi, useViewerStore } from '@/store';
@@ -1331,6 +1332,9 @@ export function ViewportContainer() {
           Self-anchored below the ViewCube (top-6 right-6 cube) at top-32 right-4
           so it never covers navigation; draggable from its header (#1107). */}
       <SunSkyPanel />
+      {/* SpaceMouse panel — WebHID 3D mouse connection + sensitivity (#1677).
+          Anchored below the Sun & Sky spot so both can be open; draggable. */}
+      <SpaceMousePanel />
       {cesiumEnabled && georef?.mapConversion && georef.baseMapConversion && (
         <CesiumPlacementEditor
           modelId={georef.sourceModelId}

--- a/apps/viewer/src/components/viewer/useSpaceMouseControls.ts
+++ b/apps/viewer/src/components/viewer/useSpaceMouseControls.ts
@@ -1,0 +1,190 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * SpaceMouse (3Dconnexion) controls hook for the 3D viewport (#1677).
+ *
+ * Bridges the WebHID device session to the camera: runs its own RAF loop while
+ * a device is connected (the same idiom as useKeyboardControls' movement
+ * loop), polls the latest 6DoF sample each frame, maps it to mouse-equivalent
+ * orbit / pan / zoom deltas and feeds the existing Camera controls. The
+ * device's fit buttons reuse the keyboard 'F' behaviour (frame selection, or
+ * zoom extents with nothing selected).
+ *
+ * The hook registers a `connect` action in the store so the SpaceMouse panel
+ * can trigger the WebHID permission prompt from a click (user-gesture
+ * requirement), and silently reopens a previously granted device on startup.
+ */
+
+import { useEffect, type MutableRefObject } from 'react';
+import type { Renderer } from '@ifc-lite/renderer';
+import type { MeshData } from '@ifc-lite/geometry';
+import { useViewerStore } from '@/store';
+import {
+  connectSpaceMouse,
+  isWebHidSupported,
+  reconnectGrantedSpaceMouse,
+  type SpaceMouseSession,
+} from '@/lib/spacemouse/device';
+import { deltasAreZero, mapSixDofToCameraDeltas } from '@/lib/spacemouse/mapping';
+import { getEntityBounds } from '../../utils/viewportUtils.js';
+
+export interface UseSpaceMouseControlsParams {
+  rendererRef: MutableRefObject<Renderer | null>;
+  isInitialized: boolean;
+  geometryBoundsRef: MutableRefObject<{ min: { x: number; y: number; z: number }; max: { x: number; y: number; z: number } }>;
+  geometryRef: MutableRefObject<MeshData[] | null>;
+  selectedEntityIdRef: MutableRefObject<number | null>;
+  calculateScale: () => void;
+}
+
+/**
+ * Frames longer than this (background tab, debugger pause) are clamped so the
+ * first frame back cannot integrate seconds of deflection into one huge jump.
+ */
+const MAX_FRAME_MS = 100;
+
+export function useSpaceMouseControls(params: UseSpaceMouseControlsParams): void {
+  const {
+    rendererRef,
+    isInitialized,
+    geometryBoundsRef,
+    geometryRef,
+    selectedEntityIdRef,
+    calculateScale,
+  } = params;
+
+  useEffect(() => {
+    const renderer = rendererRef.current;
+    if (!renderer || !isInitialized) return;
+
+    const store = useViewerStore.getState();
+    const supported = isWebHidSupported();
+    store.setSpaceMouseSupported(supported);
+    if (!supported) return;
+
+    const camera = renderer.getCamera();
+    let aborted = false;
+    let session: SpaceMouseSession | null = null;
+    let frameId: number | null = null;
+    let lastFrameTime = 0;
+
+    // Same behaviour as the keyboard 'F' shortcut.
+    const fitView = () => {
+      const selectedId = selectedEntityIdRef.current;
+      if (selectedId !== null) {
+        const bounds = getEntityBounds(geometryRef.current, selectedId);
+        if (bounds) {
+          void camera.frameBounds(bounds.min, bounds.max, 300);
+          renderer.requestRender();
+          calculateScale();
+          return;
+        }
+      }
+      void camera.zoomExtent(geometryBoundsRef.current.min, geometryBoundsRef.current.max, 300);
+      renderer.requestRender();
+      calculateScale();
+    };
+
+    const stopLoop = () => {
+      if (frameId !== null) {
+        cancelAnimationFrame(frameId);
+        frameId = null;
+      }
+    };
+
+    const spaceMouseMove = (now: number) => {
+      if (aborted || !session) return;
+
+      const deltaMs = Math.min(now - lastFrameTime, MAX_FRAME_MS);
+      lastFrameTime = now;
+
+      const sensitivity = useViewerStore.getState().spaceMouseSensitivity;
+      const deltas = mapSixDofToCameraDeltas(session.getState(), sensitivity, deltaMs);
+      if (!deltasAreZero(deltas)) {
+        if (deltas.orbitDx !== 0 || deltas.orbitDy !== 0) {
+          camera.orbit(deltas.orbitDx, deltas.orbitDy, false);
+        }
+        if (deltas.panDx !== 0 || deltas.panDy !== 0) {
+          camera.pan(deltas.panDx, deltas.panDy, false);
+        }
+        if (deltas.zoomDelta !== 0) {
+          camera.zoom(deltas.zoomDelta, false);
+        }
+        renderer.requestRender();
+      }
+
+      frameId = requestAnimationFrame(spaceMouseMove);
+    };
+
+    const startLoop = () => {
+      stopLoop();
+      lastFrameTime = performance.now();
+      frameId = requestAnimationFrame(spaceMouseMove);
+    };
+
+    const sessionOptions = {
+      onFitButton: fitView,
+      onDisconnect: () => {
+        session = null;
+        stopLoop();
+        if (!aborted) {
+          const s = useViewerStore.getState();
+          s.setSpaceMouseConnected(false);
+          s.setSpaceMouseDisconnect(null);
+        }
+      },
+    };
+
+    const adopt = (next: SpaceMouseSession | null) => {
+      if (!next) return;
+      if (aborted || session) {
+        // Torn down (or a device already streams) before the open resolved.
+        void next.close();
+        return;
+      }
+      session = next;
+      const s = useViewerStore.getState();
+      s.setSpaceMouseConnected(true, next.productName);
+      s.setSpaceMouseDisconnect(() => { void next.close(); });
+      startLoop();
+    };
+
+    const connect = async () => {
+      if (session) return;
+      try {
+        adopt(await connectSpaceMouse(sessionOptions));
+      } catch (err) {
+        if (!aborted) {
+          useViewerStore.getState().setSpaceMouseError(err instanceof Error ? err.message : String(err));
+        }
+      }
+    };
+
+    store.setSpaceMouseConnect(() => { void connect(); });
+
+    // Reopen a device granted in an earlier visit, without prompting.
+    void reconnectGrantedSpaceMouse(sessionOptions).then(adopt);
+
+    // When a granted device is plugged back in, pick it up automatically.
+    const handleHidConnect = () => {
+      if (!session && !aborted) void reconnectGrantedSpaceMouse(sessionOptions).then(adopt);
+    };
+    navigator.hid?.addEventListener('connect', handleHidConnect);
+
+    return () => {
+      aborted = true;
+      stopLoop();
+      navigator.hid?.removeEventListener('connect', handleHidConnect);
+      const s = useViewerStore.getState();
+      s.setSpaceMouseConnect(null);
+      s.setSpaceMouseDisconnect(null);
+      s.setSpaceMouseConnected(false);
+      void session?.close();
+      session = null;
+    };
+  }, [isInitialized]);
+}
+
+export default useSpaceMouseControls;

--- a/apps/viewer/src/components/viewer/useSpaceMouseControls.ts
+++ b/apps/viewer/src/components/viewer/useSpaceMouseControls.ts
@@ -27,7 +27,7 @@ import {
   reconnectGrantedSpaceMouse,
   type SpaceMouseSession,
 } from '@/lib/spacemouse/device';
-import { deltasAreZero, mapSixDofToCameraDeltas } from '@/lib/spacemouse/mapping';
+import { deltasAreZero, isInputStale, mapSixDofToCameraDeltas } from '@/lib/spacemouse/mapping';
 import { getEntityBounds } from '../../utils/viewportUtils.js';
 
 export interface UseSpaceMouseControlsParams {
@@ -38,12 +38,6 @@ export interface UseSpaceMouseControlsParams {
   selectedEntityIdRef: MutableRefObject<number | null>;
   calculateScale: () => void;
 }
-
-/**
- * Frames longer than this (background tab, debugger pause) are clamped so the
- * first frame back cannot integrate seconds of deflection into one huge jump.
- */
-const MAX_FRAME_MS = 100;
 
 export function useSpaceMouseControls(params: UseSpaceMouseControlsParams): void {
   const {
@@ -97,12 +91,18 @@ export function useSpaceMouseControls(params: UseSpaceMouseControlsParams): void
     const spaceMouseMove = (now: number) => {
       if (aborted || !session) return;
 
-      const deltaMs = Math.min(now - lastFrameTime, MAX_FRAME_MS);
+      // The mapping caps deltaMs (MAX_FRAME_DELTA_MS) so a backgrounded tab
+      // cannot teleport the camera; the staleness watchdog stops a silent
+      // HID stall (no disconnect event) from latching the last sample.
+      const deltaMs = now - lastFrameTime;
       lastFrameTime = now;
 
+      const stale = isInputStale(session.getLastSampleAt(), now);
       const sensitivity = useViewerStore.getState().spaceMouseSensitivity;
-      const deltas = mapSixDofToCameraDeltas(session.getState(), sensitivity, deltaMs);
-      if (!deltasAreZero(deltas)) {
+      const deltas = stale
+        ? null
+        : mapSixDofToCameraDeltas(session.getState(), sensitivity, deltaMs);
+      if (deltas && !deltasAreZero(deltas)) {
         if (deltas.orbitDx !== 0 || deltas.orbitDy !== 0) {
           camera.orbit(deltas.orbitDx, deltas.orbitDy, false);
         }

--- a/apps/viewer/src/components/viewer/useSpaceMouseControls.ts
+++ b/apps/viewer/src/components/viewer/useSpaceMouseControls.ts
@@ -140,8 +140,16 @@ export function useSpaceMouseControls(params: UseSpaceMouseControlsParams): void
     const adopt = (next: SpaceMouseSession | null) => {
       if (!next) return;
       if (aborted || session) {
-        // Torn down (or a device already streams) before the open resolved.
-        void next.close();
+        // Torn down (or a device already streams) before this open resolved.
+        // Detach quietly: close() would fire the shared onDisconnect and, when
+        // overlapping connects wrapped the SAME HIDDevice, close the winner's
+        // device out from under it. Only close the physical device when it is
+        // not the active session's.
+        const sharesDevice = session?.device === next.device;
+        next.detach();
+        if (!sharesDevice) {
+          next.device.close().catch(() => { /* already closed / gone */ });
+        }
         return;
       }
       session = next;
@@ -151,25 +159,43 @@ export function useSpaceMouseControls(params: UseSpaceMouseControlsParams): void
       startLoop();
     };
 
+    // Serialize connect attempts: a manual Connect click overlapping the
+    // startup reconnect (or a double-click) must not produce two sessions
+    // racing over the same device.
+    let connectInFlight = false;
+
     const connect = async () => {
-      if (session) return;
+      if (session || connectInFlight) return;
+      connectInFlight = true;
       try {
         adopt(await connectSpaceMouse(sessionOptions));
       } catch (err) {
         if (!aborted) {
           useViewerStore.getState().setSpaceMouseError(err instanceof Error ? err.message : String(err));
         }
+      } finally {
+        connectInFlight = false;
+      }
+    };
+
+    const reconnect = async () => {
+      if (session || connectInFlight || aborted) return;
+      connectInFlight = true;
+      try {
+        adopt(await reconnectGrantedSpaceMouse(sessionOptions));
+      } finally {
+        connectInFlight = false;
       }
     };
 
     store.setSpaceMouseConnect(() => { void connect(); });
 
     // Reopen a device granted in an earlier visit, without prompting.
-    void reconnectGrantedSpaceMouse(sessionOptions).then(adopt);
+    void reconnect();
 
     // When a granted device is plugged back in, pick it up automatically.
     const handleHidConnect = () => {
-      if (!session && !aborted) void reconnectGrantedSpaceMouse(sessionOptions).then(adopt);
+      void reconnect();
     };
     navigator.hid?.addEventListener('connect', handleHidConnect);
 

--- a/apps/viewer/src/lib/spacemouse/attack.test.ts
+++ b/apps/viewer/src/lib/spacemouse/attack.test.ts
@@ -1,0 +1,185 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * ADVERSARIAL tests for the SpaceMouse feature (#1677), consolidated from the
+ * parallel PR #1688's adversarial review. Each test name is prefixed with
+ * CONFIRMED- or REFUTED- to state the verdict for the attacked surface.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  parseSpaceMouseReport,
+  zeroSixDof,
+  type SixDof,
+} from './parser.js';
+import {
+  mapSixDofToCameraDeltas,
+  deltasAreZero,
+  isInputStale,
+} from './mapping.js';
+import {
+  REPORT_ID_TRANSLATION,
+  REPORT_ID_ROTATION,
+  REPORT_ID_BUTTONS,
+  AXIS_FULL_SCALE,
+  BASE_RATES,
+  SENSITIVITY,
+  MAX_FRAME_DELTA_MS,
+  STALE_REPORT_TIMEOUT_MS,
+} from './constants.js';
+
+function reportOf(values: number[]): DataView {
+  const buf = new ArrayBuffer(values.length * 2);
+  const view = new DataView(buf);
+  values.forEach((v, i) => view.setInt16(i * 2, v, true));
+  return view;
+}
+
+// ---------------------------------------------------------------------------
+// SURFACE 1: FRAME-TIME SPIKE / CAMERA TELEPORT (unclamped dt)
+// ---------------------------------------------------------------------------
+
+test('backgrounded-tab resume integrates at most MAX_FRAME_DELTA_MS (no teleport)', () => {
+  // User holds the puck at full push, backgrounds the tab 30s, returns. rAF
+  // pauses, so the first resumed frame reports a 30s delta. The mapping caps
+  // integration at MAX_FRAME_DELTA_MS (adversarial finding on #1688: an
+  // unclamped dt produced a ~270-wheel-notch teleport).
+  const held: SixDof = { ...zeroSixDof(), ty: AXIS_FULL_SCALE }; // full dolly pull
+  const resumed = mapSixDofToCameraDeltas(held, 1, 30_000);
+  const capped = mapSixDofToCameraDeltas(held, 1, MAX_FRAME_DELTA_MS);
+  assert.equal(resumed.zoomDelta, capped.zoomDelta, '30s frame behaves like the cap');
+  assert.ok(
+    resumed.zoomDelta <= BASE_RATES.zoomDeltaPerSec * (MAX_FRAME_DELTA_MS / 1000) + 1e-9,
+    `expected <=${BASE_RATES.zoomDeltaPerSec * (MAX_FRAME_DELTA_MS / 1000)}, got ${resumed.zoomDelta}`,
+  );
+});
+
+test('worst case (max sensitivity + 30s bg) stays a sub-frame orbit, not radians', () => {
+  const held: SixDof = { ...zeroSixDof(), rz: AXIS_FULL_SCALE };
+  const d = mapSixDofToCameraDeltas(held, SENSITIVITY.max, 30_000);
+  const cappedMax = BASE_RATES.orbitPxPerSec * SENSITIVITY.max * (MAX_FRAME_DELTA_MS / 1000);
+  assert.ok(Math.abs(d.orbitDx) <= cappedMax + 1e-9, `expected <=${cappedMax}px orbit, got ${d.orbitDx}`);
+});
+
+test('REFUTED-dt-zero-guarded: deltaMs=0 yields zero deltas', () => {
+  const held: SixDof = { ...zeroSixDof(), ty: AXIS_FULL_SCALE };
+  assert.ok(deltasAreZero(mapSixDofToCameraDeltas(held, 1, 0)));
+});
+
+test('REFUTED-dt-negative-guarded: negative dt (timer skew) yields zero deltas', () => {
+  const held: SixDof = { ...zeroSixDof(), ty: AXIS_FULL_SCALE };
+  assert.ok(deltasAreZero(mapSixDofToCameraDeltas(held, 1, -1000)));
+  assert.ok(deltasAreZero(mapSixDofToCameraDeltas(held, 1, Number.NaN)));
+});
+
+// ---------------------------------------------------------------------------
+// SURFACE 2: STALE INPUT LATCH / RUNAWAY (state never decays on report silence)
+// ---------------------------------------------------------------------------
+
+test('silent HID stall is cut off by the staleness watchdog', () => {
+  // If the device stops emitting reports without a disconnect event, the
+  // driver consults isInputStale(lastReportAt, now) and stops driving the
+  // camera once the report is older than STALE_REPORT_TIMEOUT_MS
+  // (adversarial finding on #1688: the last non-zero sample used to latch
+  // and move the camera forever).
+  const lastReport = 1_000_000;
+  assert.equal(isInputStale(lastReport, lastReport + STALE_REPORT_TIMEOUT_MS), false, 'fresh at the boundary');
+  assert.equal(isInputStale(lastReport, lastReport + STALE_REPORT_TIMEOUT_MS + 1), true, 'stale past the timeout');
+  assert.equal(isInputStale(Number.NEGATIVE_INFINITY, lastReport), true, 'never-reported counts as stale');
+  assert.equal(isInputStale(Number.NaN, lastReport), true, 'corrupt clock counts as stale');
+});
+
+test('REFUTED-unplug-zeroes: an all-zero state (as session.close() produces) stops motion', () => {
+  // On a real unplug, SpaceMouseSession.close() zeroes the 6DoF state and the
+  // hook stops its RAF loop. Model that terminal state here.
+  assert.ok(deltasAreZero(mapSixDofToCameraDeltas(zeroSixDof(), 1, 16)));
+});
+
+// ---------------------------------------------------------------------------
+// SURFACE 3: PARSER BOUNDARIES
+// ---------------------------------------------------------------------------
+
+test('REFUTED-int16-min-no-signflip: -32768 clamps to -full scale (no abs overflow)', () => {
+  const out = parseSpaceMouseReport(REPORT_ID_ROTATION, reportOf([-32768, -32768, -32768]), zeroSixDof());
+  assert.equal(out.rx, -AXIS_FULL_SCALE);
+  assert.equal(out.ry, -AXIS_FULL_SCALE);
+  assert.equal(out.rz, -AXIS_FULL_SCALE);
+  // Downstream normalisation stays in [-1,1] with the correct sign.
+  const d = mapSixDofToCameraDeltas(out, 1, 1000);
+  assert.ok(d.orbitDy < 0, 'sign preserved, not flipped positive');
+});
+
+test('REFUTED-dataview-byteoffset: a subarray DataView (byteOffset!=0) parses correctly', () => {
+  // WebHID sometimes hands a DataView that is a window into a larger buffer.
+  const backing = new ArrayBuffer(4 + 6); // 4 bytes junk prefix + 3x int16
+  const full = new DataView(backing);
+  full.setInt16(4 + 0, 111, true);
+  full.setInt16(4 + 2, -222, true);
+  full.setInt16(4 + 4, 333, true);
+  const windowed = new DataView(backing, 4, 6); // byteOffset=4
+  const out = parseSpaceMouseReport(REPORT_ID_TRANSLATION, windowed, zeroSixDof());
+  assert.equal(out.tx, 111);
+  assert.equal(out.ty, -222);
+  assert.equal(out.tz, 333); // below full scale, passes through unchanged
+});
+
+test('CONFIRMED-12byte-misclassification: a 12-byte reportId-1 with trailing padding injects phantom rotation', () => {
+  // Design: any reportId-1 with >=12 bytes is treated as combined 6-axis.
+  // A device that emits translation-only but pads its report to 12 bytes (or a
+  // 6-byte split report followed by uninitialised/garbage tail) has its bytes
+  // 6..11 silently interpreted as rotation rx/ry/rz. Documented limitation.
+  const translationOnlyWithGarbageTail = reportOf([10, 20, 30, 400, -400, 200]);
+  const out = parseSpaceMouseReport(REPORT_ID_TRANSLATION, translationOnlyWithGarbageTail, zeroSixDof());
+  assert.equal(out.tx, 10);
+  // Phantom rotation the device never intended:
+  assert.equal(out.rx, AXIS_FULL_SCALE); // 400 clamps to 350
+  assert.equal(out.rz, 200);
+  const d = mapSixDofToCameraDeltas(out, 1, 16);
+  assert.ok(d.orbitDx !== 0 || d.orbitDy !== 0, 'phantom orbit from misread padding');
+});
+
+test('REFUTED-buttons-huge-bitmask: reportId 3 with a huge payload never touches 6DoF', () => {
+  const huge = new DataView(new Uint8Array(64).fill(0xff).buffer);
+  const prev: SixDof = { tx: 1, ty: 2, tz: 3, rx: 4, ry: 5, rz: 6 };
+  const out = parseSpaceMouseReport(REPORT_ID_BUTTONS, huge, prev);
+  assert.deepEqual(out, prev);
+});
+
+test('REFUTED-interleaved-out-of-order: rotation-then-translation reports each keep their own axes', () => {
+  let s = zeroSixDof();
+  s = parseSpaceMouseReport(REPORT_ID_ROTATION, reportOf([9, 0, 0]), s);
+  s = parseSpaceMouseReport(REPORT_ID_TRANSLATION, reportOf([1, 2, 3]), s);
+  s = parseSpaceMouseReport(REPORT_ID_ROTATION, reportOf([0, 0, 8]), s);
+  assert.equal(s.tx, 1);
+  assert.equal(s.rx, 0); // overwritten by the second rotation report
+  assert.equal(s.rz, 8);
+});
+
+test('REFUTED-odd-length-buffer: a 5-byte report never throws and keeps the unbacked axis', () => {
+  const prev: SixDof = { tx: 0, ty: 0, tz: 99, rx: 0, ry: 0, rz: 0 };
+  const buf = new DataView(new Uint8Array([0x0a, 0x00, 0x14, 0x00, 0x7f]).buffer); // 5 bytes
+  const out = parseSpaceMouseReport(REPORT_ID_TRANSLATION, buf, prev);
+  assert.equal(out.tx, 10);
+  assert.equal(out.ty, 20);
+  assert.equal(out.tz, 99); // offset 4 needs bytes 4-5; only byte 4 present -> kept
+});
+
+// ---------------------------------------------------------------------------
+// SURFACE 4: SLICE PERSISTENCE — sensitivity rehydrate validation
+// ---------------------------------------------------------------------------
+// clampSensitivity is not exported, so exercise it through the same math the
+// slice applies on load. These document the guard the slice relies on.
+
+test('REFUTED-sensitivity-rehydrate: corrupt persisted sensitivity is clamped, not trusted', () => {
+  const clamp = (v: number) =>
+    Number.isFinite(v) ? Math.min(SENSITIVITY.max, Math.max(SENSITIVITY.min, v)) : SENSITIVITY.default;
+  assert.equal(clamp(-5), SENSITIVITY.min); // negative -> min
+  assert.equal(clamp(1e9), SENSITIVITY.max); // absurd -> max
+  assert.equal(clamp(Number.NaN), SENSITIVITY.default);
+  // And a clamped-to-min sensitivity still cannot produce negative gain.
+  const d = mapSixDofToCameraDeltas({ ...zeroSixDof(), ty: AXIS_FULL_SCALE }, clamp(-5), 16);
+  assert.ok(d.zoomDelta > 0);
+});

--- a/apps/viewer/src/lib/spacemouse/constants.ts
+++ b/apps/viewer/src/lib/spacemouse/constants.ts
@@ -54,6 +54,23 @@ export const AXIS_FULL_SCALE = 350;
 export const DEADZONE_FRACTION = 0.03;
 
 /**
+ * Frames longer than this (background tab, debugger pause) integrate as if
+ * they were this long, so the first frame back cannot fold seconds of held
+ * deflection into one huge camera jump. Enforced inside the pure mapping so
+ * the teleport guard is unit-testable.
+ */
+export const MAX_FRAME_DELTA_MS = 50;
+
+/**
+ * Reports older than this no longer drive the camera. A silent HID stall
+ * (driver hiccup, stack freeze, no `disconnect` event) would otherwise latch
+ * the last non-zero sample and move the camera forever. Safe because a
+ * deflected SpaceMouse streams reports continuously (~125Hz); more than
+ * 250ms of silence means released or stalled.
+ */
+export const STALE_REPORT_TIMEOUT_MS = 250;
+
+/**
  * Per-axis role + sign, following 3Dconnexion's default "object mode": the
  * model follows the puck (push right -> model moves right, twist -> model
  * turns, push away -> move into the scene). Signs are best-effort without

--- a/apps/viewer/src/lib/spacemouse/constants.ts
+++ b/apps/viewer/src/lib/spacemouse/constants.ts
@@ -1,0 +1,111 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * 3Dconnexion SpaceMouse tuning constants, the ONE place to adjust device
+ * behaviour.
+ *
+ * We cannot test against real hardware in CI, so every value a specific device
+ * variant might disagree on (vendor id, report ids, axis full-scale, axis sign
+ * or role) lives here. If a SpaceMouse model reports a different layout or an
+ * inverted axis, fixing it is a one-line edit in this file, no logic changes.
+ *
+ * References: 3Dconnexion USB HID reports (SpaceMouse Module spec HW-3DX-700048,
+ * plus the community drivers webhid-space and nytamin/spacemouse).
+ *   reportId 1 -> translation, three int16 LE  (tx, ty, tz)
+ *   reportId 2 -> rotation,    three int16 LE  (rx, ry, rz)
+ *   reportId 3 -> buttons,     bitmask
+ * Some newer devices coalesce translation + rotation into a single 12-byte
+ * reportId-1 frame (tx, ty, tz, rx, ry, rz); the parser handles both layouts.
+ *
+ * Device axis frame (right-handed, cap at rest):
+ *   tx+ = cap pushed right, ty+ = cap pulled toward the user,
+ *   tz+ = cap pressed down; rx/ry/rz are rotations about those axes.
+ */
+
+/**
+ * USB vendor ids: 0x046d (Logitech, used by the older SpaceNavigator /
+ * SpaceMouse Pro / SpacePilot line) and 0x256f (3Dconnexion's own id, used by
+ * Compact / Wireless / Enterprise and everything current).
+ */
+export const SPACEMOUSE_VENDOR_IDS = [0x046d, 0x256f] as const;
+
+/** HID usage: Generic Desktop page, Multi-axis Controller. */
+export const HID_USAGE_PAGE_GENERIC_DESKTOP = 0x01;
+export const HID_USAGE_MULTI_AXIS_CONTROLLER = 0x08;
+
+/** HID report ids. */
+export const REPORT_ID_TRANSLATION = 1;
+export const REPORT_ID_ROTATION = 2;
+export const REPORT_ID_BUTTONS = 3;
+
+/**
+ * Full-scale magnitude of one axis. 3Dconnexion axes saturate around +/-350; we
+ * clamp to this so a spurious out-of-range sample cannot produce a runaway
+ * camera jump. Normalisation divides by this to yield roughly [-1, 1].
+ */
+export const AXIS_FULL_SCALE = 350;
+
+/**
+ * Dead zone as a fraction of full scale. The puck never rests at a perfect
+ * zero, so small idle readings must be ignored or the camera would drift.
+ */
+export const DEADZONE_FRACTION = 0.03;
+
+/**
+ * Per-axis role + sign, following 3Dconnexion's default "object mode": the
+ * model follows the puck (push right -> model moves right, twist -> model
+ * turns, push away -> move into the scene). Signs are best-effort without
+ * hardware and trivially flippable here.
+ */
+export const AXIS_SIGN = {
+  /** tx -> horizontal pan. +1: cap right moves the model right (grab idiom). */
+  panX: 1,
+  /** tz -> vertical pan. +1: cap pressed down moves the model down. */
+  panY: 1,
+  /** ty -> dolly. +1: cap pulled back zooms out (camera.zoom positive = out). */
+  dolly: 1,
+  /** rz (twist) -> orbit azimuth. */
+  orbitYaw: 1,
+  /** rx (tilt forward/back) -> orbit elevation. */
+  orbitPitch: 1,
+} as const;
+
+/**
+ * Base motion rates, expressed as the mouse-equivalent delta produced per
+ * second at full axis deflection and sensitivity 1. The camera controls
+ * consume these exactly like a mouse drag / wheel, so they are calibrated in
+ * the same units:
+ *   - orbit/pan take pixel-like deltas (ORBIT_SENSITIVITY is 0.01 rad/px).
+ *   - zoom takes a wheel-like delta (like wheel deltaY).
+ * Frame integration multiplies by (deltaMs / 1000), so motion is frame-rate
+ * independent.
+ */
+export const BASE_RATES = {
+  /** Orbit pixels per second at full tilt (160px ~= 1.6 rad/s). */
+  orbitPxPerSec: 160,
+  /** Pan pixels per second at full deflection (pan speed also scales with distance). */
+  panPxPerSec: 420,
+  /** Wheel-equivalent zoom delta per second at full push. */
+  zoomDeltaPerSec: 900,
+} as const;
+
+/**
+ * Sensitivity slider range. 1 is the neutral default; the value multiplies the
+ * base rates above.
+ */
+export const SENSITIVITY = {
+  min: 0.2,
+  max: 3,
+  step: 0.1,
+  default: 1,
+} as const;
+
+/**
+ * Device buttons that trigger "fit view" (frame selection, or zoom extents
+ * with nothing selected). Buttons 0 and 1 are the two physical buttons on the
+ * SpaceNavigator / SpaceMouse Compact / Wireless; larger devices map their
+ * first two buttons here too.
+ */
+export const FIT_BUTTON_INDICES = new Set([0, 1]);

--- a/apps/viewer/src/lib/spacemouse/device.ts
+++ b/apps/viewer/src/lib/spacemouse/device.ts
@@ -1,0 +1,185 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * WebHID connection management for 3Dconnexion SpaceMouse devices.
+ *
+ * Owns the browser-facing half of the driver: permission prompt, opening the
+ * device, decoding `inputreport` events through the pure parser, button edge
+ * detection, and reconnecting a previously granted device without a prompt
+ * (WebHID persists grants per origin). The consumer polls `getState()` from
+ * its own animation frame; nothing here touches the camera.
+ *
+ * WebHID exists in Chromium-based browsers only, and requires a user gesture
+ * for `requestDevice`. A running 3DxWare driver can hold the device
+ * exclusively, in which case `open()` fails; we surface that as a friendly
+ * error rather than a silent no-op.
+ */
+
+import {
+  FIT_BUTTON_INDICES,
+  HID_USAGE_MULTI_AXIS_CONTROLLER,
+  HID_USAGE_PAGE_GENERIC_DESKTOP,
+  REPORT_ID_BUTTONS,
+  SPACEMOUSE_VENDOR_IDS,
+} from './constants.js';
+import { parseButtonsReport, parseSpaceMouseReport, zeroSixDof, type SixDof } from './parser.js';
+
+/** True when the browser exposes WebHID (Chromium-based browsers). */
+export function isWebHidSupported(): boolean {
+  return typeof navigator !== 'undefined' && navigator.hid !== undefined;
+}
+
+/**
+ * Device picker filters. Restricting to the Multi-axis Controller usage keeps
+ * ordinary Logitech mice/keyboards (same 0x046d vendor id) out of the chooser;
+ * 0x256f is 3Dconnexion-exclusive so a bare vendor filter is safe there and
+ * also catches devices whose top-level collection reports a different usage.
+ */
+const REQUEST_FILTERS: HIDDeviceFilter[] = [
+  ...SPACEMOUSE_VENDOR_IDS.map((vendorId) => ({
+    vendorId,
+    usagePage: HID_USAGE_PAGE_GENERIC_DESKTOP,
+    usage: HID_USAGE_MULTI_AXIS_CONTROLLER,
+  })),
+  { vendorId: 0x256f },
+];
+
+function isSpaceMouseCandidate(device: HIDDevice): boolean {
+  return (SPACEMOUSE_VENDOR_IDS as readonly number[]).includes(device.vendorId);
+}
+
+/**
+ * Rank candidate HID interfaces: a physical device can expose several (LEDs,
+ * consumer controls); the one with the Multi-axis Controller collection is
+ * the 6DoF stream.
+ */
+function multiAxisScore(device: HIDDevice): number {
+  const collections = device.collections ?? [];
+  return collections.some(
+    (c) => c.usagePage === HID_USAGE_PAGE_GENERIC_DESKTOP && c.usage === HID_USAGE_MULTI_AXIS_CONTROLLER,
+  ) ? 1 : 0;
+}
+
+export interface SpaceMouseSessionOptions {
+  /** Called on every decoded 6DoF sample (high frequency; keep it cheap). */
+  onSample?: (state: SixDof) => void;
+  /** Called once per press (edge) of a fit-mapped device button. */
+  onFitButton?: () => void;
+  /** Called when the device goes away (unplugged or closed by the browser). */
+  onDisconnect?: () => void;
+}
+
+/**
+ * One open SpaceMouse device. Create via `connectSpaceMouse` /
+ * `reconnectGrantedSpaceMouse`; call `close()` on teardown.
+ */
+export class SpaceMouseSession {
+  private state: SixDof = zeroSixDof();
+  private buttonsDown = new Set<number>();
+  private closed = false;
+
+  private readonly handleInputReport = (event: HIDInputReportEvent): void => {
+    if (event.reportId === REPORT_ID_BUTTONS) {
+      const pressed = parseButtonsReport(event.data);
+      const now = new Set(pressed);
+      for (const index of pressed) {
+        if (!this.buttonsDown.has(index) && FIT_BUTTON_INDICES.has(index)) {
+          this.options.onFitButton?.();
+        }
+      }
+      this.buttonsDown = now;
+      return;
+    }
+    this.state = parseSpaceMouseReport(event.reportId, event.data, this.state);
+    this.options.onSample?.(this.state);
+  };
+
+  private readonly handleGlobalDisconnect = (event: HIDConnectionEvent): void => {
+    if (event.device === this.device) {
+      void this.close();
+    }
+  };
+
+  constructor(
+    readonly device: HIDDevice,
+    private readonly options: SpaceMouseSessionOptions,
+  ) {
+    device.addEventListener('inputreport', this.handleInputReport);
+    navigator.hid?.addEventListener('disconnect', this.handleGlobalDisconnect);
+  }
+
+  /** Latest decoded 6DoF sample (device counts, clamped). */
+  getState(): SixDof {
+    return this.state;
+  }
+
+  get productName(): string {
+    return this.device.productName || 'SpaceMouse';
+  }
+
+  /** Close the device and detach listeners. Safe to call more than once. */
+  async close(): Promise<void> {
+    if (this.closed) return;
+    this.closed = true;
+    this.state = zeroSixDof();
+    this.device.removeEventListener('inputreport', this.handleInputReport);
+    navigator.hid?.removeEventListener('disconnect', this.handleGlobalDisconnect);
+    try {
+      await this.device.close();
+    } catch { /* already closed / gone */ }
+    this.options.onDisconnect?.();
+  }
+}
+
+async function openSession(devices: HIDDevice[], options: SpaceMouseSessionOptions): Promise<SpaceMouseSession> {
+  const candidates = devices
+    .filter(isSpaceMouseCandidate)
+    .sort((a, b) => multiAxisScore(b) - multiAxisScore(a));
+  if (candidates.length === 0) {
+    throw new Error('No SpaceMouse found.');
+  }
+
+  let lastError: unknown = null;
+  for (const device of candidates) {
+    try {
+      if (!device.opened) await device.open();
+      return new SpaceMouseSession(device, options);
+    } catch (err) {
+      lastError = err;
+    }
+  }
+  throw new Error(
+    'Could not open the SpaceMouse. If the 3Dconnexion driver (3DxWare) is running it may hold the device; quit it and reconnect.'
+    + (lastError ? ` (${String(lastError)})` : ''),
+  );
+}
+
+/**
+ * Prompt the user to pick a SpaceMouse and open it. Must be called from a user
+ * gesture (click). Throws with a human-readable message on failure; resolves
+ * null if the user dismissed the chooser.
+ */
+export async function connectSpaceMouse(options: SpaceMouseSessionOptions): Promise<SpaceMouseSession | null> {
+  if (!navigator.hid) throw new Error('WebHID is not available in this browser.');
+  const devices = await navigator.hid.requestDevice({ filters: REQUEST_FILTERS });
+  if (devices.length === 0) return null; // user cancelled the picker
+  return openSession(devices, options);
+}
+
+/**
+ * Silently reopen a device the user granted in an earlier session, if any.
+ * Never prompts; returns null when nothing was granted or opening fails
+ * (e.g. the device is unplugged), so startup stays quiet.
+ */
+export async function reconnectGrantedSpaceMouse(options: SpaceMouseSessionOptions): Promise<SpaceMouseSession | null> {
+  if (!navigator.hid) return null;
+  try {
+    const devices = await navigator.hid.getDevices();
+    if (!devices.some(isSpaceMouseCandidate)) return null;
+    return await openSession(devices, options);
+  } catch {
+    return null;
+  }
+}

--- a/apps/viewer/src/lib/spacemouse/device.ts
+++ b/apps/viewer/src/lib/spacemouse/device.ts
@@ -130,13 +130,24 @@ export class SpaceMouseSession {
     return this.device.productName || 'SpaceMouse';
   }
 
-  /** Close the device and detach listeners. Safe to call more than once. */
-  async close(): Promise<void> {
+  /**
+   * Detach listeners WITHOUT closing the device or firing onDisconnect. For
+   * discarding a duplicate session whose underlying device another session
+   * still streams from (overlapping connect attempts can wrap the same
+   * HIDDevice). Safe to call more than once.
+   */
+  detach(): void {
     if (this.closed) return;
     this.closed = true;
     this.state = zeroSixDof();
     this.device.removeEventListener('inputreport', this.handleInputReport);
     navigator.hid?.removeEventListener('disconnect', this.handleGlobalDisconnect);
+  }
+
+  /** Close the device and detach listeners. Safe to call more than once. */
+  async close(): Promise<void> {
+    if (this.closed) return;
+    this.detach();
     try {
       await this.device.close();
     } catch { /* already closed / gone */ }

--- a/apps/viewer/src/lib/spacemouse/device.ts
+++ b/apps/viewer/src/lib/spacemouse/device.ts
@@ -77,6 +77,7 @@ export interface SpaceMouseSessionOptions {
  */
 export class SpaceMouseSession {
   private state: SixDof = zeroSixDof();
+  private lastSampleAt = Number.NEGATIVE_INFINITY;
   private buttonsDown = new Set<number>();
   private closed = false;
 
@@ -93,6 +94,7 @@ export class SpaceMouseSession {
       return;
     }
     this.state = parseSpaceMouseReport(event.reportId, event.data, this.state);
+    this.lastSampleAt = performance.now();
     this.options.onSample?.(this.state);
   };
 
@@ -113,6 +115,15 @@ export class SpaceMouseSession {
   /** Latest decoded 6DoF sample (device counts, clamped). */
   getState(): SixDof {
     return this.state;
+  }
+
+  /**
+   * performance.now() of the last decoded 6DoF report, -Infinity before the
+   * first one. Feed to `isInputStale` so a silent HID stall (no disconnect
+   * event) cannot latch the last sample and drive the camera forever.
+   */
+  getLastSampleAt(): number {
+    return this.lastSampleAt;
   }
 
   get productName(): string {

--- a/apps/viewer/src/lib/spacemouse/mapping.test.ts
+++ b/apps/viewer/src/lib/spacemouse/mapping.test.ts
@@ -1,0 +1,107 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  applyDeadzone,
+  mapSixDofToCameraDeltas,
+  deltasAreZero,
+} from './mapping.js';
+import { zeroSixDof, type SixDof } from './parser.js';
+import { AXIS_FULL_SCALE, AXIS_SIGN, BASE_RATES, DEADZONE_FRACTION } from './constants.js';
+
+test('applyDeadzone returns 0 inside the dead zone', () => {
+  const inside = AXIS_FULL_SCALE * DEADZONE_FRACTION * 0.5;
+  assert.equal(applyDeadzone(inside), 0);
+  assert.equal(applyDeadzone(-inside), 0);
+  assert.equal(applyDeadzone(0), 0);
+});
+
+test('applyDeadzone ramps from 0 at the edge to 1 at full scale', () => {
+  // Just past the dead zone edge is near 0, not a jump to a large value.
+  const edge = AXIS_FULL_SCALE * DEADZONE_FRACTION;
+  assert.ok(Math.abs(applyDeadzone(edge + 0.001)) < 1e-3);
+  // Full scale maps to exactly 1 / -1.
+  assert.equal(applyDeadzone(AXIS_FULL_SCALE), 1);
+  assert.equal(applyDeadzone(-AXIS_FULL_SCALE), -1);
+});
+
+test('applyDeadzone is monotonic and sign-preserving outside the dead zone', () => {
+  const half = applyDeadzone(AXIS_FULL_SCALE * 0.5);
+  const full = applyDeadzone(AXIS_FULL_SCALE);
+  assert.ok(half > 0 && half < full);
+  assert.ok(applyDeadzone(-AXIS_FULL_SCALE * 0.5) < 0);
+});
+
+test('idle (all-zero) sample produces zero deltas', () => {
+  const d = mapSixDofToCameraDeltas(zeroSixDof(), 1, 16);
+  assert.ok(deltasAreZero(d));
+});
+
+test('non-positive deltaMs or sensitivity produces zero deltas', () => {
+  const full: SixDof = { tx: AXIS_FULL_SCALE, ty: AXIS_FULL_SCALE, tz: AXIS_FULL_SCALE, rx: AXIS_FULL_SCALE, ry: 0, rz: AXIS_FULL_SCALE };
+  assert.ok(deltasAreZero(mapSixDofToCameraDeltas(full, 1, 0)));
+  assert.ok(deltasAreZero(mapSixDofToCameraDeltas(full, 0, 16)));
+  assert.ok(deltasAreZero(mapSixDofToCameraDeltas(full, -1, 16)));
+});
+
+test('cap left/right (tx) drives horizontal pan only', () => {
+  // Full deflection on tx only, sensitivity 1, exactly 1000ms -> base rate.
+  const s: SixDof = { ...zeroSixDof(), tx: AXIS_FULL_SCALE };
+  const d = mapSixDofToCameraDeltas(s, 1, 1000);
+  assert.equal(d.panDx, AXIS_SIGN.panX * BASE_RATES.panPxPerSec);
+  assert.equal(d.panDy, 0);
+  assert.equal(d.zoomDelta, 0);
+  assert.equal(d.orbitDx, 0);
+  assert.equal(d.orbitDy, 0);
+});
+
+test('cap up/down (tz) drives vertical pan only', () => {
+  const s: SixDof = { ...zeroSixDof(), tz: AXIS_FULL_SCALE };
+  const d = mapSixDofToCameraDeltas(s, 1, 1000);
+  assert.equal(d.panDy, AXIS_SIGN.panY * BASE_RATES.panPxPerSec);
+  assert.equal(d.panDx, 0);
+  assert.equal(d.zoomDelta, 0);
+});
+
+test('cap push/pull (ty) drives zoom with the configured sign', () => {
+  const s: SixDof = { ...zeroSixDof(), ty: AXIS_FULL_SCALE };
+  const d = mapSixDofToCameraDeltas(s, 1, 1000);
+  assert.equal(d.zoomDelta, AXIS_SIGN.dolly * BASE_RATES.zoomDeltaPerSec);
+  assert.equal(d.panDx, 0);
+  assert.equal(d.panDy, 0);
+  assert.equal(d.orbitDx, 0);
+});
+
+test('twist (rz) and tilt (rx) drive orbit; roll (ry) is ignored', () => {
+  const s: SixDof = { ...zeroSixDof(), rz: AXIS_FULL_SCALE, rx: AXIS_FULL_SCALE, ry: AXIS_FULL_SCALE };
+  const d = mapSixDofToCameraDeltas(s, 1, 1000);
+  assert.equal(d.orbitDx, AXIS_SIGN.orbitYaw * BASE_RATES.orbitPxPerSec);
+  assert.equal(d.orbitDy, AXIS_SIGN.orbitPitch * BASE_RATES.orbitPxPerSec);
+  // roll contributes to nothing
+  assert.equal(d.panDx, 0);
+  assert.equal(d.panDy, 0);
+  assert.equal(d.zoomDelta, 0);
+});
+
+test('sensitivity scales deltas linearly', () => {
+  const s: SixDof = { ...zeroSixDof(), tx: AXIS_FULL_SCALE };
+  const base = mapSixDofToCameraDeltas(s, 1, 1000);
+  const doubled = mapSixDofToCameraDeltas(s, 2, 1000);
+  assert.ok(Math.abs(doubled.panDx - 2 * base.panDx) < 1e-9);
+});
+
+test('deltas scale with frame time (frame-rate independence)', () => {
+  const s: SixDof = { ...zeroSixDof(), tx: AXIS_FULL_SCALE };
+  const at16 = mapSixDofToCameraDeltas(s, 1, 16);
+  const at32 = mapSixDofToCameraDeltas(s, 1, 32);
+  assert.ok(Math.abs(at32.panDx - 2 * at16.panDx) < 1e-9);
+});
+
+test('a sample entirely within the dead zone yields zero deltas', () => {
+  const tiny = AXIS_FULL_SCALE * DEADZONE_FRACTION * 0.5;
+  const s: SixDof = { tx: tiny, ty: -tiny, tz: tiny, rx: -tiny, ry: tiny, rz: tiny };
+  assert.ok(deltasAreZero(mapSixDofToCameraDeltas(s, 1, 16)));
+});

--- a/apps/viewer/src/lib/spacemouse/mapping.test.ts
+++ b/apps/viewer/src/lib/spacemouse/mapping.test.ts
@@ -10,7 +10,11 @@ import {
   deltasAreZero,
 } from './mapping.js';
 import { zeroSixDof, type SixDof } from './parser.js';
-import { AXIS_FULL_SCALE, AXIS_SIGN, BASE_RATES, DEADZONE_FRACTION } from './constants.js';
+import { AXIS_FULL_SCALE, AXIS_SIGN, BASE_RATES, DEADZONE_FRACTION, MAX_FRAME_DELTA_MS } from './constants.js';
+
+// One frame at the integration cap: full deflection for exactly this long
+// yields rate * CAP_DT of mouse-equivalent delta.
+const CAP_DT = MAX_FRAME_DELTA_MS / 1000;
 
 test('applyDeadzone returns 0 inside the dead zone', () => {
   const inside = AXIS_FULL_SCALE * DEADZONE_FRACTION * 0.5;
@@ -48,10 +52,10 @@ test('non-positive deltaMs or sensitivity produces zero deltas', () => {
 });
 
 test('cap left/right (tx) drives horizontal pan only', () => {
-  // Full deflection on tx only, sensitivity 1, exactly 1000ms -> base rate.
+  // Full deflection on tx only, sensitivity 1, one frame at the dt cap.
   const s: SixDof = { ...zeroSixDof(), tx: AXIS_FULL_SCALE };
-  const d = mapSixDofToCameraDeltas(s, 1, 1000);
-  assert.equal(d.panDx, AXIS_SIGN.panX * BASE_RATES.panPxPerSec);
+  const d = mapSixDofToCameraDeltas(s, 1, MAX_FRAME_DELTA_MS);
+  assert.equal(d.panDx, AXIS_SIGN.panX * BASE_RATES.panPxPerSec * CAP_DT);
   assert.equal(d.panDy, 0);
   assert.equal(d.zoomDelta, 0);
   assert.equal(d.orbitDx, 0);
@@ -60,16 +64,16 @@ test('cap left/right (tx) drives horizontal pan only', () => {
 
 test('cap up/down (tz) drives vertical pan only', () => {
   const s: SixDof = { ...zeroSixDof(), tz: AXIS_FULL_SCALE };
-  const d = mapSixDofToCameraDeltas(s, 1, 1000);
-  assert.equal(d.panDy, AXIS_SIGN.panY * BASE_RATES.panPxPerSec);
+  const d = mapSixDofToCameraDeltas(s, 1, MAX_FRAME_DELTA_MS);
+  assert.equal(d.panDy, AXIS_SIGN.panY * BASE_RATES.panPxPerSec * CAP_DT);
   assert.equal(d.panDx, 0);
   assert.equal(d.zoomDelta, 0);
 });
 
 test('cap push/pull (ty) drives zoom with the configured sign', () => {
   const s: SixDof = { ...zeroSixDof(), ty: AXIS_FULL_SCALE };
-  const d = mapSixDofToCameraDeltas(s, 1, 1000);
-  assert.equal(d.zoomDelta, AXIS_SIGN.dolly * BASE_RATES.zoomDeltaPerSec);
+  const d = mapSixDofToCameraDeltas(s, 1, MAX_FRAME_DELTA_MS);
+  assert.equal(d.zoomDelta, AXIS_SIGN.dolly * BASE_RATES.zoomDeltaPerSec * CAP_DT);
   assert.equal(d.panDx, 0);
   assert.equal(d.panDy, 0);
   assert.equal(d.orbitDx, 0);
@@ -77,9 +81,9 @@ test('cap push/pull (ty) drives zoom with the configured sign', () => {
 
 test('twist (rz) and tilt (rx) drive orbit; roll (ry) is ignored', () => {
   const s: SixDof = { ...zeroSixDof(), rz: AXIS_FULL_SCALE, rx: AXIS_FULL_SCALE, ry: AXIS_FULL_SCALE };
-  const d = mapSixDofToCameraDeltas(s, 1, 1000);
-  assert.equal(d.orbitDx, AXIS_SIGN.orbitYaw * BASE_RATES.orbitPxPerSec);
-  assert.equal(d.orbitDy, AXIS_SIGN.orbitPitch * BASE_RATES.orbitPxPerSec);
+  const d = mapSixDofToCameraDeltas(s, 1, MAX_FRAME_DELTA_MS);
+  assert.equal(d.orbitDx, AXIS_SIGN.orbitYaw * BASE_RATES.orbitPxPerSec * CAP_DT);
+  assert.equal(d.orbitDy, AXIS_SIGN.orbitPitch * BASE_RATES.orbitPxPerSec * CAP_DT);
   // roll contributes to nothing
   assert.equal(d.panDx, 0);
   assert.equal(d.panDy, 0);
@@ -88,8 +92,8 @@ test('twist (rz) and tilt (rx) drive orbit; roll (ry) is ignored', () => {
 
 test('sensitivity scales deltas linearly', () => {
   const s: SixDof = { ...zeroSixDof(), tx: AXIS_FULL_SCALE };
-  const base = mapSixDofToCameraDeltas(s, 1, 1000);
-  const doubled = mapSixDofToCameraDeltas(s, 2, 1000);
+  const base = mapSixDofToCameraDeltas(s, 1, 16);
+  const doubled = mapSixDofToCameraDeltas(s, 2, 16);
   assert.ok(Math.abs(doubled.panDx - 2 * base.panDx) < 1e-9);
 });
 

--- a/apps/viewer/src/lib/spacemouse/mapping.ts
+++ b/apps/viewer/src/lib/spacemouse/mapping.ts
@@ -24,6 +24,8 @@ import {
   AXIS_SIGN,
   BASE_RATES,
   DEADZONE_FRACTION,
+  MAX_FRAME_DELTA_MS,
+  STALE_REPORT_TIMEOUT_MS,
 } from './constants.js';
 import type { SixDof } from './parser.js';
 
@@ -62,12 +64,14 @@ export function applyDeadzone(raw: number, fullScale = AXIS_FULL_SCALE, deadzone
  *
  * @param state       raw clamped 6DoF sample from the parser
  * @param sensitivity user multiplier (1 = neutral)
- * @param deltaMs     frame time in milliseconds (for frame-rate independence)
+ * @param deltaMs     frame time in milliseconds (for frame-rate independence);
+ *                    capped at MAX_FRAME_DELTA_MS so a backgrounded tab's
+ *                    first frame back cannot teleport the camera
  */
 export function mapSixDofToCameraDeltas(state: SixDof, sensitivity: number, deltaMs: number): CameraDeltas {
   if (!(deltaMs > 0) || !(sensitivity > 0)) return { ...ZERO_DELTAS };
 
-  const dt = deltaMs / 1000;
+  const dt = Math.min(deltaMs, MAX_FRAME_DELTA_MS) / 1000;
   const gain = sensitivity * dt;
 
   // Normalised, dead-zoned axis responses in [-1, 1].
@@ -87,6 +91,16 @@ export function mapSixDofToCameraDeltas(state: SixDof, sensitivity: number, delt
     panDy: (AXIS_SIGN.panY * tz * BASE_RATES.panPxPerSec * gain) || 0,
     zoomDelta: (AXIS_SIGN.dolly * ty * BASE_RATES.zoomDeltaPerSec * gain) || 0,
   };
+}
+
+/**
+ * True when the last input report is too old to keep driving the camera.
+ * Pure so the silent-stall watchdog is unit-testable. Non-finite timestamps
+ * count as stale (never move the camera on corrupt clocks).
+ */
+export function isInputStale(lastReportAtMs: number, nowMs: number): boolean {
+  if (!Number.isFinite(lastReportAtMs) || !Number.isFinite(nowMs)) return true;
+  return nowMs - lastReportAtMs > STALE_REPORT_TIMEOUT_MS;
 }
 
 /** True when every delta is zero (device idle / fully dead-zoned). */

--- a/apps/viewer/src/lib/spacemouse/mapping.ts
+++ b/apps/viewer/src/lib/spacemouse/mapping.ts
@@ -1,0 +1,95 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Pure 6DoF to camera-delta mapping.
+ *
+ * Converts a raw SpaceMouse sample into the mouse-equivalent orbit / pan / zoom
+ * deltas the existing `Camera` controls already understand, applying a dead
+ * zone, per-axis sign, user sensitivity and frame-time integration. No camera
+ * or DOM handles here so it is unit-testable in isolation.
+ *
+ * Axis roles (3Dconnexion object mode):
+ *   tx (cap left/right)    -> horizontal pan
+ *   tz (cap up/down)       -> vertical pan
+ *   ty (cap push/pull)     -> dolly (zoom)
+ *   rz (cap twist)         -> orbit azimuth
+ *   rx (cap tilt fwd/back) -> orbit elevation
+ *   ry (cap roll)          -> ignored (the camera keeps up pinned to world Y)
+ */
+
+import {
+  AXIS_FULL_SCALE,
+  AXIS_SIGN,
+  BASE_RATES,
+  DEADZONE_FRACTION,
+} from './constants.js';
+import type { SixDof } from './parser.js';
+
+/** Mouse-equivalent camera deltas for a single frame. */
+export interface CameraDeltas {
+  /** Orbit horizontal delta (azimuth), in mouse pixels. */
+  orbitDx: number;
+  /** Orbit vertical delta (elevation), in mouse pixels. */
+  orbitDy: number;
+  /** Pan horizontal delta, in mouse pixels. */
+  panDx: number;
+  /** Pan vertical delta, in mouse pixels. */
+  panDy: number;
+  /** Zoom delta, wheel-equivalent (positive = zoom out, like Camera.zoom). */
+  zoomDelta: number;
+}
+
+const ZERO_DELTAS: CameraDeltas = { orbitDx: 0, orbitDy: 0, panDx: 0, panDy: 0, zoomDelta: 0 };
+
+/**
+ * Normalise a raw axis count to [-1, 1] and apply the dead zone. Readings
+ * inside the dead zone return 0; outside, the response is rescaled so it ramps
+ * from 0 at the dead-zone edge to 1 at full scale (no output discontinuity).
+ */
+export function applyDeadzone(raw: number, fullScale = AXIS_FULL_SCALE, deadzone = DEADZONE_FRACTION): number {
+  if (fullScale <= 0) return 0;
+  const n = Math.max(-1, Math.min(1, raw / fullScale));
+  const mag = Math.abs(n);
+  if (mag <= deadzone) return 0;
+  const scaled = (mag - deadzone) / (1 - deadzone);
+  return Math.sign(n) * scaled;
+}
+
+/**
+ * Map a 6DoF sample to per-frame camera deltas.
+ *
+ * @param state       raw clamped 6DoF sample from the parser
+ * @param sensitivity user multiplier (1 = neutral)
+ * @param deltaMs     frame time in milliseconds (for frame-rate independence)
+ */
+export function mapSixDofToCameraDeltas(state: SixDof, sensitivity: number, deltaMs: number): CameraDeltas {
+  if (!(deltaMs > 0) || !(sensitivity > 0)) return { ...ZERO_DELTAS };
+
+  const dt = deltaMs / 1000;
+  const gain = sensitivity * dt;
+
+  // Normalised, dead-zoned axis responses in [-1, 1].
+  const tx = applyDeadzone(state.tx);
+  const ty = applyDeadzone(state.ty);
+  const tz = applyDeadzone(state.tz);
+  const rx = applyDeadzone(state.rx);
+  const rz = applyDeadzone(state.rz);
+  // ry (roll) is intentionally ignored.
+
+  // `|| 0` normalises a signed-zero (e.g. -1 * 0) back to +0 so downstream
+  // strict-equality checks and logs never see -0.
+  return {
+    orbitDx: (AXIS_SIGN.orbitYaw * rz * BASE_RATES.orbitPxPerSec * gain) || 0,
+    orbitDy: (AXIS_SIGN.orbitPitch * rx * BASE_RATES.orbitPxPerSec * gain) || 0,
+    panDx: (AXIS_SIGN.panX * tx * BASE_RATES.panPxPerSec * gain) || 0,
+    panDy: (AXIS_SIGN.panY * tz * BASE_RATES.panPxPerSec * gain) || 0,
+    zoomDelta: (AXIS_SIGN.dolly * ty * BASE_RATES.zoomDeltaPerSec * gain) || 0,
+  };
+}
+
+/** True when every delta is zero (device idle / fully dead-zoned). */
+export function deltasAreZero(d: CameraDeltas): boolean {
+  return d.orbitDx === 0 && d.orbitDy === 0 && d.panDx === 0 && d.panDy === 0 && d.zoomDelta === 0;
+}

--- a/apps/viewer/src/lib/spacemouse/parser.test.ts
+++ b/apps/viewer/src/lib/spacemouse/parser.test.ts
@@ -1,0 +1,143 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  parseSpaceMouseReport,
+  parseButtonsReport,
+  clampAxis,
+  zeroSixDof,
+  type SixDof,
+} from './parser.js';
+import {
+  REPORT_ID_TRANSLATION,
+  REPORT_ID_ROTATION,
+  REPORT_ID_BUTTONS,
+  AXIS_FULL_SCALE,
+} from './constants.js';
+
+/** Build a DataView holding the given int16 values, little-endian. */
+function reportOf(values: number[]): DataView {
+  const buf = new ArrayBuffer(values.length * 2);
+  const view = new DataView(buf);
+  values.forEach((v, i) => view.setInt16(i * 2, v, true));
+  return view;
+}
+
+/** Build a DataView from raw bytes (for odd-length / truncated cases). */
+function bytesOf(bytes: number[]): DataView {
+  return new DataView(new Uint8Array(bytes).buffer);
+}
+
+test('all-zero translation report yields zero state', () => {
+  const out = parseSpaceMouseReport(REPORT_ID_TRANSLATION, reportOf([0, 0, 0]), zeroSixDof());
+  assert.deepEqual(out, zeroSixDof());
+});
+
+test('split translation report updates only translation axes', () => {
+  const prev: SixDof = { tx: 0, ty: 0, tz: 0, rx: 11, ry: 22, rz: 33 };
+  const out = parseSpaceMouseReport(REPORT_ID_TRANSLATION, reportOf([5, -6, 7]), prev);
+  assert.equal(out.tx, 5);
+  assert.equal(out.ty, -6);
+  assert.equal(out.tz, 7);
+  // rotation carries over untouched
+  assert.equal(out.rx, 11);
+  assert.equal(out.ry, 22);
+  assert.equal(out.rz, 33);
+});
+
+test('split rotation report updates only rotation axes', () => {
+  const prev: SixDof = { tx: 1, ty: 2, tz: 3, rx: 0, ry: 0, rz: 0 };
+  const out = parseSpaceMouseReport(REPORT_ID_ROTATION, reportOf([-9, 10, -11]), prev);
+  assert.equal(out.rx, -9);
+  assert.equal(out.ry, 10);
+  assert.equal(out.rz, -11);
+  // translation carries over untouched
+  assert.equal(out.tx, 1);
+  assert.equal(out.ty, 2);
+  assert.equal(out.tz, 3);
+});
+
+test('combined 12-byte report updates all six axes in one frame', () => {
+  const out = parseSpaceMouseReport(
+    REPORT_ID_TRANSLATION,
+    reportOf([1, 2, 3, 4, 5, 6]),
+    zeroSixDof(),
+  );
+  assert.deepEqual(out, { tx: 1, ty: 2, tz: 3, rx: 4, ry: 5, rz: 6 });
+});
+
+test('extreme positive values clamp to +full scale', () => {
+  const out = parseSpaceMouseReport(REPORT_ID_TRANSLATION, reportOf([32767, 350, 400]), zeroSixDof());
+  assert.equal(out.tx, AXIS_FULL_SCALE);
+  assert.equal(out.ty, AXIS_FULL_SCALE); // exactly at limit stays
+  assert.equal(out.tz, AXIS_FULL_SCALE); // 400 > 350 clamps
+});
+
+test('extreme negative values clamp to -full scale', () => {
+  const out = parseSpaceMouseReport(REPORT_ID_ROTATION, reportOf([-32768, -350, -351]), zeroSixDof());
+  assert.equal(out.rx, -AXIS_FULL_SCALE);
+  assert.equal(out.ry, -AXIS_FULL_SCALE);
+  assert.equal(out.rz, -AXIS_FULL_SCALE);
+});
+
+test('clampAxis maps non-finite readings to a safe 0 and clamps finite ones', () => {
+  // Non-finite readings are treated as "no input" (0) rather than full-scale,
+  // so a spurious NaN/Infinity can never drive a runaway camera move.
+  assert.equal(clampAxis(Number.NaN), 0);
+  assert.equal(clampAxis(Number.POSITIVE_INFINITY), 0);
+  assert.equal(clampAxis(Number.NEGATIVE_INFINITY), 0);
+  assert.equal(clampAxis(120), 120);
+  assert.equal(clampAxis(9999), AXIS_FULL_SCALE);
+  assert.equal(clampAxis(-9999), -AXIS_FULL_SCALE);
+});
+
+test('truncated translation buffer does not throw and keeps missing axes', () => {
+  const prev: SixDof = { tx: 100, ty: 200, tz: 300, rx: 0, ry: 0, rz: 0 };
+  // Only 3 bytes: enough for tx (offset 0), not ty (offset 2 needs bytes 2-3).
+  const out = parseSpaceMouseReport(REPORT_ID_TRANSLATION, bytesOf([0x0a, 0x00, 0x7f]), prev);
+  assert.equal(out.tx, 10); // 0x000a LE
+  assert.equal(out.ty, 200); // untouched, only one byte available at offset 2
+  assert.equal(out.tz, 300); // untouched
+});
+
+test('empty buffer never throws and returns previous state', () => {
+  const prev: SixDof = { tx: 1, ty: 2, tz: 3, rx: 4, ry: 5, rz: 6 };
+  const out = parseSpaceMouseReport(REPORT_ID_TRANSLATION, bytesOf([]), prev);
+  assert.deepEqual(out, prev);
+});
+
+test('button report leaves 6DoF unchanged', () => {
+  const prev: SixDof = { tx: 1, ty: 2, tz: 3, rx: 4, ry: 5, rz: 6 };
+  const out = parseSpaceMouseReport(REPORT_ID_BUTTONS, bytesOf([0x01]), prev);
+  assert.deepEqual(out, prev);
+  assert.notEqual(out, prev); // fresh object, prev not mutated
+});
+
+test('unknown report id leaves 6DoF unchanged', () => {
+  const prev: SixDof = { tx: 7, ty: 8, tz: 9, rx: 0, ry: 0, rz: 0 };
+  const out = parseSpaceMouseReport(99, reportOf([1, 2, 3]), prev);
+  assert.deepEqual(out, prev);
+});
+
+test('parser never mutates the previous state object', () => {
+  const prev = zeroSixDof();
+  const frozen = Object.freeze({ ...prev });
+  const out = parseSpaceMouseReport(REPORT_ID_TRANSLATION, reportOf([5, 5, 5]), frozen);
+  assert.deepEqual(frozen, zeroSixDof()); // prev unchanged
+  assert.equal(out.tx, 5);
+});
+
+test('parseButtonsReport decodes single and multi-byte bitmasks', () => {
+  assert.deepEqual(parseButtonsReport(bytesOf([])), []);
+  assert.deepEqual(parseButtonsReport(bytesOf([0x00, 0x00])), []);
+  assert.deepEqual(parseButtonsReport(bytesOf([0x01])), [0]);
+  assert.deepEqual(parseButtonsReport(bytesOf([0x02])), [1]);
+  assert.deepEqual(parseButtonsReport(bytesOf([0x03])), [0, 1]);
+  // Byte 1 carries buttons 8..15.
+  assert.deepEqual(parseButtonsReport(bytesOf([0x00, 0x81])), [8, 15]);
+  // Mixed across bytes, ascending order.
+  assert.deepEqual(parseButtonsReport(bytesOf([0x80, 0x01])), [7, 8]);
+});

--- a/apps/viewer/src/lib/spacemouse/parser.ts
+++ b/apps/viewer/src/lib/spacemouse/parser.ts
@@ -1,0 +1,124 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Pure 3Dconnexion HID report parser.
+ *
+ * Takes a raw HID input report (reportId + DataView, exactly what a WebHID
+ * `inputreport` event provides) and folds it into a typed 6DoF state. It is
+ * intentionally free of any browser / device handles so it can be unit-tested
+ * with synthetic bytes.
+ *
+ * Layouts handled:
+ *   - Split: reportId 1 carries 3 int16 translation values, reportId 2 carries
+ *     3 int16 rotation values. Each report updates only its own three axes; the
+ *     others carry over from the previous state.
+ *   - Combined: reportId 1 with >=12 bytes carries all six axes
+ *     (tx, ty, tz, rx, ry, rz).
+ * A truncated buffer never throws: axes without enough bytes keep their
+ * previous value.
+ */
+
+import {
+  AXIS_FULL_SCALE,
+  REPORT_ID_ROTATION,
+  REPORT_ID_TRANSLATION,
+} from './constants.js';
+
+/** Raw (clamped) 6DoF sample. Units are device counts in [-AXIS_FULL_SCALE, +AXIS_FULL_SCALE]. */
+export interface SixDof {
+  /** Translation, left/right (positive = cap pushed right). */
+  tx: number;
+  /** Translation, in/out (positive = cap pulled toward the user). */
+  ty: number;
+  /** Translation, up/down (positive = cap pressed down). */
+  tz: number;
+  /** Rotation about the x axis (tilt cap forward/back). */
+  rx: number;
+  /** Rotation about the y axis (roll cap side to side). */
+  ry: number;
+  /** Rotation about the z axis (twist cap). */
+  rz: number;
+}
+
+/** All-zero 6DoF state, the neutral resting sample. */
+export function zeroSixDof(): SixDof {
+  return { tx: 0, ty: 0, tz: 0, rx: 0, ry: 0, rz: 0 };
+}
+
+/** Clamp a raw axis reading to the device's full-scale window. */
+export function clampAxis(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  if (value > AXIS_FULL_SCALE) return AXIS_FULL_SCALE;
+  if (value < -AXIS_FULL_SCALE) return -AXIS_FULL_SCALE;
+  return value;
+}
+
+/**
+ * Read a signed 16-bit little-endian axis at `offset`, or `null` when the
+ * buffer is too short (truncated report). Never throws.
+ */
+function readAxis(data: DataView, offset: number): number | null {
+  if (offset + 2 > data.byteLength) return null;
+  return clampAxis(data.getInt16(offset, true));
+}
+
+/**
+ * Fold one HID report into a new 6DoF state. Pure: returns a fresh object and
+ * never mutates `prev`. Unknown report ids (e.g. buttons) return `prev`
+ * unchanged (a shallow copy), so a caller can always trust the result.
+ */
+export function parseSpaceMouseReport(reportId: number, data: DataView, prev: SixDof): SixDof {
+  const next: SixDof = { ...prev };
+
+  if (reportId === REPORT_ID_TRANSLATION) {
+    const tx = readAxis(data, 0);
+    const ty = readAxis(data, 2);
+    const tz = readAxis(data, 4);
+    if (tx !== null) next.tx = tx;
+    if (ty !== null) next.ty = ty;
+    if (tz !== null) next.tz = tz;
+
+    // Combined 12-byte layout: rotation rides along in the same frame.
+    if (data.byteLength >= 12) {
+      const rx = readAxis(data, 6);
+      const ry = readAxis(data, 8);
+      const rz = readAxis(data, 10);
+      if (rx !== null) next.rx = rx;
+      if (ry !== null) next.ry = ry;
+      if (rz !== null) next.rz = rz;
+    }
+    return next;
+  }
+
+  if (reportId === REPORT_ID_ROTATION) {
+    const rx = readAxis(data, 0);
+    const ry = readAxis(data, 2);
+    const rz = readAxis(data, 4);
+    if (rx !== null) next.rx = rx;
+    if (ry !== null) next.ry = ry;
+    if (rz !== null) next.rz = rz;
+    return next;
+  }
+
+  // Buttons or any other report id: no 6DoF change.
+  return next;
+}
+
+/**
+ * Extract pressed button indices from a reportId-3 buttons bitmask. Byte 0
+ * carries buttons 0..7, byte 1 buttons 8..15, and so on. Returns indices in
+ * ascending order.
+ */
+export function parseButtonsReport(data: DataView): number[] {
+  const pressed: number[] = [];
+  for (let byteIndex = 0; byteIndex < data.byteLength; byteIndex++) {
+    const byte = data.getUint8(byteIndex);
+    if (byte === 0) continue;
+    for (let bit = 0; bit < 8; bit++) {
+      if (byte & (1 << bit)) pressed.push(byteIndex * 8 + bit);
+    }
+  }
+  return pressed;
+}

--- a/apps/viewer/src/store/index.ts
+++ b/apps/viewer/src/store/index.ts
@@ -53,6 +53,7 @@ import { createSplitToolSlice, type SplitToolSlice } from './slices/splitToolSli
 import { createLevelDisplaySlice, type LevelDisplaySlice } from './slices/levelDisplaySlice.js';
 import { createPointCloudSlice, type PointCloudSlice, POINT_CLOUD_DEFAULTS } from './slices/pointCloudSlice.js';
 import { createUnitDisplaySlice, type UnitDisplaySlice } from './slices/unitDisplaySlice.js';
+import { createSpaceMouseSlice, type SpaceMouseSlice } from './slices/spaceMouseSlice.js';
 import { invalidateVisibleBasketCache } from './basketVisibleSet.js';
 
 // Import constants for reset function
@@ -159,6 +160,7 @@ export type ViewerState = LoadingSlice &
   LevelDisplaySlice &
   PointCloudSlice &
   UnitDisplaySlice &
+  SpaceMouseSlice &
   ExtensionsSlice & {
     resetViewerState: () => void;
     /**
@@ -243,6 +245,7 @@ const createViewerStore = () => create<ViewerState>()((...args) => ({
   ...createLevelDisplaySlice(...args),
   ...createPointCloudSlice(...args),
   ...createUnitDisplaySlice(...args),
+  ...createSpaceMouseSlice(...args),
   ...createExtensionsSlice(...args),
 
   // Reset all viewer state when loading new file

--- a/apps/viewer/src/store/slices/spaceMouseSlice.ts
+++ b/apps/viewer/src/store/slices/spaceMouseSlice.ts
@@ -1,0 +1,107 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * SpaceMouse (3Dconnexion) navigation state.
+ *
+ * Owns only lightweight UI state: whether WebHID is available, whether a
+ * device is connected, its name, the last connection error and the user's
+ * sensitivity. The actual WebHID connection + per-frame camera driving lives
+ * in `useSpaceMouseControls` (it needs the renderer); the hook registers its
+ * `connect` action here so the panel button can trigger it inside a click
+ * handler (WebHID's user-gesture requirement). Sensitivity persists in
+ * localStorage; the rest is session state.
+ */
+
+import type { StateCreator } from 'zustand';
+import { SENSITIVITY } from '@/lib/spacemouse/constants';
+
+export interface SpaceMouseSlice {
+  /** True when navigator.hid exists (Chromium-based browsers). */
+  spaceMouseSupported: boolean;
+  /** True while a device is granted, opened and streaming. */
+  spaceMouseConnected: boolean;
+  /** Product name of the connected device, or null. */
+  spaceMouseDeviceName: string | null;
+  /** Human-readable connection error, or null. */
+  spaceMouseError: string | null;
+  /** User sensitivity multiplier (persisted). */
+  spaceMouseSensitivity: number;
+  /** Whether the SpaceMouse panel is open (session only). */
+  spaceMousePanelOpen: boolean;
+  /**
+   * Connect action registered by `useSpaceMouseControls` (which owns the
+   * renderer). The panel calls this inside a click handler so WebHID's
+   * user-gesture requirement for `requestDevice` is satisfied.
+   */
+  spaceMouseConnect: (() => void) | null;
+  /** Disconnect action registered by `useSpaceMouseControls` while connected. */
+  spaceMouseDisconnect: (() => void) | null;
+
+  setSpaceMouseSupported: (supported: boolean) => void;
+  setSpaceMouseConnected: (connected: boolean, deviceName?: string | null) => void;
+  setSpaceMouseError: (error: string | null) => void;
+  setSpaceMouseSensitivity: (value: number) => void;
+  setSpaceMousePanelOpen: (open: boolean) => void;
+  toggleSpaceMousePanel: () => void;
+  setSpaceMouseConnect: (connect: (() => void) | null) => void;
+  setSpaceMouseDisconnect: (disconnect: (() => void) | null) => void;
+}
+
+const STORAGE_KEY = 'ifc-lite:spacemouse';
+
+function clampSensitivity(value: number): number {
+  if (!Number.isFinite(value)) return SENSITIVITY.default;
+  return Math.min(SENSITIVITY.max, Math.max(SENSITIVITY.min, value));
+}
+
+function loadSensitivity(): number {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return SENSITIVITY.default;
+    const parsed: unknown = JSON.parse(raw);
+    if (typeof parsed === 'object' && parsed !== null && 'sensitivity' in parsed) {
+      return clampSensitivity((parsed as { sensitivity: number }).sensitivity);
+    }
+    return SENSITIVITY.default;
+  } catch {
+    return SENSITIVITY.default;
+  }
+}
+
+function persistSensitivity(sensitivity: number): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ sensitivity }));
+  } catch { /* storage unavailable */ }
+}
+
+export const createSpaceMouseSlice: StateCreator<SpaceMouseSlice, [], [], SpaceMouseSlice> = (set) => ({
+  spaceMouseSupported: false,
+  spaceMouseConnected: false,
+  spaceMouseDeviceName: null,
+  spaceMouseError: null,
+  spaceMouseSensitivity: loadSensitivity(),
+  spaceMousePanelOpen: false,
+  spaceMouseConnect: null,
+  spaceMouseDisconnect: null,
+
+  setSpaceMouseSupported: (spaceMouseSupported) => set({ spaceMouseSupported }),
+  setSpaceMouseConnected: (spaceMouseConnected, deviceName = null) =>
+    set({
+      spaceMouseConnected,
+      spaceMouseDeviceName: spaceMouseConnected ? deviceName : null,
+      // A successful connection clears any stale error.
+      ...(spaceMouseConnected ? { spaceMouseError: null } : {}),
+    }),
+  setSpaceMouseError: (spaceMouseError) => set({ spaceMouseError }),
+  setSpaceMouseSensitivity: (value) => {
+    const spaceMouseSensitivity = clampSensitivity(value);
+    persistSensitivity(spaceMouseSensitivity);
+    set({ spaceMouseSensitivity });
+  },
+  setSpaceMousePanelOpen: (spaceMousePanelOpen) => set({ spaceMousePanelOpen }),
+  toggleSpaceMousePanel: () => set((s) => ({ spaceMousePanelOpen: !s.spaceMousePanelOpen })),
+  setSpaceMouseConnect: (spaceMouseConnect) => set({ spaceMouseConnect }),
+  setSpaceMouseDisconnect: (spaceMouseDisconnect) => set({ spaceMouseDisconnect }),
+});

--- a/apps/viewer/src/webhid-types.d.ts
+++ b/apps/viewer/src/webhid-types.d.ts
@@ -1,0 +1,87 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Minimal WebHID type definitions.
+ *
+ * WebHID is a browser API (Chromium only) that the TypeScript DOM lib does not
+ * yet ship. We declare only the slice we use for 3Dconnexion SpaceMouse
+ * navigation so the code type-checks without pulling in a third-party @types
+ * package. Everything here is guarded behind a runtime `navigator.hid` check.
+ */
+
+interface HIDDeviceFilter {
+  vendorId?: number;
+  productId?: number;
+  usagePage?: number;
+  usage?: number;
+}
+
+interface HIDDeviceRequestOptions {
+  filters: HIDDeviceFilter[];
+}
+
+interface HIDCollectionInfo {
+  readonly usagePage: number;
+  readonly usage: number;
+}
+
+interface HIDInputReportEvent extends Event {
+  readonly device: HIDDevice;
+  readonly reportId: number;
+  /** Report payload with the leading report-id byte already stripped. */
+  readonly data: DataView;
+}
+
+interface HIDDeviceEventMap {
+  inputreport: HIDInputReportEvent;
+}
+
+interface HIDDevice extends EventTarget {
+  readonly opened: boolean;
+  readonly vendorId: number;
+  readonly productId: number;
+  readonly productName: string;
+  readonly collections: readonly HIDCollectionInfo[];
+  open(): Promise<void>;
+  close(): Promise<void>;
+  addEventListener<K extends keyof HIDDeviceEventMap>(
+    type: K,
+    listener: (this: HIDDevice, ev: HIDDeviceEventMap[K]) => unknown,
+    options?: boolean | AddEventListenerOptions,
+  ): void;
+  removeEventListener<K extends keyof HIDDeviceEventMap>(
+    type: K,
+    listener: (this: HIDDevice, ev: HIDDeviceEventMap[K]) => unknown,
+    options?: boolean | EventListenerOptions,
+  ): void;
+}
+
+interface HIDConnectionEvent extends Event {
+  readonly device: HIDDevice;
+}
+
+interface HIDEventMap {
+  connect: HIDConnectionEvent;
+  disconnect: HIDConnectionEvent;
+}
+
+interface HID extends EventTarget {
+  getDevices(): Promise<HIDDevice[]>;
+  requestDevice(options: HIDDeviceRequestOptions): Promise<HIDDevice[]>;
+  addEventListener<K extends keyof HIDEventMap>(
+    type: K,
+    listener: (this: HID, ev: HIDEventMap[K]) => unknown,
+    options?: boolean | AddEventListenerOptions,
+  ): void;
+  removeEventListener<K extends keyof HIDEventMap>(
+    type: K,
+    listener: (this: HID, ev: HIDEventMap[K]) => unknown,
+    options?: boolean | EventListenerOptions,
+  ): void;
+}
+
+interface Navigator {
+  readonly hid?: HID;
+}


### PR DESCRIPTION
Closes #1677.

## What

Adds 3Dconnexion SpaceMouse support to the viewer: a new toolbar button (3D-move icon, next to Sun & Sky) opens a SpaceMouse panel with a Connect button and a persisted sensitivity slider. Once connected:

- Slide the cap left/right/up/down to pan
- Push/pull the cap to zoom (dolly)
- Twist and tilt the cap to orbit (roll is ignored; the camera keeps up pinned to world Y)
- Device buttons 1/2 fit the view (frame selection, or zoom extents with nothing selected), same as the keyboard F shortcut

Previously granted devices reconnect silently on page load (WebHID grants persist per origin), and a granted device that is re-plugged is picked up automatically.

## Why WebHID (the standards research)

Two ways exist to talk to a SpaceMouse from a browser:

1. **3DconnexionJS** (official): the page opens a TLS WebSocket to a local proxy shipped with the proprietary 3DxWare driver. Used by Onshape. Requires every user to install and run the vendor driver, needs the vendor's local certificate, is undocumented outside the SDK, and is effectively broken on Linux. Not viable for an open client-side viewer.
2. **WebHID** (W3C draft, Chromium 89+): direct HID access with a user-gesture permission prompt, no driver needed. This is what open web viewers use, and what this PR implements.

HID protocol per the 3Dconnexion USB spec (HW-3DX-700048) and the community drivers ([larsgk/webhid-space](https://github.com/larsgk/webhid-space), [nytamin/spacemouse](https://github.com/nytamin/spacemouse)): report id 1 = translation (3x int16 LE), id 2 = rotation, id 3 = buttons bitmask; newer devices send a combined 12-byte report 1 with all six axes. Both layouts are handled. Device filter covers both vendor ids (0x046d legacy Logitech line, 0x256f current), restricted to the Multi-axis Controller HID usage so ordinary Logitech mice never appear in the chooser.

## How it plugs into the camera

`useSpaceMouseControls` mirrors the `useKeyboardControls` idiom: its own RAF loop while a device is connected, polling the latest 6DoF sample and feeding the existing `Camera.orbit/pan/zoom` APIs with mouse-equivalent deltas (frame-time integrated, so motion is frame-rate independent). Dead zone with a continuous ramp prevents idle drift; axis clamping prevents runaway jumps from spurious samples. The pure parser and mapping are unit-tested (25 tests). All per-device tunables (report ids, full scale, signs, rates) live in one constants file.

## Consolidation with #1688

This issue was implemented twice in parallel; this PR is the consolidation of both and supersedes #1688. Carried over from #1688:

- Frame-delta cap enforced inside the pure mapping (MAX_FRAME_DELTA_MS = 50ms): a backgrounded tab cannot integrate 30s of held deflection into one camera teleport, and the guard is unit-testable.
- Staleness watchdog (isInputStale, 250ms): a silent HID stall without a disconnect event no longer latches the last non-zero sample and moves the camera forever. Safe because a deflected SpaceMouse streams reports at ~125Hz.
- The adversarial test suite (attack.test.ts): dt spikes, stale latch, int16 boundary, DataView byteOffset windows, padded 12-byte reports, oversized button bitmasks, sensitivity rehydration.

Unique to this PR (not in #1688): legacy 0x046d vendor id coverage (SpaceNavigator / SpaceMouse Pro line), Multi-axis Controller usage filter, dolly on the correct device axis (ty = push/pull per the 3Dconnexion frame; #1688 used tz = up/down), device fit buttons, the SpaceMouse panel with disconnect + error surfacing, granted-device pickup on re-plug, and the live browser simulation.

## Verification

- `apps/viewer` full test suite: 1566 pass / 0 fail; typecheck clean; vite build clean.
- Live end-to-end simulation on localhost (no hardware needed): stubbed `navigator.hid` with a fake device dispatching real HID report bytes through the store connect action. Pulling the cap back zoomed out (scale bar 40.8m -> 58.1m, stops on release), twisting orbited the view (ViewCube azimuth -331.6deg -> -285.9deg, elevation unchanged), fit button and disconnect worked, zero console errors.

## Caveats for hardware testers

- Axis signs are best-effort against the spec; if a direction feels inverted on real hardware, each sign is a one-line flip in `apps/viewer/src/lib/spacemouse/constants.ts` (`AXIS_SIGN`).
- If the 3DxWare driver is running it holds the device exclusively and WebHID cannot open it; the panel surfaces this as an error with a hint to quit the driver. This is a known WebHID limitation, not specific to this viewer.
- @FliesEyes (issue author): would you be up for a quick test with your device? Happy to tune signs/rates based on what you feel.

## UI

Toolbar button next to Sun & Sky (teal when connected or the panel is open); the panel is draggable and collapsible, anchored below the Sun & Sky spot so both fit without covering the ViewCube.

