### PR TITLE
feat(viewer): flip #1682 render-perf defaults ON (chunks, budgets, LOD)

### DIFF
--- a/apps/viewer/src/utils/gpuBudgetConfig.ts
+++ b/apps/viewer/src/utils/gpuBudgetConfig.ts
@@ -5,31 +5,39 @@
 /**
  * GPU residency budget for the renderer scene (issue #1682, phase 3a).
  *
- * OFF BY DEFAULT (no eviction). Opt in per session, read once at renderer
- * init; the value is megabytes of GPU geometry the bucket batches may hold
- * before least-recently-drawn ones are evicted (and rebuilt on demand).
- * Meaningful together with spatial chunking (`__IFC_LITE_CHUNKS`) — without
- * it, batches are model-wide colour groups and everything is always
- * "recently drawn". Benchmark A/B env: VIEWER_BENCHMARK_GPU_BUDGET.
+ * DEFAULT 2048 MB since the #1682 sweep: a generous target that is a no-op
+ * on ordinary models (they never exceed it) and bounds the #1682-class
+ * monsters. Over-budget is safe by design — visible batches are never
+ * evicted, rendering is unaffected, the budget is a target not a cap.
+ * Kill switch: set 0. Benchmark A/B env: VIEWER_BENCHMARK_GPU_BUDGET.
  *
- *   globalThis.__IFC_LITE_GPU_BUDGET_MB = 512   // 512 MB budget
+ *   globalThis.__IFC_LITE_GPU_BUDGET_MB = 512   // custom budget
+ *   globalThis.__IFC_LITE_GPU_BUDGET_MB = 0     // off
  */
+const DEFAULT_GPU_BUDGET_MB = 2048;
+
 export function getGpuResidencyBudgetBytes(): number | null {
   const raw = (globalThis as { __IFC_LITE_GPU_BUDGET_MB?: unknown }).__IFC_LITE_GPU_BUDGET_MB;
+  if (raw === undefined || raw === null) return DEFAULT_GPU_BUDGET_MB * 1024 * 1024;
   if (typeof raw !== 'number' || !Number.isFinite(raw) || raw <= 0) return null;
   return Math.round(raw * 1024 * 1024);
 }
 
 /**
  * HOST (CPU) residency budget for bucket geometry (issue #1682 phase 3b).
- * OFF BY DEFAULT. Only effective on v13-cached models (the cold tier needs a
- * disk restore source) and together with the GPU budget (only GPU-evicted
- * buckets are cold-eligible). Benchmark A/B env: VIEWER_BENCHMARK_HOST_BUDGET.
+ * DEFAULT 3072 MB (a no-op below that; bounds the monsters). Only effective
+ * on v13-cached models (the cold tier needs a disk restore source) and
+ * together with the GPU budget (only GPU-evicted buckets are cold-eligible).
+ * Kill switch: set 0. Benchmark A/B env: VIEWER_BENCHMARK_HOST_BUDGET.
  *
- *   globalThis.__IFC_LITE_HOST_BUDGET_MB = 1024
+ *   globalThis.__IFC_LITE_HOST_BUDGET_MB = 1024   // custom
+ *   globalThis.__IFC_LITE_HOST_BUDGET_MB = 0      // off
  */
+const DEFAULT_HOST_BUDGET_MB = 3072;
+
 export function getHostResidencyBudgetBytes(): number | null {
   const raw = (globalThis as { __IFC_LITE_HOST_BUDGET_MB?: unknown }).__IFC_LITE_HOST_BUDGET_MB;
+  if (raw === undefined || raw === null) return DEFAULT_HOST_BUDGET_MB * 1024 * 1024;
   if (typeof raw !== 'number' || !Number.isFinite(raw) || raw <= 0) return null;
   return Math.round(raw * 1024 * 1024);
 }

--- a/apps/viewer/src/utils/lodConfig.ts
+++ b/apps/viewer/src/utils/lodConfig.ts
@@ -3,15 +3,20 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 /**
- * LOD1 config (issue #1682, phase 5). OFF BY DEFAULT. The value is the
- * projected screen size (device px) below which a batch draws its simplified
- * LOD1 index range. Read once at renderer init; benchmark A/B env:
- * VIEWER_BENCHMARK_LOD_PX.
+ * LOD1 config (issue #1682, phase 5). DEFAULT 48 px since the #1682 sweep
+ * (0.163% pixels differ >8/255 at the far more aggressive 120 px threshold;
+ * at 48 px the delta is imperceptible). The value is the projected screen
+ * size (device px) below which a batch draws its simplified LOD1 index
+ * range. Kill switch: set 0. Benchmark A/B env: VIEWER_BENCHMARK_LOD_PX.
  *
- *   globalThis.__IFC_LITE_LOD_PX = 80
+ *   globalThis.__IFC_LITE_LOD_PX = 80   // custom
+ *   globalThis.__IFC_LITE_LOD_PX = 0    // off
  */
+const DEFAULT_LOD_PX = 48;
+
 export function getLodScreenPx(): number | null {
   const raw = (globalThis as { __IFC_LITE_LOD_PX?: unknown }).__IFC_LITE_LOD_PX;
+  if (raw === undefined || raw === null) return DEFAULT_LOD_PX;
   if (typeof raw !== 'number' || !Number.isFinite(raw) || raw <= 0) return null;
   return raw;
 }

--- a/apps/viewer/src/utils/spatialChunkConfig.ts
+++ b/apps/viewer/src/utils/spatialChunkConfig.ts
@@ -6,10 +6,12 @@
  * Spatial chunk bucketing config for the renderer scene (issue #1682,
  * phase 2 of the chunked-residency plan).
  *
- * OFF BY DEFAULT while the draw-call cost is being characterized against the
- * benchmark's drawCalls metric. Opt in per session, read once at renderer
- * init (benchmark A/B knob VIEWER_BENCHMARK_CHUNKS sets the same global):
- *   globalThis.__IFC_LITE_CHUNKS = 1                 // on, default cell size
+ * ON BY DEFAULT (32 m cells) since the #1682 sweep: load KPIs unchanged
+ * within noise (FZK/DigitalHub/advanced_model), draw calls 13->17 / 21->85 /
+ * 275->343, and chunked batches are what give frustum/contribution culling,
+ * the residency budgets and LOD their granularity. Kill switch / override,
+ * read once at renderer init (benchmark A/B env VIEWER_BENCHMARK_CHUNKS):
+ *   globalThis.__IFC_LITE_CHUNKS = 0                 // off (kill switch)
  *   globalThis.__IFC_LITE_CHUNKS = 16                // on, 16 m cells
  *   globalThis.__IFC_LITE_CHUNKS = { cellSize: 16 }  // same, explicit
  */
@@ -18,7 +20,8 @@ import { DEFAULT_CHUNK_CELL_SIZE, type SpatialChunkingConfig } from '@ifc-lite/r
 
 export function getSpatialChunkingConfig(): SpatialChunkingConfig | null {
   const raw = (globalThis as { __IFC_LITE_CHUNKS?: unknown }).__IFC_LITE_CHUNKS;
-  if (raw === undefined || raw === null || raw === false || raw === 0) return null;
+  if (raw === undefined || raw === null) return { cellSize: DEFAULT_CHUNK_CELL_SIZE };
+  if (raw === false || raw === 0) return null;
   if (raw === true || raw === 1) return { cellSize: DEFAULT_CHUNK_CELL_SIZE };
   if (typeof raw === 'number') {
     return Number.isFinite(raw) && raw > 0 ? { cellSize: raw } : null;

--- a/tests/benchmark/viewer-benchmark-page.ts
+++ b/tests/benchmark/viewer-benchmark-page.ts
@@ -172,7 +172,9 @@ export class ViewerBenchmarkPage {
     const gpuBudgetEnv = process.env.VIEWER_BENCHMARK_GPU_BUDGET;
     if (gpuBudgetEnv) {
       const mb = Number(gpuBudgetEnv);
-      if (Number.isFinite(mb) && mb > 0) {
+      // 0 is a valid override: it injects the kill switch (the app DEFAULT is
+      // on since the #1682 flip, so an off-baseline must pass 0 through).
+      if (Number.isFinite(mb) && mb >= 0) {
         await this.page.addInitScript((v) => {
           (globalThis as unknown as { __IFC_LITE_GPU_BUDGET_MB?: number }).__IFC_LITE_GPU_BUDGET_MB = v;
         }, mb);
@@ -187,7 +189,8 @@ export class ViewerBenchmarkPage {
     const hostBudgetEnv = process.env.VIEWER_BENCHMARK_HOST_BUDGET;
     if (hostBudgetEnv) {
       const mb = Number(hostBudgetEnv);
-      if (Number.isFinite(mb) && mb > 0) {
+      // 0 = kill switch (see the GPU budget note above).
+      if (Number.isFinite(mb) && mb >= 0) {
         await this.page.addInitScript((v) => {
           (globalThis as unknown as { __IFC_LITE_HOST_BUDGET_MB?: number }).__IFC_LITE_HOST_BUDGET_MB = v;
         }, mb);
@@ -202,7 +205,8 @@ export class ViewerBenchmarkPage {
     const lodEnv = process.env.VIEWER_BENCHMARK_LOD_PX;
     if (lodEnv) {
       const px = Number(lodEnv);
-      if (Number.isFinite(px) && px > 0) {
+      // 0 = kill switch (the app default is 48px since the #1682 flip).
+      if (Number.isFinite(px) && px >= 0) {
         await this.page.addInitScript((v) => {
           (globalThis as unknown as { __IFC_LITE_LOD_PX?: number }).__IFC_LITE_LOD_PX = v;
         }, px);


### PR DESCRIPTION
The finale of the #1682 program: flip the render-perf defaults ON. **Stacked on #1708** (top of the #1703-#1708 stack).

## Decision basis (headed Chrome sweep, real WebGPU)

Full stack ON (chunks 32 m, GPU budget 2048 MB, host budget 3072 MB, LOD 48 px) vs current defaults:

| model | total (off -> on) | first visible | draw calls | resident GPU |
|---|---|---|---|---|
| FZK-Haus 2.4 MB | 300 -> 400 ms (noise) | 167 -> 191 ms | 13 -> 17 | 1.1 -> 1.1 MB |
| DigitalHub 13.4 MB | 900 -> 900 ms | 361 -> 367 ms | 21 -> 85 | 20.0 -> 20.2 MB |
| advanced_model 35 MB | 1700 -> 1700 ms | 390 -> 396 ms | 275 -> 343 | 37.2 -> 37.5 MB |

Defaults-vs-all-off pixel delta at default framing: **0.13%** (>8/255) - the LOD1-on-small-batches class, imperceptible.

What the flip buys (measured in the stack's PRs): chunk-granular culling (43/191 batches culled at corner zoom vs 2/19 unchunked), bounded GPU + host memory with byte-exact evict/restore round trips on #1682-class models, LOD1 at distance (71/191 batches, 0.163% delta at the far more aggressive 120 px), and v13 cache entries 2.2x smaller with warm loads streaming pixel-identically in half the time.

Budget defaults are deliberately generous no-ops for ordinary models: they only bite on monsters, over-budget is safe by design (visible batches are never evicted; the budget is a target, not a cap), and cold demotion additionally requires a v13-cached model.

Kill switches for everything (`= 0`): `__IFC_LITE_CHUNKS`, `__IFC_LITE_GPU_BUDGET_MB`, `__IFC_LITE_HOST_BUDGET_MB`, `__IFC_LITE_LOD_PX`, plus the existing `__IFC_LITE_CONTRIB_CULL`.

## During the sweep, one telemetry bug was found and fixed (in #1708's branch)

The post-load render-stats line raced `finalizeStreamingAsync` (its preamble clears the fragment list synchronously), reporting the FRAGMENT scene - e.g. 411 draws on DigitalHub instead of the real 86. `Scene.isFinalizeInProgress()` now flags the rebuild window and the settle detector waits on it. The sweep numbers above are post-fix.

## Verification

- 1663 viewer app tests green; typecheck + production build.
- Headed no-knobs run exercises the full default path end-to-end (correct settle stats: 85 draws / 83 batches on DigitalHub).
- All e2e harnesses from the stack (streamed cache, GPU residency, cold tier, LOD) pass on this head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
