### PR TITLE
fix(viewer): orbit-start input lag on instanced-heavy models (skip pivot raycast)

### DIFF
--- a/.changeset/renderer-instanced-entity-count.md
+++ b/.changeset/renderer-instanced-entity-count.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/renderer": patch
+---
+
+Add `Scene.getInstancedEntityCount()` (O(1)) so size heuristics — like the viewer's orbit-pivot raycast skip — can account for GPU-instanced entities. On instanced-heavy CATIA-class models the flat mesh/batch census reads deceptively small, and the first pointer-down pivot raycast then materializes tens of thousands of occurrences and builds a BVH over millions of triangles, a visible input-to-first-orbit-frame stall.

--- a/apps/viewer/src/components/viewer/orbitPivotCensus.test.ts
+++ b/apps/viewer/src/components/viewer/orbitPivotCensus.test.ts
@@ -1,0 +1,58 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  isPivotRaycastTooExpensive,
+  PIVOT_RAYCAST_MAX_ENTITIES,
+  PIVOT_RAYCAST_MAX_INDICES,
+  type PivotCensusScene,
+} from './orbitPivotCensus.js';
+
+const scene = (opts: {
+  meshes?: number;
+  instanced?: number;
+  batches?: Array<{ ids: number; indices: number }>;
+}): PivotCensusScene => ({
+  getMeshes: () => new Array(opts.meshes ?? 0),
+  getInstancedEntityCount: () => opts.instanced ?? 0,
+  getBatchedMeshes: () =>
+    (opts.batches ?? []).map((b) => ({
+      expressIds: new Array(b.ids),
+      indexCount: b.indices,
+    })),
+});
+
+describe('isPivotRaycastTooExpensive', () => {
+  it('allows the raycast on small models', () => {
+    const small = scene({ meshes: 10, instanced: 100, batches: [{ ids: 5_000, indices: 300_000 }] });
+    assert.equal(isPivotRaycastTooExpensive(small), false);
+  });
+
+  it('skips above the entity threshold (flat batch entities)', () => {
+    const big = scene({ batches: [{ ids: PIVOT_RAYCAST_MAX_ENTITIES + 1, indices: 0 }] });
+    assert.equal(isPivotRaycastTooExpensive(big), true);
+  });
+
+  it('counts GPU-instanced entities: an instanced-heavy model must not read small', () => {
+    // The CATIA regression: ~22K flat entities (under the threshold) but tens
+    // of thousands of instanced occurrences that the raycast materializes.
+    const catiaLike = scene({ instanced: 37_000, batches: [{ ids: 22_000, indices: 0 }] });
+    assert.equal(isPivotRaycastTooExpensive(catiaLike), true);
+    const flatOnly = scene({ instanced: 0, batches: [{ ids: 22_000, indices: 0 }] });
+    assert.equal(isPivotRaycastTooExpensive(flatOnly), false);
+  });
+
+  it('skips above the triangle threshold even with few entities', () => {
+    const dense = scene({ batches: [{ ids: 100, indices: PIVOT_RAYCAST_MAX_INDICES + 3 }] });
+    assert.equal(isPivotRaycastTooExpensive(dense), true);
+  });
+
+  it('accumulates across batches', () => {
+    const half = { ids: 20_000, indices: PIVOT_RAYCAST_MAX_INDICES / 2 };
+    assert.equal(isPivotRaycastTooExpensive(scene({ batches: [half] })), false);
+    assert.equal(isPivotRaycastTooExpensive(scene({ batches: [half, half, half] })), true);
+  });
+});

--- a/apps/viewer/src/components/viewer/orbitPivotCensus.test.ts
+++ b/apps/viewer/src/components/viewer/orbitPivotCensus.test.ts
@@ -45,6 +45,11 @@ describe('isPivotRaycastTooExpensive', () => {
     assert.equal(isPivotRaycastTooExpensive(flatOnly), false);
   });
 
+  it('skips a purely-instanced scene with NO batched meshes (loop never runs)', () => {
+    const instancedOnly = scene({ instanced: PIVOT_RAYCAST_MAX_ENTITIES + 1 });
+    assert.equal(isPivotRaycastTooExpensive(instancedOnly), true);
+  });
+
   it('skips above the triangle threshold even with few entities', () => {
     const dense = scene({ batches: [{ ids: 100, indices: PIVOT_RAYCAST_MAX_INDICES + 3 }] });
     assert.equal(isPivotRaycastTooExpensive(dense), true);

--- a/apps/viewer/src/components/viewer/orbitPivotCensus.ts
+++ b/apps/viewer/src/components/viewer/orbitPivotCensus.ts
@@ -32,6 +32,9 @@ export const PIVOT_RAYCAST_MAX_INDICES = 3_000_000;
 /** True when the first-pivot raycast would stall the main thread at gesture start. */
 export function isPivotRaycastTooExpensive(scene: PivotCensusScene): boolean {
   let totalEntities = scene.getMeshes().length + scene.getInstancedEntityCount();
+  // Check before the batch loop too: a purely-instanced scene has no batched
+  // meshes, so a loop-only check would never see the instanced count.
+  if (totalEntities > PIVOT_RAYCAST_MAX_ENTITIES) return true;
   let totalIndices = 0;
   for (const b of scene.getBatchedMeshes()) {
     totalEntities += b.expressIds.length;

--- a/apps/viewer/src/components/viewer/orbitPivotCensus.ts
+++ b/apps/viewer/src/components/viewer/orbitPivotCensus.ts
@@ -1,0 +1,43 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Shared "is the orbit-pivot raycast too expensive?" census for the mouse and
+ * touch orbit-start handlers.
+ *
+ * Anchoring the orbit pivot under the cursor/finger uses a CPU raycast whose
+ * first call materializes every entity (including GPU-instanced occurrences)
+ * and builds a BVH — on large models that is a visible input-to-first-frame
+ * stall right at gesture start. Skipping it degrades gracefully: the pivot
+ * falls back to the scene centre projected onto the pointer ray.
+ *
+ * The census must count GPU-instanced entities and total triangles, not just
+ * flat meshes/batches: a CATIA-class model can sit well under the entity
+ * threshold on flat entities alone while carrying tens of thousands of
+ * instanced occurrences and millions of triangles.
+ */
+
+/** Structural slice of the renderer Scene used by the census. */
+export interface PivotCensusScene {
+  getMeshes(): ReadonlyArray<unknown>;
+  getBatchedMeshes(): ReadonlyArray<{ expressIds: ArrayLike<number>; indexCount: number }>;
+  getInstancedEntityCount(): number;
+}
+
+export const PIVOT_RAYCAST_MAX_ENTITIES = 50_000;
+/** 3M indices = 1M triangles: above this the first-raycast BVH build stalls. */
+export const PIVOT_RAYCAST_MAX_INDICES = 3_000_000;
+
+/** True when the first-pivot raycast would stall the main thread at gesture start. */
+export function isPivotRaycastTooExpensive(scene: PivotCensusScene): boolean {
+  let totalEntities = scene.getMeshes().length + scene.getInstancedEntityCount();
+  let totalIndices = 0;
+  for (const b of scene.getBatchedMeshes()) {
+    totalEntities += b.expressIds.length;
+    if (totalEntities > PIVOT_RAYCAST_MAX_ENTITIES) return true;
+    totalIndices += b.indexCount;
+    if (totalIndices > PIVOT_RAYCAST_MAX_INDICES) return true;
+  }
+  return false;
+}

--- a/apps/viewer/src/components/viewer/useMouseControls.ts
+++ b/apps/viewer/src/components/viewer/useMouseControls.ts
@@ -21,6 +21,7 @@ import type {
 } from '@/store';
 import type { MeasurementConstraintEdge, OrthogonalAxis, Vec3 } from '@/store/types.js';
 import { getEntityCenter } from '../../utils/viewportUtils.js';
+import { isPivotRaycastTooExpensive } from './orbitPivotCensus.js';
 import type { MouseHandlerContext } from './mouseHandlerTypes.js';
 import { emitCameraInteracted } from '@/lib/tours/events';
 import { useViewerStore } from '@/store';
@@ -495,11 +496,11 @@ export function useMouseControls(params: UseMouseControlsParams): void {
         // For large models, skip the expensive CPU raycast (collectVisibleMeshData +
         // BVH build over 200K+ meshes can block the main thread for seconds).
         // Instead, project the camera target onto the cursor ray for a fast pivot.
+        // The census counts GPU-instanced entities and triangles too — see
+        // orbitPivotCensus.ts for why flat entities alone undercount
+        // CATIA-class models (input-to-first-orbit-frame stall on pointer down).
         const scene = renderer.getScene();
-        const batchedMeshes = scene.getBatchedMeshes();
-        let totalEntities = scene.getMeshes().length;
-        for (const b of batchedMeshes) totalEntities += b.expressIds.length;
-        const isLargeModel = totalEntities > 50_000;
+        const isLargeModel = isPivotRaycastTooExpensive(scene);
         // Outlier/sparse models (issue #1394) already carry a robust orbit
         // anchor that gives an instant, good pivot. Skip the CPU raycast for
         // them too: the first-orbit BVH build can stall the main thread for

--- a/apps/viewer/src/components/viewer/useTouchControls.ts
+++ b/apps/viewer/src/components/viewer/useTouchControls.ts
@@ -11,6 +11,7 @@ import { useEffect, type MutableRefObject, type RefObject } from 'react';
 import type { Renderer, PickResult } from '@ifc-lite/renderer';
 import type { MeshData } from '@ifc-lite/geometry';
 import type { SectionPlane } from '@/store';
+import { isPivotRaycastTooExpensive } from './orbitPivotCensus.js';
 
 /** Locked gesture mode for 2-finger interactions */
 type TwoFingerGesture = 'none' | 'pinch' | 'pan';
@@ -89,7 +90,12 @@ export function useTouchControls(params: UseTouchControlsParams): void {
       // Outlier/sparse models (issue #1394) carry a robust orbit anchor that
       // gives an instant, good pivot — skip the raycast (its first-touch BVH
       // build can stall the main thread ~1s) and orbit the model centre below.
-      const hit = camera.getOrbitAnchorBounds() !== null
+      // Large models skip it too (same input-to-first-frame stall as the
+      // mouse path — see orbitPivotCensus.ts).
+      const skipPivotRaycast =
+        camera.getOrbitAnchorBounds() !== null ||
+        isPivotRaycastTooExpensive(renderer.getScene());
+      const hit = skipPivotRaycast
         ? null
         : renderer.raycastScene(tx, ty, {
             hiddenIds: hiddenEntitiesRef.current,

--- a/packages/renderer/src/scene.ts
+++ b/packages/renderer/src/scene.ts
@@ -3010,6 +3010,13 @@ export class Scene {
     return this.instancedEntityMap.keys();
   }
 
+  /** Number of distinct GPU-instanced entities. O(1) — for size heuristics
+   *  (e.g. the orbit-pivot raycast skip) that must not miss instanced-heavy
+   *  models where the flat mesh/batch census reads deceptively small. */
+  getInstancedEntityCount(): number {
+    return this.instancedEntityMap.size;
+  }
+
   /** Materialize EVERY instanced occurrence as world-space MeshData. Transient + not
    *  retained — for one-shot full-geometry consumers (glTF / IFC5 export) that must
    *  include the instanced occurrences absent from geometryResult.meshes. Returns []


### PR DESCRIPTION
## Problem

On large models there is a distinct lag between pressing the mouse button to orbit and the first rotated frame (reported on the 883 MB CatiaA1 model after #1714 made the orbit itself smooth). Small models start rotating immediately.

## Cause

The mouse orbit-start handler anchors the pivot under the cursor via a CPU raycast, guarded by a large-model census — but the census only counted flat meshes and batch entities. CATIA-class models sit under the 50K entity threshold on flat entities alone (CatiaA1: ~22K) while carrying tens of thousands of GPU-instanced occurrences and 6.4M triangles. So **every pointer-down** paid `collectVisibleMeshData` over the whole scene plus BVH filtering: measured **221 ms input-to-first-frame at orbit start** (211 ms on repeat drags — the cost is per-gesture, not just the first-time BVH build).

The touch orbit-start path had **no** large-model guard at all (only the #1394 sparse-model anchor check), so tablets paid the same stall on every one-finger orbit.

## Fix

- New shared census `orbitPivotCensus.ts` (`isPivotRaycastTooExpensive`): counts flat meshes + batch entities + **GPU-instanced entities** (new O(1) `Scene.getInstancedEntityCount()`) and **total batch indices**; the pivot raycast is skipped above 50K entities or 1M triangles, with early-exit accumulation. The pivot falls back to the existing scene-centre-projected-onto-cursor-ray behaviour (same as before for genuinely large flat models).
- Both the mouse and touch orbit-start handlers use it.

## Measured (CatiaA1.ifc, 883 MB, real Chrome/Metal)

| input → first orbit frame | main | this PR |
|---|---|---|
| first drag after load | 221 ms | **51 ms** |
| repeat drag | 211 ms | **48 ms** |

(~50 ms is harness round-trip overhead + one frame; visually it starts immediately.) Small models are unaffected: the census result is unchanged below the thresholds and the under-cursor pivot raycast still runs.

## Tests

`orbitPivotCensus.test.ts` (5 tests): small-model pass-through, entity threshold, the CATIA shape (22K flat + 37K instanced must read large; 22K flat alone must not), triangle threshold with few entities, accumulation across batches. Renderer suite 259 pass; viewer typecheck clean.

Follow-up to #1714 (orbit smoothness); this closes the remaining input-latency half of the report.
