### PR TITLE
fix(viewer): measure controls collision + geo toggle discoverability + hierarchy tab fit + toolbar a11y

### DIFF
--- a/apps/viewer/src/components/viewer/HierarchyPanel.tsx
+++ b/apps/viewer/src/components/viewer/HierarchyPanel.tsx
@@ -804,7 +804,7 @@ export function HierarchyPanel() {
   // Multi-model layout with resizable split
   // Grouping mode toggle component (shared by both layouts)
   const groupingToggle = (
-    <div className="flex gap-1 mt-2">
+    <div className="hierarchy-grouping-tabs flex gap-1 mt-2">
       <Button
         variant={groupingMode === 'spatial' ? 'default' : 'outline'}
         size="sm"

--- a/apps/viewer/src/components/viewer/MainToolbar.tsx
+++ b/apps/viewer/src/components/viewer/MainToolbar.tsx
@@ -142,6 +142,8 @@ function ToolButton({
         <Button
           variant={isActive ? 'default' : 'ghost'}
           size="icon-sm"
+          aria-label={label}
+          aria-pressed={isActive}
           onClick={(e) => {
             // Blur button to close tooltip after click
             (e.currentTarget as HTMLButtonElement).blur();
@@ -274,6 +276,7 @@ function ActionButton({ icon: Icon, label, onClick, shortcut, disabled }: Action
         <Button
           variant="ghost"
           size="icon-sm"
+          aria-label={label}
           onClick={(e) => {
             // Blur button to close tooltip after click
             (e.currentTarget as HTMLButtonElement).blur();
@@ -940,6 +943,7 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
           <Button
             variant="ghost"
             size="icon-sm"
+            aria-label="Open IFC file"
             onClick={(e) => {
               // Blur button to close tooltip before opening file dialog
               (e.currentTarget as HTMLButtonElement).blur();
@@ -984,6 +988,7 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
             <Button
               variant="ghost"
               size="icon-sm"
+              aria-label="Add model to scene"
               onClick={(e) => {
                 (e.currentTarget as HTMLButtonElement).blur();
                 void handleAddModelClick();
@@ -1003,7 +1008,7 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
           {/* Gate on any loaded model, not the legacy single-model geometryResult:
               federated / multi-model sessions populate `models` but leave
               geometryResult null, which would hide the whole export menu (incl. KMZ). */}
-          <Button variant="ghost" size="icon-sm" disabled={!hasModelsLoaded && !ifcDataStore}>
+          <Button variant="ghost" size="icon-sm" aria-label="Export and download" disabled={!hasModelsLoaded && !ifcDataStore}>
             <Download className="h-4 w-4" />
           </Button>
         </DropdownMenuTrigger>
@@ -1085,7 +1090,7 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
         <Tooltip>
           <TooltipTrigger asChild>
             <DropdownMenuTrigger asChild>
-              <Button variant="ghost" size="icon-sm" disabled={!ifcDataStore}>
+              <Button variant="ghost" size="icon-sm" aria-label="Edit properties" disabled={!ifcDataStore}>
                 <Pencil className="h-4 w-4" />
               </Button>
             </DropdownMenuTrigger>
@@ -1352,6 +1357,8 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
           <Button
             variant={basketPresentationVisible ? 'default' : 'ghost'}
             size="icon-sm"
+            aria-label={basketPresentationVisible ? 'Hide Presentation dock' : 'Show Presentation dock'}
+            aria-pressed={basketPresentationVisible}
             onClick={(e) => {
               (e.currentTarget as HTMLButtonElement).blur();
               toggleBasketPresentationVisible();
@@ -1831,6 +1838,7 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
               variant="ghost"
               size="icon"
               className="rounded-full"
+              aria-label="Info and keyboard shortcuts"
               onClick={() => onShowShortcuts?.()}
             >
               <HelpCircle className="!h-[22px] !w-[22px]" />

--- a/apps/viewer/src/components/viewer/ViewportOverlays.tsx
+++ b/apps/viewer/src/components/viewer/ViewportOverlays.tsx
@@ -157,7 +157,7 @@ export function ViewportOverlays({ hideViewCube = false }: { hideViewCube?: bool
         >
           <Tooltip>
             <TooltipTrigger asChild>
-              <Button variant="ghost" size="icon-sm" className={cn(isMobile && 'min-h-[44px] min-w-[44px]')} onClick={handleHome}>
+              <Button variant="ghost" size="icon-sm" aria-label="Home view" className={cn(isMobile && 'min-h-[44px] min-w-[44px]')} onClick={handleHome}>
                 <Home className={cn(isMobile ? 'h-5 w-5' : 'h-4 w-4')} />
               </Button>
             </TooltipTrigger>
@@ -166,7 +166,7 @@ export function ViewportOverlays({ hideViewCube = false }: { hideViewCube?: bool
 
           <Tooltip>
             <TooltipTrigger asChild>
-              <Button variant="ghost" size="icon-sm" className={cn(isMobile && 'min-h-[44px] min-w-[44px]')} onClick={handleZoomIn}>
+              <Button variant="ghost" size="icon-sm" aria-label="Zoom in" className={cn(isMobile && 'min-h-[44px] min-w-[44px]')} onClick={handleZoomIn}>
                 <ZoomIn className={cn(isMobile ? 'h-5 w-5' : 'h-4 w-4')} />
               </Button>
             </TooltipTrigger>
@@ -175,7 +175,7 @@ export function ViewportOverlays({ hideViewCube = false }: { hideViewCube?: bool
 
           <Tooltip>
             <TooltipTrigger asChild>
-              <Button variant="ghost" size="icon-sm" className={cn(isMobile && 'min-h-[44px] min-w-[44px]')} onClick={handleZoomOut}>
+              <Button variant="ghost" size="icon-sm" aria-label="Zoom out" className={cn(isMobile && 'min-h-[44px] min-w-[44px]')} onClick={handleZoomOut}>
                 <ZoomOut className={cn(isMobile ? 'h-5 w-5' : 'h-4 w-4')} />
               </Button>
             </TooltipTrigger>

--- a/apps/viewer/src/components/viewer/hierarchy/HierarchyNode.tsx
+++ b/apps/viewer/src/components/viewer/hierarchy/HierarchyNode.tsx
@@ -138,6 +138,7 @@ export function HierarchyNode({
                   e.stopPropagation();
                   onModelVisibilityToggle(modelId, e);
                 }}
+                aria-label={modelVisible ? `Hide model ${node.name}` : `Show model ${node.name}`}
                 className="p-0.5 opacity-0 group-hover:opacity-100 transition-opacity"
               >
                 {modelVisible ? (
@@ -160,6 +161,7 @@ export function HierarchyNode({
                     e.stopPropagation();
                     onRemoveModel(modelId, e);
                   }}
+                  aria-label={`Remove model ${node.name}`}
                   className="p-0.5 opacity-0 group-hover:opacity-100 transition-opacity"
                 >
                   <X className="h-3.5 w-3.5 text-zinc-400 hover:text-red-500" />
@@ -225,6 +227,8 @@ export function HierarchyNode({
               e.stopPropagation();
               onToggleExpand(node.id);
             }}
+            aria-label={node.isExpanded ? `Collapse ${node.name}` : `Expand ${node.name}`}
+            aria-expanded={node.isExpanded}
             className="p-0.5 hover:bg-zinc-200 dark:hover:bg-zinc-700 rounded-none mr-1"
           >
             <ChevronRight
@@ -247,6 +251,7 @@ export function HierarchyNode({
                   e.stopPropagation();
                   onVisibilityToggle(node);
                 }}
+                aria-label={node.isVisible ? `Hide ${node.name}` : `Show ${node.name}`}
                 className={cn(
                   'p-0.5 opacity-0 group-hover:opacity-100 transition-opacity mr-1',
                   nodeHidden && 'opacity-100'

--- a/apps/viewer/src/components/viewer/tools/MeasurePanel.tsx
+++ b/apps/viewer/src/components/viewer/tools/MeasurePanel.tsx
@@ -196,6 +196,19 @@ export function MeasureOverlay() {
   const panelRef = React.useRef<HTMLDivElement>(null);
   const drag = useDraggablePanel(panelRef);
 
+  // The Presentation dock (BasketPresentationDock) pins a persistent pill at
+  // `bottom-4 z-30 left-1/2` and, when expanded, a tall card at the same
+  // anchor. The measure hint + live readout sit ABOVE that anchor; their
+  // bottom offset steps up while the dock is visible so neither ever overlaps
+  // it. Mirrors the storey-name pill's bottom-4 -> bottom-28 shift in
+  // ViewportOverlays. The Snap / Geo toggles used to live at this same
+  // `bottom-4 left-1/2` anchor and collided with the pill outright (measured:
+  // Presentation x 592-716 over Snap 567-633 + Geo XYZ 641-742); they now live
+  // inside the draggable panel below, well clear of the bottom strip.
+  const basketPresentationVisible = useViewerStore((s) => s.basketPresentationVisible);
+  const hintBottomClass = basketPresentationVisible ? 'bottom-32' : 'bottom-16';
+  const readoutBottomClass = basketPresentationVisible ? 'bottom-44' : 'bottom-28';
+
   return (
     <>
       {/* Hidden ref element for coordinate calculation */}
@@ -237,6 +250,44 @@ export function MeasureOverlay() {
           </div>
         </div>
 
+        {/* Snap + Geo toggles — live INSIDE the panel (top-anchored, draggable)
+            so they clear the persistent Presentation pill at bottom-4. Always
+            rendered, whether the panel is collapsed or expanded, so the
+            controls are never hidden. */}
+        <div className="flex items-center gap-1.5 border-t px-2 py-2">
+          <button
+            onClick={toggleSnap}
+            className={`px-2 py-1 font-mono text-[10px] uppercase tracking-wider border-2 transition-colors ${
+              snapEnabled
+                ? 'bg-primary text-primary-foreground border-primary'
+                : 'bg-zinc-100 dark:bg-zinc-900 text-zinc-500 border-zinc-300 dark:border-zinc-700'
+            }`}
+            title="Toggle snap (S key)"
+          >
+            Snap {snapEnabled ? 'On' : 'Off'}
+          </button>
+          {/* Geo XYZ stays visible even with no usable georef so the feature is
+              discoverable; it disables with an explanatory tooltip instead of
+              vanishing (defect: users could not tell the feature existed). */}
+          <button
+            onClick={toggleGeoReadout}
+            disabled={!anchor}
+            className={`flex items-center gap-1 px-2 py-1 font-mono text-[10px] uppercase tracking-wider border-2 transition-colors disabled:opacity-40 disabled:cursor-not-allowed ${
+              geoReadoutEnabled && anchor
+                ? 'bg-primary text-primary-foreground border-primary'
+                : 'bg-zinc-100 dark:bg-zinc-900 text-zinc-500 border-zinc-300 dark:border-zinc-700'
+            }`}
+            title={
+              anchor
+                ? 'Toggle real-world XYZ (Eastings / Northings / Height)'
+                : 'Requires map georeferencing (IfcMapConversion) in the model'
+            }
+          >
+            <Globe className="h-3 w-3" />
+            Geo XYZ {geoReadoutEnabled && anchor ? 'On' : 'Off'}
+          </button>
+        </div>
+
         {/* Expandable content */}
         {!isPanelCollapsed && (
           <div className="border-t px-2 pb-2 min-w-56">
@@ -269,7 +320,7 @@ export function MeasureOverlay() {
 
       {/* Instruction hint - brutalist style with snap-colored shadow */}
       <div
-        className="pointer-events-auto absolute bottom-16 left-1/2 -translate-x-1/2 z-30 bg-zinc-900 dark:bg-zinc-100 text-zinc-100 dark:text-zinc-900 px-3 py-1.5 border-2 border-zinc-900 dark:border-zinc-100 transition-shadow duration-150"
+        className={`pointer-events-auto absolute ${hintBottomClass} left-1/2 -translate-x-1/2 z-30 bg-zinc-900 dark:bg-zinc-100 text-zinc-100 dark:text-zinc-900 px-3 py-1.5 border-2 border-zinc-900 dark:border-zinc-100 transition-shadow duration-150`}
         style={{
           boxShadow: snapTarget
             ? `4px 4px 0px 0px ${
@@ -287,7 +338,7 @@ export function MeasureOverlay() {
 
       {/* Live real-world XYZ readout for the active / last point */}
       {liveEnh && anchor && (
-        <div className="pointer-events-none absolute bottom-28 left-1/2 -translate-x-1/2 z-30 bg-background/95 backdrop-blur-sm border-2 border-primary/60 px-3 py-1.5 shadow-lg max-w-[92vw] overflow-x-auto">
+        <div className={`pointer-events-none absolute ${readoutBottomClass} left-1/2 -translate-x-1/2 z-30 bg-background/95 backdrop-blur-sm border-2 border-primary/60 px-3 py-1.5 shadow-lg max-w-[92vw] overflow-x-auto`}>
           <div className="flex items-baseline gap-2">
             <Globe className="h-3 w-3 text-primary shrink-0 self-center" />
             <span className="font-mono text-[10px] uppercase tracking-wider text-primary shrink-0">
@@ -310,35 +361,6 @@ export function MeasureOverlay() {
           )}
         </div>
       )}
-
-      {/* Snap + Geo toggles - brutalist style */}
-      <div className="pointer-events-auto absolute bottom-4 left-1/2 -translate-x-1/2 z-30 flex items-center gap-2">
-        <button
-          onClick={toggleSnap}
-          className={`px-2 py-1 font-mono text-[10px] uppercase tracking-wider border-2 transition-colors ${
-            snapEnabled
-              ? 'bg-primary text-primary-foreground border-primary'
-              : 'bg-zinc-100 dark:bg-zinc-900 text-zinc-500 border-zinc-300 dark:border-zinc-700'
-          }`}
-          title="Toggle snap (S key)"
-        >
-          Snap {snapEnabled ? 'On' : 'Off'}
-        </button>
-        {anchor && (
-          <button
-            onClick={toggleGeoReadout}
-            className={`flex items-center gap-1 px-2 py-1 font-mono text-[10px] uppercase tracking-wider border-2 transition-colors ${
-              geoReadoutEnabled
-                ? 'bg-primary text-primary-foreground border-primary'
-                : 'bg-zinc-100 dark:bg-zinc-900 text-zinc-500 border-zinc-300 dark:border-zinc-700'
-            }`}
-            title="Toggle real-world XYZ (Eastings / Northings / Height)"
-          >
-            <Globe className="h-3 w-3" />
-            Geo XYZ {geoReadoutEnabled ? 'On' : 'Off'}
-          </button>
-        )}
-      </div>
 
       {/* Render measurement lines, labels, and snap indicators */}
       <MeasurementOverlays

--- a/apps/viewer/src/index.css
+++ b/apps/viewer/src/index.css
@@ -321,6 +321,25 @@ body {
   }
 }
 
+/* Hierarchy grouping row has 5 tabs (Spatial / Class / Type / Material /
+   Groups). Their full uppercase labels only fit above ~384px of panel width;
+   below that they truncate and overlap ("MATERIAGROUPS" at the default
+   sidebar width). Collapse to icon-only under the threshold — each button keeps
+   a `title` tooltip, so the meaning stays discoverable. The threshold sits
+   above the default content pane (~22% of the row) so a normal or narrow
+   sidebar shows clean icons, and only a deliberately widened sidebar restores
+   the text labels. This is scoped to the hierarchy tabs so it never changes
+   the shared 200px panel-compact behaviour elsewhere. */
+@container (max-width: 384px) {
+  .hierarchy-grouping-tabs .panel-compact-icon {
+    display: inline;
+  }
+
+  .hierarchy-grouping-tabs .panel-compact-text {
+    display: none;
+  }
+}
+
 /* Tab triggers */
 .tab-trigger {
   background-color: transparent !important;


### PR DESCRIPTION
Four UI/UX defects found by adversarial in-browser testing of the viewer on production. All verified in a real browser (localhost, chrome-devtools) with `getBoundingClientRect`, plus `tsc --noEmit`, the MeasurePanel/hierarchy/sidebar test suites (94 pass), and `vite build`.

## Defect 1 (HIGH) - Measure toggles collided with the Presentation pill
The Measure tool's Snap and Geo XYZ toggle pills rendered at `bottom-4 left-1/2 -translate-x-1/2 z-30` - the exact anchor of the persistent Presentation pill (`BasketPresentationDock`, same classes). Measured on prod:

| element | x range | y |
| --- | --- | --- |
| Presentation | 592-716 | bottom row |
| Snap | 567-633 | same row |
| Geo XYZ | 641-742 | same row |

The toggles were visually buried behind the pill and partly unclickable - which is why the controls "could not be seen".

**Fix:** move Snap and Geo XYZ INTO the draggable Measure panel as an always-visible controls row (present whether the panel is collapsed or expanded), top-anchored and well clear of the bottom strip. The instruction hint and live XYZ readout step their bottom offset up while the Presentation dock is visible (mirrors the storey-name pill's `bottom-4` to `bottom-28` shift), and the offset contract is documented in a comment next to the constants.

After the fix the toggles measure at y 122-149 (inside the top panel); the hint sits above the `Presentation` pill with no overlap.

## Defect 2 (HIGH) - Geo XYZ toggle was undiscoverable without georef
The toggle was hidden entirely when `hasUsableMapGeoref` was false, so users could not learn the feature existed or why it was missing.

**Fix:** always render the toggle while the Measure tool is active; disable it with the tooltip `Requires map georeferencing (IfcMapConversion) in the model` when unusable, unchanged behaviour when a georef exists. Verified: on a model without map conversion the toggle renders, is disabled, and shows that exact tooltip; on a georeferenced model it stays enabled and functional.

## Defect 3 (MEDIUM) - Hierarchy grouping tabs overflowed at default width
The `SPATIAL / CLASS / TYPE / MATERIAL / GROUPS` row truncated and overlapped ("MATERIAGROUPS") because five full uppercase labels need more room than the default sidebar pane provides.

**Fix:** a scoped container query (`.hierarchy-grouping-tabs`) collapses the row to icon-only below 384px - each button keeps its `title` tooltip so meaning stays discoverable - and restores clean labels above. Verified icon-only with no row overflow and no label clipping down to the minimum sidebar width, and clean labels with no clipping above the threshold. Scoped so the shared 200px panel-compact behaviour elsewhere is untouched.

## Defect 4 (LOW, a11y) - Icon-only buttons had no accessible name
Added `aria-label` (reusing existing tooltip text) to the toolbar tool/action buttons (`ToolButton`, `ActionButton`), Open / Add model / Export / Edit properties / Basket presentation / Info, the viewport Home / Zoom in / Zoom out controls, and the hierarchy expand / eye / remove buttons (with `aria-pressed` / `aria-expanded` where stateful). Verified zero icon-only buttons remain without an accessible name.

## Verification
- `npx tsc --noEmit` clean (rebuilt stale @ifc-lite/data + @ifc-lite/clash dists per the known worktree gotcha).
- MeasurePanel / hierarchy / sidebar test suites: 94 pass, 0 fail.
- `vite build` succeeds.
- All four fixes exercised in a live browser with measured rects.

No SpaceMouse files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)