### PR TITLE
feat(viewer): hint at True elevation when KMZ geometry carries baked-in absolute Z (#1427 follow-up)

### DIFF
--- a/apps/viewer/src/components/viewer/KmzExportDialog.tsx
+++ b/apps/viewer/src/components/viewer/KmzExportDialog.tsx
@@ -33,7 +33,7 @@ import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { useViewerStore } from '@/store';
 import { posthog } from '@/lib/analytics';
 import { toast } from '@/components/ui/toast';
-import { buildKmzForModel, type KmzBuildError } from '@/lib/geo/kmz-export';
+import { buildKmzForModel, kmzSuggestsAbsoluteAltitude, type KmzBuildError } from '@/lib/geo/kmz-export';
 import type { KmzAltitudeMode } from '@/lib/geo/kmz-exporter';
 import { downloadBlob, sanitizeFilename } from '@/lib/export/download';
 
@@ -93,6 +93,25 @@ export function KmzExportDialog({ trigger }: KmzExportDialogProps) {
     () => modelList.find((m) => m.id === selectedModelId) ?? modelList[0],
     [modelList, selectedModelId],
   );
+
+  // True when the model's elevation appears baked into geometry Z (min Z >> 0
+  // while the merged conversion's OrthogonalHeight is ~0): the clampToGround
+  // default pins project zero to the terrain and would float the building by
+  // that baked Z, so hint at "True elevation" instead (#1427 follow-up).
+  const suggestTrueElevation = useMemo(() => {
+    if (!open || !selectedModel) return false;
+    try {
+      return kmzSuggestsAbsoluteAltitude({
+        geometryResult: selectedModel.geometryResult,
+        dataStore: selectedModel.dataStore,
+        mutations: selectedModel.id === '__legacy__' ? undefined : georefMutations.get(selectedModel.id),
+      });
+    } catch (err) {
+      // A hint must never break the dialog — log and fall back to no hint.
+      console.debug('[kmz] altitude hint evaluation failed:', err);
+      return false;
+    }
+  }, [open, selectedModel, georefMutations]);
 
   const handleExport = useCallback(async () => {
     if (!selectedModel) return;
@@ -213,6 +232,12 @@ export function KmzExportDialog({ trigger }: KmzExportDialogProps) {
                   ? 'Drapes the model on the terrain so it never floats. Recommended.'
                   : "Places the model at its orthogonal height above sea level. Use only when the model's elevation is a true MSL value."}
               </p>
+              {altitudeMode === 'clampToGround' && suggestTrueElevation && (
+                <p className="text-xs text-amber-600 dark:text-amber-400">
+                  This model appears to carry absolute elevations in its geometry, so True
+                  elevation (MSL) will place it correctly here.
+                </p>
+              )}
             </div>
           </div>
 

--- a/apps/viewer/src/lib/geo/kmz-altitude-hint.test.ts
+++ b/apps/viewer/src/lib/geo/kmz-altitude-hint.test.ts
@@ -1,0 +1,148 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+
+import type { CoordinateInfo } from '@ifc-lite/geometry';
+import {
+  BAKED_MIN_Z_THRESHOLD_METERS,
+  NEAR_ZERO_ORTHOGONAL_HEIGHT_METERS,
+  modelMinZMeters,
+  shouldSuggestAbsoluteAltitude,
+  suggestAbsoluteAltitudeForKmz,
+} from './kmz-altitude-hint.js';
+
+/** CoordinateInfo with the required fields defaulted to identity. */
+function coordInfo(overrides: Partial<CoordinateInfo> = {}): CoordinateInfo {
+  return {
+    originShift: { x: 0, y: 0, z: 0 },
+    originalBounds: { min: { x: 0, y: 0, z: 0 }, max: { x: 10, y: 10, z: 10 } },
+    shiftedBounds: { min: { x: 0, y: 0, z: 0 }, max: { x: 10, y: 10, z: 10 } },
+    hasLargeCoordinates: false,
+    ...overrides,
+  };
+}
+
+describe('shouldSuggestAbsoluteAltitude', () => {
+  it('fires for a baked-MSL model: high min Z, no conversion elevation', () => {
+    // Swiss LN02 site around 500 m, OrthogonalHeight left at 0.
+    assert.strictEqual(shouldSuggestAbsoluteAltitude(500, 0), true);
+  });
+
+  it('is inclusive at the min-Z threshold and exclusive just below', () => {
+    assert.strictEqual(shouldSuggestAbsoluteAltitude(BAKED_MIN_Z_THRESHOLD_METERS, 0), true);
+    assert.strictEqual(shouldSuggestAbsoluteAltitude(BAKED_MIN_Z_THRESHOLD_METERS - 0.001, 0), false);
+  });
+
+  it('is exclusive at the orthogonal-height threshold, either sign', () => {
+    assert.strictEqual(shouldSuggestAbsoluteAltitude(500, NEAR_ZERO_ORTHOGONAL_HEIGHT_METERS), false);
+    assert.strictEqual(shouldSuggestAbsoluteAltitude(500, -NEAR_ZERO_ORTHOGONAL_HEIGHT_METERS), false);
+    assert.strictEqual(shouldSuggestAbsoluteAltitude(500, NEAR_ZERO_ORTHOGONAL_HEIGHT_METERS - 0.001), true);
+    assert.strictEqual(shouldSuggestAbsoluteAltitude(500, -(NEAR_ZERO_ORTHOGONAL_HEIGHT_METERS - 0.001)), true);
+  });
+
+  it('stays quiet for local-datum models (min Z near project zero)', () => {
+    assert.strictEqual(shouldSuggestAbsoluteAltitude(0, 0), false);
+    assert.strictEqual(shouldSuggestAbsoluteAltitude(-3.5, 0), false); // basement below zero
+  });
+
+  it('stays quiet when the conversion already carries the elevation', () => {
+    // OrthogonalHeight = 500: "True elevation" is a user choice, not a fix.
+    assert.strictEqual(shouldSuggestAbsoluteAltitude(500, 500), false);
+  });
+
+  it('rejects missing or non-finite inputs defensively', () => {
+    assert.strictEqual(shouldSuggestAbsoluteAltitude(null, 0), false);
+    assert.strictEqual(shouldSuggestAbsoluteAltitude(undefined, 0), false);
+    assert.strictEqual(shouldSuggestAbsoluteAltitude(NaN, 0), false);
+    assert.strictEqual(shouldSuggestAbsoluteAltitude(Infinity, 0), false);
+    assert.strictEqual(shouldSuggestAbsoluteAltitude(500, NaN), false);
+  });
+});
+
+describe('modelMinZMeters', () => {
+  it('reads the vertical minimum from the Y-up bounds', () => {
+    const info = coordInfo({
+      originalBounds: { min: { x: -5, y: 512.25, z: -5 }, max: { x: 5, y: 530, z: 5 } },
+    });
+    assert.strictEqual(modelMinZMeters(info), 512.25);
+  });
+
+  it('folds the origin shift back in', () => {
+    const info = coordInfo({
+      originalBounds: { min: { x: 0, y: 12.25, z: 0 }, max: { x: 5, y: 30, z: 5 } },
+      originShift: { x: 100, y: 500, z: -20 },
+    });
+    assert.strictEqual(modelMinZMeters(info), 512.25);
+  });
+
+  it('folds the wasm RTC offset back in (Z-up z is the vertical component)', () => {
+    // RTC rebase moved the geometry near the origin; the baked elevation lives
+    // in wasmRtcOffset.z (IFC Z-up), not in the bounds.
+    const info = coordInfo({
+      originalBounds: { min: { x: 0, y: 2, z: 0 }, max: { x: 5, y: 20, z: 5 } },
+      wasmRtcOffset: { x: 2600000, y: 1200000, z: 498 },
+      hasLargeCoordinates: true,
+    });
+    assert.strictEqual(modelMinZMeters(info), 500);
+  });
+
+  it('returns null without coordinate info or with non-finite bounds', () => {
+    assert.strictEqual(modelMinZMeters(undefined), null);
+    const bad = coordInfo({
+      originalBounds: { min: { x: 0, y: NaN, z: 0 }, max: { x: 5, y: 20, z: 5 } },
+    });
+    assert.strictEqual(modelMinZMeters(bad), null);
+  });
+});
+
+describe('suggestAbsoluteAltitudeForKmz', () => {
+  const highInfo = coordInfo({
+    originalBounds: { min: { x: 0, y: 512, z: 0 }, max: { x: 5, y: 530, z: 5 } },
+  });
+
+  it('fires for baked-Z geometry with a zero-height conversion', () => {
+    assert.strictEqual(
+      suggestAbsoluteAltitudeForKmz(highInfo, { orthogonalHeight: 0 }, undefined, 1),
+      true,
+    );
+  });
+
+  it('scales OrthogonalHeight from map units: 200 mm is still near zero', () => {
+    // Raw 200 >= 1, but with a millimetre map unit it is 0.2 m.
+    assert.strictEqual(
+      suggestAbsoluteAltitudeForKmz(highInfo, { orthogonalHeight: 200 }, { mapUnitScale: 0.001 }, 0.001),
+      true,
+    );
+  });
+
+  it('scales OrthogonalHeight from map units: 500000 mm carries the elevation', () => {
+    assert.strictEqual(
+      suggestAbsoluteAltitudeForKmz(highInfo, { orthogonalHeight: 500000 }, { mapUnitScale: 0.001 }, 0.001),
+      false,
+    );
+  });
+
+  it('folds the RTC offset before judging "implausibly high"', () => {
+    const rtcInfo = coordInfo({
+      originalBounds: { min: { x: 0, y: 2, z: 0 }, max: { x: 5, y: 20, z: 5 } },
+      wasmRtcOffset: { x: 2600000, y: 1200000, z: 498 },
+      hasLargeCoordinates: true,
+    });
+    assert.strictEqual(
+      suggestAbsoluteAltitudeForKmz(rtcInfo, { orthogonalHeight: 0 }, undefined, 1),
+      true,
+    );
+  });
+
+  it('stays quiet without a conversion or for low geometry', () => {
+    assert.strictEqual(suggestAbsoluteAltitudeForKmz(highInfo, undefined, undefined, 1), false);
+    const lowInfo = coordInfo();
+    assert.strictEqual(
+      suggestAbsoluteAltitudeForKmz(lowInfo, { orthogonalHeight: 0 }, undefined, 1),
+      false,
+    );
+  });
+});

--- a/apps/viewer/src/lib/geo/kmz-altitude-hint.ts
+++ b/apps/viewer/src/lib/geo/kmz-altitude-hint.ts
@@ -1,0 +1,96 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * KMZ altitude-mode hint (#1427 follow-up).
+ *
+ * The default KMZ placement (clampToGround) pins the model ORIGIN (project
+ * zero) to the terrain. Some models bake their vertical datum into geometry Z
+ * as absolute MSL elevations (e.g. Swiss LN02 sites around 500 m) while
+ * `IfcMapConversion.OrthogonalHeight` stays ~0 - clamping the origin then
+ * floats the whole building above the ground by that baked Z. Silently
+ * rebasing Z was rejected (it would surface basements and break the
+ * documented project-zero-on-terrain behaviour), so the export dialog instead
+ * HINTS that the existing "True elevation (MSL)" mode places such models
+ * correctly. This module holds the pure heuristic behind that hint.
+ */
+
+import type { CoordinateInfo } from '@ifc-lite/geometry';
+import type { MapConversion, ProjectedCRS } from '@ifc-lite/parser';
+import { getMapUnitScale } from './cesium-placement';
+
+/**
+ * Minimum geometry Z (metres, IFC world frame) at or above which the model's
+ * lowest point is implausibly high for a local "project zero" datum and reads
+ * as a baked-in absolute elevation instead. 100 m clears local-datum models
+ * (with the origin at project zero, even a tall building's LOWEST point stays
+ * near 0) while catching typical baked-MSL sites (e.g. Swiss LN02 ~400-800 m).
+ * Low-lying coastal sites slip through, but for those the float is small.
+ */
+export const BAKED_MIN_Z_THRESHOLD_METERS = 100;
+
+/**
+ * OrthogonalHeight magnitudes (metres) below this count as "the conversion
+ * carries no elevation" - i.e. the vertical datum is NOT in the georef, so a
+ * high geometry Z must be baked in.
+ */
+export const NEAR_ZERO_ORTHOGONAL_HEIGHT_METERS = 1;
+
+/**
+ * Lowest geometry Z of the model in metres, in the IFC world frame.
+ *
+ * `coordinateInfo.originalBounds` is in the renderer's Y-up frame (vertical =
+ * `y`) and has the origin shift and the wasm RTC offset subtracted, so both
+ * are folded back in - the exact reconstruction `computeModelCenterInIfcMeters`
+ * (reproject.ts) uses for the KMZ placement itself. The RTC offset is stored
+ * in IFC Z-up, so its `z` component is the vertical one.
+ */
+export function modelMinZMeters(coordinateInfo: CoordinateInfo | undefined): number | null {
+  const minY = coordinateInfo?.originalBounds?.min?.y;
+  if (minY === undefined || !Number.isFinite(minY)) return null;
+  const shiftY = coordinateInfo?.originShift?.y ?? 0;
+  const rtcYupY = coordinateInfo?.wasmRtcOffset?.z ?? 0;
+  const minZ = minY + shiftY + rtcYupY;
+  return Number.isFinite(minZ) ? minZ : null;
+}
+
+/**
+ * Whether the KMZ export dialog should recommend "True elevation (MSL)"
+ * (absolute) over the clampToGround default.
+ *
+ * Fires when the model's minimum Z is implausibly high for a local datum
+ * (>= {@link BAKED_MIN_Z_THRESHOLD_METERS}) AND the map conversion carries
+ * (near-)no elevation (|OrthogonalHeight| < {@link NEAR_ZERO_ORTHOGONAL_HEIGHT_METERS}):
+ * the elevation is baked into geometry, so clamping the origin to terrain
+ * would float the building by that Z. Both inputs are metres.
+ */
+export function shouldSuggestAbsoluteAltitude(
+  minZMeters: number | null | undefined,
+  orthogonalHeightMeters: number,
+): boolean {
+  if (minZMeters === null || minZMeters === undefined || !Number.isFinite(minZMeters)) return false;
+  if (!Number.isFinite(orthogonalHeightMeters)) return false;
+  return (
+    minZMeters >= BAKED_MIN_Z_THRESHOLD_METERS &&
+    Math.abs(orthogonalHeightMeters) < NEAR_ZERO_ORTHOGONAL_HEIGHT_METERS
+  );
+}
+
+/**
+ * {@link shouldSuggestAbsoluteAltitude} over a model's raw georef pieces:
+ * scales `OrthogonalHeight` from map units to metres with the same
+ * `getMapUnitScale` the placement math uses, and derives min Z from
+ * `coordinateInfo` via {@link modelMinZMeters}.
+ */
+export function suggestAbsoluteAltitudeForKmz(
+  coordinateInfo: CoordinateInfo | undefined,
+  conversion: Pick<MapConversion, 'orthogonalHeight'> | undefined,
+  projectedCRS: Pick<ProjectedCRS, 'mapUnitScale'> | undefined,
+  lengthUnitScale: number,
+): boolean {
+  if (!conversion) return false;
+  const orthogonalHeightMeters =
+    (conversion.orthogonalHeight ?? 0) * getMapUnitScale(projectedCRS, lengthUnitScale);
+  return shouldSuggestAbsoluteAltitude(modelMinZMeters(coordinateInfo), orthogonalHeightMeters);
+}

--- a/apps/viewer/src/lib/geo/kmz-export.ts
+++ b/apps/viewer/src/lib/geo/kmz-export.ts
@@ -15,6 +15,7 @@ import { getMapUnitScale } from './cesium-placement';
 import { mergeMapConversion, mergeProjectedCRS } from './effective-georef';
 import { reprojectToLatLon } from './reproject';
 import { buildKmz, type KmzAltitudeMode } from './kmz-exporter';
+import { suggestAbsoluteAltitudeForKmz } from './kmz-altitude-hint';
 
 /** True if the data store carries usable georeferencing (so a KMZ export can run). */
 export function modelHasGeoreference(dataStore: IfcDataStore | null | undefined): boolean {
@@ -56,6 +57,25 @@ export function computeKmzAltitude(
 ): number {
   const mapScale = getMapUnitScale(crs, lengthUnitScale);
   return (orthogonalHeight ?? 0) * mapScale + (coordinateInfo?.wasmRtcOffset?.z ?? 0);
+}
+
+/**
+ * Whether the KMZ dialog should hint at "True elevation (MSL)" for this model:
+ * true when the geometry's minimum Z is implausibly high for a local datum
+ * while the (merged) map conversion carries ~no OrthogonalHeight - i.e. the
+ * elevation is baked into geometry Z, so the clampToGround default would pin
+ * project zero to the terrain and float the building by that Z (#1427
+ * follow-up). Resolves the georef exactly like {@link buildKmzForModel}
+ * (mutations merged, map-unit scaled); cheap after the first call per store.
+ */
+export function kmzSuggestsAbsoluteAltitude(
+  input: Pick<BuildKmzInput, 'geometryResult' | 'dataStore' | 'mutations'>,
+): boolean {
+  const info = extractGeoreferencingOnDemand(input.dataStore);
+  const scale = extractLengthUnitScale(input.dataStore.source, input.dataStore.entityIndex) ?? 1;
+  const conversion = mergeMapConversion(info?.mapConversion, input.mutations?.mapConversion);
+  const crs = mergeProjectedCRS(info?.projectedCRS, input.mutations?.projectedCRS, scale);
+  return suggestAbsoluteAltitudeForKmz(input.geometryResult.coordinateInfo, conversion, crs, scale);
 }
 
 /**


### PR DESCRIPTION
## Problem

Review PR #1693 flagged this under "Flagged, not changed" (a design decision left for follow-up): the KMZ Google Earth export (#1427/#1430) defaults to `clampToGround`, which pins the model ORIGIN (project zero) to the terrain. For models whose vertical datum is baked into geometry Z - absolute MSL elevations, e.g. Swiss LN02 sites around 500 m - with horizontal georef via `IfcMapConversion`, `OrthogonalHeight` ~0, and |Z| < 10 km (so the wasm RTC rebase never fires), the default KMZ floats the whole building above the ground by that baked Z.

## Why no silent rebase

Rebasing Z automatically was rejected: it would surface basements above the terrain and break the documented project-zero-on-terrain behaviour that `clampToGround` promises. The existing "True elevation (MSL)" (`absolute`) mode already places these models correctly - the user just has no way to know they should pick it.

## Fix

A contextual hint, not a behaviour change. When the geometry suggests baked-in elevations and "Rest on ground" is selected, the KMZ export dialog shows one secondary-text line recommending "True elevation (MSL)". The default mode is unchanged, and nothing about the export itself changes.

Heuristic (`shouldSuggestAbsoluteAltitude`, pure and exported in `apps/viewer/src/lib/geo/kmz-altitude-hint.ts`):

- min geometry Z >= 100 m (implausibly high for a local "project zero" datum), AND
- |OrthogonalHeight| < 1 m after map-unit scaling (the conversion carries no elevation, so a high Z must be baked in).

Unit/frame handling:

- Min Z comes from `coordinateInfo.originalBounds.min.y` (renderer Y-up, metres) with `originShift.y` and the Z-up `wasmRtcOffset.z` folded back in - the same reconstruction `computeModelCenterInIfcMeters` uses for the KMZ placement itself, so a model whose baked elevation was absorbed by an RTC rebase is still judged on its true IFC Z.
- `OrthogonalHeight` is map units; it is scaled to metres with the same `getMapUnitScale` the placement math uses (a mm-map-unit file with a raw value of 200 counts as 0.2 m, i.e. still "near zero").

`kmzSuggestsAbsoluteAltitude` in `kmz-export.ts` resolves the georef exactly like `buildKmzForModel` (pending georef mutations merged, extraction cached per store), and the dialog evaluates it only while open, wrapped so a heuristic failure can never break the dialog.

## Testing

- New `kmz-altitude-hint.test.ts` (node:test): 15 tests covering threshold edges (inclusive at 100 m, exclusive at 1 m either sign), mm map-unit `OrthogonalHeight` scaling, origin-shift and RTC folds, and non-finite/missing-input defensiveness.
- Full viewer suite: 1564 tests, 0 fail (2 pre-existing skips).
- `tsc --noEmit` clean in `apps/viewer`.
- No render-level component test: the viewer has no component-test pattern (pure-logic node tests only), so no new framework was introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
