### PR TITLE
fix(viewer): render the GROUPS tab for IFCX models (#1622 follow-up)

### DIFF
--- a/.changeset/ifcx-system-membership-groups.md
+++ b/.changeset/ifcx-system-membership-groups.md
@@ -1,0 +1,10 @@
+---
+"@ifc-lite/ifcx": patch
+"@ifc-lite/parser": patch
+---
+
+IFC5 system membership reaches the viewer's Groups tab: the ifcx composer now
+emits AssignsToGroup relationship edges from the `bsi::ifc::system::partofsystem`
+attribute (group -> member, matching STEP direction), and the on-demand group
+member/relationship extractors fall back to the EntityTable when a store has no
+STEP byte-span index (IFCX stores ingest with an empty entityIndex.byId).

--- a/apps/viewer/src/components/viewer/hierarchy/treeDataBuilder.test.ts
+++ b/apps/viewer/src/components/viewer/hierarchy/treeDataBuilder.test.ts
@@ -4,7 +4,15 @@
 
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
-import { IfcTypeEnum, RelationshipType, type SpatialHierarchy, type SpatialNode } from '@ifc-lite/data';
+import {
+  EntityTableBuilder,
+  IfcTypeEnum,
+  RelationshipGraphBuilder,
+  RelationshipType,
+  StringTable,
+  type SpatialHierarchy,
+  type SpatialNode,
+} from '@ifc-lite/data';
 import type { IfcDataStore } from '@ifc-lite/parser';
 import { useViewerStore, type FederatedModel } from '@/store';
 import {
@@ -984,5 +992,101 @@ describe('buildGroupTree (#1622)', () => {
     assert.deepStrictEqual(order, [
       'IfcDistributionSystem', 'IfcDistributionCircuit', 'IfcZone', 'IfcGroup',
     ]);
+  });
+});
+
+// ============================================================================
+// Groups tab — IFCX-shaped stores (#1622 IFCX follow-up)
+// ============================================================================
+
+/**
+ * An IFCX-ingested store (see buildIfcxDataStore / the federated path): a REAL
+ * populated EntityTable + RelationshipGraph, but `entityIndex.byId` and
+ * `.byType` permanently EMPTY — there are no STEP byte spans to index. The
+ * Groups tab must fall back to the entity table for both group enumeration
+ * and member existence/type resolution.
+ *
+ *  - IfcDistributionSystem #1 "Water Supply": pipes #2/#3 (geometry).
+ *  - IfcGroup #10 "Misc": pipe #2. IfcGroup has NO IfcTypeEnum member, so this
+ *    exercises the rawTypeName fallback inside the type-column scan.
+ */
+function createIfcxShapedDataStore(): IfcDataStore {
+  const strings = new StringTable();
+  const builder = new EntityTableBuilder(8, strings);
+  // add(expressId, type, globalId, name, description, objectType, hasGeometry, isType)
+  builder.add(1, 'IfcDistributionSystem', 'path-system', 'Water Supply', '', '', false, false);
+  builder.add(2, 'IfcPipeSegment', 'path-pipe-1', 'Pipe 1', '', '', true, false);
+  builder.add(3, 'IfcPipeSegment', 'path-pipe-2', 'Pipe 2', '', '', true, false);
+  builder.add(10, 'IfcGroup', 'path-group', 'Misc', '', '', false, false);
+  const entities = builder.build();
+
+  const relBuilder = new RelationshipGraphBuilder();
+  relBuilder.addEdge(1, 2, RelationshipType.AssignsToGroup, 1);
+  relBuilder.addEdge(1, 3, RelationshipType.AssignsToGroup, 2);
+  relBuilder.addEdge(10, 2, RelationshipType.AssignsToGroup, 3);
+
+  return {
+    entityIndex: { byId: new Map(), byType: new Map() },
+    entities,
+    relationships: relBuilder.build(),
+  } as unknown as IfcDataStore;
+}
+
+describe('buildGroupTree — IFCX-shaped store (empty entityIndex)', () => {
+  it('lists groups with real members despite empty byType/byId', () => {
+    const ds = createIfcxShapedDataStore();
+    const nodes = buildGroupTree(
+      new Map(), ds, new Set(['group-legacy-1']), false, new Set([2, 3]),
+    );
+
+    const system = nodes.find((n) => n.type === 'group' && n.ifcType === 'IfcDistributionSystem');
+    assert.ok(system, 'the system surfaces via the entity-table fallback');
+    assert.strictEqual(system.name, 'Water Supply');
+    assert.strictEqual(system.elementCount, 2);
+    assert.deepStrictEqual([...system.globalIds].sort(), [2, 3], 'isolation ids carry member geometry');
+
+    const memberRows = nodes.filter((n) => n.type === 'group-member' && n.id.startsWith('groupmember-legacy-1-'));
+    assert.strictEqual(memberRows.length, 2);
+    assert.deepStrictEqual(
+      memberRows.map((n) => n.name).sort(),
+      ['Pipe 1', 'Pipe 2'],
+      'member rows resolve name/type from the entity table, not byId',
+    );
+    assert.ok(memberRows.every((n) => n.ifcType === 'IfcPipeSegment'));
+  });
+
+  it('surfaces a class with no IfcTypeEnum member (IfcGroup) via rawTypeName', () => {
+    const ds = createIfcxShapedDataStore();
+    const nodes = buildGroupTree(new Map(), ds, new Set(), false, new Set([2, 3]));
+    const group = nodes.find((n) => n.type === 'group' && n.ifcType === 'IfcGroup');
+    assert.ok(group, 'IfcGroup (enum-less) surfaces via the raw type-name scan');
+    assert.strictEqual(group.name, 'Misc');
+    assert.strictEqual(group.elementCount, 1);
+  });
+
+  it('returns no group rows when the model has no group entities', () => {
+    const strings = new StringTable();
+    const builder = new EntityTableBuilder(2, strings);
+    builder.add(1, 'IfcWall', 'path-wall', 'Wall', '', '', true, false);
+    const ds = {
+      entityIndex: { byId: new Map(), byType: new Map() },
+      entities: builder.build(),
+      relationships: new RelationshipGraphBuilder().build(),
+    } as unknown as IfcDataStore;
+    assert.deepStrictEqual(buildGroupTree(new Map(), ds, new Set(), false, new Set([1])), []);
+  });
+
+  it('processes a data store shared by several federated layers exactly once', () => {
+    // Federated IFCX layers share idOffset 0 (one composed expressId space),
+    // so globalId === expressId; keep the store's model registry empty.
+    useViewerStore.setState({ models: new Map() });
+    const ds = createIfcxShapedDataStore();
+    const models = new Map<string, FederatedModel>([
+      ['layer-base', { id: 'layer-base', name: 'base.ifcx', ifcDataStore: ds, idOffset: 0, maxExpressId: 0 } as unknown as FederatedModel],
+      ['layer-overlay', { id: 'layer-overlay', name: 'overlay.ifcx', ifcDataStore: ds, idOffset: 0, maxExpressId: 0 } as unknown as FederatedModel],
+    ]);
+    const nodes = buildGroupTree(models, null, new Set(), true, new Set([2, 3]));
+    const systems = nodes.filter((n) => n.type === 'group' && n.ifcType === 'IfcDistributionSystem');
+    assert.strictEqual(systems.length, 1, 'the shared store must not duplicate group rows per layer');
   });
 });

--- a/apps/viewer/src/components/viewer/hierarchy/treeDataBuilder.ts
+++ b/apps/viewer/src/components/viewer/hierarchy/treeDataBuilder.ts
@@ -1133,13 +1133,33 @@ export function buildGroupTree(
   const processDataStore = (dataStore: IfcDataStore, modelId: string) => {
     const byType = dataStore.entityIndex?.byType;
     const entities = dataStore.entities;
-    if (!byType || !entities) return;
+    if (!entities) return;
+
+    // IFCX ingest builds `entityIndex` permanently EMPTY (there are no STEP
+    // byte spans to index — see buildIfcxDataStore), so an empty byType must
+    // not read as "no groups": fall back to ONE scan of the EntityTable's
+    // type-name column, restricted to the group classes (the scope-chips
+    // pattern, #1662). STEP stores keep the O(1) index path untouched.
+    let fallbackByType: Map<string, number[]> | null = null;
+    if (!byType || byType.size === 0) {
+      fallbackByType = new Map();
+      const wanted = new Set<string>(GROUP_ENTITY_TYPES.map((t) => t.toUpperCase()));
+      for (let i = 0; i < entities.count; i++) {
+        const expressId = entities.expressId[i];
+        const upper = entities.getTypeName(expressId).toUpperCase();
+        if (!wanted.has(upper)) continue;
+        const bucket = fallbackByType.get(upper);
+        if (bucket) bucket.push(expressId);
+        else fallbackByType.set(upper, [expressId]);
+      }
+      if (fallbackByType.size === 0) return;
+    }
     const toGlobal = (expressId: number) => resolveTreeGlobalId(modelId, expressId, models);
 
     for (let rank = 0; rank < GROUP_ENTITY_TYPES.length; rank++) {
       const typeName = GROUP_ENTITY_TYPES[rank];
       if (!groupMatchesSubFilter(typeName, subFilter)) continue;
-      const groupIds = byType.get(typeName.toUpperCase());
+      const groupIds = byType?.get(typeName.toUpperCase()) ?? fallbackByType?.get(typeName.toUpperCase());
       if (!groupIds || groupIds.length === 0) continue;
 
       for (const groupId of groupIds) {
@@ -1209,8 +1229,15 @@ export function buildGroupTree(
   };
 
   if (models.size > 0) {
+    // Federated IFCX layers all share ONE composed data store (each overlay
+    // is registered as a "model" for the Models panel) — process each
+    // distinct store once or every group row would repeat per layer.
+    const processed = new Set<IfcDataStore>();
     for (const [modelId, model] of models) {
-      if (model.ifcDataStore) processDataStore(model.ifcDataStore, modelId);
+      const store = model.ifcDataStore;
+      if (!store || processed.has(store)) continue;
+      processed.add(store);
+      processDataStore(store, modelId);
     }
   } else if (ifcDataStore) {
     processDataStore(ifcDataStore, 'legacy');

--- a/packages/ifcx/src/index.ts
+++ b/packages/ifcx/src/index.ts
@@ -10,6 +10,7 @@
  */
 
 import type { IfcxFile, ComposedNode } from './types.js';
+import { ATTR } from './types.js';
 import { composeIfcx, findRoots } from './composition.js';
 import { extractEntities } from './entity-extractor.js';
 import { extractProperties, isQuantityProperty } from './property-extractor.js';
@@ -212,7 +213,9 @@ export async function parseIfcx(
 
 /**
  * Build relationship graph from composed nodes.
- * In IFCX, relationships are implicit in the children structure.
+ * In IFCX, relationships are implicit in the children structure, except for
+ * system membership which rides the `bsi::ifc::system::partofsystem`
+ * attribute (see {@link collectRefs}).
  */
 function buildRelationships(
   composed: Map<string, ComposedNode>,
@@ -233,9 +236,39 @@ function buildRelationships(
         builder.addEdge(parentId, childId, relType, relId++);
       }
     }
+
+    // IFC5 system membership: `bsi::ifc::system::partofsystem` sits on the
+    // MEMBER node and refs the IfcSystem-family node. Emit the edge in STEP
+    // direction (source = group, so 'forward' from the group yields its
+    // members) so extractGroupMembersOnDemand / the viewer's Groups tab read
+    // IFCX stores exactly like STEP ones (#1622).
+    const partOfSystem = node.attributes.get(ATTR.PART_OF_SYSTEM);
+    if (partOfSystem !== undefined) {
+      for (const ref of collectRefs(partOfSystem)) {
+        const groupId = pathToId.get(ref);
+        if (groupId !== undefined) {
+          builder.addEdge(groupId, parentId, RelationshipType.AssignsToGroup, relId++);
+        }
+      }
+    }
   }
 
   return builder.build();
+}
+
+/**
+ * Collect the `ref` targets of a relationship-valued IFCX attribute. The
+ * buildingSMART samples author these as an array of `{ ref: "<path>" }`
+ * objects; tolerate a single bare object too. Anything else yields [].
+ */
+function collectRefs(value: unknown): string[] {
+  const items = Array.isArray(value) ? value : [value];
+  const refs: string[] = [];
+  for (const item of items) {
+    const ref = (item as { ref?: unknown } | null)?.ref;
+    if (typeof ref === 'string' && ref.length > 0) refs.push(ref);
+  }
+  return refs;
 }
 
 /**

--- a/packages/ifcx/src/system-membership.test.ts
+++ b/packages/ifcx/src/system-membership.test.ts
@@ -1,0 +1,98 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * IFC5 system membership -> AssignsToGroup edges (#1622 IFCX follow-up).
+ *
+ * IFCX carries group/system membership as a `bsi::ifc::system::partofsystem`
+ * attribute on the MEMBER node (an array of `{ ref }` objects pointing at the
+ * IfcSystem-family node) — see the buildingSMART Domestic_Hot_Water sample.
+ * parseIfcx must surface those as RelationshipType.AssignsToGroup edges in
+ * STEP direction (group -> member) so the shared readers
+ * (extractGroupMembersOnDemand, the viewer's Groups tab) work unchanged.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { RelationshipType } from '@ifc-lite/data';
+import { parseIfcx } from './index.js';
+import { ATTR } from './types.js';
+
+function toBuffer(doc: unknown): ArrayBuffer {
+  const bytes = new TextEncoder().encode(JSON.stringify(doc));
+  return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
+}
+
+function ifcClass(code: string) {
+  return {
+    code,
+    uri: `https://identifier.buildingsmart.org/uri/buildingsmart/ifc/5/class/${code}`,
+  };
+}
+
+const HEADER = {
+  id: 'test/system-membership.ifcx',
+  ifcxVersion: 'ifcx_alpha',
+  dataVersion: '1.0.0',
+};
+
+describe('parseIfcx — bsi::ifc::system::partofsystem membership', () => {
+  it('emits AssignsToGroup edges (group -> member) for partofsystem refs', async () => {
+    const doc = {
+      header: HEADER,
+      imports: [],
+      schemas: {},
+      data: [
+        { path: 'system-1', attributes: { [ATTR.CLASS]: ifcClass('IfcDistributionSystem') } },
+        {
+          path: 'pipe-1',
+          attributes: {
+            [ATTR.CLASS]: ifcClass('IfcPipeSegment'),
+            // Array-of-refs form (what the buildingSMART samples author).
+            [ATTR.PART_OF_SYSTEM]: [{ ref: 'system-1' }],
+          },
+        },
+        {
+          path: 'valve-1',
+          attributes: {
+            [ATTR.CLASS]: ifcClass('IfcValve'),
+            // Single bare object form — tolerated defensively.
+            [ATTR.PART_OF_SYSTEM]: { ref: 'system-1' },
+          },
+        },
+        {
+          path: 'boiler-1',
+          attributes: {
+            [ATTR.CLASS]: ifcClass('IfcBoiler'),
+            // Dangling ref (target node has no entity) — must be skipped,
+            // not crash or fabricate an edge.
+            [ATTR.PART_OF_SYSTEM]: [{ ref: 'no-such-node' }],
+          },
+        },
+      ],
+    };
+
+    const result = await parseIfcx(toBuffer(doc));
+    const systemId = result.pathToId.get('system-1')!;
+    const pipeId = result.pathToId.get('pipe-1')!;
+    const valveId = result.pathToId.get('valve-1')!;
+    const boilerId = result.pathToId.get('boiler-1')!;
+
+    const members = result.relationships
+      .getRelated(systemId, RelationshipType.AssignsToGroup, 'forward')
+      .sort((a, b) => a - b);
+    assert.deepStrictEqual(members, [pipeId, valveId].sort((a, b) => a - b));
+
+    // Inverse direction: the member's groups (the properties-panel card path).
+    assert.deepStrictEqual(
+      result.relationships.getRelated(pipeId, RelationshipType.AssignsToGroup, 'inverse'),
+      [systemId],
+    );
+    assert.deepStrictEqual(
+      result.relationships.getRelated(boilerId, RelationshipType.AssignsToGroup, 'inverse'),
+      [],
+      'a dangling ref yields no edge',
+    );
+  });
+});

--- a/packages/ifcx/src/types.ts
+++ b/packages/ifcx/src/types.ts
@@ -122,6 +122,12 @@ export const ATTR = {
 
   // IFC Relationships (evolving)
   SPACE_BOUNDARY: 'bsi::ifc::spaceBoundary',
+
+  // IFC5 system membership (bsi::ifc::system schema): sits on the MEMBER
+  // node as `[{ ref }]` pointing at the IfcSystem-family node — the ECS
+  // successor of IfcRelAssignsToGroup (see the buildingSMART
+  // Domestic_Hot_Water sample).
+  PART_OF_SYSTEM: 'bsi::ifc::system::partofsystem',
 } as const;
 
 // ============================================================================

--- a/packages/parser/src/on-demand-extractors.ts
+++ b/packages/parser/src/on-demand-extractors.ts
@@ -624,12 +624,16 @@ export function extractRelationshipsOnDemand(
 
     const getEntityInfo = (id: number): { name?: string; type: string } => {
         const ref = store.entityIndex.byId.get(id);
-        if (!ref) return { type: 'Unknown' };
-        const name = store.entities?.getName(id);
         // Canonical IfcPascalCase (e.g. "IfcZone") for display + case-sensitive
         // consumers; `ref.type` is the raw STEP token ("IFCZONE"). Groups now
         // live in the EntityTable so getTypeName resolves them too. (#1075)
-        const type = store.entities?.getTypeName?.(id) || ref.type;
+        // IFCX stores ingest with an EMPTY entityIndex.byId (no STEP byte
+        // spans exist), so when byId misses the EntityTable is the authority
+        // for name/type instead of reporting Unknown (#1622 IFCX follow-up).
+        const tableType = store.entities?.getTypeName?.(id);
+        if (!ref && (!tableType || tableType === 'Unknown')) return { type: 'Unknown' };
+        const name = store.entities?.getName(id);
+        const type = tableType || ref?.type || 'Unknown';
         return { name: name || undefined, type };
     };
 
@@ -692,12 +696,17 @@ export function extractGroupMembersOnDemand(
     const members: GroupMember[] = [];
     for (const id of memberIds) {
         const ref = store.entityIndex.byId.get(id);
-        if (!ref) continue;
-        const name = store.entities?.getName(id);
         // Canonical IfcPascalCase (e.g. "IfcSpace") — `ref.type` is the raw STEP
         // token ("IFCSPACE"), which would break case-sensitive class checks in
         // consumers (member-isolation toggles, lens zone matching). (#1075)
-        const type = store.entities?.getTypeName(id) || ref.type;
+        const tableType = store.entities?.getTypeName(id);
+        // IFCX stores ingest with an EMPTY entityIndex.byId (no STEP byte spans
+        // exist), so existence rides the EntityTable there: keep a member when
+        // EITHER source knows the id. STEP stores keep byId as the primary gate
+        // and resolve identically to before (#1622 IFCX follow-up).
+        if (!ref && (!tableType || tableType === 'Unknown')) continue;
+        const name = store.entities?.getName(id);
+        const type = tableType || ref?.type || 'Unknown';
         members.push({ id, name: name || undefined, type });
     }
     return members;


### PR DESCRIPTION
The GROUPS hierarchy tab (#1622/#1672) was empty for every IFCX/IFC5 model - flagged as a multi-layer gap in the #1693 review session. Investigation found the data IS there: the IFC5 schema carries system membership as bsi::ifc::system::partofsystem ([{ref}] on the member node, the ECS successor of IfcRelAssignsToGroup - see the buildingSMART Domestic_Hot_Water sample). Three layers each dropped it:

## What changed

- **packages/ifcx**: the composer now reads partofsystem and emits AssignsToGroup relationship edges in STEP direction (source = group, so 'forward' from a group yields its members) - downstream readers stay format-agnostic. New system-membership test suite covers the [{ref}] array shape, a bare object, and malformed values.
- **packages/parser**: extractGroupMembersOnDemand and extractRelationshipsOnDemand gated member existence on entityIndex.byId, which IFCX stores ingest permanently empty (no STEP byte spans exist). The EntityTable is now the fallback authority for existence/name/type when byId misses. STEP stores resolve exactly as before (byId stays the primary gate); no fabricated index entries - consumers that decode byte spans are untouched.
- **apps/viewer**: buildGroupTree enumerated groups via entityIndex.byType - the same IFCX blind spot the #1667 scope chips had (fixed in #1693 via the typeEnum column). An empty index now falls back to ONE EntityTable scan restricted to GROUP_ENTITY_TYPES. Federated IFCX layers share one composed data store; they are now processed once, not once per layer (previously would have duplicated every group row).

## Not changed

Groups with members that carry no geometry anywhere still render as select-only rows (existing behaviour). The clampToGround/Z KMZ item from the same review session shipped separately (#1695).

## Testing

- packages/ifcx: 16 pass / 0 fail (tsx node:test) including the new membership suite.
- packages/parser: 247 pass / 0 fail (vitest).
- apps/viewer: 1609 pass / 0 fail incl. new treeDataBuilder coverage with an IFCX-shaped store (real EntityTableBuilder, empty byType/byId, populated relationships) asserting groups + members appear; tsc clean.
- Rebased onto current main (post #1693/#1694/#1695/#1697-adjacent merges) and re-verified.
- Changeset included (@ifc-lite/ifcx + @ifc-lite/parser, patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)