### PR TITLE
fix(viewer): IDS panel a11y + hierarchy chip contrast + explicit IDS target model

### DIFF
--- a/apps/viewer/src/components/viewer/BCFPanel.tsx
+++ b/apps/viewer/src/components/viewer/BCFPanel.tsx
@@ -440,7 +440,7 @@ export function BCFPanel({ onClose }: BCFPanelProps) {
           >
             <User className="h-4 w-4" />
           </Button>
-          <Button variant="ghost" size="icon" className="h-7 w-7" onClick={onClose}>
+          <Button variant="ghost" size="icon" className="h-7 w-7" aria-label="Close" onClick={onClose}>
             <X className="h-4 w-4" />
           </Button>
         </div>

--- a/apps/viewer/src/components/viewer/HierarchyPanel.tsx
+++ b/apps/viewer/src/components/viewer/HierarchyPanel.tsx
@@ -871,7 +871,13 @@ export function HierarchyPanel() {
           key={value}
           variant={groupFilter === value ? 'default' : 'outline'}
           size="sm"
-          className="h-5 text-[10px] flex-1 min-w-0 rounded-none uppercase tracking-wider px-1"
+          className={cn(
+            'h-5 text-[10px] flex-1 min-w-0 rounded-none uppercase tracking-wider px-1',
+            // Inactive (outline) chips inherited a too-light zinc-400 in light
+            // mode (2.52:1 at 10px). Pin a darker foreground for light mode only;
+            // dark mode kept at zinc-400 which already passes.
+            groupFilter !== value && 'text-zinc-600 dark:text-zinc-400',
+          )}
           onClick={() => setGroupFilter(value)}
         >
           {label}
@@ -1094,7 +1100,7 @@ export function HierarchyPanel() {
           </div>
         </div>
       ) : (
-        <div className="p-2 border-t-2 border-zinc-200 dark:border-zinc-800 text-[10px] uppercase tracking-wide text-zinc-500 dark:text-zinc-500 text-center bg-zinc-50 dark:bg-black font-mono">
+        <div className="p-2 border-t-2 border-zinc-200 dark:border-zinc-800 text-[10px] uppercase tracking-wide text-zinc-600 dark:text-zinc-500 text-center bg-zinc-50 dark:bg-black font-mono">
           Click to filter · Ctrl toggle
         </div>
       )}

--- a/apps/viewer/src/components/viewer/IDSPanel.tsx
+++ b/apps/viewer/src/components/viewer/IDSPanel.tsx
@@ -742,6 +742,12 @@ export function IDSPanel({ onClose }: IDSPanelProps) {
               <select
                 value={pendingModelId ?? report.modelInfo.modelId}
                 onChange={(e) => {
+                  // An active isolation (failed/passed/involved) pins
+                  // isolatedEntities to the OLD model's global ids. The new
+                  // report replaces idsIsolateMode but leaves those ids in
+                  // place, so the new target would look hidden. Clear the
+                  // isolation before validating the newly picked model.
+                  clearIsolation();
                   setPendingModelId(e.target.value);
                   void runValidation(e.target.value);
                 }}

--- a/apps/viewer/src/components/viewer/IDSPanel.tsx
+++ b/apps/viewer/src/components/viewer/IDSPanel.tsx
@@ -77,7 +77,6 @@ import { cn } from '@/lib/utils';
 import { tourAnchor, TOUR_ANCHORS } from '@/lib/tours/anchors';
 import { useViewerStore } from '@/store';
 import { IDSAuditSummary } from './IDSAuditSummary';
-import { ModelBadge } from './ModelBadge';
 import { IDSExportDialog } from './IDSExportDialog';
 import type { IDSBCFExportSettings, IDSExportProgress } from './IDSExportDialog';
 
@@ -406,6 +405,7 @@ function ReportExportButton({
                   variant="outline"
                   size="sm"
                   className="h-8 w-6 p-0 rounded-l-none"
+                  aria-label="Choose report format"
                 >
                   <ChevronDown className="h-3 w-3" />
                 </Button>
@@ -489,16 +489,13 @@ export function IDSPanel({ onClose }: IDSPanelProps) {
     bcfExportProgress,
   } = useIDS();
 
-  // Validation runs against one model at a time (the active model); when a
-  // federation is loaded, name which model these results reflect so the
-  // pass/fail counts aren't ambiguous (#1591). The report's modelId is frozen
-  // at validation time, so resolve its name here (Rules of Hooks) and gate the
-  // label on it — a model removed since validation leaves it unresolvable, and
-  // we must not render a dangling "Validated against" with no name.
+  // Validation runs against one model at a time. When a federation is loaded,
+  // surface which model the results reflect and let the user switch (#1591).
   const idsMultiModel = useViewerStore((s) => s.models.size > 1);
-  const validatedModelName = useViewerStore((s) =>
-    report ? s.models.get(report.modelInfo.modelId)?.name : undefined,
-  );
+  // Full model list for the target-model picker (federation): lets the user
+  // see which model the results reflect and switch to validate another one.
+  const idsModels = useViewerStore((s) => s.models);
+  const idsModelList = useMemo(() => Array.from(idsModels.values()), [idsModels]);
 
   // Handle file selection
   const handleFileSelect = useCallback(async (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -671,7 +668,7 @@ export function IDSPanel({ onClose }: IDSPanelProps) {
             <span className="block">
               <Button
                 className="w-full"
-                onClick={runValidation}
+                onClick={() => { void runValidation(); }}
                 disabled={loading || auditHasErrors}
                 variant={auditHasErrors ? 'secondary' : 'default'}
                 {...tourAnchor(TOUR_ANCHORS.idsRun)}
@@ -717,10 +714,24 @@ export function IDSPanel({ onClose }: IDSPanelProps) {
 
         {/* Summary Header */}
         <div className="p-3 border-b bg-muted/30" {...tourAnchor(TOUR_ANCHORS.idsSummary)}>
-          {idsMultiModel && validatedModelName && (
+          {idsMultiModel && (
             <div className="flex items-center gap-1.5 mb-2 text-xs text-muted-foreground min-w-0">
-              <span className="shrink-0">Validated against</span>
-              <ModelBadge modelId={report.modelInfo.modelId} />
+              <span className="shrink-0">Validate</span>
+              {/* Federation targets one model at a time. Surface it as a picker
+                  (same plain-select pattern as Compare) so the user can both
+                  see which model the results reflect and switch to another.
+                  Changing it re-runs validation against the chosen model. */}
+              <select
+                value={report.modelInfo.modelId}
+                onChange={(e) => { void runValidation(e.target.value); }}
+                disabled={loading}
+                aria-label="Model to validate"
+                className="min-w-0 flex-1 rounded border border-border bg-transparent px-1.5 py-0.5 text-xs text-foreground disabled:opacity-50"
+              >
+                {idsModelList.map((m) => (
+                  <option key={m.id} value={m.id}>{m.name}</option>
+                ))}
+              </select>
             </div>
           )}
           <div className="flex items-center gap-2 mb-2">
@@ -790,6 +801,7 @@ export function IDSPanel({ onClose }: IDSPanelProps) {
                 size="sm"
                 className={cn('h-8 w-8 p-0', failedActive && 'text-red-600')}
                 aria-pressed={failedActive}
+                aria-label={failedActive ? 'Show all (undo isolate failed)' : `Isolate failed${scopeSuffix}`}
                 onClick={handleIsolateFailed}
                 disabled={noActiveSpec}
                 {...tourAnchor(TOUR_ANCHORS.idsIsolateFailed)}
@@ -809,6 +821,7 @@ export function IDSPanel({ onClose }: IDSPanelProps) {
                 size="sm"
                 className={cn('h-8 w-8 p-0', passedActive && 'text-green-600')}
                 aria-pressed={passedActive}
+                aria-label={passedActive ? 'Show all (undo isolate passed)' : `Isolate passed${scopeSuffix}`}
                 onClick={handleIsolatePassed}
                 disabled={noActiveSpec}
               >
@@ -827,6 +840,7 @@ export function IDSPanel({ onClose }: IDSPanelProps) {
                 size="sm"
                 className="h-8 w-8 p-0"
                 aria-pressed={involvedActive}
+                aria-label={involvedActive ? 'Show all (undo isolate involved)' : `Isolate involved${scopeSuffix}`}
                 onClick={handleIsolateInvolved}
                 disabled={noActiveSpec}
               >
@@ -846,6 +860,7 @@ export function IDSPanel({ onClose }: IDSPanelProps) {
                 variant="ghost"
                 size="sm"
                 className="h-8 w-8 p-0"
+                aria-label="Clear isolation (show all)"
                 onClick={clearIsolation}
                 disabled={!isolationActive}
               >
@@ -857,7 +872,7 @@ export function IDSPanel({ onClose }: IDSPanelProps) {
 
           <Tooltip>
             <TooltipTrigger asChild>
-              <Button variant="ghost" size="sm" className="h-8 w-8 p-0" onClick={applyColors}>
+              <Button variant="ghost" size="sm" className="h-8 w-8 p-0" aria-label="Reapply Colors" onClick={applyColors}>
                 <RefreshCw className="h-4 w-4" />
               </Button>
             </TooltipTrigger>
@@ -919,6 +934,7 @@ export function IDSPanel({ onClose }: IDSPanelProps) {
                     variant="ghost"
                     size="sm"
                     className="h-7 w-7 p-0"
+                    aria-label="Load New IDS"
                     onClick={() => { void handleLoadIdsClick(); }}
                   >
                     <Upload className="h-3 w-3" />
@@ -937,6 +953,7 @@ export function IDSPanel({ onClose }: IDSPanelProps) {
                   variant="ghost"
                   size="sm"
                   className="h-7 w-7 p-0"
+                  aria-label="Clear IDS"
                   onClick={() => {
                     clearIDS();
                     clearValidation();
@@ -951,7 +968,7 @@ export function IDSPanel({ onClose }: IDSPanelProps) {
 
           {/* Close */}
           {onClose && (
-            <Button variant="ghost" size="sm" className="h-7 w-7 p-0" onClick={onClose}>
+            <Button variant="ghost" size="sm" className="h-7 w-7 p-0" aria-label="Close" onClick={onClose}>
               <X className="h-4 w-4" />
             </Button>
           )}

--- a/apps/viewer/src/components/viewer/IDSPanel.tsx
+++ b/apps/viewer/src/components/viewer/IDSPanel.tsx
@@ -15,7 +15,7 @@
  * - Multi-language support (EN/DE/FR)
  */
 
-import React, { useCallback, useState, useMemo, useRef } from 'react';
+import React, { useCallback, useState, useMemo, useRef, useEffect } from 'react';
 import {
   X,
   Upload,
@@ -495,7 +495,25 @@ export function IDSPanel({ onClose }: IDSPanelProps) {
   // Full model list for the target-model picker (federation): lets the user
   // see which model the results reflect and switch to validate another one.
   const idsModels = useViewerStore((s) => s.models);
-  const idsModelList = useMemo(() => Array.from(idsModels.values()), [idsModels]);
+  // Only offer models that actually carry parsed IFC data. Geometry-only,
+  // mid-load or cache-restored models have no `ifcDataStore` and cannot be
+  // validated — listing them would let the user pick a model whose report
+  // would silently reflect a different model's data (#1702 C1).
+  const idsModelList = useMemo(
+    () => Array.from(idsModels.values()).filter((m) => m.ifcDataStore != null),
+    [idsModels],
+  );
+
+  // The controlled picker binds to the landed report's model id, which only
+  // updates once a run completes. Hold the user's in-flight choice locally so
+  // the dropdown keeps showing the model being validated instead of snapping
+  // back to the previous one while `loading` (#1702 C3).
+  const [pendingModelId, setPendingModelId] = useState<string | null>(null);
+  useEffect(() => {
+    // Once a run settles (report landed or errored), fall back to the report's
+    // own model id so the picker reflects reality again.
+    if (!loading) setPendingModelId(null);
+  }, [loading]);
 
   // Handle file selection
   const handleFileSelect = useCallback(async (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -722,8 +740,11 @@ export function IDSPanel({ onClose }: IDSPanelProps) {
                   see which model the results reflect and switch to another.
                   Changing it re-runs validation against the chosen model. */}
               <select
-                value={report.modelInfo.modelId}
-                onChange={(e) => { void runValidation(e.target.value); }}
+                value={pendingModelId ?? report.modelInfo.modelId}
+                onChange={(e) => {
+                  setPendingModelId(e.target.value);
+                  void runValidation(e.target.value);
+                }}
                 disabled={loading}
                 aria-label="Model to validate"
                 className="min-w-0 flex-1 rounded border border-border bg-transparent px-1.5 py-0.5 text-xs text-foreground disabled:opacity-50"

--- a/apps/viewer/src/components/viewer/LensPanel.tsx
+++ b/apps/viewer/src/components/viewer/LensPanel.tsx
@@ -1487,6 +1487,7 @@ export function LensPanel({ onClose }: LensPanelProps) {
               variant="ghost"
               size="sm"
               className="h-7 w-7 p-0 rounded-sm"
+              aria-label="Close"
               onClick={onClose}
             >
               <X className="h-4 w-4" />

--- a/apps/viewer/src/components/viewer/ScriptPanel.tsx
+++ b/apps/viewer/src/components/viewer/ScriptPanel.tsx
@@ -280,7 +280,7 @@ export function ScriptPanel({ onClose }: ScriptPanelProps) {
           {savedScripts.length > 0 && (
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
-                <Button variant="ghost" size="icon-xs">
+                <Button variant="ghost" size="icon-xs" aria-label="Select saved script">
                   <ChevronDown className="h-3.5 w-3.5" />
                 </Button>
               </DropdownMenuTrigger>
@@ -317,6 +317,7 @@ export function ScriptPanel({ onClose }: ScriptPanelProps) {
                 size="icon-xs"
                 onClick={toggleChat}
                 className={cn(chatPanelVisible && 'bg-blue-500 hover:bg-blue-600 text-white')}
+                aria-label={chatPanelVisible ? 'Hide AI Chat' : 'Show AI Chat'}
                 {...tourAnchor(TOUR_ANCHORS.scriptChatToggle)}
               >
                 <Bot className="h-3.5 w-3.5" />
@@ -326,7 +327,7 @@ export function ScriptPanel({ onClose }: ScriptPanelProps) {
           </Tooltip>
 
           {onClose && (
-            <Button variant="ghost" size="icon-xs" onClick={onClose}>
+            <Button variant="ghost" size="icon-xs" aria-label="Close" onClick={onClose}>
               <X className="h-3.5 w-3.5" />
             </Button>
           )}
@@ -394,7 +395,7 @@ export function ScriptPanel({ onClose }: ScriptPanelProps) {
 
           <Tooltip>
             <TooltipTrigger asChild>
-              <Button variant="ghost" size="icon-xs" onClick={handleSave}>
+              <Button variant="ghost" size="icon-xs" aria-label="Save script" onClick={handleSave}>
                 <Save className="h-3.5 w-3.5" />
               </Button>
             </TooltipTrigger>
@@ -431,6 +432,7 @@ export function ScriptPanel({ onClose }: ScriptPanelProps) {
                 size="icon-xs"
                 onClick={undoScriptEditor}
                 disabled={!scriptCanUndo}
+                aria-label="Undo"
               >
                 <Undo2 className="h-3.5 w-3.5" />
               </Button>
@@ -445,6 +447,7 @@ export function ScriptPanel({ onClose }: ScriptPanelProps) {
                 size="icon-xs"
                 onClick={redoScriptEditor}
                 disabled={!scriptCanRedo}
+                aria-label="Redo"
               >
                 <Redo2 className="h-3.5 w-3.5" />
               </Button>
@@ -457,7 +460,7 @@ export function ScriptPanel({ onClose }: ScriptPanelProps) {
             <Tooltip>
               <TooltipTrigger asChild>
                 <DropdownMenuTrigger asChild>
-                  <Button variant="ghost" size="icon-xs" {...tourAnchor(TOUR_ANCHORS.scriptNew)}>
+                  <Button variant="ghost" size="icon-xs" aria-label="New script" {...tourAnchor(TOUR_ANCHORS.scriptNew)}>
                     <Plus className="h-3.5 w-3.5" />
                   </Button>
                 </DropdownMenuTrigger>
@@ -481,7 +484,7 @@ export function ScriptPanel({ onClose }: ScriptPanelProps) {
 
           <Tooltip>
             <TooltipTrigger asChild>
-              <Button variant="ghost" size="icon-xs" onClick={reset}>
+              <Button variant="ghost" size="icon-xs" aria-label="Reset sandbox" onClick={reset}>
                 <RotateCcw className="h-3.5 w-3.5" />
               </Button>
             </TooltipTrigger>

--- a/apps/viewer/src/components/viewer/bcf/BCFCreateTopicForm.tsx
+++ b/apps/viewer/src/components/viewer/bcf/BCFCreateTopicForm.tsx
@@ -130,7 +130,7 @@ export function BCFCreateTopicForm({
     <form onSubmit={handleSubmit} className="p-3 space-y-4">
       <div className="flex items-center justify-between">
         <h3 className="font-medium">{heading}</h3>
-        <Button variant="ghost" size="sm" type="button" onClick={onCancel}>
+        <Button variant="ghost" size="sm" type="button" aria-label="Close" onClick={onCancel}>
           <X className="h-4 w-4" />
         </Button>
       </div>

--- a/apps/viewer/src/components/viewer/bcf/BCFTopicDetail.tsx
+++ b/apps/viewer/src/components/viewer/bcf/BCFTopicDetail.tsx
@@ -149,6 +149,7 @@ export function BCFTopicDetail({
           size="sm"
           onClick={() => setShowDeleteConfirm(true)}
           className="text-destructive hover:text-destructive"
+          aria-label="Delete topic"
         >
           <Trash2 className="h-4 w-4" />
         </Button>
@@ -268,6 +269,7 @@ export function BCFTopicDetail({
                           variant="destructive"
                           size="icon"
                           className="absolute top-1 right-1 h-6 w-6 opacity-0 group-hover:opacity-100 transition-opacity"
+                          aria-label="Delete viewpoint"
                           onClick={(e) => {
                             e.stopPropagation();
                             onDeleteViewpoint(vp.guid);
@@ -374,6 +376,7 @@ export function BCFTopicDetail({
               variant="ghost"
               size="icon"
               className="h-6 w-6 shrink-0"
+              aria-label="Cancel viewpoint comment"
               onClick={() => setSelectedViewpointGuid(null)}
             >
               <X className="h-3 w-3" />
@@ -388,7 +391,7 @@ export function BCFTopicDetail({
             onKeyDown={handleKeyDown}
             className="flex-1"
           />
-          <Button size="icon" onClick={handleSubmitComment} disabled={!commentText.trim()}>
+          <Button size="icon" aria-label="Send comment" onClick={handleSubmitComment} disabled={!commentText.trim()}>
             <Send className="h-4 w-4" />
           </Button>
         </div>

--- a/apps/viewer/src/components/viewer/bcf/BCFTopicList.tsx
+++ b/apps/viewer/src/components/viewer/bcf/BCFTopicList.tsx
@@ -100,7 +100,7 @@ export function BCFTopicList({
             ))}
           </SelectContent>
         </Select>
-        <Button size="sm" variant="outline" onClick={onCreateTopic} {...tourAnchor(TOUR_ANCHORS.bcfNewTopic)}>
+        <Button size="sm" variant="outline" aria-label="New topic" onClick={onCreateTopic} {...tourAnchor(TOUR_ANCHORS.bcfNewTopic)}>
           <Plus className="h-4 w-4" />
         </Button>
       </div>
@@ -175,6 +175,7 @@ export function BCFTopicList({
                         setEditingEmail(true);
                       }}
                       className="h-7 text-xs shrink-0"
+                      aria-label={isDefaultEmail ? undefined : 'Edit author email'}
                     >
                       {isDefaultEmail ? 'Set email' : <Edit2 className="h-3 w-3" />}
                     </Button>

--- a/apps/viewer/src/components/viewer/lists/ListPanel.tsx
+++ b/apps/viewer/src/components/viewer/lists/ListPanel.tsx
@@ -260,7 +260,7 @@ export function ListPanel({ onClose }: ListPanelProps) {
             <>
               <Tooltip>
                 <TooltipTrigger asChild>
-                  <Button variant="ghost" size="icon-sm" onClick={handleEditFromResults}>
+                  <Button variant="ghost" size="icon-sm" aria-label="Edit Configuration" onClick={handleEditFromResults}>
                     <Settings2 className="h-3.5 w-3.5" />
                   </Button>
                 </TooltipTrigger>
@@ -268,7 +268,7 @@ export function ListPanel({ onClose }: ListPanelProps) {
               </Tooltip>
               <Tooltip>
                 <TooltipTrigger asChild>
-                  <Button variant="ghost" size="icon-sm" onClick={() => setView('library')}>
+                  <Button variant="ghost" size="icon-sm" aria-label="Back to Lists" onClick={() => setView('library')}>
                     <Table2 className="h-3.5 w-3.5" />
                   </Button>
                 </TooltipTrigger>
@@ -282,7 +282,7 @@ export function ListPanel({ onClose }: ListPanelProps) {
             </Button>
           )}
           {onClose && (
-            <Button variant="ghost" size="icon-sm" onClick={onClose}>
+            <Button variant="ghost" size="icon-sm" aria-label="Close" onClick={onClose}>
               <X className="h-3.5 w-3.5" />
             </Button>
           )}
@@ -491,6 +491,7 @@ function ListItem({ definition, isActive, executing, hasData, onExecute, onEdit,
                     if (hasData) onExecute(definition);
                   }}
                   disabled={!hasData}
+                  aria-label="Run"
                 >
                   <Play className="h-3 w-3" />
                 </Button>
@@ -508,6 +509,7 @@ function ListItem({ definition, isActive, executing, hasData, onExecute, onEdit,
                       e.stopPropagation();
                       onEdit(definition);
                     }}
+                    aria-label="Edit"
                   >
                     <Pencil className="h-3 w-3" />
                   </Button>
@@ -526,6 +528,7 @@ function ListItem({ definition, isActive, executing, hasData, onExecute, onEdit,
                       e.stopPropagation();
                       onDuplicate(definition);
                     }}
+                    aria-label={isPreset ? 'Use as Template' : 'Duplicate'}
                   >
                     <Copy className="h-3 w-3" />
                   </Button>
@@ -544,6 +547,7 @@ function ListItem({ definition, isActive, executing, hasData, onExecute, onEdit,
                       e.stopPropagation();
                       onExport(definition);
                     }}
+                    aria-label="Export"
                   >
                     <Download className="h-3 w-3" />
                   </Button>
@@ -562,6 +566,7 @@ function ListItem({ definition, isActive, executing, hasData, onExecute, onEdit,
                       e.stopPropagation();
                       onDelete(definition.id);
                     }}
+                    aria-label="Delete"
                   >
                     <Trash2 className="h-3 w-3" />
                   </Button>

--- a/apps/viewer/src/components/viewer/lists/ListPanel.tsx
+++ b/apps/viewer/src/components/viewer/lists/ListPanel.tsx
@@ -491,7 +491,7 @@ function ListItem({ definition, isActive, executing, hasData, onExecute, onEdit,
                     if (hasData) onExecute(definition);
                   }}
                   disabled={!hasData}
-                  aria-label="Run"
+                  aria-label={`Run list ${definition.name}`}
                 >
                   <Play className="h-3 w-3" />
                 </Button>
@@ -509,7 +509,7 @@ function ListItem({ definition, isActive, executing, hasData, onExecute, onEdit,
                       e.stopPropagation();
                       onEdit(definition);
                     }}
-                    aria-label="Edit"
+                    aria-label={`Edit list ${definition.name}`}
                   >
                     <Pencil className="h-3 w-3" />
                   </Button>
@@ -528,7 +528,7 @@ function ListItem({ definition, isActive, executing, hasData, onExecute, onEdit,
                       e.stopPropagation();
                       onDuplicate(definition);
                     }}
-                    aria-label={isPreset ? 'Use as Template' : 'Duplicate'}
+                    aria-label={isPreset ? `Use ${definition.name} as template` : `Duplicate list ${definition.name}`}
                   >
                     <Copy className="h-3 w-3" />
                   </Button>
@@ -547,7 +547,7 @@ function ListItem({ definition, isActive, executing, hasData, onExecute, onEdit,
                       e.stopPropagation();
                       onExport(definition);
                     }}
-                    aria-label="Export"
+                    aria-label={`Export list ${definition.name}`}
                   >
                     <Download className="h-3 w-3" />
                   </Button>
@@ -566,7 +566,7 @@ function ListItem({ definition, isActive, executing, hasData, onExecute, onEdit,
                       e.stopPropagation();
                       onDelete(definition.id);
                     }}
-                    aria-label="Delete"
+                    aria-label={`Delete list ${definition.name}`}
                   >
                     <Trash2 className="h-3 w-3" />
                   </Button>

--- a/apps/viewer/src/components/viewer/lists/ListResultsTable.tsx
+++ b/apps/viewer/src/components/viewer/lists/ListResultsTable.tsx
@@ -300,7 +300,7 @@ export function ListResultsTable({ result, listName, grouping, onGroupingChange,
         </span>
         <Tooltip>
           <TooltipTrigger asChild>
-            <Button variant="ghost" size="icon-sm" className={cn('h-6 w-6 shrink-0', filterByVisibility && 'text-primary')} onClick={() => setFilterByVisibility((p) => !p)}>
+            <Button variant="ghost" size="icon-sm" className={cn('h-6 w-6 shrink-0', filterByVisibility && 'text-primary')} aria-label={filterByVisibility ? 'Showing visible objects only' : 'Showing all objects'} aria-pressed={filterByVisibility} onClick={() => setFilterByVisibility((p) => !p)}>
               {filterByVisibility ? <Eye className="h-3.5 w-3.5" /> : <EyeOff className="h-3.5 w-3.5" />}
             </Button>
           </TooltipTrigger>
@@ -310,7 +310,7 @@ export function ListResultsTable({ result, listName, grouping, onGroupingChange,
           <Tooltip>
             <TooltipTrigger asChild>
               <DropdownMenuTrigger asChild>
-                <Button variant="ghost" size="icon-sm" className="h-6 w-6 shrink-0">
+                <Button variant="ghost" size="icon-sm" className="h-6 w-6 shrink-0" aria-label="Export">
                   <Download className="h-3.5 w-3.5" />
                 </Button>
               </DropdownMenuTrigger>

--- a/apps/viewer/src/hooks/ids/resolveValidationTarget.test.ts
+++ b/apps/viewer/src/hooks/ids/resolveValidationTarget.test.ts
@@ -1,0 +1,126 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import {
+  resolveValidationTarget,
+  type ValidationTargetModel,
+} from './resolveValidationTarget.js';
+import type { IfcDataStore } from '@ifc-lite/parser';
+
+// Minimal stand-ins: the resolver only ever reads/returns the store by
+// reference, so an opaque tagged object is enough to assert identity.
+const store = (tag: string): IfcDataStore => ({ __tag: tag } as unknown as IfcDataStore);
+
+const model = (s: IfcDataStore | null): ValidationTargetModel => ({ ifcDataStore: s });
+
+describe('resolveValidationTarget (#1702 C1)', () => {
+  it('explicit target with a data store returns that model + store (no fallback)', () => {
+    const a = store('a');
+    const b = store('b');
+    const models = new Map([
+      ['m-a', model(a)],
+      ['m-b', model(b)],
+    ]);
+    const result = resolveValidationTarget({
+      targetModelId: 'm-b',
+      activeModelId: 'm-a',
+      models,
+      legacyDataStore: null,
+    });
+    assert.deepStrictEqual(result, { modelId: 'm-b', dataStore: b });
+  });
+
+  it('explicit target WITHOUT a data store errors and does NOT fall back', () => {
+    const a = store('a');
+    const models = new Map([
+      ['m-a', model(a)],
+      ['m-geom', model(null)], // geometry-only / mid-load / cache-restored
+    ]);
+    const result = resolveValidationTarget({
+      targetModelId: 'm-geom',
+      activeModelId: 'm-a',
+      models,
+      legacyDataStore: a,
+    });
+    assert.ok('error' in result, 'expected an error result');
+    // Crucially, it must not silently return the active model's store.
+    assert.ok(!('dataStore' in result));
+  });
+
+  it('explicit unknown target id errors', () => {
+    const a = store('a');
+    const models = new Map([['m-a', model(a)]]);
+    const result = resolveValidationTarget({
+      targetModelId: 'does-not-exist',
+      activeModelId: 'm-a',
+      models,
+      legacyDataStore: null,
+    });
+    assert.ok('error' in result);
+  });
+
+  it('no target resolves to the active model', () => {
+    const a = store('a');
+    const b = store('b');
+    const models = new Map([
+      ['m-a', model(a)],
+      ['m-b', model(b)],
+    ]);
+    const result = resolveValidationTarget({
+      activeModelId: 'm-b',
+      models,
+      legacyDataStore: null,
+    });
+    assert.deepStrictEqual(result, { modelId: 'm-b', dataStore: b });
+  });
+
+  it('no target and no active model resolves to the first loaded model', () => {
+    const a = store('a');
+    const b = store('b');
+    const models = new Map([
+      ['m-a', model(a)],
+      ['m-b', model(b)],
+    ]);
+    const result = resolveValidationTarget({
+      activeModelId: null,
+      models,
+      legacyDataStore: null,
+    });
+    assert.deepStrictEqual(result, { modelId: 'm-a', dataStore: a });
+  });
+
+  it('legacy single-model path is preserved (no models, legacy store)', () => {
+    const legacy = store('legacy');
+    const result = resolveValidationTarget({
+      activeModelId: null,
+      models: new Map(),
+      legacyDataStore: legacy,
+    });
+    assert.deepStrictEqual(result, { modelId: '__legacy__', dataStore: legacy });
+  });
+
+  it('no target, active model missing its store, still falls back (behavior kept as-is)', () => {
+    const legacy = store('legacy');
+    const models = new Map([['m-a', model(null)]]);
+    const result = resolveValidationTarget({
+      activeModelId: 'm-a',
+      models,
+      legacyDataStore: legacy,
+    });
+    // Active model has no store; the no-target path is allowed to fall back to
+    // the legacy store (unchanged from the original inline logic).
+    assert.deepStrictEqual(result, { modelId: 'm-a', dataStore: legacy });
+  });
+
+  it('nothing loaded at all errors', () => {
+    const result = resolveValidationTarget({
+      activeModelId: null,
+      models: new Map(),
+      legacyDataStore: null,
+    });
+    assert.ok('error' in result);
+  });
+});

--- a/apps/viewer/src/hooks/ids/resolveValidationTarget.test.ts
+++ b/apps/viewer/src/hooks/ids/resolveValidationTarget.test.ts
@@ -102,7 +102,7 @@ describe('resolveValidationTarget (#1702 C1)', () => {
     assert.deepStrictEqual(result, { modelId: '__legacy__', dataStore: legacy });
   });
 
-  it('no target, active model missing its store, still falls back (behavior kept as-is)', () => {
+  it('no target, active model missing its store, falls back to legacy paired with __legacy__', () => {
     const legacy = store('legacy');
     const models = new Map([['m-a', model(null)]]);
     const result = resolveValidationTarget({
@@ -110,9 +110,27 @@ describe('resolveValidationTarget (#1702 C1)', () => {
       models,
       legacyDataStore: legacy,
     });
-    // Active model has no store; the no-target path is allowed to fall back to
-    // the legacy store (unchanged from the original inline logic).
-    assert.deepStrictEqual(result, { modelId: 'm-a', dataStore: legacy });
+    // Active model has no store and no other model does either; the no-target
+    // path falls back to the legacy store, but the modelId must stay coupled to
+    // that store (the '__legacy__' sentinel), never the active model's id.
+    assert.deepStrictEqual(result, { modelId: '__legacy__', dataStore: legacy });
+  });
+
+  it('no target, first model has no store, resolves to the second (coupled pair)', () => {
+    const b = store('b');
+    // Insertion order: m-a first (storeless), m-b second (loaded).
+    const models = new Map([
+      ['m-a', model(null)],
+      ['m-b', model(b)],
+    ]);
+    const result = resolveValidationTarget({
+      activeModelId: null,
+      models,
+      legacyDataStore: null,
+    });
+    // Must skip the storeless first entry and return the SECOND model with its
+    // own store, never erroring on the empty first entry.
+    assert.deepStrictEqual(result, { modelId: 'm-b', dataStore: b });
   });
 
   it('nothing loaded at all errors', () => {

--- a/apps/viewer/src/hooks/ids/resolveValidationTarget.ts
+++ b/apps/viewer/src/hooks/ids/resolveValidationTarget.ts
@@ -37,9 +37,11 @@ export type ResolveValidationTargetResult =
  *   is unknown or has no parsed data store, return an error rather than falling
  *   back — a silent fallback would validate the active model's data while the
  *   report claims to describe the picked (empty / mid-load) model.
- * - No target (active-model / legacy path): keep the existing fallback chain —
- *   active model, else first loaded, else legacy single-model — resolving the
- *   data store from that model, else the legacy store, else the first model.
+ * - No target (active-model / legacy path): every fallback branch returns a
+ *   COUPLED {modelId, dataStore} pair so the report label can never describe a
+ *   different model than the one actually validated. Order: active model (only
+ *   if it has a store), else the first loaded model that HAS a store, else the
+ *   legacy single-model store paired with the '__legacy__' sentinel.
  */
 export function resolveValidationTarget(
   input: ResolveValidationTargetInput,
@@ -57,18 +59,22 @@ export function resolveValidationTarget(
     return { modelId: targetModelId, dataStore: model.ifcDataStore };
   }
 
-  // No explicit target: active model, else first loaded, else legacy.
-  const modelId =
-    activeModelId
-    || (models.size > 0 ? Array.from(models.keys())[0] : '__legacy__');
-
-  const dataStore =
-    models.get(modelId)?.ifcDataStore
-    || legacyDataStore
-    || (models.size > 0 ? Array.from(models.values())[0]?.ifcDataStore ?? null : null);
-
-  if (!dataStore) {
-    return { error: 'No IFC model loaded' };
+  // No explicit target: active model, else first loaded WITH a store, else
+  // legacy. Each branch keeps modelId and dataStore coupled to the same model.
+  if (activeModelId) {
+    const dataStore = models.get(activeModelId)?.ifcDataStore;
+    if (dataStore) return { modelId: activeModelId, dataStore };
   }
-  return { modelId, dataStore };
+
+  for (const [modelId, model] of models) {
+    if (model.ifcDataStore) {
+      return { modelId, dataStore: model.ifcDataStore };
+    }
+  }
+
+  if (legacyDataStore) {
+    return { modelId: '__legacy__', dataStore: legacyDataStore };
+  }
+
+  return { error: 'No IFC model loaded' };
 }

--- a/apps/viewer/src/hooks/ids/resolveValidationTarget.ts
+++ b/apps/viewer/src/hooks/ids/resolveValidationTarget.ts
@@ -1,0 +1,74 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import type { IfcDataStore } from '@ifc-lite/parser';
+
+/** Minimal shape the resolver needs from a federated model. */
+export interface ValidationTargetModel {
+  ifcDataStore: IfcDataStore | null;
+}
+
+export interface ResolveValidationTargetInput {
+  /**
+   * Model explicitly requested by the caller (the federation picker). When
+   * present it is authoritative: the resolver never falls back to another
+   * model, because doing so would validate one model's data while labeling
+   * the report with a different model's id.
+   */
+  targetModelId?: string;
+  /** The active model id, or null. Used only when no explicit target is given. */
+  activeModelId: string | null;
+  /** All loaded federated models keyed by id. */
+  models: Map<string, ValidationTargetModel>;
+  /** The legacy single-model data store, or null. */
+  legacyDataStore: IfcDataStore | null;
+}
+
+export type ResolveValidationTargetResult =
+  | { modelId: string; dataStore: IfcDataStore }
+  | { error: string };
+
+/**
+ * Resolve which model to validate and the data store to validate against.
+ *
+ * Two modes:
+ * - Explicit target (federation picker): honor it exactly. If the named model
+ *   is unknown or has no parsed data store, return an error rather than falling
+ *   back — a silent fallback would validate the active model's data while the
+ *   report claims to describe the picked (empty / mid-load) model.
+ * - No target (active-model / legacy path): keep the existing fallback chain —
+ *   active model, else first loaded, else legacy single-model — resolving the
+ *   data store from that model, else the legacy store, else the first model.
+ */
+export function resolveValidationTarget(
+  input: ResolveValidationTargetInput,
+): ResolveValidationTargetResult {
+  const { targetModelId, activeModelId, models, legacyDataStore } = input;
+
+  if (targetModelId != null) {
+    const model = models.get(targetModelId);
+    if (!model) {
+      return { error: `Model "${targetModelId}" is not loaded` };
+    }
+    if (!model.ifcDataStore) {
+      return { error: 'The selected model has no parsed IFC data to validate' };
+    }
+    return { modelId: targetModelId, dataStore: model.ifcDataStore };
+  }
+
+  // No explicit target: active model, else first loaded, else legacy.
+  const modelId =
+    activeModelId
+    || (models.size > 0 ? Array.from(models.keys())[0] : '__legacy__');
+
+  const dataStore =
+    models.get(modelId)?.ifcDataStore
+    || legacyDataStore
+    || (models.size > 0 ? Array.from(models.values())[0]?.ifcDataStore ?? null : null);
+
+  if (!dataStore) {
+    return { error: 'No IFC model loaded' };
+  }
+  return { modelId, dataStore };
+}

--- a/apps/viewer/src/hooks/useIDS.ts
+++ b/apps/viewer/src/hooks/useIDS.ts
@@ -40,6 +40,7 @@ import { getEntityBounds } from '@/utils/viewportUtils';
 import { getGlobalRenderer } from '@/hooks/useBCF';
 
 import { createDataAccessor } from './ids/idsDataAccessor';
+import { resolveValidationTarget } from './ids/resolveValidationTarget';
 import { runValidationInWorker, idsWorkerSupported } from './ids/idsWorkerClient';
 import {
   DEFAULT_FAILED_COLOR,
@@ -324,24 +325,22 @@ export function useIDS(options: UseIDSOptions = {}): UseIDSResult {
       return null;
     }
 
-    // Determine model ID - a caller-supplied target wins (federation picker),
-    // otherwise the active model, otherwise the first loaded, otherwise
-    // '__legacy__' for legacy single-model mode.
-    const modelId =
-      targetModelId
-      || activeModelId
-      || (models.size > 0 ? Array.from(models.keys())[0] : '__legacy__');
-
-    // Resolve the data store for that specific model so the picker actually
-    // switches which model is validated (not just the active one).
-    const dataStore =
-      models.get(modelId)?.ifcDataStore
-      || ifcDataStore
-      || (models.size > 0 ? Array.from(models.values())[0]?.ifcDataStore : null);
-    if (!dataStore) {
-      setIdsError('No IFC model loaded');
+    // Resolve which model + data store to validate. An explicit target from the
+    // federation picker is authoritative: if it names a model with no parsed
+    // data store, we surface an error rather than silently validating the
+    // active model's data under the picked model's label. The no-target path
+    // keeps the existing active/first/legacy fallback chain.
+    const target = resolveValidationTarget({
+      targetModelId,
+      activeModelId,
+      models,
+      legacyDataStore: ifcDataStore,
+    });
+    if ('error' in target) {
+      setIdsError(target.error);
       return null;
     }
+    const { modelId, dataStore } = target;
 
     try {
       setIdsLoading(true);

--- a/apps/viewer/src/hooks/useIDS.ts
+++ b/apps/viewer/src/hooks/useIDS.ts
@@ -118,8 +118,8 @@ export interface UseIDSResult {
   clearIDS: () => void;
 
   // Validation actions
-  /** Run validation against current model(s) */
-  runValidation: () => Promise<IDSValidationReport | null>;
+  /** Run validation. Pass a modelId to target a specific loaded model; defaults to the active model. */
+  runValidation: (targetModelId?: string) => Promise<IDSValidationReport | null>;
   /** Clear validation results */
   clearValidation: () => void;
 
@@ -318,21 +318,30 @@ export function useIDS(options: UseIDSOptions = {}): UseIDSResult {
   // Validation Actions
   // ============================================================================
 
-  const runValidation = useCallback(async (): Promise<IDSValidationReport | null> => {
+  const runValidation = useCallback(async (targetModelId?: string): Promise<IDSValidationReport | null> => {
     if (!document) {
       setIdsError('No IDS document loaded');
       return null;
     }
 
-    // Get data store to validate against
-    const dataStore = ifcDataStore || (models.size > 0 ? Array.from(models.values())[0]?.ifcDataStore : null);
+    // Determine model ID - a caller-supplied target wins (federation picker),
+    // otherwise the active model, otherwise the first loaded, otherwise
+    // '__legacy__' for legacy single-model mode.
+    const modelId =
+      targetModelId
+      || activeModelId
+      || (models.size > 0 ? Array.from(models.keys())[0] : '__legacy__');
+
+    // Resolve the data store for that specific model so the picker actually
+    // switches which model is validated (not just the active one).
+    const dataStore =
+      models.get(modelId)?.ifcDataStore
+      || ifcDataStore
+      || (models.size > 0 ? Array.from(models.values())[0]?.ifcDataStore : null);
     if (!dataStore) {
       setIdsError('No IFC model loaded');
       return null;
     }
-
-    // Determine model ID - use '__legacy__' for legacy single-model mode
-    const modelId = activeModelId || (models.size > 0 ? Array.from(models.keys())[0] : '__legacy__');
 
     try {
       setIdsLoading(true);

--- a/apps/viewer/src/store/slices/modelSlice.ts
+++ b/apps/viewer/src/store/slices/modelSlice.ts
@@ -179,6 +179,11 @@ export const createModelSlice: StateCreator<ModelSlice & ModelCrossSliceState, [
     const models = get().models;
     if (models.size <= 1 && models.has(modelId)) {
       cross.clearGeneratedSchedule?.();
+      // Removing the final model empties the federation. Any surviving report
+      // (e.g. one whose stored target is the '__legacy__' sentinel, which can
+      // never match a real model id above) now references nothing loaded, so
+      // drop it regardless of its stored target id.
+      cross.clearIdsValidationReport?.();
     }
 
     set((state) => {
@@ -207,6 +212,11 @@ export const createModelSlice: StateCreator<ModelSlice & ModelCrossSliceState, [
   },
 
   clearAllModels: () => {
+    // Full federation teardown: any IDS report now references an unloaded
+    // model, so drop it too (removeModel's per-model cleanup never runs here).
+    (get() as unknown as {
+      clearIdsValidationReport?: () => void;
+    }).clearIdsValidationReport?.();
     // Clear the federation registry
     federationRegistry.clear();
     return set({

--- a/apps/viewer/src/store/slices/modelSlice.ts
+++ b/apps/viewer/src/store/slices/modelSlice.ts
@@ -157,9 +157,19 @@ export const createModelSlice: StateCreator<ModelSlice & ModelCrossSliceState, [
       clearMutations?: (id: string) => void;
       clearMutationView?: (id: string) => void;
       clearGeneratedSchedule?: () => number;
+      idsValidationReport?: { modelInfo: { modelId: string } } | null;
+      clearIdsValidationReport?: () => void;
     };
     cross.clearMutations?.(modelId);
     cross.clearMutationView?.(modelId);
+
+    // If the removed model is the one the current IDS report describes, that
+    // report is stale by definition — its results reference a model that no
+    // longer exists, and the panel's controlled model picker would bind to a
+    // now-missing option. Drop it so the panel self-heals (#1702 C2).
+    if (cross.idsValidationReport?.modelInfo.modelId === modelId) {
+      cross.clearIdsValidationReport?.();
+    }
 
     // clearMutations only clears a schedule whose source === modelId. Removing
     // the last model orphans any remaining schedule (e.g. one with a null /


### PR DESCRIPTION
Round-2 adversarial in-browser UI/UX sweep. Three remaining defects (measured live on prod with the two-model federated sample; PR #1694 covered the earlier round).

## Defect 1 - icon-only buttons with no accessible name (a11y)
The IDS Validation panel had 9 icon-only buttons with no accessible name. Radix Tooltip sets `aria-describedby` (a description), not the accessible name, so tooltip-wrapped icon buttons still fail. Added `aria-label` to all 9:

- Header: `upload` (Load New IDS), `trash2` (Clear IDS), `x` (Close)
- Filter/action row: `eye-off` (Isolate failed), `eye` (Isolate passed), `boxes` (Isolate involved), `focus` (Clear isolation), `refresh-cw` (Reapply Colors), `chevron-down` (Choose report format)

While in there, swept the other analysis panels the same way and labelled every icon-only button that lacked a name (Clash/Compare already used `title`, so those were fine):

- BCF topic list: New topic, Edit author email
- BCF topic detail: Delete topic, Delete viewpoint, Cancel viewpoint comment, Send comment
- BCF create-topic form: Close; BCF panel: Close
- Lens panel: Close
- Script editor: Select saved script, AI chat toggle, Close, Save, Undo, Redo, New script, Reset sandbox
- Entity lists panel: Edit configuration, Back to lists, Close, Run, Edit, Duplicate, Export, Delete
- List results table: visibility filter, Export

Unnamed-button count: 9 (IDS, as flagged) + 27 (sweep) = 36 -> 0.

## Defect 2 - hierarchy sub-filter chip + hint contrast (WCAG AA, light mode only)
The GROUPS sub-filter chips (All / Systems / Zones / Other, inactive) inherited a too-light `zinc-400` and the footer hint used `zinc-500`.

| Element | Before | After | Token |
|---|---|---|---|
| Inactive chip label (10px) | 2.52:1 (fail) | 7.74:1 (pass) | `text-zinc-600` on `--background` white |
| Footer hint "Click to filter" (10px) | 3.88:1 (fail) | 7.42:1 (pass) | `text-zinc-600` on `zinc-50` |

Both changes are light-mode only. Dark mode kept its already-passing tokens (`dark:text-zinc-400` chips, `dark:text-zinc-500` hint) so the 0-failure dark result is unchanged.

## Defect 3 - explicit IDS target model (UX clarity)
With a federation loaded the IDS panel showed "Validated against X" but silently validated only the active model, with no way to tell which or to switch. Replaced the static badge with a target-model `<select>` (same plain-select pattern the Compare panel uses for its A/B selects). It defaults to the active model and, on change, re-runs validation against the chosen model. `runValidation` now takes an optional `targetModelId` and resolves that model's data store (previously it always used the active model's store). Single-model loads keep no picker (the row only renders when >1 model is loaded). Also fixed the initial run button, which passed the click event straight into the new `runValidation` argument.

## Verification
- `npx tsc --noEmit` (viewer): clean, 0 errors
- `pnpm test` (viewer): 1650 pass, 2 skipped, 0 fail (1652 tests / 385 suites)
- `pnpm build` (vite): success

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * IDS validation can now target a specific loaded model in federated views via a model picker.
* **Accessibility**
  * Added/standardized `aria-label` and related accessibility states across viewer controls (panels, lists, scripts, BCF topics, and IDS actions).
* **Bug Fixes**
  * Improved cleanup so removing a model also clears any associated IDS validation report.
* **Tests**
  * Added unit tests for model-target resolution used by IDS validation.
* **Style**
  * Refined hierarchy filter chip and inactive text coloring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->