### PR TITLE
feat(docs): serve the documentation at ifclite.dev/docs

### DIFF
--- a/.changeset/docs-move-to-ifclite-dev.md
+++ b/.changeset/docs-move-to-ifclite-dev.md
@@ -1,0 +1,40 @@
+---
+'@ifc-lite/bcf': patch
+'@ifc-lite/cache': patch
+'@ifc-lite/clash': patch
+'@ifc-lite/cli': patch
+'@ifc-lite/codegen': patch
+'@ifc-lite/collab': patch
+'@ifc-lite/collab-server': patch
+'@ifc-lite/create': patch
+'create-ifc-lite': patch
+'@ifc-lite/data': patch
+'@ifc-lite/diff': patch
+'@ifc-lite/drawing-2d': patch
+'@ifc-lite/embed-protocol': patch
+'@ifc-lite/embed-sdk': patch
+'@ifc-lite/encoding': patch
+'@ifc-lite/export': patch
+'@ifc-lite/extensions': patch
+'@ifc-lite/geometry': patch
+'@ifc-lite/ids': patch
+'@ifc-lite/ifcx': patch
+'@ifc-lite/lens': patch
+'@ifc-lite/lists': patch
+'@ifc-lite/mcp': patch
+'@ifc-lite/mutations': patch
+'@ifc-lite/parser': patch
+'@ifc-lite/pointcloud': patch
+'@ifc-lite/query': patch
+'@ifc-lite/renderer': patch
+'@ifc-lite/sandbox': patch
+'@ifc-lite/sdk': patch
+'@ifc-lite/server-bin': patch
+'@ifc-lite/server-client': patch
+'@ifc-lite/solar': patch
+'@ifc-lite/spatial': patch
+'@ifc-lite/viewer-core': patch
+'@ifc-lite/wasm': patch
+---
+
+Documentation moved to https://ifclite.dev/docs/ - README links and package homepage fields now point at the new home (the GitHub Pages site remains as a mirror whose canonical URLs point there).

--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,4 @@ tests/benchmark/benchmark-results/viewer-*.console.log
 /playwright-report/
 /blob-report/
 /playwright/.cache/
+.vercel

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ const hit = await renderer.pick(120, 240);
 if (hit) console.log(`Picked expressId ${hit.expressId}`);
 ```
 
-For Three.js or Babylon.js, parse and extract geometry the same way and feed `meshes` to your engine. See [Three.js integration](https://ltplus-ag.github.io/ifc-lite/tutorials/threejs-integration/) and [Babylon.js integration](https://ltplus-ag.github.io/ifc-lite/tutorials/babylonjs-integration/).
+For Three.js or Babylon.js, parse and extract geometry the same way and feed `meshes` to your engine. See [Three.js integration](https://ifclite.dev/docs/tutorials/threejs-integration/) and [Babylon.js integration](https://ifclite.dev/docs/tutorials/babylonjs-integration/).
 
 ## Query entities
 
@@ -198,7 +198,7 @@ const ifcx = new Ifc5Exporter(store, geometryResult).export({ includeGeometry: t
 
 ## Work from the terminal
 
-The [`ifc-lite` CLI](https://ltplus-ag.github.io/ifc-lite/guide/cli/) covers the full toolkit: inspect, query, validate, export, create, diff, clash-check, merge, convert, and script IFC models without writing a line of app code.
+The [`ifc-lite` CLI](https://ifclite.dev/docs/guide/cli/) covers the full toolkit: inspect, query, validate, export, create, diff, clash-check, merge, convert, and script IFC models without writing a line of app code.
 
 ```bash
 ifc-lite info model.ifc                                  # schema, entities, storeys
@@ -212,18 +212,18 @@ ifc-lite view model.ifc                                  # 3D viewer + REST API
 ifc-lite eval model.ifc "bim.query().byType('IfcWall').count()"
 ```
 
-Building AI tooling? `ifc-lite mcp model.ifc` starts a [Model Context Protocol](https://ltplus-ag.github.io/ifc-lite/guide/cli/) server (stdio or HTTP) so agents can query and edit BIM data directly, and `ifc-lite ask model.ifc "how many walls?"` answers natural-language questions.
+Building AI tooling? `ifc-lite mcp model.ifc` starts a [Model Context Protocol](https://ifclite.dev/docs/guide/cli/) server (stdio or HTTP) so agents can query and edit BIM data directly, and `ifc-lite ask model.ifc "how many walls?"` answers natural-language questions.
 
 ## Choose your setup
 
 | Setup | Best for | You get |
 |-------|----------|---------|
-| [**Browser (WebGPU)**](https://ltplus-ag.github.io/ifc-lite/guide/quickstart/) | Viewing and inspecting models | Full-featured 3D viewer, runs entirely client-side |
-| [**Three.js / Babylon.js**](https://ltplus-ag.github.io/ifc-lite/tutorials/threejs-integration/) | Adding IFC support to an existing 3D app | IFC parsing + geometry, rendered by your engine |
-| [**CLI**](https://ltplus-ag.github.io/ifc-lite/guide/cli/) | Scripting, CI pipelines, AI agents | The whole toolkit from the terminal, JSON output everywhere |
-| [**Server**](https://ltplus-ag.github.io/ifc-lite/guide/server/) | Teams, large files, repeat access | Rust backend with caching, parallel processing, streaming |
-| [**Build for Desktop**](https://ltplus-ag.github.io/ifc-lite/guide/desktop/) | Your own offline native app, very large files (500 MB+) | Extension points to wrap the packages in Tauri, with an optional native-Rust geometry fast path |
-| [**Python (native wheel)**](https://ltplus-ag.github.io/ifc-lite/api/python/) | Analysis, scripting, scientific Python | `pip install ifclite-geom` runs the geometry kernel in-process, meshes straight to numpy |
+| [**Browser (WebGPU)**](https://ifclite.dev/docs/guide/quickstart/) | Viewing and inspecting models | Full-featured 3D viewer, runs entirely client-side |
+| [**Three.js / Babylon.js**](https://ifclite.dev/docs/tutorials/threejs-integration/) | Adding IFC support to an existing 3D app | IFC parsing + geometry, rendered by your engine |
+| [**CLI**](https://ifclite.dev/docs/guide/cli/) | Scripting, CI pipelines, AI agents | The whole toolkit from the terminal, JSON output everywhere |
+| [**Server**](https://ifclite.dev/docs/guide/server/) | Teams, large files, repeat access | Rust backend with caching, parallel processing, streaming |
+| [**Build for Desktop**](https://ifclite.dev/docs/guide/desktop/) | Your own offline native app, very large files (500 MB+) | Extension points to wrap the packages in Tauri, with an optional native-Rust geometry fast path |
+| [**Python (native wheel)**](https://ifclite.dev/docs/api/python/) | Analysis, scripting, scientific Python | `pip install ifclite-geom` runs the geometry kernel in-process, meshes straight to numpy |
 
 Not sure? Start with the browser setup. You can add a server or switch engines later.
 
@@ -251,7 +251,7 @@ Not sure? Start with the browser setup. You can add a server or switch engines l
 | Connect to a server backend | + `@ifc-lite/server-client` |
 | Give AI agents BIM access (MCP) | + `@ifc-lite/mcp` |
 
-Full list: [API Reference](https://ltplus-ag.github.io/ifc-lite/api/typescript/) (36 npm packages, 6 Rust crates on crates.io, and the `ifclite-geom` Python wheel on PyPI).
+Full list: [API Reference](https://ifclite.dev/docs/api/typescript/) (36 npm packages, 6 Rust crates on crates.io, and the `ifclite-geom` Python wheel on PyPI).
 
 ## Performance
 
@@ -261,7 +261,7 @@ Full list: [API Reference](https://ltplus-ag.github.io/ifc-lite/api/typescript/)
 - **Schema coverage:** 100% of IFC4 (776 entities) and IFC4X3 (876 entities).
 - **Footprint:** one lazily fetched WASM module (~1.2 MB gzipped) plus small per-package JS wrappers.
 
-See [benchmarks](https://ltplus-ag.github.io/ifc-lite/guide/performance/) for full numbers across model sizes and hardware.
+See [benchmarks](https://ifclite.dev/docs/guide/performance/) for full numbers across model sizes and hardware.
 
 ## Examples
 
@@ -276,13 +276,13 @@ Ready-to-run projects in [`examples/`](examples/):
 
 | | |
 |---|---|
-| **Start here** | [Quick Start](https://ltplus-ag.github.io/ifc-lite/guide/quickstart/) · [Installation](https://ltplus-ag.github.io/ifc-lite/guide/installation/) · [CLI Toolkit](https://ltplus-ag.github.io/ifc-lite/guide/cli/) · [Browser Requirements](https://ltplus-ag.github.io/ifc-lite/guide/browser-requirements/) |
-| **Guides** | [Parsing](https://ltplus-ag.github.io/ifc-lite/guide/parsing/) · [Geometry](https://ltplus-ag.github.io/ifc-lite/guide/geometry/) · [Rendering](https://ltplus-ag.github.io/ifc-lite/guide/rendering/) · [Querying](https://ltplus-ag.github.io/ifc-lite/guide/querying/) · [Exporting](https://ltplus-ag.github.io/ifc-lite/guide/exporting/) |
-| **BIM features** | [Federation](https://ltplus-ag.github.io/ifc-lite/guide/federation/) · [BCF](https://ltplus-ag.github.io/ifc-lite/guide/bcf/) · [IDS Validation](https://ltplus-ag.github.io/ifc-lite/guide/ids/) · [2D Drawings](https://ltplus-ag.github.io/ifc-lite/guide/drawing-2d/) · [Property Editing](https://ltplus-ag.github.io/ifc-lite/guide/mutations/) |
-| **Customization** | [Extensions](https://ltplus-ag.github.io/ifc-lite/guide/extensions/) · [Authoring Extensions](https://ltplus-ag.github.io/ifc-lite/guide/extension-authoring/) · [Flavors](https://ltplus-ag.github.io/ifc-lite/guide/flavors/) |
-| **Tutorials** | [Build a Viewer](https://ltplus-ag.github.io/ifc-lite/tutorials/building-viewer/) · [Three.js](https://ltplus-ag.github.io/ifc-lite/tutorials/threejs-integration/) · [Babylon.js](https://ltplus-ag.github.io/ifc-lite/tutorials/babylonjs-integration/) · [Custom Queries](https://ltplus-ag.github.io/ifc-lite/tutorials/custom-queries/) |
-| **Deep dives** | [Architecture](https://ltplus-ag.github.io/ifc-lite/architecture/overview/) · [Data Flow](https://ltplus-ag.github.io/ifc-lite/architecture/data-flow/) · [Performance](https://ltplus-ag.github.io/ifc-lite/guide/performance/) |
-| **API** | [TypeScript](https://ltplus-ag.github.io/ifc-lite/api/typescript/) · [Rust](https://ltplus-ag.github.io/ifc-lite/api/rust/) · [WASM](https://ltplus-ag.github.io/ifc-lite/api/wasm/) · [Python](https://ltplus-ag.github.io/ifc-lite/api/python/) |
+| **Start here** | [Quick Start](https://ifclite.dev/docs/guide/quickstart/) · [Installation](https://ifclite.dev/docs/guide/installation/) · [CLI Toolkit](https://ifclite.dev/docs/guide/cli/) · [Browser Requirements](https://ifclite.dev/docs/guide/browser-requirements/) |
+| **Guides** | [Parsing](https://ifclite.dev/docs/guide/parsing/) · [Geometry](https://ifclite.dev/docs/guide/geometry/) · [Rendering](https://ifclite.dev/docs/guide/rendering/) · [Querying](https://ifclite.dev/docs/guide/querying/) · [Exporting](https://ifclite.dev/docs/guide/exporting/) |
+| **BIM features** | [Federation](https://ifclite.dev/docs/guide/federation/) · [BCF](https://ifclite.dev/docs/guide/bcf/) · [IDS Validation](https://ifclite.dev/docs/guide/ids/) · [2D Drawings](https://ifclite.dev/docs/guide/drawing-2d/) · [Property Editing](https://ifclite.dev/docs/guide/mutations/) |
+| **Customization** | [Extensions](https://ifclite.dev/docs/guide/extensions/) · [Authoring Extensions](https://ifclite.dev/docs/guide/extension-authoring/) · [Flavors](https://ifclite.dev/docs/guide/flavors/) |
+| **Tutorials** | [Build a Viewer](https://ifclite.dev/docs/tutorials/building-viewer/) · [Three.js](https://ifclite.dev/docs/tutorials/threejs-integration/) · [Babylon.js](https://ifclite.dev/docs/tutorials/babylonjs-integration/) · [Custom Queries](https://ifclite.dev/docs/tutorials/custom-queries/) |
+| **Deep dives** | [Architecture](https://ifclite.dev/docs/architecture/overview/) · [Data Flow](https://ifclite.dev/docs/architecture/data-flow/) · [Performance](https://ifclite.dev/docs/guide/performance/) |
+| **API** | [TypeScript](https://ifclite.dev/docs/api/typescript/) · [Rust](https://ifclite.dev/docs/api/rust/) · [WASM](https://ifclite.dev/docs/api/wasm/) · [Python](https://ifclite.dev/docs/api/python/) |
 
 ## Contributing
 
@@ -314,7 +314,7 @@ The fixtures are stored on a GitHub Release and catalogued in
 [`tests/models/README.md`](tests/models/README.md) for the full design and
 maintainer workflow.
 
-See the [Contributing Guide](https://ltplus-ag.github.io/ifc-lite/contributing/setup/) and [Release Process](RELEASE.md).
+See the [Contributing Guide](https://ifclite.dev/docs/contributing/setup/) and [Release Process](RELEASE.md).
 
 ## Community
 

--- a/apps/landing/build-docs.sh
+++ b/apps/landing/build-docs.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#
+# Vercel build for the ifclite.dev project (root directory: apps/landing).
+# Assembles the deployed site into dist/:
+#   dist/        <- the static landing page (this directory, as-is)
+#   dist/docs/   <- the mkdocs site built from ../../mkdocs.yml
+#
+# The project has "include source files outside of the root directory"
+# enabled, so ../../docs and ../../mkdocs.yml are present in the build
+# container. Python 3 is available in the Vercel build image; the docs
+# requirements are pure-Python (mkdocs-material and two plugins).
+#
+# Locally: bash apps/landing/build-docs.sh (from anywhere) then serve
+# apps/landing/dist.
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/../.." && pwd)"
+DIST="$HERE/dist"
+
+rm -rf "$DIST"
+mkdir -p "$DIST"
+
+# 1. Static landing files. Exclude the build outputs and this script;
+#    vercel.json is read from the source dir by Vercel, not served.
+(
+  cd "$HERE"
+  for f in *; do
+    case "$f" in
+      dist | build-docs.sh | node_modules | .vercel) continue ;;
+    esac
+    cp -R "$f" "$DIST/$f"
+  done
+)
+
+# 2. Docs. The Vercel build image's system Python is externally managed
+#    (PEP 668), so installs go into a throwaway venv.
+VENV="$HERE/.venv-docs"
+python3 -m venv "$VENV"
+"$VENV/bin/pip" install --quiet --disable-pip-version-check -r "$ROOT/requirements-docs.txt"
+"$VENV/bin/python" -m mkdocs build --strict -f "$ROOT/mkdocs.yml" -d "$DIST/docs"
+
+echo "Built landing + docs into $DIST ($(du -sh "$DIST" | cut -f1))"

--- a/apps/landing/index.html
+++ b/apps/landing/index.html
@@ -102,7 +102,7 @@
       <a href="#setup">Setups</a>
       <a href="#packages">Packages</a>
       <a href="#perf">Performance</a>
-      <a href="#docs">Docs</a>
+      <a href="/docs/">Docs</a>
     </nav>
     <div class="nav-cta">
       <button class="theme-toggle" type="button" id="theme-toggle" aria-label="Toggle light / dark theme">
@@ -273,7 +273,7 @@
           <li>Runs from a CDN</li>
           <li>Chrome / Edge / Firefox / Safari 18</li>
         </ul>
-        <a class="link mono" href="https://ltplus-ag.github.io/ifc-lite/guide/quickstart/" target="_blank" rel="noopener">→ Quick start</a>
+        <a class="link mono" href="https://ifclite.dev/docs/guide/quickstart/" target="_blank" rel="noopener">→ Quick start</a>
       </div>
       <div class="setup">
         <span class="setup-tag">02 · Engine integration</span>
@@ -285,7 +285,7 @@
           <li>Instancing-friendly buffers</li>
           <li>Both engines, ready-made templates</li>
         </ul>
-        <a class="link mono" href="https://ltplus-ag.github.io/ifc-lite/tutorials/threejs-integration/" target="_blank" rel="noopener">→ Three.js tutorial</a>
+        <a class="link mono" href="https://ifclite.dev/docs/tutorials/threejs-integration/" target="_blank" rel="noopener">→ Three.js tutorial</a>
       </div>
       <div class="setup">
         <span class="setup-tag">03 · Server</span>
@@ -297,7 +297,7 @@
           <li>Content-addressed cache</li>
           <li>Docker, Fly, Render-ready</li>
         </ul>
-        <a class="link mono" href="https://ltplus-ag.github.io/ifc-lite/guide/server/" target="_blank" rel="noopener">→ Server guide</a>
+        <a class="link mono" href="https://ifclite.dev/docs/guide/server/" target="_blank" rel="noopener">→ Server guide</a>
       </div>
       <div class="setup">
         <span class="setup-tag">04 · Desktop</span>
@@ -309,7 +309,7 @@
           <li>Offline, air-gapped friendly</li>
           <li>macOS · Windows · Linux</li>
         </ul>
-        <a class="link mono" href="https://ltplus-ag.github.io/ifc-lite/guide/desktop/" target="_blank" rel="noopener">→ Desktop guide</a>
+        <a class="link mono" href="https://ifclite.dev/docs/guide/desktop/" target="_blank" rel="noopener">→ Desktop guide</a>
       </div>
     </div>
   </div>
@@ -409,37 +409,37 @@
     </div>
 
     <div class="caps">
-      <a class="cap" href="https://ltplus-ag.github.io/ifc-lite/guide/quickstart/" target="_blank" rel="noopener">
+      <a class="cap" href="https://ifclite.dev/docs/guide/quickstart/" target="_blank" rel="noopener">
         <span class="cap-num">→ guide</span>
         <h3>Quick start</h3>
         <p>Parse your first IFC file. Five minutes, one terminal, one model.</p>
         <div class="cap-meta"><span>5 min · npm</span><span class="pill">start here</span></div>
       </a>
-      <a class="cap" href="https://ltplus-ag.github.io/ifc-lite/tutorials/building-viewer/" target="_blank" rel="noopener">
+      <a class="cap" href="https://ifclite.dev/docs/tutorials/building-viewer/" target="_blank" rel="noopener">
         <span class="cap-num">→ tutorial</span>
         <h3>Build a viewer</h3>
         <p>Step-by-step: a WebGPU viewer with picking, hierarchy, and property panel.</p>
         <div class="cap-meta"><span>30 min · React</span><span class="pill">tutorial</span></div>
       </a>
-      <a class="cap" href="https://ltplus-ag.github.io/ifc-lite/guide/querying/" target="_blank" rel="noopener">
+      <a class="cap" href="https://ifclite.dev/docs/guide/querying/" target="_blank" rel="noopener">
         <span class="cap-num">→ guide</span>
         <h3>Querying data</h3>
         <p>Filters, SQL, joins across property sets. Find what you need without parsing twice.</p>
         <div class="cap-meta"><span>15 min · SQL</span><span class="pill">guide</span></div>
       </a>
-      <a class="cap" href="https://ltplus-ag.github.io/ifc-lite/guide/ids/" target="_blank" rel="noopener">
+      <a class="cap" href="https://ifclite.dev/docs/guide/ids/" target="_blank" rel="noopener">
         <span class="cap-num">→ guide</span>
         <h3>IDS validation</h3>
         <p>Write a spec, run it against a model, generate a pass / fail report.</p>
         <div class="cap-meta"><span>20 min · BCF</span><span class="pill">guide</span></div>
       </a>
-      <a class="cap" href="https://ltplus-ag.github.io/ifc-lite/architecture/overview/" target="_blank" rel="noopener">
+      <a class="cap" href="https://ifclite.dev/docs/architecture/overview/" target="_blank" rel="noopener">
         <span class="cap-num">→ reference</span>
         <h3>Architecture</h3>
         <p>How parsing, federation, and rendering are wired together end to end.</p>
         <div class="cap-meta"><span>deep dive</span><span class="pill">internals</span></div>
       </a>
-      <a class="cap" href="https://ltplus-ag.github.io/ifc-lite/api/typescript/" target="_blank" rel="noopener">
+      <a class="cap" href="https://ifclite.dev/docs/api/typescript/" target="_blank" rel="noopener">
         <span class="cap-num">→ reference</span>
         <h3>API reference</h3>
         <p>Every type, every method, every default. TypeScript and Rust both covered.</p>
@@ -479,7 +479,7 @@
             Open ifclite.com
             <span class="arrow">→</span>
           </a>
-          <a class="btn btn-ghost" href="https://ltplus-ag.github.io/ifc-lite/" target="_blank" rel="noopener">
+          <a class="btn btn-ghost" href="https://ifclite.dev/docs/" target="_blank" rel="noopener">
             Read the docs
           </a>
           <a class="btn btn-ghost" href="https://github.com/LTplus-AG/ifc-lite" target="_blank" rel="noopener">
@@ -513,10 +513,10 @@
       </div>
       <div class="foot-col">
         <h5>Docs</h5>
-        <a href="https://ltplus-ag.github.io/ifc-lite/guide/quickstart/" target="_blank" rel="noopener">Quick start</a>
-        <a href="https://ltplus-ag.github.io/ifc-lite/guide/installation/" target="_blank" rel="noopener">Installation</a>
-        <a href="https://ltplus-ag.github.io/ifc-lite/api/typescript/" target="_blank" rel="noopener">TypeScript API</a>
-        <a href="https://ltplus-ag.github.io/ifc-lite/api/rust/" target="_blank" rel="noopener">Rust API</a>
+        <a href="https://ifclite.dev/docs/guide/quickstart/" target="_blank" rel="noopener">Quick start</a>
+        <a href="https://ifclite.dev/docs/guide/installation/" target="_blank" rel="noopener">Installation</a>
+        <a href="https://ifclite.dev/docs/api/typescript/" target="_blank" rel="noopener">TypeScript API</a>
+        <a href="https://ifclite.dev/docs/api/rust/" target="_blank" rel="noopener">Rust API</a>
       </div>
       <div class="foot-col">
         <h5>Community</h5>

--- a/apps/landing/vercel-ignore.sh
+++ b/apps/landing/vercel-ignore.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#
+# Vercel "ignored build step" for the ifclite.dev project. Exit 0 skips
+# the build, any other exit builds.
+#
+# HEAD^..HEAD is exact here because main only advances by squash merges
+# (one commit per PR), so the tip commit IS the whole delta of a push.
+# If that merge policy ever changes to merge commits or multi-commit
+# pushes, widen this to the push range.
+#
+# Fail-open: if git errors for any reason (shallow clone edge cases,
+# missing parent), the non-zero exit means "build", never "skip".
+
+git diff --quiet HEAD^ HEAD -- . ../../docs ../../mkdocs.yml ../../requirements-docs.txt

--- a/apps/landing/vercel.json
+++ b/apps/landing/vercel.json
@@ -2,7 +2,7 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "buildCommand": "bash build-docs.sh",
   "outputDirectory": "dist",
-  "ignoreCommand": "git diff --quiet HEAD^ HEAD -- . ../../docs ../../mkdocs.yml ../../requirements-docs.txt",
+  "ignoreCommand": "bash vercel-ignore.sh",
   "headers": [
     {
       "source": "/(.*)",

--- a/apps/landing/vercel.json
+++ b/apps/landing/vercel.json
@@ -1,5 +1,8 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
+  "buildCommand": "bash build-docs.sh",
+  "outputDirectory": "dist",
+  "ignoreCommand": "git diff --quiet HEAD^ HEAD -- . ../../docs ../../mkdocs.yml ../../requirements-docs.txt",
   "headers": [
     {
       "source": "/(.*)",

--- a/docs/api/rust.md
+++ b/docs/api/rust.md
@@ -2,21 +2,21 @@
 
 API documentation for the Rust crates.
 
-> **Note**: Full API documentation with source links is available via `cargo doc --open`
+> **Note**: For the crates published to crates.io, full generated rustdoc with source links lives on docs.rs (linked per crate below). Locally, `cargo doc --open` builds the same documentation for the whole workspace.
 
 ## Workspace
 
 All crates live in one Cargo workspace (versioned together, MPL-2.0 licensed):
 
-| Crate | Path | Description |
-|-------|------|-------------|
-| `ifc-lite-core` | `rust/core` | High-performance IFC/STEP parser for building data |
-| `ifc-lite-geometry` | `rust/geometry` | Geometry processing and mesh generation for IFC models |
-| `ifc-lite-processing` | `rust/processing` | Shared IFC processing pipeline and types used by server and FFI |
-| `ifc-lite-export` | `rust/export` | Domain-format exporters (HBJSON, OBJ, glTF/GLB, CSV, JSON, JSON-LD, STEP/IFC, IFC5/IFCX, Merged, Parquet/.bos) |
-| `ifc-lite-clash` | `rust/clash` | High-performance geometry kernel for IFC clash detection |
-| `ifc-lite-ffi` | `rust/ffi` | C FFI bindings: native cdylib for in-process IFC parsing |
-| `ifc-lite-wasm` | `rust/wasm-bindings` | WebAssembly bindings for IFC-Lite |
+| Crate | Path | Rustdoc | Description |
+|-------|------|---------|-------------|
+| `ifc-lite-core` | `rust/core` | [docs.rs](https://docs.rs/ifc-lite-core) | High-performance IFC/STEP parser for building data |
+| `ifc-lite-geometry` | `rust/geometry` | [docs.rs](https://docs.rs/ifc-lite-geometry) | Geometry processing and mesh generation for IFC models |
+| `ifc-lite-processing` | `rust/processing` | [docs.rs](https://docs.rs/ifc-lite-processing) | Shared IFC processing pipeline and types used by server and FFI |
+| `ifc-lite-export` | `rust/export` | local `cargo doc` | Domain-format exporters (HBJSON, OBJ, glTF/GLB, CSV, JSON, JSON-LD, STEP/IFC, IFC5/IFCX, Merged, Parquet/.bos) |
+| `ifc-lite-clash` | `rust/clash` | [docs.rs](https://docs.rs/ifc-lite-clash) | High-performance geometry kernel for IFC clash detection |
+| `ifc-lite-ffi` | `rust/ffi` | [docs.rs](https://docs.rs/ifc-lite-ffi) | C FFI bindings: native cdylib for in-process IFC parsing |
+| `ifc-lite-wasm` | `rust/wasm-bindings` | [docs.rs](https://docs.rs/ifc-lite-wasm) | WebAssembly bindings for IFC-Lite |
 
 The Python bindings (`rust/python`, PyPI package `ifclite-geom`) are excluded from the workspace and documented on the [Python API page](python.md).
 

--- a/examples/babylonjs-viewer/README.md
+++ b/examples/babylonjs-viewer/README.md
@@ -40,7 +40,7 @@ IFC data in the side panel.
 ## Tutorial
 
 For a step-by-step walkthrough, see the
-[Babylon.js integration tutorial](https://ltplus-ag.github.io/ifc-lite/tutorials/babylonjs-integration/).
+[Babylon.js integration tutorial](https://ifclite.dev/docs/tutorials/babylonjs-integration/).
 
 ## License
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: IFC-Lite Documentation
-site_url: https://ltplus-ag.github.io/ifc-lite
+site_url: https://ifclite.dev/docs/
 site_description: High-performance browser-native IFC platform documentation
 site_author: IFC-Lite Contributors
 repo_url: https://github.com/LTplus-AG/ifc-lite

--- a/packages/bcf/README.md
+++ b/packages/bcf/README.md
@@ -94,7 +94,7 @@ const back = uuidToIfcGuid(uuid);
 
 ## API
 
-See the [BCF Guide](https://ltplus-ag.github.io/ifc-lite/guide/bcf/) and [API Reference](https://ltplus-ag.github.io/ifc-lite/api/typescript/#ifc-litebcf).
+See the [BCF Guide](https://ifclite.dev/docs/guide/bcf/) and [API Reference](https://ifclite.dev/docs/api/typescript/#ifc-litebcf).
 
 ## License
 

--- a/packages/bcf/package.json
+++ b/packages/bcf/package.json
@@ -32,7 +32,7 @@
     "url": "https://github.com/LTplus-AG/ifc-lite.git",
     "directory": "packages/bcf"
   },
-  "homepage": "https://ltplus-ag.github.io/ifc-lite/",
+  "homepage": "https://ifclite.dev/docs/",
   "bugs": "https://github.com/LTplus-AG/ifc-lite/issues",
   "keywords": [
     "ifc",

--- a/packages/cache/README.md
+++ b/packages/cache/README.md
@@ -91,7 +91,7 @@ This is backward compatible: entries written before the flag existed have it uns
 
 ## API
 
-See the [API Reference](https://ltplus-ag.github.io/ifc-lite/api/typescript/#ifc-litecache).
+See the [API Reference](https://ifclite.dev/docs/api/typescript/#ifc-litecache).
 
 ## License
 

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -32,7 +32,7 @@
     "url": "https://github.com/LTplus-AG/ifc-lite.git",
     "directory": "packages/cache"
   },
-  "homepage": "https://ltplus-ag.github.io/ifc-lite/",
+  "homepage": "https://ifclite.dev/docs/",
   "bugs": "https://github.com/LTplus-AG/ifc-lite/issues",
   "keywords": [
     "ifc",

--- a/packages/clash/README.md
+++ b/packages/clash/README.md
@@ -43,7 +43,7 @@ and the SDK `clash` namespace.
 
 ## Docs
 
-See the [ifc-lite docs](https://ltplus-ag.github.io/ifc-lite/) and the design
+See the [ifc-lite docs](https://ifclite.dev/docs/) and the design
 rationale in
 [clash-detection-plan.md](https://github.com/LTplus-AG/ifc-lite/blob/main/docs/architecture/clash-detection-plan.md).
 

--- a/packages/clash/package.json
+++ b/packages/clash/package.json
@@ -57,7 +57,7 @@
     "url": "https://github.com/LTplus-AG/ifc-lite.git",
     "directory": "packages/clash"
   },
-  "homepage": "https://ltplus-ag.github.io/ifc-lite/",
+  "homepage": "https://ifclite.dev/docs/",
   "bugs": "https://github.com/LTplus-AG/ifc-lite/issues",
   "keywords": [
     "ifc",

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -47,7 +47,7 @@ Global flags: `--json`, `--out <file>`, `--verbose`, `--quiet`, `--debug`, `--lo
 
 ## Links
 
-- Docs: https://ltplus-ag.github.io/ifc-lite/
+- Docs: https://ifclite.dev/docs/
 - Source: https://github.com/LTplus-AG/ifc-lite
 
 ## License

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -58,7 +58,7 @@
     "url": "https://github.com/LTplus-AG/ifc-lite.git",
     "directory": "packages/cli"
   },
-  "homepage": "https://ltplus-ag.github.io/ifc-lite/",
+  "homepage": "https://ifclite.dev/docs/",
   "bugs": "https://github.com/LTplus-AG/ifc-lite/issues",
   "keywords": [
     "ifc",

--- a/packages/codegen/README.md
+++ b/packages/codegen/README.md
@@ -93,7 +93,7 @@ SCHEMA_REGISTRY.IfcWall = {
 
 ## API
 
-See the [API Reference](https://ltplus-ag.github.io/ifc-lite/api/typescript/#ifc-litecodegen).
+See the [API Reference](https://ifclite.dev/docs/api/typescript/#ifc-litecodegen).
 
 ## License
 

--- a/packages/codegen/package.json
+++ b/packages/codegen/package.json
@@ -38,7 +38,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "homepage": "https://ltplus-ag.github.io/ifc-lite/",
+  "homepage": "https://ifclite.dev/docs/",
   "bugs": "https://github.com/LTplus-AG/ifc-lite/issues",
   "files": [
     "dist",

--- a/packages/collab-server/README.md
+++ b/packages/collab-server/README.md
@@ -52,7 +52,7 @@ Also exported: `S3Persistence`, `RedisPersistence`, `MemoryPersistence`,
 
 ## Docs
 
-See the [ifc-lite docs](https://ltplus-ag.github.io/ifc-lite/).
+See the [ifc-lite docs](https://ifclite.dev/docs/).
 
 ## License
 

--- a/packages/collab-server/package.json
+++ b/packages/collab-server/package.json
@@ -46,7 +46,7 @@
     "url": "https://github.com/LTplus-AG/ifc-lite.git",
     "directory": "packages/collab-server"
   },
-  "homepage": "https://ltplus-ag.github.io/ifc-lite/",
+  "homepage": "https://ifclite.dev/docs/",
   "bugs": "https://github.com/LTplus-AG/ifc-lite/issues",
   "keywords": [
     "ifc",

--- a/packages/collab/README.md
+++ b/packages/collab/README.md
@@ -100,7 +100,7 @@ structured events that the viewer (or any UI) can render.
 
 ## Docs
 
-See the [ifc-lite docs](https://ltplus-ag.github.io/ifc-lite/). Pair with
+See the [ifc-lite docs](https://ifclite.dev/docs/). Pair with
 [`@ifc-lite/collab-server`](https://www.npmjs.com/package/@ifc-lite/collab-server)
 for multi-peer websocket sync.
 

--- a/packages/collab/package.json
+++ b/packages/collab/package.json
@@ -59,7 +59,7 @@
     "url": "https://github.com/LTplus-AG/ifc-lite.git",
     "directory": "packages/collab"
   },
-  "homepage": "https://ltplus-ag.github.io/ifc-lite/",
+  "homepage": "https://ifclite.dev/docs/",
   "bugs": "https://github.com/LTplus-AG/ifc-lite/issues",
   "keywords": [
     "ifc",

--- a/packages/create-ifc-lite/README.md
+++ b/packages/create-ifc-lite/README.md
@@ -54,6 +54,6 @@ Each template ships with a `README.md` documenting what it does and how to exten
 
 ## Learn more
 
-- [IFClite docs](https://ltplus-ag.github.io/ifc-lite/)
+- [IFClite docs](https://ifclite.dev/docs/)
 - [GitHub repo](https://github.com/LTplus-AG/ifc-lite)
-- [Quick Start guide](https://ltplus-ag.github.io/ifc-lite/guide/quickstart/)
+- [Quick Start guide](https://ifclite.dev/docs/guide/quickstart/)

--- a/packages/create-ifc-lite/package.json
+++ b/packages/create-ifc-lite/package.json
@@ -38,6 +38,6 @@
     "@types/node": "^26.1.0",
     "typescript": "^5.3.0"
   },
-  "homepage": "https://ltplus-ag.github.io/ifc-lite/",
+  "homepage": "https://ifclite.dev/docs/",
   "bugs": "https://github.com/LTplus-AG/ifc-lite/issues"
 }

--- a/packages/create/README.md
+++ b/packages/create/README.md
@@ -34,7 +34,7 @@ const { content } = creator.toIfc(); // IFC STEP text
 
 ## Links
 
-- Docs: https://ltplus-ag.github.io/ifc-lite/
+- Docs: https://ifclite.dev/docs/
 - Source: https://github.com/LTplus-AG/ifc-lite
 
 ## License

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -33,7 +33,7 @@
     "url": "https://github.com/LTplus-AG/ifc-lite.git",
     "directory": "packages/create"
   },
-  "homepage": "https://ltplus-ag.github.io/ifc-lite/",
+  "homepage": "https://ifclite.dev/docs/",
   "bugs": "https://github.com/LTplus-AG/ifc-lite/issues",
   "keywords": [
     "ifc",

--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -73,7 +73,7 @@ The index is generated at build time and committed to the repo, so normal builds
 
 ## API
 
-See the [API Reference](https://ltplus-ag.github.io/ifc-lite/api/typescript/#ifc-litedata).
+See the [API Reference](https://ifclite.dev/docs/api/typescript/#ifc-litedata).
 
 ## License
 

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -34,7 +34,7 @@
     "url": "https://github.com/LTplus-AG/ifc-lite.git",
     "directory": "packages/data"
   },
-  "homepage": "https://ltplus-ag.github.io/ifc-lite/",
+  "homepage": "https://ifclite.dev/docs/",
   "bugs": "https://github.com/LTplus-AG/ifc-lite/issues",
   "keywords": [
     "ifc",

--- a/packages/diff/README.md
+++ b/packages/diff/README.md
@@ -83,8 +83,8 @@ never registers as a change) and tolerance-quantized. This package only
 
 ## Docs
 
-See the [ifc-lite docs](https://ltplus-ag.github.io/ifc-lite/) and the
-[API Reference](https://ltplus-ag.github.io/ifc-lite/api/typescript/).
+See the [ifc-lite docs](https://ifclite.dev/docs/) and the
+[API Reference](https://ifclite.dev/docs/api/typescript/).
 
 ## License
 

--- a/packages/diff/package.json
+++ b/packages/diff/package.json
@@ -28,7 +28,7 @@
     "url": "https://github.com/LTplus-AG/ifc-lite.git",
     "directory": "packages/diff"
   },
-  "homepage": "https://ltplus-ag.github.io/ifc-lite/",
+  "homepage": "https://ifclite.dev/docs/",
   "bugs": "https://github.com/LTplus-AG/ifc-lite/issues",
   "keywords": [
     "ifc",

--- a/packages/drawing-2d/README.md
+++ b/packages/drawing-2d/README.md
@@ -124,11 +124,11 @@ import {
 } from '@ifc-lite/drawing-2d';
 ```
 
-Each renderer returns SVG fragments that you wrap in your own `<svg>` document — see the [2D Drawings Guide](https://ltplus-ag.github.io/ifc-lite/guide/drawing-2d/) for a worked sheet-composition example.
+Each renderer returns SVG fragments that you wrap in your own `<svg>` document — see the [2D Drawings Guide](https://ifclite.dev/docs/guide/drawing-2d/) for a worked sheet-composition example.
 
 ## API
 
-See the [2D Drawings Guide](https://ltplus-ag.github.io/ifc-lite/guide/drawing-2d/) and [API Reference](https://ltplus-ag.github.io/ifc-lite/api/typescript/#ifc-litedrawing-2d).
+See the [2D Drawings Guide](https://ifclite.dev/docs/guide/drawing-2d/) and [API Reference](https://ifclite.dev/docs/api/typescript/#ifc-litedrawing-2d).
 
 ## License
 

--- a/packages/drawing-2d/package.json
+++ b/packages/drawing-2d/package.json
@@ -32,7 +32,7 @@
     "url": "https://github.com/LTplus-AG/ifc-lite.git",
     "directory": "packages/drawing-2d"
   },
-  "homepage": "https://ltplus-ag.github.io/ifc-lite/",
+  "homepage": "https://ifclite.dev/docs/",
   "bugs": "https://github.com/LTplus-AG/ifc-lite/issues",
   "keywords": [
     "ifc",

--- a/packages/embed-protocol/README.md
+++ b/packages/embed-protocol/README.md
@@ -38,7 +38,7 @@ window.addEventListener('message', (event) => {
 
 ## Links
 
-- Docs: https://ltplus-ag.github.io/ifc-lite/
+- Docs: https://ifclite.dev/docs/
 - Source: https://github.com/LTplus-AG/ifc-lite
 
 ## License

--- a/packages/embed-protocol/package.json
+++ b/packages/embed-protocol/package.json
@@ -32,6 +32,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "homepage": "https://ltplus-ag.github.io/ifc-lite/",
+  "homepage": "https://ifclite.dev/docs/",
   "bugs": "https://github.com/LTplus-AG/ifc-lite/issues"
 }

--- a/packages/embed-sdk/README.md
+++ b/packages/embed-sdk/README.md
@@ -38,7 +38,7 @@ Protocol types are shared with the viewer through `@ifc-lite/embed-protocol`.
 
 ## Links
 
-- Docs: https://ltplus-ag.github.io/ifc-lite/
+- Docs: https://ifclite.dev/docs/
 - Source: https://github.com/LTplus-AG/ifc-lite
 
 ## License

--- a/packages/embed-sdk/package.json
+++ b/packages/embed-sdk/package.json
@@ -45,6 +45,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "homepage": "https://ltplus-ag.github.io/ifc-lite/",
+  "homepage": "https://ifclite.dev/docs/",
   "bugs": "https://github.com/LTplus-AG/ifc-lite/issues"
 }

--- a/packages/encoding/README.md
+++ b/packages/encoding/README.md
@@ -38,7 +38,7 @@ parsePropertyValue(['IFCBOOLEAN', '.T.']); // { displayValue: 'True', ifcType: .
 
 ## Links
 
-- Docs: https://ltplus-ag.github.io/ifc-lite/
+- Docs: https://ifclite.dev/docs/
 - Source: https://github.com/LTplus-AG/ifc-lite
 
 ## License

--- a/packages/encoding/package.json
+++ b/packages/encoding/package.json
@@ -28,7 +28,7 @@
     "url": "https://github.com/LTplus-AG/ifc-lite.git",
     "directory": "packages/encoding"
   },
-  "homepage": "https://ltplus-ag.github.io/ifc-lite/",
+  "homepage": "https://ifclite.dev/docs/",
   "bugs": "https://github.com/LTplus-AG/ifc-lite/issues",
   "keywords": [
     "ifc",

--- a/packages/export/README.md
+++ b/packages/export/README.md
@@ -126,7 +126,7 @@ const lod1 = await generateLod1(bytes, { quality: 'medium' });
 
 ## API
 
-See the [Exporting Guide](https://ltplus-ag.github.io/ifc-lite/guide/exporting/) and [API Reference](https://ltplus-ag.github.io/ifc-lite/api/typescript/#ifc-liteexport).
+See the [Exporting Guide](https://ifclite.dev/docs/guide/exporting/) and [API Reference](https://ifclite.dev/docs/api/typescript/#ifc-liteexport).
 
 ## License
 

--- a/packages/export/package.json
+++ b/packages/export/package.json
@@ -39,7 +39,7 @@
     "url": "https://github.com/LTplus-AG/ifc-lite.git",
     "directory": "packages/export"
   },
-  "homepage": "https://ltplus-ag.github.io/ifc-lite/",
+  "homepage": "https://ifclite.dev/docs/",
   "bugs": "https://github.com/LTplus-AG/ifc-lite/issues",
   "keywords": [
     "ifc",

--- a/packages/extensions/README.md
+++ b/packages/extensions/README.md
@@ -72,7 +72,7 @@ if (result.ok) {
 
 ## Docs
 
-- [Extensions Guide](https://ltplus-ag.github.io/ifc-lite/guide/extensions/) and [Extension Authoring](https://ltplus-ag.github.io/ifc-lite/guide/extension-authoring/)
+- [Extensions Guide](https://ifclite.dev/docs/guide/extensions/) and [Extension Authoring](https://ifclite.dev/docs/guide/extension-authoring/)
 - Design references: [01-extension-model.md](https://github.com/LTplus-AG/ifc-lite/blob/main/docs/architecture/ai-customization/01-extension-model.md), [02-security.md](https://github.com/LTplus-AG/ifc-lite/blob/main/docs/architecture/ai-customization/02-security.md), [03-ui-surface.md](https://github.com/LTplus-AG/ifc-lite/blob/main/docs/architecture/ai-customization/03-ui-surface.md)
 
 Licensed under MPL-2.0.

--- a/packages/extensions/package.json
+++ b/packages/extensions/package.json
@@ -50,7 +50,7 @@
     "url": "https://github.com/LTplus-AG/ifc-lite.git",
     "directory": "packages/extensions"
   },
-  "homepage": "https://ltplus-ag.github.io/ifc-lite/",
+  "homepage": "https://ifclite.dev/docs/",
   "bugs": "https://github.com/LTplus-AG/ifc-lite/issues",
   "keywords": [
     "ifc",

--- a/packages/geometry/README.md
+++ b/packages/geometry/README.md
@@ -49,7 +49,7 @@ const processor = new GeometryProcessor({ tessellationQuality: 'high' });
 processor.setTessellationQuality('low');
 ```
 
-Unset / `'medium'` reproduces the engine's historical densities byte-for-byte. Lower levels coarsen curved surfaces (×0.5 / ×0.25 segment density) for throughput; higher levels refine them (×2 / ×4) to reduce visible faceting, with a proportional triangle-count and processing-time cost on curved-heavy models. Profile circles (opening cutters / extruded caps) never get finer than `'medium'`. Applies to the WASM paths (main-thread, streaming, worker pool); the native Tauri path does not consume it yet. See the [Geometry Guide](https://ltplus-ag.github.io/ifc-lite/guide/geometry/) for the full level table.
+Unset / `'medium'` reproduces the engine's historical densities byte-for-byte. Lower levels coarsen curved surfaces (×0.5 / ×0.25 segment density) for throughput; higher levels refine them (×2 / ×4) to reduce visible faceting, with a proportional triangle-count and processing-time cost on curved-heavy models. Profile circles (opening cutters / extruded caps) never get finer than `'medium'`. Applies to the WASM paths (main-thread, streaming, worker pool); the native Tauri path does not consume it yet. See the [Geometry Guide](https://ifclite.dev/docs/guide/geometry/) for the full level table.
 
 ## Coordinate handling
 
@@ -115,11 +115,11 @@ works.
 - **First triangles:** 300–500ms (streaming path)
 - **Throughput:** ~1.9x faster than `web-ifc` (928-column.ifc; see `tests/benchmark/benchmark-results.json`)
 - **Worker support:** files > 50 MB process off-main-thread automatically
-- **Native (Tauri):** `preferNative: true` enables the native Rust pipeline when running under a Tauri host — an extension point for third parties building their own desktop app (`@tauri-apps/api` is an optional dep; web builds never load it). See the [Building for Desktop](https://ltplus-ag.github.io/ifc-lite/guide/desktop/) guide.
+- **Native (Tauri):** `preferNative: true` enables the native Rust pipeline when running under a Tauri host — an extension point for third parties building their own desktop app (`@tauri-apps/api` is an optional dep; web builds never load it). See the [Building for Desktop](https://ifclite.dev/docs/guide/desktop/) guide.
 
 ## API
 
-See the [Geometry Guide](https://ltplus-ag.github.io/ifc-lite/guide/geometry/) and [API Reference](https://ltplus-ag.github.io/ifc-lite/api/typescript/#ifc-litegeometry).
+See the [Geometry Guide](https://ifclite.dev/docs/guide/geometry/) and [API Reference](https://ifclite.dev/docs/api/typescript/#ifc-litegeometry).
 
 ## License
 

--- a/packages/geometry/package.json
+++ b/packages/geometry/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/LTplus-AG/ifc-lite.git",
     "directory": "packages/geometry"
   },
-  "homepage": "https://ltplus-ag.github.io/ifc-lite/",
+  "homepage": "https://ifclite.dev/docs/",
   "bugs": "https://github.com/LTplus-AG/ifc-lite/issues",
   "keywords": [
     "ifc",

--- a/packages/ids/README.md
+++ b/packages/ids/README.md
@@ -100,7 +100,7 @@ for (const spec of idsSpec.specifications) {
 
 ## API
 
-See the [IDS Guide](https://ltplus-ag.github.io/ifc-lite/guide/ids/) and [API Reference](https://ltplus-ag.github.io/ifc-lite/api/typescript/#ifc-liteids).
+See the [IDS Guide](https://ifclite.dev/docs/guide/ids/) and [API Reference](https://ifclite.dev/docs/api/typescript/#ifc-liteids).
 
 ## License
 

--- a/packages/ids/package.json
+++ b/packages/ids/package.json
@@ -38,7 +38,7 @@
     "url": "https://github.com/LTplus-AG/ifc-lite.git",
     "directory": "packages/ids"
   },
-  "homepage": "https://ltplus-ag.github.io/ifc-lite/",
+  "homepage": "https://ifclite.dev/docs/",
   "bugs": "https://github.com/LTplus-AG/ifc-lite/issues",
   "keywords": [
     "ifc",

--- a/packages/ifcx/README.md
+++ b/packages/ifcx/README.md
@@ -74,7 +74,7 @@ const ifcx = exporter.export({ includeGeometry: true });
 
 ## API
 
-See the [Parsing Guide](https://ltplus-ag.github.io/ifc-lite/guide/parsing/) and [API Reference](https://ltplus-ag.github.io/ifc-lite/api/typescript/#ifc-liteifcx).
+See the [Parsing Guide](https://ifclite.dev/docs/guide/parsing/) and [API Reference](https://ifclite.dev/docs/api/typescript/#ifc-liteifcx).
 
 ## License
 

--- a/packages/ifcx/package.json
+++ b/packages/ifcx/package.json
@@ -33,7 +33,7 @@
     "url": "https://github.com/LTplus-AG/ifc-lite.git",
     "directory": "packages/ifcx"
   },
-  "homepage": "https://ltplus-ag.github.io/ifc-lite/",
+  "homepage": "https://ifclite.dev/docs/",
   "bugs": "https://github.com/LTplus-AG/ifc-lite/issues",
   "keywords": [
     "ifc",

--- a/packages/lens/README.md
+++ b/packages/lens/README.md
@@ -33,7 +33,7 @@ const result = evaluateLens(BUILTIN_LENSES[0], provider);
 
 ## Links
 
-- Docs: https://ltplus-ag.github.io/ifc-lite/
+- Docs: https://ifclite.dev/docs/
 - Source: https://github.com/LTplus-AG/ifc-lite
 
 ## License

--- a/packages/lens/package.json
+++ b/packages/lens/package.json
@@ -29,7 +29,7 @@
     "url": "https://github.com/LTplus-AG/ifc-lite.git",
     "directory": "packages/lens"
   },
-  "homepage": "https://ltplus-ag.github.io/ifc-lite/",
+  "homepage": "https://ifclite.dev/docs/",
   "bugs": "https://github.com/LTplus-AG/ifc-lite/issues",
   "keywords": [
     "ifc",

--- a/packages/lists/README.md
+++ b/packages/lists/README.md
@@ -35,7 +35,7 @@ const csv = listResultToCSV(result);
 
 ## Links
 
-- Docs: https://ltplus-ag.github.io/ifc-lite/
+- Docs: https://ifclite.dev/docs/
 - Source: https://github.com/LTplus-AG/ifc-lite
 
 ## License

--- a/packages/lists/package.json
+++ b/packages/lists/package.json
@@ -32,7 +32,7 @@
     "url": "https://github.com/LTplus-AG/ifc-lite.git",
     "directory": "packages/lists"
   },
-  "homepage": "https://ltplus-ag.github.io/ifc-lite/",
+  "homepage": "https://ifclite.dev/docs/",
   "bugs": "https://github.com/LTplus-AG/ifc-lite/issues",
   "keywords": [
     "ifc",

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -188,7 +188,7 @@ registry listing.
 
 ## Docs
 
-See the [ifc-lite docs](https://ltplus-ag.github.io/ifc-lite/) for the full
+See the [ifc-lite docs](https://ifclite.dev/docs/) for the full
 platform documentation.
 
 Licensed under MPL-2.0.

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -62,7 +62,7 @@
     "url": "https://github.com/LTplus-AG/ifc-lite.git",
     "directory": "packages/mcp"
   },
-  "homepage": "https://ltplus-ag.github.io/ifc-lite/",
+  "homepage": "https://ifclite.dev/docs/",
   "bugs": "https://github.com/LTplus-AG/ifc-lite/issues",
   "keywords": [
     "mcp",

--- a/packages/mutations/README.md
+++ b/packages/mutations/README.md
@@ -166,7 +166,7 @@ Pair this with `exportToStep(store, { applyMutations: true })` from `@ifc-lite/e
 
 ## API
 
-See the [Property Editing Guide](https://ltplus-ag.github.io/ifc-lite/guide/mutations/) and [API Reference](https://ltplus-ag.github.io/ifc-lite/api/typescript/#ifc-litemutations).
+See the [Property Editing Guide](https://ifclite.dev/docs/guide/mutations/) and [API Reference](https://ifclite.dev/docs/api/typescript/#ifc-litemutations).
 
 ## License
 

--- a/packages/mutations/package.json
+++ b/packages/mutations/package.json
@@ -31,7 +31,7 @@
     "url": "https://github.com/LTplus-AG/ifc-lite.git",
     "directory": "packages/mutations"
   },
-  "homepage": "https://ltplus-ag.github.io/ifc-lite/",
+  "homepage": "https://ifclite.dev/docs/",
   "bugs": "https://github.com/LTplus-AG/ifc-lite/issues",
   "keywords": [
     "ifc",

--- a/packages/parser/README.md
+++ b/packages/parser/README.md
@@ -121,7 +121,7 @@ if (georef?.hasGeoreference) {
 
 ## API
 
-See the [Parsing Guide](https://ltplus-ag.github.io/ifc-lite/guide/parsing/) and [API Reference](https://ltplus-ag.github.io/ifc-lite/api/typescript/#ifc-liteparser).
+See the [Parsing Guide](https://ifclite.dev/docs/guide/parsing/) and [API Reference](https://ifclite.dev/docs/api/typescript/#ifc-liteparser).
 
 ## License
 

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -39,7 +39,7 @@
     "url": "https://github.com/LTplus-AG/ifc-lite.git",
     "directory": "packages/parser"
   },
-  "homepage": "https://ltplus-ag.github.io/ifc-lite/",
+  "homepage": "https://ifclite.dev/docs/",
   "bugs": "https://github.com/LTplus-AG/ifc-lite/issues",
   "keywords": [
     "ifc",

--- a/packages/pointcloud/README.md
+++ b/packages/pointcloud/README.md
@@ -60,7 +60,7 @@ Notes:
 
 ## API
 
-See the [docs site](https://ltplus-ag.github.io/ifc-lite/) for guides and the full API reference.
+See the [docs site](https://ifclite.dev/docs/) for guides and the full API reference.
 
 ## License
 

--- a/packages/pointcloud/package.json
+++ b/packages/pointcloud/package.json
@@ -32,7 +32,7 @@
     "url": "https://github.com/LTplus-AG/ifc-lite.git",
     "directory": "packages/pointcloud"
   },
-  "homepage": "https://ltplus-ag.github.io/ifc-lite/",
+  "homepage": "https://ifclite.dev/docs/",
   "bugs": "https://github.com/LTplus-AG/ifc-lite/issues",
   "keywords": [
     "ifc",

--- a/packages/query/README.md
+++ b/packages/query/README.md
@@ -96,7 +96,7 @@ The fluent query API works without it.
 
 ## API
 
-See the [Querying Guide](https://ltplus-ag.github.io/ifc-lite/guide/querying/) and [API Reference](https://ltplus-ag.github.io/ifc-lite/api/typescript/#ifc-litequery).
+See the [Querying Guide](https://ifclite.dev/docs/guide/querying/) and [API Reference](https://ifclite.dev/docs/api/typescript/#ifc-litequery).
 
 ## License
 

--- a/packages/query/package.json
+++ b/packages/query/package.json
@@ -34,7 +34,7 @@
     "url": "https://github.com/LTplus-AG/ifc-lite.git",
     "directory": "packages/query"
   },
-  "homepage": "https://ltplus-ag.github.io/ifc-lite/",
+  "homepage": "https://ifclite.dev/docs/",
   "bugs": "https://github.com/LTplus-AG/ifc-lite/issues",
   "keywords": [
     "ifc",

--- a/packages/renderer/README.md
+++ b/packages/renderer/README.md
@@ -99,7 +99,7 @@ const { modelId, expressId } = federationRegistry.fromGlobalId(hit.expressId);
 
 ## API
 
-See the [Rendering Guide](https://ltplus-ag.github.io/ifc-lite/guide/rendering/) and [API Reference](https://ltplus-ag.github.io/ifc-lite/api/typescript/#ifc-literenderer).
+See the [Rendering Guide](https://ifclite.dev/docs/guide/rendering/) and [API Reference](https://ifclite.dev/docs/api/typescript/#ifc-literenderer).
 
 ## License
 

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -33,7 +33,7 @@
     "url": "https://github.com/LTplus-AG/ifc-lite.git",
     "directory": "packages/renderer"
   },
-  "homepage": "https://ltplus-ag.github.io/ifc-lite/",
+  "homepage": "https://ifclite.dev/docs/",
   "bugs": "https://github.com/LTplus-AG/ifc-lite/issues",
   "keywords": [
     "ifc",

--- a/packages/sandbox/README.md
+++ b/packages/sandbox/README.md
@@ -43,7 +43,7 @@ sandbox.dispose();
 
 ## Links
 
-- Docs: https://ltplus-ag.github.io/ifc-lite/
+- Docs: https://ifclite.dev/docs/
 - Source: https://github.com/LTplus-AG/ifc-lite
 
 ## License

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -37,7 +37,7 @@
     "url": "https://github.com/LTplus-AG/ifc-lite.git",
     "directory": "packages/sandbox"
   },
-  "homepage": "https://ltplus-ag.github.io/ifc-lite/",
+  "homepage": "https://ifclite.dev/docs/",
   "bugs": "https://github.com/LTplus-AG/ifc-lite/issues",
   "keywords": [
     "ifc",

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -40,7 +40,7 @@ Also exported: `BimHost` (viewer side), `RemoteBackend`, `MessagePortTransport`,
 
 ## Links
 
-- Docs: https://ltplus-ag.github.io/ifc-lite/
+- Docs: https://ifclite.dev/docs/
 - Source: https://github.com/LTplus-AG/ifc-lite
 
 ## License

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -44,7 +44,7 @@
     "url": "https://github.com/LTplus-AG/ifc-lite.git",
     "directory": "packages/sdk"
   },
-  "homepage": "https://ltplus-ag.github.io/ifc-lite/",
+  "homepage": "https://ifclite.dev/docs/",
   "bugs": "https://github.com/LTplus-AG/ifc-lite/issues",
   "keywords": [
     "ifc",

--- a/packages/server-bin/README.md
+++ b/packages/server-bin/README.md
@@ -116,7 +116,7 @@ cargo build --release
 
 ## Docs
 
-See the [Server Guide](https://ltplus-ag.github.io/ifc-lite/guide/server/).
+See the [Server Guide](https://ifclite.dev/docs/guide/server/).
 
 ## License
 

--- a/packages/server-bin/package.json
+++ b/packages/server-bin/package.json
@@ -51,7 +51,7 @@
     "url": "https://github.com/LTplus-AG/ifc-lite.git",
     "directory": "packages/server-bin"
   },
-  "homepage": "https://ltplus-ag.github.io/ifc-lite/",
+  "homepage": "https://ifclite.dev/docs/",
   "bugs": "https://github.com/LTplus-AG/ifc-lite/issues",
   "keywords": [
     "ifc",

--- a/packages/server-client/README.md
+++ b/packages/server-client/README.md
@@ -66,7 +66,7 @@ const meshes = await decodeParquetGeometry(arrayBuffer);
 
 ## API
 
-See the [Server Guide](https://ltplus-ag.github.io/ifc-lite/guide/server/) and [API Reference](https://ltplus-ag.github.io/ifc-lite/api/typescript/#ifc-liteserver-client).
+See the [Server Guide](https://ifclite.dev/docs/guide/server/) and [API Reference](https://ifclite.dev/docs/api/typescript/#ifc-liteserver-client).
 
 ## License
 

--- a/packages/server-client/package.json
+++ b/packages/server-client/package.json
@@ -38,7 +38,7 @@
     "url": "https://github.com/LTplus-AG/ifc-lite.git",
     "directory": "packages/server-client"
   },
-  "homepage": "https://ltplus-ag.github.io/ifc-lite/",
+  "homepage": "https://ifclite.dev/docs/",
   "bugs": "https://github.com/LTplus-AG/ifc-lite/issues",
   "keywords": [
     "ifc",

--- a/packages/solar/README.md
+++ b/packages/solar/README.md
@@ -50,8 +50,8 @@ architectural shadow / right-to-light studies require.
 
 ## Docs
 
-See the [ifc-lite docs](https://ltplus-ag.github.io/ifc-lite/) and the
-[API Reference](https://ltplus-ag.github.io/ifc-lite/api/typescript/).
+See the [ifc-lite docs](https://ifclite.dev/docs/) and the
+[API Reference](https://ifclite.dev/docs/api/typescript/).
 
 ## License
 

--- a/packages/solar/package.json
+++ b/packages/solar/package.json
@@ -27,7 +27,7 @@
     "url": "https://github.com/LTplus-AG/ifc-lite.git",
     "directory": "packages/solar"
   },
-  "homepage": "https://ltplus-ag.github.io/ifc-lite/",
+  "homepage": "https://ifclite.dev/docs/",
   "bugs": "https://github.com/LTplus-AG/ifc-lite/issues",
   "keywords": [
     "ifc",

--- a/packages/spatial/README.md
+++ b/packages/spatial/README.md
@@ -71,7 +71,7 @@ The renderer (`@ifc-lite/renderer`) ships its own GPU-side picking and culling â
 
 ## API
 
-See the [API Reference](https://ltplus-ag.github.io/ifc-lite/api/typescript/#ifc-litespatial).
+See the [API Reference](https://ifclite.dev/docs/api/typescript/#ifc-litespatial).
 
 ## License
 

--- a/packages/spatial/package.json
+++ b/packages/spatial/package.json
@@ -29,7 +29,7 @@
     "url": "https://github.com/LTplus-AG/ifc-lite.git",
     "directory": "packages/spatial"
   },
-  "homepage": "https://ltplus-ag.github.io/ifc-lite/",
+  "homepage": "https://ifclite.dev/docs/",
   "bugs": "https://github.com/LTplus-AG/ifc-lite/issues",
   "keywords": [
     "ifc",

--- a/packages/viewer/README.md
+++ b/packages/viewer/README.md
@@ -45,7 +45,7 @@ Note: the npm package name is `@ifc-lite/viewer-core`; in the monorepo it lives 
 
 ## Links
 
-- Docs: https://ltplus-ag.github.io/ifc-lite/
+- Docs: https://ifclite.dev/docs/
 - Source: https://github.com/LTplus-AG/ifc-lite
 
 ## License

--- a/packages/viewer/package.json
+++ b/packages/viewer/package.json
@@ -40,7 +40,7 @@
     "url": "https://github.com/LTplus-AG/ifc-lite.git",
     "directory": "packages/viewer"
   },
-  "homepage": "https://ltplus-ag.github.io/ifc-lite/",
+  "homepage": "https://ifclite.dev/docs/",
   "bugs": "https://github.com/LTplus-AG/ifc-lite/issues",
   "keywords": [
     "ifc",

--- a/packages/wasm/README.md
+++ b/packages/wasm/README.md
@@ -101,7 +101,7 @@ This package ships the bindings only. The Rust source lives in [`rust/wasm-bindi
 
 ## API
 
-See the [WASM API Reference](https://ltplus-ag.github.io/ifc-lite/api/wasm/).
+See the [WASM API Reference](https://ifclite.dev/docs/api/wasm/).
 
 ## License
 

--- a/packages/wasm/package.json
+++ b/packages/wasm/package.json
@@ -43,6 +43,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "homepage": "https://ltplus-ag.github.io/ifc-lite/",
+  "homepage": "https://ifclite.dev/docs/",
   "bugs": "https://github.com/LTplus-AG/ifc-lite/issues"
 }


### PR DESCRIPTION
Final part of the docs program (#1676, #1681, #1687). The docs move onto the main domain: **https://ifclite.dev/docs/** (landing stays at the root, per the agreed layout).

## How it works

- The existing `ifclite.dev` Vercel project (static, root `apps/landing`) gains a build step: `build-docs.sh` assembles `dist/` = landing static files + the mkdocs site at `dist/docs`. Pure vercel.json config - no dashboard changes needed (the project already includes files outside the root directory).
- `ignoreCommand` skips the build for pushes that touch neither docs nor landing, keeping Vercel build minutes flat.
- `site_url` becomes `https://ifclite.dev/docs/` (apex is canonical; www 308s to it). The GitHub Pages workflow keeps publishing unchanged as a mirror - its canonicals now point at the new home, so search consolidates without breaking old links.
- Repo-wide sweep: all 76 files referencing `ltplus-ag.github.io/ifc-lite` (READMEs, docs cross-links, landing page, package.json `homepage` fields) now point at `ifclite.dev/docs`. One changeset patch-bumps all 36 published packages so the new links reach npm.
- Landing nav's Docs entry links straight to `/docs/`.

## Verified before opening this PR

- Cloud-built preview deployment (real `buildCommand` in Vercel's builder): landing `/`, `/docs/`, guide pages, assets, and the search index all 200; `/samples/*` files unaffected. The PEP 668 externally-managed-Python wrinkle in the build image is handled with a venv.
- Canonical URLs on built pages point at `https://ifclite.dev/docs/...`.
- `docs:check-samples`, `docs:check-generated`, `docs:check-readmes` (from #1687) all green after the sweep; `mkdocs build --strict` clean.
- Failure mode is safe: if a production build ever fails, the domain keeps serving the last good deployment.

## After merge

Production deploys automatically on the merge commit; I will verify `ifclite.dev/docs/` live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)