### PR TITLE
fix(renderer): request the adapter's max buffer limits so large meshes upload

### DIFF
--- a/packages/renderer/src/device.ts
+++ b/packages/renderer/src/device.ts
@@ -33,7 +33,29 @@ export class WebGPUDevice {
       throw new Error('Failed to get GPU adapter');
     }
 
-    this.device = await this.adapter.requestDevice();
+    // Request the adapter's maximum buffer limits. The WebGPU default maxBufferSize
+    // is 256 MiB, but a single large mesh (e.g. a multi-GB IFC that meshes to one
+    // dense geometry) can need a vertex or index buffer well beyond that — its upload
+    // then fails with "Buffer size … exceeds the max buffer size limit", the buffer is
+    // invalid, and nothing renders. Adapters commonly advertise up to 2 GiB, so raise
+    // the device limits to whatever this adapter supports. Guarded so a runtime that
+    // doesn't expose `adapter.limits` (or rejects the required limits) still gets a
+    // device with the defaults.
+    const limits = this.adapter.limits;
+    const requiredLimits: Record<string, number> = {};
+    if (limits?.maxBufferSize) {
+      requiredLimits.maxBufferSize = limits.maxBufferSize;
+    }
+    if (limits?.maxStorageBufferBindingSize) {
+      requiredLimits.maxStorageBufferBindingSize = limits.maxStorageBufferBindingSize;
+    }
+    try {
+      this.device = await this.adapter.requestDevice({ requiredLimits });
+    } catch {
+      // Some drivers reject requiredLimits they nominally advertise — fall back to a
+      // default device rather than failing to initialise the renderer entirely.
+      this.device = await this.adapter.requestDevice();
+    }
     this.format = navigator.gpu.getPreferredCanvasFormat();
     this.canvas = canvas;
 


### PR DESCRIPTION
## Problem

`WebGPUDevice.init` creates the device with `adapter.requestDevice()` and **no `requiredLimits`**, so it always gets the WebGPU default `maxBufferSize` of **256 MiB**.

A single large mesh — a multi-GB IFC that meshes to one dense geometry, or any model with a vertex/index buffer over 256 MiB — then fails to upload:

```
[WebGPU] Uncaptured error: Buffer size (446236308) exceeds the max buffer size limit (268435456).
This adapter supports a higher maxBufferSize of 2147483648, which can be specified in
requiredLimits when calling requestDevice().
```

The buffer is left invalid, every command buffer that references it is invalid, and the model renders blank while the UI otherwise looks fine.

`splitMeshDataForBufferLimit` only splits *across* meshes, so it can't help when a *single* mesh already exceeds the limit.

## Fix

Request the adapter's advertised `maxBufferSize` / `maxStorageBufferBindingSize` (commonly up to 2 GiB) when creating the device. Guarded both ways:
- a runtime that doesn't expose `adapter.limits` still gets a default device;
- a driver that rejects limits it nominally advertises falls back to `requestDevice()`.

No behaviour change for models that already fit under 256 MiB.

## Context

Found while enabling multi-GB IFC models to open in the desktop app: the store now loads natively, but the model stayed blank until the device was asked for the higher buffer limit. Verified end-to-end — a 4.17 GB model with a single 10.2M-triangle / 446 MB mesh renders after this change.

Draft for review of the approach (raise to adapter max vs. a fixed cap, and whether to also raise `maxStorageBufferBindingSize` unconditionally).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebGPU device initialization by supporting larger buffer limits when available.
  * Added a fallback that allows initialization to continue when a graphics driver rejects the requested limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->