### PR TITLE
feat(viewer): publish draft layers from viewer edits (#1717 V2)

### DIFF
--- a/apps/viewer/src/components/viewer/layers/LayerDraftSection.tsx
+++ b/apps/viewer/src/components/viewer/layers/LayerDraftSection.tsx
@@ -1,0 +1,153 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Draft section of the Layers panel (#1717 V2): pending viewer edits →
+ * an immutable, content-addressed layer on the browser-local store, then
+ * straight back into the live composition as the strongest overlay so
+ * the published layer appears in the stack it just changed.
+ */
+
+import { useCallback, useMemo, useState } from 'react';
+import { PenLine, UploadCloud } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { useViewerStore } from '@/store';
+import { useIfc } from '@/hooks/useIfc';
+import { toast } from '@/components/ui/toast';
+import { getBrowserLayerStore, DEFAULT_LOCAL_REF } from '@/lib/layers/browser-store';
+import { publishViewerDraft } from '@/lib/layers/publish';
+import type { Mutation } from '@ifc-lite/mutations';
+
+const AUTHOR_STORAGE_KEY = 'ifc-lite:layer-author';
+
+function storedAuthor(): string {
+  if (typeof window === 'undefined') return 'viewer-user';
+  return window.localStorage.getItem(AUTHOR_STORAGE_KEY) ?? 'viewer-user';
+}
+
+/** Every pending mutation across the loaded federation. */
+function pendingMutations(): Mutation[] {
+  const state = useViewerStore.getState();
+  const out: Mutation[] = [];
+  for (const modelId of state.models.keys()) {
+    out.push(...state.getMutationsForModel(modelId));
+  }
+  return out;
+}
+
+export function LayerDraftSection() {
+  const { addIfcxOverlays } = useIfc();
+  // mutationVersion drives the pending count; layerStack drives eligibility.
+  const mutationVersion = useViewerStore((s) => s.mutationVersion);
+  const stackSize = useViewerStore((s) => s.layerStack.length);
+  const [intent, setIntent] = useState('');
+  const [author, setAuthor] = useState(storedAuthor);
+  const [busy, setBusy] = useState(false);
+
+  const pendingCount = useMemo(() => {
+    void mutationVersion;
+    return pendingMutations().length;
+  }, [mutationVersion]);
+
+  const publish = useCallback(async () => {
+    const state = useViewerStore.getState();
+    const trimmedIntent = intent.trim();
+    const trimmedAuthor = author.trim() || 'viewer-user';
+    if (!trimmedIntent) return;
+    window.localStorage.setItem(AUTHOR_STORAGE_KEY, trimmedAuthor);
+    setBusy(true);
+    try {
+      // Invert the composition bridge: expressId → path.
+      const idToPath = new Map<number, string>();
+      for (const [path, id] of state.layerStackPathToId ?? []) idToPath.set(id, path);
+
+      const store = await getBrowserLayerStore();
+      const result = publishViewerDraft({
+        store,
+        stackFiles: state.layerStack.map((e) => e.file),
+        mutations: pendingMutations(),
+        pathOf: (expressId) => idToPath.get(expressId),
+        intent: trimmedIntent,
+        authorPrincipal: trimmedAuthor,
+        refName: DEFAULT_LOCAL_REF,
+      });
+      if (result.unresolved.length > 0) {
+        toast.info(
+          `${result.unresolved.length} edited ${result.unresolved.length === 1 ? 'entity' : 'entities'} had no stable identity and stayed out of the layer.`,
+        );
+      }
+      // Feed the published layer back into the live composition — the
+      // federation reload recaptures the stack, so it shows up on top.
+      const json = JSON.stringify(result.file);
+      const fileName = `${trimmedIntent.slice(0, 40).replace(/[^\w-]+/g, '-') || 'layer'}.ifcx`;
+      await addIfcxOverlays([new File([json], fileName, { type: 'application/json' })]);
+      // The edits now live in the published layer; drop them as pending.
+      useViewerStore.getState().clearAllMutations();
+      setIntent('');
+      toast.success(`Published ${result.layerId.slice(0, 15)}… to '${DEFAULT_LOCAL_REF}' (${result.opCount} ops).`);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  }, [intent, author, addIfcxOverlays]);
+
+  if (stackSize === 0) return null;
+
+  return (
+    <div className="rounded-md border border-dashed bg-card/30 p-2">
+      <div className="flex items-center gap-1.5 pb-1.5 text-[11px] font-medium">
+        <PenLine className="size-3" aria-hidden />
+        <span>Draft layer</span>
+        <span
+          className={`ml-auto rounded-full border px-1.5 py-px text-[10px] leading-none ${
+            pendingCount > 0
+              ? 'border-amber-500/30 bg-amber-500/10 text-amber-600 dark:text-amber-300'
+              : 'border-border text-muted-foreground'
+          }`}
+        >
+          {pendingCount} pending {pendingCount === 1 ? 'edit' : 'edits'}
+        </span>
+      </div>
+      {pendingCount === 0 ? (
+        <p className="text-[11px] text-muted-foreground">
+          Edit properties in the model, then freeze the changes here as a new layer.
+        </p>
+      ) : (
+        <div className="flex flex-col gap-1.5">
+          <Input
+            value={intent}
+            onChange={(e) => setIntent(e.target.value)}
+            placeholder="Intent, e.g. Set fire ratings for EG walls"
+            className="h-7 text-xs"
+            disabled={busy}
+          />
+          <div className="flex items-center gap-1.5">
+            <Input
+              value={author}
+              onChange={(e) => setAuthor(e.target.value)}
+              placeholder="Author"
+              className="h-7 flex-1 text-xs"
+              disabled={busy}
+            />
+            <Button
+              size="sm"
+              className="h-7 gap-1 px-2 text-[11px]"
+              disabled={busy || intent.trim().length === 0}
+              onClick={() => void publish()}
+            >
+              <UploadCloud className="size-3" aria-hidden />
+              {busy ? 'Publishing…' : 'Publish'}
+            </Button>
+          </div>
+          <p className="text-[10px] text-muted-foreground">
+            Freezes the pending edits as a content-addressed layer on the local ref
+            &apos;{DEFAULT_LOCAL_REF}&apos; and stacks it onto the composition.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/viewer/src/components/viewer/layers/LayerDraftSection.tsx
+++ b/apps/viewer/src/components/viewer/layers/LayerDraftSection.tsx
@@ -27,12 +27,17 @@ function storedAuthor(): string {
   return window.localStorage.getItem(AUTHOR_STORAGE_KEY) ?? 'viewer-user';
 }
 
-/** Every pending mutation across the loaded federation. */
+/**
+ * Every pending mutation across the loaded federation. Reads the UNDO
+ * stacks, not the view's mutation history: the history is append-only
+ * (undo applies inverse ops without removing the record), so publishing
+ * from it would resurrect edits the user explicitly undid.
+ */
 function pendingMutations(): Mutation[] {
   const state = useViewerStore.getState();
   const out: Mutation[] = [];
   for (const modelId of state.models.keys()) {
-    out.push(...state.getMutationsForModel(modelId));
+    out.push(...(state.undoStacks.get(modelId) ?? []));
   }
   return out;
 }
@@ -73,18 +78,23 @@ export function LayerDraftSection() {
         authorPrincipal: trimmedAuthor,
         refName: DEFAULT_LOCAL_REF,
       });
-      if (result.unresolved.length > 0) {
-        toast.info(
-          `${result.unresolved.length} edited ${result.unresolved.length === 1 ? 'entity' : 'entities'} had no stable identity and stayed out of the layer.`,
-        );
-      }
       // Feed the published layer back into the live composition — the
       // federation reload recaptures the stack, so it shows up on top.
       const json = JSON.stringify(result.file);
       const fileName = `${trimmedIntent.slice(0, 40).replace(/[^\w-]+/g, '-') || 'layer'}.ifcx`;
       await addIfcxOverlays([new File([json], fileName, { type: 'application/json' })]);
-      // The edits now live in the published layer; drop them as pending.
-      useViewerStore.getState().clearAllMutations();
+      if (result.unresolved.length > 0) {
+        // A partial publish keeps ALL edits pending rather than deleting
+        // the unresolved ones with them: re-publishing after fixing
+        // identities re-emits the same values, which composition folds
+        // idempotently.
+        toast.info(
+          `${result.unresolved.length} edited ${result.unresolved.length === 1 ? 'entity' : 'entities'} had no stable identity and stayed out of the layer; the pending edits were kept.`,
+        );
+      } else {
+        // The edits now live in the published layer; drop them as pending.
+        useViewerStore.getState().clearAllMutations();
+      }
       setIntent('');
       toast.success(`Published ${result.layerId.slice(0, 15)}… to '${DEFAULT_LOCAL_REF}' (${result.opCount} ops).`);
     } catch (err) {

--- a/apps/viewer/src/components/viewer/layers/LayerDraftSection.tsx
+++ b/apps/viewer/src/components/viewer/layers/LayerDraftSection.tsx
@@ -24,20 +24,37 @@ const AUTHOR_STORAGE_KEY = 'ifc-lite:layer-author';
 
 function storedAuthor(): string {
   if (typeof window === 'undefined') return 'viewer-user';
-  return window.localStorage.getItem(AUTHOR_STORAGE_KEY) ?? 'viewer-user';
+  const stored = window.localStorage.getItem(AUTHOR_STORAGE_KEY);
+  if (stored) return stored;
+  // Authenticated registries bind the manifest author to the login
+  // principal — seed from the collab identity so pushes have a chance
+  // of matching it out of the box.
+  const identity = useViewerStore.getState().collabIdentity?.name;
+  return identity && identity.trim().length > 0 ? identity : 'viewer-user';
 }
 
 /**
- * Every pending mutation across the loaded federation. Reads the UNDO
+ * Pending mutations of the FEDERATED composition only. Reads the UNDO
  * stacks, not the view's mutation history: the history is append-only
  * (undo applies inverse ops without removing the record), so publishing
  * from it would resurrect edits the user explicitly undid.
+ *
+ * Models outside the composition (a STEP model added alongside) have
+ * their own overlapping expressId space — resolving those ids through
+ * the composition's path bridge would publish onto unrelated entities,
+ * so only models sharing the composed data store contribute. Georef
+ * pseudo-mutations (entityId 0, georef.* attribute names) carry no
+ * entity identity and are dropped.
  */
 function pendingMutations(): Mutation[] {
   const state = useViewerStore.getState();
   const out: Mutation[] = [];
-  for (const modelId of state.models.keys()) {
-    out.push(...(state.undoStacks.get(modelId) ?? []));
+  for (const [modelId, model] of state.models) {
+    if (model.ifcDataStore !== state.ifcDataStore) continue;
+    for (const mutation of state.undoStacks.get(modelId) ?? []) {
+      if (mutation.attributeName?.startsWith('georef.')) continue;
+      out.push(mutation);
+    }
   }
   return out;
 }
@@ -78,23 +95,26 @@ export function LayerDraftSection() {
         authorPrincipal: trimmedAuthor,
         refName: DEFAULT_LOCAL_REF,
       });
+      if (result.unresolved.length > 0) {
+        // A partial publish must not recompose: the federation reload
+        // resets viewer state, which would erase the very edits we
+        // promise to keep. The layer is on the ref; stack it after the
+        // identities are fixed (re-publishing folds idempotently).
+        toast.info(
+          `Published to '${DEFAULT_LOCAL_REF}', but ${result.unresolved.length} edited ${result.unresolved.length === 1 ? 'entity' : 'entities'} had no stable identity and stayed out. Pending edits were kept; the layer was not stacked.`,
+        );
+        setIntent('');
+        return;
+      }
+      // The edits now live in the published layer; drop them as pending
+      // BEFORE the recompose (the federation reload resets viewer state,
+      // so nothing of value is lost by it).
+      useViewerStore.getState().clearAllMutations();
       // Feed the published layer back into the live composition — the
       // federation reload recaptures the stack, so it shows up on top.
       const json = JSON.stringify(result.file);
       const fileName = `${trimmedIntent.slice(0, 40).replace(/[^\w-]+/g, '-') || 'layer'}.ifcx`;
       await addIfcxOverlays([new File([json], fileName, { type: 'application/json' })]);
-      if (result.unresolved.length > 0) {
-        // A partial publish keeps ALL edits pending rather than deleting
-        // the unresolved ones with them: re-publishing after fixing
-        // identities re-emits the same values, which composition folds
-        // idempotently.
-        toast.info(
-          `${result.unresolved.length} edited ${result.unresolved.length === 1 ? 'entity' : 'entities'} had no stable identity and stayed out of the layer; the pending edits were kept.`,
-        );
-      } else {
-        // The edits now live in the published layer; drop them as pending.
-        useViewerStore.getState().clearAllMutations();
-      }
       setIntent('');
       toast.success(`Published ${result.layerId.slice(0, 15)}… to '${DEFAULT_LOCAL_REF}' (${result.opCount} ops).`);
     } catch (err) {

--- a/apps/viewer/src/components/viewer/layers/LayersPanel.tsx
+++ b/apps/viewer/src/components/viewer/layers/LayersPanel.tsx
@@ -24,6 +24,7 @@ import { useViewerStore } from '@/store';
 import type { LayerAuthorKind, LayerStackEntry } from '@/store/slices/layerStackSlice';
 import { computeLayerContribution, shortContentId } from '@/lib/layers/stack';
 import { LayerDiffView } from './LayerDiffView';
+import { LayerDraftSection } from './LayerDraftSection';
 
 interface LayersPanelProps {
   onClose: () => void;
@@ -228,6 +229,7 @@ export function LayersPanel(_props: LayersPanelProps) {
       </div>
       <ScrollArea className="min-h-0 flex-1">
         <div className="flex flex-col gap-1 px-2 pb-2">
+          <LayerDraftSection />
           {strata.map((entry, i) => (
             <LayerStratum
               key={entry.id}

--- a/apps/viewer/src/hooks/useIfcFederation.ts
+++ b/apps/viewer/src/hooks/useIfcFederation.ts
@@ -26,6 +26,7 @@ import { buildSpatialIndexGuarded } from '../utils/loadingUtils.js';
 import { getDynamicBatchConfig } from '../utils/ifcConfig.js';
 import { calculateMeshBounds, createCoordinateInfo } from '../utils/localParsingUtils.js';
 import {
+  buildIfcxDataStore,
   convertIfcxMeshes,
 } from './ingest/viewerModelIngest.js';
 import { extractModelGeoref, alignGeometryToReference, findReferenceGeorefModel } from './ingest/federationAlign.js';
@@ -455,23 +456,13 @@ export function useIfcFederation(
         result.pathToId ?? null,
       );
 
-      // Create data store from federated result
-      const dataStore = {
-        fileSize: result.fileSize,
-        schemaVersion: 'IFC5' as const,
-        entityCount: result.entityCount,
-        parseTime: result.parseTime,
-        source: new Uint8Array(buffers[0].buffer),
-        entityIndex: {
-          byId: new Map(),
-          byType: new Map(),
-        },
-        strings: result.strings,
-        entities: result.entities,
-        properties: result.properties,
-        quantities: result.quantities,
-        relationships: result.relationships,
-        spatialHierarchy: result.spatialHierarchy,
+      // Create data store from federated result. Route through the shared
+      // IFCX store factory so the lazy accessors (getEntity/getProperties/
+      // getQuantities) the query + mutation paths call exist — without
+      // them, selecting or editing an entity in a federated model threw
+      // "this.store.getProperties is not a function" (#1717 V2).
+      const accessorStore = buildIfcxDataStore(result, buffers[0].buffer);
+      const dataStore = Object.assign(accessorStore, {
         // Federated-specific: store layer info and ORIGINAL BUFFERS for re-composition
         _federatedLayers: layers.map((l: { id: string; name: string; enabled: boolean }) => ({
           id: l.id,
@@ -483,7 +474,7 @@ export function useIfcFederation(
           name: b.name,
         })),
         _compositionStats: result.compositionStats,
-      } as unknown as IfcxDataStore;
+      }) as unknown as IfcxDataStore;
 
       // IfcxDataStore extends IfcDataStore (with schemaVersion: 'IFC5'), so this is safe
       setIfcDataStore(dataStore);
@@ -625,8 +616,12 @@ export function useIfcFederation(
       newBuffers.push({ buffer, name: file.name });
     }
 
-    // Combine: existing layers + new overlays (new overlays are strongest = first in array)
-    const allBuffers = [...newBuffers, ...existingBuffers];
+    // Combine: existing layers first, new overlays LAST. parseFederatedIfcx
+    // treats the first file as weakest and the last as strongest, so a new
+    // overlay must trail the existing stack — leading it made every added
+    // overlay the WEAKEST layer, silently shadowed by the model it was
+    // meant to override (#1717 V2).
+    const allBuffers = [...existingBuffers, ...newBuffers];
 
     await loadFederatedIfcxFromBuffers(allBuffers, { resetState: false });
   }, [setError, loadFederatedIfcxFromBuffers]);

--- a/apps/viewer/src/lib/layers/browser-store.ts
+++ b/apps/viewer/src/lib/layers/browser-store.ts
@@ -1,0 +1,152 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Browser-local layer store (#1717 V2): the CLI's `.ifc-lite/` layout on
+ * IndexedDB — content-addressed layers plus a named-ref record.
+ *
+ * `@ifc-lite/merge` consumes the SYNC `LayerRefStore` interface, so the
+ * working state lives in memory and IndexedDB is a write-through mirror:
+ * `open()` hydrates once, every mutation persists fire-and-forget (a
+ * failed write logs and keeps the session working; the durable copy just
+ * lags). Layers are immutable and first-write-wins per content address,
+ * mirroring the registry semantics.
+ */
+
+import { computeLayerId } from '@ifc-lite/ifcx';
+import type { IfcxFile } from '@ifc-lite/ifcx';
+import type { LayerRefStore, RefEntry } from '@ifc-lite/merge';
+
+const DB_NAME = 'ifc-lite-layer-store';
+const DB_VERSION = 1;
+const LAYERS = 'layers';
+const REFS = 'refs';
+
+/** The ref local publishes land on when the user never picked one. */
+export const DEFAULT_LOCAL_REF = 'local';
+
+function openDatabase(): Promise<IDBDatabase | null> {
+  if (typeof indexedDB === 'undefined') return Promise.resolve(null);
+  return new Promise((resolve) => {
+    const req = indexedDB.open(DB_NAME, DB_VERSION);
+    req.onupgradeneeded = () => {
+      const db = req.result;
+      if (!db.objectStoreNames.contains(LAYERS)) db.createObjectStore(LAYERS);
+      if (!db.objectStoreNames.contains(REFS)) db.createObjectStore(REFS);
+    };
+    req.onsuccess = () => resolve(req.result);
+    // A blocked/broken IDB (private mode, quota) degrades to memory-only.
+    req.onerror = () => {
+      console.warn('[layer-store] IndexedDB unavailable, layers will not persist:', req.error);
+      resolve(null);
+    };
+  });
+}
+
+function readAll<T>(db: IDBDatabase, storeName: string): Promise<Map<string, T>> {
+  return new Promise((resolve) => {
+    const out = new Map<string, T>();
+    const tx = db.transaction(storeName, 'readonly');
+    const cursorReq = tx.objectStore(storeName).openCursor();
+    cursorReq.onsuccess = () => {
+      const cursor = cursorReq.result;
+      if (!cursor) return;
+      out.set(String(cursor.key), cursor.value as T);
+      cursor.continue();
+    };
+    tx.oncomplete = () => resolve(out);
+    tx.onerror = () => resolve(out);
+  });
+}
+
+export class BrowserLayerStore implements LayerRefStore {
+  private readonly layers = new Map<string, IfcxFile>();
+  private readonly refs = new Map<string, RefEntry>();
+  private readonly db: IDBDatabase | null;
+
+  private constructor(db: IDBDatabase | null) {
+    this.db = db;
+  }
+
+  /** Hydrate the working state from IndexedDB (memory-only without it). */
+  static async open(): Promise<BrowserLayerStore> {
+    const db = await openDatabase();
+    const store = new BrowserLayerStore(db);
+    if (db) {
+      const [layers, refs] = await Promise.all([
+        readAll<IfcxFile>(db, LAYERS),
+        readAll<RefEntry>(db, REFS),
+      ]);
+      for (const [id, file] of layers) store.layers.set(id, file);
+      for (const [name, entry] of refs) store.refs.set(name, entry);
+    }
+    return store;
+  }
+
+  private persist(storeName: string, key: string, value: unknown): void {
+    if (!this.db) return;
+    try {
+      const tx = this.db.transaction(storeName, 'readwrite');
+      tx.objectStore(storeName).put(structuredClone(value), key);
+      tx.onerror = () => console.warn(`[layer-store] persist ${storeName}/${key} failed:`, tx.error);
+    } catch (err) {
+      console.warn(`[layer-store] persist ${storeName}/${key} failed:`, err);
+    }
+  }
+
+  /** Verify the content address, then store (first write wins, idempotent). */
+  storeLayer(file: IfcxFile): string {
+    const computed = computeLayerId(file);
+    if (file.header.id !== computed) {
+      throw new Error(`layer header.id ${file.header.id} does not match content address ${computed}`);
+    }
+    const existing = this.layers.get(computed);
+    if (existing !== undefined) {
+      if (JSON.stringify(existing) !== JSON.stringify(file)) {
+        throw new Error(`layer ${computed} already stored with different bytes; refusing overwrite`);
+      }
+      return computed;
+    }
+    this.layers.set(computed, structuredClone(file));
+    this.persist(LAYERS, computed, file);
+    return computed;
+  }
+
+  loadLayer(layerId: string): IfcxFile {
+    const file = this.layers.get(layerId);
+    if (!file) throw new Error(`No layer ${layerId} in the local store`);
+    return structuredClone(file);
+  }
+
+  hasLayer(layerId: string): boolean {
+    return this.layers.has(layerId);
+  }
+
+  listLayers(): string[] {
+    return [...this.layers.keys()];
+  }
+
+  getRef(name: string): RefEntry | undefined {
+    const entry = this.refs.get(name);
+    return entry === undefined ? undefined : structuredClone(entry);
+  }
+
+  setRef(name: string, entry: RefEntry): void {
+    const clean: RefEntry = { layers: [...entry.layers], ...(entry.policy ? { policy: entry.policy } : {}) };
+    this.refs.set(name, structuredClone(clean));
+    this.persist(REFS, name, clean);
+  }
+
+  listRefs(): Record<string, RefEntry> {
+    return Object.fromEntries([...this.refs.entries()].map(([name, entry]) => [name, structuredClone(entry)]));
+  }
+}
+
+let singleton: Promise<BrowserLayerStore> | null = null;
+
+/** The app-wide local layer store, opened lazily once per session. */
+export function getBrowserLayerStore(): Promise<BrowserLayerStore> {
+  singleton ??= BrowserLayerStore.open();
+  return singleton;
+}

--- a/apps/viewer/src/lib/layers/publish.test.ts
+++ b/apps/viewer/src/lib/layers/publish.test.ts
@@ -1,0 +1,146 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { getProvenance } from '@ifc-lite/ifcx';
+import type { IfcxFile } from '@ifc-lite/ifcx';
+import { extractStackState } from '@ifc-lite/merge';
+import type { Mutation } from '@ifc-lite/mutations';
+import { BrowserLayerStore } from './browser-store.js';
+import { publishViewerDraft } from './publish.js';
+
+const FIRE = 'bsi::ifc::v5a::Pset_FireSafety::FireRating';
+
+function makeBase(): IfcxFile {
+  return {
+    header: {
+      id: 'base-layer',
+      ifcxVersion: 'ifcx_alpha',
+      dataVersion: '1.0.0',
+      author: 't',
+      timestamp: '2026-07-11T00:00:00Z',
+    },
+    imports: [],
+    schemas: {},
+    data: [
+      {
+        path: 'wall-guid-1',
+        attributes: { 'bsi::ifc::class': { code: 'IfcWall', uri: 'u' }, [FIRE]: { type: 'IfcLabel', value: 'REI60' } },
+      },
+    ],
+  };
+}
+
+function mutation(partial: Partial<Mutation>): Mutation {
+  return {
+    id: 'm1',
+    type: 'UPDATE_PROPERTY',
+    timestamp: 1,
+    modelId: 'model-1',
+    entityId: 7,
+    ...partial,
+  } as Mutation;
+}
+
+// Under node:test there is no indexedDB — the store runs memory-only,
+// which exercises exactly the sync surface the merge engine consumes.
+describe('publishViewerDraft (#1717 V2)', () => {
+  it('freezes a property edit into a content-addressed, provenance-stamped layer on a ref', async () => {
+    const store = await BrowserLayerStore.open();
+    const base = makeBase();
+    const result = publishViewerDraft({
+      store,
+      stackFiles: [base],
+      mutations: [
+        mutation({ psetName: 'Pset_FireSafety', propName: 'FireRating', newValue: 'REI90' }),
+      ],
+      pathOf: (id) => (id === 7 ? 'wall-guid-1' : undefined),
+      intent: 'Raise fire rating',
+      authorPrincipal: 'louis',
+      refName: 'local',
+      created: '2026-07-11T12:00:00Z',
+    });
+
+    assert.ok(result.layerId.startsWith('blake3:'));
+    assert.deepStrictEqual(result.unresolved, []);
+    assert.deepStrictEqual(store.getRef('local')?.layers, [result.layerId]);
+
+    const stored = store.loadLayer(result.layerId);
+    const manifest = getProvenance(stored);
+    assert.strictEqual(manifest?.author.principal, 'louis');
+    assert.strictEqual(manifest?.intent, 'Raise fire rating');
+    assert.strictEqual(manifest?.base?.kind, 'stack');
+
+    // The layer composes: the merge engine sees the new value on top.
+    const state = extractStackState([base, stored]);
+    const pset = state.get('wall-guid-1')?.components.get('pset:Pset_FireSafety');
+    assert.deepStrictEqual(pset?.[FIRE], { type: 'IfcLabel', value: 'REI90' });
+  });
+
+  it('is deterministic: same edits, same created stamp, same content address', async () => {
+    const store = await BrowserLayerStore.open();
+    const init = {
+      store,
+      stackFiles: [makeBase()],
+      mutations: [mutation({ psetName: 'Pset_FireSafety', propName: 'FireRating', newValue: 'REI90' })],
+      pathOf: () => 'wall-guid-1',
+      intent: 'Raise fire rating',
+      authorPrincipal: 'louis',
+      refName: 'local',
+      created: '2026-07-11T12:00:00Z',
+    };
+    const a = publishViewerDraft(init);
+    const b = publishViewerDraft(init); // idempotent re-store, ref gains the id twice
+    assert.strictEqual(a.layerId, b.layerId);
+  });
+
+  it('reports unresolved entities and refuses an empty layer', async () => {
+    const store = await BrowserLayerStore.open();
+    assert.throws(
+      () =>
+        publishViewerDraft({
+          store,
+          stackFiles: [makeBase()],
+          mutations: [mutation({ psetName: 'Pset_X', propName: 'A', newValue: 1, entityId: 99 })],
+          pathOf: () => undefined,
+          intent: 'Nothing resolvable',
+          authorPrincipal: 'louis',
+          refName: 'local',
+        }),
+      /No publishable changes/,
+    );
+  });
+
+  it('property deletion and attribute edits serialize as removal opinions and prop keys', async () => {
+    const store = await BrowserLayerStore.open();
+    const result = publishViewerDraft({
+      store,
+      stackFiles: [makeBase()],
+      mutations: [
+        mutation({ id: 'm1', type: 'DELETE_PROPERTY', psetName: 'Pset_FireSafety', propName: 'FireRating' }),
+        mutation({ id: 'm2', type: 'UPDATE_ATTRIBUTE', attributeName: 'Name', newValue: 'Wall W1' }),
+      ],
+      pathOf: () => 'wall-guid-1',
+      intent: 'Cleanup',
+      authorPrincipal: 'louis',
+      refName: 'local',
+      created: '2026-07-11T12:00:00Z',
+    });
+    const node = result.file.data.find((n) => n.path === 'wall-guid-1');
+    assert.strictEqual(node?.attributes?.[FIRE], null);
+    assert.deepStrictEqual(node?.attributes?.['bsi::ifc::prop::Name'], { type: 'IfcLabel', value: 'Wall W1' });
+    // Composition drops the removed member.
+    const state = extractStackState([makeBase(), result.file]);
+    assert.strictEqual(state.get('wall-guid-1')?.components.get('pset:Pset_FireSafety'), undefined);
+  });
+});
+
+describe('BrowserLayerStore integrity', () => {
+  it('refuses a header id that does not match the content address', async () => {
+    const store = await BrowserLayerStore.open();
+    const bogus = { ...makeBase(), header: { ...makeBase().header, id: 'blake3:not-really' } };
+    assert.throws(() => store.storeLayer(bogus), /does not match content address/);
+  });
+});

--- a/apps/viewer/src/lib/layers/publish.test.ts
+++ b/apps/viewer/src/lib/layers/publish.test.ts
@@ -130,7 +130,9 @@ describe('publishViewerDraft (#1717 V2)', () => {
     });
     const node = result.file.data.find((n) => n.path === 'wall-guid-1');
     assert.strictEqual(node?.attributes?.[FIRE], null);
-    assert.deepStrictEqual(node?.attributes?.['bsi::ifc::prop::Name'], { type: 'IfcLabel', value: 'Wall W1' });
+    // Core attributes stay raw — the entity/hierarchy extractors only
+    // honor a plain string here.
+    assert.strictEqual(node?.attributes?.['bsi::ifc::prop::Name'], 'Wall W1');
     // Composition drops the removed member.
     const state = extractStackState([makeBase(), result.file]);
     assert.strictEqual(state.get('wall-guid-1')?.components.get('pset:Pset_FireSafety'), undefined);

--- a/apps/viewer/src/lib/layers/publish.ts
+++ b/apps/viewer/src/lib/layers/publish.ts
@@ -63,7 +63,10 @@ function wireEntry(
     return { key: `${V5A_PREFIX}${set}::${member}`, value: wire };
   }
   if (componentKey === 'attr:core') {
-    return { key: `${ATTR.PROP_PREFIX}${member}`, value: value === null ? null : typedPropertyRecord(value) };
+    // Core attributes travel RAW: the IFCX entity/hierarchy extractors
+    // only honor e.g. `bsi::ifc::prop::Name` when the composed value is
+    // a plain string — a typed record would compose but never display.
+    return { key: `${ATTR.PROP_PREFIX}${member}`, value };
   }
   return null;
 }

--- a/apps/viewer/src/lib/layers/publish.ts
+++ b/apps/viewer/src/lib/layers/publish.ts
@@ -1,0 +1,197 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Draft publishing from viewer edits (#1717 V2): pending `Mutation`s fold
+ * into component-granular ops (`changeSetToOps`), serialize as an IFCX
+ * delta document in the same wire dialect the MCP draft tools and the
+ * collab snapshot pipeline emit, then freeze into an immutable,
+ * content-addressed, provenance-stamped layer on the local store.
+ *
+ * Identity: for IFCX models the composition PATH is the stable entity
+ * identity (the node path is the GUID), so the resolver maps expressId →
+ * path via the composition's id bridge. Entities the bridge cannot
+ * resolve are reported, never guessed (04-identity.md).
+ */
+
+import {
+  computeLayerId,
+  computeStackHash,
+  createProvenanceManifest,
+  setProvenance,
+  ATTR,
+  IFCLITE_ATTR,
+} from '@ifc-lite/ifcx';
+import type { IfcxFile, IfcxNode } from '@ifc-lite/ifcx';
+import { extractStackState } from '@ifc-lite/merge';
+import { changeSetToOps } from '@ifc-lite/mutations';
+import type { ChangeSet, ChangeSetOp, Mutation, PropertyValue } from '@ifc-lite/mutations';
+import type { BrowserLayerStore } from './browser-store';
+
+const V5A_PREFIX = 'bsi::ifc::v5a::';
+
+/**
+ * Canonical wire shape for property values (#1031): scalars wrap in the
+ * typed record the collab pipeline emits, so equivalent edits hash
+ * identically in the merge engine regardless of the writer.
+ */
+function typedPropertyRecord(value: PropertyValue): unknown {
+  if (typeof value === 'boolean') return { type: 'IfcBoolean', value };
+  if (typeof value === 'number') {
+    return { type: Number.isInteger(value) ? 'IfcInteger' : 'IfcReal', value };
+  }
+  if (typeof value === 'string') return { type: 'IfcLabel', value };
+  return value;
+}
+
+/** Wire attribute key + value for one member of a component. */
+function wireEntry(
+  componentKey: string,
+  member: string,
+  value: PropertyValue | null,
+): { key: string; value: unknown } | null {
+  if (componentKey.startsWith('pset:')) {
+    const set = componentKey.slice('pset:'.length);
+    return { key: `${V5A_PREFIX}${set}::${member}`, value: value === null ? null : typedPropertyRecord(value) };
+  }
+  if (componentKey.startsWith('qset:')) {
+    const set = componentKey.slice('qset:'.length);
+    // The quantities branch stores plain finite numbers (inflation
+    // unwraps typed records under Qto_* anyway).
+    const wire = typeof value === 'number' && Number.isFinite(value) ? value : value === null ? null : typedPropertyRecord(value);
+    return { key: `${V5A_PREFIX}${set}::${member}`, value: wire };
+  }
+  if (componentKey === 'attr:core') {
+    return { key: `${ATTR.PROP_PREFIX}${member}`, value: value === null ? null : typedPropertyRecord(value) };
+  }
+  return null;
+}
+
+/**
+ * Serialize component ops as IFCX node opinions. Whole-component
+ * tombstones null every member visible in the base state — composition
+ * is per-attribute LWW, so anything not explicitly nulled shines
+ * through.
+ */
+export function buildDeltaNodes(ops: readonly ChangeSetOp[], baseFiles: readonly IfcxFile[]): IfcxNode[] {
+  const baseState = ops.some((op) => op.op === 'tombstone-component')
+    ? extractStackState(baseFiles)
+    : null;
+  const byPath = new Map<string, IfcxNode>();
+  const nodeFor = (path: string): IfcxNode => {
+    let node = byPath.get(path);
+    if (!node) {
+      node = { path };
+      byPath.set(path, node);
+    }
+    return node;
+  };
+
+  for (const op of ops) {
+    const node = nodeFor(op.entity);
+    switch (op.op) {
+      case 'set-component': {
+        for (const [member, value] of Object.entries(op.values)) {
+          const entry = wireEntry(op.componentKey, member, value);
+          if (entry) node.attributes = { ...node.attributes, [entry.key]: entry.value };
+        }
+        break;
+      }
+      case 'tombstone-component': {
+        const baseEntity = baseState?.get(op.entity);
+        const members = baseEntity?.components.get(op.componentKey);
+        for (const key of Object.keys(members ?? {})) {
+          node.attributes = { ...node.attributes, [key]: null };
+        }
+        break;
+      }
+      case 'add-entity': {
+        node.attributes = {
+          ...node.attributes,
+          ...(op.ifcType ? { [ATTR.CLASS]: { code: op.ifcType } } : {}),
+        };
+        break;
+      }
+      case 'tombstone-entity': {
+        node.attributes = { ...node.attributes, [IFCLITE_ATTR.DELETED]: true };
+        break;
+      }
+    }
+  }
+
+  return [...byPath.values()]
+    .filter((node) => node.attributes !== undefined)
+    .sort((a, b) => (a.path < b.path ? -1 : a.path > b.path ? 1 : 0));
+}
+
+export interface PublishDraftInit {
+  store: BrowserLayerStore;
+  /** The composition the edits were made against, weakest first. */
+  stackFiles: readonly IfcxFile[];
+  /** Pending viewer mutations to freeze. */
+  mutations: readonly Mutation[];
+  /** expressId → composition path (the layer-stack bridge, inverted). */
+  pathOf: (expressId: number) => string | undefined;
+  intent: string;
+  authorPrincipal: string;
+  /** Local ref the published layer appends to. */
+  refName: string;
+  created?: string;
+}
+
+export interface PublishDraftResult {
+  layerId: string;
+  file: IfcxFile;
+  opCount: number;
+  /** expressIds with no resolvable identity — excluded from the layer. */
+  unresolved: number[];
+}
+
+/** Freeze pending edits into a published layer on the local store. */
+export function publishViewerDraft(init: PublishDraftInit): PublishDraftResult {
+  const changeSet: ChangeSet = {
+    id: 'viewer-draft',
+    name: init.intent,
+    createdAt: Date.now(),
+    mutations: [...init.mutations],
+    applied: true,
+  };
+  const { ops, identityMap, unresolved } = changeSetToOps(changeSet, {
+    globalIdOf: (expressId) => init.pathOf(expressId),
+  });
+  const data = buildDeltaNodes(ops, init.stackFiles);
+  if (data.length === 0) {
+    throw new Error('No publishable changes: every pending edit failed identity resolution or was empty.');
+  }
+
+  const manifest = createProvenanceManifest({
+    author: { kind: 'human', principal: init.authorPrincipal },
+    intent: init.intent,
+    base: { kind: 'stack', id: computeStackHash(init.stackFiles.map((f) => f.header.id)) },
+    identity_map: identityMap,
+    created: init.created,
+  });
+
+  const bare: IfcxFile = {
+    header: {
+      id: '',
+      ifcxVersion: 'ifcx_alpha',
+      dataVersion: '1.0.0',
+      author: init.authorPrincipal,
+      timestamp: manifest.created,
+    },
+    imports: [],
+    schemas: {},
+    data,
+  };
+  const withManifest = setProvenance(bare, manifest);
+  const layerId = computeLayerId(withManifest);
+  const file: IfcxFile = { ...withManifest, header: { ...withManifest.header, id: layerId } };
+
+  init.store.storeLayer(file);
+  const existing = init.store.getRef(init.refName);
+  init.store.setRef(init.refName, { layers: [...(existing?.layers ?? []), layerId] });
+
+  return { layerId, file, opCount: ops.length, unresolved };
+}


### PR DESCRIPTION
## Summary

Phase V2 of #1717: viewer edits become published layers. Pending property/attribute mutations freeze into an immutable, content-addressed, provenance-stamped IFCX layer on a browser-local store, then stack straight back onto the live composition as the strongest overlay. Stacked on #1718 (V1 panel) which is stacked on #1027 — merge in that order.

## What it does

- **`BrowserLayerStore`** (`lib/layers/browser-store.ts`): the CLI's `.ifc-lite/` layout on IndexedDB — content-addressed `layers` plus a named-`refs` record. The merge engine's `LayerRefStore` interface is sync, so working state lives in memory with IndexedDB as a write-through mirror (hydrate on open, fire-and-forget persists, memory-only degradation). First-write-wins per content address with a server-parity integrity gate.
- **Publish flow** (`lib/layers/publish.ts`): pending `Mutation`s → `changeSetToOps` (identity = composition path via the layer-stack bridge; unresolved entities reported, never guessed) → IFCX delta in the same wire dialect the MCP draft tools emit (`bsi::ifc::v5a::<Set>::<Member>` with typed property records, `bsi::ifc::prop::<Attr>` for core attributes, removal opinions as nulls, whole-set tombstones null every base member) → provenance manifest (author, intent, stack-hash base, identity_map) → blake3 content address → stored + appended to the local ref.
- **Draft section** in the Layers panel: pending-edit count (live via `mutationVersion`), intent + author inputs, publish button. After publishing, the layer is fed back through `addIfcxOverlays`, so it appears as the strongest stratum with its Human badge, intent line, and content chip; pending edits clear.

## Two host bugs found by driving the flow end-to-end

- **Federated models could not be edited at all**: the federation path built its data store inline without the lazy `getEntity`/`getProperties`/`getQuantities` accessors, so selecting an entity crashed PropertiesPanel (`this.store.getProperties is not a function`). It now routes through the shared `buildIfcxDataStore` factory (same as single-file IFCX).
- **`addIfcxOverlays` added new overlays as the WEAKEST layer**: `[...newBuffers, ...existingBuffers]` with parseFederatedIfcx's first-is-weakest semantics meant every added overlay was silently shadowed by the model it was meant to override (the code comment asserted the opposite). Order flipped; a published edit now actually wins composition.

## Verification

- Unit tests: publish round-trip (content address, provenance, ref append, merge-engine composition of the result), determinism (same edits + created stamp → same blake3), unresolved-identity refusal, deletion/attribute wire forms, store integrity gate. Full viewer suite green.
- Localhost (vite + Chrome DevTools MCP): loaded hello-wall + fire-rating overlay, edited the wall's FireRating to REI120 through the real mutation view, published via the panel — stack grew to 3 with the published layer strongest (Human badge, intent, blake3 chip), composed FireRating = REI120, pending edits cleared, and both layers + the `local` ref survived a page reload in IndexedDB.

## Notes
- Merge/preview against local refs and the registry client are V3 (#1717).
- Geometry-affecting edits and collab Y.Doc drafts are follow-ups; this covers property/quantity/attribute edits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Draft layer section for publishing pending viewer edits with an intent and author.
  * Published edits are saved as immutable local layers and automatically added to the current composition.
  * Added browser-local layer storage with persistence through IndexedDB and an in-memory fallback.
  * Added provenance details and feedback messages for successful, failed, or unresolved publishes.
  * Corrected overlay ordering so newly added layers take precedence.

* **Bug Fixes**
  * Improved handling of deleted properties and component updates when publishing edits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->