### PR TITLE
feat(lists): edit columns in place + immediate-container column (#1591 follow-up)

### DIFF
--- a/.changeset/container-adversarial-fixes.md
+++ b/.changeset/container-adversarial-fixes.md
@@ -1,0 +1,10 @@
+---
+"@ifc-lite/data": patch
+"@ifc-lite/parser": patch
+"@ifc-lite/lists": patch
+---
+
+Harden the immediate-Container spatial level (#1591 follow-up):
+
+- The spatial hierarchy now records an aggregated-descendant containment walk for ANY spatial container node, not just storeys, via a new optional `SpatialHierarchy.elementToContainer` map (also carried across data-store transport). A part nested through an IfcElementAssembly under an IfcBridgePart / IfcRoadPart / IfcSpatialZone now resolves that container instead of a blank cell. Storey-only `elementToStorey` semantics are unchanged.
+- The list engine matches the spatial level string case-insensitively, so a hand-edited / imported list carrying `container` resolves the Container level rather than silently falling back to the storey name. An empty or unrecognised level still defaults to Storey.

--- a/.changeset/lists-container-spatial-level.md
+++ b/.changeset/lists-container-spatial-level.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/lists": patch
+---
+
+Add a `Container` spatial level: a `spatial` column or condition with `propertyName: 'Container'` resolves the element's IMMEDIATE spatial container (its direct IfcRelContainedInSpatialStructure parent - the storey, or for infrastructure the IfcBridgePart / IfcRoadPart / IfcSpatialZone it sits in) via the new optional `ListDataProvider.getContainerName`. Providers without the method keep returning blank cells; existing levels (`Storey` default, `Building`, `Site`, `Project`) are unchanged.

--- a/apps/viewer/src/components/viewer/lists/ListBuilder.tsx
+++ b/apps/viewer/src/components/viewer/lists/ListBuilder.tsx
@@ -42,6 +42,8 @@ import {
   isEditableColumn,
   draftFromColumn,
   columnFromDraft,
+  columnDefKey,
+  draftDefKey,
   updateColumnInPlace,
   type ColumnDraft,
 } from '@/lib/lists/column-edit';
@@ -193,16 +195,24 @@ export function ListBuilder({ providers, stores, initial, onSave, onCancel, onEx
     const building = new Set<string>();
     const site = new Set<string>();
     const project = new Set<string>();
-    // Reuse the shared collector so the site / building-like / project
-    // classification can't drift from the column resolver (#1591 review).
+    const container = new Set<string>();
+    // Reuse the shared collector so the site / building-like / project /
+    // container classification can't drift from the column resolver (#1591 review).
     for (const store of stores) {
       const names = collectSpatialContainerNames(store.spatialHierarchy, (id) => store.entities.getName(id));
       names.sites.forEach((n) => site.add(n));
       names.buildings.forEach((n) => building.add(n));
       names.projects.forEach((n) => project.add(n));
+      names.containers.forEach((n) => container.add(n));
     }
     const sorted = (s: Set<string>) => Array.from(s).sort();
-    return { Storey: storeyNames, Building: sorted(building), Site: sorted(site), Project: sorted(project) };
+    return {
+      Container: sorted(container),
+      Storey: storeyNames,
+      Building: sorted(building),
+      Site: sorted(site),
+      Project: sorted(project),
+    };
   }, [stores, storeyNames]);
 
   // Loaded model / file names — value suggestions for a `Model` filter, and the
@@ -275,6 +285,19 @@ export function ListBuilder({ providers, stores, initial, onSave, onCancel, onEx
   const toggleColumn = useCallback((col: ColumnDefinition) => {
     setColumns(prev => (prev.some(c => c.id === col.id) ? prev.filter(c => c.id !== col.id) : [...prev, col]));
   }, []);
+
+  // Would `draft` duplicate an EXISTING column's definition? Keyed by content
+  // (source + set + property), not by column id, so the guard still fires after
+  // an in-place edit drifted a column's definition away from its (stable) id.
+  // `excludeId` skips the slot being edited, so re-saving a column unchanged
+  // isn't flagged as a self-duplicate.
+  const isDuplicateColumn = useCallback(
+    (draft: ColumnDraft, excludeId?: string): boolean => {
+      const key = draftDefKey(draft);
+      return columns.some((c) => c.id !== excludeId && columnDefKey(c) === key);
+    },
+    [columns],
+  );
 
   const moveColumn = useCallback((idx: number, direction: -1 | 1) => {
     setColumns(prev => {
@@ -429,6 +452,7 @@ export function ListBuilder({ providers, stores, initial, onSave, onCancel, onEx
                 onMove={moveColumn}
                 onRemove={removeColumn}
                 onUpdate={updateColumn}
+                isDuplicate={isDuplicateColumn}
               />
             )}
             <ColumnPicker
@@ -436,6 +460,7 @@ export function ListBuilder({ providers, stores, initial, onSave, onCancel, onEx
               selectedIds={selectedColumnIds}
               onAdd={addColumn}
               onToggle={toggleColumn}
+              isDuplicate={isDuplicateColumn}
             />
           </Section>
 
@@ -541,12 +566,14 @@ function SelectedColumns({
   onMove,
   onRemove,
   onUpdate,
+  isDuplicate,
 }: {
   columns: ColumnDefinition[];
   discovered: DiscoveredColumns;
   onMove: (idx: number, dir: -1 | 1) => void;
   onRemove: (id: string) => void;
   onUpdate: (id: string, next: ColumnDefinition) => void;
+  isDuplicate: (draft: ColumnDraft, excludeId?: string) => boolean;
 }) {
   // Which column's inline editor is open (one at a time). Cleared when the
   // edited column is removed or after a save.
@@ -609,7 +636,8 @@ function SelectedColumns({
                 mode="edit"
                 discovered={discovered}
                 initial={draftFromColumn(col)}
-                onSubmit={(draft) => { onUpdate(col.id, columnFromDraft(draft, col.id)); setEditingId(null); }}
+                isDuplicate={(draft) => isDuplicate(draft, col.id)}
+                onSubmit={(draft) => { onUpdate(col.id, columnFromDraft(draft, col.id, col)); setEditingId(null); }}
                 onClose={() => setEditingId(null)}
               />
             )}
@@ -654,9 +682,10 @@ interface ColumnPickerProps {
   selectedIds: Set<string>;
   onAdd: (col: ColumnDefinition) => void;
   onToggle: (col: ColumnDefinition) => void;
+  isDuplicate: (draft: ColumnDraft, excludeId?: string) => boolean;
 }
 
-function ColumnPicker({ discovered, selectedIds, onAdd, onToggle }: ColumnPickerProps) {
+function ColumnPicker({ discovered, selectedIds, onAdd, onToggle, isDuplicate }: ColumnPickerProps) {
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
   const toggleSection = (id: string) =>
     setExpanded(prev => {
@@ -745,7 +774,7 @@ function ColumnPicker({ discovered, selectedIds, onAdd, onToggle }: ColumnPicker
           `/regex/` support so one column pulls a value across matching sets
           (issue #1591 follow-up). Progressive disclosure keeps the picker
           uncluttered until a power user reaches for it. */}
-      <CustomColumnEntry discovered={discovered} selectedIds={selectedIds} onAdd={onAdd} />
+      <CustomColumnEntry discovered={discovered} onAdd={onAdd} isDuplicate={isDuplicate} />
     </div>
   );
 }
@@ -756,12 +785,12 @@ function ColumnPicker({ discovered, selectedIds, onAdd, onToggle }: ColumnPicker
 
 function CustomColumnEntry({
   discovered,
-  selectedIds,
   onAdd,
+  isDuplicate,
 }: {
   discovered: DiscoveredColumns;
-  selectedIds: Set<string>;
   onAdd: (col: ColumnDefinition) => void;
+  isDuplicate: (draft: ColumnDraft, excludeId?: string) => boolean;
 }) {
   const [open, setOpen] = useState(false);
 
@@ -782,7 +811,7 @@ function CustomColumnEntry({
       mode="add"
       discovered={discovered}
       initial={{ source: 'property', setName: '', propName: '' }}
-      isDuplicate={(draft) => selectedIds.has(customColumnId(draft))}
+      isDuplicate={(draft) => isDuplicate(draft)}
       onSubmit={(draft) =>
         onAdd({
           id: customColumnId(draft),

--- a/apps/viewer/src/components/viewer/lists/ListBuilder.tsx
+++ b/apps/viewer/src/components/viewer/lists/ListBuilder.tsx
@@ -13,7 +13,7 @@
  */
 
 import React, { useCallback, useMemo, useState } from 'react';
-import { Play, Plus, Trash2, ChevronDown, ChevronRight, ChevronUp, Save, Check, GripVertical } from 'lucide-react';
+import { Play, Plus, Trash2, ChevronDown, ChevronRight, ChevronUp, Save, Check, GripVertical, Pencil } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { ComboInput } from '@/components/ui/combo-input';
@@ -38,6 +38,13 @@ import type {
 } from '@ifc-lite/lists';
 import { discoverColumns, ENTITY_ATTRIBUTES } from '@ifc-lite/lists';
 import { collectScopeTypes } from '@/lib/lists/scope-types';
+import {
+  isEditableColumn,
+  draftFromColumn,
+  columnFromDraft,
+  updateColumnInPlace,
+  type ColumnDraft,
+} from '@/lib/lists/column-edit';
 import { previewSetPattern, formatMatchHint } from './pattern-preview';
 
 const NO_OPTIONS: readonly string[] = [];
@@ -83,17 +90,22 @@ function discoverConditionValues(stores: IfcDataStore[]): ListConditionValues {
 /** Column descriptor shared by the quick-add grid. */
 interface CommonColumn { id: string; source: ColumnDefinition['source']; propertyName: string; label: string }
 
-/** Spatial-container levels a `spatial` column / filter can target, coarse →
- *  fine written the other way: Storey is the default (back-compat). */
-const SPATIAL_LEVELS = ['Storey', 'Building', 'Site', 'Project'] as const;
+/** Spatial-container levels a `spatial` column / filter can target, fine to
+ *  coarse: Container is the element's IMMEDIATE container (any level); Storey
+ *  is the default (back-compat). */
+const SPATIAL_LEVELS = ['Container', 'Storey', 'Building', 'Site', 'Project'] as const;
 
 /**
  * The first-class columns: built-in attributes plus the spatial / semantic
- * columns. Surfaced as a flat grid so Material / Classification / Storey /
- * Site / Building / Project / Model are as reachable as Name / Class — not
- * buried in a collapsed group. Site / Building / Project / Model identify which
- * federated file (and where in its spatial tree) each row comes from, so a list
- * over several models can be grouped and sorted by source (issue #1591).
+ * columns. Surfaced as a flat grid so Material / Classification / Container /
+ * Storey / Site / Building / Project / Model are as reachable as Name / Class —
+ * not buried in a collapsed group. Container is the element's IMMEDIATE spatial
+ * container (Bonsai's "container"): the direct IfcRelContainedInSpatialStructure
+ * parent, at whatever level — the storey, or for bridges/roads the
+ * IfcBridgePart / IfcRoadPart / IfcSpatialZone it sits in. Site / Building /
+ * Project / Model identify which federated file (and where in its spatial tree)
+ * each row comes from, so a list over several models can be grouped and sorted
+ * by source (issue #1591).
  */
 const COMMON_COLUMNS: CommonColumn[] = [
   ...ENTITY_ATTRIBUTES.map((a): CommonColumn => ({
@@ -104,6 +116,7 @@ const COMMON_COLUMNS: CommonColumn[] = [
   })),
   { id: 'col-material', source: 'material', propertyName: 'Material', label: 'Material' },
   { id: 'col-classification', source: 'classification', propertyName: 'Classification', label: 'Classification' },
+  { id: 'col-container', source: 'spatial', propertyName: 'Container', label: 'Container' },
   { id: 'col-storey', source: 'spatial', propertyName: 'Storey', label: 'Storey' },
   { id: 'col-building', source: 'spatial', propertyName: 'Building', label: 'Building' },
   { id: 'col-site', source: 'spatial', propertyName: 'Site', label: 'Site' },
@@ -250,6 +263,13 @@ export function ListBuilder({ providers, stores, initial, onSave, onCancel, onEx
       next.delete(id);
       return next;
     });
+  }, []);
+
+  // Edit a column's definition IN PLACE — same array position, same id, so the
+  // column order and the results table's per-id width / index-based sort survive
+  // (issue #1591 follow-up). The list is re-run from the existing Run action.
+  const updateColumn = useCallback((id: string, next: ColumnDefinition) => {
+    setColumns(prev => updateColumnInPlace(prev, id, next));
   }, []);
 
   const toggleColumn = useCallback((col: ColumnDefinition) => {
@@ -403,7 +423,13 @@ export function ListBuilder({ providers, stores, initial, onSave, onCancel, onEx
           {/* Columns */}
           <Section label="Columns" hint={columns.length > 0 ? `${columns.length}` : undefined}>
             {columns.length > 0 && (
-              <SelectedColumns columns={columns} onMove={moveColumn} onRemove={removeColumn} />
+              <SelectedColumns
+                columns={columns}
+                discovered={discovered}
+                onMove={moveColumn}
+                onRemove={removeColumn}
+                onUpdate={updateColumn}
+              />
             )}
             <ColumnPicker
               discovered={discovered}
@@ -511,52 +537,85 @@ function Chip({
 
 function SelectedColumns({
   columns,
+  discovered,
   onMove,
   onRemove,
+  onUpdate,
 }: {
   columns: ColumnDefinition[];
+  discovered: DiscoveredColumns;
   onMove: (idx: number, dir: -1 | 1) => void;
   onRemove: (id: string) => void;
+  onUpdate: (id: string, next: ColumnDefinition) => void;
 }) {
+  // Which column's inline editor is open (one at a time). Cleared when the
+  // edited column is removed or after a save.
+  const [editingId, setEditingId] = useState<string | null>(null);
+
   return (
     <div className="mb-3 space-y-1">
-      {columns.map((col, idx) => (
-        <div
-          key={col.id}
-          className="group flex items-center gap-1.5 rounded-md border border-border/60 bg-card px-2 py-1 text-xs"
-        >
-          <GripVertical className="h-3.5 w-3.5 shrink-0 text-muted-foreground/50" />
-          <span className="w-4 shrink-0 text-right tabular-nums text-muted-foreground">{idx + 1}</span>
-          <span className="flex-1 truncate font-medium">
-            {col.label ?? col.propertyName}
-            {col.psetName && <span className="ml-1 font-normal text-muted-foreground">· {col.psetName}</span>}
-          </span>
-          <ColSourceTag col={col} />
-          <button
-            onClick={() => onMove(idx, -1)}
-            disabled={idx === 0}
-            aria-label="Move up"
-            className="shrink-0 text-muted-foreground hover:text-foreground disabled:opacity-25"
-          >
-            <ChevronUp className="h-3.5 w-3.5" />
-          </button>
-          <button
-            onClick={() => onMove(idx, 1)}
-            disabled={idx === columns.length - 1}
-            aria-label="Move down"
-            className="shrink-0 text-muted-foreground hover:text-foreground disabled:opacity-25"
-          >
-            <ChevronDown className="h-3.5 w-3.5" />
-          </button>
-          <button
-            onClick={() => onRemove(col.id)}
-            aria-label="Remove column"
-            className="shrink-0 text-muted-foreground hover:text-destructive"
-          >
-            <Trash2 className="h-3.5 w-3.5" />
-          </button>
-        </div>
-      ))}
+      {columns.map((col, idx) => {
+        const editing = editingId === col.id;
+        const editable = isEditableColumn(col);
+        return (
+          <div key={col.id} className="space-y-1">
+            <div className="group flex items-center gap-1.5 rounded-md border border-border/60 bg-card px-2 py-1 text-xs">
+              <GripVertical className="h-3.5 w-3.5 shrink-0 text-muted-foreground/50" />
+              <span className="w-4 shrink-0 text-right tabular-nums text-muted-foreground">{idx + 1}</span>
+              <span className="flex-1 truncate font-medium">
+                {col.label ?? col.propertyName}
+                {col.psetName && <span className="ml-1 font-normal text-muted-foreground">· {col.psetName}</span>}
+              </span>
+              <ColSourceTag col={col} />
+              {editable && (
+                <button
+                  onClick={() => setEditingId(editing ? null : col.id)}
+                  aria-label={editing ? 'Close editor' : 'Edit column'}
+                  aria-pressed={editing}
+                  className={cn(
+                    'shrink-0 hover:text-foreground',
+                    editing ? 'text-primary' : 'text-muted-foreground',
+                  )}
+                >
+                  <Pencil className="h-3.5 w-3.5" />
+                </button>
+              )}
+              <button
+                onClick={() => onMove(idx, -1)}
+                disabled={idx === 0}
+                aria-label="Move up"
+                className="shrink-0 text-muted-foreground hover:text-foreground disabled:opacity-25"
+              >
+                <ChevronUp className="h-3.5 w-3.5" />
+              </button>
+              <button
+                onClick={() => onMove(idx, 1)}
+                disabled={idx === columns.length - 1}
+                aria-label="Move down"
+                className="shrink-0 text-muted-foreground hover:text-foreground disabled:opacity-25"
+              >
+                <ChevronDown className="h-3.5 w-3.5" />
+              </button>
+              <button
+                onClick={() => { if (editing) setEditingId(null); onRemove(col.id); }}
+                aria-label="Remove column"
+                className="shrink-0 text-muted-foreground hover:text-destructive"
+              >
+                <Trash2 className="h-3.5 w-3.5" />
+              </button>
+            </div>
+            {editing && editable && (
+              <ColumnEditorPanel
+                mode="edit"
+                discovered={discovered}
+                initial={draftFromColumn(col)}
+                onSubmit={(draft) => { onUpdate(col.id, columnFromDraft(draft, col.id)); setEditingId(null); }}
+                onClose={() => setEditingId(null)}
+              />
+            )}
+          </div>
+        );
+      })}
     </div>
   );
 }
@@ -705,9 +764,74 @@ function CustomColumnEntry({
   onAdd: (col: ColumnDefinition) => void;
 }) {
   const [open, setOpen] = useState(false);
-  const [source, setSource] = useState<'property' | 'quantity'>('property');
-  const [setName, setSetName] = useState('');
-  const [propName, setPropName] = useState('');
+
+  if (!open) {
+    return (
+      <button
+        onClick={() => setOpen(true)}
+        className="flex w-full items-center gap-1.5 rounded-md border border-dashed border-border px-2 py-1.5 text-xs text-muted-foreground hover:border-primary/50 hover:text-foreground"
+      >
+        <Plus className="h-3.5 w-3.5" /> Custom column
+        <span className="ml-auto font-mono text-[10px] opacity-70">Pset/Qto or /regex/</span>
+      </button>
+    );
+  }
+
+  return (
+    <ColumnEditorPanel
+      mode="add"
+      discovered={discovered}
+      initial={{ source: 'property', setName: '', propName: '' }}
+      isDuplicate={(draft) => selectedIds.has(customColumnId(draft))}
+      onSubmit={(draft) =>
+        onAdd({
+          id: customColumnId(draft),
+          source: draft.source,
+          psetName: draft.setName,
+          propertyName: draft.propName,
+          label: draft.propName,
+        })
+      }
+      onClose={() => setOpen(false)}
+    />
+  );
+}
+
+/**
+ * Id for a custom / pattern column. Slugified like the discovered-column ids
+ * (collapse whitespace) but case-PRESERVING: regex patterns are case-sensitive,
+ * so `/A/` and `/a/` are distinct sets and must not collapse to one id.
+ */
+function customColumnId(draft: ColumnDraft): string {
+  return `custom-${draft.source}-${draft.setName}-${draft.propName}`.replace(/\s+/g, '-');
+}
+
+/**
+ * The shared property/quantity column editor — the same UI for ADDING a custom
+ * column and for EDITING an existing one in place (issue #1591 follow-up), so
+ * the two never drift. `mode` only changes the primary action (Add keeps the
+ * panel open to add several in a row and clears just the property; Save applies
+ * and lets the parent close). Set + property names accept Bonsai-style
+ * `/regex/`, with the same live match preview and invalid-pattern guard.
+ */
+function ColumnEditorPanel({
+  mode,
+  discovered,
+  initial,
+  onSubmit,
+  onClose,
+  isDuplicate,
+}: {
+  mode: 'add' | 'edit';
+  discovered: DiscoveredColumns;
+  initial: ColumnDraft;
+  onSubmit: (draft: ColumnDraft) => void;
+  onClose: () => void;
+  isDuplicate?: (draft: ColumnDraft) => boolean;
+}) {
+  const [source, setSource] = useState<'property' | 'quantity'>(initial.source);
+  const [setName, setSetName] = useState(initial.setName);
+  const [propName, setPropName] = useState(initial.propName);
 
   const setOptions = useMemo<string[]>(
     () => Array.from((source === 'quantity' ? discovered.quantities : discovered.properties).keys()).sort(),
@@ -723,34 +847,20 @@ function CustomColumnEntry({
   const set = setName.trim();
   const prop = propName.trim();
   // Live preview: which discovered sets a `/regex/` set field matches, so a
-  // power user sees "matches 2 sets: ..." before adding, and a malformed pattern
-  // is flagged rather than silently added as a dead literal (issue #1591).
+  // power user sees "matches 2 sets: ..." before saving, and a malformed pattern
+  // is flagged rather than silently kept as a dead literal (issue #1591).
   const preview = useMemo(() => previewSetPattern(set, setOptions), [set, setOptions]);
-  // Slugify like the discovered-column ids (collapse whitespace) but keep the
-  // original case: regex patterns are case-sensitive, so `/A/` and `/a/` are
-  // distinct sets and must not collapse to one id.
-  const columnId = `custom-${source}-${set}-${prop}`.replace(/\s+/g, '-');
-  const canAdd = set.length > 0 && prop.length > 0 && !selectedIds.has(columnId) && !preview.isInvalid;
+  const draft: ColumnDraft = { source, setName: set, propName: prop };
+  const duplicate = isDuplicate?.(draft) ?? false;
+  const canSubmit = set.length > 0 && prop.length > 0 && !preview.isInvalid && !duplicate;
 
-  const add = () => {
-    if (!canAdd) return;
-    onAdd({ id: columnId, source, psetName: set, propertyName: prop, label: prop });
-    // Keep the set + source so several properties from the same (pattern) set
-    // can be added in a row; clear only the property.
-    setPropName('');
+  const submit = () => {
+    if (!canSubmit) return;
+    onSubmit(draft);
+    // Adding keeps the set + source so several properties from the same
+    // (pattern) set can be added in a row; editing is a one-shot apply.
+    if (mode === 'add') setPropName('');
   };
-
-  if (!open) {
-    return (
-      <button
-        onClick={() => setOpen(true)}
-        className="flex w-full items-center gap-1.5 rounded-md border border-dashed border-border px-2 py-1.5 text-xs text-muted-foreground hover:border-primary/50 hover:text-foreground"
-      >
-        <Plus className="h-3.5 w-3.5" /> Custom column
-        <span className="ml-auto font-mono text-[10px] opacity-70">Pset/Qto or /regex/</span>
-      </button>
-    );
-  }
 
   return (
     <div className="space-y-2 rounded-md border border-border/60 bg-card p-2.5">
@@ -763,8 +873,8 @@ function CustomColumnEntry({
           </span>
         )}
         <button
-          onClick={() => setOpen(false)}
-          aria-label="Close custom column"
+          onClick={onClose}
+          aria-label={mode === 'add' ? 'Close custom column' : 'Close editor'}
           className="ml-auto shrink-0 text-muted-foreground hover:text-foreground"
         >
           <ChevronUp className="h-3.5 w-3.5" />
@@ -787,12 +897,12 @@ function CustomColumnEntry({
         />
         <Button
           size="sm"
-          onClick={add}
-          disabled={!canAdd}
-          aria-label="Add custom column"
+          onClick={submit}
+          disabled={!canSubmit}
+          aria-label={mode === 'add' ? 'Add custom column' : 'Save column'}
           className="h-7 shrink-0 px-2"
         >
-          <Plus className="h-3.5 w-3.5" />
+          {mode === 'add' ? <Plus className="h-3.5 w-3.5" /> : <Check className="h-3.5 w-3.5" />}
         </Button>
       </div>
       {preview.isInvalid ? (

--- a/apps/viewer/src/lib/lists/adapter.ts
+++ b/apps/viewer/src/lib/lists/adapter.ts
@@ -96,7 +96,11 @@ export function createListDataProvider(store: IfcDataStore, modelName = ''): Lis
   let ancestryCache: SpatialAncestryIndex | null = null;
   function ancestry(): SpatialAncestryIndex {
     if (!ancestryCache) {
-      ancestryCache = buildSpatialAncestryIndex(store.spatialHierarchy, (id) => store.entities.getName(id));
+      ancestryCache = buildSpatialAncestryIndex(
+        store.spatialHierarchy,
+        (id) => store.entities.getName(id),
+        (id) => store.entities.getTypeName(id),
+      );
     }
     return ancestryCache;
   }
@@ -162,6 +166,10 @@ export function createListDataProvider(store: IfcDataStore, modelName = ''): Lis
       const storeyId = hierarchy.elementToStorey.get(entityId);
       if (!storeyId) return '';
       return store.entities.getName(storeyId) || '';
+    },
+
+    getContainerName(entityId: number): string {
+      return ancestry().containerOf(entityId);
     },
 
     getBuildingName(entityId: number): string {

--- a/apps/viewer/src/lib/lists/column-edit.adversarial.test.ts
+++ b/apps/viewer/src/lib/lists/column-edit.adversarial.test.ts
@@ -1,0 +1,226 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * ADVERSARIAL tests for edit-column-in-place (PR #1700). Pins down:
+ *  - legacy persisted columns (pre-#1591 shapes without psetName / label)
+ *  - a NO-CHANGE edit save rewriting a custom label (confirmed loss)
+ *  - regex pattern round-trip incl. flags and escapes
+ *  - the missing duplicate guard in EDIT mode + the add-guard id drift
+ *  - duplicate column ids in imported/legacy definitions
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { executeList, compileNameMatcher, type ColumnDefinition, type ListDataProvider, type ListDefinition } from '@ifc-lite/lists';
+import { IfcTypeEnum, PropertyValueType, QuantityType } from '@ifc-lite/data';
+import { isEditableColumn, draftFromColumn, columnFromDraft, columnDefKey, draftDefKey, updateColumnInPlace, type ColumnDraft } from './column-edit.js';
+
+/** The content-derived key the duplicate guard now uses (ListBuilder.tsx
+ *  `isDuplicateColumn`), mirrored here to prove the guard recognises an edited
+ *  column regardless of its (stable) id. */
+const addPathKey = (d: ColumnDraft) => draftDefKey(d);
+
+describe('legacy persisted columns (pre-feature shapes)', () => {
+  it('a legacy property column without psetName/label survives draftFromColumn', () => {
+    // Old persisted lists can carry property columns without the optional
+    // fields — psetName and label are `?` in the schema, and localStorage
+    // JSON is loaded unvalidated (persistence.ts loadListDefinitions).
+    const legacy = { id: 'old-1', source: 'property', propertyName: 'FireRating' } as ColumnDefinition;
+    assert.equal(isEditableColumn(legacy), true);
+    const draft = draftFromColumn(legacy);
+    assert.deepEqual(draft, { source: 'property', setName: '', propName: 'FireRating' });
+    // Round-trip does not throw and keeps the id.
+    const back = columnFromDraft(draft, legacy.id);
+    assert.equal(back.id, 'old-1');
+    assert.equal(back.psetName, '');
+    assert.equal(back.propertyName, 'FireRating');
+  });
+
+  it('a legacy quantity column maps to a quantity draft (source not collapsed)', () => {
+    const legacy = { id: 'old-q', source: 'quantity', psetName: 'Qto_WallBaseQuantities', propertyName: 'NetVolume' } as ColumnDefinition;
+    assert.equal(draftFromColumn(legacy).source, 'quantity');
+  });
+
+  it('FIXED: a no-change edit save preserves a custom label override (perfect no-op)', () => {
+    // ColumnDefinition.label is a "Display label override"; imported .list.json
+    // definitions can carry one. columnFromDraft now takes the PREVIOUS column
+    // and keeps a deliberate override (a label that differs from the auto-label
+    // its own definition would generate), so opening the editor and saving
+    // WITHOUT any change is a perfect no-op instead of a silent rename.
+    const col: ColumnDefinition = {
+      id: 'c', source: 'property', psetName: 'Pset_WallCommon',
+      propertyName: 'FireRating', label: 'Fire Rating (custom)',
+    };
+    const unchanged = columnFromDraft(draftFromColumn(col), col.id, col);
+    assert.equal(unchanged.psetName, col.psetName);
+    assert.equal(unchanged.propertyName, col.propertyName);
+    // The override survives, so the whole definition round-trips byte-for-byte.
+    assert.equal(unchanged.label, col.label);
+    assert.deepEqual(unchanged, col);
+  });
+
+  it('FIXED: an auto-labelled column still regenerates its label on a definition edit', () => {
+    // When the old label WAS the auto-label (== propertyName), it is not an
+    // override, so editing the property name refreshes the label as before.
+    const col: ColumnDefinition = {
+      id: 'c', source: 'property', psetName: 'Pset_WallCommon',
+      propertyName: 'FireRating', label: 'FireRating',
+    };
+    const edited = columnFromDraft({ ...draftFromColumn(col), propName: 'LoadBearing' }, col.id, col);
+    assert.equal(edited.propertyName, 'LoadBearing');
+    assert.equal(edited.label, 'LoadBearing');
+  });
+});
+
+describe('regex column round-trip through the editor', () => {
+  it('preserves a /regex/ set pattern byte-for-byte, incl. flags and escapes', () => {
+    for (const pattern of [
+      '/Qto_.*BaseQuantities/',
+      '/qto_.+/i', // flags
+      '/Pset_\\w+Common/', // escapes
+      '/^(Qto|Pset)_[A-Za-z]+$/',
+    ]) {
+      const col: ColumnDefinition = {
+        id: `custom-quantity-${pattern}-NetVolume`.replace(/\s+/g, '-'),
+        source: 'quantity', psetName: pattern, propertyName: 'NetVolume', label: 'NetVolume',
+      };
+      const roundTripped = columnFromDraft(draftFromColumn(col), col.id);
+      assert.equal(roundTripped.psetName, pattern, `pattern mangled: ${pattern}`);
+      // The pattern still compiles to the same matcher semantics.
+      assert.equal(compileNameMatcher(roundTripped.psetName!)('Qto_WallBaseQuantities'),
+        compileNameMatcher(pattern)('Qto_WallBaseQuantities'));
+    }
+  });
+
+  it('trim() cannot mutate a well-formed /…/ literal (delimiters are non-space)', () => {
+    // Inner spaces are regex content and must survive; only OUTER whitespace
+    // (which cannot be part of a /…/ literal) is trimmed.
+    const col: ColumnDefinition = {
+      id: 'x', source: 'property', psetName: '/Pset_[A-Z]{2} Common/', propertyName: 'P', label: 'P',
+    };
+    assert.equal(columnFromDraft(draftFromColumn(col), 'x').psetName, '/Pset_[A-Z]{2} Common/');
+  });
+
+  it('an edited regex column still resolves values end-to-end after the round-trip', () => {
+    const provider: ListDataProvider = {
+      getEntitiesByType: (t) => (t === IfcTypeEnum.IfcWall ? [1] : []),
+      getEntityName: () => 'W', getEntityGlobalId: () => 'g', getEntityDescription: () => '',
+      getEntityObjectType: () => '', getEntityTag: () => '', getEntityTypeName: () => 'IfcWall',
+      getPropertySets: () => [],
+      getQuantitySets: () => [
+        { name: 'Qto_WallBaseQuantities', quantities: [{ name: 'NetVolume', value: 0.28, type: QuantityType.Volume }] },
+      ],
+    };
+    const original: ColumnDefinition = {
+      id: 'vol', source: 'quantity', psetName: '/Qto_.*BaseQuantities/', propertyName: 'GrossVolume', label: 'GrossVolume',
+    };
+    // Pencil-edit: change only the quantity name, keep the pattern.
+    const edited = columnFromDraft({ ...draftFromColumn(original), propName: 'NetVolume' }, original.id);
+    const def: ListDefinition = {
+      id: 'd', name: 'd', createdAt: 0, updatedAt: 0,
+      entityTypes: [IfcTypeEnum.IfcWall], conditions: [],
+      columns: updateColumnInPlace([original], 'vol', edited),
+    };
+    assert.equal(executeList(def, provider).rows[0].values[0], 0.28);
+  });
+});
+
+describe('duplicate handling in edit mode', () => {
+  const fire: ColumnDefinition = {
+    id: 'custom-property-Pset_WallCommon-FireRating',
+    source: 'property', psetName: 'Pset_WallCommon', propertyName: 'FireRating', label: 'FireRating',
+  };
+  const acoustic: ColumnDefinition = {
+    id: 'custom-property-Pset_WallCommon-AcousticRating',
+    source: 'property', psetName: 'Pset_WallCommon', propertyName: 'AcousticRating', label: 'AcousticRating',
+  };
+
+  it('FIXED: editing a column into an exact duplicate is detectable via the definition key', () => {
+    // The pure helper still keeps ids stable (sort/width binding relies on it),
+    // so an edit CAN produce two columns with the same definition under
+    // different ids. The guard no longer keys on the id: `columnDefKey` derives
+    // identity from CONTENT, so the two collide and the UI blocks the save.
+    const draft = draftFromColumn(fire); // = FireRating definition
+    const next = updateColumnInPlace([fire, acoustic], acoustic.id, columnFromDraft(draft, acoustic.id, acoustic));
+    assert.equal(next.length, 2);
+    const [a, b] = next;
+    assert.notEqual(a.id, b.id); // ids stay distinct (no key collision) ...
+    assert.equal(columnDefKey(a), columnDefKey(b)); // ... but the DEFINITION keys collide
+    // The edit-mode guard excludes the edited slot itself, then flags any OTHER
+    // column sharing the draft's definition key — here, `fire`.
+    const isDuplicate = (d: ColumnDraft, excludeId?: string) =>
+      next.some((c) => c.id !== excludeId && columnDefKey(c) === draftDefKey(d));
+    assert.equal(isDuplicate(draft, b.id), true);
+  });
+
+  it('FIXED: after an edit, the ADD-mode duplicate guard still sees the column by definition', () => {
+    // Edit AcousticRating -> FireRating: the column keeps its OLD id.
+    const edited = columnFromDraft(draftFromColumn(fire), acoustic.id, acoustic);
+    const columns = updateColumnInPlace([acoustic], acoustic.id, edited);
+    // The add guard keys on CONTENT, not id: the fresh-add draft's definition
+    // key matches the edited column's, so "Custom column" is blocked.
+    const freshAddKey = addPathKey(draftFromColumn(fire));
+    const selectedDefKeys = new Set(columns.map((c) => columnDefKey(c)));
+    assert.equal(freshAddKey, columnDefKey(fire), 'key mirror sanity check');
+    assert.equal(selectedDefKeys.has(freshAddKey), true);
+  });
+
+  it('EDGE: duplicate ids in an imported definition make one edit rewrite BOTH slots', () => {
+    // importListDefinition never validates column-id uniqueness, so a
+    // hand-authored .list.json can carry two columns with the same id. The
+    // in-place edit maps over ALL matches.
+    const dupA = { ...fire };
+    const dupB = { ...fire, propertyName: 'LoadBearing', label: 'LoadBearing' };
+    const edited = columnFromDraft({ source: 'property', setName: 'Pset_X', propName: 'Y' }, fire.id);
+    const next = updateColumnInPlace([dupA, dupB], fire.id, edited);
+    assert.equal(next[0].propertyName, 'Y');
+    assert.equal(next[1].propertyName, 'Y'); // second slot silently rewritten too
+  });
+});
+
+describe('order / binding preservation under edit', () => {
+  it('editing column i of n keeps order and every other object identity', () => {
+    const cols: ColumnDefinition[] = [
+      { id: 'a', source: 'attribute', propertyName: 'Name' },
+      { id: 'b', source: 'property', psetName: 'P', propertyName: 'X', label: 'X' },
+      { id: 'c', source: 'spatial', propertyName: 'Container' },
+      { id: 'd', source: 'model', propertyName: 'Model' },
+    ];
+    const next = updateColumnInPlace(cols, 'b', columnFromDraft({ source: 'quantity', setName: 'Q', propName: 'Z' }, 'ignored-id'));
+    assert.deepEqual(next.map((c) => c.id), ['a', 'b', 'c', 'd'], 'order and ids stable');
+    assert.equal(next[1].id, 'b', 'id is FORCED back even when next carries another id');
+    assert.equal(next[1].source, 'quantity');
+    assert.equal(next[0], cols[0]);
+    assert.equal(next[2], cols[2]);
+    assert.equal(next[3], cols[3]);
+  });
+
+  it('grouping/sum bindings (by column id) survive an in-place edit', () => {
+    const provider: ListDataProvider = {
+      getEntitiesByType: (t) => (t === IfcTypeEnum.IfcWall ? [1, 2] : []),
+      getEntityName: (id) => `W${id}`, getEntityGlobalId: () => 'g', getEntityDescription: () => '',
+      getEntityObjectType: () => '', getEntityTag: () => '', getEntityTypeName: () => 'IfcWall',
+      getPropertySets: () => [
+        { name: 'P', globalId: 'pg', properties: [{ name: 'X', value: 'x', type: PropertyValueType.Label }] },
+      ],
+      getQuantitySets: (id) => [
+        { name: 'Q', quantities: [{ name: 'Z', value: id === 1 ? 2 : 3, type: QuantityType.Volume }] },
+      ],
+    };
+    const cols: ColumnDefinition[] = [
+      { id: 'cls', source: 'attribute', propertyName: 'Class' },
+      { id: 'v', source: 'property', psetName: 'P', propertyName: 'X', label: 'X' },
+    ];
+    // Edit the summed column from a string property to a numeric quantity.
+    const columns = updateColumnInPlace(cols, 'v', columnFromDraft({ source: 'quantity', setName: 'Q', propName: 'Z' }, 'v'));
+    const def: ListDefinition = {
+      id: 'g', name: 'g', createdAt: 0, updatedAt: 0,
+      entityTypes: [IfcTypeEnum.IfcWall], conditions: [], columns,
+      grouping: { columnId: 'cls', sumColumnIds: ['v'] },
+    };
+    const result = executeList(def, provider);
+    assert.equal(result.summary?.sums.v, 5, 'sum binding by id still resolves after the edit');
+  });
+});

--- a/apps/viewer/src/lib/lists/column-edit.test.ts
+++ b/apps/viewer/src/lib/lists/column-edit.test.ts
@@ -1,0 +1,108 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Editing a list column IN PLACE (issue #1591 follow-up). The helpers must
+ * keep the column's array position (order) and its id (the results table keys
+ * per-column width by id and sort by index), while the DEFINITION change flows
+ * through `executeList` so the re-run produces the new values.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { executeList, type ColumnDefinition, type ListDataProvider, type ListDefinition } from '@ifc-lite/lists';
+import { IfcTypeEnum, PropertyValueType } from '@ifc-lite/data';
+import { isEditableColumn, draftFromColumn, columnFromDraft, updateColumnInPlace } from './column-edit.js';
+
+/** One IfcWall carrying two Pset_WallCommon properties to switch between. */
+function stubProvider(): ListDataProvider {
+  return {
+    getEntitiesByType: (t) => (t === IfcTypeEnum.IfcWall ? [1] : []),
+    getEntityName: () => 'Wall-1',
+    getEntityGlobalId: (id) => `guid-${id}`,
+    getEntityDescription: () => '',
+    getEntityObjectType: () => '',
+    getEntityTag: () => '',
+    getEntityTypeName: () => 'IfcWall',
+    getPropertySets: () => [
+      { name: 'Pset_WallCommon', globalId: 'pset-guid', properties: [
+        { name: 'FireRating', value: 'REI 90', type: PropertyValueType.Label },
+        { name: 'AcousticRating', value: 'R52', type: PropertyValueType.Label },
+      ]},
+    ],
+    getQuantitySets: () => [],
+  };
+}
+
+const col = (id: string, propertyName: string, psetName = 'Pset_WallCommon'): ColumnDefinition => ({
+  id,
+  source: 'property',
+  psetName,
+  propertyName,
+  label: propertyName,
+});
+
+describe('column edit in place (#1591 follow-up)', () => {
+  it('only property/quantity columns (which carry a formula) are editable', () => {
+    assert.equal(isEditableColumn(col('c1', 'FireRating')), true);
+    assert.equal(isEditableColumn({ id: 'q', source: 'quantity', psetName: 'Qto', propertyName: 'NetVolume' }), true);
+    assert.equal(isEditableColumn({ id: 'n', source: 'attribute', propertyName: 'Name' }), false);
+    assert.equal(isEditableColumn({ id: 's', source: 'spatial', propertyName: 'Container' }), false);
+    assert.equal(isEditableColumn({ id: 'm', source: 'material', propertyName: 'Material' }), false);
+  });
+
+  it('draft -> column round-trips the definition and PRESERVES the original id', () => {
+    const original = col('custom-property-Pset_WallCommon-FireRating', 'FireRating');
+    const draft = draftFromColumn(original);
+    assert.deepEqual(draft, { source: 'property', setName: 'Pset_WallCommon', propName: 'FireRating' });
+    const edited = columnFromDraft({ ...draft, propName: ' AcousticRating ' }, original.id);
+    assert.equal(edited.id, original.id, 'id survives so width/sort keyed by id survive');
+    assert.equal(edited.propertyName, 'AcousticRating', 'names are trimmed');
+    assert.equal(edited.label, 'AcousticRating', 'label tracks the property, like add');
+  });
+
+  it('updateColumnInPlace keeps the column order and every other column untouched', () => {
+    const columns: ColumnDefinition[] = [
+      { id: 'name', source: 'attribute', propertyName: 'Name' },
+      col('fire', 'FireRating'),
+      { id: 'sto', source: 'spatial', propertyName: 'Storey' },
+    ];
+    const edited = columnFromDraft(
+      { source: 'property', setName: 'Pset_WallCommon', propName: 'AcousticRating' },
+      'fire',
+    );
+    const next = updateColumnInPlace(columns, 'fire', edited);
+    assert.deepEqual(next.map((c) => c.id), ['name', 'fire', 'sto'], 'order + ids preserved');
+    assert.equal(next[1].propertyName, 'AcousticRating');
+    assert.equal(next[0], columns[0], 'other columns are the same objects');
+    assert.equal(next[2], columns[2]);
+    // A stale edit (column already removed) is a no-op.
+    assert.equal(updateColumnInPlace(columns, 'gone', edited), columns);
+  });
+
+  it('re-running the list after an in-place edit yields the NEW values in the same slot', () => {
+    const provider = stubProvider();
+    const def: ListDefinition = {
+      id: 'l1',
+      name: 'Walls',
+      createdAt: 0,
+      updatedAt: 0,
+      entityTypes: [IfcTypeEnum.IfcWall],
+      conditions: [],
+      columns: [
+        { id: 'name', source: 'attribute', propertyName: 'Name' },
+        col('fire', 'FireRating'),
+      ],
+    };
+    const before = executeList(def, provider);
+    assert.deepEqual(before.rows[0].values, ['Wall-1', 'REI 90']);
+
+    // Pencil-edit: FireRating -> AcousticRating, same column slot.
+    const draft = { ...draftFromColumn(def.columns[1]), propName: 'AcousticRating' };
+    const columns = updateColumnInPlace(def.columns, 'fire', columnFromDraft(draft, 'fire'));
+    const after = executeList({ ...def, columns }, provider);
+    assert.deepEqual(after.rows[0].values, ['Wall-1', 'R52'], 'same slot, updated value');
+    assert.equal(after.columns[1].id, 'fire');
+  });
+});

--- a/apps/viewer/src/lib/lists/column-edit.ts
+++ b/apps/viewer/src/lib/lists/column-edit.ts
@@ -40,19 +40,51 @@ export function draftFromColumn(col: ColumnDefinition): ColumnDraft {
 }
 
 /**
+ * A content-derived identity for a property / quantity column DEFINITION:
+ * source + set + property, whitespace-collapsed (mirrors the add-path
+ * `customColumnId` slug, minus its `custom-` prefix). Two columns collide when
+ * their definitions resolve the same value, regardless of their `id` — so a
+ * duplicate check can catch an in-place edit that changed a column's definition
+ * while (deliberately) keeping its id stable. Case-preserving: `/A/` and `/a/`
+ * are distinct regex sets and must not fold together.
+ */
+export function columnDefKey(
+  col: Pick<ColumnDefinition, 'source' | 'psetName' | 'propertyName'>,
+): string {
+  return `${col.source}-${(col.psetName ?? '').trim()}-${col.propertyName.trim()}`.replace(/\s+/g, '-');
+}
+
+/** `columnDefKey` for an in-flight editor draft (see `columnDefKey`). */
+export function draftDefKey(draft: ColumnDraft): string {
+  return `${draft.source}-${draft.setName.trim()}-${draft.propName.trim()}`.replace(/\s+/g, '-');
+}
+
+/**
  * Build the edited column from the editor draft, PRESERVING the original id so
  * the results table's width (keyed by id) and sort (by column index) survive.
- * The label tracks the property name, matching how columns are added.
+ *
+ * The label tracks the property name, matching how columns are added — EXCEPT
+ * when `previous` carries a deliberate label override (a label that differs
+ * from the auto-label its own definition would generate, e.g. an imported
+ * `.list.json` display name or a renamed column). That override is kept, so a
+ * definition edit — and in particular a zero-change save — never silently
+ * renames the column.
  */
-export function columnFromDraft(draft: ColumnDraft, id: string): ColumnDefinition {
+export function columnFromDraft(
+  draft: ColumnDraft,
+  id: string,
+  previous?: ColumnDefinition,
+): ColumnDefinition {
   const setName = draft.setName.trim();
   const propName = draft.propName.trim();
+  const hadOverride =
+    previous?.label !== undefined && previous.label !== previous.propertyName;
   return {
     id,
     source: draft.source,
     psetName: setName,
     propertyName: propName,
-    label: propName,
+    label: hadOverride ? previous!.label : propName,
   };
 }
 

--- a/apps/viewer/src/lib/lists/column-edit.ts
+++ b/apps/viewer/src/lib/lists/column-edit.ts
@@ -1,0 +1,71 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Editing a list column's definition IN PLACE (issue #1591 follow-up).
+ *
+ * Before this, a column's definition (set / property name, or a `/regex/`
+ * pattern) could not be changed once added — the user had to delete the column
+ * and add a new one, losing its position and any table width / sort state that
+ * is keyed by column id. These pure helpers back the pencil-edit affordance in
+ * the list builder: they replace a column IN PLACE, keeping both its array
+ * position (column order) and its `id` (so the results table's per-id width and
+ * index-based sort survive the edit).
+ */
+
+import type { ColumnDefinition } from '@ifc-lite/lists';
+
+/** A column whose free-text definition (set + property, incl. `/regex/`) is
+ *  editable. Built-in attribute / material / classification / spatial / model
+ *  columns are picked by chip and carry no free-text formula to edit. */
+export function isEditableColumn(col: ColumnDefinition): boolean {
+  return col.source === 'property' || col.source === 'quantity';
+}
+
+/** The editor's working fields — a property/quantity set + a property name. */
+export interface ColumnDraft {
+  source: 'property' | 'quantity';
+  setName: string;
+  propName: string;
+}
+
+/** Seed the editor's fields from an existing column. */
+export function draftFromColumn(col: ColumnDefinition): ColumnDraft {
+  return {
+    source: col.source === 'quantity' ? 'quantity' : 'property',
+    setName: col.psetName ?? '',
+    propName: col.propertyName,
+  };
+}
+
+/**
+ * Build the edited column from the editor draft, PRESERVING the original id so
+ * the results table's width (keyed by id) and sort (by column index) survive.
+ * The label tracks the property name, matching how columns are added.
+ */
+export function columnFromDraft(draft: ColumnDraft, id: string): ColumnDefinition {
+  const setName = draft.setName.trim();
+  const propName = draft.propName.trim();
+  return {
+    id,
+    source: draft.source,
+    psetName: setName,
+    propertyName: propName,
+    label: propName,
+  };
+}
+
+/**
+ * Replace the column with `id` by `next` (its `id` forced to stay `id`),
+ * keeping every other column and the overall ORDER untouched. Returns the
+ * array unchanged when no column matches, so a stale edit is a no-op.
+ */
+export function updateColumnInPlace(
+  columns: ColumnDefinition[],
+  id: string,
+  next: ColumnDefinition,
+): ColumnDefinition[] {
+  if (!columns.some((c) => c.id === id)) return columns;
+  return columns.map((c) => (c.id === id ? { ...next, id } : c));
+}

--- a/apps/viewer/src/utils/spatialHierarchy.container-adversarial.test.ts
+++ b/apps/viewer/src/utils/spatialHierarchy.container-adversarial.test.ts
@@ -1,0 +1,192 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * ADVERSARIAL tests for `containerOf` (PR #1700, Container column). Pins down:
+ *  - aggregated parts of an assembly contained in a STOREY (storey fallback OK)
+ *  - aggregated parts of an assembly contained in a NON-storey container
+ *    (elementToStorey never propagates -> blank, while the assembly resolves)
+ *  - elements contained in an IfcSpatialZone / directly in an IfcSite
+ *  - a container node DISCONNECTED from the project tree
+ *  - zero spatial tree (hierarchy undefined)
+ *  - unnamed AND typeless containers (getClass missing or empty)
+ *  - the spatial container's OWN containerOf
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  EntityTableBuilder,
+  RelationshipGraphBuilder,
+  RelationshipType,
+  StringTable,
+} from '@ifc-lite/data';
+import { rebuildSpatialHierarchy, buildSpatialAncestryIndex } from './spatialHierarchy';
+
+function indexFrom(builderSetup: (eb: EntityTableBuilder, rels: RelationshipGraphBuilder) => void) {
+  const strings = new StringTable();
+  const eb = new EntityTableBuilder(16, strings);
+  const rels = new RelationshipGraphBuilder();
+  builderSetup(eb, rels);
+  const et = eb.build();
+  const h = rebuildSpatialHierarchy(et, rels.build());
+  assert.ok(h, 'hierarchy builds');
+  return {
+    hierarchy: h,
+    idx: buildSpatialAncestryIndex(h, (id) => et.getName(id), (id) => et.getTypeName(id)),
+  };
+}
+
+describe('containerOf for aggregated assembly parts', () => {
+  it('assembly contained in a STOREY: parts fall back to the storey (correct label)', () => {
+    const { idx } = indexFrom((eb, rels) => {
+      eb.add(1, 'IFCPROJECT', 'p', 'Project', '', '');
+      eb.add(2, 'IFCSITE', 's', 'Site', '', '');
+      eb.add(3, 'IFCBUILDING', 'b', 'Building', '', '');
+      eb.add(4, 'IFCBUILDINGSTOREY', 'st', 'Level 1', '', '');
+      eb.add(5, 'IFCELEMENTASSEMBLY', 'asm', 'Truss T1', '', '', true);
+      eb.add(6, 'IFCBEAM', 'beam', 'Chord', '', '', true);
+      rels.addEdge(1, 2, RelationshipType.Aggregates, 100);
+      rels.addEdge(2, 3, RelationshipType.Aggregates, 101);
+      rels.addEdge(3, 4, RelationshipType.Aggregates, 102);
+      rels.addEdge(4, 5, RelationshipType.ContainsElements, 103); // assembly in storey
+      rels.addEdge(5, 6, RelationshipType.Aggregates, 104); // beam aggregated, NOT contained
+    });
+    assert.equal(idx.containerOf(5), 'Level 1');
+    // IFC containment is inherited through decomposition, so labelling the
+    // part with the assembly's storey is semantically right.
+    assert.equal(idx.containerOf(6), 'Level 1');
+  });
+
+  it('FIXED: assembly contained in a NON-storey container attributes its parts to that container', () => {
+    // Infrastructure shape: assembly contained in an IfcBridgePart. The
+    // builder now records an aggregated-descendant containment walk for ANY
+    // spatial container node (not just storeys) into `elementToContainer`, so
+    // the beam resolves the Deck it demonstrably lives under.
+    const { hierarchy, idx } = indexFrom((eb, rels) => {
+      eb.add(1, 'IFCPROJECT', 'p', 'Infra', '', '');
+      eb.add(2, 'IFCBRIDGE', 'br', 'Bridge A', '', '');
+      eb.add(3, 'IFCBRIDGEPART', 'deck', 'Deck', '', '');
+      eb.add(4, 'IFCELEMENTASSEMBLY', 'asm', 'Truss T1', '', '', true);
+      eb.add(5, 'IFCBEAM', 'beam', 'Chord', '', '', true);
+      rels.addEdge(1, 2, RelationshipType.Aggregates, 100);
+      rels.addEdge(2, 3, RelationshipType.Aggregates, 101);
+      rels.addEdge(3, 4, RelationshipType.ContainsElements, 102); // assembly in bridge part
+      rels.addEdge(4, 5, RelationshipType.Aggregates, 103); // beam aggregated into assembly
+    });
+    // The assembly itself resolves its immediate container.
+    assert.equal(idx.containerOf(4), 'Deck');
+    // Its aggregated part now inherits the Deck via the new elementToContainer
+    // map — the beam's Container cell is no longer blank.
+    assert.equal(idx.containerOf(5), 'Deck');
+    assert.equal(hierarchy.elementToContainer?.get(5), 3);
+    // elementToStorey semantics stay byte-identical: still storey-only, so the
+    // beam has NO storey entry and the pre-existing storey-backed columns
+    // (buildingOf) are unchanged.
+    assert.equal(hierarchy.elementToStorey.get(5), undefined);
+    assert.equal(idx.buildingOf(5), '');
+  });
+});
+
+describe('containerOf across container kinds', () => {
+  it('element contained in an IfcSpatialZone resolves the zone; the zone resolves its storey', () => {
+    const { idx } = indexFrom((eb, rels) => {
+      eb.add(1, 'IFCPROJECT', 'p', 'Project', '', '');
+      eb.add(2, 'IFCBUILDING', 'b', 'Building', '', '');
+      eb.add(3, 'IFCBUILDINGSTOREY', 'st', 'Level 1', '', '');
+      eb.add(4, 'IFCSPATIALZONE', 'z', 'GFA Apt', '', '', true);
+      eb.add(5, 'IFCWALL', 'w', 'Wall', '', '', true);
+      rels.addEdge(1, 2, RelationshipType.Aggregates, 100);
+      rels.addEdge(2, 3, RelationshipType.Aggregates, 101);
+      rels.addEdge(3, 4, RelationshipType.Aggregates, 102); // zone under storey
+      rels.addEdge(4, 5, RelationshipType.ContainsElements, 103); // wall in zone
+    });
+    assert.equal(idx.containerOf(5), 'GFA Apt');
+    // The zone is a child NODE (never in `elements`); it falls back to its
+    // storey via elementToStorey — its nearest containing structure.
+    assert.equal(idx.containerOf(4), 'Level 1');
+  });
+
+  it('element contained directly in an IfcSite resolves the site', () => {
+    const { idx } = indexFrom((eb, rels) => {
+      eb.add(1, 'IFCPROJECT', 'p', 'Project', '', '');
+      eb.add(2, 'IFCSITE', 's', 'North Site', '', '');
+      eb.add(3, 'IFCWALL', 'w', 'Retaining Wall', '', '', true);
+      rels.addEdge(1, 2, RelationshipType.Aggregates, 100);
+      rels.addEdge(2, 3, RelationshipType.ContainsElements, 101);
+    });
+    assert.equal(idx.containerOf(3), 'North Site');
+  });
+
+  it('container DISCONNECTED from the project tree: element resolves blank, no crash', () => {
+    // A zone that is never aggregated under the project is unreachable by the
+    // tree walk; its contained element has no reverse entry anywhere.
+    const { idx } = indexFrom((eb, rels) => {
+      eb.add(1, 'IFCPROJECT', 'p', 'Project', '', '');
+      eb.add(2, 'IFCBUILDING', 'b', 'Building', '', '');
+      eb.add(5, 'IFCSPATIALZONE', 'z', 'Orphan Zone', '', '', true);
+      eb.add(6, 'IFCWALL', 'w', 'Wall', '', '', true);
+      rels.addEdge(1, 2, RelationshipType.Aggregates, 100);
+      rels.addEdge(5, 6, RelationshipType.ContainsElements, 101); // zone floats free
+    });
+    assert.equal(idx.containerOf(6), '');
+  });
+
+  it('the spatial container itself (a storey) has no container: blank, no self-label', () => {
+    const { idx } = indexFrom((eb, rels) => {
+      eb.add(1, 'IFCPROJECT', 'p', 'Project', '', '');
+      eb.add(2, 'IFCBUILDING', 'b', 'Building', '', '');
+      eb.add(3, 'IFCBUILDINGSTOREY', 'st', 'Level 1', '', '');
+      rels.addEdge(1, 2, RelationshipType.Aggregates, 100);
+      rels.addEdge(2, 3, RelationshipType.Aggregates, 101);
+    });
+    // Unlike siteOf/buildingOf (self-inclusive), containerOf never returns the
+    // element itself; a storey listed as a row shows a blank Container cell.
+    assert.equal(idx.containerOf(3), '');
+  });
+});
+
+describe('containerOf degenerate inputs', () => {
+  it('zero spatial tree (hierarchy undefined): every lookup is "" and never throws', () => {
+    const idx = buildSpatialAncestryIndex(undefined, () => '', () => 'IfcWall');
+    assert.equal(idx.containerOf(1), '');
+    assert.equal(idx.containerOf(0), '');
+    assert.equal(idx.containerOf(-1), '');
+    assert.equal(idx.projectName, '');
+  });
+
+  it('unnamed container with NO getClass (legacy caller) resolves "" not undefined', () => {
+    const strings = new StringTable();
+    const eb = new EntityTableBuilder(4, strings);
+    eb.add(1, 'IFCPROJECT', 'p', 'Project', '', '');
+    eb.add(2, 'IFCBUILDINGSTOREY', 'st', '', '', ''); // unnamed storey
+    eb.add(3, 'IFCWALL', 'w', 'Wall', '', '', true);
+    const rels = new RelationshipGraphBuilder();
+    rels.addEdge(1, 2, RelationshipType.Aggregates, 100);
+    rels.addEdge(2, 3, RelationshipType.ContainsElements, 101);
+    const et = eb.build();
+    const h = rebuildSpatialHierarchy(et, rels.build());
+    assert.ok(h);
+    // Two-arg call (the pre-PR signature): the class fallback is simply off.
+    const idx = buildSpatialAncestryIndex(h, (id) => et.getName(id));
+    assert.equal(typeof idx.containerOf(3), 'string');
+    assert.equal(idx.containerOf(3), '');
+  });
+
+  it('unnamed container whose getClass also yields "" resolves "" (fully anonymous)', () => {
+    const strings = new StringTable();
+    const eb = new EntityTableBuilder(4, strings);
+    eb.add(1, 'IFCPROJECT', 'p', 'Project', '', '');
+    eb.add(2, 'IFCBUILDINGSTOREY', 'st', '', '', '');
+    eb.add(3, 'IFCWALL', 'w', 'Wall', '', '', true);
+    const rels = new RelationshipGraphBuilder();
+    rels.addEdge(1, 2, RelationshipType.Aggregates, 100);
+    rels.addEdge(2, 3, RelationshipType.ContainsElements, 101);
+    const et = eb.build();
+    const h = rebuildSpatialHierarchy(et, rels.build());
+    assert.ok(h);
+    const idx = buildSpatialAncestryIndex(h, (id) => et.getName(id), () => '');
+    assert.equal(idx.containerOf(3), '');
+  });
+});

--- a/apps/viewer/src/utils/spatialHierarchy.test.ts
+++ b/apps/viewer/src/utils/spatialHierarchy.test.ts
@@ -374,6 +374,61 @@ describe('buildSpatialAncestryIndex', () => {
     assert.equal(idx.buildingOf(6), 'House');
   });
 
+  // #1591 follow-up: `containerOf` resolves the element's IMMEDIATE container
+  // (the direct IfcRelContainedInSpatialStructure parent), at whatever level —
+  // a non-storey IfcBridgePart here — with the container's IFC class as the
+  // fallback when it is unnamed, and '' for an unplaced element.
+  it('containerOf resolves the immediate non-storey container, class fallback when unnamed', () => {
+    const strings = new StringTable();
+    const eb = new EntityTableBuilder(6, strings);
+    eb.add(1, 'IFCPROJECT', 'p0', 'Infra Project', '', '');
+    eb.add(2, 'IFCBRIDGE', 'br', 'Bridge A', '', '');
+    eb.add(3, 'IFCBRIDGEPART', 'deck', 'Deck', '', '');
+    eb.add(4, 'IFCBRIDGEPART', 'pier', '', '', ''); // unnamed part
+    eb.add(5, 'IFCWALL', 'w0', 'Barrier', '', '', true);
+    eb.add(6, 'IFCWALL', 'w1', 'Parapet', '', '', true);
+    const rels = new RelationshipGraphBuilder();
+    rels.addEdge(1, 2, RelationshipType.Aggregates, 100);
+    rels.addEdge(2, 3, RelationshipType.Aggregates, 101);
+    rels.addEdge(2, 4, RelationshipType.Aggregates, 102);
+    rels.addEdge(3, 5, RelationshipType.ContainsElements, 103);
+    rels.addEdge(4, 6, RelationshipType.ContainsElements, 104);
+    const et = eb.build();
+    const h = rebuildSpatialHierarchy(et, rels.build());
+    assert.ok(h);
+    const idx = buildSpatialAncestryIndex(h, (id) => et.getName(id), (id) => et.getTypeName(id));
+    // The immediate container, NOT the bridge/facility above it.
+    assert.equal(idx.containerOf(5), 'Deck');
+    // Unnamed container falls back to its IFC class.
+    assert.equal(idx.containerOf(6), 'IfcBridgePart');
+    // An element the hierarchy doesn't place resolves to ''.
+    assert.equal(idx.containerOf(9999), '');
+  });
+
+  it('containerOf resolves the storey for storey-contained elements and aggregated parts', () => {
+    const strings = new StringTable();
+    const eb = new EntityTableBuilder(6, strings);
+    eb.add(1, 'IFCPROJECT', 'p0', 'Project', '', '');
+    eb.add(2, 'IFCSITE', 's0', 'Site', '', '');
+    eb.add(3, 'IFCBUILDING', 'b0', 'Building', '', '');
+    eb.add(4, 'IFCBUILDINGSTOREY', 'st0', 'Level 1', '', '');
+    eb.add(5, 'IFCWALL', 'w0', 'Wall', '', '', true);
+    eb.add(6, 'IFCBUILDINGELEMENTPART', 'part', 'Layer A', '', '', true);
+    const rels = new RelationshipGraphBuilder();
+    rels.addEdge(1, 2, RelationshipType.Aggregates, 100);
+    rels.addEdge(2, 3, RelationshipType.Aggregates, 101);
+    rels.addEdge(3, 4, RelationshipType.Aggregates, 102);
+    rels.addEdge(4, 5, RelationshipType.ContainsElements, 103);
+    rels.addEdge(5, 6, RelationshipType.Aggregates, 104); // part: aggregated, not contained
+    const et = eb.build();
+    const h = rebuildSpatialHierarchy(et, rels.build());
+    assert.ok(h);
+    const idx = buildSpatialAncestryIndex(h, (id) => et.getName(id), (id) => et.getTypeName(id));
+    assert.equal(idx.containerOf(5), 'Level 1');
+    // Aggregated part: not directly contained, falls back to its storey.
+    assert.equal(idx.containerOf(6), 'Level 1');
+  });
+
   it('uses the nearest named site when a nested inner site IS named', () => {
     const strings = new StringTable();
     const eb = new EntityTableBuilder(5, strings);

--- a/apps/viewer/src/utils/spatialHierarchy.ts
+++ b/apps/viewer/src/utils/spatialHierarchy.ts
@@ -103,6 +103,16 @@ export interface SpatialAncestryIndex {
   projectName: string;
   siteOf(elementId: number): string;
   buildingOf(elementId: number): string;
+  /**
+   * Name of the element's IMMEDIATE spatial container — the direct
+   * IfcRelContainedInSpatialStructure parent (the node that lists it in its
+   * `elements`), which may be a storey OR a non-storey container such as an
+   * IfcBridgePart / IfcRoadPart / IfcSpatialZone / IfcSpace. Falls back to the
+   * container's IFC class when it is unnamed (via `getClass`), and to '' when
+   * the element is uncontained. Spaces and aggregated parts, which are not
+   * directly contained, resolve to their storey (their nearest container).
+   */
+  containerOf(elementId: number): string;
 }
 
 /**
@@ -114,7 +124,9 @@ export interface SpatialAncestryIndex {
  * `getName` resolves an entity's real IFC `Name` — pass the store's
  * `entities.getName` so an UNNAMED container resolves to '' (matching how the
  * storey column behaves), rather than the `SpatialNode.name` placeholder the
- * hierarchy builder synthesizes (`Entity #N`). "Building" spans every
+ * hierarchy builder synthesizes (`Entity #N`). `getClass` (optional) resolves an
+ * entity's IFC class name, used only as the `containerOf` fallback for an
+ * unnamed immediate container. "Building" spans every
  * building-like spatial type (IFC4X3 IfcFacility / IfcBridge / IfcRoad / …), so
  * infrastructure federations resolve too.
  *
@@ -127,6 +139,7 @@ export interface SpatialAncestryIndex {
 export function buildSpatialAncestryIndex(
   hierarchy: SpatialHierarchy | undefined | null,
   getName: (expressId: number) => string,
+  getClass?: (expressId: number) => string,
 ): SpatialAncestryIndex {
   // container node id -> nearest {site, building} name (self-inclusive).
   const ancestry = new Map<number, { site: string; building: string }>();
@@ -162,6 +175,17 @@ export function buildSpatialAncestryIndex(
     return hierarchy?.elementToStorey.get(elementId); // parts/aggregated descendants
   };
 
+  // Immediate container: the node that DIRECTLY lists the element in its
+  // `elements` (IfcRelContainedInSpatialStructure), at whatever spatial level.
+  // Unlike `containerFor`, the element itself is never its own container. Spaces
+  // (child nodes) and aggregated parts are not directly contained, so they fall
+  // back to their storey — their nearest containing structure.
+  const immediateContainerFor = (elementId: number): number | undefined => {
+    const direct = elementToContainer.get(elementId);
+    if (direct !== undefined) return direct;
+    return hierarchy?.elementToStorey.get(elementId);
+  };
+
   return {
     projectName,
     siteOf(elementId: number): string {
@@ -171,6 +195,12 @@ export function buildSpatialAncestryIndex(
     buildingOf(elementId: number): string {
       const c = containerFor(elementId);
       return c === undefined ? '' : (ancestry.get(c)?.building ?? '');
+    },
+    containerOf(elementId: number): string {
+      const c = immediateContainerFor(elementId);
+      if (c === undefined) return '';
+      // Real IFC Name, else the container's IFC class (e.g. "IfcBridgePart").
+      return getName(c) || (getClass ? getClass(c) : '');
     },
   };
 }

--- a/apps/viewer/src/utils/spatialHierarchy.ts
+++ b/apps/viewer/src/utils/spatialHierarchy.ts
@@ -65,16 +65,19 @@ function spatialContainerLevel(node: SpatialNode): 'site' | 'building' | 'projec
  * Collect the distinct REAL IFC names of every IfcSite / building-like /
  * IfcProject container in a hierarchy (unnamed containers contribute nothing,
  * matching the column values). `getName` resolves an entity's real Name.
- * Powers the spatial-filter value suggestions, sharing node classification with
- * `buildSpatialAncestryIndex`.
+ * `containers` gathers the name of every node that DIRECTLY contains elements
+ * at any level — the immediate-Container column's possible values (storeys,
+ * spaces / zones, IfcBridgePart / IfcRoadPart, …). Powers the spatial-filter
+ * value suggestions, sharing node classification with `buildSpatialAncestryIndex`.
  */
 export function collectSpatialContainerNames(
   hierarchy: SpatialHierarchy | undefined | null,
   getName: (expressId: number) => string,
-): { sites: string[]; buildings: string[]; projects: string[] } {
+): { sites: string[]; buildings: string[]; projects: string[]; containers: string[] } {
   const sites = new Set<string>();
   const buildings = new Set<string>();
   const projects = new Set<string>();
+  const containers = new Set<string>();
   const root = hierarchy?.project;
   if (root) {
     const walk = (node: SpatialNode): void => {
@@ -84,13 +87,20 @@ export function collectSpatialContainerNames(
         if (level === 'site') sites.add(name);
         else if (level === 'building') buildings.add(name);
         else if (level === 'project') projects.add(name);
+        // Any node that directly lists elements is an immediate Container.
+        if (node.elements.length > 0) containers.add(name);
       }
       for (const child of node.children) walk(child);
     };
     walk(root);
   }
   const sorted = (s: Set<string>) => Array.from(s).sort();
-  return { sites: sorted(sites), buildings: sorted(buildings), projects: sorted(projects) };
+  return {
+    sites: sorted(sites),
+    buildings: sorted(buildings),
+    projects: sorted(projects),
+    containers: sorted(containers),
+  };
 }
 
 /**
@@ -177,12 +187,19 @@ export function buildSpatialAncestryIndex(
 
   // Immediate container: the node that DIRECTLY lists the element in its
   // `elements` (IfcRelContainedInSpatialStructure), at whatever spatial level.
-  // Unlike `containerFor`, the element itself is never its own container. Spaces
-  // (child nodes) and aggregated parts are not directly contained, so they fall
-  // back to their storey — their nearest containing structure.
+  // Unlike `containerFor`, the element itself is never its own container.
+  // Aggregated parts (e.g. an IfcBeam nested through an IfcElementAssembly) are
+  // not directly contained, so they resolve via the builder's
+  // `elementToContainer` map — their nearest containing spatial node at any
+  // level (a storey, but also an IfcBridgePart / IfcRoadPart / IfcSpatialZone).
+  // Spaces (child nodes) fall back to their storey. `elementToStorey` remains
+  // the final fallback so hierarchies that predate `elementToContainer` still
+  // resolve parts under a storey.
   const immediateContainerFor = (elementId: number): number | undefined => {
     const direct = elementToContainer.get(elementId);
     if (direct !== undefined) return direct;
+    const aggregated = hierarchy?.elementToContainer?.get(elementId);
+    if (aggregated !== undefined) return aggregated;
     return hierarchy?.elementToStorey.get(elementId);
   };
 

--- a/packages/data/src/types.ts
+++ b/packages/data/src/types.ts
@@ -243,7 +243,18 @@ export interface SpatialHierarchy {
   storeyElevations: Map<number, number>;  // storeyId -> elevation (z)
   storeyHeights: Map<number, number>;     // storeyId -> floor-to-floor height (calculated from elevation differences)
   elementToStorey: Map<number, number>;  // elementId -> storeyId (reverse lookup)
-  
+  /**
+   * elementId -> the nearest spatial container node that ultimately contains
+   * it, at ANY level (storey, IfcSpace / IfcSpatialZone, or an infrastructure
+   * IfcBridgePart / IfcRoadPart / …). Unlike `elementToStorey` (storey-only),
+   * this also records aggregated descendants of a directly-contained element
+   * (e.g. an IfcBeam aggregated into an IfcElementAssembly that is contained in
+   * an IfcBridgePart), so the "immediate Container" lookup resolves under
+   * non-storey containers too. Optional: legacy / non-parser hierarchies that
+   * predate it fall back to `elementToStorey`.
+   */
+  elementToContainer?: Map<number, number>;
+
   // Helper methods
   getStoreyElements(storeyId: number): number[];
   getStoreyByElevation(z: number): number | null;

--- a/packages/lists/src/engine.container-adversarial.test.ts
+++ b/packages/lists/src/engine.container-adversarial.test.ts
@@ -1,0 +1,227 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * ADVERSARIAL tests for the Container spatial level (#1591 follow-up, PR #1700).
+ * Each test pins a suspected failure mode down as CONFIRMED or REFUTED:
+ *  - condition vs column value consistency (incl. the class-name fallback)
+ *  - case sensitivity of Container conditions
+ *  - matching behaviour for an EMPTY ('' / uncontained) container
+ *  - legacy providers without getContainerName
+ *  - level-string casing ('container' vs 'Container')
+ *  - engine sortBy binding after an in-place column edit (same id, new def)
+ *  - federated models sharing local express ids
+ */
+
+import { describe, it, expect } from 'vitest';
+import { IfcTypeEnum } from '@ifc-lite/data';
+import { executeList } from './engine.js';
+import type { ListDataProvider, ListDefinition, PropertyCondition } from './types.js';
+
+/**
+ * Four walls with distinct container situations:
+ *  1 -> 'Level 0'         (named storey container)
+ *  2 -> 'Abutment East'   (named non-storey container)
+ *  3 -> ''                (uncontained -> adapter returns '')
+ *  4 -> 'IfcBridgePart'   (UNNAMED container: adapter already resolved the
+ *                          class-name fallback, exactly what containerOf returns)
+ */
+function provider(containerNames: Map<number, string> = new Map([
+  [1, 'Level 0'],
+  [2, 'Abutment East'],
+  [3, ''],
+  [4, 'IfcBridgePart'],
+])): ListDataProvider {
+  const names = new Map([[1, 'W1'], [2, 'W2'], [3, 'W3'], [4, 'W4']]);
+  return {
+    getEntitiesByType: (t) => (t === IfcTypeEnum.IfcWall ? [1, 2, 3, 4] : []),
+    getEntityName: (id) => names.get(id) ?? '',
+    getEntityGlobalId: (id) => `g${id}`,
+    getEntityDescription: () => '',
+    getEntityObjectType: () => '',
+    getEntityTag: () => '',
+    getEntityTypeName: (id) => (names.has(id) ? 'IfcWall' : ''),
+    getPropertySets: () => [],
+    getQuantitySets: () => [],
+    getAllEntityIds: () => [...names.keys()],
+    getContainerName: (id) => containerNames.get(id) ?? '',
+    getStoreyName: (id) => (id === 1 ? 'Level 0' : id === 2 ? 'Level 9' : ''),
+  };
+}
+
+function defWith(conditions: PropertyCondition[], columns?: ListDefinition['columns']): ListDefinition {
+  return {
+    id: 'adv', name: 'adv', createdAt: 0, updatedAt: 0,
+    entityTypes: [IfcTypeEnum.IfcWall],
+    conditions,
+    columns: columns ?? [
+      { id: 'name', source: 'attribute', propertyName: 'Name' },
+      { id: 'container', source: 'spatial', propertyName: 'Container' },
+    ],
+  };
+}
+
+const rowNames = (def: ListDefinition, p = provider()) =>
+  executeList(def, p).rows.map((r) => r.values[0]).sort();
+
+describe('Container condition vs column consistency', () => {
+  it('the condition sees EXACTLY the value the column shows, including the class fallback', () => {
+    // Column values first.
+    const result = executeList(defWith([]), provider());
+    const cells = new Map(result.rows.map((r) => [r.values[0], r.values[1]]));
+    expect(cells.get('W1')).toBe('Level 0');
+    expect(cells.get('W2')).toBe('Abutment East');
+    expect(cells.get('W3')).toBeNull(); // '' coerced to null -> blank cell
+    expect(cells.get('W4')).toBe('IfcBridgePart'); // class fallback IS the cell
+
+    // A filter on the class-fallback value matches the same row the column
+    // labels with it — no name-vs-class divergence between filter and column.
+    expect(rowNames(defWith([
+      { source: 'spatial', propertyName: 'Container', operator: 'equals', value: 'IfcBridgePart' },
+    ]))).toEqual(['W4']);
+
+    // And when the container HAS a real name, filtering by its class matches
+    // NOTHING for that element: the condition sees the name, not the class.
+    expect(rowNames(defWith([
+      { source: 'spatial', propertyName: 'Container', operator: 'equals', value: 'IfcBuildingStorey' },
+    ]))).toEqual([]);
+  });
+});
+
+describe('Container condition case sensitivity', () => {
+  it('equals is CASE-SENSITIVE (same as Storey/attribute equals)', () => {
+    expect(rowNames(defWith([
+      { source: 'spatial', propertyName: 'Container', operator: 'equals', value: 'abutment east' },
+    ]))).toEqual([]);
+    expect(rowNames(defWith([
+      { source: 'spatial', propertyName: 'Container', operator: 'equals', value: 'Abutment East' },
+    ]))).toEqual(['W2']);
+  });
+
+  it('contains is case-INSENSITIVE (same asymmetry as every scalar source)', () => {
+    expect(rowNames(defWith([
+      { source: 'spatial', propertyName: 'Container', operator: 'contains', value: 'ABUTMENT' },
+    ]))).toEqual(['W2']);
+  });
+});
+
+describe('empty-string container matching', () => {
+  it('an uncontained element can NEVER be matched: equals "" fails (empty string -> null)', () => {
+    expect(rowNames(defWith([
+      { source: 'spatial', propertyName: 'Container', operator: 'equals', value: '' },
+    ]))).toEqual([]);
+  });
+
+  it('notEquals also EXCLUDES uncontained elements (null short-circuits to false)', () => {
+    // W3 has no container; "Container != Abutment East" still drops it.
+    expect(rowNames(defWith([
+      { source: 'spatial', propertyName: 'Container', operator: 'notEquals', value: 'Abutment East' },
+    ]))).toEqual(['W1', 'W4']);
+  });
+
+  it('exists treats "" as absent, so it is the only (one-sided) uncontained probe', () => {
+    expect(rowNames(defWith([
+      { source: 'spatial', propertyName: 'Container', operator: 'exists', value: '' },
+    ]))).toEqual(['W1', 'W2', 'W4']);
+  });
+});
+
+describe('legacy provider without getContainerName', () => {
+  const legacy = provider();
+  delete (legacy as { getContainerName?: unknown }).getContainerName;
+
+  it('the Container column resolves null (blank) instead of throwing', () => {
+    const result = executeList(defWith([]), legacy);
+    expect(result.rows.map((r) => r.values[1])).toEqual([null, null, null, null]);
+  });
+
+  it('a Container condition matches nothing instead of throwing', () => {
+    const def = defWith([
+      { source: 'spatial', propertyName: 'Container', operator: 'equals', value: 'Level 0' },
+    ]);
+    expect(executeList(def, legacy).rows).toEqual([]);
+  });
+});
+
+describe('level-string is matched case-insensitively', () => {
+  it("'container' (lowercase) resolves the Container level, not the storey fallback", () => {
+    // FIXED: the level parser lower-cases the level string, so a hand-edited /
+    // imported list carrying 'container' resolves the immediate-Container value
+    // (getContainerName) instead of silently showing the storey name.
+    const result = executeList(defWith([], [
+      { id: 'name', source: 'attribute', propertyName: 'Name' },
+      { id: 'c', source: 'spatial', propertyName: 'container' },
+    ]), provider());
+    const cells = new Map(result.rows.map((r) => [r.values[0], r.values[1]]));
+    expect(cells.get('W2')).toBe('Abutment East'); // container, NOT the storey 'Level 9'
+  });
+
+  it('a genuinely unrecognised level still falls back to Storey (level-less legacy)', () => {
+    // The back-compat default is untouched: an empty / unknown level resolves
+    // the storey name, so lists authored before the level existed keep working.
+    const result = executeList(defWith([], [
+      { id: 'name', source: 'attribute', propertyName: 'Name' },
+      { id: 'c', source: 'spatial', propertyName: '' },
+    ]), provider());
+    const cells = new Map(result.rows.map((r) => [r.values[0], r.values[1]]));
+    expect(cells.get('W1')).toBe('Level 0'); // storey fallback
+    expect(cells.get('W2')).toBe('Level 9');
+  });
+});
+
+describe('engine sortBy binding across an in-place column edit', () => {
+  it('sortBy.columnId keeps pointing at the edited slot and sorts the NEW values', () => {
+    const p: ListDataProvider = {
+      ...provider(),
+      getEntitiesByType: (t) => (t === IfcTypeEnum.IfcWall ? [1, 2] : []),
+      getQuantitySets: (id) => [{
+        name: 'Qto_WallBaseQuantities',
+        quantities: id === 1
+          ? [{ name: 'Length', value: 5.0, type: 0 }, { name: 'Width', value: 0.1, type: 0 }]
+          : [{ name: 'Length', value: 3.5, type: 0 }, { name: 'Width', value: 0.9, type: 0 }],
+      }],
+    };
+    const before: ListDefinition = {
+      id: 's', name: 's', createdAt: 0, updatedAt: 0,
+      entityTypes: [IfcTypeEnum.IfcWall], conditions: [],
+      columns: [
+        { id: 'name', source: 'attribute', propertyName: 'Name' },
+        { id: 'custom-quantity-Qto_WallBaseQuantities-Length', source: 'quantity', psetName: 'Qto_WallBaseQuantities', propertyName: 'Length' },
+      ],
+      sortBy: { columnId: 'custom-quantity-Qto_WallBaseQuantities-Length', direction: 'asc' },
+    };
+    // asc by Length: W2 (3.5) before W1 (5.0).
+    expect(executeList(before, p).rows.map((r) => r.values[0])).toEqual(['W2', 'W1']);
+
+    // In-place edit: same id (preserved by columnFromDraft), definition now Width.
+    const after: ListDefinition = {
+      ...before,
+      columns: [
+        before.columns[0],
+        { ...before.columns[1], propertyName: 'Width', label: 'Width' },
+      ],
+    };
+    // The sort binding (by id) survives and sorts by the NEW values:
+    // asc by Width: W1 (0.1) before W2 (0.9).
+    expect(executeList(after, p).rows.map((r) => r.values[0])).toEqual(['W1', 'W2']);
+  });
+});
+
+describe('federated models with colliding express ids', () => {
+  it('each model resolves the container from ITS OWN provider', () => {
+    // Same local expressId 1 means a different element in each model.
+    const pa = provider(new Map([[1, 'Level A']]));
+    const pb = provider(new Map([[1, 'Pier West']]));
+    const def = defWith([]);
+    const ra = executeList(def, pa, 'model-a');
+    const rb = executeList(def, pb, 'model-b');
+    const cellA = ra.rows.find((r) => r.entityId === 1)!;
+    const cellB = rb.rows.find((r) => r.entityId === 1)!;
+    expect(cellA.values[1]).toBe('Level A');
+    expect(cellB.values[1]).toBe('Pier West');
+    // Merged rows (what ListPanel does) stay distinguishable by modelId.
+    expect(cellA.modelId).toBe('model-a');
+    expect(cellB.modelId).toBe('model-b');
+  });
+});

--- a/packages/lists/src/engine.test.ts
+++ b/packages/lists/src/engine.test.ts
@@ -105,6 +105,14 @@ function createMockProvider(): ListDataProvider {
     [3, 'Main Site'],
   ]);
 
+  // Immediate spatial containers (#1591 follow-up): Wall-01 sits directly in
+  // its storey; Wall-02 in a NON-storey container (an IfcBridgePart-style
+  // part); the slab is uncontained, so its container is '' (a blank cell).
+  const containerNames = new Map<number, string>([
+    [1, 'Level 0'],
+    [2, 'Abutment East'],
+  ]);
+
   const predefinedTypes = new Map<number, string>([
     [1, 'SOLIDWALL'],
     // entity 2 intentionally has no PredefinedType
@@ -125,6 +133,7 @@ function createMockProvider(): ListDataProvider {
     getMaterialNames: (id) => materialNames.get(id) ?? [],
     getClassifications: (id) => classifications.get(id) ?? [],
     getStoreyName: (id) => storeyNames.get(id) ?? '',
+    getContainerName: (id) => containerNames.get(id) ?? '',
     getBuildingName: (id) => buildingNames.get(id) ?? '',
     getSiteName: (id) => siteNames.get(id) ?? '',
     getProjectName: () => 'Sample Project',
@@ -342,6 +351,30 @@ describe('executeList', () => {
     expect(byName.get('Slab-01')).toEqual(['Slab-01', 'model-a.ifc', 'Sample Project', 'Main Site', 'Building B', 'Level 0']);
   });
 
+  // #1591 follow-up: the Container column is the element's IMMEDIATE spatial
+  // container — the storey when directly contained there, a non-storey
+  // container (IfcBridgePart / IfcRoadPart / IfcSpatialZone) for infra, and a
+  // blank cell (null) when the element is uncontained.
+  it('extracts the immediate-container spatial column, blank when uncontained', () => {
+    const provider = createMockProvider();
+    const result = executeList({
+      id: 'container-col',
+      name: 'Test',
+      createdAt: 0,
+      updatedAt: 0,
+      entityTypes: [IfcTypeEnum.IfcWall, IfcTypeEnum.IfcSlab],
+      conditions: [],
+      columns: [
+        { id: 'name', source: 'attribute', propertyName: 'Name' },
+        { id: 'container', source: 'spatial', propertyName: 'Container' },
+      ],
+    }, provider);
+    const byName = new Map(result.rows.map((r) => [r.values[0], r.values[1]]));
+    expect(byName.get('Wall-01')).toBe('Level 0'); // contained in its storey
+    expect(byName.get('Wall-02')).toBe('Abutment East'); // non-storey container
+    expect(byName.get('Slab-01')).toBeNull(); // uncontained -> blank
+  });
+
   // A `spatial` column authored before the level existed carries an empty
   // propertyName; it must still resolve the storey name (back-compat with
   // persisted lists / the pre-#1591 Storey chip).
@@ -376,6 +409,8 @@ describe('executeList', () => {
     // #1591: leveled spatial + model filters. Building B holds only the slab;
     // every element shares one site and one source model.
     { source: 'spatial', propertyName: 'Building', operator: 'equals', value: 'Building B', expected: ['Slab-01'] },
+    // Immediate container: only Wall-02 sits in the non-storey container.
+    { source: 'spatial', propertyName: 'Container', operator: 'equals', value: 'Abutment East', expected: ['Wall-02'] },
     { source: 'spatial', propertyName: 'Site', operator: 'equals', value: 'Main Site', expected: ['Slab-01', 'Wall-01', 'Wall-02'] },
     { source: 'model', propertyName: 'Model', operator: 'equals', value: 'model-a.ifc', expected: ['Slab-01', 'Wall-01', 'Wall-02'] },
     { source: 'model', propertyName: 'Model', operator: 'equals', value: 'other.ifc', expected: [] },

--- a/packages/lists/src/engine.ts
+++ b/packages/lists/src/engine.ts
@@ -271,27 +271,30 @@ function getConditionValue(
 
 /**
  * Resolve a `spatial` column/condition to a spatial-container name at the
- * requested level. `propertyName` selects the level; an empty or unrecognised
- * level falls back to `Storey`, so lists authored before the level existed
- * keep resolving the storey name. `Container` is the element's IMMEDIATE
- * container (nearest IfcRelContainedInSpatialStructure parent, any level);
- * `Project` is constant per model.
+ * requested level. `propertyName` selects the level, matched
+ * CASE-INSENSITIVELY so a hand-edited / imported list with `container` resolves
+ * the Container level rather than silently falling through. An empty or
+ * genuinely unrecognised level still falls back to `Storey`, so level-less
+ * lists authored before the level existed keep resolving the storey name.
+ * `Container` is the element's IMMEDIATE container (nearest
+ * IfcRelContainedInSpatialStructure parent, any level); `Project` is constant
+ * per model.
  */
 function getSpatialValue(
   entityId: number,
   level: string,
   provider: ListDataProvider,
 ): CellValue {
-  switch (level) {
-    case 'Container':
+  switch (level.toLowerCase()) {
+    case 'container':
       return provider.getContainerName?.(entityId) || null;
-    case 'Building':
+    case 'building':
       return provider.getBuildingName?.(entityId) || null;
-    case 'Site':
+    case 'site':
       return provider.getSiteName?.(entityId) || null;
-    case 'Project':
+    case 'project':
       return provider.getProjectName?.() || null;
-    case 'Storey':
+    case 'storey':
     default:
       return provider.getStoreyName?.(entityId) || null;
   }

--- a/packages/lists/src/engine.ts
+++ b/packages/lists/src/engine.ts
@@ -273,7 +273,9 @@ function getConditionValue(
  * Resolve a `spatial` column/condition to a spatial-container name at the
  * requested level. `propertyName` selects the level; an empty or unrecognised
  * level falls back to `Storey`, so lists authored before the level existed
- * keep resolving the storey name. `Project` is constant per model.
+ * keep resolving the storey name. `Container` is the element's IMMEDIATE
+ * container (nearest IfcRelContainedInSpatialStructure parent, any level);
+ * `Project` is constant per model.
  */
 function getSpatialValue(
   entityId: number,
@@ -281,6 +283,8 @@ function getSpatialValue(
   provider: ListDataProvider,
 ): CellValue {
   switch (level) {
+    case 'Container':
+      return provider.getContainerName?.(entityId) || null;
     case 'Building':
       return provider.getBuildingName?.(entityId) || null;
     case 'Site':

--- a/packages/lists/src/types.ts
+++ b/packages/lists/src/types.ts
@@ -71,6 +71,13 @@ export interface ListDataProvider {
   getClassifications?(expressId: number): ListClassificationRef[];
   /** Building-storey name the element belongs to, or '' when unplaced. */
   getStoreyName?(expressId: number): string;
+  /** Name of the element's IMMEDIATE spatial container — the direct
+   *  IfcRelContainedInSpatialStructure parent (a storey, or for infrastructure
+   *  the IfcBridgePart / IfcRoadPart / IfcSpatialZone it sits in). Falls back to
+   *  the container's IFC class when the container is unnamed, '' when the element
+   *  is uncontained. Used by the `spatial` column at `Container` level (Bonsai's
+   *  "container"). */
+  getContainerName?(expressId: number): string;
   /** IfcBuilding name containing the element, or '' when unplaced. Used by the
    *  `spatial` column at `Building` level. */
   getBuildingName?(expressId: number): string;
@@ -159,14 +166,14 @@ export interface PropertyCondition {
    * - `material` — any of the element's material names (multi-valued)
    * - `classification` — any classification code or name (multi-valued)
    * - `spatial` — a spatial-container name; `propertyName` selects the level
-   *   (`Storey` (default), `Building`, `Site`, or `Project`)
+   *   (`Container`, `Storey` (default), `Building`, `Site`, or `Project`)
    * - `model` — the source model / file name (federation identity)
    */
   source: 'attribute' | 'property' | 'quantity' | 'material' | 'classification' | 'spatial' | 'model';
   /** Property set name (for property/quantity sources) */
   psetName?: string;
   /** Attribute / property / quantity name, or the spatial level for `spatial`
-   *  (`Storey` | `Building` | `Site` | `Project`). Ignored for
+   *  (`Container` | `Storey` | `Building` | `Site` | `Project`). Ignored for
    *  material/classification/model. */
   propertyName: string;
   operator: ConditionOperator;
@@ -192,14 +199,15 @@ export interface ColumnDefinition {
   /**
    * Where the column value comes from. `material` / `classification` are
    * multi-valued (joined with ", "); `spatial` is a spatial-container name at
-   * the level named by `propertyName` (`Storey` (default) | `Building` | `Site`
-   * | `Project`); `model` is the source model / file name (federation identity).
+   * the level named by `propertyName` (`Container` | `Storey` (default) |
+   * `Building` | `Site` | `Project`); `model` is the source model / file name
+   * (federation identity).
    */
   source: 'attribute' | 'property' | 'quantity' | 'material' | 'classification' | 'spatial' | 'model';
   /** For property: pset name. For quantity: qset name. */
   psetName?: string;
   /** Attribute / property / quantity name, or the spatial level for `spatial`
-   *  (`Storey` | `Building` | `Site` | `Project`). Ignored for
+   *  (`Container` | `Storey` | `Building` | `Site` | `Project`). Ignored for
    *  material/classification/model. */
   propertyName: string;
   /** Display label override */

--- a/packages/parser/src/data-store-transport.ts
+++ b/packages/parser/src/data-store-transport.ts
@@ -122,6 +122,7 @@ export interface SpatialHierarchyColumns {
   storeyElevations: Array<[number, number]>;
   storeyHeights: Array<[number, number]>;
   elementToStorey: Array<[number, number]>;
+  elementToContainer?: Array<[number, number]>;
 }
 
 function serializeSpatialNode(node: SpatialNode): SerializedSpatialNode {
@@ -158,6 +159,9 @@ export function spatialHierarchyToColumns(hierarchy: SpatialHierarchy): SpatialH
     storeyElevations: [...hierarchy.storeyElevations.entries()],
     storeyHeights: [...hierarchy.storeyHeights.entries()],
     elementToStorey: [...hierarchy.elementToStorey.entries()],
+    elementToContainer: hierarchy.elementToContainer
+      ? [...hierarchy.elementToContainer.entries()]
+      : undefined,
   };
 }
 
@@ -170,6 +174,9 @@ export function spatialHierarchyFromColumns(columns: SpatialHierarchyColumns): S
   const storeyElevations = new Map<number, number>(columns.storeyElevations);
   const storeyHeights = new Map<number, number>(columns.storeyHeights);
   const elementToStorey = new Map<number, number>(columns.elementToStorey);
+  const elementToContainer = columns.elementToContainer
+    ? new Map<number, number>(columns.elementToContainer)
+    : undefined;
 
   // elementToSpace is the inverse of bySpace and is what `getContainingSpace`
   // queries. Only this direction is shipped over the wire because it is
@@ -190,6 +197,7 @@ export function spatialHierarchyFromColumns(columns: SpatialHierarchyColumns): S
     storeyElevations,
     storeyHeights,
     elementToStorey,
+    elementToContainer,
 
     getStoreyElements(storeyId: number): number[] {
       return byStorey.get(storeyId) ?? [];

--- a/packages/parser/src/spatial-hierarchy-builder.ts
+++ b/packages/parser/src/spatial-hierarchy-builder.ts
@@ -50,6 +50,10 @@ interface BuildContext {
   bySpace: Map<number, number[]>;
   storeyElevations: Map<number, number>;
   elementToStorey: Map<number, number>;
+  /** elementId -> nearest containing spatial node at ANY level (see the
+   *  SpatialHierarchy field docs). Covers aggregated descendants of a
+   *  directly-contained element, unlike the storey-only `elementToStorey`. */
+  elementToContainer: Map<number, number>;
   visited: Set<number>;
   attrSource?: AttributeSource;
   /** One extractor reused across the recursion when a source is available, so
@@ -103,6 +107,7 @@ export class SpatialHierarchyBuilder {
       bySpace: new Map(),
       storeyElevations: new Map(),
       elementToStorey: new Map(),
+      elementToContainer: new Map(),
       visited: new Set(),
       attrSource,
       attrExtractor: attrSource ? new EntityExtractor(attrSource.source) : undefined,
@@ -126,7 +131,7 @@ export class SpatialHierarchyBuilder {
       console.warn('[SpatialHierarchyBuilder] No buildings found in spatial hierarchy');
     }
 
-    const { byStorey, byBuilding, bySite, bySpace, storeyElevations, elementToStorey } = ctx;
+    const { byStorey, byBuilding, bySite, bySpace, storeyElevations, elementToStorey, elementToContainer } = ctx;
 
     // Pre-build the element -> space lookup for O(1) getContainingSpace.
     const elementToSpace = new Map<number, number>();
@@ -146,6 +151,7 @@ export class SpatialHierarchyBuilder {
       // storeyHeights stays empty: both paths use on-demand property extraction.
       storeyHeights: new Map<number, number>(),
       elementToStorey,
+      elementToContainer,
 
       getStoreyElements(storeyId: number): number[] {
         return byStorey.get(storeyId) ?? [];
@@ -315,6 +321,34 @@ export class SpatialHierarchyBuilder {
       for (const childId of spatialChildIds) {
         if (!ctx.elementToStorey.has(childId)) {
           ctx.elementToStorey.set(childId, expressId);
+        }
+      }
+    }
+
+    // Attribute every directly-contained element AND its aggregated descendants
+    // to THIS spatial container, at ANY level - not just storeys. This is what
+    // lets the "immediate Container" lookup resolve a part nested through an
+    // IfcElementAssembly under an IfcBridgePart / IfcRoadPart / IfcSpatialZone,
+    // instead of leaving it blank. It is intentionally SEPARATE from the
+    // storey-only `elementToStorey` above, whose semantics stay byte-identical.
+    // Recursion visits inner containers before their parent, so the nearest
+    // (innermost) container claims a shared descendant first.
+    if (typeEnum !== IfcTypeEnum.IfcProject) {
+      for (const elementId of containedElements) {
+        ctx.elementToContainer.set(elementId, expressId);
+        const stack: number[] = [elementId];
+        const seen = new Set<number>([elementId]);
+        while (stack.length > 0) {
+          const current = stack.pop() as number;
+          const aggregatedKids = relationships.getRelated(current, RelationshipType.Aggregates, 'forward');
+          for (const kid of aggregatedKids) {
+            if (seen.has(kid)) continue;
+            seen.add(kid);
+            if (!ctx.elementToContainer.has(kid)) {
+              ctx.elementToContainer.set(kid, expressId);
+            }
+            stack.push(kid);
+          }
         }
       }
     }


### PR DESCRIPTION
Follow-up to the latest feedback on #1591 (does not close it).

## 1. Edit a list column in place

- Property/quantity columns in the Columns list get a pencil affordance that reopens the column editor pre-filled with the column's set + property (incl. `/regex/` patterns), following the existing add-column UX with the same live match preview and invalid-pattern guard.
- Saving updates the definition **in the same slot with the same id**, so column order, per-id table widths and index-based sort all survive; the list re-runs from the existing Run action.
- `CustomColumnEntry` is now a thin wrapper over the shared `ColumnEditorPanel` (add mode keeps the panel open and clears only the property; edit mode is a one-shot apply), so the add and edit UIs can never drift.
- Built-in attribute / material / classification / spatial / model columns carry no free-text formula, so they stay chip-toggled only.

## 2. `Container` built-in column

- New quick-add column (and spatial filter level) resolving the element's **immediate** spatial container via `IfcRelContainedInSpatialStructure`: the storey for buildings, or the `IfcBridgePart` / `IfcRoadPart` / `IfcSpatialZone` it actually sits in for infrastructure.
- Shows the container's real IFC `Name`, falling back to the container's IFC class when unnamed, and blank when the element is uncontained. Aggregated parts (not directly contained) fall back to their storey.
- Wired through a new optional `ListDataProvider.getContainerName` resolved per model provider, so federated multi-model lists resolve each row against its own model's spatial tree.
- Changeset included (patch `@ifc-lite/lists`); providers without the new method keep returning blank cells.

## Tests

- `packages/lists` engine: Container column values (storey, non-storey, blank when uncontained) + Container condition filtering.
- `spatialHierarchy`: `containerOf` resolves the immediate non-storey container (IfcBridgePart), class fallback when unnamed, '' when unplaced, storey fallback for aggregated parts.
- New `column-edit` suite: editability rules, draft round-trip preserving the id, in-place update preserving order and object identity of untouched columns, and an executeList re-run proving the edited slot yields the new values.

## Verification

- `npx tsc --noEmit` clean (viewer)
- `vitest` (packages/lists): 57 passed
- viewer lists + spatialHierarchy suites: all passing
- `vite build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)
