### PR TITLE
perf(renderer): cull instanced-template draws + adaptive interaction throttle (choppy orbit on CATIA-class models)

### DIFF
--- a/.changeset/renderer-instanced-cull.md
+++ b/.changeset/renderer-instanced-cull.md
@@ -1,0 +1,9 @@
+---
+"@ifc-lite/renderer": minor
+---
+
+Cull GPU-instanced template draws (frustum + contribution) and report instanced frame stats.
+
+The instanced pass previously drew every template unconditionally — on CATIA-class models that is ~97% of all draw calls (e.g. 8,929 of 9,213), which made orbiting choppy. Each template now carries cull metadata built at shard-upload time (union of occurrence world AABBs + largest single-occurrence bounding-sphere radius): templates are frustum-culled against the union box, and contribution-culled when even the largest occurrence projected at the union box's nearest view depth falls below the active pixel threshold — a conservative upper bound that works for bolts-scattered-everywhere templates whose union box is model-sized. Templates with a selected occurrence are exempt from contribution culling; non-finite occurrence matrices poison a template's metadata so it fails open (never culled); Exploded-mode translates grow the union so moved occurrences can't be culled by pre-move bounds. `FrameStats` gains `instancedDrawn` / `instancedFrustumCulled` / `instancedContributionCulled`.
+
+Measured on an 883 MB CATIA model: draw calls 9,213 → 2,122 and fast-orbit frame rate 25.5 → 58.4 FPS, with unchanged GPU residency.

--- a/apps/viewer/src/components/viewer/useAnimationLoop.ts
+++ b/apps/viewer/src/components/viewer/useAnimationLoop.ts
@@ -125,29 +125,33 @@ export function useAnimationLoop(params: UseAnimationLoopParams): void {
     let wasAnimating = false;
     let residencyRestoreErrorLogged = false;
 
-    // Adaptive render throttle: large models get fewer FPS during continuous
-    // rendering (interaction + inertia) to prevent the main thread from being
-    // overwhelmed. Model "size" is measured by total triangle count across all
-    // batched geometry — individual mesh count is near 0 for batched models.
-    let continuousThrottleMs = 0; // 0 = no throttle (small models)
+    // Adaptive render throttle: cap the continuous-render cadence (interaction
+    // + inertia) from the MEASURED cost of recent renders, not a triangle-count
+    // guess. The old tiers (25ms above 1M triangles, 33ms above 5M) capped
+    // orbiting at 40/30 fps even when frames were cheap — culling means a 6M-
+    // triangle model can render in a few ms, and the cap itself was the
+    // choppiness on CATIA-class models. renderer.render() wall time covers
+    // encoder work AND swap-chain backpressure (getCurrentTexture blocks when
+    // the GPU falls behind), so genuinely heavy scenes still degrade to the
+    // same 40/30 fps floors within a few frames; a 200K-mesh model that takes
+    // 30ms a frame cannot overwhelm the main thread any more than before.
+    let continuousThrottleMs = 0; // 0 = no throttle
+    let emaRenderMs = 0;          // EMA of render() wall time, rendered frames only
 
-    function updateThrottle() {
-      let totalIndices = 0;
-      for (const batch of scene.getBatchedMeshes()) {
-        totalIndices += batch.indexCount;
-      }
-      // Also account for individual meshes
-      totalIndices += scene.getMeshes().reduce((s, m) => s + (m.indexCount ?? 0), 0);
-      const triangles = totalIndices / 3;
-      if (triangles > 5_000_000) {
-        continuousThrottleMs = 33; // ~30 fps — huge models (>5M triangles)
-      } else if (triangles > 1_000_000) {
-        continuousThrottleMs = 25; // ~40 fps — large models (>1M triangles)
-      } else {
+    function updateThrottle(renderMs: number) {
+      emaRenderMs = emaRenderMs === 0 ? renderMs : renderMs * 0.2 + emaRenderMs * 0.8;
+      // Hysteresis ladder — engage above, release below, hold in between,
+      // so the cadence doesn't flap around a band edge mid-gesture.
+      if (emaRenderMs >= 26) {
+        continuousThrottleMs = 33; // ~30 fps
+      } else if (emaRenderMs >= 14) {
+        if (continuousThrottleMs !== 33 || emaRenderMs < 20) {
+          continuousThrottleMs = 25; // ~40 fps
+        }
+      } else if (emaRenderMs <= 10) {
         continuousThrottleMs = 0;
       }
     }
-    updateThrottle();
 
     const animate = (currentTime: number) => {
       if (aborted) return;
@@ -164,7 +168,6 @@ export function useAnimationLoop(params: UseAnimationLoopParams): void {
           queueFlushed = scene.flushPending(device, pipeline);
           if (queueFlushed) {
             renderer.clearCaches();
-            updateThrottle();
           }
         }
       }
@@ -228,6 +231,7 @@ export function useAnimationLoop(params: UseAnimationLoopParams): void {
 
       if (willRender) {
         renderer.consumeRenderRequest();
+        const renderStart = performance.now();
         renderer.render({
           hiddenIds: hiddenEntitiesRef.current,
           isolatedIds: isolatedEntitiesRef.current,
@@ -268,6 +272,7 @@ export function useAnimationLoop(params: UseAnimationLoopParams): void {
           } : undefined,
           terrainClipY: terrainClipYRef.current ?? undefined,
         });
+        updateThrottle(performance.now() - renderStart);
         lastRenderTime = currentTime;
         // Snapshot the renderer's current model bounds so the section
         // face-pick handler can compute a correct cardinal-fallback

--- a/apps/viewer/src/utils/renderStatsReport.ts
+++ b/apps/viewer/src/utils/renderStatsReport.ts
@@ -87,7 +87,9 @@ export async function reportRenderStats(context: {
       `[ifc-lite] render stats: ${stats.drawCalls} draw calls, ` +
       `${gpuMB.toFixed(1)} MB GPU resident ` +
       `(${stats.batchesDrawn} batches drawn, ${stats.batchesFrustumCulled} frustum-culled, ` +
-      `${stats.batchesContributionCulled} contribution-culled)`
+      `${stats.batchesContributionCulled} contribution-culled; ` +
+      `${stats.instancedDrawn} instanced drawn, ${stats.instancedFrustumCulled} frustum-culled, ` +
+      `${stats.instancedContributionCulled} contribution-culled)`
     );
     posthog.capture('viewer_render_stats', {
       file_size_mb: Math.round(context.fileSizeMB * 100) / 100,
@@ -98,6 +100,9 @@ export async function reportRenderStats(context: {
       batches_drawn: stats.batchesDrawn,
       batches_frustum_culled: stats.batchesFrustumCulled,
       batches_contribution_culled: stats.batchesContributionCulled,
+      instanced_drawn: stats.instancedDrawn,
+      instanced_frustum_culled: stats.instancedFrustumCulled,
+      instanced_contribution_culled: stats.instancedContributionCulled,
     });
   } catch (err) {
     // Telemetry must never break a load.

--- a/packages/renderer/src/contribution-cull.test.ts
+++ b/packages/renderer/src/contribution-cull.test.ts
@@ -7,6 +7,7 @@ import assert from 'node:assert';
 
 import {
   projectedAabbRadiusPx,
+  projectedInstancedRadiusPx,
   resolveContributionThresholdPx,
   type CullCameraState,
 } from './contribution-cull.ts';
@@ -130,5 +131,114 @@ describe('projectedAabbRadiusPx (orthographic)', () => {
 
   it('never culls on a degenerate ortho volume', () => {
     assert.strictEqual(projectedAabbRadiusPx([-1, -1, -11], [1, 1, -9], orthoCam(0)), Infinity);
+  });
+});
+
+describe('projectedInstancedRadiusPx (instanced templates)', () => {
+  // tan(fov/2)=1, halfViewport=500 → px = r / minDepth * 500.
+  it('projects the max occurrence radius at the union box NEAREST view depth', () => {
+    // Union box z ∈ [-200, -100] looking down -Z: nearest depth = 100.
+    const px = projectedInstancedRadiusPx([-50, -50, -200], [50, 50, -100], 1, perspectiveCam());
+    assert.ok(Math.abs(px - (1 / 100) * 500) < 1e-9, `got ${px}`);
+  });
+
+  it('is an upper bound for every real occurrence in the box', () => {
+    const cam = perspectiveCam();
+    const unionMin: [number, number, number] = [-40, -40, -300];
+    const unionMax: [number, number, number] = [40, 40, -100];
+    const maxOccRadius = 0.5;
+    const bound = projectedInstancedRadiusPx(unionMin, unionMax, maxOccRadius, cam);
+    // Sample occurrence spheres of radius <= maxOccRadius centred inside the box.
+    for (const [x, y, z, r] of [
+      [0, 0, -100.5, 0.5], // nearest face, max radius — the worst case
+      [39, -39, -150, 0.4],
+      [0, 40, -299, 0.1],
+    ] as const) {
+      const occ = projectedAabbRadiusPx(
+        [x - r, y - r, z - r],
+        [x + r, y + r, z + r],
+        cam,
+      );
+      // The occurrence's own AABB half-diagonal is sqrt(3)*r (> r), so compare
+      // against the sphere projection directly: r / depth * 500.
+      const sphere = (r / -z) * 500;
+      assert.ok(sphere <= bound + 1e-9, `occ at z=${z} r=${r}: sphere ${sphere} > bound ${bound}`);
+      assert.ok(occ >= sphere, 'sanity: AABB projection over-estimates the sphere');
+    }
+  });
+
+  it('picks the nearest corner per viewDir sign (not a fixed corner)', () => {
+    // Looking down +Z from z=0: nearest depth of box z ∈ [100, 200] is 100.
+    const cam = perspectiveCam({ viewDir: { x: 0, y: 0, z: 1 } });
+    const px = projectedInstancedRadiusPx([-10, -10, 100], [10, 10, 200], 2, cam);
+    assert.ok(Math.abs(px - (2 / 100) * 500) < 1e-9, `got ${px}`);
+  });
+
+  it('fails open when an occurrence could reach the camera plane (minDepth <= radius)', () => {
+    const px = projectedInstancedRadiusPx([-10, -10, -10], [10, 10, -1], 5, perspectiveCam());
+    assert.strictEqual(px, Infinity);
+  });
+
+  it('fails open when the union box is behind the camera', () => {
+    const px = projectedInstancedRadiusPx([-1, -1, 50], [1, 1, 100], 0.5, perspectiveCam());
+    assert.strictEqual(px, Infinity);
+  });
+
+  it('fails open on poisoned metadata (maxOccRadius = Infinity) and NaN radius', () => {
+    assert.strictEqual(
+      projectedInstancedRadiusPx([-1, -1, -101], [1, 1, -99], Infinity, perspectiveCam()),
+      Infinity,
+    );
+    assert.strictEqual(
+      projectedInstancedRadiusPx([-1, -1, -101], [1, 1, -99], NaN, perspectiveCam()),
+      Infinity,
+    );
+  });
+
+  it('fails open on degenerate camera (viewport, viewDir, fov)', () => {
+    const args: [readonly [number, number, number], readonly [number, number, number], number] =
+      [[-1, -1, -101], [1, 1, -99], 0.5];
+    assert.strictEqual(
+      projectedInstancedRadiusPx(...args, perspectiveCam({ viewportHeightPx: 0 })),
+      Infinity,
+    );
+    assert.strictEqual(
+      projectedInstancedRadiusPx(...args, perspectiveCam({ viewDir: { x: 0, y: 0, z: 0 } })),
+      Infinity,
+    );
+    assert.strictEqual(
+      projectedInstancedRadiusPx(...args, perspectiveCam({ fovYRadians: 0 })),
+      Infinity,
+    );
+  });
+
+  it('orthographic: depth-independent, scales with zoom', () => {
+    const cam: CullCameraState = {
+      eye: { x: 0, y: 0, z: 0 },
+      mode: 'orthographic',
+      fovYRadians: 0,
+      orthoHalfHeight: 100,
+      viewportHeightPx: 1000,
+    };
+    const px = projectedInstancedRadiusPx([-1, -1, -1e6], [1, 1, -1e6 + 2], 0.5, cam);
+    assert.ok(Math.abs(px - (0.5 / 100) * 500) < 1e-9, `got ${px}`);
+    assert.strictEqual(
+      projectedInstancedRadiusPx([-1, -1, -10], [1, 1, -8], 0.5, { ...cam, orthoHalfHeight: 0 }),
+      Infinity,
+    );
+  });
+
+  it('a bolts-everywhere template culls at threshold even though its union box is model-sized', () => {
+    // 200m union box starting 20m from the camera; each bolt <= 5mm radius.
+    // Upper bound: 0.005 / 20 * 500 = 0.125 px — below any practical threshold,
+    // while the union box itself would project as Infinity (camera inside).
+    const cam = perspectiveCam();
+    const px = projectedInstancedRadiusPx([-100, -100, -220], [100, 100, -20], 0.005, cam);
+    assert.ok(px < 0.2, `got ${px}`);
+    assert.strictEqual(
+      projectedAabbRadiusPx([-100, -100, -220], [100, 100, -20], cam),
+      Infinity,
+      'sanity: the union box itself is useless for culling',
+    );
   });
 });

--- a/packages/renderer/src/contribution-cull.ts
+++ b/packages/renderer/src/contribution-cull.ts
@@ -79,6 +79,59 @@ export function resolveContributionThresholdPx(
  * the camera is the frustum test's job, not this one's. Degenerate/empty
  * bounds project to 0 and are culled at any positive threshold.
  */
+/**
+ * Conservative projected radius (device pixels) of the LARGEST single
+ * occurrence of a GPU-instanced template.
+ *
+ * A template's occurrences are scattered inside `unionMin..unionMax` (the
+ * union of their world AABBs), so the union box itself is useless for
+ * contribution culling — bolts spread across a 100m model union to a
+ * model-sized box that never reads small. What CAN be bounded is any single
+ * occurrence: its projected radius is at most `maxOccRadius` (the largest
+ * occurrence bounding-sphere radius) projected at the SMALLEST view depth any
+ * occurrence can have, which is the union box's nearest point along the view
+ * direction. If even that upper bound is below the pixel threshold, no
+ * occurrence can exceed it and the whole template is safely skippable.
+ *
+ * Fails open (Infinity) whenever a bound cannot be established: degenerate
+ * camera, non-finite radius, or the nearest possible occurrence overlapping
+ * the camera plane (minDepth <= maxOccRadius).
+ */
+export function projectedInstancedRadiusPx(
+  unionMin: readonly [number, number, number],
+  unionMax: readonly [number, number, number],
+  maxOccRadius: number,
+  cam: CullCameraState,
+): number {
+  if (!Number.isFinite(maxOccRadius)) return Infinity;
+  const halfViewportPx = cam.viewportHeightPx * 0.5;
+  if (!(halfViewportPx > 0)) return Infinity;
+
+  if (cam.mode === 'orthographic') {
+    if (!(cam.orthoHalfHeight > 0)) return Infinity;
+    return (maxOccRadius / cam.orthoHalfHeight) * halfViewportPx;
+  }
+
+  const dirLenSq =
+    cam.viewDir.x * cam.viewDir.x + cam.viewDir.y * cam.viewDir.y + cam.viewDir.z * cam.viewDir.z;
+  if (!(dirLenSq > 0.5) || !Number.isFinite(dirLenSq)) return Infinity;
+  // Minimum view depth over the union box: per axis, the corner that
+  // minimizes the dot product with viewDir.
+  const nx = cam.viewDir.x >= 0 ? unionMin[0] : unionMax[0];
+  const ny = cam.viewDir.y >= 0 ? unionMin[1] : unionMax[1];
+  const nz = cam.viewDir.z >= 0 ? unionMin[2] : unionMax[2];
+  const minDepth =
+    (nx - cam.eye.x) * cam.viewDir.x +
+    (ny - cam.eye.y) * cam.viewDir.y +
+    (nz - cam.eye.z) * cam.viewDir.z;
+  // An occurrence could reach the camera plane: no valid upper bound.
+  if (!(minDepth > maxOccRadius)) return Infinity;
+
+  const tanHalfFov = Math.tan(cam.fovYRadians * 0.5);
+  if (!(tanHalfFov > 0)) return Infinity;
+  return (maxOccRadius / (minDepth * tanHalfFov)) * halfViewportPx;
+}
+
 export function projectedAabbRadiusPx(
   min: readonly [number, number, number],
   max: readonly [number, number, number],

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -92,7 +92,7 @@ export type {
 import { WebGPUDevice } from './device.js';
 import { RenderPipeline } from './pipeline.js';
 import { Camera } from './camera.js';
-import { Scene } from './scene.js';
+import { Scene, type InstancedTemplateGPU } from './scene.js';
 import { Picker } from './picker.js';
 import { MathUtils } from './math.js';
 import { FrustumUtils } from '@ifc-lite/spatial';
@@ -124,7 +124,7 @@ import { PickingManager } from './picking-manager.js';
 import { RaycastEngine } from './raycast-engine.js';
 import { PostProcessor } from './post-processor.js';
 import { InteractionEffectsGovernor } from './interaction-effects-governor.js';
-import { resolveContributionThresholdPx, projectedAabbRadiusPx, type CullCameraState } from './contribution-cull.js';
+import { resolveContributionThresholdPx, projectedAabbRadiusPx, projectedInstancedRadiusPx, type CullCameraState } from './contribution-cull.js';
 import type { FrameStats } from './render-stats.js';
 import { EdlPass } from './edl-pass.js';
 import { SkyPass } from './sky-pass.js';
@@ -1131,6 +1131,9 @@ export class Renderer {
         let frameBatchesContributionCulled = 0;
         let frameBatchesNotResident = 0;
         let frameBatchesAtLod1 = 0;
+        let frameInstancedDrawn = 0;
+        let frameInstancedFrustumCulled = 0;
+        let frameInstancedContributionCulled = 0;
         // Residency ages are measured in RENDERED frames (idle never ages out).
         this.scene.beginResidencyFrame();
         // Capture renders restore evicted batches SYNCHRONOUSLY so isolation
@@ -2089,7 +2092,43 @@ export class Renderer {
                 // IFC Z-up→WebGL Y-up swap, so the uniform's model is unused here;
                 // we reuse the frame's viewProj + section + flags from `tpl`.
                 const instancedTemplates = this.scene.getInstancedTemplates();
+                // Cull templates ONCE per frame; the transparent instanced
+                // sub-pass below reuses this list. Frustum: the union of the
+                // occurrences' world AABBs off-screen ⇒ every occurrence is.
+                // Contribution: the LARGEST occurrence projected at the union
+                // box's nearest view depth is an upper bound for any single
+                // occurrence — bolts-scattered-everywhere templates cull as
+                // soon as no bolt can exceed the pixel threshold, even though
+                // the union box itself is model-sized. Templates with a
+                // selected occurrence are exempt so the highlight can't vanish.
+                // CATIA-class models put ~97% of draw calls in this pass, so
+                // this is where interactive frame cost lives (issue #1682).
+                let visibleInstanced: InstancedTemplateGPU[] | readonly InstancedTemplateGPU[] =
+                    instancedTemplates;
                 if (instancedTemplates.length > 0) {
+                    const kept: InstancedTemplateGPU[] = [];
+                    for (const it of instancedTemplates) {
+                        if (it.bounds) {
+                            if (!FrustumUtils.isAABBVisible(frustum, it.bounds)) {
+                                frameInstancedFrustumCulled++;
+                                continue;
+                            }
+                            if (
+                                contribThresholdPx > 0 &&
+                                cullCam &&
+                                it.selectedCount === 0 &&
+                                projectedInstancedRadiusPx(it.bounds.min, it.bounds.max, it.maxOccRadius, cullCam) <
+                                    contribThresholdPx
+                            ) {
+                                frameInstancedContributionCulled++;
+                                continue;
+                            }
+                        }
+                        kept.push(it);
+                    }
+                    visibleInstanced = kept;
+                }
+                if (visibleInstanced.length > 0) {
                     // Opaque instanced pass. flags.x bit 2 marks "instanced pass" so the
                     // shader routes per-instance opacity: opaque (or selected) occurrences
                     // draw here; translucent ones (lens/x-ray/compare overrides) are
@@ -2098,12 +2137,13 @@ export class Renderer {
                     pass.setPipeline(this.pipeline.getInstancedPipeline());
                     pass.setBindGroup(0, this.pipeline.getBindGroup());
                     pass.setBindGroup(1, this.pipeline.getEnvironmentBindGroup());
-                    for (const it of instancedTemplates) {
+                    for (const it of visibleInstanced) {
                         pass.setVertexBuffer(0, it.vertexBuffer);
                         pass.setVertexBuffer(1, it.instanceBuffer);
                         pass.setIndexBuffer(it.indexBuffer, 'uint32');
                         pass.drawIndexed(it.indexCount, it.instanceCount);
                         frameDrawCalls++;
+                        frameInstancedDrawn++;
                     }
                     pass.setPipeline(this.pipeline.getPipeline());
                     // The TRANSPARENT instanced sub-pass is drawn later, alongside the
@@ -2290,10 +2330,9 @@ export class Renderer {
                 // a complete depth buffer. Only runs when an override actually made some
                 // occurrence translucent (otherwise zero cost). flags.x bit 3 flips the
                 // shader's opacity routing so only translucent occurrences draw here.
-                const instancedTransparent = this.scene.getInstancedTemplates();
                 const instancedTransparentPipeline = this.pipeline.getInstancedTransparentPipeline();
                 if (
-                    instancedTransparent.length > 0 &&
+                    visibleInstanced.length > 0 &&
                     this.scene.hasTransparentInstances() &&
                     instancedTransparentPipeline !== null
                 ) {
@@ -2301,7 +2340,7 @@ export class Renderer {
                     pass.setPipeline(instancedTransparentPipeline);
                     pass.setBindGroup(0, this.pipeline.getBindGroup());
                     pass.setBindGroup(1, this.pipeline.getEnvironmentBindGroup());
-                    for (const it of instancedTransparent) {
+                    for (const it of visibleInstanced) {
                         pass.setVertexBuffer(0, it.vertexBuffer);
                         pass.setVertexBuffer(1, it.instanceBuffer);
                         pass.setIndexBuffer(it.indexBuffer, 'uint32');
@@ -2650,6 +2689,9 @@ export class Renderer {
                 batchesContributionCulled: frameBatchesContributionCulled,
                 batchesNotResident: frameBatchesNotResident,
                 batchesAtLod1: frameBatchesAtLod1,
+                instancedDrawn: frameInstancedDrawn,
+                instancedFrustumCulled: frameInstancedFrustumCulled,
+                instancedContributionCulled: frameInstancedContributionCulled,
                 timestamp: performance.now(),
             };
 

--- a/packages/renderer/src/instanced-render.test.ts
+++ b/packages/renderer/src/instanced-render.test.ts
@@ -8,6 +8,7 @@ import {
   composeInstanceMatrix,
   writeInstanceRecord,
   prepareInstancedRender,
+  foldOccurrenceWorldBox,
   INSTANCE_STRIDE_BYTES,
   INSTANCE_FLAGS_OFFSET,
   INSTANCE_FLAG_SELECTED,
@@ -222,5 +223,55 @@ describe('prepareInstancedRender — grouping + buffer assembly', () => {
     assert.strictEqual(t0.instanceCount, 1, 'the transparent occurrence of template 0 is excluded');
     const dv = new DataView(t0.instanceBuffer);
     assert.strictEqual(dv.getUint32(64, true), 1, 'the kept instance is the opaque one (entityId 1)');
+  });
+});
+
+describe('foldOccurrenceWorldBox — template cull metadata', () => {
+  const freshMeta = () => ({ bounds: null as { min: [number, number, number]; max: [number, number, number] } | null, maxOccRadius: 0 });
+  const box = (minX: number, minY: number, minZ: number, maxX: number, maxY: number, maxZ: number) =>
+    ({ minX, minY, minZ, maxX, maxY, maxZ });
+
+  it('initializes bounds from the first occurrence and grows the union after', () => {
+    const meta = freshMeta();
+    foldOccurrenceWorldBox(meta, box(0, 0, 0, 2, 2, 2));
+    assert.deepStrictEqual(meta.bounds, { min: [0, 0, 0], max: [2, 2, 2] });
+    assert.ok(Math.abs(meta.maxOccRadius - Math.sqrt(12) / 2) < 1e-9);
+
+    foldOccurrenceWorldBox(meta, box(-5, 1, 1, -4, 2, 2));
+    assert.deepStrictEqual(meta.bounds, { min: [-5, 0, 0], max: [2, 2, 2] });
+  });
+
+  it('maxOccRadius tracks the LARGEST single occurrence, not the union diagonal', () => {
+    const meta = freshMeta();
+    foldOccurrenceWorldBox(meta, box(0, 0, 0, 1, 1, 1));       // r = sqrt(3)/2
+    foldOccurrenceWorldBox(meta, box(100, 0, 0, 101, 1, 1));   // same size, far away
+    const single = Math.sqrt(3) / 2;
+    assert.ok(Math.abs(meta.maxOccRadius - single) < 1e-9, `got ${meta.maxOccRadius}`);
+    // The union spans >100 units — the occurrence radius must NOT.
+    assert.ok(meta.maxOccRadius < 1);
+  });
+
+  it('poisons on a non-finite box: bounds wiped, radius pinned to Infinity', () => {
+    const meta = freshMeta();
+    foldOccurrenceWorldBox(meta, box(0, 0, 0, 1, 1, 1));
+    foldOccurrenceWorldBox(meta, box(NaN, 0, 0, 1, 1, 1));
+    assert.strictEqual(meta.bounds, null);
+    assert.strictEqual(meta.maxOccRadius, Infinity);
+  });
+
+  it('poison is sticky: later finite occurrences must not resurrect bounds', () => {
+    const meta = freshMeta();
+    foldOccurrenceWorldBox(meta, box(Infinity, 0, 0, Infinity, 1, 1));
+    foldOccurrenceWorldBox(meta, box(0, 0, 0, 1, 1, 1));
+    assert.strictEqual(meta.bounds, null, 'bounds stay null after poison');
+    assert.strictEqual(meta.maxOccRadius, Infinity);
+  });
+
+  it('poisons when min/max are individually finite-summing but a coordinate is NaN', () => {
+    const meta = freshMeta();
+    // NaN in max only; min sum is finite.
+    foldOccurrenceWorldBox(meta, box(0, 0, 0, NaN, 1, 1));
+    assert.strictEqual(meta.bounds, null);
+    assert.strictEqual(meta.maxOccRadius, Infinity);
   });
 });

--- a/packages/renderer/src/instanced-render.ts
+++ b/packages/renderer/src/instanced-render.ts
@@ -201,3 +201,58 @@ export function prepareInstancedRender(shard: DecodedInstancedShard): InstancedR
   }
   return out;
 }
+
+/** Per-template cull metadata (structurally satisfied by InstancedTemplateGPU). */
+export interface InstancedCullMeta {
+  /** Union of the occurrences' world AABBs; null = uncullable. */
+  bounds: { min: [number, number, number]; max: [number, number, number] } | null;
+  /** Largest single-occurrence bounding-sphere radius. Infinity marks a
+   *  POISONED template (a non-finite occurrence box was seen): it is never
+   *  culled and later finite occurrences must not resurrect its bounds. */
+  maxOccRadius: number;
+}
+
+/** One occurrence's world AABB, as produced by the shard-upload transform. */
+export interface OccurrenceWorldBox {
+  minX: number; minY: number; minZ: number;
+  maxX: number; maxY: number; maxZ: number;
+}
+
+/**
+ * Fold one occurrence's world AABB into a template's cull metadata: grow the
+ * union bounds and the max occurrence bounding-sphere radius.
+ *
+ * A non-finite box (NaN/Infinity occurrence matrix) POISONS the template —
+ * bounds are wiped and maxOccRadius pinned to Infinity so the render loop
+ * fails OPEN (culling on poisoned metadata would hide real geometry), and the
+ * poison is sticky against later finite occurrences.
+ */
+export function foldOccurrenceWorldBox(meta: InstancedCullMeta, w: OccurrenceWorldBox): void {
+  if (meta.maxOccRadius === Infinity) return; // sticky poison
+  const dx = w.maxX - w.minX, dy = w.maxY - w.minY, dz = w.maxZ - w.minZ;
+  const occRadius = 0.5 * Math.sqrt(dx * dx + dy * dy + dz * dz);
+  if (
+    !Number.isFinite(occRadius) ||
+    !Number.isFinite(w.minX + w.minY + w.minZ) ||
+    !Number.isFinite(w.maxX + w.maxY + w.maxZ)
+  ) {
+    meta.bounds = null;
+    meta.maxOccRadius = Infinity;
+    return;
+  }
+  if (occRadius > meta.maxOccRadius) meta.maxOccRadius = occRadius;
+  const tb = meta.bounds;
+  if (!tb) {
+    meta.bounds = {
+      min: [w.minX, w.minY, w.minZ],
+      max: [w.maxX, w.maxY, w.maxZ],
+    };
+  } else {
+    if (w.minX < tb.min[0]) tb.min[0] = w.minX;
+    if (w.minY < tb.min[1]) tb.min[1] = w.minY;
+    if (w.minZ < tb.min[2]) tb.min[2] = w.minZ;
+    if (w.maxX > tb.max[0]) tb.max[0] = w.maxX;
+    if (w.maxY > tb.max[1]) tb.max[1] = w.maxY;
+    if (w.maxZ > tb.max[2]) tb.max[2] = w.maxZ;
+  }
+}

--- a/packages/renderer/src/render-stats.ts
+++ b/packages/renderer/src/render-stats.ts
@@ -35,6 +35,16 @@ export interface FrameStats {
   batchesNotResident: number;
   /** Batches drawn at their simplified LOD1 index range this frame. */
   batchesAtLod1: number;
+  /** GPU-instanced templates drawn this frame (one draw call each). */
+  instancedDrawn: number;
+  /** Instanced templates rejected by the frustum test (union world AABB). */
+  instancedFrustumCulled: number;
+  /**
+   * Instanced templates rejected by contribution culling: even the largest
+   * single occurrence, projected at the union box's nearest view depth,
+   * fell below the pixel threshold.
+   */
+  instancedContributionCulled: number;
   /** `performance.now()` timestamp taken at the end of the render call. */
   timestamp: number;
 }

--- a/packages/renderer/src/scene.ts
+++ b/packages/renderer/src/scene.ts
@@ -2810,6 +2810,9 @@ export class Scene {
   addInstancedShard(device: GPUDevice, shard: DecodedInstancedShard): void {
     this.instancedDevice = device; // cached for per-instance selection/overlay writeBuffer
     const prepared = prepareInstancedRender(shard);
+    // Selected ids whose occurrences arrived in THIS shard (selection recorded
+    // before the shard streamed in) — their flags are written after upload.
+    const lateSelectedEids = new Set<number>();
     for (const t of prepared) {
       const vcount = Math.floor(t.positions.length / 3);
       if (vcount === 0 || t.indices.length === 0 || t.instanceCount === 0) continue;
@@ -2918,6 +2921,16 @@ export class Scene {
         }
         arr.push({ templateIndex, byteOffset, originalColor });
 
+        // A shard can stream in AFTER a selection was recorded (its ids may
+        // exist in earlier shards or the flat path). setInstancedSelection
+        // diffs by id and would early-return on the unchanged set, so seed the
+        // late occurrences here: count them for the contribution-cull
+        // exemption and remember the id to write its selected flag below.
+        if (this.instancedSelected.has(eid)) {
+          template.selectedCount++;
+          lateSelectedEids.add(eid);
+        }
+
         if (haveBox) {
           const w = this.unionInstancedWorldAabb(eid, cdv, byteOffset, lmnx, lmny, lmnz, lmxx, lmxy, lmxz);
           // Fold the occurrence's world box into the template's cull metadata
@@ -2927,6 +2940,12 @@ export class Scene {
           foldOccurrenceWorldBox(template, w);
         }
       }
+    }
+    // Write the selected flag for ids whose occurrences arrived after the
+    // selection was recorded (idempotent for their pre-existing occurrences),
+    // so the highlight shows on late-streamed geometry too.
+    for (const eid of lateSelectedEids) {
+      this.writeInstanceFlags(device, eid);
     }
     // New occurrences default to flags=0 (visible). Force the next setInstancedVisibility
     // to recompute so an already-active isolate/hide also applies to geometry that

--- a/packages/renderer/src/scene.ts
+++ b/packages/renderer/src/scene.ts
@@ -28,6 +28,7 @@ import { OPAQUE_ALPHA_CUTOFF } from './overlay-routing.js';
 import type { DecodedInstancedShard } from '@ifc-lite/geometry';
 import {
   prepareInstancedRender,
+  foldOccurrenceWorldBox,
   INSTANCE_STRIDE_BYTES,
   INSTANCE_COLOR_OFFSET,
   INSTANCE_FLAGS_OFFSET,
@@ -91,6 +92,18 @@ export interface InstancedTemplateGPU {
   indexCount: number;
   instanceBuffer: GPUBuffer;
   instanceCount: number;
+  /** Union of the occurrences' world AABBs (null when no occurrence has a
+   *  finite box — such templates are never culled). Same tuple layout as
+   *  BatchedMesh.bounds so the render loop's frustum test is shared. */
+  bounds: { min: [number, number, number]; max: [number, number, number] } | null;
+  /** Largest single-occurrence bounding-sphere radius (world units). Upper
+   *  bound for the contribution cull: no occurrence can project larger than
+   *  this radius at the union box's nearest view depth. */
+  maxOccRadius: number;
+  /** Occurrences currently selected (highlight flag set). A template with a
+   *  selected occurrence is exempt from contribution culling so the highlight
+   *  can't vanish while the entity is the user's focus. */
+  selectedCount: number;
 }
 
 /** Shared empty result for getInstancedTemplates() when the instanced pass is hidden. */
@@ -1468,11 +1481,18 @@ export class Scene {
       const cpu = this.instancedTemplateCpu[occ.templateIndex];
       if (!cpu) continue;
       const dv = new DataView(cpu.instanceData);
-      this.unionInstancedWorldAabb(
+      const w = this.unionInstancedWorldAabb(
         expressId, dv, occ.byteOffset,
         cpu.localMin[0], cpu.localMin[1], cpu.localMin[2],
         cpu.localMax[0], cpu.localMax[1], cpu.localMax[2],
       );
+      // GROW the template's cull union so a moved occurrence (Exploded mode,
+      // #1289) can't be frustum/contribution-culled by its pre-move bounds.
+      // The pre-move region stays in the union — monotonic growth only ever
+      // culls LESS — and translation never changes an occurrence's size, so
+      // maxOccRadius needs no update.
+      const template = this.instancedTemplates[occ.templateIndex];
+      if (template) foldOccurrenceWorldBox(template, w);
     }
   }
 
@@ -2841,13 +2861,17 @@ export class Scene {
       instanceBuffer.unmap();
 
       const templateIndex = this.instancedTemplates.length;
-      this.instancedTemplates.push({
+      const template: InstancedTemplateGPU = {
         vertexBuffer,
         indexBuffer,
         indexCount: t.indices.length,
         instanceBuffer,
         instanceCount: t.instanceCount,
-      });
+        bounds: null,
+        maxOccRadius: 0,
+        selectedCount: 0,
+      };
+      this.instancedTemplates.push(template);
 
       // Template-local AABB (used to derive per-occurrence world AABBs cheaply).
       let lmnx = Infinity, lmny = Infinity, lmnz = Infinity;
@@ -2895,7 +2919,12 @@ export class Scene {
         arr.push({ templateIndex, byteOffset, originalColor });
 
         if (haveBox) {
-          this.unionInstancedWorldAabb(eid, cdv, byteOffset, lmnx, lmny, lmnz, lmxx, lmxy, lmxz);
+          const w = this.unionInstancedWorldAabb(eid, cdv, byteOffset, lmnx, lmny, lmnz, lmxx, lmxy, lmxz);
+          // Fold the occurrence's world box into the template's cull metadata
+          // (union bounds + largest occurrence bounding-sphere radius) for the
+          // per-frame instanced frustum/contribution culls. Non-finite boxes
+          // poison the template so it fails OPEN (never culled).
+          foldOccurrenceWorldBox(template, w);
         }
       }
     }
@@ -2907,14 +2936,15 @@ export class Scene {
 
   /** Transform a template's local AABB by an occurrence's column-major mat4 (read
    *  from the packed instance record at `matOffset`) and union the world box into
-   *  boundingBoxes[eid]. */
+   *  boundingBoxes[eid]. Returns the occurrence's world box so the caller can also
+   *  fold it into the template's cull metadata. */
   private unionInstancedWorldAabb(
     eid: number,
     dv: DataView,
     matOffset: number,
     lmnx: number, lmny: number, lmnz: number,
     lmxx: number, lmxy: number, lmxz: number,
-  ): void {
+  ): { minX: number; minY: number; minZ: number; maxX: number; maxY: number; maxZ: number } {
     const m0 = dv.getFloat32(matOffset + 0, true), m1 = dv.getFloat32(matOffset + 4, true), m2 = dv.getFloat32(matOffset + 8, true);
     const m4 = dv.getFloat32(matOffset + 16, true), m5 = dv.getFloat32(matOffset + 20, true), m6 = dv.getFloat32(matOffset + 24, true);
     const m8 = dv.getFloat32(matOffset + 32, true), m9 = dv.getFloat32(matOffset + 36, true), m10 = dv.getFloat32(matOffset + 40, true);
@@ -2939,6 +2969,7 @@ export class Scene {
     } else {
       this.boundingBoxes.set(eid, { min: { x: minX, y: minY, z: minZ }, max: { x: maxX, y: maxY, z: maxZ } });
     }
+    return { minX, minY, minZ, maxX, maxY, maxZ };
   }
 
   /** True if `expressId` is a GPU-instanced occurrence (lives only in the instanced
@@ -3051,10 +3082,28 @@ export class Scene {
     const prev = this.instancedSelected;
     this.instancedSelected = new Set(expressIds);
     for (const eid of prev) {
-      if (!expressIds.has(eid)) this.writeInstanceFlags(device, eid);
+      if (!expressIds.has(eid)) {
+        this.writeInstanceFlags(device, eid);
+        this.bumpTemplateSelectedCount(eid, -1);
+      }
     }
     for (const eid of expressIds) {
-      if (!prev.has(eid)) this.writeInstanceFlags(device, eid);
+      if (!prev.has(eid)) {
+        this.writeInstanceFlags(device, eid);
+        this.bumpTemplateSelectedCount(eid, +1);
+      }
+    }
+  }
+
+  /** Keep each template's selectedCount in sync with selection flips so the
+   *  render loop can exempt templates with selected occurrences from
+   *  contribution culling (the highlight must not vanish on the user's focus). */
+  private bumpTemplateSelectedCount(eid: number, delta: number): void {
+    const occurrences = this.instancedEntityMap.get(eid);
+    if (!occurrences) return;
+    for (const occ of occurrences) {
+      const t = this.instancedTemplates[occ.templateIndex];
+      if (t) t.selectedCount = Math.max(0, t.selectedCount + delta);
     }
   }
 

--- a/packages/renderer/src/scene.ts
+++ b/packages/renderer/src/scene.ts
@@ -1244,6 +1244,12 @@ export class Scene {
       this.instancedHidden.add(expressId);
       this.writeInstanceFlags(device, expressId);
     }
+    // Release the contribution-cull exemption BEFORE forgetting the occurrence
+    // locations — deleting the map entry first would leak selectedCount and
+    // leave the templates permanently uncullable.
+    if (this.instancedSelected.has(expressId)) {
+      this.bumpTemplateSelectedCount(expressId, -1);
+    }
     this.instancedEntityMap.delete(expressId);
     this.instancedSelected.delete(expressId);
     this.instancedHidden.delete(expressId);

--- a/tests/benchmark/viewer-benchmark-page.ts
+++ b/tests/benchmark/viewer-benchmark-page.ts
@@ -39,6 +39,9 @@ export interface ViewerBenchmarkMetrics {
   drawCalls: number | null;
   residentGpuMB: number | null;
   batchesContributionCulled: number | null;
+  instancedDrawn: number | null;
+  instancedFrustumCulled: number | null;
+  instancedContributionCulled: number | null;
 }
 
 export class ViewerBenchmarkPage {
@@ -565,6 +568,12 @@ export class ViewerBenchmarkPage {
       this.metrics.drawCalls = parseInt(renderStatsMatch[1], 10);
       this.metrics.residentGpuMB = parseFloat(renderStatsMatch[2]);
       this.metrics.batchesContributionCulled = parseInt(renderStatsMatch[5], 10);
+      // Instanced groups are optional (absent in pre-cull logs).
+      if (renderStatsMatch[6] !== undefined) {
+        this.metrics.instancedDrawn = parseInt(renderStatsMatch[6], 10);
+        this.metrics.instancedFrustumCulled = parseInt(renderStatsMatch[7], 10);
+        this.metrics.instancedContributionCulled = parseInt(renderStatsMatch[8], 10);
+      }
     }
   }
 
@@ -598,6 +607,9 @@ export class ViewerBenchmarkPage {
       drawCalls: this.metrics.drawCalls ?? null,
       residentGpuMB: this.metrics.residentGpuMB ?? null,
       batchesContributionCulled: this.metrics.batchesContributionCulled ?? null,
+      instancedDrawn: this.metrics.instancedDrawn ?? null,
+      instancedFrustumCulled: this.metrics.instancedFrustumCulled ?? null,
+      instancedContributionCulled: this.metrics.instancedContributionCulled ?? null,
     };
   }
 

--- a/tests/benchmark/viewer-benchmark-page.ts
+++ b/tests/benchmark/viewer-benchmark-page.ts
@@ -556,9 +556,10 @@ export class ViewerBenchmarkPage {
     // Steady-state render stats (issue #1682), emitted post-settle by
     // apps/viewer/src/utils/renderStatsReport.ts — keep formats in sync:
     //   [ifc-lite] render stats: 143 draw calls, 512.3 MB GPU resident
-    //   (140 batches drawn, 2 frustum-culled, 1 contribution-culled)
+    //   (140 batches drawn, 2 frustum-culled, 1 contribution-culled;
+    //   90 instanced drawn, 3 frustum-culled, 8 contribution-culled)
     const renderStatsMatch = logs.match(
-      /\[ifc-lite\] render stats: (\d+) draw calls, ([\d.]+) MB GPU resident \((\d+) batches drawn, (\d+) frustum-culled, (\d+) contribution-culled\)/
+      /\[ifc-lite\] render stats: (\d+) draw calls, ([\d.]+) MB GPU resident \((\d+) batches drawn, (\d+) frustum-culled, (\d+) contribution-culled(?:; (\d+) instanced drawn, (\d+) frustum-culled, (\d+) contribution-culled)?\)/
     );
     if (renderStatsMatch) {
       this.metrics.drawCalls = parseInt(renderStatsMatch[1], 10);

--- a/tests/benchmark/viewer-benchmark.spec.ts
+++ b/tests/benchmark/viewer-benchmark.spec.ts
@@ -208,6 +208,9 @@ test.describe('Viewer Performance Benchmarks', () => {
       console.log(`  Draw Calls: ${metrics.drawCalls?.toLocaleString() || 'N/A'}`);
       console.log(`  Resident GPU: ${metrics.residentGpuMB?.toFixed(1) || 'N/A'} MB`);
       console.log(`  Contribution-Culled Batches: ${metrics.batchesContributionCulled?.toLocaleString() || 'N/A'}`);
+      console.log(`  Instanced Drawn: ${metrics.instancedDrawn?.toLocaleString() || 'N/A'}`);
+      console.log(`  Instanced Frustum-Culled: ${metrics.instancedFrustumCulled?.toLocaleString() || 'N/A'}`);
+      console.log(`  Instanced Contribution-Culled: ${metrics.instancedContributionCulled?.toLocaleString() || 'N/A'}`);
 
       if (baselineMetrics) {
         console.log(`\n--- Comparison with Baseline ---`);


### PR DESCRIPTION
## Problem

Large CATIA-class models feel choppy when orbiting; frame rate drops to ~45 FPS or lower on fast spins (reported on an 883 MB CatiaA1 model). Two compounding causes:

1. **The GPU-instanced pass drew every template unconditionally.** On the reported model that is 8,929 of 9,213 draw calls (~97%) — outside every per-frame gate the #1682 program added for colour batches (no frustum cull, no contribution cull), at 4 encoder calls per template per frame.
2. **The interaction throttle capped continuous rendering by triangle count** (25 ms above 1M triangles, 33 ms above 5M), so even cheap frames could not exceed 40/30 FPS. The model finalizes at 6.4M triangles, i.e. a hard ~30 FPS ceiling regardless of actual frame cost.

## Fix

**Instanced-template culling** (`@ifc-lite/renderer`): each template now carries cull metadata built during shard upload — the union of its occurrences' world AABBs and the largest single-occurrence bounding-sphere radius (folded in the same loop that already computed per-occurrence world boxes; no extra passes).

- **Frustum cull** against the union box (exact; always on, like batch frustum culling).
- **Contribution cull** via a conservative upper bound: the largest occurrence projected at the union box's **nearest view depth**. A bolts-scattered-everywhere template has a model-sized union box that never reads small, but no single bolt can project larger than this bound — so the whole template culls once every occurrence is sub-threshold. Shares the batch thresholds (0.5 px rest / 2 px interacting) and the `__IFC_LITE_CONTRIB_CULL=0` kill switch.
- **Safety rails:** templates with a selected occurrence are exempt from contribution culling (the highlight cannot vanish on the user's focus); a non-finite occurrence matrix poisons the template's metadata so it fails open (never culled), sticky against later finite occurrences; Exploded-mode translates (#1289) grow the union so moved occurrences cannot be culled by pre-move bounds. The on-demand pick pass stays exhaustive.

**Adaptive interaction throttle** (viewer): replaces the triangle-count tiers with an EMA of measured `renderer.render()` wall time (which includes swap-chain backpressure) and a hysteresis ladder mapping to the same 0 / 25 ms / 33 ms cadences. Cheap frames now run at full display rate; genuinely heavy scenes degrade to the same floors as before within a few frames.

**Observability:** `FrameStats` gains `instancedDrawn` / `instancedFrustumCulled` / `instancedContributionCulled`; the post-settle `[ifc-lite] render stats:` line, the `viewer_render_stats` PostHog event and the benchmark parser (backwards-compatible regex) carry the new fields.

## Measurements (CatiaA1.ifc, 883 MB, real Chrome/Metal, 6 s fast drag-orbit)

| | main | this PR |
|---|---|---|
| Rendered FPS during spin (GPU submits) | 25.5 | **58.4** |
| Draw calls | 9,213 | **2,122** |
| rAF frame time p95 | 33.3 ms | **18.3 ms** |
| GPU resident | 722.7 MB | 722.7 MB |
| Batches drawn / culled | 284 / 17 | 284 / 17 (unchanged) |

At-rest pixel delta with instanced contribution culling on vs off (kill switch, deterministic home camera): **0.153% of pixels** (>2/255), visually identical — same order as the accepted LOD1 flip (0.16%). 7,091 of 8,929 templates contribution-cull at rest at the 0.5 px threshold.

## Tests

- `projectedInstancedRadiusPx`: known-value projection at nearest depth, upper-bound property vs sampled occurrences, per-axis nearest-corner selection, fail-open on camera-plane overlap / behind-camera / degenerate camera / poisoned metadata, orthographic mode, and the bolts-everywhere case where the union box itself is uncullable.
- `foldOccurrenceWorldBox`: union growth, max-occurrence-radius (not union diagonal), poison + sticky-poison semantics.
- Full renderer suite: 259 pass.

Part of the #1682 interactive-performance follow-up (mega-draw vertex pulling remains the recorded next step if draw-call-bound interaction reappears).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Enhanced GPU-instanced rendering with per-template frustum culling plus conservative contribution culling, reducing unnecessary draws (including in exploded views). Selected elements are exempted from contribution culling, and culling safely fails open for invalid camera/instance bounds.
  - Improved adaptive render throttling by basing pacing on measured renderer render-time (EMA) rather than scene estimates.

- **Monitoring**
  - Expanded render-stat reporting to include instanced drawn, frustum-culled, and contribution-culled counts in logs, telemetry, and benchmarks.
  - Updated render-stats parsing to support the newer multi-part metrics format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->