### PR TITLE
fix(geometry): post-condition guard on traversal pocket rebuild (#1660 follow-up)

### DIFF
--- a/rust/geometry/src/kernel/retriangulate_audit.rs
+++ b/rust/geometry/src/kernel/retriangulate_audit.rs
@@ -16,7 +16,7 @@
 
 use super::interner::{Interner, Vid};
 use super::retriangulate::{
-    cmp_lex_v, edge_exists, lex_cmp, orient2d_v, Canonical, Mesh2d,
+    cmp_lex_v, edge_exists, lex_cmp, orient2d_v, tri_edges, Canonical, Mesh2d, SubTri,
 };
 use super::retriangulate_recover::{between, recover_via_traversal};
 use super::{DropAxis, Sign};
@@ -49,6 +49,34 @@ fn chain_of(mesh: &Mesh2d, it: &Interner, axis: DropAxis, cs: Vid, ct: Vid) -> V
     chain
 }
 
+/// POST-CONDITION on the replacement triangles a pocket rebuild
+/// ([`recover_via_traversal`]) is about to commit (#1660 follow-up). Earcut's
+/// degenerate-pocket fan fallback has no simple-polygon guarantee on a
+/// pathological pinched chain, and committing a bad cover would make
+/// `edge_exists` falsely report the constraint recovered - silently passing the
+/// conformity gate (the volume oracle only runs when the gate rejects).
+/// Rejects (a) any Vid-degenerate triangle (a `[p, x, p]` fakes an edge between
+/// its two distinct vertices) and (b) any directed edge appearing twice across
+/// the set (two triangles on the same side of an edge = overlapping cover).
+/// Deliberately NOT stricter: zero-area slivers with three distinct Vids are
+/// legitimate fan-fallback output that downstream consolidation cleans up, so
+/// rejecting those would change behavior on currently-passing inputs. Runs
+/// only on the small replacement set: O(k log k) sort/dedup, no HashMap
+/// (matching the kernel's platform-determinism style).
+pub(crate) fn pocket_rebuild_valid(new_tris: &[SubTri]) -> bool {
+    let mut directed: Vec<(Vid, Vid)> = Vec::with_capacity(new_tris.len() * 3);
+    for &t in new_tris {
+        if t[0] == t[1] || t[1] == t[2] || t[0] == t[2] {
+            return false;
+        }
+        directed.extend(tri_edges(t));
+    }
+    let n = directed.len();
+    directed.sort_unstable();
+    directed.dedup();
+    directed.len() == n
+}
+
 /// Recover any missing constraint sub-edge (last-chance robust traversal), then set
 /// `mesh.unrecovered` from a fresh count over the settled mesh.
 pub(crate) fn audit_and_recover(mesh: &mut Mesh2d, it: &Interner, canon: &Canonical, axis: DropAxis) {
@@ -67,3 +95,7 @@ pub(crate) fn audit_and_recover(mesh: &mut Mesh2d, it: &Interner, canon: &Canoni
         }
     }
 }
+
+#[cfg(test)]
+#[path = "retriangulate_audit_tests.rs"]
+mod retriangulate_audit_tests;

--- a/rust/geometry/src/kernel/retriangulate_audit_tests.rs
+++ b/rust/geometry/src/kernel/retriangulate_audit_tests.rs
@@ -1,0 +1,147 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Tests for [`super::pocket_rebuild_valid`] (the #1660 follow-up post-condition
+//! on `recover_via_traversal`'s rebuilt pocket cover) and for the fail-safe
+//! accounting chain a rejected rebuild relies on: a traversal that bails leaves
+//! the mesh UNCHANGED, so the conformity audit counts the constraint as
+//! unrecovered and the batched void path hard-rejects to the sequential
+//! fallback (never a silent false "recovered").
+
+use super::super::interner::{Interner, Vid};
+use super::super::retriangulate::{edge_exists, Canonical, Mesh2d, SubTri};
+use super::super::retriangulate_recover::{enforce_constraint, recover_via_traversal};
+use super::super::{DropAxis, ImplicitPoint, Sign};
+use super::{audit_and_recover, pocket_rebuild_valid};
+use std::collections::BTreeMap;
+
+fn e2(x: f64, y: f64) -> ImplicitPoint {
+    ImplicitPoint::Explicit([x, y, 0.0])
+}
+
+/// Four distinct Vids for the pure set-level validation tests.
+fn vids4() -> [Vid; 4] {
+    let mut it = Interner::new();
+    [
+        it.intern(e2(0.0, 0.0)),
+        it.intern(e2(1.0, 0.0)),
+        it.intern(e2(1.0, 1.0)),
+        it.intern(e2(0.0, 1.0)),
+    ]
+}
+
+#[test]
+fn accepts_a_valid_two_pocket_cover() {
+    let [a, b, c, d] = vids4();
+    // Split quad: the shared diagonal appears once per DIRECTION (a,c)/(c,a) -
+    // exactly the legitimate adjacent-triangle configuration.
+    assert!(pocket_rebuild_valid(&[[a, b, c], [a, c, d]]));
+    // Vacuously valid: no replacement triangles, nothing to commit wrongly.
+    assert!(pocket_rebuild_valid(&[]));
+}
+
+#[test]
+fn accepts_a_zero_area_sliver_with_distinct_vids() {
+    // Collinear but Vid-distinct: legitimate output of earcut's fan fallback on
+    // currently-passing inputs (downstream consolidation cleans it up).
+    // Rejecting it would change behavior - the guard must stay narrower.
+    let mut it = Interner::new();
+    let a = it.intern(e2(0.0, 0.0));
+    let m = it.intern(e2(1.0, 0.0));
+    let b = it.intern(e2(2.0, 0.0));
+    assert!(pocket_rebuild_valid(&[[a, m, b]]));
+}
+
+#[test]
+fn rejects_vid_degenerate_triangles_in_every_position() {
+    let [a, b, _, _] = vids4();
+    // A [p, x, p] would fake an a-b edge for `edge_exists` without covering any
+    // area - the exact false-recovery the post-condition exists to stop.
+    assert!(!pocket_rebuild_valid(&[[a, b, a]]));
+    assert!(!pocket_rebuild_valid(&[[a, a, b]]));
+    assert!(!pocket_rebuild_valid(&[[b, a, a]]));
+    assert!(!pocket_rebuild_valid(&[[a, a, a]]));
+}
+
+#[test]
+fn rejects_a_duplicated_directed_edge() {
+    let [a, b, c, d] = vids4();
+    // Identical triangle twice: every directed edge duplicated.
+    assert!(!pocket_rebuild_valid(&[[a, b, c], [a, b, c]]));
+    // Subtler: the fan a hypothetical degenerate-pocket fallback produces from
+    // a ring visiting the same vertex twice, e.g. fan over [a,b,c,?,b,d] -
+    // directed edge (a,b) appears in two triangles (same side twice = overlap).
+    assert!(!pocket_rebuild_valid(&[[a, b, c], [a, c, b], [a, b, d]]));
+}
+
+/// One w0-positive triangle [a,u,v]; constraint (a,b) exits the mesh through
+/// edge (u,v), so the ordered traversal finds its entry triangle but the
+/// crossed edge is a mesh BOUNDARY - `recover_via_traversal` must bail with the
+/// mesh unchanged (same return discipline as a rejected pocket rebuild, which
+/// returns before any mesh mutation).
+fn boundary_exit_mesh(it: &mut Interner) -> (Mesh2d, Vid, Vid) {
+    let a = it.intern(e2(0.0, 0.0));
+    let u = it.intern(e2(2.0, 1.0));
+    let v = it.intern(e2(1.0, 2.0));
+    let b = it.intern(e2(3.0, 3.0));
+    let mesh = Mesh2d {
+        tris: vec![[a, u, v]],
+        axis: DropAxis::Z,
+        w0: Sign::Positive,
+        unrecovered: 0,
+        audit_needed: false,
+        coords: BTreeMap::new(),
+    };
+    (mesh, a, b)
+}
+
+#[test]
+fn bailed_traversal_leaves_mesh_unchanged_and_audit_counts_unrecovered() {
+    let mut it = Interner::new();
+    let (mut mesh, a, b) = boundary_exit_mesh(&mut it);
+    let before: Vec<SubTri> = mesh.tris.clone();
+
+    recover_via_traversal(&mut mesh, &it, a, b);
+    assert_eq!(
+        mesh.tris, before,
+        "a bailing traversal must not touch the mesh"
+    );
+    assert!(!edge_exists(&mesh, a, b));
+
+    // The audit re-tries the traversal, then counts against the settled mesh:
+    // the unforced edge lands in `unrecovered`, which the batched void path
+    // treats as a hard reject (difference_all -> sequential fallback).
+    let canon = Canonical {
+        corners: [a, mesh.tris[0][1], mesh.tris[0][2]],
+        segments: vec![(a, b)],
+        points: vec![],
+    };
+    let axis = mesh.axis;
+    audit_and_recover(&mut mesh, &it, &canon, axis);
+    assert_eq!(
+        mesh.tris, before,
+        "audit recovery must also leave the mesh unchanged"
+    );
+    assert_eq!(
+        mesh.unrecovered, 1,
+        "the unforced constraint must be counted"
+    );
+}
+
+#[test]
+fn enforce_constraint_reports_audit_needed_when_recovery_fails() {
+    let mut it = Interner::new();
+    let (mut mesh, a, b) = boundary_exit_mesh(&mut it);
+    // Full phase-D path: the pocket split can't force (a,b) (endpoint b is not
+    // even a mesh vertex), the traversal fallback bails - `audit_needed` must
+    // stay requested so `triangulate` runs the conformity audit at all. This is
+    // the same reporting channel a post-condition rejection rides on the
+    // enforce_constraint path.
+    enforce_constraint(&mut mesh, &it, a, b);
+    assert!(!edge_exists(&mesh, a, b));
+    assert!(
+        mesh.audit_needed,
+        "failed recovery must request the conformity audit"
+    );
+}

--- a/rust/geometry/src/kernel/retriangulate_recover.rs
+++ b/rust/geometry/src/kernel/retriangulate_recover.rs
@@ -17,6 +17,7 @@ use super::retriangulate::{
     cmp_lex_v, coord2d_cached, earcut, edge_exists, insert_point, lex_cmp, orient2d_v, orient_ring,
     tri_aabb_disjoint, tri_edges, Mesh2d, SubTri, PREFILTER_MIN,
 };
+use super::retriangulate_audit::pocket_rebuild_valid;
 use super::Sign;
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -38,16 +39,14 @@ pub(crate) fn recover_subsegment(mesh: &mut Mesh2d, it: &Interner, a: Vid, b: Vi
     mesh.audit_needed = true;
 
     let (axis, w0) = (mesh.axis, mesh.w0);
-    // Does any open edge of `tri` PROPERLY cross the open segment (a,b)? This is
-    // the dominant cost of constraint recovery (#1109): it runs per triangle for
-    // every constraint sub-segment. The naive form recomputes `orient(a,b,vertex)`
-    // for each of the triangle's three edges — but a triangle has only THREE
-    // vertices, so we compute each vertex's side of the (a,b) line ONCE, then an
-    // edge can only cross when its two endpoints straddle that line (opposite
-    // nonzero signs); only then do we run the reciprocal `orient(edge, a/b)` test.
-    // Identical exact result to the per-edge form (same signs, same crossing
-    // definition), ~3 predicates/triangle instead of up to 12 — byte-identical
-    // channel ⇒ parity preserved.
+    // Does any open edge of `tri` PROPERLY cross the open segment (a,b)? The
+    // dominant cost of constraint recovery (#1109): runs per triangle for every
+    // constraint sub-segment. Each vertex's side of the (a,b) line is computed
+    // ONCE (a triangle has only THREE vertices); an edge can only cross when its
+    // endpoints straddle that line (opposite nonzero signs), and only then run
+    // the reciprocal `orient(edge, a/b)` tests. Identical exact result to the
+    // per-edge form, ~3 predicates/triangle instead of up to 12 - byte-identical
+    // channel, parity preserved.
     let tri_crosses = |tri: SubTri| {
         let s = [
             orient2d_v(it, a, b, tri[0], axis),
@@ -71,12 +70,11 @@ pub(crate) fn recover_subsegment(mesh: &mut Mesh2d, it: &Interner, a: Vid, b: Vi
         }
         false
     };
-    // Broadphase: only a triangle whose 2D f64 AABB overlaps the (a,b) segment's
-    // AABB can have an edge that properly crosses (a,b). Skip the four exact
-    // orient2d crossing tests for triangles whose widened AABB is disjoint — the
-    // margin makes this conservative (a genuinely crossing triangle is never
-    // skipped on any platform), so the channel — and recovery — is byte-identical.
-    // Engaged only once the triangle set is large enough to amortise the cache.
+    // Broadphase: only a triangle whose widened 2D f64 AABB overlaps the (a,b)
+    // segment's AABB can properly cross it; skip the exact tests otherwise. The
+    // margin is conservative (a crossing triangle is never skipped on any
+    // platform), so the channel - and recovery - is byte-identical. Engaged
+    // only once the triangle set is large enough to amortise the cache.
     let ab_box: Option<[f64; 4]> = if mesh.tris.len() > PREFILTER_MIN {
         match (
             coord2d_cached(it, a, axis, &mut mesh.coords),
@@ -121,19 +119,17 @@ pub(crate) fn recover_subsegment(mesh: &mut Mesh2d, it: &Interner, a: Vid, b: Vi
             next.insert(u, v);
         }
     }
-    // Walk the boundary loop. A degenerate channel (the segment crosses a
-    // non-simply-connected region, or the boundary branches) yields a non-traversable
-    // loop — bail gracefully (leave the constraint unrecovered) rather than panic.
-    // The triangulation stays valid; only this one sub-segment isn't forced as an edge.
-    //
-    // The walk starts at `a` when `a` is on the boundary; otherwise at the
-    // lexicographically-least boundary vertex (deterministic — Vids and the
+    // Walk the boundary loop. A degenerate channel (non-simply-connected region,
+    // or a branching boundary) yields a non-traversable loop - bail gracefully
+    // (leave the constraint unrecovered) rather than panic; the triangulation
+    // stays valid. The walk starts at `a` when `a` is on the boundary; otherwise
+    // at the lexicographically-least boundary vertex (deterministic - Vids and
     // BTreeMap order are platform-stable). `a`/`b` can legitimately be channel-
     // INTERIOR vertices: a long skinny fan triangle incident to the endpoint can
     // re-cross the open segment far from the endpoint, putting the endpoint's
-    // whole fan in the channel (the 559171 back-face door jamb — the endpoint
-    // is then "swallowed" exactly like 552611's corner, but the a–b pocket
-    // split can't run). See the (ia, ib) match below for that case.
+    // whole fan in the channel (the 559171 back-face door jamb - the endpoint is
+    // then "swallowed" exactly like 552611's corner, but the a-b pocket split
+    // can't run). See the (ia, ib) match below for that case.
     let start = if next.contains_key(&a) {
         a
     } else {
@@ -158,16 +154,15 @@ pub(crate) fn recover_subsegment(mesh: &mut Mesh2d, it: &Interner, a: Vid, b: Vi
         }
     }
     // Vertices STRICTLY INTERIOR to the channel (every incident triangle is in
-    // the channel, so none of their edges reach the boundary loop). This happens
-    // when the segment passes so close to a vertex that it properly crosses ALL
-    // of the vertex's fan spokes (552611: the tiny middle-quad diagonal
-    // (5.027,3.800)→(5.142,3.5) swallows the corner (5.142,3.800) of the
-    // adjacent through-slot rectangle). The pocket-ring rebuild below would
-    // silently DESTROY such vertices — and with them every previously-enforced
-    // constraint edge through them — leaving host sub-triangles that overlap
-    // the cutter footprint (the 552611 4× over-cut). Re-insert them after the
-    // rebuild; the enforcement fixed-point loop in [`triangulate`] then
-    // re-forces any constraint edge the rebuild broke.
+    // the channel, so none of their edges reach the boundary loop): the segment
+    // passes so close to a vertex that it properly crosses ALL of the vertex's
+    // fan spokes (552611: the tiny middle-quad diagonal (5.027,3.800)->(5.142,3.5)
+    // swallows the corner (5.142,3.800) of the adjacent through-slot rectangle).
+    // The pocket-ring rebuild below would silently DESTROY such vertices - and
+    // every previously-enforced constraint edge through them - leaving host
+    // sub-triangles that overlap the cutter footprint (the 552611 4x over-cut).
+    // Re-insert them after the rebuild; the enforcement fixed-point loop in
+    // [`triangulate`] then re-forces any constraint edge the rebuild broke.
     let loop_set: BTreeSet<Vid> = loop_v.iter().copied().collect();
     let mut lost: Vec<Vid> = channel
         .iter()
@@ -275,8 +270,8 @@ pub(crate) fn between(it: &Interner, s: Vid, t: Vid, v: Vid) -> bool {
 /// faces cut by many windows (issue #098 V5C). It removes the crossed triangles
 /// and earcuts the two chains, each closed by `a–b`, forcing `a–b` as their
 /// shared edge. Leaves the mesh UNCHANGED (constraint stays unrecovered, never
-/// wrong geometry) if the traversal can't start or complete. Only runs when the
-/// fast path failed, so the common case is byte-identical.
+/// wrong geometry) if the traversal can't start or complete, or if the rebuilt
+/// cover fails [`pocket_rebuild_valid`]. Only runs when the fast path failed.
 pub(crate) fn recover_via_traversal(mesh: &mut Mesh2d, it: &Interner, a: Vid, b: Vid) {
     let (axis, w0) = (mesh.axis, mesh.w0);
     // Undirected edge -> the (≤2) triangles using it.
@@ -358,6 +353,11 @@ pub(crate) fn recover_via_traversal(mesh: &mut Mesh2d, it: &Interner, a: Vid, b:
             let ring = orient_ring(it, chain, axis, w0);
             new_tris.extend(earcut(it, &ring, axis, w0));
         }
+    }
+    // Post-condition (#1660 follow-up): reject a degenerate/overlapping rebuilt
+    // cover - bail UNCHANGED so the audit counts the edge unrecovered.
+    if !pocket_rebuild_valid(&new_tris) {
+        return;
     }
     let crossed_set: BTreeSet<usize> = crossed.into_iter().collect();
     mesh.tris = mesh


### PR DESCRIPTION
Closes the one PLAUSIBLE-UNPROVEN tail from the #1693 review session: earcut's degenerate-pocket fan fallback has no simple-polygon guarantee on a pathological pinched chain, and a Vid-degenerate output triangle ([p, x, p]) would make edge_exists falsely report a constraint recovered - silently passing the conformity gate (the volume oracle only runs when the gate rejects).

## What it does

pocket_rebuild_valid (in retriangulate_audit.rs, called from recover_via_traversal just before committing the rebuilt pocket) rejects:
- any Vid-degenerate replacement triangle, and
- any directed edge appearing twice across the replacement set (two triangles on the same side of an edge = overlapping cover).

On rejection the mesh is left UNCHANGED, so the audit's fresh recount sees the edge unrecovered and the batch routes down the existing fail-safe chain: gate reject -> volume oracle -> per-opening sequential fallback. Deliberately not stricter: zero-area slivers with three distinct Vids are legitimate fan-fallback output that downstream consolidation cleans up.

## Why a post-condition and not a bail-on-duplicate-apex

The #1693 verification proved the duplicate apex push is load-bearing (it encodes a kept island in a figure-8 pinch channel) and that bailing on it would regress the dense faceted-reveal walls #1660 fixed. The pinch regression test (retriangulate_recover_tests.rs, on main since #1693) still passes with this guard - it is the over-hardening tripwire.

## Cost and determinism

O(k log k) sort/dedup on the small replacement set only, no HashMap (platform-deterministic), zero behaviour change on every currently-passing input (all 434 geometry-crate tests, including the pinch test, pass unchanged).

Some pre-existing comment blocks in retriangulate_recover.rs were tightened to keep the file at its frozen 438-line module-size budget; the ratchet gate passes.

## Testing

- cargo test -p ifc-lite-geometry --lib: 434 passed, 0 failed (includes the figure-8 pinch test and the new retriangulate_audit_tests.rs covering degenerate rejection, duplicate-edge rejection, acceptance of valid covers, and mesh-unchanged-on-bail).
- module_size_ratchet: 4 passed.
- cargo check --workspace --all-targets clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved constraint recovery reliability by rejecting invalid or overlapping replacement triangulations.
  * Meshes now remain unchanged when recovery cannot safely complete, allowing the issue to be audited and retried later.
  * Preserved missing constraints and audit status when recovery fails.

* **Tests**
  * Added coverage for valid replacements, degenerate triangles, overlapping edges, boundary exits, and failed constraint recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->