### PR TITLE
perf(renderer): opt-in GPU residency budget with LRU eviction + on-demand restore (#1682 phase 3a)

### DIFF
--- a/.changeset/renderer-gpu-residency-budget.md
+++ b/.changeset/renderer-gpu-residency-budget.md
@@ -1,0 +1,7 @@
+---
+"@ifc-lite/renderer": minor
+---
+
+Opt-in GPU residency budget (issue #1682, phase 3a of the chunked-residency plan).
+
+`Scene.setGpuResidencyBudget(bytes)` evicts least-recently-drawn bucket batches (GPU buffers destroyed, CPU meshData + metadata shell kept) once their combined bytes exceed the budget, and rebuilds them on demand when the draw loop wants them again (`requestBatchResidency` + time-budgeted `processResidencyRestores`). Never evicts batches drawn this frame or idle fewer than 30 rendered frames; no-ops during streaming, in ephemeral mode, or after geometry release. `FrameStats` gains `batchesNotResident`. Off by default; pairs with spatial chunk bucketing.

--- a/apps/viewer/src/components/viewer/Viewport.tsx
+++ b/apps/viewer/src/components/viewer/Viewport.tsx
@@ -31,6 +31,7 @@ import { useLatestRef } from '../../hooks/useLatestRef.js';
 import { CLASH_COLOR_OVERLAP } from '@/lib/clash/clash-colors';
 import { projectToCssScreen } from '../../utils/projectScreen.js';
 import { getSpatialChunkingConfig } from '../../utils/spatialChunkConfig.js';
+import { getGpuResidencyBudgetBytes } from '../../utils/gpuBudgetConfig.js';
 import {
   getEntityBounds,
   getThemeClearColor,
@@ -723,6 +724,14 @@ export function Viewport({
       if (chunking) {
         renderer.getScene().setSpatialChunking(chunking);
         console.log(`[Viewport] spatial chunk bucketing on (cellSize=${chunking.cellSize}m)`);
+      }
+      // GPU residency budget (issue #1682 phase 3a) — session knob, off by
+      // default. Evicts least-recently-drawn chunk batches over the budget;
+      // the animation loop pumps the on-demand rebuilds.
+      const gpuBudget = getGpuResidencyBudgetBytes();
+      if (gpuBudget !== null) {
+        renderer.getScene().setGpuResidencyBudget(gpuBudget);
+        console.log(`[Viewport] GPU residency budget on (${(gpuBudget / 1048576).toFixed(0)}MB)`);
       }
       // Read-only debug/e2e hook (same convention as __ifc_lite_viewer_store__):
       // live frame stats + resident GPU bytes for Playwright assertions and

--- a/apps/viewer/src/components/viewer/useAnimationLoop.ts
+++ b/apps/viewer/src/components/viewer/useAnimationLoop.ts
@@ -119,6 +119,7 @@ export function useAnimationLoop(params: UseAnimationLoopParams): void {
     let lastScaleUpdate = 0;
     let lastRenderTime = 0;
     let wasAnimating = false;
+    let residencyRestoreErrorLogged = false;
 
     // Adaptive render throttle: large models get fewer FPS during continuous
     // rendering (interaction + inertia) to prevent the main thread from being
@@ -166,12 +167,21 @@ export function useAnimationLoop(params: UseAnimationLoopParams): void {
 
       // 1b. Rebuild GPU-evicted batches the last frame asked for (residency
       // budget, issue #1682 phase 3a). Time-budgeted; requests a render so
-      // the restored batches appear on the next frame.
+      // the restored batches appear on the next frame. Guarded like the
+      // instanced-shard drain: an uncaught throw here (e.g. buffer creation
+      // on a lost device) would kill the rAF loop and blank the canvas.
       if (scene.hasResidencyRestoreWork()) {
-        const device = renderer.getGPUDevice();
-        const pipeline = renderer.getPipeline();
-        if (device && pipeline && scene.processResidencyRestores(device, pipeline) > 0) {
-          renderer.requestRender();
+        try {
+          const device = renderer.getGPUDevice();
+          const pipeline = renderer.getPipeline();
+          if (device && pipeline && scene.processResidencyRestores(device, pipeline) > 0) {
+            renderer.requestRender();
+          }
+        } catch (err) {
+          if (!residencyRestoreErrorLogged) {
+            residencyRestoreErrorLogged = true;
+            console.warn('[useAnimationLoop] residency restore failed (will keep rendering):', err);
+          }
         }
       }
 

--- a/apps/viewer/src/components/viewer/useAnimationLoop.ts
+++ b/apps/viewer/src/components/viewer/useAnimationLoop.ts
@@ -164,6 +164,17 @@ export function useAnimationLoop(params: UseAnimationLoopParams): void {
         }
       }
 
+      // 1b. Rebuild GPU-evicted batches the last frame asked for (residency
+      // budget, issue #1682 phase 3a). Time-budgeted; requests a render so
+      // the restored batches appear on the next frame.
+      if (scene.hasResidencyRestoreWork()) {
+        const device = renderer.getGPUDevice();
+        const pipeline = renderer.getPipeline();
+        if (device && pipeline && scene.processResidencyRestores(device, pipeline) > 0) {
+          renderer.requestRender();
+        }
+      }
+
       // 2. Camera update (animation / inertia)
       const isAnimating = camera.update(deltaTime);
 

--- a/apps/viewer/src/hooks/useClash.ts
+++ b/apps/viewer/src/hooks/useClash.ts
@@ -582,7 +582,10 @@ export function useClash() {
               isolation.add(m.a.ref);
               isolation.add(m.b.ref);
             }
-            renderer.render({ isolatedIds: isolation, selectedId: null, clearColor: SNAPSHOT_CLEAR_COLOR });
+            // restoreEvictedForCapture: isolation may reveal batches evicted
+            // under the GPU residency budget — restore synchronously so the
+            // BCF snapshot is complete.
+            renderer.render({ isolatedIds: isolation, selectedId: null, clearColor: SNAPSHOT_CLEAR_COLOR, restoreEvictedForCapture: true });
             const device = renderer.getGPUDevice();
             if (device) await device.queue.onSubmittedWorkDone();
             // Let the compositor present the frame before reading the canvas.

--- a/apps/viewer/src/hooks/useIDS.ts
+++ b/apps/viewer/src/hooks/useIDS.ts
@@ -989,6 +989,9 @@ export function useIDS(options: UseIDSOptions = {}): UseIDSResult {
             isolatedIds: isolationSet,
             selectedId: null,           // No cyan selection highlight
             clearColor: SNAPSHOT_CLEAR_COLOR,
+            // Isolation may reveal batches evicted under the GPU residency
+            // budget — restore them synchronously so the capture is complete.
+            restoreEvictedForCapture: true,
           });
 
           // Wait for GPU commands to complete

--- a/apps/viewer/src/utils/gpuBudgetConfig.ts
+++ b/apps/viewer/src/utils/gpuBudgetConfig.ts
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * GPU residency budget for the renderer scene (issue #1682, phase 3a).
+ *
+ * OFF BY DEFAULT (no eviction). Opt in per session, read once at renderer
+ * init; the value is megabytes of GPU geometry the bucket batches may hold
+ * before least-recently-drawn ones are evicted (and rebuilt on demand).
+ * Meaningful together with spatial chunking (`__IFC_LITE_CHUNKS`) — without
+ * it, batches are model-wide colour groups and everything is always
+ * "recently drawn". Benchmark A/B env: VIEWER_BENCHMARK_GPU_BUDGET.
+ *
+ *   globalThis.__IFC_LITE_GPU_BUDGET_MB = 512   // 512 MB budget
+ */
+export function getGpuResidencyBudgetBytes(): number | null {
+  const raw = (globalThis as { __IFC_LITE_GPU_BUDGET_MB?: unknown }).__IFC_LITE_GPU_BUDGET_MB;
+  if (typeof raw !== 'number' || !Number.isFinite(raw) || raw <= 0) return null;
+  return Math.round(raw * 1024 * 1024);
+}

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -1103,6 +1103,11 @@ export class Renderer {
         let frameBatchesNotResident = 0;
         // Residency ages are measured in RENDERED frames (idle never ages out).
         this.scene.beginResidencyFrame();
+        // Capture renders restore evicted batches SYNCHRONOUSLY so isolation
+        // snapshots are complete in this very frame (see RenderOptions doc).
+        if (options.restoreEvictedForCapture && this.pipeline) {
+            this.scene.restoreAllEvicted(device, this.pipeline);
+        }
         const visualEnhancement = this.resolveVisualEnhancement(options.visualEnhancement);
         // Post effects during interaction (orbit/pan/zoom) are governed
         // adaptively: they stay on while the interactive frame cadence holds

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -61,6 +61,8 @@ export { resolveContributionThresholdPx, projectedAabbRadiusPx } from './contrib
 export type { ContributionCullOptions, CullCameraState } from './contribution-cull.js';
 export { chunkCellKey, bucketBaseKeyFor, DEFAULT_CHUNK_CELL_SIZE } from './chunk-grid.js';
 export type { SpatialChunkingConfig, ChunkAnchorSource } from './chunk-grid.js';
+export { selectEvictions, MIN_EVICTION_AGE_FRAMES } from './residency.js';
+export type { ResidencyShell } from './residency.js';
 export { sumResidentGpuBytes } from './render-stats.js';
 export type { FrameStats, ResidentGpuBytes } from './render-stats.js';
 export { RaycastEngine } from './raycast-engine.js';
@@ -1098,6 +1100,9 @@ export class Renderer {
         let frameBatchesDrawn = 0;
         let frameBatchesFrustumCulled = 0;
         let frameBatchesContributionCulled = 0;
+        let frameBatchesNotResident = 0;
+        // Residency ages are measured in RENDERED frames (idle never ages out).
+        this.scene.beginResidencyFrame();
         const visualEnhancement = this.resolveVisualEnhancement(options.visualEnhancement);
         // Post effects during interaction (orbit/pan/zoom) are governed
         // adaptively: they stay on while the interactive frame cadence holds
@@ -1868,7 +1873,19 @@ export class Renderer {
                         }
                     }
 
-                    // Fully visible (or no filtering). Transparent batches with mixed
+                    // Fully visible (or no filtering) — this batch draws from its OWN
+                    // GPU buffers. An evicted batch (residency budget, #1682 phase 3a)
+                    // is skipped for a frame while its rebuild is queued; the partial
+                    // path above is unaffected (sub-batches own separate buffers built
+                    // from CPU meshData).
+                    if (batch.gpuResident === false) {
+                        this.scene.requestBatchResidency(batch);
+                        frameBatchesNotResident++;
+                        continue;
+                    }
+                    this.scene.recordBatchDrawn(batch);
+
+                    // Transparent batches with mixed
                     // override membership must be split so non-overridden batchmates
                     // stay transparent — see splitVisibleIdsByPromotion / issue #677.
                     if (nativelyTransparent) {
@@ -2540,8 +2557,14 @@ export class Renderer {
                 batchesDrawn: frameBatchesDrawn,
                 batchesFrustumCulled: frameBatchesFrustumCulled,
                 batchesContributionCulled: frameBatchesContributionCulled,
+                batchesNotResident: frameBatchesNotResident,
                 timestamp: performance.now(),
             };
+
+            // GPU residency budget (issue #1682 phase 3a): evict least-recently
+            // drawn bucket batches after submit — destruction of just-submitted
+            // buffers is deferred past in-flight work by WebGPU.
+            this.scene.enforceGpuBudget();
 
             // Pop validation error scope and capture the exact error
             if (captureGpuError) {

--- a/packages/renderer/src/render-stats.ts
+++ b/packages/renderer/src/render-stats.ts
@@ -27,6 +27,12 @@ export interface FrameStats {
   batchesFrustumCulled: number;
   /** Colour batches rejected by contribution (projected-size) culling. */
   batchesContributionCulled: number;
+  /**
+   * Visible batches skipped because their GPU buffers were evicted under the
+   * residency budget; a rebuild was requested and they draw again within a
+   * frame or two (issue #1682 phase 3a).
+   */
+  batchesNotResident: number;
   /** `performance.now()` timestamp taken at the end of the render call. */
   timestamp: number;
 }

--- a/packages/renderer/src/residency.test.ts
+++ b/packages/renderer/src/residency.test.ts
@@ -1,0 +1,58 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+
+import { selectEvictions, MIN_EVICTION_AGE_FRAMES } from './residency.ts';
+
+const MB = 1024 * 1024;
+const FRAME = 1000; // current frame, comfortably past the min age
+
+const shell = (key: string, bytes: number, lastDrawnFrame: number) => ({ key, bytes, lastDrawnFrame });
+
+describe('selectEvictions', () => {
+  it('returns nothing when within budget', () => {
+    const shells = [shell('a', 10 * MB, 0)];
+    assert.deepStrictEqual(selectEvictions(shells, 10 * MB, 10 * MB, FRAME), []);
+    assert.deepStrictEqual(selectEvictions(shells, 5 * MB, 10 * MB, FRAME), []);
+  });
+
+  it('evicts least-recently-drawn first, only until the budget is met', () => {
+    const shells = [
+      shell('recent', 10 * MB, 900),
+      shell('oldest', 10 * MB, 1),
+      shell('middle', 10 * MB, 500),
+    ];
+    // 30MB resident, 15MB budget → need 15MB → evict oldest + middle (20MB)
+    assert.deepStrictEqual(selectEvictions(shells, 30 * MB, 15 * MB, FRAME), ['oldest', 'middle']);
+    // 30MB resident, 25MB budget → 5MB excess → one eviction suffices
+    assert.deepStrictEqual(selectEvictions(shells, 30 * MB, 25 * MB, FRAME), ['oldest']);
+  });
+
+  it('never evicts batches younger than the minimum idle age', () => {
+    const shells = [
+      shell('just-left-frustum', 10 * MB, FRAME - 1),
+      shell('old', 10 * MB, FRAME - MIN_EVICTION_AGE_FRAMES),
+    ];
+    // Only 'old' is idle long enough, even though the budget wants both.
+    assert.deepStrictEqual(selectEvictions(shells, 20 * MB, 0, FRAME), ['old']);
+  });
+
+  it('treats never-drawn (-1) as the coldest candidates', () => {
+    const shells = [shell('drawn-once', MB, 10), shell('never-drawn', MB, -1)];
+    assert.deepStrictEqual(selectEvictions(shells, 2 * MB, 0, FRAME), ['never-drawn', 'drawn-once']);
+  });
+
+  it('honours a custom min age', () => {
+    const shells = [shell('a', MB, FRAME - 5)];
+    assert.deepStrictEqual(selectEvictions(shells, MB, 0, FRAME, 10), []);
+    assert.deepStrictEqual(selectEvictions(shells, MB, 0, FRAME, 5), ['a']);
+  });
+
+  it('returns everything eligible when even full eviction cannot meet the budget', () => {
+    const shells = [shell('a', MB, 0), shell('b', MB, 1)];
+    assert.deepStrictEqual(selectEvictions(shells, 100 * MB, MB, FRAME), ['a', 'b']);
+  });
+});

--- a/packages/renderer/src/residency.ts
+++ b/packages/renderer/src/residency.ts
@@ -1,0 +1,69 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * GPU residency policy (issue #1682, phase 3a of the chunked-residency plan).
+ *
+ * With spatial chunk bucketing (phase 2) a batch is a spatially compact,
+ * independently destroyable GPU unit. This module decides WHICH resident
+ * batches to evict when the scene exceeds a GPU byte budget. Eviction
+ * destroys the batch's GPU buffers but keeps the batch object as a metadata
+ * shell (bounds/expressIds/counts) and keeps the bucket's CPU `meshData`, so
+ * the batch can be rebuilt on demand when the camera wants it again.
+ *
+ * Policy (two rules, mirroring the eviction hysteresis in Cesium-class
+ * streamers):
+ *   1. Never evict a batch drawn this frame — the budget is a target, not a
+ *      hard cap; a scene whose visible set alone exceeds the budget renders
+ *      correctly and stays over budget (callers may log/telemeter that).
+ *   2. Among the rest, evict least-recently-drawn first, and only batches
+ *      idle for at least `minAgeFrames` rendered frames — a batch that just
+ *      left the frustum during an orbit is likely to come right back, and
+ *      re-uploading it every half-gesture would thrash.
+ *
+ * Pure function over plain shells so the policy is unit-testable without a
+ * GPU; the Scene owns the actual destroy/rebuild.
+ */
+
+/** Residency view of one bucket-owned batch. */
+export interface ResidencyShell {
+  /** Bucket key (identifies the bucket to rebuild from). */
+  key: string;
+  /** GPU bytes this batch holds (vertex + index + uniform). */
+  bytes: number;
+  /** Scene frame counter value when this batch was last drawn (-1 = never). */
+  lastDrawnFrame: number;
+}
+
+/** Batches idle for fewer rendered frames than this are never evicted. */
+export const MIN_EVICTION_AGE_FRAMES = 30;
+
+/**
+ * Select batches to evict so `residentBytes` drops to `budgetBytes` or below.
+ * `shells` must contain only ELIGIBLE batches (resident, bucket-owned, CPU
+ * geometry retained, not drawn this frame). Returns the keys to evict, LRU
+ * first; empty when already within budget or nothing is old enough.
+ */
+export function selectEvictions(
+  shells: readonly ResidencyShell[],
+  residentBytes: number,
+  budgetBytes: number,
+  currentFrame: number,
+  minAgeFrames: number = MIN_EVICTION_AGE_FRAMES,
+): string[] {
+  let excess = residentBytes - budgetBytes;
+  if (excess <= 0) return [];
+
+  const candidates = shells
+    .filter((s) => currentFrame - s.lastDrawnFrame >= minAgeFrames)
+    .sort((a, b) => a.lastDrawnFrame - b.lastDrawnFrame);
+
+  const evict: string[] = [];
+  for (const shell of candidates) {
+    if (excess <= 0) break;
+    evict.push(shell.key);
+    excess -= shell.bytes;
+  }
+  return evict;
+}

--- a/packages/renderer/src/scene.ts
+++ b/packages/renderer/src/scene.ts
@@ -336,6 +336,33 @@ export class Scene {
   }
 
   /**
+   * Synchronously rebuild EVERY evicted bucket batch (no time budget) —
+   * for one-shot capture renders (IDS/clash/BCF snapshots) whose isolation
+   * options may reveal batches that aged out under the budget. The live
+   * view never needs this: visible batches are never evicted. The budget
+   * pass re-evicts unused batches after the usual idle age.
+   * Returns the number of batches restored.
+   */
+  restoreAllEvicted(device: GPUDevice, pipeline: RenderPipeline): number {
+    if (this.geometryReleased || this.ephemeralStreamingMode) return 0;
+    let restored = 0;
+    for (const bucket of this.buckets.values()) {
+      const old = bucket.batchedMesh;
+      if (!old || old.gpuResident !== false || bucket.meshData.length === 0) continue;
+      const rebuilt = this.createBatchedMesh(bucket.meshData, bucket.meshData[0].color, device, pipeline, bucket.key);
+      bucket.batchedMesh = rebuilt;
+      const idx = this.batchedMeshes.indexOf(old);
+      if (idx >= 0) this.batchedMeshes[idx] = rebuilt;
+      else this.batchedMeshes.push(rebuilt);
+      this.lastDrawnFrame.delete(old.id);
+      this.lastDrawnFrame.set(rebuilt.id, this.residencyFrame);
+      this.residencyRestoreQueue.delete(bucket.key);
+      restored++;
+    }
+    return restored;
+  }
+
+  /**
    * Evict least-recently-drawn bucket batches until the resident set fits
    * the budget. Called after each frame's submit; destroying just-submitted
    * buffers is safe (WebGPU defers destruction past in-flight work). Never

--- a/packages/renderer/src/scene.ts
+++ b/packages/renderer/src/scene.ts
@@ -21,6 +21,7 @@ import {
 import { mergeGeometry, splitMeshDataForBufferLimit, colorSaltByte, packEntityLane } from './scene-geometry.js';
 import { sumResidentGpuBytes, type ResidentGpuBytes } from './render-stats.js';
 import { bucketBaseKeyFor, type SpatialChunkingConfig } from './chunk-grid.js';
+import { selectEvictions, type ResidencyShell } from './residency.js';
 import { OPAQUE_ALPHA_CUTOFF } from './overlay-routing.js';
 import type { DecodedInstancedShard } from '@ifc-lite/geometry';
 import {
@@ -146,6 +147,15 @@ export class Scene {
   // grid-cell prefix so batches are spatially compact and cullable. Null = off
   // (plain colour bucketing, the historical behaviour).
   private spatialChunking: SpatialChunkingConfig | null = null;
+  // GPU residency budget (issue #1682 phase 3a): when set, bucket-owned
+  // batches not drawn recently are evicted (GPU buffers destroyed, CPU
+  // meshData + metadata shell kept) once their combined bytes exceed the
+  // budget, and rebuilt on demand when the draw loop wants them again.
+  private gpuBudgetBytes: number | null = null;
+  private residencyFrame = 0;                                  // bumped once per render()
+  private lastDrawnFrame: Map<number, number> = new Map();     // batch.id -> residencyFrame
+  private residencyRestoreQueue: Set<string> = new Set();      // bucket keys awaiting re-upload
+  private residencyOverBudgetWarned = false;
   private nextSplitId: number = 0; // Monotonic counter for sub-bucket keys
   private nextBatchId: number = 0; // Monotonic counter for unique batch identifiers
   // Shared local-frame origin for ALL batches (set from the first batch's world
@@ -240,6 +250,157 @@ export class Scene {
 
   getSpatialChunking(): SpatialChunkingConfig | null {
     return this.spatialChunking;
+  }
+
+  // ─── GPU residency (issue #1682 phase 3a) ──────────────────────────────
+  // The budget applies to bucket-owned colour/chunk batches (the evictable
+  // set). Streaming fragments, partial sub-batches, overlay batches,
+  // textured meshes and instanced templates are never evicted: fragments are
+  // transient, the rest are small or lack a rebuild source. Enforcement
+  // no-ops while geometry is released or in ephemeral streaming mode (no CPU
+  // meshData to rebuild from — that is phase 3b's evict-to-disk territory).
+
+  /** Set (or clear) the GPU residency budget in bytes. */
+  setGpuResidencyBudget(bytes: number | null): void {
+    if (bytes !== null && !(Number.isFinite(bytes) && bytes > 0)) {
+      console.warn('[Scene] ignoring invalid GPU residency budget:', bytes);
+      return;
+    }
+    this.gpuBudgetBytes = bytes;
+    this.residencyOverBudgetWarned = false;
+  }
+
+  getGpuResidencyBudget(): number | null {
+    return this.gpuBudgetBytes;
+  }
+
+  /** Called once at the start of every Renderer.render() — residency ages
+   *  are measured in RENDERED frames, so idle scenes never age out. */
+  beginResidencyFrame(): void {
+    this.residencyFrame++;
+  }
+
+  /** Record that the draw loop drew this batch this frame. */
+  recordBatchDrawn(batch: BatchedMesh): void {
+    if (this.gpuBudgetBytes === null) return;
+    this.lastDrawnFrame.set(batch.id, this.residencyFrame);
+  }
+
+  /**
+   * The draw loop wants an evicted batch back on the GPU. Queues its bucket
+   * for a time-budgeted rebuild in processResidencyRestores (driven by the
+   * app's animation loop) — the batch is skipped this frame and pops back in
+   * within a frame or two.
+   */
+  requestBatchResidency(batch: BatchedMesh): void {
+    const bucket = this.buckets.get(batch.colorKey);
+    if (bucket && bucket.batchedMesh === batch && bucket.meshData.length > 0) {
+      this.residencyRestoreQueue.add(bucket.key);
+    }
+  }
+
+  hasResidencyRestoreWork(): boolean {
+    return this.residencyRestoreQueue.size > 0;
+  }
+
+  /**
+   * Rebuild evicted batches from their buckets' CPU meshData, up to
+   * `budgetMs` per call (same time-slicing philosophy as flushPending).
+   * Returns the number of batches restored.
+   */
+  processResidencyRestores(device: GPUDevice, pipeline: RenderPipeline, budgetMs: number = 6): number {
+    if (this.residencyRestoreQueue.size === 0) return 0;
+    const start = performance.now();
+    let restored = 0;
+    for (const key of this.residencyRestoreQueue) {
+      this.residencyRestoreQueue.delete(key);
+      const bucket = this.buckets.get(key);
+      const old = bucket?.batchedMesh;
+      // Only restore a still-evicted, still-rebuildable bucket batch — a
+      // recolour/finalize may have rebuilt (or emptied) it in the meantime.
+      if (!bucket || !old || old.gpuResident !== false || bucket.meshData.length === 0) continue;
+
+      const rebuilt = this.createBatchedMesh(bucket.meshData, bucket.meshData[0].color, device, pipeline, key);
+      bucket.batchedMesh = rebuilt;
+      const idx = this.batchedMeshes.indexOf(old);
+      if (idx >= 0) this.batchedMeshes[idx] = rebuilt;
+      else this.batchedMeshes.push(rebuilt);
+      this.lastDrawnFrame.delete(old.id);
+      // Seed as just-drawn so the budget pass can't evict it before the
+      // frame that asked for it gets to draw it.
+      this.lastDrawnFrame.set(rebuilt.id, this.residencyFrame);
+      restored++;
+      if (performance.now() - start >= budgetMs) break;
+    }
+    return restored;
+  }
+
+  /**
+   * Evict least-recently-drawn bucket batches until the resident set fits
+   * the budget. Called after each frame's submit; destroying just-submitted
+   * buffers is safe (WebGPU defers destruction past in-flight work). Never
+   * evicts a batch drawn this frame — a visible set larger than the budget
+   * renders correctly and stays over budget (warned once).
+   */
+  enforceGpuBudget(): void {
+    const budget = this.gpuBudgetBytes;
+    if (budget === null) return;
+    if (this.geometryReleased || this.ephemeralStreamingMode) return;
+    // During streaming the batch set churns (fragments + finalize rebuild
+    // everything anyway) — start enforcing once the scene is stable.
+    if (this.streamingFragments.length > 0) return;
+
+    let residentBytes = 0;
+    const shells: ResidencyShell[] = [];
+    for (const bucket of this.buckets.values()) {
+      const b = bucket.batchedMesh;
+      if (!b || b.gpuResident === false) continue;
+      const bytes = b.vertexBuffer.size + b.indexBuffer.size + (b.uniformBuffer?.size ?? 0);
+      residentBytes += bytes;
+      const lastDrawn = this.lastDrawnFrame.get(b.id) ?? -1;
+      if (lastDrawn === this.residencyFrame) continue;      // drawn this frame: not evictable
+      if (bucket.meshData.length === 0) continue;           // no rebuild source: keep resident
+      shells.push({ key: bucket.key, bytes, lastDrawnFrame: lastDrawn });
+    }
+    if (residentBytes <= budget) return;
+
+    const evictKeys = selectEvictions(shells, residentBytes, budget, this.residencyFrame);
+    let evictedBytes = 0;
+    for (const key of evictKeys) {
+      const bucket = this.buckets.get(key);
+      const batch = bucket?.batchedMesh;
+      if (!bucket || !batch || batch.gpuResident === false) continue;
+      destroyGpuResources(batch);
+      batch.gpuResident = false;
+      evictedBytes += batch.vertexBuffer.size + batch.indexBuffer.size + (batch.uniformBuffer?.size ?? 0);
+      this.lastDrawnFrame.delete(batch.id);
+      this.dropPartialCacheForBatch(batch);
+    }
+
+    if (residentBytes - evictedBytes > budget && !this.residencyOverBudgetWarned) {
+      this.residencyOverBudgetWarned = true;
+      console.warn(
+        `[Scene] GPU residency budget ${(budget / 1048576).toFixed(0)}MB exceeded by the ` +
+        `recently-drawn set (${((residentBytes - evictedBytes) / 1048576).toFixed(0)}MB resident) — ` +
+        `nothing old enough to evict. Rendering is unaffected.`
+      );
+    }
+  }
+
+  /** Destroy + drop cached partial sub-batches derived from `batch` (their
+   *  sourceBatchKeys embed the batch id, so they are stale once it is
+   *  evicted/replaced). */
+  private dropPartialCacheForBatch(batch: BatchedMesh): void {
+    const prefix = `${batch.colorKey}:${batch.id}`;
+    for (const [sourceBatchKey, cacheKey] of this.partialBatchCacheKeys) {
+      if (!sourceBatchKey.startsWith(prefix)) continue;
+      const cached = this.partialBatchCache.get(cacheKey);
+      if (cached) {
+        destroyGpuResources(cached);
+        this.partialBatchCache.delete(cacheKey);
+      }
+      this.partialBatchCacheKeys.delete(sourceBatchKey);
+    }
   }
 
   /**
@@ -1389,6 +1550,8 @@ export class Scene {
     this.buckets.clear();
     this.meshDataBucket = new Map();
     this.activeBucketKey.clear();
+    this.lastDrawnFrame.clear();
+    this.residencyRestoreQueue.clear();
     this.pendingBatchKeys.clear();
     // Destroy cached partial batches — their colorKeys are now stale
     for (const batch of this.partialBatchCache.values()) destroyGpuResources(batch);
@@ -1462,6 +1625,8 @@ export class Scene {
     this.buckets.clear();
     this.meshDataBucket = new Map();
     this.activeBucketKey.clear();
+    this.lastDrawnFrame.clear();
+    this.residencyRestoreQueue.clear();
     this.pendingBatchKeys.clear();
     for (const batch of this.partialBatchCache.values()) destroyGpuResources(batch);
     this.partialBatchCache.clear();
@@ -1576,6 +1741,8 @@ export class Scene {
     // AABBs already live in boundingBoxes, so bbox-raycast still finds instanced ids.
     this.instancedTemplateCpu = [];
     this.activeBucketKey.clear();
+    this.lastDrawnFrame.clear();
+    this.residencyRestoreQueue.clear();
     this.pendingBatchKeys.clear();
     for (const batch of this.partialBatchCache.values()) destroyGpuResources(batch);
     this.partialBatchCache.clear();
@@ -1658,6 +1825,8 @@ export class Scene {
     }
     this.meshDataBucket = new Map();
     this.activeBucketKey.clear();
+    this.lastDrawnFrame.clear();
+    this.residencyRestoreQueue.clear();
 
     // 3. Clear partial batch cache (would need mesh data to rebuild)
     for (const batch of this.partialBatchCache.values()) destroyGpuResources(batch);
@@ -2162,7 +2331,9 @@ export class Scene {
    */
   getResidentGpuBytes(): ResidentGpuBytes {
     return sumResidentGpuBytes({
-      batches: this.batchedMeshes,
+      // Evicted batches are metadata shells — their destroyed buffers still
+      // report .size, so they must be excluded from the resident sum.
+      batches: this.batchedMeshes.filter((b) => b.gpuResident !== false),
       partialBatches: this.partialBatchCache.values(),
       meshes: this.meshes,
       textured: this.texturedMeshes,
@@ -2749,6 +2920,8 @@ export class Scene {
     this.meshDataMap.clear();
     this.boundingBoxes.clear();
     this.activeBucketKey.clear();
+    this.lastDrawnFrame.clear();
+    this.residencyRestoreQueue.clear();
     this.cachedMaxBufferSize = 0;
     this.pendingBatchKeys.clear();
     this.partialBatchCache.clear();

--- a/packages/renderer/src/types.ts
+++ b/packages/renderer/src/types.ts
@@ -281,6 +281,15 @@ export interface RenderOptions {
    * option stay exhaustive.
    */
   contributionCull?: import('./contribution-cull.js').ContributionCullOptions;
+  /**
+   * One-shot capture renders (IDS/clash/BCF snapshots): synchronously
+   * rebuild every GPU-evicted batch before drawing, so isolation options
+   * that reveal batches aged out under the residency budget still capture a
+   * complete image. Has a frame-time cost proportional to the evicted set —
+   * do NOT pass it on the interactive render loop (evicted batches restore
+   * asynchronously there).
+   */
+  restoreEvictedForCapture?: boolean;
 }
 
 /**

--- a/packages/renderer/src/types.ts
+++ b/packages/renderer/src/types.ts
@@ -75,6 +75,12 @@ export interface BatchedMesh {
    *  space (world = origin + position). Keeps f32 vertex coords element-small at
    *  building/georef scale (no fan collapse). [0,0,0] = absolute (legacy). */
   origin?: [number, number, number];
+  /** GPU residency (issue #1682 phase 3a): `false` = evicted metadata shell —
+   *  bounds/expressIds/counts remain valid for culling, picking-fallback and
+   *  bookkeeping, but the GPU buffers are destroyed and MUST NOT be bound.
+   *  The draw loop skips such batches and requests a rebuild via
+   *  `Scene.requestBatchResidency`. `undefined`/`true` = resident. */
+  gpuResident?: boolean;
 }
 
 // Section plane for clipping

--- a/scripts/api-surface.json
+++ b/scripts/api-surface.json
@@ -3353,6 +3353,7 @@
     "HatchPatternId: type",
     "Intersection: interface",
     "LightingEnvironment: interface",
+    "MIN_EVICTION_AGE_FRAMES: const",
     "MagneticSnapResult: interface",
     "Mat4: interface",
     "Material: interface",
@@ -3387,6 +3388,7 @@
     "RenderOptions: interface",
     "RenderPipeline: class",
     "Renderer: class",
+    "ResidencyShell: interface",
     "ResidentGpuBytes: interface",
     "ResolvedEnvironment: type",
     "Scene: class",
@@ -3428,6 +3430,7 @@
     "projectedAabbRadiusPx: function",
     "resolveContributionThresholdPx: function",
     "resolveEnvironment: function",
+    "selectEvictions: function",
     "sumResidentGpuBytes: function"
   ],
   "@ifc-lite/sandbox": [

--- a/tests/benchmark/viewer-benchmark-page.ts
+++ b/tests/benchmark/viewer-benchmark-page.ts
@@ -167,6 +167,21 @@ export class ViewerBenchmarkPage {
       }
     }
 
+    // Optional GPU residency budget for A/B runs (issue #1682 phase 3a).
+    // Set VIEWER_BENCHMARK_GPU_BUDGET to a number of megabytes. Unset ⇒ off.
+    const gpuBudgetEnv = process.env.VIEWER_BENCHMARK_GPU_BUDGET;
+    if (gpuBudgetEnv) {
+      const mb = Number(gpuBudgetEnv);
+      if (Number.isFinite(mb) && mb > 0) {
+        await this.page.addInitScript((v) => {
+          (globalThis as unknown as { __IFC_LITE_GPU_BUDGET_MB?: number }).__IFC_LITE_GPU_BUDGET_MB = v;
+        }, mb);
+        console.log(`[Benchmark] GPU residency budget override: ${mb}MB`);
+      } else {
+        console.warn(`[Benchmark] invalid VIEWER_BENCHMARK_GPU_BUDGET: ${gpuBudgetEnv}`);
+      }
+    }
+
     // Navigate to viewer app
     await this.page.goto('http://localhost:3000');
     


### PR DESCRIPTION
Phase 3a of the chunked-residency plan for #1682. **Stacked on #1704** (needs spatially compact chunk batches to have anything meaningful to evict); retarget as the stack merges.

## What

Opt-in **GPU residency budget**: `Scene.setGpuResidencyBudget(bytes)`. After each frame's submit, bucket-owned batches not drawn recently are evicted LRU-first - GPU buffer trio destroyed, CPU `meshData` and the batch metadata shell (bounds/expressIds/counts) kept - until the resident set fits the budget. When the camera wants an evicted batch back, the draw loop skips it for one frame, queues its bucket, and the animation loop rebuilds it time-budgeted on the next tick.

Policy (pure functions in `residency.ts`, unit-tested):
- **Never evict a batch drawn this frame.** The budget is a target, not a hard cap: a visible set larger than the budget renders correctly and stays over budget (warned once). No blank screens, ever.
- **Never evict a batch idle fewer than 30 rendered frames** - a chunk that just left the frustum mid-orbit comes right back; re-uploading it every half-gesture would thrash.
- **Ages are measured in rendered frames**, so an idle scene never decays.
- Enforcement no-ops during streaming (batch set churns, finalize rebuilds anyway), in ephemeral mode, and after geometry release - no rebuild source there; evict-to-disk against the chunked cache format is phase 3b.

Correctness details: restored batches are seeded as just-drawn so the budget pass cannot evict them before the frame that requested them draws them; eviction drops the batch's cached partial sub-batches (their source ids go stale); `getResidentGpuBytes` excludes shells (destroyed `GPUBuffer`s still report `.size`); all metadata consumers of `getBatchedMeshes()` (model bounds, orbit heuristics, CPU raycast, throttle sizing) were audited - only the draw loop touches GPU buffers, and it now checks `gpuResident`.

Knobs: `globalThis.__IFC_LITE_GPU_BUDGET_MB` (off by default), benchmark env `VIEWER_BENCHMARK_GPU_BUDGET`. `FrameStats` gains `batchesNotResident`.

## Measured (headed Chrome, real WebGPU, FM_ARC_DigitalHub 14 MB, 16 m chunks, 6 MB budget)

| | batches drawn | resident GPU (bucket batches) |
|---|---|---|
| initial full framing | 191 | 20.02 MB |
| zoomed into a corner (orbiting) | 39 | 7.81 MB |
| `fitAll` back out | **191** | **20.02 MB** |

Eviction converges toward the budget while zoomed in, and the restore path recovers the full scene **byte-exact** with `batchesNotResident` back at 0 - no permanently missing geometry.

## Verification

- 230 renderer + 1659 viewer app tests green (new: eviction ordering, budget math, min-age hysteresis, never-drawn coldness, custom age, insufficient-eviction case).
- Headed end-to-end residency harness (numbers above), exercising evict -> skip -> queue -> rebuild -> re-draw round trip through real user input.
- App typecheck + production build; api-surface snapshot updated; changeset included (`@ifc-lite/renderer` minor).

Same stacked-CI caveat as #1704: Test/Benchmark workflows run once retargeted to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an opt-in GPU residency budget to reduce memory usage by evicting inactive GPU data and restoring it as needed.
  - Added frame statistics showing visible batches awaiting GPU restoration.
  - Added configuration support for setting the GPU budget in megabytes.
  - Ensured exported snapshots restore evicted data for complete imagery.

- **Bug Fixes**
  - GPU restoration errors are now handled without interrupting the rendering loop.
  - Added safeguards to avoid evicting recently used or actively rendered data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->