### PR TITLE
fix: review-session sweep - extract-entities integrity, KMZ altitude, IFCX scope chips + pinch pin

### DIFF
--- a/.changeset/extract-entities-closure-byte-fidelity.md
+++ b/.changeset/extract-entities-closure-byte-fidelity.md
@@ -1,0 +1,8 @@
+---
+"@ifc-lite/cli": patch
+---
+
+`extract-entities` fixes: void/fill relations now close over their own references (a
+relation-only OwnerHistory no longer leaves a dangling `#ref` in the subset), raw
+Latin-1 high bytes round-trip byte-identically instead of being mangled to U+FFFD,
+and files beyond the V8 string cap fail with a clear error instead of crashing.

--- a/apps/viewer/src/lib/geo/kmz-export.test.ts
+++ b/apps/viewer/src/lib/geo/kmz-export.test.ts
@@ -1,0 +1,31 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+
+import type { CoordinateInfo } from '@ifc-lite/geometry';
+
+import { computeKmzAltitude } from './kmz-export.js';
+
+describe('computeKmzAltitude', () => {
+  it('scales OrthogonalHeight from map units to metres (mm-CRS file is not 1000x off)', () => {
+    // OrthogonalHeight authored as 500000 mm with a mm map unit = 500 m MSL.
+    assert.strictEqual(computeKmzAltitude(500_000, { mapUnitScale: 0.001 }, 1, undefined), 500);
+  });
+
+  it('folds the wasm RTC Z offset back in (RTC-rebased models are not placed rtc.z too low)', () => {
+    // The COLLADA exporter bakes post-RTC mesh Z; the KML altitude must restore it.
+    const coordinateInfo = { wasmRtcOffset: { x: 0, y: 0, z: 417 } } as CoordinateInfo;
+    assert.strictEqual(computeKmzAltitude(100, undefined, 1, coordinateInfo), 517);
+  });
+
+  it('defaults to 0 with no OrthogonalHeight, CRS, or coordinate info', () => {
+    assert.strictEqual(computeKmzAltitude(undefined, undefined, 1, undefined), 0);
+  });
+
+  it('matches the pre-fix behaviour for the common metre-CRS, non-RTC model', () => {
+    assert.strictEqual(computeKmzAltitude(455.5, { mapUnitScale: 1 }, 1, {} as CoordinateInfo), 455.5);
+  });
+});

--- a/apps/viewer/src/lib/geo/kmz-export.ts
+++ b/apps/viewer/src/lib/geo/kmz-export.ts
@@ -8,9 +8,10 @@
  * both go through one georef → WGS84 → COLLADA KMZ path (#1427).
  */
 
-import { extractGeoreferencingOnDemand, extractLengthUnitScale, type IfcDataStore } from '@ifc-lite/parser';
-import type { GeometryResult, MeshData } from '@ifc-lite/geometry';
+import { extractGeoreferencingOnDemand, extractLengthUnitScale, type IfcDataStore, type ProjectedCRS } from '@ifc-lite/parser';
+import type { CoordinateInfo, GeometryResult, MeshData } from '@ifc-lite/geometry';
 import type { GeorefMutationData } from '@/store/slices/mutationSlice';
+import { getMapUnitScale } from './cesium-placement';
 import { mergeMapConversion, mergeProjectedCRS } from './effective-georef';
 import { reprojectToLatLon } from './reproject';
 import { buildKmz, type KmzAltitudeMode } from './kmz-exporter';
@@ -40,6 +41,24 @@ export interface BuildKmzInput {
 export type KmzBuildError = 'not-georeferenced' | 'unprojectable' | 'no-geometry';
 
 /**
+ * KML `<altitude>`: metres MSL of the model ORIGIN (ignored under clampToGround).
+ * OrthogonalHeight is authored in map units, not metres — a mm-CRS file was
+ * placed 1000x off — and when the wasm RTC rebase fired it subtracted its offset
+ * from every mesh Z the COLLADA exporter later bakes, so fold `rtc.z` back in.
+ * Mirrors `computeIfcOriginHeight` (cesium-placement.ts), minus the model-centre
+ * term: the .dae keeps geometry Z, whereas the Cesium GLB is re-centred.
+ */
+export function computeKmzAltitude(
+  orthogonalHeight: number | undefined,
+  crs: Pick<ProjectedCRS, 'mapUnitScale'> | undefined,
+  lengthUnitScale: number,
+  coordinateInfo: CoordinateInfo | undefined,
+): number {
+  const mapScale = getMapUnitScale(crs, lengthUnitScale);
+  return (orthogonalHeight ?? 0) * mapScale + (coordinateInfo?.wasmRtcOffset?.z ?? 0);
+}
+
+/**
  * Resolve a model's (merged) georeference to WGS84 and build a Google Earth KMZ
  * (a COLLADA model + KML placement). Returns the KMZ bytes, or a `KmzBuildError`
  * string when the model isn't georeferenced or its location can't be projected.
@@ -59,7 +78,12 @@ export async function buildKmzForModel(input: BuildKmzInput): Promise<Uint8Array
   if (!latLon) return 'unprojectable';
   return buildKmz({
     latLon,
-    altitude: conversion.orthogonalHeight ?? 0,
+    altitude: computeKmzAltitude(
+      conversion.orthogonalHeight,
+      crs,
+      scale,
+      input.geometryResult.coordinateInfo,
+    ),
     xAxisAbscissa: conversion.xAxisAbscissa,
     xAxisOrdinate: conversion.xAxisOrdinate,
     meshes: input.geometryResult.meshes as MeshData[],

--- a/apps/viewer/src/lib/lists/scope-types.test.ts
+++ b/apps/viewer/src/lib/lists/scope-types.test.ts
@@ -17,20 +17,15 @@ import { collectScopeTypes, isScopeTargetType, type ScopeTypeStore } from './sco
 /** [expressId, STEP type name, hasGeometry, isType] */
 type Row = [number, string, boolean?, boolean?];
 
-/** Build a minimal store (entity table + byType index) from a row list. */
+/** Build a minimal store (entity table only, like an IFCX ingest) from a row list. */
 function makeStore(rows: Row[]): ScopeTypeStore {
   const strings = new StringTable();
   const builder = new EntityTableBuilder(rows.length, strings);
-  const byType = new Map<string, number[]>();
   for (const [id, type, hasGeometry = false, isType = false] of rows) {
     builder.add(id, type, `guid-${id}`, `${type}-${id}`, '', '', hasGeometry, isType);
-    const upper = type.toUpperCase();
-    const bucket = byType.get(upper) ?? [];
-    bucket.push(id);
-    byType.set(upper, bucket);
   }
   const entities: EntityTable = builder.build();
-  return { entities, entityIndex: { byType } };
+  return { entities };
 }
 
 describe('collectScopeTypes (#1662)', () => {
@@ -96,6 +91,16 @@ describe('collectScopeTypes (#1662)', () => {
     const offered = collectScopeTypes([a, b]);
     const wall = offered.find((o) => o.type === IfcTypeEnum.IfcWall);
     assert.strictEqual(wall?.count, 3);
+  });
+
+  it('offers chips for IFCX-shaped stores whose entityIndex.byType is permanently empty (#1667 regression)', () => {
+    // buildIfcxDataStore creates `entityIndex: { byId: new Map(), byType: new Map() }`
+    // and never fills byType; the chips must come from the entity table itself.
+    const { entities } = makeStore([[1, 'IFCWALL', true], [2, 'IFCSPACE', true]]);
+    const ifcxShaped = { entities, entityIndex: { byId: new Map(), byType: new Map() } };
+    const types = new Set(collectScopeTypes([ifcxShaped]).map((o) => o.type));
+    assert.ok(types.has(IfcTypeEnum.IfcWall), 'IFCX store must still offer Walls');
+    assert.ok(types.has(IfcTypeEnum.IfcSpace), 'IFCX store must still offer Spaces');
   });
 
   it('predicate rejects the non-element categories directly', () => {

--- a/apps/viewer/src/lib/lists/scope-types.ts
+++ b/apps/viewer/src/lib/lists/scope-types.ts
@@ -120,8 +120,7 @@ export function isScopeTargetType(type: IfcTypeEnum, name: string): boolean {
 
 /** The narrow store surface `collectScopeTypes` reads (full IfcDataStore assignable). */
 export interface ScopeTypeStore {
-  entities: Pick<EntityTable, 'getByType' | 'getTypeEnum' | 'getTypeName'>;
-  entityIndex: { byType: Map<string, number[]> };
+  entities: Pick<EntityTable, 'getByType' | 'getTypeName' | 'typeEnum'>;
 }
 
 /**
@@ -133,23 +132,25 @@ export function collectScopeTypes(stores: ScopeTypeStore[]): ScopeTypeOption[] {
   const byEnum = new Map<IfcTypeEnum, { label: string; count: number }>();
 
   for (const store of stores) {
-    // Dedupe per store: several STEP names can share one enum (IfcDoor +
-    // IfcDoorStandardCase), and getByType already merges them, so count once.
-    const counted = new Set<IfcTypeEnum>();
-    for (const ids of store.entityIndex.byType.values()) {
+    // Enumerate present classes from the EntityTable's typeEnum column: it is
+    // populated on every store shape, whereas entityIndex.byType stays
+    // permanently empty for IFCX-ingested stores (and typeRanges is deprecated
+    // on server-loaded ones) — driving the chips off byType left IFCX models
+    // with no scope chips at all. The Set also dedupes several STEP names that
+    // share one enum (IfcDoor + IfcDoorStandardCase), which getByType merges.
+    const present = new Set<IfcTypeEnum>();
+    const column = store.entities.typeEnum;
+    for (let i = 0; i < column.length; i++) present.add(column[i] as IfcTypeEnum);
+    for (const type of present) {
+      if (type === IfcTypeEnum.Unknown) continue;
+      const ids = store.entities.getByType(type);
       if (ids.length === 0) continue;
-      const sample = ids[0];
-      const type = store.entities.getTypeEnum(sample);
-      if (type === IfcTypeEnum.Unknown || counted.has(type)) continue;
-      counted.add(type);
-      const name = store.entities.getTypeName(sample);
+      const name = store.entities.getTypeName(ids[0]);
       if (!isScopeTargetType(type, name)) continue;
-      const count = store.entities.getByType(type).length;
-      if (count === 0) continue;
       const label = SCOPE_TYPE_LABELS[type] ?? name;
       const entry = byEnum.get(type);
-      if (entry) entry.count += count;
-      else byEnum.set(type, { label, count });
+      if (entry) entry.count += ids.length;
+      else byEnum.set(type, { label, count: ids.length });
     }
   }
 

--- a/packages/cli/src/commands/extract-entities.test.ts
+++ b/packages/cli/src/commands/extract-entities.test.ts
@@ -2,6 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+import { mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import {
   parseStep,
@@ -10,6 +13,7 @@ import {
   buildSubset,
   serializeSubset,
   scoreTriage,
+  extractEntitiesCommand,
 } from './extract-entities.js';
 
 // A tiny but representative model: project + units + geometric context + a
@@ -188,6 +192,55 @@ describe('buildSubset — voids and fills', () => {
     for (const m of out.matchAll(/^#(\d+)=/gm)) defined.add(Number(m[1]));
     const data = out.slice(out.indexOf('DATA;'));
     for (const m of data.matchAll(/#(\d+)/g)) expect(defined.has(Number(m[1]))).toBe(true);
+  });
+});
+
+// Variant where each relation carries a DEDICATED IfcOwnerHistory (#11/#12)
+// referenced by nothing else in the file. Closing over only the opening/filler
+// (instead of the relation itself) used to leave these dangling in the subset.
+const REL_OWNED_MODEL = VOID_MODEL.replace(
+  "#104= IFCRELVOIDSELEMENT('VOID00000000000000000X',$,$,$,#70,#103);",
+  "#11= IFCOWNERHISTORY(#13,#14,$,.NOCHANGE.,$,$,$,0);\n" +
+    "#13= IFCPERSONANDORGANIZATION(#15,#16,$);\n" +
+    "#15= IFCPERSON($,'p',$,$,$,$,$,$);\n" +
+    "#16= IFCORGANIZATION($,'o',$,$,$);\n" +
+    "#14= IFCAPPLICATION(#16,'1','app','app');\n" +
+    "#104= IFCRELVOIDSELEMENT('VOID00000000000000000X',#11,$,$,#70,#103);",
+).replace(
+  "#113= IFCRELFILLSELEMENT('FILL00000000000000000X',$,$,$,#103,#112);",
+  "#12= IFCOWNERHISTORY($,$,$,$,$,$,$,0);\n" +
+    "#113= IFCRELFILLSELEMENT('FILL00000000000000000X',#12,$,$,#103,#112);",
+);
+
+describe('buildSubset — void/fill relations close over their own refs', () => {
+  const p = parseStep(REL_OWNED_MODEL);
+  const keep = buildSubset(new Set([70]), p);
+
+  it('keeps a rel-only OwnerHistory (and its subtree) for both relation kinds', () => {
+    for (const id of [11, 13, 14, 15, 16, 12]) expect(keep.has(id)).toBe(true);
+  });
+
+  it('serializes with zero dangling references', () => {
+    const out = serializeSubset(keep, p);
+    const defined = new Set<number>();
+    for (const m of out.matchAll(/^#(\d+)=/gm)) defined.add(Number(m[1]));
+    const data = out.slice(out.indexOf('DATA;'));
+    for (const m of data.matchAll(/#(\d+)/g)) expect(defined.has(Number(m[1]))).toBe(true);
+  });
+});
+
+describe('extract-entities byte fidelity', () => {
+  it('round-trips raw Latin-1 high bytes unchanged (no U+FFFD mangling)', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'ifc-extract-'));
+    const src = join(dir, 'in.ifc');
+    const out = join(dir, 'sub.ifc');
+    // 0xFC ('ü' in Latin-1) is an invalid standalone UTF-8 byte; real-world
+    // exports carry such raw bytes and must survive extraction untouched.
+    await writeFile(src, Buffer.from(VOID_MODEL.replace("'Wall'", "'Türwand'"), 'latin1'));
+    await extractEntitiesCommand([src, '--product', '#70', '--out', out]);
+    const bytes = await readFile(out);
+    expect(bytes.includes(Buffer.from([0xfc]))).toBe(true);
+    expect(bytes.includes(Buffer.from([0xef, 0xbf, 0xbd]))).toBe(false); // U+FFFD
   });
 });
 

--- a/packages/cli/src/commands/extract-entities.ts
+++ b/packages/cli/src/commands/extract-entities.ts
@@ -24,6 +24,7 @@
  * heuristics (oversized AABB, needle/burst triangulation) that are frequently
  * legitimate for thin or large elements and must be eyeballed, not trusted.
  */
+import { constants as bufferConstants } from 'node:buffer';
 import { readFile, writeFile } from 'node:fs/promises';
 import { basename } from 'node:path';
 import { fatal, getFlag, getAllFlags, hasFlag } from '../output.js';
@@ -281,8 +282,9 @@ export function buildSubset(seedProducts: Set<number>, parsed: ParsedStep): Set<
         const host = refs[refs.length - 2];
         const opening = refs[refs.length - 1];
         if (host !== undefined && opening !== undefined && keep.has(host)) {
-          keep.add(inst.id);
-          forwardClosure([opening], parsed, keep);
+          // Close over the relation itself, not just the opening: the rel's own
+          // OwnerHistory must be kept too or the subset emits a dangling ref.
+          forwardClosure([inst.id], parsed, keep);
           grew = true;
         }
       } else if (inst.type === 'IFCRELFILLSELEMENT') {
@@ -290,8 +292,7 @@ export function buildSubset(seedProducts: Set<number>, parsed: ParsedStep): Set<
         const opening = refs[refs.length - 2];
         const filler = refs[refs.length - 1];
         if (opening !== undefined && filler !== undefined && keep.has(opening)) {
-          keep.add(inst.id);
-          forwardClosure([filler], parsed, keep);
+          forwardClosure([inst.id], parsed, keep);
           grew = true;
         }
       }
@@ -407,7 +408,18 @@ export async function extractEntitiesCommand(args: string[]): Promise<void> {
   }
 
   const buf = await readFile(filePath);
-  const text = buf.toString('utf8');
+  if (buf.length >= bufferConstants.MAX_STRING_LENGTH) {
+    fatal(
+      `File is too large to extract from (${buf.length} bytes >= V8 string cap); ` +
+        'split it first or file an issue if you hit this on a real model.',
+    );
+    return;
+  }
+  // latin1 is a lossless byte<->char bijection: STEP tokenization is ASCII-only,
+  // and re-emitting `full` through latin1 round-trips raw high bytes (unescaped
+  // umlauts in real-world exports) byte-identically where utf8 would mangle
+  // them to U+FFFD.
+  const text = buf.toString('latin1');
   const parsed = parseStep(text);
   logger.info(`Parsed ${parsed.instances.size} STEP instances from ${basename(filePath)}`);
 
@@ -480,7 +492,7 @@ export async function extractEntitiesCommand(args: string[]): Promise<void> {
 
   const keep = buildSubset(seeds, parsed);
   const out = serializeSubset(keep, parsed);
-  await writeFile(outPath, out);
+  await writeFile(outPath, out, 'latin1');
   process.stdout.write(
     `Extracted ${seeds.size} product(s) → ${keep.size} instances → ${outPath}\n`,
   );

--- a/rust/geometry/src/kernel/mod.rs
+++ b/rust/geometry/src/kernel/mod.rs
@@ -34,6 +34,8 @@ pub mod retriangulate;
 mod retriangulate_audit;
 mod retriangulate_cleanup;
 mod retriangulate_recover;
+#[cfg(test)]
+mod retriangulate_recover_tests;
 pub mod tritri;
 
 /// Three-valued exact sign.

--- a/rust/geometry/src/kernel/retriangulate_recover_tests.rs
+++ b/rust/geometry/src/kernel/retriangulate_recover_tests.rs
@@ -1,0 +1,164 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Pins the figure-8 pinch capability of [`super::retriangulate_recover`]
+//! (#1660, ISSUE_098 dense faceted-BREP reveal walls).
+//!
+//! When a constraint segment's crossed-triangle channel transits the same
+//! vertex's star twice (a "W"-shaped link with a kept island between the
+//! lobes), `recover_via_traversal` pushes that vertex into a boundary chain
+//! TWICE. That duplicate push is load-bearing, not a bug: the chain is an
+//! edge-path that self-touches (never self-crosses), the sub-loop between the
+//! twin pushes encodes the kept island as a hole, and earcut's Vid-identity
+//! ear test tiles pocket-minus-island exactly. A well-meaning "bail when the
+//! apex is already in the chain" hardening would fail exactly the dense
+//! reveal-wall family the traversal was added for — this test fails under
+//! that change (`edge_exists` assert), under any fallback that emits
+//! Vid-degenerate triangles, and under any overlap/hole in the rebuilt cover
+//! (exact BigRational area + directed-edge uniqueness, no tolerances).
+
+use super::interner::{Interner, Vid};
+use super::rational::{point_of, tri_area2};
+use super::retriangulate::{edge_exists, orient2d_v, tri_edges, Mesh2d, SubTri};
+use super::retriangulate_recover::{recover_subsegment, recover_via_traversal};
+use super::{DropAxis, ImplicitPoint, Sign};
+use num_rational::BigRational;
+use num_traits::Zero;
+use std::collections::BTreeMap;
+
+fn e2(x: f64, y: f64) -> ImplicitPoint {
+    ImplicitPoint::Explicit([x, y, 0.0])
+}
+
+/// Segment a=(0,0)->b=(10,0). Vertex p=(5,2) sits above the line with a
+/// "W"-shaped star: two lobes of its fan dip below y=0 (via link verts
+/// L2=(2.5,-1) and L4=(7.5,-1)) with a kept island triangle (p,y1,y2)
+/// (y1=(4,.5), y2=(6,.5), all three above the line) between them. The
+/// ordered Sloan walk transits p's star TWICE, so apex `p` is pushed into
+/// `upper` twice — the figure-8 pinch configuration.
+fn pinch_mesh(it: &mut Interner) -> (Mesh2d, Vid, Vid) {
+    let a = it.intern(e2(0.0, 0.0));
+    let b = it.intern(e2(10.0, 0.0));
+    let p = it.intern(e2(5.0, 2.0));
+    let l1 = it.intern(e2(2.0, 1.0));
+    let l2 = it.intern(e2(2.5, -1.0));
+    let y1 = it.intern(e2(4.0, 0.5));
+    let y2 = it.intern(e2(6.0, 0.5));
+    let l4 = it.intern(e2(7.5, -1.0));
+    let l5 = it.intern(e2(8.0, 1.0));
+    let l6 = it.intern(e2(5.0, 4.0));
+    let b1 = it.intern(e2(3.0, -3.0));
+    let b2 = it.intern(e2(7.0, -3.0));
+    let tris: Vec<SubTri> = vec![
+        // star of p (link L6,L1,L2,y1,y2,L4,L5 — CCW around p)
+        [p, l6, l1],
+        [p, l1, l2],
+        [p, l2, y1],
+        [p, y1, y2], // the island: all verts above y=0 => NOT crossed => kept
+        [p, y2, l4],
+        [p, l4, l5],
+        [p, l5, l6],
+        // region between the star and the outer boundary
+        [a, l2, l1],
+        [a, b1, l2],
+        [b1, y1, l2],
+        [b1, y2, y1],
+        [b1, b2, y2],
+        [b2, l4, y2],
+        [b2, b, l4],
+        [b, l5, l4],
+    ];
+    let mesh = Mesh2d {
+        tris,
+        axis: DropAxis::Z,
+        w0: Sign::Positive,
+        unrecovered: 0,
+        audit_needed: false,
+        coords: BTreeMap::new(),
+    };
+    (mesh, a, b)
+}
+
+fn area_sum(it: &Interner, tris: &[SubTri], axis: DropAxis) -> BigRational {
+    let pt = |v: Vid| point_of(it.get(v));
+    tris.iter().fold(BigRational::zero(), |acc, &t| {
+        acc + tri_area2(&pt(t[0]), &pt(t[1]), &pt(t[2]), axis)
+    })
+}
+
+#[test]
+fn traversal_recovers_figure8_pinch_with_exact_coverage() {
+    let mut it = Interner::new();
+    let (mut mesh, a, b) = pinch_mesh(&mut it);
+    let axis = mesh.axis;
+    let w0 = mesh.w0;
+    let before = area_sum(&it, &mesh.tris, axis);
+    assert!(
+        !edge_exists(&mesh, a, b),
+        "precondition: a-b not yet an edge"
+    );
+
+    // Routing sanity: the pocket-split boundary walk must BAIL on this pinch
+    // (its next-map collapses p's two successors) and request the audit —
+    // that bail is what routes the real pipeline into recover_via_traversal.
+    let mut probe = Mesh2d {
+        tris: mesh.tris.clone(),
+        axis,
+        w0,
+        unrecovered: 0,
+        audit_needed: false,
+        coords: BTreeMap::new(),
+    };
+    recover_subsegment(&mut probe, &it, a, b);
+    assert!(
+        !edge_exists(&probe, a, b),
+        "expected the pocket-split boundary walk to bail on the pinch"
+    );
+    assert!(
+        probe.audit_needed,
+        "bailing recover_subsegment must request the audit"
+    );
+
+    recover_via_traversal(&mut mesh, &it, a, b);
+
+    // Genuine recovery, not a degenerate-triangle artifact.
+    assert!(edge_exists(&mesh, a, b), "traversal failed to recover a-b");
+    // No Vid-degenerate triangles like [p, x, p].
+    for t in &mesh.tris {
+        assert!(
+            t[0] != t[1] && t[1] != t[2] && t[0] != t[2],
+            "Vid-degenerate triangle emitted: {t:?}"
+        );
+    }
+    // Every output triangle wound w0.
+    for &t in &mesh.tris {
+        assert_eq!(
+            orient2d_v(&it, t[0], t[1], t[2], axis),
+            w0,
+            "triangle not oriented w0: {t:?}"
+        );
+    }
+    // Exact coverage: signed 2-area conserved (BigRational, no tolerance).
+    let after = area_sum(&it, &mesh.tris, axis);
+    assert_eq!(
+        after, before,
+        "coverage changed: overlap or hole in the rebuilt pocket"
+    );
+    // Stronger: no directed edge appears twice (two triangles on the same
+    // side of an edge would mean overlapping cover).
+    let mut directed: Vec<(Vid, Vid)> = Vec::new();
+    for &t in &mesh.tris {
+        for e in tri_edges(t) {
+            directed.push(e);
+        }
+    }
+    let n = directed.len();
+    directed.sort_unstable();
+    directed.dedup();
+    assert_eq!(
+        directed.len(),
+        n,
+        "a directed edge appears twice: overlapping triangles"
+    );
+}


### PR DESCRIPTION
Full review session over the 33 substantive commits merged since 2026-07-06 (void-cut CDT repairs #1658/#1660, FixedInt exact predicates #1675, CATIA walls #1673, multi-item instancing #1641, parser multi-line typed values #1664, malformed-input hardening #1645/#1649, processing perf #1646-#1648, KMZ #1430, extract-entities #1656, viewer features #1667/#1670/#1672/#1674/#1679). Every finding was adversarially verified (refute-first, with live repros) before any fix; every fix carries a regression test demonstrated to fail on the pre-fix code.

## Confirmed and fixed

**1. `extract-entities` (#1656) - three bugs (`fix(cli)`)**
- Void/fill relations were added with `keep.add` + closure over only the opening/filler, so a relation-only `IfcOwnerHistory` left a dangling `#ref` in the emitted subset (reproduced: `dangling refs: 11`). Now `forwardClosure([inst.id], ...)` closes over the relation itself.
- The whole-file `buf.toString('utf8')` mangled raw Latin-1 high bytes (unescaped umlauts) to U+FFFD on re-emission, breaking the "re-emitted unchanged" contract (reproduced byte diff: `54 fc 72` -> `54 ef bf bd 72`). Now latin1 in/out - a lossless byte<->char bijection; STEP tokenization is ASCII-only.
- Same decode crashed with `ERR_STRING_TOO_LONG` at the ~512MiB V8 string cap - unique to this command (every other CLI command hands `Uint8Array` subranges to the parser). Now fails loudly with guidance.

**2. KMZ absolute-mode altitude (#1430) - `fix(viewer)`**
`<altitude>` passed raw `OrthogonalHeight`: a mm-map-unit CRS placed the model 1000x off, and when the wasm RTC rebase fired, the subtracted `rtc.z` was never restored (model too low). Extracted `computeKmzAltitude` mirroring `computeIfcOriginHeight` minus the model-centre term (the .dae keeps geometry Z; the Cesium GLB is re-centred). `clampToGround` (the default) ignores `<altitude>`, so its behaviour is unchanged. No geoid interaction with #1456: KML absolute mode expects EGM96 MSL, so orthometric heights are already correct there.

**3. IFCX scope chips (#1667 regression) - `fix(lists)`**
`collectScopeTypes` iterated `entityIndex.byType`, which IFCX-ingested stores never populate (their `idsByType` is a local closure feeding only the `getEntitiesByType` override) - New List scope chips vanished entirely for .ifcx/IFC5 models, where the pre-#1667 provider-based path worked. Now enumerates the `EntityTable.typeEnum` column, populated on every store shape. `typeRanges` deliberately avoided (serverDataModel pins it to an empty deprecated Map). Verified with a live repro: old code chips > 0, new code = 0 on an IFCX-shaped store; fixed code correct on both shapes.

**4. Figure-8 pinch in `recover_via_traversal` (#1660) - finding REFUTED, behaviour pinned (`test(geometry)`)**
Review flagged the traversal's unconditional apex push as a corruption risk (duplicate vertex -> non-simple ring -> earcut fan fallback). Adversarial verification confirmed the walk CAN revisit a vertex (constructed W-star mesh, instrumented revisit) but proved the output stays exact: BigRational area conservation, no Vid-degenerate triangles, no duplicated directed edges, all triangles w0-wound. The duplicate push is the designed encoding of a kept island between channel lobes - a "bail on duplicate" hardening would regress the dense faceted-reveal walls #1660 fixed. Added `retriangulate_recover_tests.rs` pinning this: it fails under that bail, under degenerate-triangle fallbacks, and under any overlap/hole, and asserts `recover_subsegment` bails on the same input with `audit_needed` set (the routing precondition).

## Verified clean (no action)

FixedInt exact-predicate rewrite #1675 (limb carries, MIN-boundary narrowing, sign handling, i64/f64 conversions all sound; differentially fuzzed), constraint-drop tolerance + bit-exact cutter weld #1658, volume-safe batch budget #1660, CATIA blank-RepresentationType veto + edge-curve samplers #1673, multi-item instancing compose order #1641, flap-clip pad clamp #1643, parser multi-line typed values #1664 (quote-aware splitter can't desync), material-layer span index #1648, lazy space/zone psets #1646 (byte-identical demand path), bulk entity-index export #1647, hardening caps #1645/#1649 (all far above legitimate model sizes), mimalloc pin #1632, geo XYZ measure + async lat/lon #1674/#1679 (origin folding + stale-async guard correct), regex preview #1670 (try/caught compile, no per-keystroke rescan), GROUPS selection wiring #1672, glTF emissive byte-parity #1430.

## Flagged, not changed (design decisions for follow-up)

- **KMZ clampToGround + baked-in absolute Z**: a model with horizontal georef via MapConversion but vertical datum baked into geometry Z (<10km, so RTC never rescues it) floats by that Z in the default mode - the vertical analog of the #1427 horizontal offset. The current behaviour is deliberate and documented (project-zero on terrain, basements below); silently rebasing by min-Z would break that. Options if wanted: a UI hint recommending "True elevation" when min-Z is implausibly high, or a threshold-gated rebase.
- **GROUPS tab is empty for IFCX models**: `buildGroupTree` and `extractGroupMembersOnDemand` need `entityIndex.byType`/`byId` and relationship edges that the IFCX ingest never builds - a multi-layer new-feature gap (#1672 is new in this window), not a regression; needs its own work item.

## Testing

- New regression tests proven to fail pre-fix: extract-entities 3/3, scope-types 5/6 suite failures on old code; KMZ altitude asserts values the old code cannot produce.
- Full suites green: cargo workspace (all crates, fixtures staged), packages/cli vitest 156/156, apps/viewer 1542 pass / 0 fail, viewer tsc clean, module-size ratchet passes (test file is `_tests.rs`-exempt; `kernel/mod.rs` +2 lines).
- Rebased onto latest main (post #1683/#1687/#1456/#1684/#1680) and re-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
