### PR TITLE
chore(docs): sweep the last old-docs links out of source strings

### DIFF
--- a/.changeset/docs-link-stragglers.md
+++ b/.changeset/docs-link-stragglers.md
@@ -1,0 +1,6 @@
+---
+'create-ifc-lite': patch
+'@ifc-lite/wasm': patch
+---
+
+Point the remaining old docs links at https://ifclite.dev/docs/: the project templates scaffolded by create-ifc-lite, and the committed wasm pkg README (wasm-pack's copy of the root README, refreshed to the current one).

--- a/apps/viewer/src/components/viewer/KeyboardShortcutsDialog.tsx
+++ b/apps/viewer/src/components/viewer/KeyboardShortcutsDialog.tsx
@@ -118,7 +118,7 @@ function AboutTab() {
           <ExternalLink className="h-3 w-3" />
         </a>
         <a
-          href="https://ltplus-ag.github.io/ifc-lite/"
+          href="https://ifclite.dev/docs/"
           target="_blank"
           rel="noopener noreferrer"
           className="flex items-center gap-1.5 text-muted-foreground hover:text-foreground transition-colors"
@@ -400,7 +400,7 @@ function ShortcutsTab() {
         </a>
         <span className="mx-1.5 opacity-40">·</span>
         <a
-          href="https://ltplus-ag.github.io/ifc-lite/"
+          href="https://ifclite.dev/docs/"
           target="_blank"
           rel="noopener noreferrer"
           className="underline-offset-2 hover:underline hover:text-primary transition-colors"

--- a/packages/create-ifc-lite/src/templates/babylonjs.ts
+++ b/packages/create-ifc-lite/src/templates/babylonjs.ts
@@ -274,6 +274,6 @@ Open http://localhost:3000 and drop an IFC file.
 
 ## Learn More
 
-- [IFC-Lite Documentation](https://ltplus-ag.github.io/ifc-lite/)
+- [IFC-Lite Documentation](https://ifclite.dev/docs/)
 `);
 }

--- a/packages/create-ifc-lite/src/templates/basic.ts
+++ b/packages/create-ifc-lite/src/templates/basic.ts
@@ -104,7 +104,7 @@ npm run parse ./your-model.ifc
 
 ## Learn More
 
-- [IFC-Lite Documentation](https://ltplus-ag.github.io/ifc-lite/)
-- [API Reference](https://ltplus-ag.github.io/ifc-lite/api/)
+- [IFC-Lite Documentation](https://ifclite.dev/docs/)
+- [API Reference](https://ifclite.dev/docs/api/)
 `);
 }

--- a/packages/create-ifc-lite/src/templates/react.ts
+++ b/packages/create-ifc-lite/src/templates/react.ts
@@ -586,8 +586,8 @@ Open the app in your browser and drop an IFC file onto the viewport.
 
 ## Learn More
 
-- [IFC-Lite Documentation](https://ltplus-ag.github.io/ifc-lite/)
-- [Rendering Guide](https://ltplus-ag.github.io/ifc-lite/guide/rendering/)
-- [Geometry Guide](https://ltplus-ag.github.io/ifc-lite/guide/geometry/)
+- [IFC-Lite Documentation](https://ifclite.dev/docs/)
+- [Rendering Guide](https://ifclite.dev/docs/guide/rendering/)
+- [Geometry Guide](https://ifclite.dev/docs/guide/geometry/)
 `);
 }

--- a/packages/create-ifc-lite/src/templates/server-native.ts
+++ b/packages/create-ifc-lite/src/templates/server-native.ts
@@ -412,7 +412,7 @@ npx create-ifc-lite my-app --template server
 
 ## Learn More
 
-- [IFC-Lite Documentation](https://ltplus-ag.github.io/ifc-lite/)
+- [IFC-Lite Documentation](https://ifclite.dev/docs/)
 - [GitHub Repository](https://github.com/LTplus-AG/ifc-lite)
 `);
 

--- a/packages/create-ifc-lite/src/templates/server.ts
+++ b/packages/create-ifc-lite/src/templates/server.ts
@@ -618,8 +618,8 @@ RUST_LOG=info
 
 ## Learn More
 
-- [IFC-Lite Documentation](https://ltplus-ag.github.io/ifc-lite/)
-- [Server API Reference](https://ltplus-ag.github.io/ifc-lite/api/server/)
+- [IFC-Lite Documentation](https://ifclite.dev/docs/)
+- [Server API Reference](https://ifclite.dev/docs/api/server/)
 - [GitHub Repository](https://github.com/LTplus-AG/ifc-lite)
 `);
 

--- a/packages/create-ifc-lite/src/templates/threejs.ts
+++ b/packages/create-ifc-lite/src/templates/threejs.ts
@@ -293,7 +293,7 @@ Open http://localhost:3000 and drop an IFC file.
 
 ## Learn More
 
-- [Three.js Integration Guide](https://ltplus-ag.github.io/ifc-lite/tutorials/threejs-integration/)
-- [IFC-Lite Documentation](https://ltplus-ag.github.io/ifc-lite/)
+- [Three.js Integration Guide](https://ifclite.dev/docs/tutorials/threejs-integration/)
+- [IFC-Lite Documentation](https://ifclite.dev/docs/)
 `);
 }

--- a/packages/wasm/pkg/README.md
+++ b/packages/wasm/pkg/README.md
@@ -27,9 +27,9 @@ Open, view, and work with IFC files. Right in the browser.
 
 # IFClite
 
-Parse, view, query, edit, and export IFC files in the browser. Rust + WASM core, WebGPU rendering, ~260 KB gzipped, 5× faster geometry than the next best option.
+Parse, view, query, edit, validate, and export IFC files, entirely client-side. A Rust core compiled to WASM does the parsing and geometry, a WebGPU renderer puts it on screen, and 36 npm packages let you pick exactly the pieces you need. Geometry processing is up to 5x faster than web-ifc (median ~2.2x across the benchmark corpus).
 
-Works with **IFC2X3**, **IFC4 / IFC4X3** and **IFC5 (IFCX)**. Live demo at [ifclite.com](https://www.ifclite.com/) and more info here: [ifclite.dev](https://www.ifclite.dev/).
+Works with **IFC2X3**, **IFC4 / IFC4X3** and **IFC5 (IFCX)**. Live demo at [ifclite.com](https://www.ifclite.com/) and more info at [ifclite.dev](https://www.ifclite.dev/).
 
 ## Get Started
 
@@ -44,6 +44,13 @@ To add IFClite to an existing project:
 
 ```bash
 npm install @ifc-lite/parser @ifc-lite/geometry @ifc-lite/renderer
+```
+
+Prefer the terminal? The whole toolkit is also a CLI:
+
+```bash
+npm install -g @ifc-lite/cli
+ifc-lite info model.ifc
 ```
 
 ## Parse an IFC file
@@ -90,7 +97,7 @@ const hit = await renderer.pick(120, 240);
 if (hit) console.log(`Picked expressId ${hit.expressId}`);
 ```
 
-For Three.js or Babylon.js, parse + extract geometry the same way and feed `meshes` to your engine. See [Three.js integration](https://ltplus-ag.github.io/ifc-lite/tutorials/threejs-integration/) and [Babylon.js integration](https://ltplus-ag.github.io/ifc-lite/tutorials/babylonjs-integration/).
+For Three.js or Babylon.js, parse and extract geometry the same way and feed `meshes` to your engine. See [Three.js integration](https://ifclite.dev/docs/tutorials/threejs-integration/) and [Babylon.js integration](https://ifclite.dev/docs/tutorials/babylonjs-integration/).
 
 ## Query entities
 
@@ -126,13 +133,20 @@ console.table(result.rows);
 
 ```typescript
 import { parseIDS, validateIDS, createTranslationService } from '@ifc-lite/ids';
+import { createDataAccessor } from '@ifc-lite/ids/bridge';
 
 const idsSpec = parseIDS(idsXmlContent);
+const accessor = createDataAccessor(store);
+const modelInfo = {
+  modelId: 'my-model',
+  schemaVersion: store.schemaVersion,
+  entityCount: store.entityCount,
+};
 const translator = createTranslationService('en');
-const report = await validateIDS(idsSpec, store, { translator });
+const report = await validateIDS(idsSpec, accessor, modelInfo, { translator });
 
 for (const spec of report.specificationResults) {
-  console.log(`${spec.specificationName}: ${spec.passRate}% passed`);
+  console.log(`${spec.specification.name}: ${spec.passRate}% passed`);
 }
 ```
 
@@ -161,34 +175,55 @@ console.log(view.getMutations()); // change history for undo / export
 import { exportToStep, ParquetExporter, Ifc5Exporter } from '@ifc-lite/export';
 import { GeometryProcessor } from '@ifc-lite/geometry';
 
-// IFC STEP — applies any pending mutations
+// Assumes the earlier parse/geometry steps: `store` (parsed IfcDataStore),
+// `bytes` (raw IFC Uint8Array), `meshes` + `geometryResult` (from geometry).
+
+// IFC STEP, applies any pending mutations
 const stepText = exportToStep(store, { schema: 'IFC4', applyMutations: true });
 
-// glTF / GLB, CSV and JSON-LD are assembled in Rust (ifc-lite-export) via the
-// GeometryProcessor — the standalone GLTFExporter/CSVExporter/JSONLDExporter
-// classes were retired.
+// glTF / GLB, CSV and JSON-LD are assembled in Rust (ifc-lite-export)
+// via the GeometryProcessor
 const gp = new GeometryProcessor();
 await gp.init();
-const glb = gp.exportGlbFromMeshes(result.meshes); // Uint8Array (no re-mesh)
-const csv = gp.exportCsv(buffer, 'entities', ',', /* includeProperties */ true);
-const jsonld = gp.exportJsonld(buffer);
+const glb = gp.exportGlbFromMeshes(meshes);  // Uint8Array (no re-mesh)
+const csv = gp.exportCsv(bytes, 'entities', ',', /* includeProperties */ true);
+const jsonld = gp.exportJsonld(bytes);
 
-// Parquet — columnar, ~20× smaller than JSON, queryable from DuckDB / Polars
-const parquet = await new ParquetExporter().exportEntities(parseResult);
+// Parquet: columnar, queryable from DuckDB / Polars
+const parquet = await new ParquetExporter(store).exportTable('entities');
 
-// IFC5 / IFCX — JSON + USD geometry
-const ifcx = new Ifc5Exporter(store, meshes).export({ includeGeometry: true });
+// IFC5 / IFCX: JSON + USD geometry
+const ifcx = new Ifc5Exporter(store, geometryResult).export({ includeGeometry: true });
 ```
+
+## Work from the terminal
+
+The [`ifc-lite` CLI](https://ifclite.dev/docs/guide/cli/) covers the full toolkit: inspect, query, validate, export, create, diff, clash-check, merge, convert, and script IFC models without writing a line of app code.
+
+```bash
+ifc-lite info model.ifc                                  # schema, entities, storeys
+ifc-lite query model.ifc --type IfcWall --json           # entities with properties
+ifc-lite ids model.ifc requirements.ids                  # IDS validation
+ifc-lite clash model.ifc --matrix --bcf clashes.bcfzip   # clash detection to BCF
+ifc-lite diff model-v1.ifc model-v2.ifc                  # model comparison
+ifc-lite merge arch.ifc struct.ifc mep.ifc --out fed.ifc # federation
+ifc-lite convert model.ifc --schema IFC4 --out out.ifc   # schema conversion
+ifc-lite view model.ifc                                  # 3D viewer + REST API
+ifc-lite eval model.ifc "bim.query().byType('IfcWall').count()"
+```
+
+Building AI tooling? `ifc-lite mcp model.ifc` starts a [Model Context Protocol](https://ifclite.dev/docs/guide/cli/) server (stdio or HTTP) so agents can query and edit BIM data directly, and `ifc-lite ask model.ifc "how many walls?"` answers natural-language questions.
 
 ## Choose your setup
 
 | Setup | Best for | You get |
 |-------|----------|---------|
-| [**Browser (WebGPU)**](https://ltplus-ag.github.io/ifc-lite/guide/quickstart/) | Viewing and inspecting models | Full-featured 3D viewer, runs entirely client-side |
-| [**Three.js / Babylon.js**](https://ltplus-ag.github.io/ifc-lite/tutorials/threejs-integration/) | Adding IFC support to an existing 3D app | IFC parsing + geometry, rendered by your engine |
-| [**Server**](https://ltplus-ag.github.io/ifc-lite/guide/server/) | Teams, large files, repeat access | Rust backend with caching, parallel processing, streaming |
-| [**Build for Desktop**](https://ltplus-ag.github.io/ifc-lite/guide/desktop/) | Your own offline native app, very large files (500 MB+) | Extension points to wrap the packages in Tauri, with an optional native-Rust geometry fast path |
-| [**Python (native wheel)**](https://ltplus-ag.github.io/ifc-lite/api/python/) | Analysis, scripting, scientific Python | `pip install ifclite-geom` runs the geometry kernel in-process, meshes straight to numpy |
+| [**Browser (WebGPU)**](https://ifclite.dev/docs/guide/quickstart/) | Viewing and inspecting models | Full-featured 3D viewer, runs entirely client-side |
+| [**Three.js / Babylon.js**](https://ifclite.dev/docs/tutorials/threejs-integration/) | Adding IFC support to an existing 3D app | IFC parsing + geometry, rendered by your engine |
+| [**CLI**](https://ifclite.dev/docs/guide/cli/) | Scripting, CI pipelines, AI agents | The whole toolkit from the terminal, JSON output everywhere |
+| [**Server**](https://ifclite.dev/docs/guide/server/) | Teams, large files, repeat access | Rust backend with caching, parallel processing, streaming |
+| [**Build for Desktop**](https://ifclite.dev/docs/guide/desktop/) | Your own offline native app, very large files (500 MB+) | Extension points to wrap the packages in Tauri, with an optional native-Rust geometry fast path |
+| [**Python (native wheel)**](https://ifclite.dev/docs/api/python/) | Analysis, scripting, scientific Python | `pip install ifclite-geom` runs the geometry kernel in-process, meshes straight to numpy |
 
 Not sure? Start with the browser setup. You can add a server or switch engines later.
 
@@ -205,44 +240,55 @@ Not sure? Start with the browser setup. You can add a server or switch engines l
 | Generate 2D drawings | + `@ifc-lite/drawing-2d` |
 | Create IFC files from scratch | `@ifc-lite/create` |
 | Export to glTF / IFC / Parquet | + `@ifc-lite/export` |
-| Connect to a server backend | + `@ifc-lite/server-client` |
+| Detect clashes | + `@ifc-lite/clash` |
+| Diff two model versions | + `@ifc-lite/diff` |
 | BCF issue tracking | + `@ifc-lite/bcf` |
+| Filter and colorize in 3D by rules | + `@ifc-lite/lens` |
+| Build schedules and property tables | + `@ifc-lite/lists` |
+| Script models with the `bim.*` API | + `@ifc-lite/sdk` |
+| Real-time collaboration (CRDT on IFCX) | + `@ifc-lite/collab` + `@ifc-lite/collab-server` |
+| Embed the viewer in any page (iframe) | + `@ifc-lite/embed-sdk` |
+| Connect to a server backend | + `@ifc-lite/server-client` |
+| Give AI agents BIM access (MCP) | + `@ifc-lite/mcp` |
 
-Full list: [API Reference](https://ltplus-ag.github.io/ifc-lite/api/typescript/) (25 TypeScript packages, 4 Rust crates).
+Full list: [API Reference](https://ifclite.dev/docs/api/typescript/) (36 npm packages, 6 Rust crates on crates.io, and the `ifclite-geom` Python wheel on PyPI).
 
 ## Performance
 
-- **First triangles:** 200–500ms for a typical 50 MB model in the browser.
-- **Geometry processing:** up to 5× faster than `web-ifc` on the same hardware.
-- **Bundle size:** ~260 KB gzipped (parser + geometry + renderer).
+- **Streaming first render:** geometry is processed in batches, so the first triangles are on screen while the rest of the file is still parsing.
+- **Geometry processing:** up to 5x faster than `web-ifc` (median ~2.2x across the benchmark corpus).
+- **Parse speed:** STEP tokenization runs at roughly 1.2 GB/s; a full parse lands around 50 MB/s.
 - **Schema coverage:** 100% of IFC4 (776 entities) and IFC4X3 (876 entities).
-- **Parse throughput:** ~1,259 MB/s tokenization on a typical M1 / M2 laptop.
+- **Footprint:** one lazily fetched WASM module (~1.2 MB gzipped) plus small per-package JS wrappers.
 
-See [benchmarks](https://ltplus-ag.github.io/ifc-lite/guide/performance/) for full numbers across model sizes and hardware.
+See [benchmarks](https://ifclite.dev/docs/guide/performance/) for full numbers across model sizes and hardware.
 
 ## Examples
 
 Ready-to-run projects in [`examples/`](examples/):
 
-- [**Three.js Viewer**](examples/threejs-viewer/) — IFC viewer using Three.js (WebGL)
-- [**Babylon.js Viewer**](examples/babylonjs-viewer/) — IFC viewer using Babylon.js (WebGL)
+- [**Three.js Viewer**](examples/threejs-viewer/) - IFC viewer using Three.js (WebGL)
+- [**Babylon.js Viewer**](examples/babylonjs-viewer/) - IFC viewer using Babylon.js (WebGL)
+- [**Collab Demo**](examples/collab-demo/) - real-time collaborative editing over websockets
+- [**Three.js Collab**](examples/threejs-collab/) - collaborative 3D viewing in Three.js
 
 ## Documentation
 
 | | |
 |---|---|
-| **Start here** | [Quick Start](https://ltplus-ag.github.io/ifc-lite/guide/quickstart/) · [Installation](https://ltplus-ag.github.io/ifc-lite/guide/installation/) · [Browser Requirements](https://ltplus-ag.github.io/ifc-lite/guide/browser-requirements/) |
-| **Guides** | [Parsing](https://ltplus-ag.github.io/ifc-lite/guide/parsing/) · [Geometry](https://ltplus-ag.github.io/ifc-lite/guide/geometry/) · [Rendering](https://ltplus-ag.github.io/ifc-lite/guide/rendering/) · [Querying](https://ltplus-ag.github.io/ifc-lite/guide/querying/) · [Exporting](https://ltplus-ag.github.io/ifc-lite/guide/exporting/) |
-| **BIM features** | [Federation](https://ltplus-ag.github.io/ifc-lite/guide/federation/) · [BCF](https://ltplus-ag.github.io/ifc-lite/guide/bcf/) · [IDS Validation](https://ltplus-ag.github.io/ifc-lite/guide/ids/) · [2D Drawings](https://ltplus-ag.github.io/ifc-lite/guide/drawing-2d/) · [Property Editing](https://ltplus-ag.github.io/ifc-lite/guide/mutations/) |
-| **Tutorials** | [Build a Viewer](https://ltplus-ag.github.io/ifc-lite/tutorials/building-viewer/) · [Three.js](https://ltplus-ag.github.io/ifc-lite/tutorials/threejs-integration/) · [Babylon.js](https://ltplus-ag.github.io/ifc-lite/tutorials/babylonjs-integration/) · [Custom Queries](https://ltplus-ag.github.io/ifc-lite/tutorials/custom-queries/) |
-| **Deep dives** | [Architecture](https://ltplus-ag.github.io/ifc-lite/architecture/overview/) · [Data Flow](https://ltplus-ag.github.io/ifc-lite/architecture/data-flow/) · [Performance](https://ltplus-ag.github.io/ifc-lite/guide/performance/) |
-| **API** | [TypeScript](https://ltplus-ag.github.io/ifc-lite/api/typescript/) · [Rust](https://ltplus-ag.github.io/ifc-lite/api/rust/) · [WASM](https://ltplus-ag.github.io/ifc-lite/api/wasm/) · [Python](https://ltplus-ag.github.io/ifc-lite/api/python/) |
+| **Start here** | [Quick Start](https://ifclite.dev/docs/guide/quickstart/) · [Installation](https://ifclite.dev/docs/guide/installation/) · [CLI Toolkit](https://ifclite.dev/docs/guide/cli/) · [Browser Requirements](https://ifclite.dev/docs/guide/browser-requirements/) |
+| **Guides** | [Parsing](https://ifclite.dev/docs/guide/parsing/) · [Geometry](https://ifclite.dev/docs/guide/geometry/) · [Rendering](https://ifclite.dev/docs/guide/rendering/) · [Querying](https://ifclite.dev/docs/guide/querying/) · [Exporting](https://ifclite.dev/docs/guide/exporting/) |
+| **BIM features** | [Federation](https://ifclite.dev/docs/guide/federation/) · [BCF](https://ifclite.dev/docs/guide/bcf/) · [IDS Validation](https://ifclite.dev/docs/guide/ids/) · [2D Drawings](https://ifclite.dev/docs/guide/drawing-2d/) · [Property Editing](https://ifclite.dev/docs/guide/mutations/) |
+| **Customization** | [Extensions](https://ifclite.dev/docs/guide/extensions/) · [Authoring Extensions](https://ifclite.dev/docs/guide/extension-authoring/) · [Flavors](https://ifclite.dev/docs/guide/flavors/) |
+| **Tutorials** | [Build a Viewer](https://ifclite.dev/docs/tutorials/building-viewer/) · [Three.js](https://ifclite.dev/docs/tutorials/threejs-integration/) · [Babylon.js](https://ifclite.dev/docs/tutorials/babylonjs-integration/) · [Custom Queries](https://ifclite.dev/docs/tutorials/custom-queries/) |
+| **Deep dives** | [Architecture](https://ifclite.dev/docs/architecture/overview/) · [Data Flow](https://ifclite.dev/docs/architecture/data-flow/) · [Performance](https://ifclite.dev/docs/guide/performance/) |
+| **API** | [TypeScript](https://ifclite.dev/docs/api/typescript/) · [Rust](https://ifclite.dev/docs/api/rust/) · [WASM](https://ifclite.dev/docs/api/wasm/) · [Python](https://ifclite.dev/docs/api/python/) |
 
 ## Contributing
 
 The WASM bundle is built from `rust/` on every fresh build, so a Rust
 toolchain is required. `rust-toolchain.toml` pins the nightly channel
-and the `wasm32-unknown-unknown` target — `rustup show` (or the
+and the `wasm32-unknown-unknown` target. `rustup show` (or the
 contributing setup guide) installs everything needed.
 
 ```bash
@@ -264,18 +310,18 @@ pnpm fixtures:check     # CI-friendly: exit 1 if anything is missing or stale
 ```
 
 The fixtures are stored on a GitHub Release and catalogued in
-[`tests/models/manifest.json`](tests/models/manifest.json) — see
+[`tests/models/manifest.json`](tests/models/manifest.json). See
 [`tests/models/README.md`](tests/models/README.md) for the full design and
 maintainer workflow.
 
-See the [Contributing Guide](https://ltplus-ag.github.io/ifc-lite/contributing/setup/) and [Release Process](RELEASE.md).
+See the [Contributing Guide](https://ifclite.dev/docs/contributing/setup/) and [Release Process](RELEASE.md).
 
 ## Community
 
-- [GitHub Discussions](https://github.com/LTplus-AG/ifc-lite/discussions) — questions, ideas, show-and-tell
-- [Issues](https://github.com/LTplus-AG/ifc-lite/issues) — bug reports and feature requests
-- [Releases](https://github.com/LTplus-AG/ifc-lite/releases) — changelog and version notes
+- [GitHub Discussions](https://github.com/LTplus-AG/ifc-lite/discussions) - questions, ideas, show-and-tell
+- [Issues](https://github.com/LTplus-AG/ifc-lite/issues) - bug reports and feature requests
+- [Releases](https://github.com/LTplus-AG/ifc-lite/releases) - changelog and version notes
 
 ## License
 
-[MPL-2.0](LICENSE) — use, modify, redistribute. Source files modified under MPL must remain MPL.
+[MPL-2.0](LICENSE) - use, modify, redistribute. Source files modified under MPL must remain MPL.


### PR DESCRIPTION
Follow-up to #1691. That sweep covered markdown/json/html/yml/jsx but not source-code strings. A repo-wide audit found three straggler categories, all user-facing:

- **create-ifc-lite templates** (6 files): scaffolded projects shipped READMEs and comments linking the old GitHub Pages docs
- **Viewer keyboard-shortcuts dialog** (2 links): live UI at ifclite.com pointed at the old site
- **packages/wasm/pkg/README.md**: wasm-pack's committed snapshot of the root README predated the whole docs refresh; replaced with the current root README (byte-identical to what the next wasm build regenerates, per `readme = "../../README.md"` in the crate manifest)

`git grep ltplus-ag.github.io` is now zero outside CHANGELOG history. Changeset patch-bumps create-ifc-lite and @ifc-lite/wasm (both ship the touched files to npm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)