### PR TITLE
feat(viewer): layer-stack panel with provenance and per-layer diff (#1717 V1)

### DIFF
--- a/apps/viewer/package.json
+++ b/apps/viewer/package.json
@@ -34,6 +34,8 @@
     "@ifc-lite/create": "workspace:^",
     "@ifc-lite/data": "workspace:^",
     "@ifc-lite/diff": "workspace:^",
+    "@ifc-lite/ifcx": "workspace:^",
+    "@ifc-lite/merge": "workspace:^",
     "@ifc-lite/drawing-2d": "workspace:^",
     "@ifc-lite/encoding": "workspace:^",
     "@ifc-lite/export": "workspace:^",

--- a/apps/viewer/src/components/viewer/layers/LayerDiffView.tsx
+++ b/apps/viewer/src/components/viewer/layers/LayerDiffView.tsx
@@ -1,0 +1,142 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * A layer's contribution rendered from the shared StackDiff contract
+ * (#1717 V1): what the layer adds, deletes, and modifies on top of the
+ * stack below it. Rows select in 3D through the composition's path →
+ * expressId bridge when the path resolves to a meshed entity.
+ */
+
+import { useCallback, useMemo, useState } from 'react';
+import type { StackDiff } from '@ifc-lite/merge';
+import { useViewerStore } from '@/store';
+import type { LayerStackEntry } from '@/store/slices/layerStackSlice';
+import { pathTail } from '@/lib/layers/stack';
+
+type ChangeKind = 'added' | 'deleted' | 'modified';
+
+interface DiffRow {
+  path: string;
+  kind: ChangeKind;
+  components: string[];
+}
+
+const KIND_META: Record<ChangeKind, { dot: string; label: string; chip: string }> = {
+  added: {
+    dot: 'bg-emerald-500',
+    label: 'added',
+    chip: 'border-emerald-500/30 bg-emerald-500/10 text-emerald-600 dark:text-emerald-300',
+  },
+  modified: {
+    dot: 'bg-amber-500',
+    label: 'modified',
+    chip: 'border-amber-500/30 bg-amber-500/10 text-amber-600 dark:text-amber-300',
+  },
+  deleted: {
+    dot: 'bg-red-500',
+    label: 'deleted',
+    chip: 'border-red-500/30 bg-red-500/10 text-red-600 dark:text-red-300',
+  },
+};
+
+/** Trim a componentKey to its display tail (`pset:Pset_WallCommon` → `Pset_WallCommon`). */
+function componentLabel(key: string): string {
+  const idx = key.indexOf(':');
+  return idx >= 0 ? key.slice(idx + 1) : key;
+}
+
+const ROW_LIMIT = 200;
+
+export function LayerDiffView({ entry, diff }: { entry: LayerStackEntry; diff: StackDiff }) {
+  const [kindFilter, setKindFilter] = useState<ChangeKind | null>(null);
+
+  const rows = useMemo<DiffRow[]>(() => {
+    const out: DiffRow[] = [];
+    for (const path of diff.added) out.push({ path, kind: 'added', components: [] });
+    for (const entity of diff.modified) {
+      out.push({ path: entity.path, kind: 'modified', components: entity.components });
+    }
+    for (const path of diff.deleted) out.push({ path, kind: 'deleted', components: [] });
+    return out;
+  }, [diff]);
+
+  const visible = kindFilter ? rows.filter((r) => r.kind === kindFilter) : rows;
+
+  const selectPath = useCallback((path: string) => {
+    const state = useViewerStore.getState();
+    const expressId = state.layerStackPathToId?.get(path);
+    if (expressId !== undefined) state.setSelectedEntityIds([expressId]);
+  }, []);
+
+  const counts: Array<{ kind: ChangeKind; count: number }> = [
+    { kind: 'added', count: diff.added.length },
+    { kind: 'modified', count: diff.modified.length },
+    { kind: 'deleted', count: diff.deleted.length },
+  ];
+
+  return (
+    <div className="animate-in fade-in slide-in-from-top-1 rounded-md border bg-card/30 p-2">
+      <div className="flex items-center justify-between gap-2 pb-1.5">
+        <span className="truncate text-[11px] font-medium" title={entry.name}>
+          Changes by {entry.name}
+        </span>
+      </div>
+      <div className="flex items-center gap-1 pb-1.5">
+        {counts.map(({ kind, count }) => {
+          const m = KIND_META[kind];
+          const active = kindFilter === kind;
+          return (
+            <button
+              key={kind}
+              type="button"
+              disabled={count === 0}
+              onClick={() => setKindFilter(active ? null : kind)}
+              className={`rounded-full border px-1.5 py-px text-[10px] font-medium leading-none transition-colors disabled:opacity-40 ${
+                active ? m.chip : 'border-border text-muted-foreground hover:bg-muted/60'
+              }`}
+            >
+              {count} {m.label}
+            </button>
+          );
+        })}
+      </div>
+      {visible.length === 0 ? (
+        <p className="py-2 text-center text-[11px] text-muted-foreground">
+          This layer changes nothing on top of the stack below it.
+        </p>
+      ) : (
+        <div className="flex flex-col">
+          {visible.slice(0, ROW_LIMIT).map((row) => {
+            const m = KIND_META[row.kind];
+            return (
+              <button
+                key={`${row.kind}:${row.path}`}
+                type="button"
+                onClick={() => selectPath(row.path)}
+                className="group flex items-start gap-1.5 rounded px-1 py-0.5 text-left transition-colors hover:bg-muted/60"
+                title={row.path}
+              >
+                <span className={`mt-1.5 size-1.5 shrink-0 rounded-full ${m.dot}`} aria-hidden />
+                <span className="min-w-0 flex-1">
+                  <span className="block truncate text-[11px]">{pathTail(row.path)}</span>
+                  {row.components.length > 0 && (
+                    <span className="block truncate text-[10px] text-muted-foreground">
+                      {row.components.map(componentLabel).join(', ')}
+                    </span>
+                  )}
+                </span>
+              </button>
+            );
+          })}
+          {visible.length > ROW_LIMIT && (
+            <p className="px-1 py-1 text-[10px] text-muted-foreground">
+              Showing {ROW_LIMIT} of {visible.length} changes.
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/viewer/src/components/viewer/layers/LayersPanel.tsx
+++ b/apps/viewer/src/components/viewer/layers/LayersPanel.tsx
@@ -1,0 +1,252 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Layer-stack panel (#1717 V1) — the composition behind a federated IFCX
+ * model, rendered as strata: strongest opinion on top, exactly the order
+ * the composition engine resolves. Each stratum carries its provenance
+ * (author kind, intent, checks, content address) and can isolate its
+ * contribution as a stack diff (05-merge.md StackDiff shape).
+ *
+ * Registered as the `layers` workspace panel; the activity bar surfaces it
+ * only while a federated stack is loaded. All layer data is path-keyed —
+ * expressIds are synthetic per parse — so 3D selection goes through the
+ * composition's `layerStackPathToId` bridge and nothing here persists ids.
+ */
+
+import { useCallback } from 'react';
+import { Bot, GitMerge, Layers, User, Users2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { useViewerStore } from '@/store';
+import type { LayerAuthorKind, LayerStackEntry } from '@/store/slices/layerStackSlice';
+import { computeLayerContribution, shortContentId } from '@/lib/layers/stack';
+import { LayerDiffView } from './LayerDiffView';
+
+interface LayersPanelProps {
+  onClose: () => void;
+}
+
+/** Author kind → badge tint + icon. Mirrors the RoomPanel role-badge system. */
+const AUTHOR_META: Record<LayerAuthorKind, { label: string; cls: string; Icon: typeof User }> = {
+  human: {
+    label: 'Human',
+    cls: 'border-emerald-500/30 bg-emerald-500/10 text-emerald-600 dark:text-emerald-300',
+    Icon: User,
+  },
+  agent: {
+    label: 'Agent',
+    cls: 'border-violet-500/30 bg-violet-500/10 text-violet-600 dark:text-violet-300',
+    Icon: Bot,
+  },
+  hybrid: {
+    label: 'Hybrid',
+    cls: 'border-amber-500/30 bg-amber-500/10 text-amber-600 dark:text-amber-300',
+    Icon: Users2,
+  },
+};
+
+/** Stratum accent by author kind; unsigned layers stay neutral. */
+function accentClass(kind: LayerAuthorKind | undefined): string {
+  switch (kind) {
+    case 'human': return 'bg-emerald-500/60';
+    case 'agent': return 'bg-violet-500/60';
+    case 'hybrid': return 'bg-amber-500/60';
+    default: return 'bg-border';
+  }
+}
+
+function AuthorBadge({ kind, principal }: { kind?: LayerAuthorKind; principal?: string }) {
+  if (!kind) {
+    return (
+      <span className="shrink-0 rounded-full border border-dashed px-1.5 py-px text-[10px] leading-none text-muted-foreground">
+        unsigned
+      </span>
+    );
+  }
+  const m = AUTHOR_META[kind];
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span
+          className={`inline-flex shrink-0 items-center gap-1 rounded-full border px-1.5 py-px text-[10px] font-medium leading-none ${m.cls}`}
+        >
+          <m.Icon className="size-2.5" aria-hidden />
+          {m.label}
+        </span>
+      </TooltipTrigger>
+      {principal && <TooltipContent side="top">{principal}</TooltipContent>}
+    </Tooltip>
+  );
+}
+
+/** One stratum row. `position` is 1-based from the TOP (1 = strongest). */
+function LayerStratum({
+  entry,
+  position,
+  total,
+  active,
+  busy,
+  onInspect,
+}: {
+  entry: LayerStackEntry;
+  position: number;
+  total: number;
+  active: boolean;
+  busy: boolean;
+  onInspect: () => void;
+}) {
+  const created = entry.created ? entry.created.slice(0, 10) : undefined;
+  const subParts: string[] = [];
+  if (entry.authorPrincipal) subParts.push(entry.authorPrincipal);
+  if (created) subParts.push(created);
+  subParts.push(`${entry.nodeCount} ${entry.nodeCount === 1 ? 'node' : 'nodes'}`);
+
+  return (
+    <div
+      className={`group relative flex animate-in fade-in slide-in-from-top-1 items-stretch gap-2 rounded-md border bg-card/50 py-1.5 pl-0 pr-1.5 transition-colors hover:bg-muted/50 ${
+        active ? 'border-primary/40 bg-muted/40' : ''
+      }`}
+      style={{ animationDelay: `${(position - 1) * 40}ms`, animationFillMode: 'backwards' }}
+    >
+      {/* Stratum accent: author-kind tinted, the panel's one signature detail. */}
+      <span className={`w-[3px] shrink-0 self-stretch rounded-full ${accentClass(entry.authorKind)}`} aria-hidden />
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-1.5">
+          <span className="shrink-0 rounded bg-muted px-1 font-mono text-[10px] leading-4 text-muted-foreground">
+            {total - position + 1}
+          </span>
+          <span className="truncate text-xs font-medium" title={entry.name}>
+            {entry.name}
+          </span>
+          {entry.isMerge && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <GitMerge className="size-3 shrink-0 text-muted-foreground" aria-label="Merge layer" />
+              </TooltipTrigger>
+              <TooltipContent side="top">Merge layer</TooltipContent>
+            </Tooltip>
+          )}
+          <AuthorBadge kind={entry.authorKind} principal={entry.authorPrincipal} />
+        </div>
+        {entry.intent && (
+          <div className="truncate text-[11px] italic text-muted-foreground" title={entry.intent}>
+            {entry.intent}
+          </div>
+        )}
+        <div className="flex items-center gap-1.5 text-[10px] text-muted-foreground">
+          <span className="truncate">{subParts.join(' · ')}</span>
+          {entry.checksTotal !== undefined && (
+            <span
+              className={`shrink-0 rounded-full border px-1 leading-3 ${
+                entry.checksPassed === entry.checksTotal
+                  ? 'border-emerald-500/30 text-emerald-600 dark:text-emerald-300'
+                  : 'border-amber-500/30 text-amber-600 dark:text-amber-300'
+              }`}
+            >
+              {entry.checksPassed}/{entry.checksTotal} checks
+            </span>
+          )}
+          {entry.contentId && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span className="shrink-0 rounded bg-muted px-1 font-mono leading-3">
+                  {shortContentId(entry.contentId)}
+                </span>
+              </TooltipTrigger>
+              <TooltipContent side="top" className="font-mono text-[10px]">
+                {entry.contentId}
+              </TooltipContent>
+            </Tooltip>
+          )}
+        </div>
+      </div>
+      <Button
+        variant="ghost"
+        size="sm"
+        className="h-6 shrink-0 self-center px-1.5 text-[11px] opacity-0 transition-opacity focus-visible:opacity-100 group-hover:opacity-100"
+        disabled={busy}
+        onClick={onInspect}
+      >
+        {active ? 'Hide' : 'Changes'}
+      </Button>
+    </div>
+  );
+}
+
+export function LayersPanel(_props: LayersPanelProps) {
+  const layerStack = useViewerStore((s) => s.layerStack);
+  const layerStackDiff = useViewerStore((s) => s.layerStackDiff);
+  const layerDiffBusy = useViewerStore((s) => s.layerDiffBusy);
+
+  const inspect = useCallback(
+    async (layerId: string) => {
+      const state = useViewerStore.getState();
+      if (state.layerStackDiff?.layerId === layerId) {
+        state.setLayerStackDiff(null);
+        return;
+      }
+      state.setLayerDiffBusy(true);
+      try {
+        const diff = await computeLayerContribution(state.layerStack, layerId);
+        if (diff) useViewerStore.getState().setLayerStackDiff({ layerId, diff });
+      } finally {
+        useViewerStore.getState().setLayerDiffBusy(false);
+      }
+    },
+    [],
+  );
+
+  if (layerStack.length === 0) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-2 p-6 text-center">
+        <Layers className="size-8 text-muted-foreground/50" aria-hidden />
+        <p className="text-xs font-medium">No layer stack loaded</p>
+        <p className="max-w-[26ch] text-[11px] text-muted-foreground">
+          Drop several .ifcx files together to load a model as composed layers.
+        </p>
+      </div>
+    );
+  }
+
+  // Composition order in the slice is weakest first; the stack renders the
+  // way it resolves — strongest opinion on top.
+  const strata = [...layerStack].reverse();
+  const activeEntry = layerStackDiff
+    ? layerStack.find((entry) => entry.id === layerStackDiff.layerId)
+    : undefined;
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex items-center gap-1.5 px-3 pb-1 pt-2 text-[11px] text-muted-foreground">
+        <Layers className="size-3.5" aria-hidden />
+        <span>
+          {layerStack.length} {layerStack.length === 1 ? 'layer' : 'layers'}, strongest on top
+        </span>
+      </div>
+      <ScrollArea className="min-h-0 flex-1">
+        <div className="flex flex-col gap-1 px-2 pb-2">
+          {strata.map((entry, i) => (
+            <LayerStratum
+              key={entry.id}
+              entry={entry}
+              position={i + 1}
+              total={strata.length}
+              active={layerStackDiff?.layerId === entry.id}
+              busy={layerDiffBusy}
+              onInspect={() => void inspect(entry.id)}
+            />
+          ))}
+          {layerDiffBusy && (
+            <p className="px-1 py-2 text-center text-[11px] text-muted-foreground">Computing changes…</p>
+          )}
+          {layerStackDiff && activeEntry && !layerDiffBusy && (
+            <LayerDiffView entry={activeEntry} diff={layerStackDiff.diff} />
+          )}
+        </div>
+      </ScrollArea>
+    </div>
+  );
+}

--- a/apps/viewer/src/components/viewer/sidebar/ActivityBar.tsx
+++ b/apps/viewer/src/components/viewer/sidebar/ActivityBar.tsx
@@ -58,6 +58,8 @@ export function ActivityBar() {
   const setPanelShownInSidebar = useViewerStore((s) => s.setPanelShownInSidebar);
   const reorder = useViewerStore((s) => s.reorderSidebarPanel);
   const resetLayout = useViewerStore((s) => s.resetSidebarLayout);
+  // Layer-stack panel (#1717) only surfaces while a federated stack is loaded.
+  const hasLayerStack = useViewerStore((s) => s.layerStack.length > 0);
 
   const { isOpen, panelLocation, toggle, openInHome, floatPanel, popOutPanel, activePanel } = usePanelControls();
 
@@ -70,7 +72,10 @@ export function ActivityBar() {
   // dedicated Hidden section, not by an inline greyed icon here. The collab
   // Room panel only surfaces while the collab feature flag is on.
   const visibleIds = order.filter(
-    (id) => (!hidden.has(id) || id === 'properties') && (id !== 'collab' || isCollabEnabled()),
+    (id) =>
+      (!hidden.has(id) || id === 'properties') &&
+      (id !== 'collab' || isCollabEnabled()) &&
+      (id !== 'layers' || hasLayerStack),
   );
 
   const onIconClick = (id: WorkspacePanelId) => {

--- a/apps/viewer/src/hooks/useIfcFederation.ts
+++ b/apps/viewer/src/hooks/useIfcFederation.ts
@@ -13,6 +13,7 @@
 import { useCallback, useRef } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useViewerStore, type FederatedModel, type SchemaVersion } from '../store/index.js';
+import { layerStackEntry } from '../lib/layers/stack.js';
 import {
   detectFormat,
   parseFederatedIfcx,
@@ -444,6 +445,15 @@ export function useIfcFederation(
 
       // Get layer info with mesh counts
       const layers = result.layerStack.getLayers();
+
+      // Layers panel (#1717): expose the stack behind this composition.
+      // getLayers() is strongest-first; the panel slice keeps composition
+      // order (weakest first). The parser retains each parsed IfcxFile, so
+      // entries reference them without re-parsing.
+      useViewerStore.getState().setLayerStack(
+        [...layers].reverse().map((layer) => layerStackEntry(layer)),
+        result.pathToId ?? null,
+      );
 
       // Create data store from federated result
       const dataStore = {

--- a/apps/viewer/src/hooks/useIfcLoader.ts
+++ b/apps/viewer/src/hooks/useIfcLoader.ts
@@ -265,6 +265,8 @@ export function useIfcLoader() {
       if (target.kind === 'primary') {
         resetViewerState();
         clearAllModels();
+        // A non-federated load has no layer stack behind it (#1717).
+        useViewerStore.getState().clearLayerStack();
       }
 
       // Reset memory accounting so per-load summaries don't accumulate across files.

--- a/apps/viewer/src/hooks/usePanelControls.ts
+++ b/apps/viewer/src/hooks/usePanelControls.ts
@@ -59,6 +59,7 @@ function setDockedVisible(id: AnalysisPanelId, visible: boolean): void {
     case 'script': s.setScriptPanelVisible(visible); break;
     case 'gantt': s.setGanttPanelVisible(visible); break;
     case 'lists': s.setListPanelVisible(visible); break;
+    case 'layers': s.setLayersPanelVisible(visible); break;
   }
 }
 

--- a/apps/viewer/src/lib/layers/stack.ts
+++ b/apps/viewer/src/lib/layers/stack.ts
@@ -43,8 +43,11 @@ export function layerStackEntry(layer: FederationLayerLike): LayerStackEntry {
   if (typeof headerId === 'string' && headerId.startsWith('blake3:')) {
     entry.contentId = headerId;
   }
+  // The manifest is raw foreign JSON: this runs INSIDE the federated
+  // load, so a malformed value (checks: [null], author: "x") must
+  // degrade to an unsigned-looking entry, never throw the whole load.
   const manifest = getProvenance(layer.file);
-  if (manifest) {
+  if (manifest && typeof manifest === 'object') {
     if (isAuthorKind(manifest.author?.kind)) entry.authorKind = manifest.author.kind;
     if (typeof manifest.author?.principal === 'string') entry.authorPrincipal = manifest.author.principal;
     if (typeof manifest.intent === 'string') entry.intent = manifest.intent;
@@ -53,7 +56,9 @@ export function layerStackEntry(layer: FederationLayerLike): LayerStackEntry {
     const checks = Array.isArray(manifest.checks) ? manifest.checks : [];
     if (checks.length > 0) {
       entry.checksTotal = checks.length;
-      entry.checksPassed = checks.filter((c) => c.result === 'pass').length;
+      entry.checksPassed = checks.filter(
+        (c) => typeof c === 'object' && c !== null && (c as { result?: unknown }).result === 'pass',
+      ).length;
     }
   }
   return entry;

--- a/apps/viewer/src/lib/layers/stack.ts
+++ b/apps/viewer/src/lib/layers/stack.ts
@@ -1,0 +1,89 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Layer-stack helpers for the Layers panel (#1717 V1): provenance summary
+ * extraction from parsed IFCX layers, and the per-layer contribution diff.
+ * All layer data here is PATH-keyed; translate to expressIds only at the
+ * selection boundary (`layerStackPathToId`).
+ */
+
+import { getProvenance } from '@ifc-lite/ifcx';
+import type { IfcxFile } from '@ifc-lite/ifcx';
+import { diffLayerStacks } from '@ifc-lite/merge';
+import type { StackDiff } from '@ifc-lite/merge';
+import type { LayerAuthorKind, LayerStackEntry } from '@/store/slices/layerStackSlice';
+
+/** Federation-parser layer shape we consume (subset of `IfcxLayer`). */
+export interface FederationLayerLike {
+  id: string;
+  name: string;
+  file: IfcxFile;
+  buffer: ArrayBuffer;
+}
+
+function isAuthorKind(value: unknown): value is LayerAuthorKind {
+  return value === 'human' || value === 'agent' || value === 'hybrid';
+}
+
+/**
+ * Build a panel entry from a federation layer: provenance summary when the
+ * layer carries a manifest, content address when blake3-addressed.
+ */
+export function layerStackEntry(layer: FederationLayerLike): LayerStackEntry {
+  const entry: LayerStackEntry = {
+    id: layer.id,
+    name: layer.name,
+    file: layer.file,
+    nodeCount: Array.isArray(layer.file.data) ? layer.file.data.length : 0,
+    byteLength: layer.buffer.byteLength,
+  };
+  const headerId = layer.file.header?.id;
+  if (typeof headerId === 'string' && headerId.startsWith('blake3:')) {
+    entry.contentId = headerId;
+  }
+  const manifest = getProvenance(layer.file);
+  if (manifest) {
+    if (isAuthorKind(manifest.author?.kind)) entry.authorKind = manifest.author.kind;
+    if (typeof manifest.author?.principal === 'string') entry.authorPrincipal = manifest.author.principal;
+    if (typeof manifest.intent === 'string') entry.intent = manifest.intent;
+    if (typeof manifest.created === 'string') entry.created = manifest.created;
+    if (manifest.merge) entry.isMerge = true;
+    const checks = Array.isArray(manifest.checks) ? manifest.checks : [];
+    if (checks.length > 0) {
+      entry.checksTotal = checks.length;
+      entry.checksPassed = checks.filter((c) => c.result === 'pass').length;
+    }
+  }
+  return entry;
+}
+
+/**
+ * What did this layer change on top of everything below it? Diffs the stack
+ * prefix without the layer against the prefix including it. Runs on the
+ * main thread after a macrotask yield, mirroring the compare engine.
+ */
+export async function computeLayerContribution(
+  stack: readonly LayerStackEntry[],
+  layerId: string,
+): Promise<StackDiff | null> {
+  const index = stack.findIndex((entry) => entry.id === layerId);
+  if (index < 0) return null;
+  // Yield so the busy state paints before the synchronous fold.
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  const files = stack.map((entry) => entry.file);
+  return diffLayerStacks(files.slice(0, index), files.slice(0, index + 1));
+}
+
+/** Short display form of a blake3 content address. */
+export function shortContentId(contentId: string): string {
+  const hex = contentId.startsWith('blake3:') ? contentId.slice('blake3:'.length) : contentId;
+  return hex.slice(0, 8);
+}
+
+/** Last path segment, for row labels; the full path stays in the tooltip. */
+export function pathTail(path: string): string {
+  const idx = path.lastIndexOf('/');
+  return idx >= 0 ? path.slice(idx + 1) : path;
+}

--- a/apps/viewer/src/lib/panels/registry.ts
+++ b/apps/viewer/src/lib/panels/registry.ts
@@ -30,6 +30,7 @@ import {
   Table2,
   ListTree,
   Users,
+  Layers as LayersIcon,
   type LucideIcon,
 } from 'lucide-react';
 
@@ -50,7 +51,8 @@ export type WorkspacePanelId =
   | 'script'
   | 'gantt'
   | 'lists'
-  | 'collab';
+  | 'collab'
+  | 'layers';
 
 /** Activity-bar clustering — a divider is drawn whenever the group changes. */
 export type PanelGroup = 'navigate' | 'inspect' | 'review' | 'author' | 'work';
@@ -96,6 +98,10 @@ export const WORKSPACE_PANELS: readonly WorkspacePanelDef[] = [
   // Alt+1..0 mapping stays intact (no Alt shortcut). The activity bar hides it
   // while the collab feature flag is off (see ActivityBar).
   { id: 'collab', title: 'Collaboration room', short: 'Room', Icon: Users, group: 'review', region: 'side' },
+  // IFCX layer stack + per-layer diff (#1717). APPENDED so the frozen
+  // Alt+1..0 mapping stays intact (no Alt shortcut). The activity bar only
+  // surfaces it while a federated layer stack is loaded.
+  { id: 'layers', title: 'Layer stack', short: 'Layers', Icon: LayersIcon, group: 'review', region: 'side' },
 ];
 
 /** The bottom-strip panel ids, mapped to their store visibility flag + setter

--- a/apps/viewer/src/lib/panels/renderPanelBody.tsx
+++ b/apps/viewer/src/lib/panels/renderPanelBody.tsx
@@ -25,6 +25,7 @@ import { ScriptPanel } from '@/components/viewer/ScriptPanel';
 import { GanttPanel } from '@/components/viewer/schedule/GanttPanel';
 import { ListPanel } from '@/components/viewer/lists/ListPanel';
 import { RoomPanel } from '@/components/viewer/RoomPanel';
+import { LayersPanel } from '@/components/viewer/layers/LayersPanel';
 
 /**
  * Render the body for a workspace panel. `onClose` is the host's "close this
@@ -47,5 +48,6 @@ export function renderPanelBody(id: WorkspacePanelId, onClose: () => void): Reac
     case 'gantt': return <GanttPanel onClose={onClose} />;
     case 'lists': return <ListPanel onClose={onClose} />;
     case 'collab': return <RoomPanel onClose={onClose} />;
+    case 'layers': return <LayersPanel onClose={onClose} />;
   }
 }

--- a/apps/viewer/src/store/index.ts
+++ b/apps/viewer/src/store/index.ts
@@ -55,6 +55,7 @@ import { createLevelDisplaySlice, type LevelDisplaySlice } from './slices/levelD
 import { createPointCloudSlice, type PointCloudSlice, POINT_CLOUD_DEFAULTS } from './slices/pointCloudSlice.js';
 import { createUnitDisplaySlice, type UnitDisplaySlice } from './slices/unitDisplaySlice.js';
 import { createSpaceMouseSlice, type SpaceMouseSlice } from './slices/spaceMouseSlice.js';
+import { createLayerStackSlice, type LayerStackSlice } from './slices/layerStackSlice.js';
 import { invalidateVisibleBasketCache } from './basketVisibleSet.js';
 
 // Import constants for reset function
@@ -98,6 +99,7 @@ export type { PinboardSlice } from './slices/pinboardSlice.js';
 // Re-export Lens types
 export type { LensSlice, Lens, LensRule, LensCriteria } from './slices/lensSlice.js';
 export type { CompareSlice, CompareResult } from './slices/compareSlice.js';
+export type { LayerStackSlice, LayerStackEntry, LayerStackDiffResult, LayerAuthorKind } from './slices/layerStackSlice.js';
 export type { DockSlice, FloatingPanelState, SnapZone } from './slices/dockSlice.js';
 export type { SidebarSlice, SidebarMode, SidebarLayoutSnapshot } from './slices/sidebarSlice.js';
 
@@ -147,6 +149,7 @@ export type ViewerState = LoadingSlice &
   LensSlice &
   ClashSlice &
   CompareSlice &
+  LayerStackSlice &
   DockSlice &
   SidebarSlice &
   ScriptSlice &
@@ -233,6 +236,7 @@ const createViewerStore = () => create<ViewerState>()((...args) => ({
   ...createLensSlice(...args),
   ...createClashSlice(...args),
   ...createCompareSlice(...args),
+  ...createLayerStackSlice(...args),
   ...createDockSlice(...args),
   ...createSidebarSlice(...args),
   ...createScriptSlice(...args),
@@ -558,6 +562,7 @@ const createViewerStore = () => create<ViewerState>()((...args) => ({
       comparePanelVisible: panel === 'compare',
       extensionsPanelVisible: panel === 'extensions',
       collabPanelVisible: panel === 'collab',
+      layersPanelVisible: panel === 'layers',
       rightPanelCollapsed: false,
     });
     if (get().sidebarMode !== 'expanded') get().setSidebarMode('expanded');
@@ -592,6 +597,7 @@ const createViewerStore = () => create<ViewerState>()((...args) => ({
         comparePanelVisible: false,
         extensionsPanelVisible: false,
         collabPanelVisible: false,
+        layersPanelVisible: false,
         rightPanelCollapsed: false,
       });
       get().setSidebarActivePanel('properties');
@@ -670,6 +676,7 @@ const SIDEBAR_PANEL_FLAGS: ReadonlyArray<readonly [keyof ViewerState, WorkspaceP
   ['comparePanelVisible', 'compare'],
   ['extensionsPanelVisible', 'extensions'],
   ['collabPanelVisible', 'collab'],
+  ['layersPanelVisible', 'layers'],
 ];
 
 /**

--- a/apps/viewer/src/store/slices/layerStackSlice.test.ts
+++ b/apps/viewer/src/store/slices/layerStackSlice.test.ts
@@ -1,0 +1,136 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert';
+import { createProvenanceManifest, setProvenance } from '@ifc-lite/ifcx';
+import type { IfcxFile } from '@ifc-lite/ifcx';
+import { createLayerStackSlice, type LayerStackSlice, type LayerStackEntry } from './layerStackSlice.js';
+import { layerStackEntry, computeLayerContribution, shortContentId, pathTail } from '../../lib/layers/stack.js';
+
+function makeFile(data: IfcxFile['data'], id = 'layer-x'): IfcxFile {
+  return {
+    header: { id, ifcxVersion: 'ifcx_alpha', dataVersion: '1.0.0', author: 't', timestamp: '2026-07-11T00:00:00Z' },
+    imports: [],
+    schemas: {},
+    data,
+  };
+}
+
+function entryFor(file: IfcxFile, id: string, name: string): LayerStackEntry {
+  return layerStackEntry({ id, name, file, buffer: new ArrayBuffer(8) });
+}
+
+describe('LayerStackSlice (#1717)', () => {
+  let state: LayerStackSlice;
+  let setState: (partial: Partial<LayerStackSlice> | ((s: LayerStackSlice) => Partial<LayerStackSlice>)) => void;
+
+  beforeEach(() => {
+    setState = (partial) => {
+      state = { ...state, ...(typeof partial === 'function' ? partial(state) : partial) };
+    };
+    state = createLayerStackSlice(setState, () => state, {} as never);
+  });
+
+  it('starts empty', () => {
+    assert.deepStrictEqual(state.layerStack, []);
+    assert.strictEqual(state.layerStackPathToId, null);
+    assert.strictEqual(state.layerStackDiff, null);
+  });
+
+  it('setLayerStack replaces the stack and resets the diff', () => {
+    const entry = entryFor(makeFile([{ path: 'wall-1', attributes: { A: 1 } }]), 'l1', 'base.ifcx');
+    state.setLayerStackDiff({ layerId: 'stale', diff: { added: [], deleted: [], modified: [] } });
+    state.setLayerStack([entry], new Map([['wall-1', 7]]));
+    assert.strictEqual(state.layerStack.length, 1);
+    assert.strictEqual(state.layerStackPathToId?.get('wall-1'), 7);
+    assert.strictEqual(state.layerStackDiff, null);
+  });
+
+  it('clearLayerStack resets everything including busy', () => {
+    const entry = entryFor(makeFile([{ path: 'wall-1' }]), 'l1', 'base.ifcx');
+    state.setLayerStack([entry], null);
+    state.setLayerDiffBusy(true);
+    state.clearLayerStack();
+    assert.deepStrictEqual(state.layerStack, []);
+    assert.strictEqual(state.layerDiffBusy, false);
+  });
+});
+
+describe('layerStackEntry provenance summary', () => {
+  it('summarizes an unsigned layer', () => {
+    const entry = entryFor(makeFile([{ path: 'a' }, { path: 'b' }]), 'l1', 'plain.ifcx');
+    assert.strictEqual(entry.nodeCount, 2);
+    assert.strictEqual(entry.authorKind, undefined);
+    assert.strictEqual(entry.contentId, undefined);
+  });
+
+  it('keeps a blake3 content address, drops synthetic ids', () => {
+    const addressed = entryFor(makeFile([], 'blake3:abcdef1234567890'), 'l1', 'a.ifcx');
+    assert.strictEqual(addressed.contentId, 'blake3:abcdef1234567890');
+    const synthetic = entryFor(makeFile([], 'layer-3'), 'l2', 'b.ifcx');
+    assert.strictEqual(synthetic.contentId, undefined);
+  });
+
+  it('extracts author kind, intent, and check tallies from the header manifest', () => {
+    const manifest = createProvenanceManifest({
+      author: { kind: 'agent', principal: 'bot-7' },
+      intent: 'Set fire ratings',
+      created: '2026-07-10T12:00:00Z',
+      base: null,
+      checks: [
+        { tool: '@ifc-lite/ids@2.x', spec: 'fire.ids', result: 'pass' },
+        { tool: '@ifc-lite/ids@2.x', spec: 'geo.ids', result: 'fail' },
+      ],
+    });
+    const file = setProvenance(makeFile([{ path: 'wall-1' }]), manifest);
+    const entry = entryFor(file, 'l1', 'agent-layer.ifcx');
+    assert.strictEqual(entry.authorKind, 'agent');
+    assert.strictEqual(entry.authorPrincipal, 'bot-7');
+    assert.strictEqual(entry.intent, 'Set fire ratings');
+    assert.strictEqual(entry.checksTotal, 2);
+    assert.strictEqual(entry.checksPassed, 1);
+  });
+});
+
+describe('computeLayerContribution', () => {
+  const FIRE = 'bsi::ifc::v5a::Pset_FireSafety::FireRating';
+
+  it('isolates what one layer changes on top of the stack below it', async () => {
+    const base = entryFor(
+      makeFile([{ path: 'wall-1', attributes: { [FIRE]: 'REI60', Name: 'W1' } }]),
+      'l1',
+      'base.ifcx',
+    );
+    const overlay = entryFor(
+      makeFile([
+        { path: 'wall-1', attributes: { [FIRE]: 'REI90' } },
+        { path: 'door-1', attributes: { Name: 'D1' } },
+      ]),
+      'l2',
+      'overlay.ifcx',
+    );
+    const diff = await computeLayerContribution([base, overlay], 'l2');
+    assert.ok(diff);
+    assert.deepStrictEqual(diff.added, ['door-1']);
+    assert.deepStrictEqual(diff.deleted, []);
+    assert.strictEqual(diff.modified.length, 1);
+    assert.strictEqual(diff.modified[0].path, 'wall-1');
+  });
+
+  it('returns null for an unknown layer id', async () => {
+    const base = entryFor(makeFile([{ path: 'wall-1' }]), 'l1', 'base.ifcx');
+    assert.strictEqual(await computeLayerContribution([base], 'nope'), null);
+  });
+});
+
+describe('display helpers', () => {
+  it('shortContentId trims the scheme and truncates', () => {
+    assert.strictEqual(shortContentId('blake3:abcdef1234567890'), 'abcdef12');
+  });
+  it('pathTail keeps the last segment', () => {
+    assert.strictEqual(pathTail('site/building/wall-1'), 'wall-1');
+    assert.strictEqual(pathTail('wall-1'), 'wall-1');
+  });
+});

--- a/apps/viewer/src/store/slices/layerStackSlice.ts
+++ b/apps/viewer/src/store/slices/layerStackSlice.ts
@@ -1,0 +1,97 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Layer-stack panel state (issue #1717, Layer PRs viewer integration V1).
+ *
+ * Holds the ordered IFCX layer stack behind the current federated
+ * composition — each entry keeps the parsed layer document (the federation
+ * parser retains it anyway) plus a provenance summary for the panel — and
+ * the last per-layer stack diff. Orchestration (running `diffLayerStacks`,
+ * translating paths to selections) lives in `useLayerStack`; this slice is
+ * deliberately dumb, mirroring `compareSlice` + `useCompare`.
+ *
+ * NOT related to the `mergeLayers` ui state, which is the multilayer-WALL
+ * geometry feature.
+ */
+
+import type { StateCreator } from 'zustand';
+import type { IfcxFile } from '@ifc-lite/ifcx';
+import type { StackDiff } from '@ifc-lite/merge';
+
+/** Provenance manifest author kinds (03-provenance.md). */
+export type LayerAuthorKind = 'human' | 'agent' | 'hybrid';
+
+/** One stratum of the loaded stack, weakest first (composition order). */
+export interface LayerStackEntry {
+  /** LayerStack id from the federation parser (stable for this session). */
+  id: string;
+  /** Display name (usually the file name). */
+  name: string;
+  /** The parsed layer document — the diff engine consumes these directly. */
+  file: IfcxFile;
+  /** Content address when the layer is blake3-addressed (published layers). */
+  contentId?: string;
+  /** Opinion-carrying nodes in this layer. */
+  nodeCount: number;
+  byteLength: number;
+  /** Provenance summary, when the layer carries a manifest. */
+  authorKind?: LayerAuthorKind;
+  authorPrincipal?: string;
+  intent?: string;
+  created?: string;
+  /** True when the manifest records a merge (this is a merge layer). */
+  isMerge?: boolean;
+  /** Check evidence attached to the manifest: passed / total. */
+  checksPassed?: number;
+  checksTotal?: number;
+}
+
+/** A computed per-layer contribution diff: prefix-below vs prefix-including. */
+export interface LayerStackDiffResult {
+  /** The entry whose contribution the diff isolates. */
+  layerId: string;
+  diff: StackDiff;
+}
+
+export interface LayerStackSlice {
+  /**
+   * The IFCX layers behind the current composition, weakest first. Empty
+   * for non-federated (STEP / single-file / GLB) models.
+   */
+  layerStack: LayerStackEntry[];
+  /** path → expressId for the current composition (3D selection bridge). */
+  layerStackPathToId: Map<string, number> | null;
+  /** Which layer's contribution diff is shown, or null. */
+  layerStackDiff: LayerStackDiffResult | null;
+  /** True while a diff is being computed (main thread, yielded). */
+  layerDiffBusy: boolean;
+  /** Docked-sidebar visibility flag (single-tenant slot, see SIDEBAR_PANEL_FLAGS). */
+  layersPanelVisible: boolean;
+
+  setLayersPanelVisible: (visible: boolean) => void;
+  setLayerStack: (entries: LayerStackEntry[], pathToId: Map<string, number> | null) => void;
+  clearLayerStack: () => void;
+  setLayerStackDiff: (result: LayerStackDiffResult | null) => void;
+  setLayerDiffBusy: (busy: boolean) => void;
+}
+
+export const createLayerStackSlice: StateCreator<LayerStackSlice, [], [], LayerStackSlice> = (
+  set,
+) => ({
+  layerStack: [],
+  layerStackPathToId: null,
+  layerStackDiff: null,
+  layerDiffBusy: false,
+  layersPanelVisible: false,
+
+  setLayersPanelVisible: (visible) => set({ layersPanelVisible: visible }),
+
+  setLayerStack: (entries, pathToId) =>
+    set({ layerStack: entries, layerStackPathToId: pathToId, layerStackDiff: null }),
+  clearLayerStack: () =>
+    set({ layerStack: [], layerStackPathToId: null, layerStackDiff: null, layerDiffBusy: false }),
+  setLayerStackDiff: (result) => set({ layerStackDiff: result }),
+  setLayerDiffBusy: (busy) => set({ layerDiffBusy: busy }),
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -129,6 +129,9 @@ importers:
       '@ifc-lite/ids':
         specifier: workspace:^
         version: link:../../packages/ids
+      '@ifc-lite/ifcx':
+        specifier: workspace:^
+        version: link:../../packages/ifcx
       '@ifc-lite/lens':
         specifier: workspace:^
         version: link:../../packages/lens
@@ -138,6 +141,9 @@ importers:
       '@ifc-lite/mcp':
         specifier: workspace:^
         version: link:../../packages/mcp
+      '@ifc-lite/merge':
+        specifier: workspace:^
+        version: link:../../packages/merge
       '@ifc-lite/mutations':
         specifier: workspace:^
         version: link:../../packages/mutations


### PR DESCRIPTION
## Summary

Phase V1 of #1717: the viewer surfaces the IFCX layer stack behind a federated composition, with per-layer provenance and a per-layer contribution diff. Stacked on #1027 (consumes `@ifc-lite/merge` and the ifcx provenance surface) — do not merge before it.

## What it does

- **Layer stack capture**: `useIfcFederation` now records the composition's layers (the parser already retains each parsed `IfcxFile`) into a new `layerStackSlice`, weakest first, together with the composition's `pathToId` bridge. Single-file/STEP/GLB loads clear it.
- **Layers panel** (`layers`, appended to `WORKSPACE_PANELS`; Alt+1..0 mapping untouched): strata rendered strongest-on-top with an author-kind accent (human emerald / agent violet / hybrid amber / unsigned neutral), provenance badges (author, intent, created, merge marker, check tallies), and a mono blake3 chip for content-addressed layers. The activity bar surfaces the panel only while a stack is loaded.
- **Contribution diff**: per layer, `diffLayerStacks(prefix-below, prefix-including)` from `@ifc-lite/merge` runs main-thread (same pattern as compare) and renders the shared `StackDiff` contract: added/modified/deleted chips (filterable) and rows with component keys. Rows select the entity in 3D through the path → expressId bridge.
- New sidebar panel plumbing: `layersPanelVisible` flag registered in `SIDEBAR_PANEL_FLAGS` / `openWorkspacePanel` / `showWorkspacePanel`.

## Verification

- Unit tests: slice state, provenance summary extraction (header manifest), contribution diff, display helpers (17 assertions), plus the full viewer suite green.
- Localhost (vite + Chrome DevTools MCP) with `Hello_Wall_hello-wall.ifcx` + two fire-rating overlays: stack captured (62/1/2 nodes, weakest first), rail icon gated on stack presence, panel opens via flag system, base layer diff = 27 added, strongest overlay diff = 1 added (`Window_001`) + 1 modified (`prop:FireRating`), row click selects the wall in 3D.

## Notes

- All layer data is path-keyed; expressIds are synthetic per parse and never persisted — translation happens only at the selection boundary.
- Not named anything with `mergeLayers` (that is the multilayer-wall geometry feature).
- Next phases per #1717: V2 draft authoring from viewer edits, V3 registry client + merge/review UI, V4 perf.
