### PR TITLE
perf(renderer): opt-in contribution culling + draw-call/GPU-memory observability (#1682)

### DIFF
--- a/.changeset/renderer-contribution-cull-stats.md
+++ b/.changeset/renderer-contribution-cull-stats.md
@@ -1,0 +1,9 @@
+---
+"@ifc-lite/renderer": minor
+---
+
+Contribution culling + frame/GPU-memory stats (issue #1682 observability).
+
+- New opt-in `RenderOptions.contributionCull`: skip colour batches whose world AABB projects below a pixel threshold (raised while the camera moves). Conservative bounding-sphere math; never culls when the camera is inside a batch's bounds. Off by default.
+- New `Renderer.getFrameStats()`: draw calls issued plus batches drawn / frustum-culled / contribution-culled for the last completed frame.
+- New `Scene.getResidentGpuBytes()`: byte-accurate sum of GPU buffers held by colour batches, partial sub-batches, hydrated meshes, textured meshes and instanced templates.

--- a/apps/viewer/src/components/viewer/useAnimationLoop.ts
+++ b/apps/viewer/src/components/viewer/useAnimationLoop.ts
@@ -21,6 +21,7 @@ import type { Renderer, VisualEnhancementOptions, LightingEnvironment } from '@i
 import type { CoordinateInfo } from '@ifc-lite/geometry';
 import type { SectionPlane } from '@/store';
 import { projectToCssScreen } from '../../utils/projectScreen.js';
+import { getContributionCullConfig } from '../../utils/renderCullConfig.js';
 
 export interface UseAnimationLoopParams {
   canvasRef: RefObject<HTMLCanvasElement | null>;
@@ -108,6 +109,11 @@ export function useAnimationLoop(params: UseAnimationLoopParams): void {
     const camera = renderer.getCamera();
     const scene = renderer.getScene();
     let aborted = false;
+
+    // Contribution culling (issue #1682): resolved once per session — the
+    // knob is a load-time A/B switch, not a live setting. Only this loop
+    // passes it; snapshot renders (clash/IDS/BCF) stay exhaustive.
+    const contributionCull = getContributionCullConfig();
 
     let lastRotationUpdate = 0;
     let lastScaleUpdate = 0;
@@ -212,6 +218,7 @@ export function useAnimationLoop(params: UseAnimationLoopParams): void {
           // Let the effects governor judge missed frames against the
           // intentional large-model throttle instead of display refresh.
           interactionFrameIntervalMs: continuousThrottleMs || undefined,
+          contributionCull,
           buildingRotation: coordinateInfoRef.current?.buildingRotation,
           sectionPlane: activeToolRef.current === 'section' ? {
             axis: sectionPlaneRef.current.axis,

--- a/apps/viewer/src/hooks/useIfcLoader.ts
+++ b/apps/viewer/src/hooks/useIfcLoader.ts
@@ -56,6 +56,7 @@ import { getGlobalRenderer } from './useBCF.js';
 import { extractModelGeoref, alignGeometryToReference, findReferenceGeorefModel } from './ingest/federationAlign.js';
 import { toast } from '../components/ui/toast.js';
 import { posthog } from '../lib/analytics.js';
+import { reportRenderStats } from '../utils/renderStatsReport.js';
 import { classifyLoadError, formatLoadError } from '../lib/load-errors.js';
 
 /**
@@ -731,6 +732,9 @@ export function useIfcLoader() {
               });
               console.log(`[useIfc] TOTAL LOAD TIME (from cache): ${(performance.now() - totalStartTime).toFixed(0)}ms`);
               posthog.capture('ifc_model_loaded', { format, file_size_mb: Math.round(fileSizeMB * 100) / 100, load_target: target.kind, load_path: 'cache', total_elapsed_ms: Math.round(performance.now() - totalStartTime) });
+              // Steady-state draw-call/GPU telemetry — same reporter as the
+              // fresh path so warm (cache) loads are comparable (issue #1682).
+              void reportRenderStats({ fileName: file.name, fileSizeMB });
               setLoading(false);
               // Belt-and-suspenders for the source-decoupled tier: revalidate the
               // TRUE full-file hash off the main thread and, if the source changed
@@ -1485,6 +1489,11 @@ export function useIfcLoader() {
         first_visible_geometry_ms: firstVisibleGeometryMs != null ? Math.round(firstVisibleGeometryMs) : undefined,
         stream_complete_ms: streamCompleteMs != null ? Math.round(streamCompleteMs) : undefined,
       });
+      // Steady-state draw-call/GPU-memory telemetry (issue #1682) — fired
+      // separately from ifc_model_loaded because it must wait for the scene
+      // to settle (queue drain + fragment finalize), which happens after this
+      // summary on large models. Fire-and-forget by design.
+      void reportRenderStats({ fileName: file.name, fileSizeMB });
       setLoading(false);
       setGeometryStreamingActive(false);
       // Normalize progress to a terminal state, mirroring the loading /

--- a/apps/viewer/src/hooks/useIfcLoader.ts
+++ b/apps/viewer/src/hooks/useIfcLoader.ts
@@ -734,7 +734,11 @@ export function useIfcLoader() {
               posthog.capture('ifc_model_loaded', { format, file_size_mb: Math.round(fileSizeMB * 100) / 100, load_target: target.kind, load_path: 'cache', total_elapsed_ms: Math.round(performance.now() - totalStartTime) });
               // Steady-state draw-call/GPU telemetry — same reporter as the
               // fresh path so warm (cache) loads are comparable (issue #1682).
-              void reportRenderStats({ fileName: file.name, fileSizeMB });
+              void reportRenderStats({
+                fileName: file.name,
+                fileSizeMB,
+                isStale: () => loadSessionRef.current !== currentSession,
+              });
               setLoading(false);
               // Belt-and-suspenders for the source-decoupled tier: revalidate the
               // TRUE full-file hash off the main thread and, if the source changed
@@ -1492,8 +1496,13 @@ export function useIfcLoader() {
       // Steady-state draw-call/GPU-memory telemetry (issue #1682) — fired
       // separately from ifc_model_loaded because it must wait for the scene
       // to settle (queue drain + fragment finalize), which happens after this
-      // summary on large models. Fire-and-forget by design.
-      void reportRenderStats({ fileName: file.name, fileSizeMB });
+      // summary on large models. Fire-and-forget by design; the stale guard
+      // hands off to the newer load's reporter when a load supersedes this one.
+      void reportRenderStats({
+        fileName: file.name,
+        fileSizeMB,
+        isStale: () => loadSessionRef.current !== currentSession,
+      });
       setLoading(false);
       setGeometryStreamingActive(false);
       // Normalize progress to a terminal state, mirroring the loading /

--- a/apps/viewer/src/utils/renderCullConfig.ts
+++ b/apps/viewer/src/utils/renderCullConfig.ts
@@ -39,19 +39,22 @@ export function getContributionCullConfig(): ContributionCullOptions | undefined
   const raw = (globalThis as { __IFC_LITE_CONTRIB_CULL?: unknown }).__IFC_LITE_CONTRIB_CULL;
   if (raw === undefined || raw === null) return DEFAULT_CONTRIBUTION_CULL;
   if (raw === false || raw === 0) return undefined;
+  // Only finite positive thresholds are meaningful — Infinity/NaN would cull
+  // everything (or nothing deterministically), so they disable instead.
+  const finitePositive = (v: unknown): v is number =>
+    typeof v === 'number' && Number.isFinite(v) && v > 0;
   if (typeof raw === 'number') {
-    if (!(raw > 0)) return undefined;
+    if (!finitePositive(raw)) return undefined;
     return { pixelRadius: raw, interactingPixelRadius: raw * INTERACTING_FACTOR };
   }
   if (typeof raw === 'object') {
     const cfg = raw as Partial<ContributionCullOptions>;
-    if (typeof cfg.pixelRadius === 'number' && cfg.pixelRadius > 0) {
+    if (finitePositive(cfg.pixelRadius)) {
       return {
         pixelRadius: cfg.pixelRadius,
-        interactingPixelRadius:
-          typeof cfg.interactingPixelRadius === 'number'
-            ? cfg.interactingPixelRadius
-            : cfg.pixelRadius * INTERACTING_FACTOR,
+        interactingPixelRadius: finitePositive(cfg.interactingPixelRadius)
+          ? cfg.interactingPixelRadius
+          : cfg.pixelRadius * INTERACTING_FACTOR,
       };
     }
     return undefined;

--- a/apps/viewer/src/utils/renderCullConfig.ts
+++ b/apps/viewer/src/utils/renderCullConfig.ts
@@ -1,0 +1,61 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Contribution-culling configuration for the viewport render loop
+ * (issue #1682).
+ *
+ * Defaults are deliberately conservative: a colour batch is only skipped when
+ * its ENTIRE world AABB projects to under half a device pixel at rest (2 px
+ * while the camera moves). With today's model-wide colour batches this fires
+ * only when a whole colour group is far off in the distance; it becomes the
+ * real draw-call/vertex-load lever once batches are spatially chunked
+ * (phase 2 of the residency plan).
+ *
+ * Override / kill switch (benchmark A/B + console debugging), read once per
+ * viewer session:
+ *   globalThis.__IFC_LITE_CONTRIB_CULL = 0                     // disable
+ *   globalThis.__IFC_LITE_CONTRIB_CULL = 1.5                   // rest px (interacting = 4x)
+ *   globalThis.__IFC_LITE_CONTRIB_CULL = { pixelRadius: 1, interactingPixelRadius: 3 }
+ */
+
+import type { ContributionCullOptions } from '@ifc-lite/renderer';
+
+export const DEFAULT_CONTRIBUTION_CULL: ContributionCullOptions = {
+  pixelRadius: 0.5,
+  interactingPixelRadius: 2,
+};
+
+/** Multiplier applied to a bare-number override to derive the interacting threshold. */
+const INTERACTING_FACTOR = 4;
+
+/**
+ * Resolve the session's contribution-cull options from the optional
+ * `__IFC_LITE_CONTRIB_CULL` global. Returns `undefined` when culling is
+ * disabled (renderer treats absent options as off).
+ */
+export function getContributionCullConfig(): ContributionCullOptions | undefined {
+  const raw = (globalThis as { __IFC_LITE_CONTRIB_CULL?: unknown }).__IFC_LITE_CONTRIB_CULL;
+  if (raw === undefined || raw === null) return DEFAULT_CONTRIBUTION_CULL;
+  if (raw === false || raw === 0) return undefined;
+  if (typeof raw === 'number') {
+    if (!(raw > 0)) return undefined;
+    return { pixelRadius: raw, interactingPixelRadius: raw * INTERACTING_FACTOR };
+  }
+  if (typeof raw === 'object') {
+    const cfg = raw as Partial<ContributionCullOptions>;
+    if (typeof cfg.pixelRadius === 'number' && cfg.pixelRadius > 0) {
+      return {
+        pixelRadius: cfg.pixelRadius,
+        interactingPixelRadius:
+          typeof cfg.interactingPixelRadius === 'number'
+            ? cfg.interactingPixelRadius
+            : cfg.pixelRadius * INTERACTING_FACTOR,
+      };
+    }
+    return undefined;
+  }
+  console.warn('[renderCullConfig] ignoring invalid __IFC_LITE_CONTRIB_CULL:', raw);
+  return DEFAULT_CONTRIBUTION_CULL;
+}

--- a/apps/viewer/src/utils/renderStatsReport.ts
+++ b/apps/viewer/src/utils/renderStatsReport.ts
@@ -37,8 +37,16 @@ const nextFrame = () =>
  *
  * Numbers are scene-wide: on a federated load they cover ALL loaded models,
  * which is the right shape for "what is this tab holding" telemetry.
+ *
+ * `isStale` lets the caller cancel a superseded report (a newer load started
+ * while this one was settling): a stale reporter exits silently — the newer
+ * load's own reporter emits the definitive line for the current scene.
  */
-export async function reportRenderStats(context: { fileName: string; fileSizeMB: number }): Promise<void> {
+export async function reportRenderStats(context: {
+  fileName: string;
+  fileSizeMB: number;
+  isStale?: () => boolean;
+}): Promise<void> {
   try {
     const renderer = getGlobalRenderer();
     if (!renderer) {
@@ -54,14 +62,17 @@ export async function reportRenderStats(context: { fileName: string; fileSizeMB:
       (scene.hasQueuedMeshes() || scene.hasStreamingFragments()) &&
       performance.now() < deadline
     ) {
+      if (context.isStale?.()) return;
       await sleep(SETTLE_POLL_MS);
     }
+    if (context.isStale?.()) return;
 
     // Ensure the stats snapshot reflects the settled scene: request a frame
     // and give the animation loop two ticks to render it.
     renderer.requestRender();
     await nextFrame();
     await nextFrame();
+    if (context.isStale?.()) return;
 
     const stats = renderer.getFrameStats();
     if (!stats) {

--- a/apps/viewer/src/utils/renderStatsReport.ts
+++ b/apps/viewer/src/utils/renderStatsReport.ts
@@ -1,0 +1,95 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Post-load render/memory telemetry (issue #1682 observability).
+ *
+ * Fired once per model load, AFTER the scene settles (mesh queue drained and
+ * streaming fragments merged into final batches), so the numbers describe the
+ * steady state the user actually keeps, not a mid-stream snapshot. Emits one
+ * console line (parsed by tests/benchmark/viewer-benchmark-page.ts — keep the
+ * format in sync) and one PostHog event.
+ */
+
+import { getGlobalRenderer } from '../hooks/useBCF.js';
+import { posthog } from '../lib/analytics.js';
+
+/** Max time to wait for the scene to settle before reporting anyway. */
+const SETTLE_TIMEOUT_MS = 60_000;
+const SETTLE_POLL_MS = 250;
+
+const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+/** Wait for a fresh frame; falls back to a timer when rAF is throttled (hidden tab). */
+const nextFrame = () =>
+  new Promise<void>((resolve) => {
+    const timer = setTimeout(resolve, 300);
+    requestAnimationFrame(() => {
+      clearTimeout(timer);
+      resolve();
+    });
+  });
+
+/**
+ * Report steady-state render stats for the current scene. Fire-and-forget:
+ * never throws, no-ops when the renderer is unavailable (headless loads).
+ *
+ * Numbers are scene-wide: on a federated load they cover ALL loaded models,
+ * which is the right shape for "what is this tab holding" telemetry.
+ */
+export async function reportRenderStats(context: { fileName: string; fileSizeMB: number }): Promise<void> {
+  try {
+    const renderer = getGlobalRenderer();
+    if (!renderer) {
+      // Keep the line present in every load's console stream so log parsers
+      // (benchmark harness) never wait for a report that cannot come.
+      console.log('[ifc-lite] render stats: unavailable (no renderer)');
+      return;
+    }
+    const scene = renderer.getScene();
+
+    const deadline = performance.now() + SETTLE_TIMEOUT_MS;
+    while (
+      (scene.hasQueuedMeshes() || scene.hasStreamingFragments()) &&
+      performance.now() < deadline
+    ) {
+      await sleep(SETTLE_POLL_MS);
+    }
+
+    // Ensure the stats snapshot reflects the settled scene: request a frame
+    // and give the animation loop two ticks to render it.
+    renderer.requestRender();
+    await nextFrame();
+    await nextFrame();
+
+    const stats = renderer.getFrameStats();
+    if (!stats) {
+      // No frame ever completed (e.g. WebGPU init failed in headless CI).
+      console.log('[ifc-lite] render stats: unavailable (no completed frame)');
+      return;
+    }
+    const gpu = scene.getResidentGpuBytes();
+    const gpuMB = gpu.total / (1024 * 1024);
+
+    console.log(
+      `[ifc-lite] render stats: ${stats.drawCalls} draw calls, ` +
+      `${gpuMB.toFixed(1)} MB GPU resident ` +
+      `(${stats.batchesDrawn} batches drawn, ${stats.batchesFrustumCulled} frustum-culled, ` +
+      `${stats.batchesContributionCulled} contribution-culled)`
+    );
+    posthog.capture('viewer_render_stats', {
+      file_size_mb: Math.round(context.fileSizeMB * 100) / 100,
+      draw_calls: stats.drawCalls,
+      resident_gpu_mb: Math.round(gpuMB * 10) / 10,
+      resident_gpu_batches_mb: Math.round((gpu.batches / (1024 * 1024)) * 10) / 10,
+      resident_gpu_instanced_mb: Math.round((gpu.instanced / (1024 * 1024)) * 10) / 10,
+      batches_drawn: stats.batchesDrawn,
+      batches_frustum_culled: stats.batchesFrustumCulled,
+      batches_contribution_culled: stats.batchesContributionCulled,
+    });
+  } catch (err) {
+    // Telemetry must never break a load.
+    console.warn('[ifc-lite] render stats capture failed:', err);
+  }
+}

--- a/packages/renderer/src/contribution-cull.test.ts
+++ b/packages/renderer/src/contribution-cull.test.ts
@@ -1,0 +1,100 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+
+import {
+  projectedAabbRadiusPx,
+  resolveContributionThresholdPx,
+  type CullCameraState,
+} from './contribution-cull.ts';
+
+const perspectiveCam = (overrides: Partial<CullCameraState> = {}): CullCameraState => ({
+  eye: { x: 0, y: 0, z: 0 },
+  mode: 'perspective',
+  fovYRadians: Math.PI / 2, // tan(fov/2) = 1 → pixels = radius / dist * halfViewport
+  orthoHalfHeight: 0,
+  viewportHeightPx: 1000,
+  ...overrides,
+});
+
+describe('resolveContributionThresholdPx', () => {
+  it('returns 0 (disabled) without options or with non-positive radius', () => {
+    assert.strictEqual(resolveContributionThresholdPx(undefined, false), 0);
+    assert.strictEqual(resolveContributionThresholdPx({ pixelRadius: 0 }, false), 0);
+    assert.strictEqual(resolveContributionThresholdPx({ pixelRadius: -1 }, true), 0);
+    assert.strictEqual(resolveContributionThresholdPx({ pixelRadius: NaN }, true), 0);
+  });
+
+  it('uses pixelRadius at rest and interactingPixelRadius while moving', () => {
+    const opts = { pixelRadius: 0.5, interactingPixelRadius: 2 };
+    assert.strictEqual(resolveContributionThresholdPx(opts, false), 0.5);
+    assert.strictEqual(resolveContributionThresholdPx(opts, true), 2);
+  });
+
+  it('falls back to pixelRadius while moving when no interacting radius is set', () => {
+    assert.strictEqual(resolveContributionThresholdPx({ pixelRadius: 0.5 }, true), 0.5);
+  });
+
+  it('never culls LESS during motion: interacting radius is clamped up to pixelRadius', () => {
+    const opts = { pixelRadius: 2, interactingPixelRadius: 0.5 };
+    assert.strictEqual(resolveContributionThresholdPx(opts, true), 2);
+  });
+});
+
+describe('projectedAabbRadiusPx (perspective)', () => {
+  it('projects a unit-diagonal box at known distance to the expected pixel radius', () => {
+    // Box centred at z=-100, half-diagonal = sqrt(3*4)/2 = sqrt(12)/2 ≈ 1.732.
+    // With tan(fov/2)=1 and halfViewport=500: px = r / dist * 500.
+    const px = projectedAabbRadiusPx([-1, -1, -101], [1, 1, -99], perspectiveCam());
+    const r = Math.sqrt(12) / 2;
+    assert.ok(Math.abs(px - (r / 100) * 500) < 1e-9, `got ${px}`);
+  });
+
+  it('shrinks with distance (monotonic falloff)', () => {
+    const near = projectedAabbRadiusPx([-1, -1, -11], [1, 1, -9], perspectiveCam());
+    const far = projectedAabbRadiusPx([-1, -1, -1001], [1, 1, -999], perspectiveCam());
+    assert.ok(near > far);
+  });
+
+  it('returns Infinity when the camera is inside the bounding sphere (never cull)', () => {
+    const px = projectedAabbRadiusPx([-10, -10, -10], [10, 10, 10], perspectiveCam());
+    assert.strictEqual(px, Infinity);
+  });
+
+  it('projects a degenerate (point) AABB to 0 px', () => {
+    const px = projectedAabbRadiusPx([5, 5, -50], [5, 5, -50], perspectiveCam());
+    assert.strictEqual(px, 0);
+  });
+
+  it('is conservative: a behind-camera box still reports its sphere size (frustum test owns rejection)', () => {
+    const px = projectedAabbRadiusPx([-1, -1, 99], [1, 1, 101], perspectiveCam());
+    assert.ok(px > 0 && Number.isFinite(px));
+  });
+});
+
+describe('projectedAabbRadiusPx (orthographic)', () => {
+  const orthoCam = (orthoHalfHeight: number): CullCameraState => ({
+    eye: { x: 0, y: 0, z: 0 },
+    mode: 'orthographic',
+    fovYRadians: 0,
+    orthoHalfHeight,
+    viewportHeightPx: 1000,
+  });
+
+  it('is distance-independent and scales with ortho zoom', () => {
+    const a = projectedAabbRadiusPx([-1, -1, -11], [1, 1, -9], orthoCam(100));
+    const b = projectedAabbRadiusPx([-1, -1, -100001], [1, 1, -99999], orthoCam(100));
+    assert.strictEqual(a, b);
+    // halfViewport=500, r=sqrt(12)/2, halfHeight=100 → px = r/100*500
+    assert.ok(Math.abs(a - (Math.sqrt(12) / 2 / 100) * 500) < 1e-9);
+    // Zooming in (smaller half-height) makes everything bigger on screen.
+    assert.ok(projectedAabbRadiusPx([-1, -1, -11], [1, 1, -9], orthoCam(10)) > a);
+  });
+
+  it('never culls on a degenerate ortho volume', () => {
+    assert.strictEqual(projectedAabbRadiusPx([-1, -1, -11], [1, 1, -9], orthoCam(0)), Infinity);
+  });
+});

--- a/packages/renderer/src/contribution-cull.test.ts
+++ b/packages/renderer/src/contribution-cull.test.ts
@@ -88,6 +88,17 @@ describe('projectedAabbRadiusPx (perspective)', () => {
     assert.strictEqual(px, Infinity);
   });
 
+  it('fails open on a zero/negative viewport height (mid-resize race)', () => {
+    for (const viewportHeightPx of [0, -100]) {
+      const px = projectedAabbRadiusPx(
+        [-1, -1, -101],
+        [1, 1, -99],
+        perspectiveCam({ viewportHeightPx }),
+      );
+      assert.strictEqual(px, Infinity);
+    }
+  });
+
   it('fails open on a degenerate/zero view direction', () => {
     const px = projectedAabbRadiusPx(
       [-1, -1, -101],

--- a/packages/renderer/src/contribution-cull.test.ts
+++ b/packages/renderer/src/contribution-cull.test.ts
@@ -13,8 +13,9 @@ import {
 
 const perspectiveCam = (overrides: Partial<CullCameraState> = {}): CullCameraState => ({
   eye: { x: 0, y: 0, z: 0 },
+  viewDir: { x: 0, y: 0, z: -1 }, // looking down -Z
   mode: 'perspective',
-  fovYRadians: Math.PI / 2, // tan(fov/2) = 1 → pixels = radius / dist * halfViewport
+  fovYRadians: Math.PI / 2, // tan(fov/2) = 1 → pixels = radius / depth * halfViewport
   orthoHalfHeight: 0,
   viewportHeightPx: 1000,
   ...overrides,
@@ -69,9 +70,31 @@ describe('projectedAabbRadiusPx (perspective)', () => {
     assert.strictEqual(px, 0);
   });
 
-  it('is conservative: a behind-camera box still reports its sphere size (frustum test owns rejection)', () => {
+  it('uses view DEPTH, not Euclidean distance: off-axis boxes never read smaller than on-axis', () => {
+    // Same depth (100), one on-axis, one far off-axis (Euclidean distance 100*sqrt(2)).
+    const onAxis = projectedAabbRadiusPx([-1, -1, -101], [1, 1, -99], perspectiveCam());
+    const offAxis = projectedAabbRadiusPx([99, -1, -101], [101, 1, -99], perspectiveCam());
+    assert.ok(Math.abs(onAxis - offAxis) < 1e-9, `on=${onAxis} off=${offAxis}`);
+  });
+
+  it('never culls a near-camera box even when its centre is beside the eye (depth <= radius)', () => {
+    // Centre at depth 0.5, sphere radius ~1.7: overlaps the camera plane.
+    const px = projectedAabbRadiusPx([9, -1, -1.5], [11, 1, 0.5], perspectiveCam());
+    assert.strictEqual(px, Infinity);
+  });
+
+  it('never culls behind-camera boxes (frustum test owns that rejection)', () => {
     const px = projectedAabbRadiusPx([-1, -1, 99], [1, 1, 101], perspectiveCam());
-    assert.ok(px > 0 && Number.isFinite(px));
+    assert.strictEqual(px, Infinity);
+  });
+
+  it('fails open on a degenerate/zero view direction', () => {
+    const px = projectedAabbRadiusPx(
+      [-1, -1, -101],
+      [1, 1, -99],
+      perspectiveCam({ viewDir: { x: 0, y: 0, z: 0 } }),
+    );
+    assert.strictEqual(px, Infinity);
   });
 });
 

--- a/packages/renderer/src/contribution-cull.ts
+++ b/packages/renderer/src/contribution-cull.ts
@@ -92,6 +92,9 @@ export function projectedAabbRadiusPx(
   if (!Number.isFinite(radius)) return Infinity;
 
   const halfViewportPx = cam.viewportHeightPx * 0.5;
+  // Fail open on a zero/negative viewport (e.g. mid-resize race): 0 would
+  // project EVERY box to 0 px and cull the whole scene.
+  if (!(halfViewportPx > 0)) return Infinity;
 
   if (cam.mode === 'orthographic') {
     if (!(cam.orthoHalfHeight > 0)) return Infinity;

--- a/packages/renderer/src/contribution-cull.ts
+++ b/packages/renderer/src/contribution-cull.ts
@@ -13,11 +13,15 @@
  * most pressure (same policy as contribution culling in Cesium/xeokit-class
  * viewers).
  *
- * The math is a conservative bounding-sphere estimate (half the AABB
- * diagonal projected at the AABB centre distance), not an exact projected
- * footprint: it can only OVER-estimate the on-screen size of the box, so a
- * batch is never culled while any part of it could still cover more than
- * the threshold.
+ * The math is a bounding-sphere estimate (half the AABB diagonal projected
+ * at the sphere centre's VIEW DEPTH, not its Euclidean distance — depth is
+ * what perspective projection divides by, so off-axis geometry is not
+ * under-sized). It is exact for a sphere on the view axis and over-estimates
+ * boxes elsewhere, except for one residual: the radial stretch of far-corner
+ * perspective projection can exceed the estimate by at most 1/cos(theta) of
+ * the diagonal half-FOV (~1.7x at fov 60). With the sub-pixel default
+ * thresholds that residual stays visually lossless; treat the threshold as a
+ * perceptual heuristic, not a hard guarantee.
  */
 
 export interface ContributionCullOptions {
@@ -38,6 +42,8 @@ export interface ContributionCullOptions {
 export interface CullCameraState {
   /** Camera eye position in world space. */
   eye: { x: number; y: number; z: number };
+  /** Normalized view direction (eye toward target), perspective mode. */
+  viewDir: { x: number; y: number; z: number };
   mode: 'perspective' | 'orthographic';
   /** Vertical field of view in radians (perspective mode). */
   fovYRadians: number;
@@ -62,12 +68,15 @@ export function resolveContributionThresholdPx(
 }
 
 /**
- * Conservative projected radius of a world-space AABB, in device pixels.
+ * Projected radius of a world-space AABB, in device pixels.
  *
  * Uses the AABB's bounding sphere (radius = half diagonal). In perspective
- * mode the sphere is projected at the distance of the box centre; when the
- * camera is inside (or closer than) the sphere the box can fill the screen,
- * so `Infinity` is returned and the caller never culls. Degenerate/empty
+ * mode the sphere is projected at the box centre's VIEW DEPTH (distance
+ * along `viewDir`), so off-axis boxes never read smaller than an on-axis
+ * box at the same depth. When the sphere reaches the camera plane
+ * (depth <= radius: camera inside, beside, or behind-but-overlapping),
+ * `Infinity` is returned and the caller never culls — a box fully behind
+ * the camera is the frustum test's job, not this one's. Degenerate/empty
  * bounds project to 0 and are culled at any positive threshold.
  */
 export function projectedAabbRadiusPx(
@@ -92,11 +101,16 @@ export function projectedAabbRadiusPx(
   const cx = (min[0] + max[0]) * 0.5 - cam.eye.x;
   const cy = (min[1] + max[1]) * 0.5 - cam.eye.y;
   const cz = (min[2] + max[2]) * 0.5 - cam.eye.z;
-  const dist = Math.sqrt(cx * cx + cy * cy + cz * cz);
-  // Camera inside (or touching) the bounding sphere: never cull.
-  if (dist <= radius) return Infinity;
+  // View depth: what the perspective divide actually uses. A degenerate
+  // (non-normalized garbage / zero) viewDir must fail open, not cull.
+  const dirLenSq =
+    cam.viewDir.x * cam.viewDir.x + cam.viewDir.y * cam.viewDir.y + cam.viewDir.z * cam.viewDir.z;
+  if (!(dirLenSq > 0.5) || !Number.isFinite(dirLenSq)) return Infinity;
+  const depth = cx * cam.viewDir.x + cy * cam.viewDir.y + cz * cam.viewDir.z;
+  // Sphere reaches (or is behind) the camera plane: never cull.
+  if (depth <= radius) return Infinity;
 
   const tanHalfFov = Math.tan(cam.fovYRadians * 0.5);
   if (!(tanHalfFov > 0)) return Infinity;
-  return (radius / (dist * tanHalfFov)) * halfViewportPx;
+  return (radius / (depth * tanHalfFov)) * halfViewportPx;
 }

--- a/packages/renderer/src/contribution-cull.ts
+++ b/packages/renderer/src/contribution-cull.ts
@@ -1,0 +1,102 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Contribution culling: skip draws whose world AABB projects below a pixel
+ * threshold on screen. Sub-pixel geometry costs a full draw call + vertex
+ * work but contributes at most a flicker of a pixel, so dropping it is
+ * visually near-lossless while cutting draw calls and vertex load on large
+ * models (issue #1682). The threshold is intentionally raised while the
+ * camera is moving: quality matters least mid-gesture, and the cheaper
+ * frames keep interaction smooth exactly when the renderer is under the
+ * most pressure (same policy as contribution culling in Cesium/xeokit-class
+ * viewers).
+ *
+ * The math is a conservative bounding-sphere estimate (half the AABB
+ * diagonal projected at the AABB centre distance), not an exact projected
+ * footprint: it can only OVER-estimate the on-screen size of the box, so a
+ * batch is never culled while any part of it could still cover more than
+ * the threshold.
+ */
+
+export interface ContributionCullOptions {
+  /**
+   * Projected AABB radius in device pixels below which a draw is skipped
+   * while the camera is at rest. `<= 0` disables contribution culling.
+   */
+  pixelRadius: number;
+  /**
+   * Threshold while the camera is interacting/animating. Defaults to
+   * `pixelRadius` (no motion boost). Values below `pixelRadius` are
+   * clamped up to it — motion must never cull LESS than rest.
+   */
+  interactingPixelRadius?: number;
+}
+
+/** Camera state snapshot needed to project an AABB radius to pixels. */
+export interface CullCameraState {
+  /** Camera eye position in world space. */
+  eye: { x: number; y: number; z: number };
+  mode: 'perspective' | 'orthographic';
+  /** Vertical field of view in radians (perspective mode). */
+  fovYRadians: number;
+  /** Half the vertical world-space extent of the view volume (orthographic mode). */
+  orthoHalfHeight: number;
+  /** Canvas height in device pixels. */
+  viewportHeightPx: number;
+}
+
+/**
+ * Resolve the active pixel threshold for this frame.
+ * Returns 0 when culling is disabled (absent options or non-positive radius).
+ */
+export function resolveContributionThresholdPx(
+  options: ContributionCullOptions | undefined,
+  interacting: boolean,
+): number {
+  if (!options || !(options.pixelRadius > 0)) return 0;
+  if (!interacting) return options.pixelRadius;
+  const moving = options.interactingPixelRadius ?? options.pixelRadius;
+  return Math.max(options.pixelRadius, moving);
+}
+
+/**
+ * Conservative projected radius of a world-space AABB, in device pixels.
+ *
+ * Uses the AABB's bounding sphere (radius = half diagonal). In perspective
+ * mode the sphere is projected at the distance of the box centre; when the
+ * camera is inside (or closer than) the sphere the box can fill the screen,
+ * so `Infinity` is returned and the caller never culls. Degenerate/empty
+ * bounds project to 0 and are culled at any positive threshold.
+ */
+export function projectedAabbRadiusPx(
+  min: readonly [number, number, number],
+  max: readonly [number, number, number],
+  cam: CullCameraState,
+): number {
+  const dx = max[0] - min[0];
+  const dy = max[1] - min[1];
+  const dz = max[2] - min[2];
+  // Half of the AABB diagonal = bounding-sphere radius.
+  const radius = 0.5 * Math.sqrt(dx * dx + dy * dy + dz * dz);
+  if (!Number.isFinite(radius)) return Infinity;
+
+  const halfViewportPx = cam.viewportHeightPx * 0.5;
+
+  if (cam.mode === 'orthographic') {
+    if (!(cam.orthoHalfHeight > 0)) return Infinity;
+    return (radius / cam.orthoHalfHeight) * halfViewportPx;
+  }
+
+  const cx = (min[0] + max[0]) * 0.5 - cam.eye.x;
+  const cy = (min[1] + max[1]) * 0.5 - cam.eye.y;
+  const cz = (min[2] + max[2]) * 0.5 - cam.eye.z;
+  const dist = Math.sqrt(cx * cx + cy * cy + cz * cz);
+  // Camera inside (or touching) the bounding sphere: never cull.
+  if (dist <= radius) return Infinity;
+
+  const tanHalfFov = Math.tan(cam.fovYRadians * 0.5);
+  if (!(tanHalfFov > 0)) return Infinity;
+  return (radius / (dist * tanHalfFov)) * halfViewportPx;
+}

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -1715,13 +1715,23 @@ export class Renderer {
                     options.contributionCull,
                     interacting,
                 );
-                const cullCam: CullCameraState | null = contribThresholdPx > 0 ? {
-                    eye: this.camera.getPosition(),
-                    mode: this.camera.getProjectionMode(),
-                    fovYRadians: this.camera.getFOV(),
-                    orthoHalfHeight: this.camera.getOrthoSize(),
-                    viewportHeightPx: this.canvas.height,
-                } : null;
+                let cullCam: CullCameraState | null = null;
+                if (contribThresholdPx > 0) {
+                    const eye = this.camera.getPosition();
+                    const tgt = this.camera.getTarget();
+                    const dx = tgt.x - eye.x, dy = tgt.y - eye.y, dz = tgt.z - eye.z;
+                    const len = Math.sqrt(dx * dx + dy * dy + dz * dz);
+                    cullCam = {
+                        eye,
+                        // Degenerate (eye == target) stays zero-length — the
+                        // projection helper fails open (never culls) on it.
+                        viewDir: len > 0 ? { x: dx / len, y: dy / len, z: dz / len } : { x: 0, y: 0, z: 0 },
+                        mode: this.camera.getProjectionMode(),
+                        fovYRadians: this.camera.getFOV(),
+                        orthoHalfHeight: this.camera.getOrthoSize(),
+                        viewportHeightPx: this.canvas.height,
+                    };
+                }
 
                 // Pre-compute visibility for each batch (only when filtering is active)
                 // A batch is visible if ANY of its elements are visible

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -57,6 +57,10 @@ export type { SnapTarget, SnapOptions, EdgeLockInput, MagneticSnapResult } from 
 // Extracted manager classes
 export { PickingManager } from './picking-manager.js';
 export type { PointPickProvider } from './picking-manager.js';
+export { resolveContributionThresholdPx, projectedAabbRadiusPx } from './contribution-cull.js';
+export type { ContributionCullOptions, CullCameraState } from './contribution-cull.js';
+export { sumResidentGpuBytes } from './render-stats.js';
+export type { FrameStats, ResidentGpuBytes } from './render-stats.js';
 export { RaycastEngine } from './raycast-engine.js';
 export { PointPicker, decodePickSample } from './point-picker.js';
 export type { PointPickNode, DecodedPickSample } from './point-picker.js';
@@ -113,6 +117,8 @@ import { PickingManager } from './picking-manager.js';
 import { RaycastEngine } from './raycast-engine.js';
 import { PostProcessor } from './post-processor.js';
 import { InteractionEffectsGovernor } from './interaction-effects-governor.js';
+import { resolveContributionThresholdPx, projectedAabbRadiusPx, type CullCameraState } from './contribution-cull.js';
+import type { FrameStats } from './render-stats.js';
 import { EdlPass } from './edl-pass.js';
 import { SkyPass } from './sky-pass.js';
 import { skyShaderSource } from './shaders/sky.wgsl.js';
@@ -231,6 +237,8 @@ export class Renderer {
     // Diagnostic counters for mobile debugging
     private _renderCallCount: number = 0;
     private _renderSkipCount: number = 0;
+    /** Snapshot of the last completed render() — see getFrameStats(). */
+    private _lastFrameStats: FrameStats | null = null;
     private _renderErrorCount: number = 0;
     private _lastRenderError: string = '';
 
@@ -1026,6 +1034,16 @@ export class Renderer {
         };
     }
 
+    /**
+     * Statistics of the last COMPLETED render() call (draw calls issued,
+     * batches drawn / frustum-culled / contribution-culled), or null before
+     * the first frame. Pair with `getScene().getResidentGpuBytes()` for the
+     * load-complete telemetry snapshot (issue #1682 observability).
+     */
+    getFrameStats(): FrameStats | null {
+        return this._lastFrameStats;
+    }
+
     render(options: RenderOptions = {}): void {
         this._renderCallCount++;
         if (!this.device.isInitialized() || !this.pipeline) {
@@ -1072,6 +1090,12 @@ export class Renderer {
 
         const device = this.device.getDevice();
         const viewProj = this.camera.getViewProjMatrix().m;
+        // Frame stats (issue #1682): geometry draw calls + per-frame cull
+        // outcomes, snapshotted into _lastFrameStats before queue.submit.
+        let frameDrawCalls = 0;
+        let frameBatchesDrawn = 0;
+        let frameBatchesFrustumCulled = 0;
+        let frameBatchesContributionCulled = 0;
         const visualEnhancement = this.resolveVisualEnhancement(options.visualEnhancement);
         // Post effects during interaction (orbit/pan/zoom) are governed
         // adaptively: they stay on while the interactive frame cadence holds
@@ -1683,6 +1707,22 @@ export class Renderer {
                 // This is the primary performance optimization for large models (200K+ meshes)
                 const frustum = FrustumUtils.fromViewProjMatrix(viewProj);
 
+                // Contribution culling (issue #1682): skip batches whose world
+                // AABB projects below a pixel threshold. Disabled unless the
+                // caller opts in via options.contributionCull; the threshold is
+                // raised while interacting (quality matters least mid-gesture).
+                const contribThresholdPx = resolveContributionThresholdPx(
+                    options.contributionCull,
+                    interacting,
+                );
+                const cullCam: CullCameraState | null = contribThresholdPx > 0 ? {
+                    eye: this.camera.getPosition(),
+                    mode: this.camera.getProjectionMode(),
+                    fovYRadians: this.camera.getFOV(),
+                    orthoHalfHeight: this.camera.getOrthoSize(),
+                    viewportHeightPx: this.canvas.height,
+                } : null;
+
                 // Pre-compute visibility for each batch (only when filtering is active)
                 // A batch is visible if ANY of its elements are visible
                 // A batch is fully visible if ALL of its elements are visible
@@ -1777,7 +1817,19 @@ export class Renderer {
                     if (batch.bounds) {
                         const batchAABB = { min: batch.bounds.min, max: batch.bounds.max };
                         if (!FrustumUtils.isAABBVisible(frustum, batchAABB)) {
+                            frameBatchesFrustumCulled++;
                             continue; // Entire batch is off-screen
+                        }
+                        // Contribution cull: the whole batch projects below the
+                        // pixel threshold — drawing it could change at most a
+                        // (sub-)pixel. Selected entities still highlight: the
+                        // selection pass draws per-mesh, independent of batches.
+                        if (
+                            cullCam &&
+                            projectedAabbRadiusPx(batch.bounds.min, batch.bounds.max, cullCam) < contribThresholdPx
+                        ) {
+                            frameBatchesContributionCulled++;
+                            continue;
                         }
                     }
 
@@ -1892,6 +1944,8 @@ export class Renderer {
                     pass.setVertexBuffer(0, batch.vertexBuffer);
                     pass.setIndexBuffer(batch.indexBuffer, 'uint32');
                     pass.drawIndexed(batch.indexCount);
+                    frameDrawCalls++;
+                    frameBatchesDrawn++;
                 };
 
                 // Render opaque batches with the opaque (double-sided) pipeline.
@@ -1931,6 +1985,7 @@ export class Renderer {
                         pass.setVertexBuffer(1, it.instanceBuffer);
                         pass.setIndexBuffer(it.indexBuffer, 'uint32');
                         pass.drawIndexed(it.indexCount, it.instanceCount);
+                        frameDrawCalls++;
                     }
                     pass.setPipeline(this.pipeline.getPipeline());
                     // The TRANSPARENT instanced sub-pass is drawn later, alongside the
@@ -1982,6 +2037,7 @@ export class Renderer {
                         pass.setVertexBuffer(0, tm.vertexBuffer);
                         pass.setIndexBuffer(tm.indexBuffer, 'uint32');
                         pass.drawIndexed(tm.indexCount);
+                        frameDrawCalls++;
                     }
                     // Restore the opaque pipeline for the passes that follow.
                     pass.setPipeline(this.pipeline.getPipeline());
@@ -2131,6 +2187,7 @@ export class Renderer {
                         pass.setVertexBuffer(1, it.instanceBuffer);
                         pass.setIndexBuffer(it.indexBuffer, 'uint32');
                         pass.drawIndexed(it.indexCount, it.instanceCount);
+                        frameDrawCalls++;
                     }
                     pass.setPipeline(this.pipeline.getPipeline());
                 }
@@ -2180,6 +2237,7 @@ export class Renderer {
                         pass.setVertexBuffer(0, mesh.vertexBuffer);
                         pass.setIndexBuffer(mesh.indexBuffer, 'uint32');
                         pass.drawIndexed(mesh.indexCount, 1, 0, 0, 0);
+                        frameDrawCalls++;
                     }
                 }
 
@@ -2238,6 +2296,7 @@ export class Renderer {
                     pass.setVertexBuffer(0, mesh.vertexBuffer);
                     pass.setIndexBuffer(mesh.indexBuffer, 'uint32');
                     pass.drawIndexed(mesh.indexCount, 1, 0, 0, 0);
+                    frameDrawCalls++;
                 }
             } else {
                 // Fallback: render individual meshes (only when no batches exist)
@@ -2251,6 +2310,7 @@ export class Renderer {
                     pass.setVertexBuffer(0, mesh.vertexBuffer);
                     pass.setIndexBuffer(mesh.indexBuffer, 'uint32');
                     pass.drawIndexed(mesh.indexCount, 1, 0, 0, 0);
+                    frameDrawCalls++;
                 }
 
                 // Render transparent meshes with transparent pipeline (alpha blending)
@@ -2265,6 +2325,7 @@ export class Renderer {
                         pass.setVertexBuffer(0, mesh.vertexBuffer);
                         pass.setIndexBuffer(mesh.indexBuffer, 'uint32');
                         pass.drawIndexed(mesh.indexCount, 1, 0, 0, 0);
+                        frameDrawCalls++;
                     }
                 }
             }
@@ -2461,6 +2522,14 @@ export class Renderer {
             }
 
             device.queue.submit([encoder.finish()]);
+
+            this._lastFrameStats = {
+                drawCalls: frameDrawCalls,
+                batchesDrawn: frameBatchesDrawn,
+                batchesFrustumCulled: frameBatchesFrustumCulled,
+                batchesContributionCulled: frameBatchesContributionCulled,
+                timestamp: performance.now(),
+            };
 
             // Pop validation error scope and capture the exact error
             if (captureGpuError) {

--- a/packages/renderer/src/render-stats.test.ts
+++ b/packages/renderer/src/render-stats.test.ts
@@ -1,0 +1,67 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+
+import { sumResidentGpuBytes } from './render-stats.ts';
+
+const buf = (size: number) => ({ size });
+
+describe('sumResidentGpuBytes', () => {
+  it('returns zeros for an empty scene', () => {
+    const r = sumResidentGpuBytes({
+      batches: [],
+      partialBatches: [],
+      meshes: [],
+      textured: [],
+      instanced: [],
+    });
+    assert.deepStrictEqual(r, { batches: 0, meshes: 0, textured: 0, instanced: 0, total: 0 });
+  });
+
+  it('sums vertex + index + optional uniform per batch, incl. partial sub-batches', () => {
+    const r = sumResidentGpuBytes({
+      batches: [
+        { vertexBuffer: buf(1000), indexBuffer: buf(400), uniformBuffer: buf(224) },
+        { vertexBuffer: buf(2000), indexBuffer: buf(800) }, // no uniform yet
+      ],
+      partialBatches: [{ vertexBuffer: buf(100), indexBuffer: buf(40), uniformBuffer: buf(224) }],
+      meshes: [],
+      textured: [],
+      instanced: [],
+    });
+    assert.strictEqual(r.batches, 1000 + 400 + 224 + 2000 + 800 + 100 + 40 + 224);
+    assert.strictEqual(r.total, r.batches);
+  });
+
+  it('estimates textures at 4 bytes per texel across array layers', () => {
+    const r = sumResidentGpuBytes({
+      batches: [],
+      partialBatches: [],
+      meshes: [],
+      textured: [{
+        vertexBuffer: buf(360),
+        indexBuffer: buf(120),
+        uniformBuffer: buf(224),
+        texture: { width: 16, height: 8, depthOrArrayLayers: 2 },
+      }],
+      instanced: [],
+    });
+    assert.strictEqual(r.textured, 360 + 120 + 224 + 16 * 8 * 2 * 4);
+  });
+
+  it('counts instanced templates including the per-occurrence instance buffer', () => {
+    const r = sumResidentGpuBytes({
+      batches: [],
+      partialBatches: [],
+      meshes: [{ vertexBuffer: buf(280), indexBuffer: buf(120), uniformBuffer: buf(224) }],
+      textured: [],
+      instanced: [{ vertexBuffer: buf(2800), indexBuffer: buf(1200), instanceBuffer: buf(88 * 32) }],
+    });
+    assert.strictEqual(r.meshes, 280 + 120 + 224);
+    assert.strictEqual(r.instanced, 2800 + 1200 + 88 * 32);
+    assert.strictEqual(r.total, r.meshes + r.instanced);
+  });
+});

--- a/packages/renderer/src/render-stats.ts
+++ b/packages/renderer/src/render-stats.ts
@@ -1,0 +1,103 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Frame + memory statistics for the renderer (issue #1682 observability).
+ *
+ * `FrameStats` is a snapshot of the last completed `Renderer.render()`;
+ * `sumResidentGpuBytes` walks the scene's GPU-resident collections and sums
+ * actual `GPUBuffer.size` values (allocation-accurate: it reflects what was
+ * requested from the device, including any internal padding the buffers were
+ * created with). Textures are estimated from their dimensions at 4 B/texel.
+ */
+
+/** Statistics for one rendered frame (the main render pass only). */
+export interface FrameStats {
+  /**
+   * Geometry draw calls issued by the last main render pass: colour batches,
+   * partial/overlay sub-batches, instanced templates, textured meshes,
+   * transparent + selected meshes. Excludes the sky pass, section-plane
+   * overlays and the on-demand pick pass.
+   */
+  drawCalls: number;
+  /** Colour batches that passed all per-frame gates and were drawn. */
+  batchesDrawn: number;
+  /** Colour batches rejected by the frustum test this frame. */
+  batchesFrustumCulled: number;
+  /** Colour batches rejected by contribution (projected-size) culling. */
+  batchesContributionCulled: number;
+  /** `performance.now()` timestamp taken at the end of the render call. */
+  timestamp: number;
+}
+
+/** Minimal structural slice of a GPU buffer (real `GPUBuffer` satisfies it). */
+interface SizedBuffer {
+  size: number;
+}
+
+interface BatchLike {
+  vertexBuffer: SizedBuffer;
+  indexBuffer: SizedBuffer;
+  uniformBuffer?: SizedBuffer;
+}
+
+interface TexturedLike extends BatchLike {
+  texture: { width: number; height: number; depthOrArrayLayers: number };
+}
+
+interface InstancedLike {
+  vertexBuffer: SizedBuffer;
+  indexBuffer: SizedBuffer;
+  instanceBuffer: SizedBuffer;
+}
+
+/** Byte totals per GPU-resident collection. All values in bytes. */
+export interface ResidentGpuBytes {
+  /** Colour batches (incl. streaming fragments) + cached partial sub-batches. */
+  batches: number;
+  /** Individually hydrated meshes (selection/picking/fallback paths). */
+  meshes: number;
+  /** Textured meshes, including an estimated 4 B/texel for the texture. */
+  textured: number;
+  /** Instanced templates: template geometry + per-occurrence instance buffers. */
+  instanced: number;
+  total: number;
+}
+
+const sumBatch = (b: BatchLike): number =>
+  b.vertexBuffer.size + b.indexBuffer.size + (b.uniformBuffer?.size ?? 0);
+
+/**
+ * Sum the GPU bytes held by the scene's mesh collections.
+ *
+ * Not covered (owned outside the scene's mesh tables): point-cloud buffers,
+ * pick/post-process render targets, and the depth/MSAA attachments.
+ */
+export function sumResidentGpuBytes(input: {
+  batches: Iterable<BatchLike>;
+  partialBatches: Iterable<BatchLike>;
+  meshes: Iterable<BatchLike>;
+  textured: Iterable<TexturedLike>;
+  instanced: Iterable<InstancedLike>;
+}): ResidentGpuBytes {
+  let batches = 0;
+  for (const b of input.batches) batches += sumBatch(b);
+  for (const b of input.partialBatches) batches += sumBatch(b);
+
+  let meshes = 0;
+  for (const m of input.meshes) meshes += sumBatch(m);
+
+  let textured = 0;
+  for (const t of input.textured) {
+    textured += sumBatch(t);
+    textured += t.texture.width * t.texture.height * t.texture.depthOrArrayLayers * 4;
+  }
+
+  let instanced = 0;
+  for (const t of input.instanced) {
+    instanced += t.vertexBuffer.size + t.indexBuffer.size + t.instanceBuffer.size;
+  }
+
+  return { batches, meshes, textured, instanced, total: batches + meshes + textured + instanced };
+}

--- a/packages/renderer/src/scene.ts
+++ b/packages/renderer/src/scene.ts
@@ -19,6 +19,7 @@ import {
   rayIntersectsBox,
 } from './scene-raycaster.js';
 import { mergeGeometry, splitMeshDataForBufferLimit, colorSaltByte, packEntityLane } from './scene-geometry.js';
+import { sumResidentGpuBytes, type ResidentGpuBytes } from './render-stats.js';
 import { OPAQUE_ALPHA_CUTOFF } from './overlay-routing.js';
 import type { DecodedInstancedShard } from '@ifc-lite/geometry';
 import {
@@ -2059,6 +2060,26 @@ export class Scene {
   /** Textured meshes (#961) for the renderer's dedicated textured sub-pass. */
   getTexturedMeshes(): readonly TexturedMesh[] {
     return this.texturedMeshes;
+  }
+
+  /**
+   * GPU bytes currently held by the scene's mesh collections (issue #1682
+   * observability). Sums actual `GPUBuffer.size` values across colour batches
+   * (streaming fragments are members of `batchedMeshes`, so they are counted
+   * exactly once), cached partial sub-batches, hydrated individual meshes,
+   * textured meshes (plus a 4 B/texel texture estimate) and instanced
+   * templates. Instanced templates are counted even while hidden in the Types
+   * view: hiding does not free their buffers. O(collections) walk with no GPU
+   * calls, intended for on-demand telemetry, not per-frame use.
+   */
+  getResidentGpuBytes(): ResidentGpuBytes {
+    return sumResidentGpuBytes({
+      batches: this.batchedMeshes,
+      partialBatches: this.partialBatchCache.values(),
+      meshes: this.meshes,
+      textured: this.texturedMeshes,
+      instanced: this.instancedTemplates,
+    });
   }
 
   /**

--- a/packages/renderer/src/types.ts
+++ b/packages/renderer/src/types.ts
@@ -265,6 +265,16 @@ export interface RenderOptions {
   // the display refresh — a deliberately throttled 33ms cadence is not a
   // GPU miss.
   interactionFrameIntervalMs?: number;
+  /**
+   * Contribution culling (issue #1682): skip colour batches whose world AABB
+   * projects below `pixelRadius` device pixels (raised to
+   * `interactingPixelRadius` while the camera moves). Applies to the batched
+   * draw path only — instanced templates, textured meshes and the no-batches
+   * fallback are never contribution-culled. Absent or `pixelRadius <= 0`
+   * disables it (the default), so snapshot/export renders that omit the
+   * option stay exhaustive.
+   */
+  contributionCull?: import('./contribution-cull.js').ContributionCullOptions;
 }
 
 /**

--- a/scripts/api-surface.json
+++ b/scripts/api-surface.json
@@ -3334,6 +3334,8 @@
     "Camera: class",
     "ClipBox: interface",
     "ContactShadingQuality: type",
+    "ContributionCullOptions: interface",
+    "CullCameraState: interface",
     "CutPolygon2D: interface",
     "DEFAULT_CAP_STYLE: const",
     "DecodedPickSample: interface",
@@ -3343,6 +3345,7 @@
     "FederationRegistry: class",
     "FitPolicy: interface",
     "FitPolicyKind: type",
+    "FrameStats: interface",
     "GlobalIdLookup: interface",
     "HATCH_PATTERN_IDS: const",
     "HatchPatternId: type",
@@ -3382,6 +3385,7 @@
     "RenderOptions: interface",
     "RenderPipeline: class",
     "Renderer: class",
+    "ResidentGpuBytes: interface",
     "ResolvedEnvironment: type",
     "Scene: class",
     "Section2DOverlayCapStyle: interface",
@@ -3416,7 +3420,10 @@
     "packEnvironmentUniforms: function",
     "pickFitPolicy: function",
     "planeBasis: function",
-    "resolveEnvironment: function"
+    "projectedAabbRadiusPx: function",
+    "resolveContributionThresholdPx: function",
+    "resolveEnvironment: function",
+    "sumResidentGpuBytes: function"
   ],
   "@ifc-lite/sandbox": [
     "DEFAULT_LIMITS: const",

--- a/tests/benchmark/viewer-benchmark-page.ts
+++ b/tests/benchmark/viewer-benchmark-page.ts
@@ -34,6 +34,11 @@ export interface ViewerBenchmarkMetrics {
   // New: Actual render time
   renderCompleteMs: number | null;
   canvasHasContent: boolean;
+  // Steady-state render stats (issue #1682): parsed from the app's
+  // "[ifc-lite] render stats: …" line, emitted after the scene settles.
+  drawCalls: number | null;
+  residentGpuMB: number | null;
+  batchesContributionCulled: number | null;
 }
 
 export class ViewerBenchmarkPage {
@@ -126,6 +131,23 @@ export class ViewerBenchmarkPage {
         console.log(`[Benchmark] visibility filter: ${visFilterEnv}`);
       } catch (e) {
         console.warn(`[Benchmark] invalid VIEWER_BENCHMARK_VISIBILITY_FILTER: ${visFilterEnv}`);
+      }
+    }
+
+    // Optional contribution-culling override for A/B runs (issue #1682).
+    // Set VIEWER_BENCHMARK_CONTRIB_CULL to "0" (disable), a number (rest px),
+    // or JSON like {"pixelRadius":1,"interactingPixelRadius":3}. Unset ⇒ the
+    // app default (see apps/viewer/src/utils/renderCullConfig.ts).
+    const contribCullEnv = process.env.VIEWER_BENCHMARK_CONTRIB_CULL;
+    if (contribCullEnv) {
+      try {
+        const cfg = JSON.parse(contribCullEnv);
+        await this.page.addInitScript((c) => {
+          (globalThis as unknown as { __IFC_LITE_CONTRIB_CULL?: unknown }).__IFC_LITE_CONTRIB_CULL = c;
+        }, cfg);
+        console.log(`[Benchmark] contribution cull override: ${contribCullEnv}`);
+      } catch {
+        console.warn(`[Benchmark] invalid VIEWER_BENCHMARK_CONTRIB_CULL: ${contribCullEnv}`);
       }
     }
 
@@ -261,6 +283,18 @@ export class ViewerBenchmarkPage {
     // totalWallClockMs log).
     if (renderCompleteTime && this.loadEndTime) {
       this.metrics.renderCompleteMs = this.loadEndTime - this.loadStartTime;
+    }
+
+    // Best-effort wait for the steady-state render-stats line — it fires
+    // after the scene settles (queue drain + fragment finalize), which is
+    // shortly after the final load summary on the CI models. Non-fatal: the
+    // stats metrics stay null when it doesn't arrive in time.
+    const statsDeadline = Date.now() + 30000;
+    while (
+      Date.now() < statsDeadline &&
+      !this.consoleLogs.some((log) => log.includes('[ifc-lite] render stats:'))
+    ) {
+      await this.page.waitForTimeout(250);
     }
 
     // Parse metrics from console logs
@@ -438,6 +472,19 @@ export class ViewerBenchmarkPage {
       this.metrics.totalMeshes = this.metrics.totalMeshes ?? parseInt(finalSummaryMatch[2].replace(/,/g, ''), 10);
       this.metrics.totalWallClockMs = Math.round(parseFloat(finalSummaryMatch[3]) * 1000);
     }
+
+    // Steady-state render stats (issue #1682), emitted post-settle by
+    // apps/viewer/src/utils/renderStatsReport.ts — keep formats in sync:
+    //   [ifc-lite] render stats: 143 draw calls, 512.3 MB GPU resident
+    //   (140 batches drawn, 2 frustum-culled, 1 contribution-culled)
+    const renderStatsMatch = logs.match(
+      /\[ifc-lite\] render stats: (\d+) draw calls, ([\d.]+) MB GPU resident \((\d+) batches drawn, (\d+) frustum-culled, (\d+) contribution-culled\)/
+    );
+    if (renderStatsMatch) {
+      this.metrics.drawCalls = parseInt(renderStatsMatch[1], 10);
+      this.metrics.residentGpuMB = parseFloat(renderStatsMatch[2]);
+      this.metrics.batchesContributionCulled = parseInt(renderStatsMatch[5], 10);
+    }
   }
 
   getMetrics(): ViewerBenchmarkMetrics {
@@ -467,6 +514,9 @@ export class ViewerBenchmarkPage {
       fileSizeMB: this.metrics.fileSizeMB ?? null,
       renderCompleteMs: this.metrics.renderCompleteMs ?? null,
       canvasHasContent: this.metrics.canvasHasContent ?? false,
+      drawCalls: this.metrics.drawCalls ?? null,
+      residentGpuMB: this.metrics.residentGpuMB ?? null,
+      batchesContributionCulled: this.metrics.batchesContributionCulled ?? null,
     };
   }
 

--- a/tests/benchmark/viewer-benchmark-page.ts
+++ b/tests/benchmark/viewer-benchmark-page.ts
@@ -288,8 +288,9 @@ export class ViewerBenchmarkPage {
     // Best-effort wait for the steady-state render-stats line — it fires
     // after the scene settles (queue drain + fragment finalize), which is
     // shortly after the final load summary on the CI models. Non-fatal: the
-    // stats metrics stay null when it doesn't arrive in time.
-    const statsDeadline = Date.now() + 30000;
+    // stats metrics stay null when it doesn't arrive in time. Bounded by the
+    // caller's overall timeout budget as well as its own 30s cap.
+    const statsDeadline = Math.min(Date.now() + 30000, startTime + timeoutMs);
     while (
       Date.now() < statsDeadline &&
       !this.consoleLogs.some((log) => log.includes('[ifc-lite] render stats:'))

--- a/tests/benchmark/viewer-benchmark.spec.ts
+++ b/tests/benchmark/viewer-benchmark.spec.ts
@@ -204,6 +204,11 @@ test.describe('Viewer Performance Benchmarks', () => {
       console.log(`  Data Model Parse: ${metrics.dataModelParseMs?.toFixed(0) || 'N/A'} ms`);
       console.log(`  Data Model Entities: ${metrics.dataModelEntityCount?.toLocaleString() || 'N/A'}`);
 
+      console.log(`\n--- Render Stats (steady state, issue #1682) ---`);
+      console.log(`  Draw Calls: ${metrics.drawCalls?.toLocaleString() || 'N/A'}`);
+      console.log(`  Resident GPU: ${metrics.residentGpuMB?.toFixed(1) || 'N/A'} MB`);
+      console.log(`  Contribution-Culled Batches: ${metrics.batchesContributionCulled?.toLocaleString() || 'N/A'}`);
+
       if (baselineMetrics) {
         console.log(`\n--- Comparison with Baseline ---`);
         const comparisonMetrics: Array<keyof ThresholdConfig> = [


### PR DESCRIPTION
Phase 0 + 1 of the chunked-residency renderer plan (context: #1682, prior art: IfcOpenShell's `ifcviewer-wgpu` / PR IfcOpenShell/IfcOpenShell#8139).

## What

**Observability (phase 0)**
- `Renderer.getFrameStats()`: geometry draw calls + batches drawn / frustum-culled / contribution-culled for the last completed frame.
- `Scene.getResidentGpuBytes()`: `GPUBuffer.size` sums across colour batches (streaming fragments counted once via `batchedMeshes`), partial sub-batches, hydrated meshes, textured meshes (+4 B/texel estimate) and instanced templates (counted even while hidden - hiding does not free buffers).
- Post-settle `[ifc-lite] render stats: ...` console line + `viewer_render_stats` PostHog event from both the fresh-WASM and cache load paths. Waits for queue drain + fragment finalize so the numbers describe steady state; stale-session guard hands off to a superseding load's reporter. Emits an explicit `unavailable` line when no frame ever completed (headless CI without WebGPU) so log parsers never hang.
- Benchmark harness parses `drawCalls` / `residentGpuMB` / `batchesContributionCulled` into `ViewerBenchmarkMetrics` (not threshold-gated; the CI regression script iterates a fixed threshold list, so the new keys are additive-safe).

**Contribution culling (phase 1)**
- Opt-in `RenderOptions.contributionCull`: skip colour batches whose world AABB projects below a pixel threshold, raised while the camera moves (quality matters least mid-gesture). Off by default in the renderer package.
- Projection is a bounding-sphere estimate at the batch centre's view depth (what the perspective divide uses), exact on-axis, fails open (never culls) when the sphere reaches the camera plane, on degenerate view dirs, and behind the camera (frustum owns that). Ortho supported via `orthoSize`.
- Viewer defaults: 0.5 px rest / 2 px interacting via `getContributionCullConfig()`. Kill switch / A-B knob: `globalThis.__IFC_LITE_CONTRIB_CULL` (0 = off, number, or `{pixelRadius, interactingPixelRadius}`), surfaced to the benchmark as `VIEWER_BENCHMARK_CONTRIB_CULL`. Snapshot renders (clash/IDS/BCF) never pass the option and stay exhaustive; the selection highlight pass draws per-mesh, so selected entities still highlight regardless.
- With today's model-wide colour batches this only fires when a whole colour group is distant; it becomes the real lever once batches are Morton-chunked (phase 2).

## Verification

- 214 renderer unit tests (new: projection math incl. off-axis / near-camera / behind-camera / degenerate-dir regressions; threshold resolution; GPU byte summing) + 1659 viewer app tests green.
- Headed-Chrome benchmark (FZK-Haus, real WebGPU):
  - default: 13 draw calls, 1.1 MB resident, 0 contribution-culled, mesh count 317 (unchanged)
  - `VIEWER_BENCHMARK_CONTRIB_CULL='{"pixelRadius":100000}'`: 9 batches culled, draws 13 -> 4
  - `VIEWER_BENCHMARK_CONTRIB_CULL='0'`: identical to baseline
- SwiftShader CI-mode run exercises the `unavailable` path (WebGPU init fails there) without stalling the harness.
- CodeRabbit review: 4 findings (view-depth projection, stale-session guard, finite-threshold guard, deadline bound) all fixed; re-review clean.

Changeset included (`@ifc-lite/renderer` minor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added opt-in contribution culling to skip rendering of small projected color batches during camera movement (disabled by default).
  * Added `getFrameStats()` to expose last-frame draw and culling counters.
  * Added `getResidentGpuBytes()` to report resident GPU memory totals for scene resources.
  * Added steady-state render/memory telemetry in the viewer and extended benchmarks to surface these stats.
* **Bug Fixes**
  * Improved fail-open behavior so culling/metrics gracefully disable or report “unavailable” when inputs or frame data are invalid.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->