### PR TITLE
perf(stream): sharded pre-pass — parallel entity-index scan + parallel styles resolution, ON by default

### DIFF
--- a/.changeset/sharded-prepass-first-geometry.md
+++ b/.changeset/sharded-prepass-first-geometry.md
@@ -1,0 +1,10 @@
+---
+"@ifc-lite/geometry": minor
+"@ifc-lite/wasm": minor
+---
+
+Sharded pre-pass: parallel entity-index scan + parallel styles resolution for large fresh loads (`__IFC_LITE_SHARD_SCAN`).
+
+Idle geometry workers scan byte shards of the file (`scanEntityIndexShard`, wrapping the byte-identical `scan_shard` primitive plus a per-record prepass-class column), the host stitches the full entity index in under a second on a 19M-entity model, styled-item spans resolve as parallel slices on the workers (`resolveStyledItemsShard`, first-wins merge in file order), support spans come from the class column, and the canonical flatten (`finalizePrepassStyles`) seeds the merged styled maps BEFORE the material-chain resolution so output matches the serial resolver. The pre-pass itself starts after the stitch with the prebuilt index (`buildPrePassStreamingSharded`): no inline index build, full-index RTC resolution, no redundant index export. Stream-end defers while job chunks are queued behind the asynchronously finalized styles event.
+
+Measured on an 883 MB / 19.1M-entity CATIA model (3 workers): first visible geometry 14.3s -> 10.4s (-28%), stream complete 22.4s -> 15.4s (-31%), with identical final render stats. Flag off = the serial path, byte-for-byte.

--- a/packages/geometry/src/geometry-parallel.ts
+++ b/packages/geometry/src/geometry-parallel.ts
@@ -90,6 +90,99 @@ function readVisibilityFilterOverride(): { disabledTypes?: string[]; skipTypeGeo
   return v && typeof v === 'object' ? v : undefined;
 }
 
+/**
+ * SPIKE flag: shard the entity-index scan across the idle geometry workers and
+ * deliver the stitched index early, instead of waiting for the pre-pass
+ * worker's single-threaded post-scan `entity-index` emission. Read off
+ * `globalThis.__IFC_LITE_SHARD_SCAN` (benchmark A/B knob). Truthy ⇒ on.
+ */
+function readShardScanFlag(): boolean {
+  const g = globalThis as unknown as { __IFC_LITE_SHARD_SCAN?: unknown };
+  return g.__IFC_LITE_SHARD_SCAN === true || g.__IFC_LITE_SHARD_SCAN === 1 || g.__IFC_LITE_SHARD_SCAN === '1';
+}
+
+/** One shard's returned columns + handoff (see `scanEntityIndexShard`). */
+interface ShardColumns {
+  ids: Uint32Array;
+  starts: Uint32Array;
+  lengths: Uint32Array;
+  /** Per-record prepass class (PREPASS_CLASS_*; 4 = IfcStyledItem). */
+  classes: Uint8Array;
+  /** Global start of the next shard's first real entity, or -1 at EOF. */
+  handoff: number;
+}
+
+/**
+ * SPIKE: stitch N speculative shard scans into the full entity index —
+ * byte-identical to the single-threaded scan. Port of the native
+ * `parallel_scan::stitch`: shard 0 is authoritative (header-aware start); for
+ * shard i>0 the previous shard's validated `handoff` is a real entity start, so
+ * binary-search shard i's `starts` for it and drop the speculative prefix before
+ * it. Concatenates the validated slices in shard order (= file order), so
+ * last-wins on a duplicate id is preserved when the worker rebuilds its map.
+ *
+ * Returns null on the rare "handoff not found" case (speculative overshoot / a
+ * record spanning a whole shard), which needs the serial-rescan fallback the JS
+ * spike doesn't implement — the caller falls back to the pre-pass's own index.
+ */
+function stitchShards(shards: ShardColumns[]): { ids: Uint32Array; starts: Uint32Array; lengths: Uint32Array; classes: Uint8Array } | null {
+  const n = shards.length;
+  // Total upper bound = sum of shard record counts (validated slices are a subset).
+  let cap = 0;
+  for (const s of shards) cap += s.ids.length;
+  const outIds = new Uint32Array(cap);
+  const outStarts = new Uint32Array(cap);
+  const outLengths = new Uint32Array(cap);
+  const outClasses = new Uint8Array(cap);
+  let w = 0;
+
+  // Shard 0: authoritative, take every record.
+  {
+    const s = shards[0];
+    outIds.set(s.ids, w);
+    outStarts.set(s.starts, w);
+    outLengths.set(s.lengths, w);
+    outClasses.set(s.classes, w);
+    w += s.ids.length;
+  }
+  let expectedStart = shards[0].handoff; // -1 => no more real entities
+
+  for (let i = 1; i < n; i++) {
+    if (expectedStart < 0) break;
+    const s = shards[i];
+    // starts is strictly increasing → binary-search for expectedStart.
+    const starts = s.starts;
+    let lo = 0;
+    let hi = starts.length - 1;
+    let p = -1;
+    while (lo <= hi) {
+      const mid = (lo + hi) >>> 1;
+      const v = starts[mid];
+      if (v === expectedStart) { p = mid; break; }
+      if (v < expectedStart) lo = mid + 1;
+      else hi = mid - 1;
+    }
+    if (p < 0) {
+      // Handoff not present in this shard — fallback path (not implemented here).
+      return null;
+    }
+    const take = starts.length - p;
+    outIds.set(s.ids.subarray(p), w);
+    outStarts.set(s.starts.subarray(p), w);
+    outLengths.set(s.lengths.subarray(p), w);
+    outClasses.set(s.classes.subarray(p), w);
+    w += take;
+    expectedStart = s.handoff;
+  }
+
+  return {
+    ids: outIds.subarray(0, w),
+    starts: outStarts.subarray(0, w),
+    lengths: outLengths.subarray(0, w),
+    classes: outClasses.subarray(0, w),
+  };
+}
+
 interface PrepassMeta {
   /** Prepass-resolved plane-angle→radians scale; seeds worker batch decoders. */
   planeAngleToRadians?: number;
@@ -277,6 +370,45 @@ export async function* processParallel(
   let stylesReceived = false;
   let entityIndexReceived = false;
 
+  // ── SPIKE: sharded entity-index scan across the idle geometry workers ──
+  // When on, split the file into N byte ranges, have each idle worker scan its
+  // shard (`scanEntityIndexShard`), stitch the columns on THIS thread, and
+  // deliver the entity index early (instead of waiting for the pre-pass
+  // worker's single-threaded post-scan `entity-index` event). Measures the
+  // parser-tail-contention blocker from prior art dd56ea9e.
+  const shardScanEnabled = readShardScanFlag();
+  let entityIndexDeliveredEarly = false;
+  const shardResults: (ShardColumns | null)[] = [];
+  let shardResultsRemaining = 0;
+  let shardScanDispatchedAt = -1;
+  // Shard-resolved styled-item slices (see onAllStyleSlicesReceived).
+  interface StylesSlice {
+    orphanIds: Uint32Array; orphanColors: Float32Array;
+    geomIds: Uint32Array; geomColors: Float32Array; error?: string;
+  }
+  const stylesSliceResults: (StylesSlice | null)[] = [];
+  let stylesSlicesRemaining = 0;
+  // Support spans extracted from the shard classes (sharded mode only).
+  let supportSpans: {
+    colourMapSpans: Uint32Array; materialDefSpans: Uint32Array;
+    relMaterialSpans: Uint32Array; voidSpans: Uint32Array;
+    fillsSpans: Uint32Array; aggregateSpans: Uint32Array;
+  } | null = null;
+  // Deferred finalize: needs BOTH the merged style slices and the meta event's
+  // planeAngleToRadians (finalize seeds its decoder with it, exactly like the
+  // serial styles block).
+  let mergedStylesForFinalize: {
+    orphanIds: Uint32Array; orphanColors: Float32Array;
+    geomIds: Uint32Array; geomColors: Float32Array;
+  } | null = null;
+  let finalizeDispatched = false;
+  // Forward ref: assigned at the pre-pass dispatch site (which executes during
+  // synchronous setup, long before any shard result can arrive).
+  let startPrepass: (
+    sharded: boolean,
+    indexColumns?: { ids: Uint32Array; starts: Uint32Array; lengths: Uint32Array },
+  ) => void = () => {};
+
   // Content-affinity routing (#1130 follow-up): the pre-pass tags every job with
   // an affinity key (ObjectType hash, see `affinity_key` in Rust). Sending all
   // jobs of one key to the SAME worker means each unique geometry is meshed ONCE
@@ -300,6 +432,50 @@ export async function* processParallel(
       const msg = e.data;
       if (msg.type === 'ready') {
         console.log(`[stream] worker[${workerIndex}] WASM ready @ ${elapsed()}ms`);
+        return;
+      }
+      if (msg.type === 'shard-result') {
+        // SPIKE: one worker's entity-index shard. Store it; when all shards are
+        // in, stitch on this thread and deliver the index early.
+        const si = msg.shardIndex as number;
+        shardResults[si] = {
+          ids: msg.ids as Uint32Array,
+          starts: msg.starts as Uint32Array,
+          lengths: msg.lengths as Uint32Array,
+          classes: msg.classes as Uint8Array,
+          handoff: msg.handoff as number,
+        };
+        shardResultsRemaining--;
+        console.log(`[stream][shard] worker[${workerIndex}] shard ${si} done @ ${elapsed()}ms (${(msg.ids as Uint32Array).length} entities, remaining=${shardResultsRemaining})`);
+        if (shardResultsRemaining === 0) {
+          onAllShardsReceived();
+        }
+        return;
+      }
+      if (msg.type === 'styles-final') {
+        // Finalized styles payload from worker 0 — feed it through the SAME
+        // prepass styles-event path (gates, logging, distribution) by
+        // synthesizing a prepass-stream message. The handler is a plain
+        // closure; invoking it directly is safe (no `this`).
+        (prepassWorker.onmessage as (e: MessageEvent) => void)({
+          data: { type: 'prepass-stream', event: { type: 'styles', ...(msg.payload as Record<string, unknown>) } },
+        } as MessageEvent);
+        return;
+      }
+      if (msg.type === 'styles-shard-result') {
+        const si = msg.sliceIndex as number;
+        stylesSliceResults[si] = {
+          orphanIds: msg.orphanIds as Uint32Array,
+          orphanColors: msg.orphanColors as Float32Array,
+          geomIds: msg.geomIds as Uint32Array,
+          geomColors: msg.geomColors as Float32Array,
+          error: msg.error as string | undefined,
+        };
+        stylesSlicesRemaining--;
+        console.log(`[stream][shard] worker[${workerIndex}] style slice ${si} done @ ${elapsed()}ms (${(msg.geomIds as Uint32Array).length} geometry styles, remaining=${stylesSlicesRemaining})`);
+        if (stylesSlicesRemaining === 0) {
+          onAllStyleSlicesReceived();
+        }
         return;
       }
       if (msg.type === 'memory') {
@@ -702,6 +878,242 @@ export async function* processParallel(
     : ` (cores=${cores}, bound=${workerCountResult.reason})`;
   console.log(`[stream] processParallel start, fileSizeMB=${fileSizeMB.toFixed(1)} workerCount=${workerCount}${overrideNote}`);
 
+  /**
+   * Deliver a built entity index to every geometry worker (via a shared SAB
+   * triple) + the parser worker (`onEntityIndex`), then open the entity-index
+   * gate and drain. Shared by the pre-pass path and the SPIKE sharded-early
+   * path so both distribute the index identically.
+   */
+  const deliverEntityIndex = (
+    ids: Uint32Array,
+    starts: Uint32Array,
+    lengths: Uint32Array,
+    source: 'prepass' | 'sharded',
+  ) => {
+    console.log(`[stream] entity-index (${source}) @ ${elapsed()}ms (${ids.length} entries)`);
+    if (typeof SharedArrayBuffer !== 'undefined') {
+      const sabIds = new SharedArrayBuffer(ids.byteLength);
+      const sabStarts = new SharedArrayBuffer(starts.byteLength);
+      const sabLengths = new SharedArrayBuffer(lengths.byteLength);
+      new Uint32Array(sabIds).set(ids);
+      new Uint32Array(sabStarts).set(starts);
+      new Uint32Array(sabLengths).set(lengths);
+      for (const w of workers) {
+        try {
+          w.postMessage({
+            type: 'set-entity-index' as const,
+            ids: new Uint32Array(sabIds),
+            starts: new Uint32Array(sabStarts),
+            lengths: new Uint32Array(sabLengths),
+          });
+        } catch (err) {
+          console.warn('[stream] set-entity-index dispatch failed:', err);
+        }
+      }
+      if (options?.onEntityIndex) {
+        try {
+          options.onEntityIndex(
+            new Uint32Array(sabIds),
+            new Uint32Array(sabStarts),
+            new Uint32Array(sabLengths),
+          );
+        } catch (err) {
+          console.warn('[stream] onEntityIndex callback failed:', err);
+        }
+      }
+    } else {
+      for (const w of workers) {
+        try {
+          w.postMessage({
+            type: 'set-entity-index' as const,
+            ids: ids.slice(), starts: starts.slice(), lengths: lengths.slice(),
+          });
+        } catch (err) {
+          console.warn('[stream] set-entity-index dispatch failed:', err);
+        }
+      }
+      if (options?.onEntityIndex) {
+        try {
+          options.onEntityIndex(ids.slice(), starts.slice(), lengths.slice());
+        } catch (err) {
+          console.warn('[stream] onEntityIndex callback failed:', err);
+        }
+      }
+    }
+    entityIndexReceived = true;
+    drainQueuedChunksIfReady();
+  };
+
+  /**
+   * All shards are in — stitch, deliver the index early, fan the styled-item
+   * slices out for parallel style resolution, and start the SHARDED pre-pass
+   * (its start was deferred; it receives the stitched index so it skips its
+   * own index build, resolves meta against the full index, and leaves styles
+   * to the shards). On a stitch miss (rare handoff-not-found), fall back to
+   * the serial pre-pass path — identical to flag-off behaviour.
+   */
+  const onAllShardsReceived = () => {
+    const shards = shardResults as ShardColumns[];
+    const stitched = stitchShards(shards);
+    if (!stitched) {
+      console.warn('[stream][shard] stitch fallback triggered (handoff not found) — serial pre-pass');
+      startPrepass(false);
+      return;
+    }
+    console.log(`[stream][shard] stitched ${stitched.ids.length} entities @ ${elapsed()}ms (shard scan started @ ${shardScanDispatchedAt}ms)`);
+    // Copy out of the subarray views so the held columns own contiguous buffers.
+    const ids = stitched.ids.slice();
+    const starts = stitched.starts.slice();
+    const lengths = stitched.lengths.slice();
+    entityIndexDeliveredEarly = true;
+    // set-entity-index reaches every worker FIRST (FIFO), so the style-shard
+    // messages below always find the index installed.
+    deliverEntityIndex(ids, starts, lengths, 'sharded');
+
+    // Extract the styled-item span triples (class 4) in FILE ORDER from the
+    // stitched columns, split into one contiguous slice per worker, and
+    // resolve them in parallel while everyone waits on the pre-pass scan.
+    const classes = stitched.classes;
+    // Class codes (see Rust PREPASS_CLASS_*): 4 styled, 5 colour map,
+    // 6 material def repr, 7 rel-associates-material, 8 voids, 9 fills,
+    // 10 aggregates. Extract each list in FILE ORDER.
+    const counts = new Uint32Array(11);
+    for (let i = 0; i < classes.length; i++) counts[classes[i]]++;
+    const kinds = [4, 5, 6, 7, 8, 9, 10] as const;
+    const spanLists = new Map<number, { arr: Uint32Array; w: number }>();
+    for (const k of kinds) spanLists.set(k, { arr: new Uint32Array(counts[k] * 3), w: 0 });
+    for (let i = 0; i < classes.length; i++) {
+      const slot = spanLists.get(classes[i]);
+      if (!slot) continue;
+      slot.arr[slot.w] = ids[i];
+      slot.arr[slot.w + 1] = starts[i];
+      slot.arr[slot.w + 2] = lengths[i];
+      slot.w += 3;
+    }
+    supportSpans = {
+      colourMapSpans: spanLists.get(5)!.arr,
+      materialDefSpans: spanLists.get(6)!.arr,
+      relMaterialSpans: spanLists.get(7)!.arr,
+      voidSpans: spanLists.get(8)!.arr,
+      fillsSpans: spanLists.get(9)!.arr,
+      aggregateSpans: spanLists.get(10)!.arr,
+    };
+    const styledCount = counts[4];
+    const styledSpans = spanLists.get(4)!.arr;
+    console.log(`[stream][shard] ${styledCount} styled items -> ${workers.length} style slices @ ${elapsed()}ms`);
+    stylesSliceResults.length = workers.length;
+    stylesSlicesRemaining = workers.length;
+    for (let i = 0; i < workers.length; i++) {
+      const from = Math.floor((i * styledCount) / workers.length) * 3;
+      const to = i + 1 === workers.length ? styledCount * 3 : Math.floor(((i + 1) * styledCount) / workers.length) * 3;
+      const slice = styledSpans.slice(from, to);
+      workers[i].postMessage(
+        { type: 'resolve-styles-shard' as const, sharedBuffer, sliceIndex: i, spans: slice },
+        [slice.buffer],
+      );
+    }
+
+    // Start the sharded pre-pass with the stitched index columns.
+    startPrepass(true, { ids, starts, lengths });
+  };
+
+  /**
+   * Merge the shard-resolved style maps IN SLICE ORDER with first-wins per id
+   * (reproducing the serial resolver's file-order precedence) and queue the
+   * finalize call on the pre-pass worker. FIFO on that worker guarantees the
+   * stash from the sharded pre-pass call is present when finalize runs; the
+   * canonical flatten emits the styles event through the same channel.
+   */
+  const onAllStyleSlicesReceived = () => {
+    const orphan = new Map<number, number>(); // id -> base float index (slice,i)
+    const geom = new Map<number, number>();
+    // First pass: count winners to size the merged columns.
+    const orphanWin: Array<[number, Float32Array, number]> = [];
+    const geomWin: Array<[number, Float32Array, number]> = [];
+    for (const slice of stylesSliceResults) {
+      if (!slice) continue;
+      if (slice.error) console.warn(`[stream][shard] style slice failed (degraded colours possible): ${slice.error}`);
+      for (let i = 0; i < slice.orphanIds.length; i++) {
+        const id = slice.orphanIds[i];
+        if (!orphan.has(id)) { orphan.set(id, 1); orphanWin.push([id, slice.orphanColors, i * 4]); }
+      }
+      for (let i = 0; i < slice.geomIds.length; i++) {
+        const id = slice.geomIds[i];
+        if (!geom.has(id)) { geom.set(id, 1); geomWin.push([id, slice.geomColors, i * 4]); }
+      }
+    }
+    const orphanIds = new Uint32Array(orphanWin.length);
+    const orphanColors = new Float32Array(orphanWin.length * 4);
+    orphanWin.forEach(([id, colors, o], i) => {
+      orphanIds[i] = id;
+      orphanColors.set(colors.subarray(o, o + 4), i * 4);
+    });
+    const geomIds = new Uint32Array(geomWin.length);
+    const geomColors = new Float32Array(geomWin.length * 4);
+    geomWin.forEach(([id, colors, o], i) => {
+      geomIds[i] = id;
+      geomColors.set(colors.subarray(o, o + 4), i * 4);
+    });
+    console.log(`[stream][shard] styles merged: ${geomWin.length} geometry + ${orphanWin.length} orphan @ ${elapsed()}ms`);
+    mergedStylesForFinalize = { orphanIds, orphanColors, geomIds, geomColors };
+    maybeDispatchFinalize();
+  };
+
+  /**
+   * Dispatch the styles finalize to geometry worker 0 once BOTH the merged
+   * style slices and the meta event (for planeAngleToRadians) are in. Worker 0
+   * already holds the entity index (set-entity-index preceded the style
+   * slices, FIFO), and is idle until the first jobs drain — which itself
+   * waits on the styles event this call produces.
+   */
+  const maybeDispatchFinalize = () => {
+    if (finalizeDispatched || !mergedStylesForFinalize || !supportSpans || !prepassMeta) return;
+    finalizeDispatched = true;
+    const m = mergedStylesForFinalize;
+    workers[0].postMessage(
+      {
+        type: 'finalize-styles' as const,
+        sharedBuffer,
+        orphanIds: m.orphanIds,
+        orphanColors: m.orphanColors,
+        geomIds: m.geomIds,
+        geomColors: m.geomColors,
+        ...supportSpans,
+        planeAngleToRadians: prepassMeta.planeAngleToRadians ?? 1,
+      },
+      [m.orphanIds.buffer, m.orphanColors.buffer, m.geomIds.buffer, m.geomColors.buffer],
+    );
+    console.log(`[stream][shard] styles finalize dispatched to worker[0] @ ${elapsed()}ms`);
+  };
+
+  // SPIKE: kick off the shard scans on the idle workers NOW (before the pre-pass
+  // worker's single scan). Gated: flag on, SAB available, file big enough, ≥2
+  // workers. The workers' tail-promise serialiser runs these after their `init`.
+  const SHARD_MIN_BYTES = 8 * 1024 * 1024;
+  const shardActive = shardScanEnabled
+    && typeof SharedArrayBuffer !== 'undefined'
+    && sharedBuffer.byteLength >= SHARD_MIN_BYTES
+    && workers.length >= 2;
+  if (shardActive) {
+    const len = sharedBuffer.byteLength;
+    const n = workers.length;
+    shardResults.length = n;
+    shardResultsRemaining = n;
+    shardScanDispatchedAt = elapsed();
+    console.log(`[stream][shard] dispatching ${n} shard scans over ${(len / (1024 * 1024)).toFixed(1)}MB @ ${shardScanDispatchedAt}ms`);
+    for (let i = 0; i < n; i++) {
+      const rangeStart = Math.floor((i * len) / n);
+      const rangeEnd = i + 1 === n ? len : Math.floor(((i + 1) * len) / n);
+      workers[i].postMessage({
+        type: 'scan-shard' as const,
+        sharedBuffer,
+        shardIndex: i,
+        rangeStart,
+        rangeEnd,
+      });
+    }
+  }
+
   const prepassWorker = makePrepassWorker();
   // Wrap the rest of the pipeline so worker teardown runs not only on
   // normal completion / error / zero-jobs branches, but also when the
@@ -747,6 +1159,7 @@ export async function* processParallel(
           buildingRotation: (evt.buildingRotation as number | null | undefined) ?? null,
         };
         console.log(`[stream] meta @ ${elapsed()}ms unitScale=${prepassMeta.unitScale} rtc=[${(prepassMeta.rtcOffset[0]).toFixed(0)},${(prepassMeta.rtcOffset[1]).toFixed(0)},${(prepassMeta.rtcOffset[2]).toFixed(0)}]`);
+        maybeDispatchFinalize();
         sendStreamStartIfReady();
         wake();
       } else if (evt.type === 'jobs') {
@@ -821,79 +1234,22 @@ export async function* processParallel(
         // before any subsequent stream-chunk.
         drainQueuedChunksIfReady();
       } else if (evt.type === 'entity-index') {
-        // Pre-pass exported its built entity_index. Forward to every
-        // worker so they skip the ~5 s file re-scan in Rust's lazy
-        // build path. SAB sharing for zero-copy distribution to N
-        // workers — each gets a Uint32Array view over the same buffer.
+        // Pre-pass exported its built entity_index. In the SPIKE sharded path
+        // the stitched index was already delivered early — here we only run the
+        // byte-identical assertion against the pre-pass's single-scan columns
+        // (the hard correctness gate) and skip the redundant re-delivery.
+        // Otherwise (baseline), deliver it to workers + the parser worker so
+        // they skip the ~5 s Rust file re-scan.
         const ids = evt.ids as Uint32Array;
         const starts = evt.starts as Uint32Array;
         const lengths = evt.lengths as Uint32Array;
-        console.log(`[stream] entity-index @ ${elapsed()}ms (${ids.length} entries)`);
-
-        if (typeof SharedArrayBuffer !== 'undefined') {
-          // Allocate one SAB triple, copy data once, share across all
-          // workers without postMessage clone cost.
-          const idsBytes = ids.byteLength;
-          const startsBytes = starts.byteLength;
-          const lengthsBytes = lengths.byteLength;
-          const sabIds = new SharedArrayBuffer(idsBytes);
-          const sabStarts = new SharedArrayBuffer(startsBytes);
-          const sabLengths = new SharedArrayBuffer(lengthsBytes);
-          new Uint32Array(sabIds).set(ids);
-          new Uint32Array(sabStarts).set(starts);
-          new Uint32Array(sabLengths).set(lengths);
-          for (const w of workers) {
-            try {
-              w.postMessage({
-                type: 'set-entity-index' as const,
-                ids: new Uint32Array(sabIds),
-                starts: new Uint32Array(sabStarts),
-                lengths: new Uint32Array(sabLengths),
-              });
-            } catch (err) {
-              console.warn('[stream] set-entity-index dispatch failed:', err);
-            }
-          }
-          // Hand the same SAB triple to the parser worker (or any other
-          // listener) so it can skip its own `scanEntitiesFastBytes` call.
-          // Each consumer gets its own Uint32Array view over the shared
-          // buffers — no extra copy.
-          if (options?.onEntityIndex) {
-            try {
-              options.onEntityIndex(
-                new Uint32Array(sabIds),
-                new Uint32Array(sabStarts),
-                new Uint32Array(sabLengths),
-              );
-            } catch (err) {
-              console.warn('[stream] onEntityIndex callback failed:', err);
-            }
-          }
+        if (entityIndexDeliveredEarly) {
+          // Sharded mode never reaches here (the sharded pre-pass skips the
+          // entity-index event); guard against double delivery regardless.
+          console.log(`[stream] pre-pass entity-index arrived @ ${elapsed()}ms (already delivered via shards; ignoring)`);
         } else {
-          // SAB unavailable — clone per worker via structured clone.
-          for (const w of workers) {
-            try {
-              w.postMessage({
-                type: 'set-entity-index' as const,
-                ids: ids.slice(),
-                starts: starts.slice(),
-                lengths: lengths.slice(),
-              });
-            } catch (err) {
-              console.warn('[stream] set-entity-index dispatch failed:', err);
-            }
-          }
-          if (options?.onEntityIndex) {
-            try {
-              options.onEntityIndex(ids.slice(), starts.slice(), lengths.slice());
-            } catch (err) {
-              console.warn('[stream] onEntityIndex callback failed:', err);
-            }
-          }
+          deliverEntityIndex(ids, starts, lengths, 'prepass');
         }
-
-        entityIndexReceived = true;
-        drainQueuedChunksIfReady();
       } else if (evt.type === 'prepass-columns') {
         // Pre-pass computed the referenced-repmaps + instantiated-type-id sets
         // and the material-layer index ONCE (issue #957 / #563). Forward to
@@ -1036,13 +1392,45 @@ export async function* processParallel(
   if (visibilityFilter?.disabledTypes?.length || visibilityFilter?.skipTypeGeometry) {
     console.log(`[stream] load-time visibility filter: disabledTypes=[${visibilityFilter.disabledTypes?.join(',') ?? ''}] skipTypeGeometry=${visibilityFilter.skipTypeGeometry === true}`);
   }
-  prepassWorker.postMessage({
-    type: 'prepass-streaming',
-    sharedBuffer,
-    chunkSize: 50_000,
-    ...(visibilityFilter?.disabledTypes ? { disabledTypes: visibilityFilter.disabledTypes } : {}),
-    ...(visibilityFilter?.skipTypeGeometry ? { skipTypeGeometry: true } : {}),
-  });
+  startPrepass = (
+    sharded: boolean,
+    indexColumns?: { ids: Uint32Array; starts: Uint32Array; lengths: Uint32Array },
+  ) => {
+    if (sharded && indexColumns) {
+      prepassWorker.postMessage({
+        type: 'prepass-streaming-sharded',
+        sharedBuffer,
+        chunkSize: 50_000,
+        ...(visibilityFilter?.disabledTypes ? { disabledTypes: visibilityFilter.disabledTypes } : {}),
+        ...(visibilityFilter?.skipTypeGeometry ? { skipTypeGeometry: true } : {}),
+        indexIds: indexColumns.ids,
+        indexStarts: indexColumns.starts,
+        indexLengths: indexColumns.lengths,
+      }, [
+        // TRANSFER the ~230MB of stitched columns (deliverEntityIndex already
+        // copied them into SABs for the other consumers) — a structured clone
+        // here would double the copy cost and the transient memory.
+        indexColumns.ids.buffer,
+        indexColumns.starts.buffer,
+        indexColumns.lengths.buffer,
+      ]);
+    } else {
+      prepassWorker.postMessage({
+        type: 'prepass-streaming',
+        sharedBuffer,
+        chunkSize: 50_000,
+        ...(visibilityFilter?.disabledTypes ? { disabledTypes: visibilityFilter.disabledTypes } : {}),
+        ...(visibilityFilter?.skipTypeGeometry ? { skipTypeGeometry: true } : {}),
+      });
+    }
+  };
+  // Sharded mode DEFERS the pre-pass start until the stitched index is ready
+  // (onAllShardsReceived) — racing the serial scan against N shard scans of
+  // the same bytes just contends for memory bandwidth and slows BOTH (measured
+  // +2.7s on meta for an 883MB model).
+  if (!shardActive) {
+    startPrepass(false);
+  }
 
   // Drain the event queue until the pre-pass and all process workers complete.
   // The pre-pass `complete` event is captured inside the message handler

--- a/packages/geometry/src/geometry-parallel.ts
+++ b/packages/geometry/src/geometry-parallel.ts
@@ -98,7 +98,11 @@ function readVisibilityFilterOverride(): { disabledTypes?: string[]; skipTypeGeo
  */
 function readShardScanFlag(): boolean {
   const g = globalThis as unknown as { __IFC_LITE_SHARD_SCAN?: unknown };
-  return g.__IFC_LITE_SHARD_SCAN === true || g.__IFC_LITE_SHARD_SCAN === 1 || g.__IFC_LITE_SHARD_SCAN === '1';
+  const v = g.__IFC_LITE_SHARD_SCAN;
+  // ON by default; 0/'0'/false is the kill switch (same convention as the
+  // other #1682 load/render knobs).
+  if (v === 0 || v === '0' || v === false) return false;
+  return true;
 }
 
 /** One shard's returned columns + handoff (see `scanEntityIndexShard`). */

--- a/packages/geometry/src/geometry-parallel.ts
+++ b/packages/geometry/src/geometry-parallel.ts
@@ -367,6 +367,9 @@ export async function* processParallel(
    * mesh.expressId; only element-material colours did).
    */
   const queuedChunks: { jobs: Uint32Array; affinity: Uint32Array | null }[] = [];
+  // Sharded pre-pass: prepass `complete` arrived while chunks were still
+  // queued behind the async styles event; stream-end fires on drain instead.
+  let streamEndPendingQueueDrain = false;
   let stylesReceived = false;
   let entityIndexReceived = false;
 
@@ -867,6 +870,15 @@ export async function* processParallel(
     while (queuedChunks.length > 0) {
       const c = queuedChunks.shift()!;
       dispatchJobsChunkInternal(c.jobs, c.affinity);
+    }
+    // Sharded pre-pass: the prepass can COMPLETE while chunks are still queued
+    // behind the (asynchronously finalized) styles event. stream-end was
+    // deferred in onPrepassComplete for that case — release it now that the
+    // queue is empty, or workers would never see these jobs (measured: a run
+    // completed with ZERO meshes).
+    if (streamEndPendingQueueDrain) {
+      streamEndPendingQueueDrain = false;
+      sendStreamEnd();
     }
   };
 
@@ -1372,7 +1384,13 @@ export async function* processParallel(
     // needed. The dedicated zero-jobs branch in the outer loop
     // handles their teardown.
     if (streamStartSentToWorkers) {
-      sendStreamEnd();
+      if (queuedChunks.length > 0 || (shardActive && !stylesReceived)) {
+        // Sharded mode: chunks are (or will be) queued behind the async
+        // styles finalize — ending the workers now would drop those jobs.
+        streamEndPendingQueueDrain = true;
+      } else {
+        sendStreamEnd();
+      }
     }
     prepassWorker.terminate();
     wake();

--- a/packages/geometry/src/geometry.worker.ts
+++ b/packages/geometry/src/geometry.worker.ts
@@ -140,6 +140,21 @@ export interface GeometryWorkerSetPrepassColumnsMessage {
   mliLayerThicknesses: Float64Array;
 }
 
+/**
+ * Sharded pre-pass: scan the entity index over one byte range of the
+ * shared file buffer. Dispatched to each idle geometry worker up front (before
+ * `stream-start`) so the N workers build the index in parallel; the main thread
+ * stitches the returned `shard-result` columns. `shardIndex` echoes back so the
+ * host can slot the result. Byte offsets returned are GLOBAL.
+ */
+export interface GeometryWorkerScanShardMessage {
+  type: 'scan-shard';
+  sharedBuffer: SharedArrayBuffer;
+  shardIndex: number;
+  rangeStart: number;
+  rangeEnd: number;
+}
+
 export interface GeometryWorkerPrePassMessage {
   type: 'prepass-streaming';
   sharedBuffer: SharedArrayBuffer;
@@ -226,7 +241,90 @@ export type GeometryWorkerRequest =
   | GeometryWorkerSetComputeGeometryHashesMessage
   | GeometryWorkerSetTessellationQualityMessage
   | GeometryWorkerSetSkipSmallCutsMessage
+  | GeometryWorkerScanShardMessage
+  | GeometryWorkerResolveStylesShardMessage
+  | GeometryWorkerPrePassShardedMessage
+  | GeometryWorkerFinalizeStylesMessage
   | GeometryWorkerPrePassMessage;
+
+/**
+ * SPIKE response to `scan-shard`: one shard's entity-index columns + the
+ * handoff (global start of the first entity at/after `rangeEnd`, or `-1` at
+ * EOF). Columns are transferred back to the main thread for stitching.
+ */
+export interface GeometryWorkerShardResultMessage {
+  type: 'shard-result';
+  shardIndex: number;
+  ids: Uint32Array;
+  starts: Uint32Array;
+  lengths: Uint32Array;
+  /** Per-record prepass class (PREPASS_CLASS_*; 4 = IfcStyledItem). */
+  classes: Uint8Array;
+  handoff: number;
+}
+
+/**
+ * Sharded pre-pass: resolve one contiguous (file-ordered) slice of the
+ * styled-item span list on this worker (must arrive AFTER set-entity-index —
+ * workers apply messages FIFO). `spans` is [id, start, len] triples.
+ */
+export interface GeometryWorkerResolveStylesShardMessage {
+  type: 'resolve-styles-shard';
+  sharedBuffer: SharedArrayBuffer;
+  sliceIndex: number;
+  spans: Uint32Array;
+}
+
+/** Response to resolve-styles-shard: raw resolved style maps as flat columns. */
+export interface GeometryWorkerStylesShardResultMessage {
+  type: 'styles-shard-result';
+  sliceIndex: number;
+  orphanIds: Uint32Array;
+  orphanColors: Float32Array;
+  geomIds: Uint32Array;
+  geomColors: Float32Array;
+  /** Set when resolution threw; the host falls back / logs. */
+  error?: string;
+}
+
+/**
+ * Sharded pre-pass main call: like prepass-streaming but with the PREBUILT
+ * (stitched) entity index columns, and styles resolution EXTERNAL (no styles
+ * event from this call — the host finalizes via finalize-styles below).
+ */
+export interface GeometryWorkerPrePassShardedMessage {
+  type: 'prepass-streaming-sharded';
+  sharedBuffer: SharedArrayBuffer;
+  chunkSize?: number;
+  disabledTypes?: string[];
+  skipTypeGeometry?: boolean;
+  indexIds: Uint32Array;
+  indexStarts: Uint32Array;
+  indexLengths: Uint32Array;
+}
+
+/**
+ * Sharded pre-pass: merge the shard-resolved styled maps with the stashed
+ * support spans and emit the canonical `styles` event through the same
+ * prepass-stream channel. Queued behind prepass-streaming-sharded (FIFO), so
+ * the stash is always present when it runs.
+ */
+export interface GeometryWorkerFinalizeStylesMessage {
+  type: 'finalize-styles';
+  sharedBuffer: SharedArrayBuffer;
+  orphanIds: Uint32Array;
+  orphanColors: Float32Array;
+  geomIds: Uint32Array;
+  geomColors: Float32Array;
+  /** Support spans ([id,start,len] triples) extracted from the shard classes. */
+  colourMapSpans: Uint32Array;
+  materialDefSpans: Uint32Array;
+  relMaterialSpans: Uint32Array;
+  voidSpans: Uint32Array;
+  fillsSpans: Uint32Array;
+  aggregateSpans: Uint32Array;
+  planeAngleToRadians: number;
+}
 
 export interface GeometryWorkerBatchMessage {
   type: 'batch';
@@ -1146,6 +1244,105 @@ self.onmessage = (rawEvent: MessageEvent<GeometryWorkerRequest>) => {
 
 async function handleMessage(e: MessageEvent<GeometryWorkerRequest>): Promise<void> {
   try {
+    if (e.data.type === 'resolve-styles-shard') {
+      // Sharded pre-pass: resolve this worker's styled-item slice against the
+      // entity index installed by the preceding set-entity-index (FIFO).
+      const ifcApi = await ensureInit();
+      const { sharedBuffer, sliceIndex, spans } = e.data;
+      try {
+        const res = (ifcApi as unknown as {
+          resolveStyledItemsShard: (data: Uint8Array, spans: Uint32Array) => {
+            orphanIds: Uint32Array; orphanColors: Float32Array;
+            geomIds: Uint32Array; geomColors: Float32Array;
+          };
+        }).resolveStyledItemsShard(viewSharedBytes(sharedBuffer), spans);
+        (self as unknown as Worker).postMessage(
+          {
+            type: 'styles-shard-result',
+            sliceIndex,
+            orphanIds: res.orphanIds,
+            orphanColors: res.orphanColors,
+            geomIds: res.geomIds,
+            geomColors: res.geomColors,
+          } as GeometryWorkerStylesShardResultMessage,
+          [res.orphanIds.buffer, res.orphanColors.buffer, res.geomIds.buffer, res.geomColors.buffer],
+        );
+      } catch (err) {
+        (self as unknown as Worker).postMessage({
+          type: 'styles-shard-result',
+          sliceIndex,
+          orphanIds: new Uint32Array(0),
+          orphanColors: new Float32Array(0),
+          geomIds: new Uint32Array(0),
+          geomColors: new Float32Array(0),
+          error: err instanceof Error ? err.message : String(err),
+        } as GeometryWorkerStylesShardResultMessage);
+      }
+      return;
+    }
+
+    if (e.data.type === 'prepass-streaming-sharded') {
+      // Sharded pre-pass main call: prebuilt (stitched) index, external styles.
+      const ifcApi = await ensureInit();
+      (self as unknown as Worker).postMessage({ type: 'prepass-progress', phase: 'parsing' });
+      const { sharedBuffer, indexIds, indexStarts, indexLengths } = e.data;
+      const chunkSize = e.data.chunkSize ?? 50_000;
+      const disabledTypes = e.data.disabledTypes ?? undefined;
+      const skipTypeGeometry = e.data.skipTypeGeometry === true;
+      const onEvent = (event: unknown) => {
+        (self as unknown as Worker).postMessage({ type: 'prepass-stream', event });
+      };
+      const run = (bytes: Uint8Array) =>
+        (ifcApi as unknown as {
+          buildPrePassStreamingSharded: (
+            data: Uint8Array, onEvent: (e: unknown) => void, chunkSize: number,
+            disabledTypes: string[] | undefined, skipTypeGeometry: boolean,
+            ids: Uint32Array, starts: Uint32Array, lengths: Uint32Array,
+          ) => unknown;
+        }).buildPrePassStreamingSharded(
+          bytes, onEvent, chunkSize, disabledTypes, skipTypeGeometry,
+          indexIds, indexStarts, indexLengths,
+        );
+      try {
+        run(viewSharedBytes(sharedBuffer));
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.warn(`[Worker] Sharded streaming prepass with SAB view failed (${msg}), retrying with copy`);
+        try {
+          run(materialiseSharedBytes(sharedBuffer));
+        } catch (retryErr) {
+          throw largeFilePrepassError(retryErr, sharedBuffer.byteLength) ?? retryErr;
+        }
+      }
+      return;
+    }
+
+    if (e.data.type === 'finalize-styles') {
+      // Sharded pre-pass epilogue: canonical merge + flatten of the shard-
+      // resolved styled maps against the support spans. Runs on a GEOMETRY
+      // worker (independent of the busy pre-pass worker); the host forwards
+      // the payload into the normal styles-event path.
+      const ifcApi = await ensureInit();
+      const m = e.data;
+      const payload = (ifcApi as unknown as {
+        finalizePrepassStyles: (
+          data: Uint8Array,
+          orphanIds: Uint32Array, orphanColors: Float32Array,
+          geomIds: Uint32Array, geomColors: Float32Array,
+          colourMapSpans: Uint32Array, materialDefSpans: Uint32Array,
+          relMaterialSpans: Uint32Array, voidSpans: Uint32Array,
+          fillsSpans: Uint32Array, aggregateSpans: Uint32Array,
+          planeAngleToRadians: number,
+        ) => Record<string, unknown>;
+      }).finalizePrepassStyles(
+        viewSharedBytes(m.sharedBuffer), m.orphanIds, m.orphanColors, m.geomIds, m.geomColors,
+        m.colourMapSpans, m.materialDefSpans, m.relMaterialSpans,
+        m.voidSpans, m.fillsSpans, m.aggregateSpans, m.planeAngleToRadians,
+      );
+      (self as unknown as Worker).postMessage({ type: 'styles-final', payload });
+      return;
+    }
+
     if (e.data.type === 'prepass-streaming') {
       const ifcApi = await ensureInit();
       // Heartbeat: lets the host watchdog know the worker is alive even
@@ -1180,6 +1377,35 @@ async function handleMessage(e: MessageEvent<GeometryWorkerRequest>): Promise<vo
           throw largeFilePrepassError(retryErr, sharedBuffer.byteLength) ?? retryErr;
         }
       }
+      return;
+    }
+
+    if (e.data.type === 'scan-shard') {
+      // SPIKE (sharded pre-pass): scan this worker's byte range of the file and
+      // post the entity-index columns + handoff back for main-thread stitching.
+      // Runs while the worker is otherwise idle (before stream-start).
+      const ifcApi = await ensureInit();
+      const { sharedBuffer, shardIndex, rangeStart, rangeEnd } = e.data;
+      const view = viewSharedBytes(sharedBuffer);
+      const shard = (ifcApi as unknown as {
+        scanEntityIndexShard: (
+          data: Uint8Array,
+          rangeStart: number,
+          rangeEnd: number,
+        ) => { ids: Uint32Array; starts: Uint32Array; lengths: Uint32Array; classes: Uint8Array; handoff: number };
+      }).scanEntityIndexShard(view, rangeStart, rangeEnd);
+      (self as unknown as Worker).postMessage(
+        {
+          type: 'shard-result',
+          shardIndex,
+          ids: shard.ids,
+          starts: shard.starts,
+          lengths: shard.lengths,
+          classes: shard.classes,
+          handoff: shard.handoff,
+        } as GeometryWorkerShardResultMessage,
+        [shard.ids.buffer, shard.starts.buffer, shard.lengths.buffer],
+      );
       return;
     }
 

--- a/packages/geometry/src/geometry.worker.ts
+++ b/packages/geometry/src/geometry.worker.ts
@@ -1427,7 +1427,7 @@ async function handleMessage(e: MessageEvent<GeometryWorkerRequest>): Promise<vo
           classes: shard.classes,
           handoff: shard.handoff,
         } as GeometryWorkerShardResultMessage,
-        [shard.ids.buffer, shard.starts.buffer, shard.lengths.buffer],
+        [shard.ids.buffer, shard.starts.buffer, shard.lengths.buffer, shard.classes.buffer],
       );
       return;
     }

--- a/packages/geometry/src/geometry.worker.ts
+++ b/packages/geometry/src/geometry.worker.ts
@@ -1250,12 +1250,19 @@ async function handleMessage(e: MessageEvent<GeometryWorkerRequest>): Promise<vo
       const ifcApi = await ensureInit();
       const { sharedBuffer, sliceIndex, spans } = e.data;
       try {
-        const res = (ifcApi as unknown as {
+        const styleApi = (ifcApi as unknown as {
           resolveStyledItemsShard: (data: Uint8Array, spans: Uint32Array) => {
             orphanIds: Uint32Array; orphanColors: Float32Array;
             geomIds: Uint32Array; geomColors: Float32Array;
           };
-        }).resolveStyledItemsShard(viewSharedBytes(sharedBuffer), spans);
+        });
+        let res;
+        try {
+          res = styleApi.resolveStyledItemsShard(viewSharedBytes(sharedBuffer), spans);
+        } catch {
+          // SAB-view rejection fallback (see scan-shard above).
+          res = styleApi.resolveStyledItemsShard(materialiseSharedBytes(sharedBuffer), spans);
+        }
         (self as unknown as Worker).postMessage(
           {
             type: 'styles-shard-result',
@@ -1324,7 +1331,7 @@ async function handleMessage(e: MessageEvent<GeometryWorkerRequest>): Promise<vo
       // the payload into the normal styles-event path.
       const ifcApi = await ensureInit();
       const m = e.data;
-      const payload = (ifcApi as unknown as {
+      const finalizeApi = (ifcApi as unknown as {
         finalizePrepassStyles: (
           data: Uint8Array,
           orphanIds: Uint32Array, orphanColors: Float32Array,
@@ -1334,11 +1341,19 @@ async function handleMessage(e: MessageEvent<GeometryWorkerRequest>): Promise<vo
           fillsSpans: Uint32Array, aggregateSpans: Uint32Array,
           planeAngleToRadians: number,
         ) => Record<string, unknown>;
-      }).finalizePrepassStyles(
-        viewSharedBytes(m.sharedBuffer), m.orphanIds, m.orphanColors, m.geomIds, m.geomColors,
+      });
+      const callFinalize = (bytes: Uint8Array) => finalizeApi.finalizePrepassStyles(
+        bytes, m.orphanIds, m.orphanColors, m.geomIds, m.geomColors,
         m.colourMapSpans, m.materialDefSpans, m.relMaterialSpans,
         m.voidSpans, m.fillsSpans, m.aggregateSpans, m.planeAngleToRadians,
       );
+      let payload;
+      try {
+        payload = callFinalize(viewSharedBytes(m.sharedBuffer));
+      } catch {
+        // SAB-view rejection fallback (see scan-shard above).
+        payload = callFinalize(materialiseSharedBytes(m.sharedBuffer));
+      }
       (self as unknown as Worker).postMessage({ type: 'styles-final', payload });
       return;
     }
@@ -1387,13 +1402,21 @@ async function handleMessage(e: MessageEvent<GeometryWorkerRequest>): Promise<vo
       const ifcApi = await ensureInit();
       const { sharedBuffer, shardIndex, rangeStart, rangeEnd } = e.data;
       const view = viewSharedBytes(sharedBuffer);
-      const shard = (ifcApi as unknown as {
+      const scanApi = (ifcApi as unknown as {
         scanEntityIndexShard: (
           data: Uint8Array,
           rangeStart: number,
           rangeEnd: number,
         ) => { ids: Uint32Array; starts: Uint32Array; lengths: Uint32Array; classes: Uint8Array; handoff: number };
-      }).scanEntityIndexShard(view, rangeStart, rangeEnd);
+      });
+      let shard;
+      try {
+        shard = scanApi.scanEntityIndexShard(view, rangeStart, rangeEnd);
+      } catch {
+        // Some runtimes reject SAB-backed views at the wasm boundary (same
+        // fallback the streaming pre-pass ships) — retry with a copy.
+        shard = scanApi.scanEntityIndexShard(materialiseSharedBytes(sharedBuffer), rangeStart, rangeEnd);
+      }
       (self as unknown as Worker).postMessage(
         {
           type: 'shard-result',

--- a/packages/wasm/pkg/ifc-lite.d.ts
+++ b/packages/wasm/pkg/ifc-lite.d.ts
@@ -227,6 +227,34 @@ export class IfcAPI {
    */
   buildPrePassOnce(data: Uint8Array): any;
   /**
+   * Sharded pre-pass: merge the shard-resolved styled-item columns with the
+   * SUPPORT spans (extracted host-side from the shard classes) and run the
+   * CANONICAL styles flatten. Returns the exact `styles` event payload the
+   * serial path emits. Runs on any worker with `setEntityIndex` installed.
+   * Span arguments are `[id, start, len]` triples; `plane_angle_to_radians`
+   * comes from the meta event.
+   */
+  finalizePrepassStyles(data: Uint8Array, orphan_ids: Uint32Array, orphan_colors: Float32Array, geom_ids: Uint32Array, geom_colors: Float32Array, colour_map_spans: Uint32Array, material_def_spans: Uint32Array, rel_material_spans: Uint32Array, void_spans: Uint32Array, fills_spans: Uint32Array, aggregate_spans: Uint32Array, plane_angle_to_radians: number): any;
+  /**
+   * SPIKE (sharded pre-pass): scan the entity index over a single byte range.
+   *
+   * Each idle browser geometry worker calls this on its `[range_start,
+   * range_end)` shard; the main thread stitches the returned columns into the
+   * full entity index (byte-identical to the single-threaded
+   * `build_entity_index`) by binary-searching each shard for the previous
+   * shard's `handoff`. Delegates to `ifc_lite_processing::scan_shard`, the
+   * exact per-chunk primitive the native `build_entity_index_parallel` fans
+   * across cores — so the sharded merge cannot drift from the serial builder.
+   *
+   * Byte offsets returned are GLOBAL (relative to file start), so shards
+   * concatenate without rewriting. Returns a plain object:
+   *   `{ ids: Uint32Array, starts: Uint32Array, lengths: Uint32Array,
+   *      handoff: number }`
+   * where `handoff` is the global start of the first entity at/after
+   * `range_end` (the next shard's first real entity), or `-1` at EOF.
+   */
+  scanEntityIndexShard(data: Uint8Array, range_start: number, range_end: number): any;
+  /**
    * Streaming pre-pass: emits geometry jobs in chunks via a JS callback
    * instead of waiting for the full file scan to complete.
    *
@@ -252,6 +280,33 @@ export class IfcAPI {
    *   `{ type: "complete", totalJobs }`
    */
   buildPrePassStreaming(data: Uint8Array, on_event: Function, chunk_size: number, disabled_type_names: string[] | null | undefined, skip_type_geometry: boolean): any;
+  /**
+   * Sharded pre-pass: resolve ONE contiguous (file-ordered) slice of the
+   * styled-item span list on this worker, against the entity index installed
+   * by `setEntityIndex`. Returns raw resolved maps as flat columns:
+   * `{ orphanIds, orphanColors (f32 rgba per id), geomIds, geomColors }`.
+   * The host merges shard results IN SHARD ORDER with first-wins per
+   * geometry id, reproducing the serial resolver's file-order precedence,
+   * then hands the merged columns to `finalizePrepassStyles`.
+   * `spans` is `[id, start, len]` triples.
+   */
+  resolveStyledItemsShard(data: Uint8Array, spans: Uint32Array): any;
+  /**
+   * Sharded pre-pass variant: same scan/discovery/jobs/columns pipeline as
+   * `buildPrePassStreaming`, but
+   *  1. the entity index is PREBUILT from the host's stitched shard columns
+   *     (file order; see `scanEntityIndexShard`) — the scan skips its inline
+   *     index build, the meta RTC ladder resolves against the FULL index
+   *     (no partial-ladder full-rescan detour), and the post-scan
+   *     `entity-index` event is skipped (the host already delivered it), and
+   *  2. styles resolution is EXTERNAL: the styled-item spans are resolved as
+   *     shard slices on the geometry workers (`resolveStyledItemsShard`);
+   *     this call stashes the SUPPORT spans + plane-angle scale, and the
+   *     follow-up `finalizePrepassStyles` merges + flattens into the exact
+   *     styles payload the serial path emits. NO `styles` event is emitted
+   *     here.
+   */
+  buildPrePassStreamingSharded(data: Uint8Array, on_event: Function, chunk_size: number, disabled_type_names: string[] | null | undefined, skip_type_geometry: boolean, index_ids: Uint32Array, index_starts: Uint32Array, index_lengths: Uint32Array): any;
   /**
    * Parse the file and return structured per-axis data (tag + endpoints) in
    * the renderer's Y-up world space (RTC-subtracted, metres). Use this when
@@ -1239,6 +1294,7 @@ export interface InitOutput {
   readonly gridaxisjs_tag: (a: number, b: number) => void;
   readonly ifcapi_buildPrePassOnce: (a: number, b: number, c: number) => number;
   readonly ifcapi_buildPrePassStreaming: (a: number, b: number, c: number, d: number, e: number, f: number, g: number, h: number, i: number) => void;
+  readonly ifcapi_buildPrePassStreamingSharded: (a: number, b: number, c: number, d: number, e: number, f: number, g: number, h: number, i: number, j: number, k: number, l: number, m: number, n: number, o: number) => void;
   readonly ifcapi_clearPrePassCache: (a: number) => void;
   readonly ifcapi_diagnoseGeometry: (a: number, b: number, c: number) => number;
   readonly ifcapi_exportCsv: (a: number, b: number, c: number, d: number, e: number, f: number, g: number, h: number, i: number) => void;
@@ -1254,6 +1310,7 @@ export interface InitOutput {
   readonly ifcapi_exportObj: (a: number, b: number, c: number, d: number, e: number, f: number, g: number, h: number, i: number) => void;
   readonly ifcapi_exportStep: (a: number, b: number, c: number, d: number, e: number, f: number, g: number, h: number, i: number, j: number) => void;
   readonly ifcapi_extractProfiles: (a: number, b: number, c: number, d: number) => number;
+  readonly ifcapi_finalizePrepassStyles: (a: number, b: number, c: number, d: number, e: number, f: number, g: number, h: number, i: number, j: number, k: number, l: number, m: number, n: number, o: number, p: number, q: number, r: number, s: number, t: number, u: number, v: number, w: number, x: number, y: number) => void;
   readonly ifcapi_getMemory: (a: number) => number;
   readonly ifcapi_getPipelineDiagnostics: (a: number) => number;
   readonly ifcapi_is_ready: (a: number) => number;
@@ -1267,8 +1324,10 @@ export interface InitOutput {
   readonly ifcapi_processGeometryBatchInstanced: (a: number, b: number, c: number, d: number, e: number, f: number, g: number, h: number, i: number, j: number, k: number, l: number, m: number, n: number, o: number, p: number, q: number, r: number, s: number, t: number, u: number, v: number, w: number, x: number, y: number, z: number, a1: number, b1: number, c1: number) => void;
   readonly ifcapi_processGeometryBatchPartitioned: (a: number, b: number, c: number, d: number, e: number, f: number, g: number, h: number, i: number, j: number, k: number, l: number, m: number, n: number, o: number, p: number, q: number, r: number, s: number, t: number, u: number, v: number, w: number, x: number, y: number, z: number, a1: number, b1: number) => number;
   readonly ifcapi_processGeometryBatchPartitionedFromSource: (a: number, b: number, c: number, d: number, e: number, f: number, g: number, h: number, i: number, j: number, k: number, l: number, m: number, n: number, o: number, p: number, q: number, r: number, s: number, t: number, u: number, v: number, w: number, x: number, y: number, z: number) => number;
+  readonly ifcapi_resolveStyledItemsShard: (a: number, b: number, c: number, d: number, e: number, f: number) => void;
   readonly ifcapi_scanEntitiesFast: (a: number, b: number, c: number) => number;
   readonly ifcapi_scanEntitiesFastBytes: (a: number, b: number, c: number) => number;
+  readonly ifcapi_scanEntityIndexShard: (a: number, b: number, c: number, d: number, e: number) => number;
   readonly ifcapi_scanGeometryEntitiesFast: (a: number, b: number, c: number) => number;
   readonly ifcapi_setComputeGeometryHashes: (a: number, b: number, c: number) => void;
   readonly ifcapi_setEntityIndex: (a: number, b: number, c: number, d: number, e: number, f: number, g: number) => void;

--- a/packages/wasm/pkg/ifc-lite.d.ts
+++ b/packages/wasm/pkg/ifc-lite.d.ts
@@ -156,6 +156,61 @@ export class IfcAPI {
    */
   exportObj(content: Uint8Array, include_normals: boolean, hidden: Uint32Array, isolated: Uint32Array): Uint8Array;
   /**
+   * Sharded pre-pass: merge the shard-resolved styled-item columns with the
+   * SUPPORT spans (extracted host-side from the shard classes) and run the
+   * CANONICAL styles flatten. Returns the exact `styles` event payload the
+   * serial path emits. Runs on any worker with `setEntityIndex` installed.
+   * Span arguments are `[id, start, len]` triples; `plane_angle_to_radians`
+   * comes from the meta event.
+   */
+  finalizePrepassStyles(data: Uint8Array, orphan_ids: Uint32Array, orphan_colors: Float32Array, geom_ids: Uint32Array, geom_colors: Float32Array, colour_map_spans: Uint32Array, material_def_spans: Uint32Array, rel_material_spans: Uint32Array, void_spans: Uint32Array, fills_spans: Uint32Array, aggregate_spans: Uint32Array, plane_angle_to_radians: number): any;
+  /**
+   * SPIKE (sharded pre-pass): scan the entity index over a single byte range.
+   *
+   * Each idle browser geometry worker calls this on its `[range_start,
+   * range_end)` shard; the main thread stitches the returned columns into the
+   * full entity index (byte-identical to the single-threaded
+   * `build_entity_index`) by binary-searching each shard for the previous
+   * shard's `handoff`. Delegates to `ifc_lite_processing::scan_shard`, the
+   * exact per-chunk primitive the native `build_entity_index_parallel` fans
+   * across cores — so the sharded merge cannot drift from the serial builder.
+   *
+   * Byte offsets returned are GLOBAL (relative to file start), so shards
+   * concatenate without rewriting. Returns a plain object:
+   *   `{ ids: Uint32Array, starts: Uint32Array, lengths: Uint32Array,
+   *      handoff: number }`
+   * where `handoff` is the global start of the first entity at/after
+   * `range_end` (the next shard's first real entity), or `-1` at EOF.
+   */
+  scanEntityIndexShard(data: Uint8Array, range_start: number, range_end: number): any;
+  /**
+   * Sharded pre-pass: resolve ONE contiguous (file-ordered) slice of the
+   * styled-item span list on this worker, against the entity index installed
+   * by `setEntityIndex`. Returns raw resolved maps as flat columns:
+   * `{ orphanIds, orphanColors (f32 rgba per id), geomIds, geomColors }`.
+   * The host merges shard results IN SHARD ORDER with first-wins per
+   * geometry id, reproducing the serial resolver's file-order precedence,
+   * then hands the merged columns to `finalizePrepassStyles`.
+   * `spans` is `[id, start, len]` triples.
+   */
+  resolveStyledItemsShard(data: Uint8Array, spans: Uint32Array): any;
+  /**
+   * Sharded pre-pass variant: same scan/discovery/jobs/columns pipeline as
+   * `buildPrePassStreaming`, but
+   *  1. the entity index is PREBUILT from the host's stitched shard columns
+   *     (file order; see `scanEntityIndexShard`) — the scan skips its inline
+   *     index build, the meta RTC ladder resolves against the FULL index
+   *     (no partial-ladder full-rescan detour), and the post-scan
+   *     `entity-index` event is skipped (the host already delivered it), and
+   *  2. styles resolution is EXTERNAL: the styled-item spans are resolved as
+   *     shard slices on the geometry workers (`resolveStyledItemsShard`);
+   *     this call stashes the SUPPORT spans + plane-angle scale, and the
+   *     follow-up `finalizePrepassStyles` merges + flattens into the exact
+   *     styles payload the serial path emits. NO `styles` event is emitted
+   *     here.
+   */
+  buildPrePassStreamingSharded(data: Uint8Array, on_event: Function, chunk_size: number, disabled_type_names: string[] | null | undefined, skip_type_geometry: boolean, index_ids: Uint32Array, index_starts: Uint32Array, index_lengths: Uint32Array): any;
+  /**
    * Store the whole IFC source file ONCE per load so the `*FromSource` batch
    * variants can read it from the wasm heap instead of re-copying it per call.
    *
@@ -227,34 +282,6 @@ export class IfcAPI {
    */
   buildPrePassOnce(data: Uint8Array): any;
   /**
-   * Sharded pre-pass: merge the shard-resolved styled-item columns with the
-   * SUPPORT spans (extracted host-side from the shard classes) and run the
-   * CANONICAL styles flatten. Returns the exact `styles` event payload the
-   * serial path emits. Runs on any worker with `setEntityIndex` installed.
-   * Span arguments are `[id, start, len]` triples; `plane_angle_to_radians`
-   * comes from the meta event.
-   */
-  finalizePrepassStyles(data: Uint8Array, orphan_ids: Uint32Array, orphan_colors: Float32Array, geom_ids: Uint32Array, geom_colors: Float32Array, colour_map_spans: Uint32Array, material_def_spans: Uint32Array, rel_material_spans: Uint32Array, void_spans: Uint32Array, fills_spans: Uint32Array, aggregate_spans: Uint32Array, plane_angle_to_radians: number): any;
-  /**
-   * SPIKE (sharded pre-pass): scan the entity index over a single byte range.
-   *
-   * Each idle browser geometry worker calls this on its `[range_start,
-   * range_end)` shard; the main thread stitches the returned columns into the
-   * full entity index (byte-identical to the single-threaded
-   * `build_entity_index`) by binary-searching each shard for the previous
-   * shard's `handoff`. Delegates to `ifc_lite_processing::scan_shard`, the
-   * exact per-chunk primitive the native `build_entity_index_parallel` fans
-   * across cores — so the sharded merge cannot drift from the serial builder.
-   *
-   * Byte offsets returned are GLOBAL (relative to file start), so shards
-   * concatenate without rewriting. Returns a plain object:
-   *   `{ ids: Uint32Array, starts: Uint32Array, lengths: Uint32Array,
-   *      handoff: number }`
-   * where `handoff` is the global start of the first entity at/after
-   * `range_end` (the next shard's first real entity), or `-1` at EOF.
-   */
-  scanEntityIndexShard(data: Uint8Array, range_start: number, range_end: number): any;
-  /**
    * Streaming pre-pass: emits geometry jobs in chunks via a JS callback
    * instead of waiting for the full file scan to complete.
    *
@@ -280,33 +307,6 @@ export class IfcAPI {
    *   `{ type: "complete", totalJobs }`
    */
   buildPrePassStreaming(data: Uint8Array, on_event: Function, chunk_size: number, disabled_type_names: string[] | null | undefined, skip_type_geometry: boolean): any;
-  /**
-   * Sharded pre-pass: resolve ONE contiguous (file-ordered) slice of the
-   * styled-item span list on this worker, against the entity index installed
-   * by `setEntityIndex`. Returns raw resolved maps as flat columns:
-   * `{ orphanIds, orphanColors (f32 rgba per id), geomIds, geomColors }`.
-   * The host merges shard results IN SHARD ORDER with first-wins per
-   * geometry id, reproducing the serial resolver's file-order precedence,
-   * then hands the merged columns to `finalizePrepassStyles`.
-   * `spans` is `[id, start, len]` triples.
-   */
-  resolveStyledItemsShard(data: Uint8Array, spans: Uint32Array): any;
-  /**
-   * Sharded pre-pass variant: same scan/discovery/jobs/columns pipeline as
-   * `buildPrePassStreaming`, but
-   *  1. the entity index is PREBUILT from the host's stitched shard columns
-   *     (file order; see `scanEntityIndexShard`) — the scan skips its inline
-   *     index build, the meta RTC ladder resolves against the FULL index
-   *     (no partial-ladder full-rescan detour), and the post-scan
-   *     `entity-index` event is skipped (the host already delivered it), and
-   *  2. styles resolution is EXTERNAL: the styled-item spans are resolved as
-   *     shard slices on the geometry workers (`resolveStyledItemsShard`);
-   *     this call stashes the SUPPORT spans + plane-angle scale, and the
-   *     follow-up `finalizePrepassStyles` merges + flattens into the exact
-   *     styles payload the serial path emits. NO `styles` event is emitted
-   *     here.
-   */
-  buildPrePassStreamingSharded(data: Uint8Array, on_event: Function, chunk_size: number, disabled_type_names: string[] | null | undefined, skip_type_geometry: boolean, index_ids: Uint32Array, index_starts: Uint32Array, index_lengths: Uint32Array): any;
   /**
    * Parse the file and return structured per-axis data (tag + endpoints) in
    * the renderer's Y-up world space (RTC-subtracted, metres). Use this when

--- a/rust/processing/src/lib.rs
+++ b/rust/processing/src/lib.rs
@@ -9,11 +9,12 @@
 
 pub mod determinism;
 pub(crate) mod parallel_scan;
-pub use parallel_scan::{
-    build_entity_index_parallel, scan_shard, scan_shard_classified,
-    PREPASS_CLASS_INDEXED_COLOUR_MAP, PREPASS_CLASS_MATERIAL_DEF_REPR, PREPASS_CLASS_NONE,
-    PREPASS_CLASS_REL_AGGREGATES, PREPASS_CLASS_REL_ASSOCIATES_MATERIAL, PREPASS_CLASS_REL_FILLS,
-    PREPASS_CLASS_REL_VOIDS, PREPASS_CLASS_STYLED_ITEM,
+mod shard_classes;
+pub use parallel_scan::{build_entity_index_parallel, scan_shard, ShardRecords};
+pub use shard_classes::{
+    scan_shard_classified, PREPASS_CLASS_INDEXED_COLOUR_MAP, PREPASS_CLASS_MATERIAL_DEF_REPR,
+    PREPASS_CLASS_NONE, PREPASS_CLASS_REL_AGGREGATES, PREPASS_CLASS_REL_ASSOCIATES_MATERIAL,
+    PREPASS_CLASS_REL_FILLS, PREPASS_CLASS_REL_VOIDS, PREPASS_CLASS_STYLED_ITEM,
 };
 // `determinism::diff_report` unit tests (#1549) live in this sibling
 // `_tests.rs` file, declared from here rather than inside `determinism.rs`,
@@ -30,6 +31,7 @@ pub mod geometry_export;
 mod georeferencing;
 pub mod pipeline_diagnostics;
 pub mod prepass;
+mod prepass_styled;
 mod processor;
 pub mod stream_meta;
 pub mod style;

--- a/rust/processing/src/lib.rs
+++ b/rust/processing/src/lib.rs
@@ -9,7 +9,12 @@
 
 pub mod determinism;
 pub(crate) mod parallel_scan;
-pub use parallel_scan::build_entity_index_parallel;
+pub use parallel_scan::{
+    build_entity_index_parallel, scan_shard, scan_shard_classified,
+    PREPASS_CLASS_INDEXED_COLOUR_MAP, PREPASS_CLASS_MATERIAL_DEF_REPR, PREPASS_CLASS_NONE,
+    PREPASS_CLASS_REL_AGGREGATES, PREPASS_CLASS_REL_ASSOCIATES_MATERIAL, PREPASS_CLASS_REL_FILLS,
+    PREPASS_CLASS_REL_VOIDS, PREPASS_CLASS_STYLED_ITEM,
+};
 // `determinism::diff_report` unit tests (#1549) live in this sibling
 // `_tests.rs` file, declared from here rather than inside `determinism.rs`,
 // because that module already sits exactly at its frozen

--- a/rust/processing/src/parallel_scan.rs
+++ b/rust/processing/src/parallel_scan.rs
@@ -52,7 +52,93 @@
 //! parallel driver buys nothing and only adds merge overhead — the wasm build
 //! delegates straight to the serial scanner and is unchanged.
 
-use ifc_lite_core::EntityIndex;
+use ifc_lite_core::{EntityIndex, EntityScanner};
+
+/// One shard's speculative scan over `[range_start, range_end)`.
+///
+/// This is the exact per-chunk primitive [`build_entity_index_parallel`] fans
+/// across cores, exposed for the wasm **sharded pre-pass**: each browser
+/// geometry worker calls it on a byte range and the main thread stitches the
+/// columns (binary-searching each shard for the previous shard's handoff — see
+/// the [`native::stitch`] doc). Compiled on all targets (the `native` merge is
+/// wasm-gated, but the shard primitive itself is target-independent).
+///
+/// Chunk 0 (`range_start == 0`) uses the header-aware [`EntityScanner::new`];
+/// every other shard starts *speculatively* at `range_start` via
+/// [`EntityScanner::new_at`] (which may land mid-record — the handoff stitch
+/// makes that exact, not heuristic). Returns every record with
+/// `start < range_end` (strictly increasing in `start`) plus the `handoff`: the
+/// `start` of the first record at/after `range_end` (the next shard's first real
+/// entity), or `None` at EOF.
+pub fn scan_shard(
+    content: &[u8],
+    range_start: usize,
+    range_end: usize,
+) -> (Vec<(u32, usize, usize)>, Option<usize>) {
+    let (records, _classes, handoff) = scan_shard_classified(content, range_start, range_end);
+    (records, handoff)
+}
+
+/// Per-record prepass class emitted by [`scan_shard_classified`].
+///
+/// Only the codes a downstream consumer needs are defined; everything else is
+/// [`PREPASS_CLASS_NONE`]. Classification happens AT SCAN TIME from the same
+/// `type_name` string the serial pre-pass matches on, so a consumer that
+/// filters records by class reproduces the serial pre-pass's span collection
+/// byte-for-byte (same keyword compare, same file order).
+pub const PREPASS_CLASS_NONE: u8 = 0;
+/// `IFCSTYLEDITEM` — the styled-item spans the pre-pass resolver classifies
+/// into orphan (material appearance) vs geometry-attached styles.
+pub const PREPASS_CLASS_STYLED_ITEM: u8 = 4;
+/// `IFCINDEXEDCOLOURMAP` (#663/#858).
+pub const PREPASS_CLASS_INDEXED_COLOUR_MAP: u8 = 5;
+/// `IFCMATERIALDEFINITIONREPRESENTATION` (#407).
+pub const PREPASS_CLASS_MATERIAL_DEF_REPR: u8 = 6;
+/// `IFCRELASSOCIATESMATERIAL` (#407).
+pub const PREPASS_CLASS_REL_ASSOCIATES_MATERIAL: u8 = 7;
+/// `IFCRELVOIDSELEMENT`.
+pub const PREPASS_CLASS_REL_VOIDS: u8 = 8;
+/// `IFCRELFILLSELEMENT`.
+pub const PREPASS_CLASS_REL_FILLS: u8 = 9;
+/// `IFCRELAGGREGATES`.
+pub const PREPASS_CLASS_REL_AGGREGATES: u8 = 10;
+
+/// [`scan_shard`] plus a parallel per-record class column (see the
+/// `PREPASS_CLASS_*` codes). Same records, same handoff; the class byte lets
+/// the browser host extract pre-pass span lists (today: styled items) from the
+/// stitched shard columns WITHOUT waiting for the serial pre-pass scan.
+pub fn scan_shard_classified(
+    content: &[u8],
+    range_start: usize,
+    range_end: usize,
+) -> (Vec<(u32, usize, usize)>, Vec<u8>, Option<usize>) {
+    let mut scanner = if range_start == 0 {
+        EntityScanner::new(content)
+    } else {
+        EntityScanner::new_at(content, range_start)
+    };
+    let mut records = Vec::new();
+    let mut classes = Vec::new();
+    let mut handoff = None;
+    while let Some((id, type_name, start, entity_end)) = scanner.next_entity() {
+        if start >= range_end {
+            handoff = Some(start);
+            break;
+        }
+        records.push((id, start, entity_end));
+        classes.push(match type_name {
+            "IFCSTYLEDITEM" => PREPASS_CLASS_STYLED_ITEM,
+            "IFCINDEXEDCOLOURMAP" => PREPASS_CLASS_INDEXED_COLOUR_MAP,
+            "IFCMATERIALDEFINITIONREPRESENTATION" => PREPASS_CLASS_MATERIAL_DEF_REPR,
+            "IFCRELASSOCIATESMATERIAL" => PREPASS_CLASS_REL_ASSOCIATES_MATERIAL,
+            "IFCRELVOIDSELEMENT" => PREPASS_CLASS_REL_VOIDS,
+            "IFCRELFILLSELEMENT" => PREPASS_CLASS_REL_FILLS,
+            "IFCRELAGGREGATES" => PREPASS_CLASS_REL_AGGREGATES,
+            _ => PREPASS_CLASS_NONE,
+        });
+    }
+    (records, classes, handoff)
+}
 
 /// Build the entity index (expressId -> byte span) across all available cores.
 ///
@@ -129,23 +215,13 @@ mod native {
     }
 
     fn scan_chunk(content: &[u8], i: usize, n_chunks: usize) -> ChunkScan {
+        let start = i * content.len() / n_chunks;
         let end = range_end(i, n_chunks, content.len());
-        // Chunk 0 MUST use `new` for the exact header-skip / quoted-`DATA;`
-        // semantics; every other chunk starts speculatively at its byte offset.
-        let mut scanner = if i == 0 {
-            EntityScanner::new(content)
-        } else {
-            EntityScanner::new_at(content, i * content.len() / n_chunks)
-        };
-        let mut records = Vec::new();
-        let mut handoff = None;
-        while let Some((id, _type_name, start, entity_end)) = scanner.next_entity() {
-            if start >= end {
-                handoff = Some(start);
-                break;
-            }
-            records.push((id, start, entity_end));
-        }
+        // Chunk 0 uses `new` for the exact header-skip / quoted-`DATA;`
+        // semantics (`scan_shard` selects it on `range_start == 0`); every other
+        // chunk starts speculatively at its byte offset. Same shard primitive the
+        // wasm sharded pre-pass calls per worker, so the merge cannot drift.
+        let (records, handoff) = super::scan_shard(content, start, end);
         ChunkScan { records, handoff }
     }
 
@@ -177,7 +253,7 @@ mod native {
         }
         let mut expected_start = chunks[0].handoff;
 
-        for (i, chunk) in chunks.iter().enumerate().skip(1) {
+        for i in 1..n_chunks {
             // `expected_start` is the real entity start where chunk `i` begins,
             // validated by chunk `i-1`. `None` => no more real entities.
             let target = match expected_start {
@@ -185,7 +261,7 @@ mod native {
                 None => break,
             };
             let end = range_end(i, n_chunks, len);
-            let recs = &chunk.records;
+            let recs = &chunks[i].records;
             // `records` is strictly increasing in `start`, so a binary search
             // locates the real boundary (or proves the chunk never re-synced).
             match recs.binary_search_by(|&(_, start, _)| start.cmp(&target)) {
@@ -193,7 +269,7 @@ mod native {
                     for &(id, start, e) in &recs[p..] {
                         index.insert(id, (start, e));
                     }
-                    expected_start = chunk.handoff;
+                    expected_start = chunks[i].handoff;
                 }
                 Err(_) => {
                     // Rare: the speculative scan overshot the real boundary, or a

--- a/rust/processing/src/parallel_scan.rs
+++ b/rust/processing/src/parallel_scan.rs
@@ -52,7 +52,7 @@
 //! parallel driver buys nothing and only adds merge overhead — the wasm build
 //! delegates straight to the serial scanner and is unchanged.
 
-use ifc_lite_core::{EntityIndex, EntityScanner};
+use ifc_lite_core::EntityIndex;
 
 /// One shard's speculative scan over `[range_start, range_end)`.
 ///
@@ -78,70 +78,11 @@ pub fn scan_shard(
     range_start: usize,
     range_end: usize,
 ) -> (ShardRecords, Option<usize>) {
-    let (records, _classes, handoff) = scan_shard_classified(content, range_start, range_end);
+    let (records, _classes, handoff) =
+        crate::shard_classes::scan_shard_classified(content, range_start, range_end);
     (records, handoff)
 }
 
-/// Per-record prepass class emitted by [`scan_shard_classified`].
-///
-/// Only the codes a downstream consumer needs are defined; everything else is
-/// [`PREPASS_CLASS_NONE`]. Classification happens AT SCAN TIME from the same
-/// `type_name` string the serial pre-pass matches on, so a consumer that
-/// filters records by class reproduces the serial pre-pass's span collection
-/// byte-for-byte (same keyword compare, same file order).
-pub const PREPASS_CLASS_NONE: u8 = 0;
-/// `IFCSTYLEDITEM` — the styled-item spans the pre-pass resolver classifies
-/// into orphan (material appearance) vs geometry-attached styles.
-pub const PREPASS_CLASS_STYLED_ITEM: u8 = 4;
-/// `IFCINDEXEDCOLOURMAP` (#663/#858).
-pub const PREPASS_CLASS_INDEXED_COLOUR_MAP: u8 = 5;
-/// `IFCMATERIALDEFINITIONREPRESENTATION` (#407).
-pub const PREPASS_CLASS_MATERIAL_DEF_REPR: u8 = 6;
-/// `IFCRELASSOCIATESMATERIAL` (#407).
-pub const PREPASS_CLASS_REL_ASSOCIATES_MATERIAL: u8 = 7;
-/// `IFCRELVOIDSELEMENT`.
-pub const PREPASS_CLASS_REL_VOIDS: u8 = 8;
-/// `IFCRELFILLSELEMENT`.
-pub const PREPASS_CLASS_REL_FILLS: u8 = 9;
-/// `IFCRELAGGREGATES`.
-pub const PREPASS_CLASS_REL_AGGREGATES: u8 = 10;
-
-/// [`scan_shard`] plus a parallel per-record class column (see the
-/// `PREPASS_CLASS_*` codes). Same records, same handoff; the class byte lets
-/// the browser host extract pre-pass span lists (today: styled items) from the
-/// stitched shard columns WITHOUT waiting for the serial pre-pass scan.
-pub fn scan_shard_classified(
-    content: &[u8],
-    range_start: usize,
-    range_end: usize,
-) -> (ShardRecords, Vec<u8>, Option<usize>) {
-    let mut scanner = if range_start == 0 {
-        EntityScanner::new(content)
-    } else {
-        EntityScanner::new_at(content, range_start)
-    };
-    let mut records = Vec::new();
-    let mut classes = Vec::new();
-    let mut handoff = None;
-    while let Some((id, type_name, start, entity_end)) = scanner.next_entity() {
-        if start >= range_end {
-            handoff = Some(start);
-            break;
-        }
-        records.push((id, start, entity_end));
-        classes.push(match type_name {
-            "IFCSTYLEDITEM" => PREPASS_CLASS_STYLED_ITEM,
-            "IFCINDEXEDCOLOURMAP" => PREPASS_CLASS_INDEXED_COLOUR_MAP,
-            "IFCMATERIALDEFINITIONREPRESENTATION" => PREPASS_CLASS_MATERIAL_DEF_REPR,
-            "IFCRELASSOCIATESMATERIAL" => PREPASS_CLASS_REL_ASSOCIATES_MATERIAL,
-            "IFCRELVOIDSELEMENT" => PREPASS_CLASS_REL_VOIDS,
-            "IFCRELFILLSELEMENT" => PREPASS_CLASS_REL_FILLS,
-            "IFCRELAGGREGATES" => PREPASS_CLASS_REL_AGGREGATES,
-            _ => PREPASS_CLASS_NONE,
-        });
-    }
-    (records, classes, handoff)
-}
 
 /// Build the entity index (expressId -> byte span) across all available cores.
 ///

--- a/rust/processing/src/parallel_scan.rs
+++ b/rust/processing/src/parallel_scan.rs
@@ -70,11 +70,14 @@ use ifc_lite_core::{EntityIndex, EntityScanner};
 /// `start < range_end` (strictly increasing in `start`) plus the `handoff`: the
 /// `start` of the first record at/after `range_end` (the next shard's first real
 /// entity), or `None` at EOF.
+/// One shard's records: `(id, start, end)` per entity, strictly increasing in `start`.
+pub type ShardRecords = Vec<(u32, usize, usize)>;
+
 pub fn scan_shard(
     content: &[u8],
     range_start: usize,
     range_end: usize,
-) -> (Vec<(u32, usize, usize)>, Option<usize>) {
+) -> (ShardRecords, Option<usize>) {
     let (records, _classes, handoff) = scan_shard_classified(content, range_start, range_end);
     (records, handoff)
 }
@@ -111,7 +114,7 @@ pub fn scan_shard_classified(
     content: &[u8],
     range_start: usize,
     range_end: usize,
-) -> (Vec<(u32, usize, usize)>, Vec<u8>, Option<usize>) {
+) -> (ShardRecords, Vec<u8>, Option<usize>) {
     let mut scanner = if range_start == 0 {
         EntityScanner::new(content)
     } else {
@@ -253,7 +256,7 @@ mod native {
         }
         let mut expected_start = chunks[0].handoff;
 
-        for i in 1..n_chunks {
+        for (i, chunk) in chunks.iter().enumerate().skip(1) {
             // `expected_start` is the real entity start where chunk `i` begins,
             // validated by chunk `i-1`. `None` => no more real entities.
             let target = match expected_start {
@@ -261,7 +264,7 @@ mod native {
                 None => break,
             };
             let end = range_end(i, n_chunks, len);
-            let recs = &chunks[i].records;
+            let recs = &chunk.records;
             // `records` is strictly increasing in `start`, so a binary search
             // locates the real boundary (or proves the chunk never re-synced).
             match recs.binary_search_by(|&(_, start, _)| start.cmp(&target)) {
@@ -269,7 +272,7 @@ mod native {
                     for &(id, start, e) in &recs[p..] {
                         index.insert(id, (start, e));
                     }
-                    expected_start = chunks[i].handoff;
+                    expected_start = chunk.handoff;
                 }
                 Err(_) => {
                     // Rare: the speculative scan overshot the real boundary, or a

--- a/rust/processing/src/prepass.rs
+++ b/rust/processing/src/prepass.rs
@@ -156,7 +156,28 @@ pub fn resolve_prepass(
     decoder: &mut EntityDecoder,
     opts: ResolveOptions,
 ) -> ResolvedPrepass {
+    resolve_prepass_with_style_seeds(spans, decoder, opts, None)
+}
+
+/// [`resolve_prepass`] with PRE-RESOLVED styled-item maps (the sharded
+/// pre-pass resolves styled items on the geometry workers). Seeds MUST be
+/// installed before the colour-map/material/void loops below — the material
+/// chain consults `orphan_styled_items`, so injecting after the fact loses
+/// material-dependent styles (measured: 1960 -> 1134 styles on a real model).
+/// With seeds present the styled-item loop is skipped (spans.styled_items is
+/// expected to be empty in that mode).
+pub fn resolve_prepass_with_style_seeds(
+    spans: &PrepassSpans,
+    decoder: &mut EntityDecoder,
+    opts: ResolveOptions,
+    style_seeds: Option<(FxHashMap<u32, [f32; 4]>, FxHashMap<u32, GeometryStyleInfo>)>,
+) -> ResolvedPrepass {
     let mut out = ResolvedPrepass::default();
+
+    if let Some((orphan, geom)) = style_seeds {
+        out.orphan_styled_items = orphan;
+        out.geometry_style_index = geom;
+    }
 
     // ── Styled items: orphan (material appearance) vs geometry-attached ──
     resolve_styled_items_into(

--- a/rust/processing/src/prepass.rs
+++ b/rust/processing/src/prepass.rs
@@ -159,6 +159,9 @@ pub fn resolve_prepass(
     resolve_prepass_with_style_seeds(spans, decoder, opts, None)
 }
 
+/// Pre-resolved styled maps: `(orphan id -> rgba, geometry id -> style info)`.
+pub type StyleSeeds = (FxHashMap<u32, [f32; 4]>, FxHashMap<u32, GeometryStyleInfo>);
+
 /// [`resolve_prepass`] with PRE-RESOLVED styled-item maps (the sharded
 /// pre-pass resolves styled items on the geometry workers). Seeds MUST be
 /// installed before the colour-map/material/void loops below — the material
@@ -170,7 +173,7 @@ pub fn resolve_prepass_with_style_seeds(
     spans: &PrepassSpans,
     decoder: &mut EntityDecoder,
     opts: ResolveOptions,
-    style_seeds: Option<(FxHashMap<u32, [f32; 4]>, FxHashMap<u32, GeometryStyleInfo>)>,
+    style_seeds: Option<StyleSeeds>,
 ) -> ResolvedPrepass {
     let mut out = ResolvedPrepass::default();
 

--- a/rust/processing/src/prepass.rs
+++ b/rust/processing/src/prepass.rs
@@ -30,7 +30,7 @@ pub type Span = (u32, usize, usize);
 
 /// Entity spans a scan collected for post-scan resolution. Both scan loops
 /// fill this; neither decodes these entities mid-scan.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct PrepassSpans {
     /// `IFCSTYLEDITEM` — geometry-attached AND orphan (material appearance);
     /// the resolver classifies them (the classifying decode is the cost of
@@ -110,6 +110,45 @@ pub struct ResolvedPrepass {
     pub deferred_attached_styled_spans: Vec<(usize, usize)>,
 }
 
+/// The styled-item classification/resolution loop of [`resolve_prepass`],
+/// exposed so the browser's SHARDED pre-pass can fan slices of the (file-
+/// ordered) styled-item span list across workers: each worker resolves its
+/// contiguous slice with this exact loop, and the host merges shard results in
+/// shard order with first-wins per geometry id — reproducing the serial
+/// resolver's file-order first-wins precedence (`collect_geometry_style_info`
+/// skips ids already present).
+pub fn resolve_styled_items_into(
+    styled_items: &[Span],
+    decoder: &mut EntityDecoder,
+    defer_attached_styles: bool,
+    orphan_styled_items: &mut FxHashMap<u32, [f32; 4]>,
+    geometry_style_index: &mut FxHashMap<u32, GeometryStyleInfo>,
+    deferred_attached_styled_spans: &mut Vec<(usize, usize)>,
+) {
+    for &(id, start, end) in styled_items {
+        let Ok(styled_item) = decoder.decode_at_with_id(id, start, end) else {
+            if defer_attached_styles {
+                // Undecodable now — let the replay try again later, matching
+                // the historic defer behaviour.
+                deferred_attached_styled_spans.push((start, end));
+            }
+            continue;
+        };
+        if styled_item.get_ref(0).is_none() {
+            // Orphan styled item (null Item) = a material appearance (#407).
+            // Always resolved up front — even in defer mode — or
+            // material-only-styled elements render default-gray (#913 §2c).
+            if let Some(info) = extract_style_info_from_styled_item(&styled_item, decoder) {
+                orphan_styled_items.insert(id, info.color);
+            }
+        } else if defer_attached_styles {
+            deferred_attached_styled_spans.push((start, end));
+        } else {
+            collect_geometry_style_info(geometry_style_index, &styled_item, decoder);
+        }
+    }
+}
+
 /// THE canonical post-scan resolution. Spans are processed in file order so
 /// first-wins precedence matches what the historic inline scans produced.
 pub fn resolve_prepass(
@@ -120,28 +159,14 @@ pub fn resolve_prepass(
     let mut out = ResolvedPrepass::default();
 
     // ── Styled items: orphan (material appearance) vs geometry-attached ──
-    for &(id, start, end) in &spans.styled_items {
-        let Ok(styled_item) = decoder.decode_at_with_id(id, start, end) else {
-            if opts.defer_attached_styles {
-                // Undecodable now — let the replay try again later, matching
-                // the historic defer behaviour.
-                out.deferred_attached_styled_spans.push((start, end));
-            }
-            continue;
-        };
-        if styled_item.get_ref(0).is_none() {
-            // Orphan styled item (null Item) = a material appearance (#407).
-            // Always resolved up front — even in defer mode — or
-            // material-only-styled elements render default-gray (#913 §2c).
-            if let Some(info) = extract_style_info_from_styled_item(&styled_item, decoder) {
-                out.orphan_styled_items.insert(id, info.color);
-            }
-        } else if opts.defer_attached_styles {
-            out.deferred_attached_styled_spans.push((start, end));
-        } else {
-            collect_geometry_style_info(&mut out.geometry_style_index, &styled_item, decoder);
-        }
-    }
+    resolve_styled_items_into(
+        &spans.styled_items,
+        decoder,
+        opts.defer_attached_styles,
+        &mut out.orphan_styled_items,
+        &mut out.geometry_style_index,
+        &mut out.deferred_attached_styled_spans,
+    );
 
     // ── IfcIndexedColourMap (#663/#858) ──
     for &(id, start, end) in &spans.indexed_colour_maps {

--- a/rust/processing/src/prepass.rs
+++ b/rust/processing/src/prepass.rs
@@ -28,8 +28,7 @@ use rustc_hash::FxHashMap;
 /// One stashed entity span: `(express_id, start, end)`.
 pub type Span = (u32, usize, usize);
 
-/// Entity spans a scan collected for post-scan resolution. Both scan loops
-/// fill this; neither decodes these entities mid-scan.
+/// Entity spans a scan collected for post-scan resolution (no mid-scan decode).
 #[derive(Debug, Default, Clone)]
 pub struct PrepassSpans {
     /// `IFCSTYLEDITEM` — geometry-attached AND orphan (material appearance);
@@ -53,8 +52,7 @@ pub struct PrepassSpans {
     pub aggregate_rels: Vec<Span>,
 }
 
-/// Resolution switches. Both pipelines use the same resolver with different
-/// collection needs.
+/// Resolution switches (both pipelines share the resolver).
 #[derive(Debug, Clone, Copy)]
 pub struct ResolveOptions {
     /// Collect the FULL per-triangle palette maps (#858). The native pipeline
@@ -104,53 +102,14 @@ pub struct ResolvedPrepass {
     pub void_index: FxHashMap<u32, Vec<u32>>,
     /// Opening id → filling element id (native opening filter input).
     pub filling_by_opening: FxHashMap<u32, u32>,
-    /// Geometry-attached styled-item spans NOT resolved because
-    /// [`ResolveOptions::defer_attached_styles`] was set; replay them with
-    /// [`resolve_styled_item_spans`].
+    /// Geometry-attached styled spans left unresolved under
+    /// [`ResolveOptions::defer_attached_styles`]; replay via [`resolve_styled_item_spans`].
     pub deferred_attached_styled_spans: Vec<(usize, usize)>,
 }
 
-/// The styled-item classification/resolution loop of [`resolve_prepass`],
-/// exposed so the browser's SHARDED pre-pass can fan slices of the (file-
-/// ordered) styled-item span list across workers: each worker resolves its
-/// contiguous slice with this exact loop, and the host merges shard results in
-/// shard order with first-wins per geometry id — reproducing the serial
-/// resolver's file-order first-wins precedence (`collect_geometry_style_info`
-/// skips ids already present).
-pub fn resolve_styled_items_into(
-    styled_items: &[Span],
-    decoder: &mut EntityDecoder,
-    defer_attached_styles: bool,
-    orphan_styled_items: &mut FxHashMap<u32, [f32; 4]>,
-    geometry_style_index: &mut FxHashMap<u32, GeometryStyleInfo>,
-    deferred_attached_styled_spans: &mut Vec<(usize, usize)>,
-) {
-    for &(id, start, end) in styled_items {
-        let Ok(styled_item) = decoder.decode_at_with_id(id, start, end) else {
-            if defer_attached_styles {
-                // Undecodable now — let the replay try again later, matching
-                // the historic defer behaviour.
-                deferred_attached_styled_spans.push((start, end));
-            }
-            continue;
-        };
-        if styled_item.get_ref(0).is_none() {
-            // Orphan styled item (null Item) = a material appearance (#407).
-            // Always resolved up front — even in defer mode — or
-            // material-only-styled elements render default-gray (#913 §2c).
-            if let Some(info) = extract_style_info_from_styled_item(&styled_item, decoder) {
-                orphan_styled_items.insert(id, info.color);
-            }
-        } else if defer_attached_styles {
-            deferred_attached_styled_spans.push((start, end));
-        } else {
-            collect_geometry_style_info(geometry_style_index, &styled_item, decoder);
-        }
-    }
-}
+pub use crate::prepass_styled::{resolve_styled_items_into, StyleSeeds};
 
-/// THE canonical post-scan resolution. Spans are processed in file order so
-/// first-wins precedence matches what the historic inline scans produced.
+/// THE canonical post-scan resolution (file-order, first-wins precedence).
 pub fn resolve_prepass(
     spans: &PrepassSpans,
     decoder: &mut EntityDecoder,
@@ -159,16 +118,9 @@ pub fn resolve_prepass(
     resolve_prepass_with_style_seeds(spans, decoder, opts, None)
 }
 
-/// Pre-resolved styled maps: `(orphan id -> rgba, geometry id -> style info)`.
-pub type StyleSeeds = (FxHashMap<u32, [f32; 4]>, FxHashMap<u32, GeometryStyleInfo>);
-
-/// [`resolve_prepass`] with PRE-RESOLVED styled-item maps (the sharded
-/// pre-pass resolves styled items on the geometry workers). Seeds MUST be
-/// installed before the colour-map/material/void loops below — the material
-/// chain consults `orphan_styled_items`, so injecting after the fact loses
-/// material-dependent styles (measured: 1960 -> 1134 styles on a real model).
-/// With seeds present the styled-item loop is skipped (spans.styled_items is
-/// expected to be empty in that mode).
+/// [`resolve_prepass`] with PRE-RESOLVED styled maps (sharded pre-pass). Seeds
+/// MUST install before the material/void loops: the material chain consults
+/// `orphan_styled_items` — injecting after loses material-dependent styles.
 pub fn resolve_prepass_with_style_seeds(
     spans: &PrepassSpans,
     decoder: &mut EntityDecoder,
@@ -181,7 +133,6 @@ pub fn resolve_prepass_with_style_seeds(
         out.orphan_styled_items = orphan;
         out.geometry_style_index = geom;
     }
-
     // ── Styled items: orphan (material appearance) vs geometry-attached ──
     resolve_styled_items_into(
         &spans.styled_items,

--- a/rust/processing/src/prepass_styled.rs
+++ b/rust/processing/src/prepass_styled.rs
@@ -1,0 +1,56 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Styled-item resolution helpers for the pre-pass (split from `prepass.rs`).
+//! The loop here is byte-identical to the historic inline loop in
+//! `resolve_prepass`; the sharded pre-pass fans slices of it across workers.
+
+use ifc_lite_core::EntityDecoder;
+use rustc_hash::FxHashMap;
+
+use crate::prepass::{collect_geometry_style_info, extract_style_info_from_styled_item, Span};
+use crate::style::GeometryStyleInfo;
+
+/// Pre-resolved styled maps: `(orphan id -> rgba, geometry id -> style info)`.
+pub type StyleSeeds = (FxHashMap<u32, [f32; 4]>, FxHashMap<u32, GeometryStyleInfo>);
+
+/// The styled-item classification/resolution loop of [`resolve_prepass`],
+/// exposed so the browser's SHARDED pre-pass can fan slices of the (file-
+/// ordered) styled-item span list across workers: each worker resolves its
+/// contiguous slice with this exact loop, and the host merges shard results in
+/// shard order with first-wins per geometry id — reproducing the serial
+/// resolver's file-order first-wins precedence (`collect_geometry_style_info`
+/// skips ids already present).
+pub fn resolve_styled_items_into(
+    styled_items: &[Span],
+    decoder: &mut EntityDecoder,
+    defer_attached_styles: bool,
+    orphan_styled_items: &mut FxHashMap<u32, [f32; 4]>,
+    geometry_style_index: &mut FxHashMap<u32, GeometryStyleInfo>,
+    deferred_attached_styled_spans: &mut Vec<(usize, usize)>,
+) {
+    for &(id, start, end) in styled_items {
+        let Ok(styled_item) = decoder.decode_at_with_id(id, start, end) else {
+            if defer_attached_styles {
+                // Undecodable now — let the replay try again later, matching
+                // the historic defer behaviour.
+                deferred_attached_styled_spans.push((start, end));
+            }
+            continue;
+        };
+        if styled_item.get_ref(0).is_none() {
+            // Orphan styled item (null Item) = a material appearance (#407).
+            // Always resolved up front — even in defer mode — or
+            // material-only-styled elements render default-gray (#913 §2c).
+            if let Some(info) = extract_style_info_from_styled_item(&styled_item, decoder) {
+                orphan_styled_items.insert(id, info.color);
+            }
+        } else if defer_attached_styles {
+            deferred_attached_styled_spans.push((start, end));
+        } else {
+            collect_geometry_style_info(geometry_style_index, &styled_item, decoder);
+        }
+    }
+}
+

--- a/rust/processing/src/shard_classes.rs
+++ b/rust/processing/src/shard_classes.rs
@@ -1,0 +1,72 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Per-record prepass classification for the sharded scan (split from
+//! `parallel_scan.rs` — the byte-identical shard/stitch protocol lives there;
+//! this module owns the class codes and the classified scan variant the
+//! browser's sharded pre-pass consumes).
+
+use crate::parallel_scan::ShardRecords;
+use ifc_lite_core::EntityScanner;
+
+/// Per-record prepass class emitted by [`scan_shard_classified`].
+///
+/// Only the codes a downstream consumer needs are defined; everything else is
+/// [`PREPASS_CLASS_NONE`]. Classification happens AT SCAN TIME from the same
+/// `type_name` string the serial pre-pass matches on, so a consumer that
+/// filters records by class reproduces the serial pre-pass's span collection
+/// byte-for-byte (same keyword compare, same file order).
+pub const PREPASS_CLASS_NONE: u8 = 0;
+/// `IFCSTYLEDITEM` — the styled-item spans the pre-pass resolver classifies
+/// into orphan (material appearance) vs geometry-attached styles.
+pub const PREPASS_CLASS_STYLED_ITEM: u8 = 4;
+/// `IFCINDEXEDCOLOURMAP` (#663/#858).
+pub const PREPASS_CLASS_INDEXED_COLOUR_MAP: u8 = 5;
+/// `IFCMATERIALDEFINITIONREPRESENTATION` (#407).
+pub const PREPASS_CLASS_MATERIAL_DEF_REPR: u8 = 6;
+/// `IFCRELASSOCIATESMATERIAL` (#407).
+pub const PREPASS_CLASS_REL_ASSOCIATES_MATERIAL: u8 = 7;
+/// `IFCRELVOIDSELEMENT`.
+pub const PREPASS_CLASS_REL_VOIDS: u8 = 8;
+/// `IFCRELFILLSELEMENT`.
+pub const PREPASS_CLASS_REL_FILLS: u8 = 9;
+/// `IFCRELAGGREGATES`.
+pub const PREPASS_CLASS_REL_AGGREGATES: u8 = 10;
+
+/// [`scan_shard`] plus a parallel per-record class column (see the
+/// `PREPASS_CLASS_*` codes). Same records, same handoff; the class byte lets
+/// the browser host extract pre-pass span lists (today: styled items) from the
+/// stitched shard columns WITHOUT waiting for the serial pre-pass scan.
+pub fn scan_shard_classified(
+    content: &[u8],
+    range_start: usize,
+    range_end: usize,
+) -> (ShardRecords, Vec<u8>, Option<usize>) {
+    let mut scanner = if range_start == 0 {
+        EntityScanner::new(content)
+    } else {
+        EntityScanner::new_at(content, range_start)
+    };
+    let mut records = Vec::new();
+    let mut classes = Vec::new();
+    let mut handoff = None;
+    while let Some((id, type_name, start, entity_end)) = scanner.next_entity() {
+        if start >= range_end {
+            handoff = Some(start);
+            break;
+        }
+        records.push((id, start, entity_end));
+        classes.push(match type_name {
+            "IFCSTYLEDITEM" => PREPASS_CLASS_STYLED_ITEM,
+            "IFCINDEXEDCOLOURMAP" => PREPASS_CLASS_INDEXED_COLOUR_MAP,
+            "IFCMATERIALDEFINITIONREPRESENTATION" => PREPASS_CLASS_MATERIAL_DEF_REPR,
+            "IFCRELASSOCIATESMATERIAL" => PREPASS_CLASS_REL_ASSOCIATES_MATERIAL,
+            "IFCRELVOIDSELEMENT" => PREPASS_CLASS_REL_VOIDS,
+            "IFCRELFILLSELEMENT" => PREPASS_CLASS_REL_FILLS,
+            "IFCRELAGGREGATES" => PREPASS_CLASS_REL_AGGREGATES,
+            _ => PREPASS_CLASS_NONE,
+        });
+    }
+    (records, classes, handoff)
+}

--- a/rust/wasm-bindings/src/api/gpu_meshes/mod.rs
+++ b/rust/wasm-bindings/src/api/gpu_meshes/mod.rs
@@ -11,4 +11,5 @@ mod batch;
 mod batch_from_source;
 mod instancing;
 pub(crate) mod prepass;
+mod prepass_sharded;
 mod void_index;

--- a/rust/wasm-bindings/src/api/gpu_meshes/mod.rs
+++ b/rust/wasm-bindings/src/api/gpu_meshes/mod.rs
@@ -10,5 +10,5 @@
 mod batch;
 mod batch_from_source;
 mod instancing;
-mod prepass;
+pub(crate) mod prepass;
 mod void_index;

--- a/rust/wasm-bindings/src/api/gpu_meshes/prepass.rs
+++ b/rust/wasm-bindings/src/api/gpu_meshes/prepass.rs
@@ -930,9 +930,11 @@ impl IfcAPI {
         crate::api::set_js_prop(&result, "ids", &ids);
         crate::api::set_js_prop(&result, "starts", &starts);
         crate::api::set_js_prop(&result, "lengths", &lengths);
-        // Per-record prepass class (PREPASS_CLASS_*): today only styled items
-        // are tagged, letting the host extract the styled-item span list from
-        // the stitched columns without waiting for the serial pre-pass scan.
+        // Per-record prepass class (PREPASS_CLASS_*): styled items plus the
+        // colour-map/material/void/fills/aggregate support classes are tagged,
+        // letting the host extract every span list resolveStyledItemsShard +
+        // finalizePrepassStyles need from the stitched columns without waiting
+        // for the serial pre-pass scan.
         crate::api::set_js_prop(&result, "classes", &js_sys::Uint8Array::from(classes.as_slice()));
         let handoff_val: f64 = match handoff {
             Some(h) => h as f64,

--- a/rust/wasm-bindings/src/api/gpu_meshes/prepass.rs
+++ b/rust/wasm-bindings/src/api/gpu_meshes/prepass.rs
@@ -201,6 +201,71 @@ impl IfcAPI {
         disabled_type_names: Option<Vec<String>>,
         skip_type_geometry: bool,
     ) -> Result<JsValue, JsValue> {
+        self.pre_pass_streaming_impl(
+            data,
+            on_event,
+            chunk_size,
+            disabled_type_names,
+            skip_type_geometry,
+            None,
+            false,
+        )
+    }
+
+    /// Sharded pre-pass variant: same scan/discovery/jobs/columns pipeline as
+    /// `buildPrePassStreaming`, but
+    ///  1. the entity index is PREBUILT from the host's stitched shard columns
+    ///     (file order; see `scanEntityIndexShard`) — the scan skips its inline
+    ///     index build, the meta RTC ladder resolves against the FULL index
+    ///     (no partial-ladder full-rescan detour), and the post-scan
+    ///     `entity-index` event is skipped (the host already delivered it), and
+    ///  2. styles resolution is EXTERNAL: the styled-item spans are resolved as
+    ///     shard slices on the geometry workers (`resolveStyledItemsShard`);
+    ///     this call stashes the SUPPORT spans + plane-angle scale, and the
+    ///     follow-up `finalizePrepassStyles` merges + flattens into the exact
+    ///     styles payload the serial path emits. NO `styles` event is emitted
+    ///     here.
+    #[wasm_bindgen(js_name = buildPrePassStreamingSharded)]
+    #[allow(clippy::too_many_arguments)]
+    pub fn build_pre_pass_streaming_sharded(
+        &self,
+        data: &[u8],
+        on_event: &Function,
+        chunk_size: u32,
+        disabled_type_names: Option<Vec<String>>,
+        skip_type_geometry: bool,
+        index_ids: &[u32],
+        index_starts: &[u32],
+        index_lengths: &[u32],
+    ) -> Result<JsValue, JsValue> {
+        let prebuilt = ifc_lite_core::ColumnarEntityIndex::from_columns(
+            index_ids,
+            index_starts,
+            index_lengths,
+        );
+        self.pre_pass_streaming_impl(
+            data,
+            on_event,
+            chunk_size,
+            disabled_type_names,
+            skip_type_geometry,
+            Some(prebuilt),
+            true,
+        )
+    }
+
+    fn pre_pass_streaming_impl(
+        &self,
+        data: &[u8],
+        on_event: &Function,
+        chunk_size: u32,
+        disabled_type_names: Option<Vec<String>>,
+        skip_type_geometry: bool,
+        prebuilt: Option<ifc_lite_core::ColumnarEntityIndex>,
+        external_styles: bool,
+    ) -> Result<JsValue, JsValue> {
+        let prebuilt_arc: Option<std::sync::Arc<ifc_lite_core::ColumnarEntityIndex>> =
+            prebuilt.map(std::sync::Arc::new);
         // Load START on the streaming pre-pass path (see build_pre_pass_once).
         self.reset_pipeline_diagnostics();
         use ifc_lite_core::{has_geometry_by_name, EntityDecoder, EntityScanner, IfcType};
@@ -314,7 +379,11 @@ impl IfcAPI {
 
         while let Some((id, type_name, start, end)) = scanner.next_entity() {
             // Build entity index inline (same data we'd otherwise re-scan for).
-            entity_index.insert(id, (start, end));
+            // With a PREBUILT index (sharded pre-pass) the map stays empty — the
+            // decoders below use the prebuilt columnar index instead.
+            if prebuilt_arc.is_none() {
+                entity_index.insert(id, (start, end));
+            }
 
             match type_name {
                 "IFCPROJECT" => {
@@ -408,15 +477,32 @@ impl IfcAPI {
                 // are buffered, near the top of the file, so workers spin up
                 // early. Do NOT move this to a post-scan point — that regresses
                 // every large file.
-                let mut decoder = EntityDecoder::with_index(content, entity_index.clone());
-                let meta_res = resolve_stream_meta(
-                    MetaMode::StreamingPartial,
-                    content,
-                    project_id,
-                    site_position,
-                    &buffered_jobs,
-                    &mut decoder,
-                );
+                // PREBUILT index (sharded pre-pass): the FULL index is already
+                // available, so run the single-stage full-index ladder — the
+                // exact resolution the partial ladder escalates to on a chain
+                // miss — instead of partial-detect + full-index-rescan detour.
+                let meta_res = if let Some(pi) = &prebuilt_arc {
+                    let mut decoder =
+                        EntityDecoder::with_arc_columnar_index(content, pi.clone());
+                    resolve_stream_meta(
+                        MetaMode::SmallFileSingle,
+                        content,
+                        project_id,
+                        site_position,
+                        &buffered_jobs,
+                        &mut decoder,
+                    )
+                } else {
+                    let mut decoder = EntityDecoder::with_index(content, entity_index.clone());
+                    resolve_stream_meta(
+                        MetaMode::StreamingPartial,
+                        content,
+                        project_id,
+                        site_position,
+                        &buffered_jobs,
+                        &mut decoder,
+                    )
+                };
                 plane_angle_to_radians = meta_res.plane_angle_to_radians;
 
                 // Emit meta event.
@@ -443,15 +529,27 @@ impl IfcAPI {
             // full entity index is already complete here — the single-stage
             // `SmallFileSingle` ladder (one detect_rtc_offset_with_fallback) is
             // correct, sharing its resolution with `buildPrePassOnce`.
-            let mut decoder = EntityDecoder::with_index(content, entity_index.clone());
-            let meta_res = resolve_stream_meta(
-                MetaMode::SmallFileSingle,
-                content,
-                project_id,
-                site_position,
-                &buffered_jobs,
-                &mut decoder,
-            );
+            let meta_res = if let Some(pi) = &prebuilt_arc {
+                let mut decoder = EntityDecoder::with_arc_columnar_index(content, pi.clone());
+                resolve_stream_meta(
+                    MetaMode::SmallFileSingle,
+                    content,
+                    project_id,
+                    site_position,
+                    &buffered_jobs,
+                    &mut decoder,
+                )
+            } else {
+                let mut decoder = EntityDecoder::with_index(content, entity_index.clone());
+                resolve_stream_meta(
+                    MetaMode::SmallFileSingle,
+                    content,
+                    project_id,
+                    site_position,
+                    &buffered_jobs,
+                    &mut decoder,
+                )
+            };
             plane_angle_to_radians = meta_res.plane_angle_to_radians;
 
             let meta = js_sys::Object::new();
@@ -464,9 +562,14 @@ impl IfcAPI {
         // into a compact columnar index (sorted u32 columns + binary search):
         // ~229 MB vs the hashmap's ~436 MB on a 19.1 M-entity model (#1682).
         // Consuming frees the map before sorting: one interleaved transient.
-        let entity_index_arc = std::sync::Arc::new(
-            ifc_lite_core::ColumnarEntityIndex::from_hashmap_consuming(entity_index),
-        );
+        let entity_index_arc = match prebuilt_arc {
+            Some(pi) => pi,
+            None => std::sync::Arc::new(ifc_lite_core::ColumnarEntityIndex::from_hashmap_consuming(
+                entity_index,
+            )),
+        };
+        let have_prebuilt = external_styles; // sharded mode always passes both
+
         // Mutex held only briefly to install the Arc.
         {
             let mut slot = self
@@ -492,7 +595,9 @@ impl IfcAPI {
 
         // (A) Entity-index — workers re-scan the whole file (~5 s) without it, so
         // it must reach them as early as possible. Built from the complete index.
-        {
+        // Skipped in sharded mode: the host stitched + delivered it before this
+        // call even started.
+        if !have_prebuilt {
             // Bulk-copy in 3 boundary crossings, not ~8.4M per-entry set_index
             // calls (workers' critical path). Columns are already sorted by id,
             // so consumers hit ColumnarEntityIndex::from_columns' O(n)
@@ -516,22 +621,40 @@ impl IfcAPI {
         // IfcRelAggregates spans, keeping void-parity with the server.
         let mut decoder = EntityDecoder::with_arc_columnar_index(content, entity_index_arc.clone());
         decoder.seed_unit_scales(1.0, plane_angle_to_radians);
-        let resolved = ifc_lite_processing::prepass::resolve_prepass(
-            &prepass_spans,
-            &mut decoder,
-            ifc_lite_processing::prepass::ResolveOptions {
-                collect_indexed_colour_full: false,
-                defer_attached_styles: false,
-            },
-        );
-        let (style_ids_vec, style_colors_vec) =
-            ifc_lite_processing::prepass::flat_styles_rgba8(&resolved, &mut decoder);
-        let (void_keys_vec, void_counts_vec, void_values_vec) =
-            ifc_lite_processing::prepass::flat_voids(&resolved.void_index);
-        let (mat_ids_vec, mat_counts_vec, mat_colors_vec) =
-            ifc_lite_processing::prepass::flat_material_colors(
-                &resolved.element_material_colors,
+        // External-styles (sharded) mode: styles resolve entirely off the shard
+        // classes — styled slices on the geometry workers, support spans
+        // extracted host-side, canonical flatten via finalizePrepassStyles on a
+        // geometry worker. This call emits NO styles event.
+        let styles_block: Option<(
+            Vec<u32>, Vec<u8>, Vec<u32>, Vec<u32>, Vec<u32>, Vec<u32>, Vec<u32>, Vec<u8>,
+        )> = if external_styles {
+            None
+        } else {
+            let resolved = ifc_lite_processing::prepass::resolve_prepass(
+                &prepass_spans,
+                &mut decoder,
+                ifc_lite_processing::prepass::ResolveOptions {
+                    collect_indexed_colour_full: false,
+                    defer_attached_styles: false,
+                },
             );
+            let (style_ids_vec, style_colors_vec) =
+                ifc_lite_processing::prepass::flat_styles_rgba8(&resolved, &mut decoder);
+            let (void_keys_vec, void_counts_vec, void_values_vec) =
+                ifc_lite_processing::prepass::flat_voids(&resolved.void_index);
+            let (mat_ids_vec, mat_counts_vec, mat_colors_vec) =
+                ifc_lite_processing::prepass::flat_material_colors(
+                    &resolved.element_material_colors,
+                );
+            Some((
+                style_ids_vec, style_colors_vec, void_keys_vec, void_counts_vec,
+                void_values_vec, mat_ids_vec, mat_counts_vec, mat_colors_vec,
+            ))
+        };
+        if let Some((
+            style_ids_vec, style_colors_vec, void_keys_vec, void_counts_vec,
+            void_values_vec, mat_ids_vec, mat_counts_vec, mat_colors_vec,
+        )) = styles_block {
         let styles_event = js_sys::Object::new();
         crate::api::set_js_prop(&styles_event, "type", &"styles".into());
         crate::api::set_js_prop(
@@ -575,6 +698,7 @@ impl IfcAPI {
             &js_sys::Uint8Array::from(mat_colors_vec.as_slice()),
         );
         on_event.call1(&JsValue::NULL, &styles_event.into())?;
+        }
 
         // (B2) Pre-pass columns — the three per-content structures each geometry
         // worker would otherwise rebuild with its OWN full-file walk on its first
@@ -759,6 +883,233 @@ impl IfcAPI {
         Ok(JsValue::UNDEFINED)
     }
 }
+
+#[wasm_bindgen]
+impl IfcAPI {
+    /// SPIKE (sharded pre-pass): scan the entity index over a single byte range.
+    ///
+    /// Each idle browser geometry worker calls this on its `[range_start,
+    /// range_end)` shard; the main thread stitches the returned columns into the
+    /// full entity index (byte-identical to the single-threaded
+    /// `build_entity_index`) by binary-searching each shard for the previous
+    /// shard's `handoff`. Delegates to `ifc_lite_processing::scan_shard`, the
+    /// exact per-chunk primitive the native `build_entity_index_parallel` fans
+    /// across cores — so the sharded merge cannot drift from the serial builder.
+    ///
+    /// Byte offsets returned are GLOBAL (relative to file start), so shards
+    /// concatenate without rewriting. Returns a plain object:
+    ///   `{ ids: Uint32Array, starts: Uint32Array, lengths: Uint32Array,
+    ///      handoff: number }`
+    /// where `handoff` is the global start of the first entity at/after
+    /// `range_end` (the next shard's first real entity), or `-1` at EOF.
+    #[wasm_bindgen(js_name = scanEntityIndexShard)]
+    pub fn scan_entity_index_shard(
+        &self,
+        data: &[u8],
+        range_start: u32,
+        range_end: u32,
+    ) -> JsValue {
+        let total = data.len();
+        let start = (range_start as usize).min(total);
+        let end = (range_end as usize).min(total);
+        let (records, classes, handoff) =
+            ifc_lite_processing::scan_shard_classified(data, start, end);
+
+        let n = records.len() as u32;
+        let ids = js_sys::Uint32Array::new_with_length(n);
+        let starts = js_sys::Uint32Array::new_with_length(n);
+        let lengths = js_sys::Uint32Array::new_with_length(n);
+        for (i, &(id, s, e)) in records.iter().enumerate() {
+            let i = i as u32;
+            ids.set_index(i, id);
+            starts.set_index(i, s as u32);
+            lengths.set_index(i, (e - s) as u32);
+        }
+
+        let result = js_sys::Object::new();
+        crate::api::set_js_prop(&result, "ids", &ids);
+        crate::api::set_js_prop(&result, "starts", &starts);
+        crate::api::set_js_prop(&result, "lengths", &lengths);
+        // Per-record prepass class (PREPASS_CLASS_*): today only styled items
+        // are tagged, letting the host extract the styled-item span list from
+        // the stitched columns without waiting for the serial pre-pass scan.
+        crate::api::set_js_prop(&result, "classes", &js_sys::Uint8Array::from(classes.as_slice()));
+        let handoff_val: f64 = match handoff {
+            Some(h) => h as f64,
+            None => -1.0,
+        };
+        crate::api::set_js_prop(&result, "handoff", &handoff_val.into());
+        result.into()
+    }
+
+    /// Sharded pre-pass: resolve ONE contiguous (file-ordered) slice of the
+    /// styled-item span list on this worker, against the entity index installed
+    /// by `setEntityIndex`. Returns raw resolved maps as flat columns:
+    /// `{ orphanIds, orphanColors (f32 rgba per id), geomIds, geomColors }`.
+    /// The host merges shard results IN SHARD ORDER with first-wins per
+    /// geometry id, reproducing the serial resolver's file-order precedence,
+    /// then hands the merged columns to `finalizePrepassStyles`.
+    /// `spans` is `[id, start, len]` triples.
+    #[wasm_bindgen(js_name = resolveStyledItemsShard)]
+    pub fn resolve_styled_items_shard(&self, data: &[u8], spans: &[u32]) -> Result<JsValue, JsValue> {
+        use ifc_lite_core::EntityDecoder;
+        let index = {
+            let slot = self
+                .cached_entity_index
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            slot.clone()
+        };
+        let Some(index) = index else {
+            return Err(JsValue::from_str(
+                "resolveStyledItemsShard: no entity index installed (setEntityIndex must run first)",
+            ));
+        };
+        let mut decoder = EntityDecoder::with_arc_columnar_index(data, index);
+        let styled: Vec<(u32, usize, usize)> = spans
+            .chunks_exact(3)
+            .map(|c| (c[0], c[1] as usize, c[1] as usize + c[2] as usize))
+            .collect();
+        let mut orphan = rustc_hash::FxHashMap::default();
+        let mut geom = rustc_hash::FxHashMap::default();
+        let mut deferred = Vec::new();
+        ifc_lite_processing::prepass::resolve_styled_items_into(
+            &styled,
+            &mut decoder,
+            false,
+            &mut orphan,
+            &mut geom,
+            &mut deferred,
+        );
+
+        let orphan_ids = js_sys::Uint32Array::new_with_length(orphan.len() as u32);
+        let orphan_colors = js_sys::Float32Array::new_with_length((orphan.len() * 4) as u32);
+        for (i, (&id, color)) in orphan.iter().enumerate() {
+            orphan_ids.set_index(i as u32, id);
+            for (j, &c) in color.iter().enumerate() {
+                orphan_colors.set_index((i * 4 + j) as u32, c);
+            }
+        }
+        let geom_ids = js_sys::Uint32Array::new_with_length(geom.len() as u32);
+        let geom_colors = js_sys::Float32Array::new_with_length((geom.len() * 4) as u32);
+        for (i, (&id, info)) in geom.iter().enumerate() {
+            geom_ids.set_index(i as u32, id);
+            for (j, &c) in info.color.iter().enumerate() {
+                geom_colors.set_index((i * 4 + j) as u32, c);
+            }
+        }
+        let result = js_sys::Object::new();
+        crate::api::set_js_prop(&result, "orphanIds", &orphan_ids);
+        crate::api::set_js_prop(&result, "orphanColors", &orphan_colors);
+        crate::api::set_js_prop(&result, "geomIds", &geom_ids);
+        crate::api::set_js_prop(&result, "geomColors", &geom_colors);
+        Ok(result.into())
+    }
+
+    /// Sharded pre-pass: merge the shard-resolved styled-item columns with the
+    /// SUPPORT spans (extracted host-side from the shard classes) and run the
+    /// CANONICAL styles flatten. Returns the exact `styles` event payload the
+    /// serial path emits. Runs on any worker with `setEntityIndex` installed.
+    /// Span arguments are `[id, start, len]` triples; `plane_angle_to_radians`
+    /// comes from the meta event.
+    #[wasm_bindgen(js_name = finalizePrepassStyles)]
+    #[allow(clippy::too_many_arguments)]
+    pub fn finalize_prepass_styles(
+        &self,
+        data: &[u8],
+        orphan_ids: &[u32],
+        orphan_colors: &[f32],
+        geom_ids: &[u32],
+        geom_colors: &[f32],
+        colour_map_spans: &[u32],
+        material_def_spans: &[u32],
+        rel_material_spans: &[u32],
+        void_spans: &[u32],
+        fills_spans: &[u32],
+        aggregate_spans: &[u32],
+        plane_angle_to_radians: f64,
+    ) -> Result<JsValue, JsValue> {
+        use ifc_lite_core::EntityDecoder;
+        fn triples(v: &[u32]) -> Vec<(u32, usize, usize)> {
+            v.chunks_exact(3)
+                .map(|c| (c[0], c[1] as usize, c[1] as usize + c[2] as usize))
+                .collect()
+        }
+        let stashed_support = ifc_lite_processing::prepass::PrepassSpans {
+            styled_items: Vec::new(),
+            indexed_colour_maps: triples(colour_map_spans),
+            material_def_reprs: triples(material_def_spans),
+            rel_associates_material: triples(rel_material_spans),
+            void_rels: triples(void_spans),
+            fills_rels: triples(fills_spans),
+            aggregate_rels: triples(aggregate_spans),
+        };
+        let index = {
+            let slot = self
+                .cached_entity_index
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            slot.clone()
+        };
+        let Some(index) = index else {
+            return Err(JsValue::from_str("finalizePrepassStyles: no entity index"));
+        };
+        let mut decoder = EntityDecoder::with_arc_columnar_index(data, index);
+        decoder.seed_unit_scales(1.0, plane_angle_to_radians);
+
+        // Support spans (colour maps, materials, voids, aggregates) resolve
+        // here — styled_items is empty, so this adds nothing to the styled maps.
+        let mut resolved = ifc_lite_processing::prepass::resolve_prepass(
+            &stashed_support,
+            &mut decoder,
+            ifc_lite_processing::prepass::ResolveOptions {
+                collect_indexed_colour_full: false,
+                defer_attached_styles: false,
+            },
+        );
+        // Inject the shard-merged styled maps.
+        for (i, &id) in orphan_ids.iter().enumerate() {
+            let c = [
+                orphan_colors[i * 4],
+                orphan_colors[i * 4 + 1],
+                orphan_colors[i * 4 + 2],
+                orphan_colors[i * 4 + 3],
+            ];
+            resolved.orphan_styled_items.insert(id, c);
+        }
+        for (i, &id) in geom_ids.iter().enumerate() {
+            let c = [
+                geom_colors[i * 4],
+                geom_colors[i * 4 + 1],
+                geom_colors[i * 4 + 2],
+                geom_colors[i * 4 + 3],
+            ];
+            resolved.geometry_style_index.insert(
+                id,
+                ifc_lite_processing::style::GeometryStyleInfo::from_color(c),
+            );
+        }
+
+        let (style_ids_vec, style_colors_vec) =
+            ifc_lite_processing::prepass::flat_styles_rgba8(&resolved, &mut decoder);
+        let (void_keys_vec, void_counts_vec, void_values_vec) =
+            ifc_lite_processing::prepass::flat_voids(&resolved.void_index);
+        let (mat_ids_vec, mat_counts_vec, mat_colors_vec) =
+            ifc_lite_processing::prepass::flat_material_colors(&resolved.element_material_colors);
+
+        let result = js_sys::Object::new();
+        crate::api::set_js_prop(&result, "styleIds", &js_sys::Uint32Array::from(style_ids_vec.as_slice()));
+        crate::api::set_js_prop(&result, "styleColors", &js_sys::Uint8Array::from(style_colors_vec.as_slice()));
+        crate::api::set_js_prop(&result, "voidKeys", &js_sys::Uint32Array::from(void_keys_vec.as_slice()));
+        crate::api::set_js_prop(&result, "voidCounts", &js_sys::Uint32Array::from(void_counts_vec.as_slice()));
+        crate::api::set_js_prop(&result, "voidValues", &js_sys::Uint32Array::from(void_values_vec.as_slice()));
+        crate::api::set_js_prop(&result, "materialElementIds", &js_sys::Uint32Array::from(mat_ids_vec.as_slice()));
+        crate::api::set_js_prop(&result, "materialColorCounts", &js_sys::Uint32Array::from(mat_counts_vec.as_slice()));
+        crate::api::set_js_prop(&result, "materialColors", &js_sys::Uint8Array::from(mat_colors_vec.as_slice()));
+        Ok(result.into())
+    }
+}
+
 
 #[cfg(test)]
 mod affinity_tests {

--- a/rust/wasm-bindings/src/api/gpu_meshes/prepass.rs
+++ b/rust/wasm-bindings/src/api/gpu_meshes/prepass.rs
@@ -21,29 +21,6 @@ fn fold_u128_to_u32(h: u128) -> u32 {
 // The per-submesh #858 palette split lives inside the canonical per-element
 // producer (`ifc_lite_processing::element`) — shared with the native pipeline.
 
-/// Serialize the shared [`StreamMeta`] onto a JS object as the wire fields the
-/// host reads: `unitScale`, `planeAngleToRadians`, `rtcOffset` (`[x,y,z]`),
-/// `needsShift`, `buildingRotation` (`null` when absent). Used by both the
-/// `buildPrePassOnce` result object and the streaming `meta` events so all
-/// three emission points serialize identically.
-fn set_stream_meta_props(
-    obj: &js_sys::Object,
-    meta: &ifc_lite_processing::stream_meta::StreamMeta,
-) {
-    crate::api::set_js_prop(obj, "unitScale", &meta.length_unit_scale.into());
-    crate::api::set_js_prop(obj, "planeAngleToRadians", &meta.plane_angle_to_radians.into());
-    let rtc_arr = js_sys::Float64Array::new_with_length(3);
-    rtc_arr.set_index(0, meta.rtc_offset.0);
-    rtc_arr.set_index(1, meta.rtc_offset.1);
-    rtc_arr.set_index(2, meta.rtc_offset.2);
-    crate::api::set_js_prop(obj, "rtcOffset", &rtc_arr);
-    crate::api::set_js_prop(obj, "needsShift", &meta.needs_shift.into());
-    match meta.building_rotation {
-        Some(rot) => crate::api::set_js_prop(obj, "buildingRotation", &rot.into()),
-        None => crate::api::set_js_prop(obj, "buildingRotation", &JsValue::NULL),
-    };
-}
-
 #[wasm_bindgen]
 impl IfcAPI {
     /// Run the pre-pass ONCE and return serialized results for worker distribution.
@@ -146,7 +123,7 @@ impl IfcAPI {
         crate::api::set_js_prop(&result, "totalJobs", &(total_jobs as f64).into());
         // unitScale / planeAngleToRadians / rtcOffset / needsShift / buildingRotation
         // from the shared resolver.
-        set_stream_meta_props(&result, &meta);
+        super::prepass_sharded::set_stream_meta_props(&result, &meta);
 
         crate::api::set_js_prop(&result, "voidKeys", &void_keys);
         crate::api::set_js_prop(&result, "voidCounts", &void_counts);
@@ -212,49 +189,7 @@ impl IfcAPI {
         )
     }
 
-    /// Sharded pre-pass variant: same scan/discovery/jobs/columns pipeline as
-    /// `buildPrePassStreaming`, but
-    ///  1. the entity index is PREBUILT from the host's stitched shard columns
-    ///     (file order; see `scanEntityIndexShard`) — the scan skips its inline
-    ///     index build, the meta RTC ladder resolves against the FULL index
-    ///     (no partial-ladder full-rescan detour), and the post-scan
-    ///     `entity-index` event is skipped (the host already delivered it), and
-    ///  2. styles resolution is EXTERNAL: the styled-item spans are resolved as
-    ///     shard slices on the geometry workers (`resolveStyledItemsShard`);
-    ///     this call stashes the SUPPORT spans + plane-angle scale, and the
-    ///     follow-up `finalizePrepassStyles` merges + flattens into the exact
-    ///     styles payload the serial path emits. NO `styles` event is emitted
-    ///     here.
-    #[wasm_bindgen(js_name = buildPrePassStreamingSharded)]
-    #[allow(clippy::too_many_arguments)]
-    pub fn build_pre_pass_streaming_sharded(
-        &self,
-        data: &[u8],
-        on_event: &Function,
-        chunk_size: u32,
-        disabled_type_names: Option<Vec<String>>,
-        skip_type_geometry: bool,
-        index_ids: &[u32],
-        index_starts: &[u32],
-        index_lengths: &[u32],
-    ) -> Result<JsValue, JsValue> {
-        let prebuilt = ifc_lite_core::ColumnarEntityIndex::from_columns(
-            index_ids,
-            index_starts,
-            index_lengths,
-        );
-        self.pre_pass_streaming_impl(
-            data,
-            on_event,
-            chunk_size,
-            disabled_type_names,
-            skip_type_geometry,
-            Some(prebuilt),
-            true,
-        )
-    }
-
-    fn pre_pass_streaming_impl(
+    pub(crate) fn pre_pass_streaming_impl(
         &self,
         data: &[u8],
         on_event: &Function,
@@ -378,9 +313,8 @@ impl IfcAPI {
         let mut prepass_spans = ifc_lite_processing::prepass::PrepassSpans::default();
 
         while let Some((id, type_name, start, end)) = scanner.next_entity() {
-            // Build entity index inline (same data we'd otherwise re-scan for).
-            // With a PREBUILT index (sharded pre-pass) the map stays empty — the
-            // decoders below use the prebuilt columnar index instead.
+            // Build entity index inline (prebuilt/sharded mode: map stays
+            // empty; decoders use the prebuilt columnar index instead).
             if prebuilt_arc.is_none() {
                 entity_index.insert(id, (start, end));
             }
@@ -477,10 +411,9 @@ impl IfcAPI {
                 // are buffered, near the top of the file, so workers spin up
                 // early. Do NOT move this to a post-scan point — that regresses
                 // every large file.
-                // PREBUILT index (sharded pre-pass): the FULL index is already
-                // available, so run the single-stage full-index ladder — the
-                // exact resolution the partial ladder escalates to on a chain
-                // miss — instead of partial-detect + full-index-rescan detour.
+                // PREBUILT index (sharded): full index available, so run the
+                // single-stage full-index ladder (what the partial ladder
+                // escalates to anyway) — no mid-scan full-rescan detour.
                 let meta_res = if let Some(pi) = &prebuilt_arc {
                     let mut decoder =
                         EntityDecoder::with_arc_columnar_index(content, pi.clone());
@@ -508,7 +441,7 @@ impl IfcAPI {
                 // Emit meta event.
                 let meta = js_sys::Object::new();
                 crate::api::set_js_prop(&meta, "type", &"meta".into());
-                set_stream_meta_props(&meta, &meta_res);
+                super::prepass_sharded::set_stream_meta_props(&meta, &meta_res);
                 on_event.call1(&JsValue::NULL, &meta.into())?;
                 meta_emitted = true;
                 // NOTE: jobs are NOT drained here. They are buffered through the
@@ -554,7 +487,7 @@ impl IfcAPI {
 
             let meta = js_sys::Object::new();
             crate::api::set_js_prop(&meta, "type", &"meta".into());
-            set_stream_meta_props(&meta, &meta_res);
+            super::prepass_sharded::set_stream_meta_props(&meta, &meta_res);
             on_event.call1(&JsValue::NULL, &meta.into())?;
         }
 
@@ -584,19 +517,12 @@ impl IfcAPI {
         let index_for_export = entity_index_arc.clone();
 
         // ── FAST FIRST GEOMETRY ──
-        // Workers gate on three post-scan events: entity-index, styles, and the
-        // first jobs chunk. Previously all three waited behind a whole-model
-        // per-job affinity hash (geometry_routing_key over every job, ~4 s), and
-        // the entity-index event was emitted LAST of all — so workers idled until
-        // ~the end of the pre-pass. Now we ship entity-index + styles + a SMALL
-        // first job wave right here (the index is already complete), then run the
-        // affinity pass only over the REST. Only the first wave routes by id; the
-        // bulk keeps exact geometry-hash affinity, so dedup distribution is intact.
+        // Workers gate on entity-index + styles + the first jobs chunk; all
+        // three ship right here post-scan (a SMALL id-routed first wave, then
+        // the affinity pass over the REST — dedup distribution stays intact).
 
-        // (A) Entity-index — workers re-scan the whole file (~5 s) without it, so
-        // it must reach them as early as possible. Built from the complete index.
-        // Skipped in sharded mode: the host stitched + delivered it before this
-        // call even started.
+        // (A) Entity-index — workers re-scan the whole file (~5 s) without it.
+        // Sharded mode skips this: the host delivered the stitched index first.
         if !have_prebuilt {
             // Bulk-copy in 3 boundary crossings, not ~8.4M per-entry set_index
             // calls (workers' critical path). Columns are already sorted by id,
@@ -613,23 +539,14 @@ impl IfcAPI {
             on_event.call1(&JsValue::NULL, &index_event.into())?;
         }
 
-        // (B) Styles + voids — workers also gate on this. Resolve once (the same
-        // shared resolver the native pipeline and buildPrePassOnce run) and emit.
+        // (B) Styles + voids — workers also gate on this. Serial mode resolves
+        // + emits here (shared resolver; MaterialLayerIndex::from_content is
+        // deliberately skipped, aggregate void propagation included); sharded
+        // (external_styles) mode leaves styles to the worker shards + finalize.
         // `decoder` stays in scope below for the orphan type-geometry pass.
-        // MaterialLayerIndex::from_content is deliberately skipped (its own full
-        // scan); aggregate void propagation IS included via the stashed
-        // IfcRelAggregates spans, keeping void-parity with the server.
         let mut decoder = EntityDecoder::with_arc_columnar_index(content, entity_index_arc.clone());
         decoder.seed_unit_scales(1.0, plane_angle_to_radians);
-        // External-styles (sharded) mode: styles resolve entirely off the shard
-        // classes — styled slices on the geometry workers, support spans
-        // extracted host-side, canonical flatten via finalizePrepassStyles on a
-        // geometry worker. This call emits NO styles event.
-        let styles_block: Option<(
-            Vec<u32>, Vec<u8>, Vec<u32>, Vec<u32>, Vec<u32>, Vec<u32>, Vec<u32>, Vec<u8>,
-        )> = if external_styles {
-            None
-        } else {
+        if !external_styles {
             let resolved = ifc_lite_processing::prepass::resolve_prepass(
                 &prepass_spans,
                 &mut decoder,
@@ -638,66 +555,9 @@ impl IfcAPI {
                     defer_attached_styles: false,
                 },
             );
-            let (style_ids_vec, style_colors_vec) =
-                ifc_lite_processing::prepass::flat_styles_rgba8(&resolved, &mut decoder);
-            let (void_keys_vec, void_counts_vec, void_values_vec) =
-                ifc_lite_processing::prepass::flat_voids(&resolved.void_index);
-            let (mat_ids_vec, mat_counts_vec, mat_colors_vec) =
-                ifc_lite_processing::prepass::flat_material_colors(
-                    &resolved.element_material_colors,
-                );
-            Some((
-                style_ids_vec, style_colors_vec, void_keys_vec, void_counts_vec,
-                void_values_vec, mat_ids_vec, mat_counts_vec, mat_colors_vec,
-            ))
-        };
-        if let Some((
-            style_ids_vec, style_colors_vec, void_keys_vec, void_counts_vec,
-            void_values_vec, mat_ids_vec, mat_counts_vec, mat_colors_vec,
-        )) = styles_block {
-        let styles_event = js_sys::Object::new();
-        crate::api::set_js_prop(&styles_event, "type", &"styles".into());
-        crate::api::set_js_prop(
-            &styles_event,
-            "styleIds",
-            &js_sys::Uint32Array::from(style_ids_vec.as_slice()),
-        );
-        crate::api::set_js_prop(
-            &styles_event,
-            "styleColors",
-            &js_sys::Uint8Array::from(style_colors_vec.as_slice()),
-        );
-        crate::api::set_js_prop(
-            &styles_event,
-            "voidKeys",
-            &js_sys::Uint32Array::from(void_keys_vec.as_slice()),
-        );
-        crate::api::set_js_prop(
-            &styles_event,
-            "voidCounts",
-            &js_sys::Uint32Array::from(void_counts_vec.as_slice()),
-        );
-        crate::api::set_js_prop(
-            &styles_event,
-            "voidValues",
-            &js_sys::Uint32Array::from(void_values_vec.as_slice()),
-        );
-        crate::api::set_js_prop(
-            &styles_event,
-            "materialElementIds",
-            &js_sys::Uint32Array::from(mat_ids_vec.as_slice()),
-        );
-        crate::api::set_js_prop(
-            &styles_event,
-            "materialColorCounts",
-            &js_sys::Uint32Array::from(mat_counts_vec.as_slice()),
-        );
-        crate::api::set_js_prop(
-            &styles_event,
-            "materialColors",
-            &js_sys::Uint8Array::from(mat_colors_vec.as_slice()),
-        );
-        on_event.call1(&JsValue::NULL, &styles_event.into())?;
+            let styles_event = super::prepass_sharded::styles_payload(&resolved, &mut decoder);
+            crate::api::set_js_prop(&styles_event, "type", &"styles".into());
+            on_event.call1(&JsValue::NULL, &styles_event.into())?;
         }
 
         // (B2) Pre-pass columns — the three per-content structures each geometry
@@ -883,237 +743,6 @@ impl IfcAPI {
         Ok(JsValue::UNDEFINED)
     }
 }
-
-#[wasm_bindgen]
-impl IfcAPI {
-    /// SPIKE (sharded pre-pass): scan the entity index over a single byte range.
-    ///
-    /// Each idle browser geometry worker calls this on its `[range_start,
-    /// range_end)` shard; the main thread stitches the returned columns into the
-    /// full entity index (byte-identical to the single-threaded
-    /// `build_entity_index`) by binary-searching each shard for the previous
-    /// shard's `handoff`. Delegates to `ifc_lite_processing::scan_shard`, the
-    /// exact per-chunk primitive the native `build_entity_index_parallel` fans
-    /// across cores — so the sharded merge cannot drift from the serial builder.
-    ///
-    /// Byte offsets returned are GLOBAL (relative to file start), so shards
-    /// concatenate without rewriting. Returns a plain object:
-    ///   `{ ids: Uint32Array, starts: Uint32Array, lengths: Uint32Array,
-    ///      handoff: number }`
-    /// where `handoff` is the global start of the first entity at/after
-    /// `range_end` (the next shard's first real entity), or `-1` at EOF.
-    #[wasm_bindgen(js_name = scanEntityIndexShard)]
-    pub fn scan_entity_index_shard(
-        &self,
-        data: &[u8],
-        range_start: u32,
-        range_end: u32,
-    ) -> JsValue {
-        let total = data.len();
-        let start = (range_start as usize).min(total);
-        let end = (range_end as usize).min(total);
-        let (records, classes, handoff) =
-            ifc_lite_processing::scan_shard_classified(data, start, end);
-
-        let n = records.len() as u32;
-        let ids = js_sys::Uint32Array::new_with_length(n);
-        let starts = js_sys::Uint32Array::new_with_length(n);
-        let lengths = js_sys::Uint32Array::new_with_length(n);
-        for (i, &(id, s, e)) in records.iter().enumerate() {
-            let i = i as u32;
-            ids.set_index(i, id);
-            starts.set_index(i, s as u32);
-            lengths.set_index(i, (e - s) as u32);
-        }
-
-        let result = js_sys::Object::new();
-        crate::api::set_js_prop(&result, "ids", &ids);
-        crate::api::set_js_prop(&result, "starts", &starts);
-        crate::api::set_js_prop(&result, "lengths", &lengths);
-        // Per-record prepass class (PREPASS_CLASS_*): styled items plus the
-        // colour-map/material/void/fills/aggregate support classes are tagged,
-        // letting the host extract every span list resolveStyledItemsShard +
-        // finalizePrepassStyles need from the stitched columns without waiting
-        // for the serial pre-pass scan.
-        crate::api::set_js_prop(&result, "classes", &js_sys::Uint8Array::from(classes.as_slice()));
-        let handoff_val: f64 = match handoff {
-            Some(h) => h as f64,
-            None => -1.0,
-        };
-        crate::api::set_js_prop(&result, "handoff", &handoff_val.into());
-        result.into()
-    }
-
-    /// Sharded pre-pass: resolve ONE contiguous (file-ordered) slice of the
-    /// styled-item span list on this worker, against the entity index installed
-    /// by `setEntityIndex`. Returns raw resolved maps as flat columns:
-    /// `{ orphanIds, orphanColors (f32 rgba per id), geomIds, geomColors }`.
-    /// The host merges shard results IN SHARD ORDER with first-wins per
-    /// geometry id, reproducing the serial resolver's file-order precedence,
-    /// then hands the merged columns to `finalizePrepassStyles`.
-    /// `spans` is `[id, start, len]` triples.
-    #[wasm_bindgen(js_name = resolveStyledItemsShard)]
-    pub fn resolve_styled_items_shard(&self, data: &[u8], spans: &[u32]) -> Result<JsValue, JsValue> {
-        use ifc_lite_core::EntityDecoder;
-        let index = {
-            let slot = self
-                .cached_entity_index
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner);
-            slot.clone()
-        };
-        let Some(index) = index else {
-            return Err(JsValue::from_str(
-                "resolveStyledItemsShard: no entity index installed (setEntityIndex must run first)",
-            ));
-        };
-        let mut decoder = EntityDecoder::with_arc_columnar_index(data, index);
-        let styled: Vec<(u32, usize, usize)> = spans
-            .chunks_exact(3)
-            .map(|c| (c[0], c[1] as usize, c[1] as usize + c[2] as usize))
-            .collect();
-        let mut orphan = rustc_hash::FxHashMap::default();
-        let mut geom = rustc_hash::FxHashMap::default();
-        let mut deferred = Vec::new();
-        ifc_lite_processing::prepass::resolve_styled_items_into(
-            &styled,
-            &mut decoder,
-            false,
-            &mut orphan,
-            &mut geom,
-            &mut deferred,
-        );
-
-        let orphan_ids = js_sys::Uint32Array::new_with_length(orphan.len() as u32);
-        let orphan_colors = js_sys::Float32Array::new_with_length((orphan.len() * 4) as u32);
-        for (i, (&id, color)) in orphan.iter().enumerate() {
-            orphan_ids.set_index(i as u32, id);
-            for (j, &c) in color.iter().enumerate() {
-                orphan_colors.set_index((i * 4 + j) as u32, c);
-            }
-        }
-        let geom_ids = js_sys::Uint32Array::new_with_length(geom.len() as u32);
-        let geom_colors = js_sys::Float32Array::new_with_length((geom.len() * 4) as u32);
-        for (i, (&id, info)) in geom.iter().enumerate() {
-            geom_ids.set_index(i as u32, id);
-            for (j, &c) in info.color.iter().enumerate() {
-                geom_colors.set_index((i * 4 + j) as u32, c);
-            }
-        }
-        let result = js_sys::Object::new();
-        crate::api::set_js_prop(&result, "orphanIds", &orphan_ids);
-        crate::api::set_js_prop(&result, "orphanColors", &orphan_colors);
-        crate::api::set_js_prop(&result, "geomIds", &geom_ids);
-        crate::api::set_js_prop(&result, "geomColors", &geom_colors);
-        Ok(result.into())
-    }
-
-    /// Sharded pre-pass: merge the shard-resolved styled-item columns with the
-    /// SUPPORT spans (extracted host-side from the shard classes) and run the
-    /// CANONICAL styles flatten. Returns the exact `styles` event payload the
-    /// serial path emits. Runs on any worker with `setEntityIndex` installed.
-    /// Span arguments are `[id, start, len]` triples; `plane_angle_to_radians`
-    /// comes from the meta event.
-    #[wasm_bindgen(js_name = finalizePrepassStyles)]
-    #[allow(clippy::too_many_arguments)]
-    pub fn finalize_prepass_styles(
-        &self,
-        data: &[u8],
-        orphan_ids: &[u32],
-        orphan_colors: &[f32],
-        geom_ids: &[u32],
-        geom_colors: &[f32],
-        colour_map_spans: &[u32],
-        material_def_spans: &[u32],
-        rel_material_spans: &[u32],
-        void_spans: &[u32],
-        fills_spans: &[u32],
-        aggregate_spans: &[u32],
-        plane_angle_to_radians: f64,
-    ) -> Result<JsValue, JsValue> {
-        use ifc_lite_core::EntityDecoder;
-        fn triples(v: &[u32]) -> Vec<(u32, usize, usize)> {
-            v.chunks_exact(3)
-                .map(|c| (c[0], c[1] as usize, c[1] as usize + c[2] as usize))
-                .collect()
-        }
-        let stashed_support = ifc_lite_processing::prepass::PrepassSpans {
-            styled_items: Vec::new(),
-            indexed_colour_maps: triples(colour_map_spans),
-            material_def_reprs: triples(material_def_spans),
-            rel_associates_material: triples(rel_material_spans),
-            void_rels: triples(void_spans),
-            fills_rels: triples(fills_spans),
-            aggregate_rels: triples(aggregate_spans),
-        };
-        let index = {
-            let slot = self
-                .cached_entity_index
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner);
-            slot.clone()
-        };
-        let Some(index) = index else {
-            return Err(JsValue::from_str("finalizePrepassStyles: no entity index"));
-        };
-        let mut decoder = EntityDecoder::with_arc_columnar_index(data, index);
-        decoder.seed_unit_scales(1.0, plane_angle_to_radians);
-
-        // Rebuild the shard-merged styled maps and SEED them into the resolver
-        // BEFORE the support-span loops: the material chain consults
-        // orphan_styled_items, so injecting after resolve_prepass loses
-        // material-dependent styles.
-        let mut orphan_seed = rustc_hash::FxHashMap::default();
-        for (i, &id) in orphan_ids.iter().enumerate() {
-            orphan_seed.insert(id, [
-                orphan_colors[i * 4],
-                orphan_colors[i * 4 + 1],
-                orphan_colors[i * 4 + 2],
-                orphan_colors[i * 4 + 3],
-            ]);
-        }
-        let mut geom_seed = rustc_hash::FxHashMap::default();
-        for (i, &id) in geom_ids.iter().enumerate() {
-            geom_seed.insert(
-                id,
-                ifc_lite_processing::style::GeometryStyleInfo::from_color([
-                    geom_colors[i * 4],
-                    geom_colors[i * 4 + 1],
-                    geom_colors[i * 4 + 2],
-                    geom_colors[i * 4 + 3],
-                ]),
-            );
-        }
-        let mut resolved = ifc_lite_processing::prepass::resolve_prepass_with_style_seeds(
-            &stashed_support,
-            &mut decoder,
-            ifc_lite_processing::prepass::ResolveOptions {
-                collect_indexed_colour_full: false,
-                defer_attached_styles: false,
-            },
-            Some((orphan_seed, geom_seed)),
-        );
-
-        let (style_ids_vec, style_colors_vec) =
-            ifc_lite_processing::prepass::flat_styles_rgba8(&resolved, &mut decoder);
-        let (void_keys_vec, void_counts_vec, void_values_vec) =
-            ifc_lite_processing::prepass::flat_voids(&resolved.void_index);
-        let (mat_ids_vec, mat_counts_vec, mat_colors_vec) =
-            ifc_lite_processing::prepass::flat_material_colors(&resolved.element_material_colors);
-
-        let result = js_sys::Object::new();
-        crate::api::set_js_prop(&result, "styleIds", &js_sys::Uint32Array::from(style_ids_vec.as_slice()));
-        crate::api::set_js_prop(&result, "styleColors", &js_sys::Uint8Array::from(style_colors_vec.as_slice()));
-        crate::api::set_js_prop(&result, "voidKeys", &js_sys::Uint32Array::from(void_keys_vec.as_slice()));
-        crate::api::set_js_prop(&result, "voidCounts", &js_sys::Uint32Array::from(void_counts_vec.as_slice()));
-        crate::api::set_js_prop(&result, "voidValues", &js_sys::Uint32Array::from(void_values_vec.as_slice()));
-        crate::api::set_js_prop(&result, "materialElementIds", &js_sys::Uint32Array::from(mat_ids_vec.as_slice()));
-        crate::api::set_js_prop(&result, "materialColorCounts", &js_sys::Uint32Array::from(mat_counts_vec.as_slice()));
-        crate::api::set_js_prop(&result, "materialColors", &js_sys::Uint8Array::from(mat_colors_vec.as_slice()));
-        Ok(result.into())
-    }
-}
-
 
 #[cfg(test)]
 mod affinity_tests {

--- a/rust/wasm-bindings/src/api/gpu_meshes/prepass.rs
+++ b/rust/wasm-bindings/src/api/gpu_meshes/prepass.rs
@@ -1057,38 +1057,40 @@ impl IfcAPI {
         let mut decoder = EntityDecoder::with_arc_columnar_index(data, index);
         decoder.seed_unit_scales(1.0, plane_angle_to_radians);
 
-        // Support spans (colour maps, materials, voids, aggregates) resolve
-        // here — styled_items is empty, so this adds nothing to the styled maps.
-        let mut resolved = ifc_lite_processing::prepass::resolve_prepass(
+        // Rebuild the shard-merged styled maps and SEED them into the resolver
+        // BEFORE the support-span loops: the material chain consults
+        // orphan_styled_items, so injecting after resolve_prepass loses
+        // material-dependent styles.
+        let mut orphan_seed = rustc_hash::FxHashMap::default();
+        for (i, &id) in orphan_ids.iter().enumerate() {
+            orphan_seed.insert(id, [
+                orphan_colors[i * 4],
+                orphan_colors[i * 4 + 1],
+                orphan_colors[i * 4 + 2],
+                orphan_colors[i * 4 + 3],
+            ]);
+        }
+        let mut geom_seed = rustc_hash::FxHashMap::default();
+        for (i, &id) in geom_ids.iter().enumerate() {
+            geom_seed.insert(
+                id,
+                ifc_lite_processing::style::GeometryStyleInfo::from_color([
+                    geom_colors[i * 4],
+                    geom_colors[i * 4 + 1],
+                    geom_colors[i * 4 + 2],
+                    geom_colors[i * 4 + 3],
+                ]),
+            );
+        }
+        let mut resolved = ifc_lite_processing::prepass::resolve_prepass_with_style_seeds(
             &stashed_support,
             &mut decoder,
             ifc_lite_processing::prepass::ResolveOptions {
                 collect_indexed_colour_full: false,
                 defer_attached_styles: false,
             },
+            Some((orphan_seed, geom_seed)),
         );
-        // Inject the shard-merged styled maps.
-        for (i, &id) in orphan_ids.iter().enumerate() {
-            let c = [
-                orphan_colors[i * 4],
-                orphan_colors[i * 4 + 1],
-                orphan_colors[i * 4 + 2],
-                orphan_colors[i * 4 + 3],
-            ];
-            resolved.orphan_styled_items.insert(id, c);
-        }
-        for (i, &id) in geom_ids.iter().enumerate() {
-            let c = [
-                geom_colors[i * 4],
-                geom_colors[i * 4 + 1],
-                geom_colors[i * 4 + 2],
-                geom_colors[i * 4 + 3],
-            ];
-            resolved.geometry_style_index.insert(
-                id,
-                ifc_lite_processing::style::GeometryStyleInfo::from_color(c),
-            );
-        }
 
         let (style_ids_vec, style_colors_vec) =
             ifc_lite_processing::prepass::flat_styles_rgba8(&resolved, &mut decoder);

--- a/rust/wasm-bindings/src/api/gpu_meshes/prepass_sharded.rs
+++ b/rust/wasm-bindings/src/api/gpu_meshes/prepass_sharded.rs
@@ -1,0 +1,320 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Sharded pre-pass wasm APIs (split from `prepass.rs`): the per-worker
+//! entity-index shard scan, the per-worker styled-item slice resolver, and
+//! the canonical styles finalize that merges the shard results. The main
+//! sharded pre-pass entry (`buildPrePassStreamingSharded`) stays in
+//! `prepass.rs` beside its serial twin.
+
+use crate::api::IfcAPI;
+use js_sys::Function;
+use wasm_bindgen::prelude::*;
+
+/// Serialize the shared [`StreamMeta`] onto a JS object as the wire fields the
+/// host reads: `unitScale`, `planeAngleToRadians`, `rtcOffset` (`[x,y,z]`),
+/// `needsShift`, `buildingRotation` (`null` when absent). Used by both the
+/// `buildPrePassOnce` result object and the streaming `meta` events so all
+/// three emission points serialize identically.
+pub(super) fn set_stream_meta_props(
+    obj: &js_sys::Object,
+    meta: &ifc_lite_processing::stream_meta::StreamMeta,
+) {
+    crate::api::set_js_prop(obj, "unitScale", &meta.length_unit_scale.into());
+    crate::api::set_js_prop(obj, "planeAngleToRadians", &meta.plane_angle_to_radians.into());
+    let rtc_arr = js_sys::Float64Array::new_with_length(3);
+    rtc_arr.set_index(0, meta.rtc_offset.0);
+    rtc_arr.set_index(1, meta.rtc_offset.1);
+    rtc_arr.set_index(2, meta.rtc_offset.2);
+    crate::api::set_js_prop(obj, "rtcOffset", &rtc_arr);
+    crate::api::set_js_prop(obj, "needsShift", &meta.needs_shift.into());
+    match meta.building_rotation {
+        Some(rot) => crate::api::set_js_prop(obj, "buildingRotation", &rot.into()),
+        None => crate::api::set_js_prop(obj, "buildingRotation", &JsValue::NULL),
+    };
+}
+
+#[wasm_bindgen]
+impl IfcAPI {
+    /// Sharded pre-pass variant: same scan/discovery/jobs/columns pipeline as
+    /// `buildPrePassStreaming`, but
+    ///  1. the entity index is PREBUILT from the host's stitched shard columns
+    ///     (file order; see `scanEntityIndexShard`) — the scan skips its inline
+    ///     index build, the meta RTC ladder resolves against the FULL index
+    ///     (no partial-ladder full-rescan detour), and the post-scan
+    ///     `entity-index` event is skipped (the host already delivered it), and
+    ///  2. styles resolution is EXTERNAL: the styled-item spans are resolved as
+    ///     shard slices on the geometry workers (`resolveStyledItemsShard`);
+    ///     this call stashes the SUPPORT spans + plane-angle scale, and the
+    ///     follow-up `finalizePrepassStyles` merges + flattens into the exact
+    ///     styles payload the serial path emits. NO `styles` event is emitted
+    ///     here.
+    #[wasm_bindgen(js_name = buildPrePassStreamingSharded)]
+    #[allow(clippy::too_many_arguments)]
+    pub fn build_pre_pass_streaming_sharded(
+        &self,
+        data: &[u8],
+        on_event: &Function,
+        chunk_size: u32,
+        disabled_type_names: Option<Vec<String>>,
+        skip_type_geometry: bool,
+        index_ids: &[u32],
+        index_starts: &[u32],
+        index_lengths: &[u32],
+    ) -> Result<JsValue, JsValue> {
+        let prebuilt = ifc_lite_core::ColumnarEntityIndex::from_columns(
+            index_ids,
+            index_starts,
+            index_lengths,
+        );
+        self.pre_pass_streaming_impl(
+            data,
+            on_event,
+            chunk_size,
+            disabled_type_names,
+            skip_type_geometry,
+            Some(prebuilt),
+            true,
+        )
+    }
+
+    /// SPIKE (sharded pre-pass): scan the entity index over a single byte range.
+    ///
+    /// Each idle browser geometry worker calls this on its `[range_start,
+    /// range_end)` shard; the main thread stitches the returned columns into the
+    /// full entity index (byte-identical to the single-threaded
+    /// `build_entity_index`) by binary-searching each shard for the previous
+    /// shard's `handoff`. Delegates to `ifc_lite_processing::scan_shard`, the
+    /// exact per-chunk primitive the native `build_entity_index_parallel` fans
+    /// across cores — so the sharded merge cannot drift from the serial builder.
+    ///
+    /// Byte offsets returned are GLOBAL (relative to file start), so shards
+    /// concatenate without rewriting. Returns a plain object:
+    ///   `{ ids: Uint32Array, starts: Uint32Array, lengths: Uint32Array,
+    ///      handoff: number }`
+    /// where `handoff` is the global start of the first entity at/after
+    /// `range_end` (the next shard's first real entity), or `-1` at EOF.
+    #[wasm_bindgen(js_name = scanEntityIndexShard)]
+    pub fn scan_entity_index_shard(
+        &self,
+        data: &[u8],
+        range_start: u32,
+        range_end: u32,
+    ) -> JsValue {
+        let total = data.len();
+        let start = (range_start as usize).min(total);
+        let end = (range_end as usize).min(total);
+        let (records, classes, handoff) =
+            ifc_lite_processing::scan_shard_classified(data, start, end);
+
+        let n = records.len() as u32;
+        let ids = js_sys::Uint32Array::new_with_length(n);
+        let starts = js_sys::Uint32Array::new_with_length(n);
+        let lengths = js_sys::Uint32Array::new_with_length(n);
+        for (i, &(id, s, e)) in records.iter().enumerate() {
+            let i = i as u32;
+            ids.set_index(i, id);
+            starts.set_index(i, s as u32);
+            lengths.set_index(i, (e - s) as u32);
+        }
+
+        let result = js_sys::Object::new();
+        crate::api::set_js_prop(&result, "ids", &ids);
+        crate::api::set_js_prop(&result, "starts", &starts);
+        crate::api::set_js_prop(&result, "lengths", &lengths);
+        // Per-record prepass class (PREPASS_CLASS_*): styled items plus the
+        // colour-map/material/void/fills/aggregate support classes are tagged,
+        // letting the host extract every span list resolveStyledItemsShard +
+        // finalizePrepassStyles need from the stitched columns without waiting
+        // for the serial pre-pass scan.
+        crate::api::set_js_prop(&result, "classes", &js_sys::Uint8Array::from(classes.as_slice()));
+        let handoff_val: f64 = match handoff {
+            Some(h) => h as f64,
+            None => -1.0,
+        };
+        crate::api::set_js_prop(&result, "handoff", &handoff_val.into());
+        result.into()
+    }
+
+    /// Sharded pre-pass: resolve ONE contiguous (file-ordered) slice of the
+    /// styled-item span list on this worker, against the entity index installed
+    /// by `setEntityIndex`. Returns raw resolved maps as flat columns:
+    /// `{ orphanIds, orphanColors (f32 rgba per id), geomIds, geomColors }`.
+    /// The host merges shard results IN SHARD ORDER with first-wins per
+    /// geometry id, reproducing the serial resolver's file-order precedence,
+    /// then hands the merged columns to `finalizePrepassStyles`.
+    /// `spans` is `[id, start, len]` triples.
+    #[wasm_bindgen(js_name = resolveStyledItemsShard)]
+    pub fn resolve_styled_items_shard(&self, data: &[u8], spans: &[u32]) -> Result<JsValue, JsValue> {
+        use ifc_lite_core::EntityDecoder;
+        let index = {
+            let slot = self
+                .cached_entity_index
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            slot.clone()
+        };
+        let Some(index) = index else {
+            return Err(JsValue::from_str(
+                "resolveStyledItemsShard: no entity index installed (setEntityIndex must run first)",
+            ));
+        };
+        let mut decoder = EntityDecoder::with_arc_columnar_index(data, index);
+        let styled: Vec<(u32, usize, usize)> = spans
+            .chunks_exact(3)
+            .map(|c| (c[0], c[1] as usize, c[1] as usize + c[2] as usize))
+            .collect();
+        let mut orphan = rustc_hash::FxHashMap::default();
+        let mut geom = rustc_hash::FxHashMap::default();
+        let mut deferred = Vec::new();
+        ifc_lite_processing::prepass::resolve_styled_items_into(
+            &styled,
+            &mut decoder,
+            false,
+            &mut orphan,
+            &mut geom,
+            &mut deferred,
+        );
+
+        let orphan_ids = js_sys::Uint32Array::new_with_length(orphan.len() as u32);
+        let orphan_colors = js_sys::Float32Array::new_with_length((orphan.len() * 4) as u32);
+        for (i, (&id, color)) in orphan.iter().enumerate() {
+            orphan_ids.set_index(i as u32, id);
+            for (j, &c) in color.iter().enumerate() {
+                orphan_colors.set_index((i * 4 + j) as u32, c);
+            }
+        }
+        let geom_ids = js_sys::Uint32Array::new_with_length(geom.len() as u32);
+        let geom_colors = js_sys::Float32Array::new_with_length((geom.len() * 4) as u32);
+        for (i, (&id, info)) in geom.iter().enumerate() {
+            geom_ids.set_index(i as u32, id);
+            for (j, &c) in info.color.iter().enumerate() {
+                geom_colors.set_index((i * 4 + j) as u32, c);
+            }
+        }
+        let result = js_sys::Object::new();
+        crate::api::set_js_prop(&result, "orphanIds", &orphan_ids);
+        crate::api::set_js_prop(&result, "orphanColors", &orphan_colors);
+        crate::api::set_js_prop(&result, "geomIds", &geom_ids);
+        crate::api::set_js_prop(&result, "geomColors", &geom_colors);
+        Ok(result.into())
+    }
+
+    /// Sharded pre-pass: merge the shard-resolved styled-item columns with the
+    /// SUPPORT spans (extracted host-side from the shard classes) and run the
+    /// CANONICAL styles flatten. Returns the exact `styles` event payload the
+    /// serial path emits. Runs on any worker with `setEntityIndex` installed.
+    /// Span arguments are `[id, start, len]` triples; `plane_angle_to_radians`
+    /// comes from the meta event.
+    #[wasm_bindgen(js_name = finalizePrepassStyles)]
+    #[allow(clippy::too_many_arguments)]
+    pub fn finalize_prepass_styles(
+        &self,
+        data: &[u8],
+        orphan_ids: &[u32],
+        orphan_colors: &[f32],
+        geom_ids: &[u32],
+        geom_colors: &[f32],
+        colour_map_spans: &[u32],
+        material_def_spans: &[u32],
+        rel_material_spans: &[u32],
+        void_spans: &[u32],
+        fills_spans: &[u32],
+        aggregate_spans: &[u32],
+        plane_angle_to_radians: f64,
+    ) -> Result<JsValue, JsValue> {
+        use ifc_lite_core::EntityDecoder;
+        fn triples(v: &[u32]) -> Vec<(u32, usize, usize)> {
+            v.chunks_exact(3)
+                .map(|c| (c[0], c[1] as usize, c[1] as usize + c[2] as usize))
+                .collect()
+        }
+        let stashed_support = ifc_lite_processing::prepass::PrepassSpans {
+            styled_items: Vec::new(),
+            indexed_colour_maps: triples(colour_map_spans),
+            material_def_reprs: triples(material_def_spans),
+            rel_associates_material: triples(rel_material_spans),
+            void_rels: triples(void_spans),
+            fills_rels: triples(fills_spans),
+            aggregate_rels: triples(aggregate_spans),
+        };
+        let index = {
+            let slot = self
+                .cached_entity_index
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            slot.clone()
+        };
+        let Some(index) = index else {
+            return Err(JsValue::from_str("finalizePrepassStyles: no entity index"));
+        };
+        let mut decoder = EntityDecoder::with_arc_columnar_index(data, index);
+        decoder.seed_unit_scales(1.0, plane_angle_to_radians);
+
+        // Rebuild the shard-merged styled maps and SEED them into the resolver
+        // BEFORE the support-span loops: the material chain consults
+        // orphan_styled_items, so injecting after resolve_prepass loses
+        // material-dependent styles.
+        let mut orphan_seed = rustc_hash::FxHashMap::default();
+        for (i, &id) in orphan_ids.iter().enumerate() {
+            orphan_seed.insert(id, [
+                orphan_colors[i * 4],
+                orphan_colors[i * 4 + 1],
+                orphan_colors[i * 4 + 2],
+                orphan_colors[i * 4 + 3],
+            ]);
+        }
+        let mut geom_seed = rustc_hash::FxHashMap::default();
+        for (i, &id) in geom_ids.iter().enumerate() {
+            geom_seed.insert(
+                id,
+                ifc_lite_processing::style::GeometryStyleInfo::from_color([
+                    geom_colors[i * 4],
+                    geom_colors[i * 4 + 1],
+                    geom_colors[i * 4 + 2],
+                    geom_colors[i * 4 + 3],
+                ]),
+            );
+        }
+        let mut resolved = ifc_lite_processing::prepass::resolve_prepass_with_style_seeds(
+            &stashed_support,
+            &mut decoder,
+            ifc_lite_processing::prepass::ResolveOptions {
+                collect_indexed_colour_full: false,
+                defer_attached_styles: false,
+            },
+            Some((orphan_seed, geom_seed)),
+        );
+
+        Ok(styles_payload(&resolved, &mut decoder).into())
+    }
+}
+
+/// Serialize a [`ResolvedPrepass`] into the flat `styles` wire payload
+/// (styleIds/styleColors/voidKeys/voidCounts/voidValues/materialElementIds/
+/// materialColorCounts/materialColors). Shared by the serial pre-pass's
+/// styles event and the sharded finalize so the two cannot drift.
+pub(super) fn styles_payload(
+    resolved: &ifc_lite_processing::prepass::ResolvedPrepass,
+    decoder: &mut ifc_lite_core::EntityDecoder,
+) -> js_sys::Object {
+    let (style_ids_vec, style_colors_vec) =
+        ifc_lite_processing::prepass::flat_styles_rgba8(resolved, decoder);
+    let (void_keys_vec, void_counts_vec, void_values_vec) =
+        ifc_lite_processing::prepass::flat_voids(&resolved.void_index);
+    let (mat_ids_vec, mat_counts_vec, mat_colors_vec) =
+        ifc_lite_processing::prepass::flat_material_colors(&resolved.element_material_colors);
+    let result = js_sys::Object::new();
+    crate::api::set_js_prop(&result, "styleIds", &js_sys::Uint32Array::from(style_ids_vec.as_slice()));
+    crate::api::set_js_prop(&result, "styleColors", &js_sys::Uint8Array::from(style_colors_vec.as_slice()));
+    crate::api::set_js_prop(&result, "voidKeys", &js_sys::Uint32Array::from(void_keys_vec.as_slice()));
+    crate::api::set_js_prop(&result, "voidCounts", &js_sys::Uint32Array::from(void_counts_vec.as_slice()));
+    crate::api::set_js_prop(&result, "voidValues", &js_sys::Uint32Array::from(void_values_vec.as_slice()));
+    crate::api::set_js_prop(&result, "materialElementIds", &js_sys::Uint32Array::from(mat_ids_vec.as_slice()));
+    crate::api::set_js_prop(&result, "materialColorCounts", &js_sys::Uint32Array::from(mat_counts_vec.as_slice()));
+    crate::api::set_js_prop(&result, "materialColors", &js_sys::Uint8Array::from(mat_colors_vec.as_slice()));
+    result
+}
+
+

--- a/tests/benchmark/viewer-benchmark-page.ts
+++ b/tests/benchmark/viewer-benchmark-page.ts
@@ -137,6 +137,16 @@ export class ViewerBenchmarkPage {
       }
     }
 
+    // Sharded entity-index scan A/B knob: shard the scan across the idle
+    // geometry workers + deliver the stitched index early. Set
+    // VIEWER_BENCHMARK_SHARD_SCAN=1 to enable; unset => baseline.
+    if (process.env.VIEWER_BENCHMARK_SHARD_SCAN === '1') {
+      await this.page.addInitScript(() => {
+        (globalThis as unknown as { __IFC_LITE_SHARD_SCAN?: number }).__IFC_LITE_SHARD_SCAN = 1;
+      });
+      console.log('[Benchmark] sharded entity-index scan: ON');
+    }
+
     // Optional contribution-culling override for A/B runs (issue #1682).
     // Set VIEWER_BENCHMARK_CONTRIB_CULL to "0" (disable), a number (rest px),
     // or JSON like {"pixelRadius":1,"interactingPixelRadius":3}. Unset ⇒ the

--- a/tests/benchmark/viewer-benchmark-page.ts
+++ b/tests/benchmark/viewer-benchmark-page.ts
@@ -137,14 +137,20 @@ export class ViewerBenchmarkPage {
       }
     }
 
-    // Sharded entity-index scan A/B knob: shard the scan across the idle
-    // geometry workers + deliver the stitched index early. Set
-    // VIEWER_BENCHMARK_SHARD_SCAN=1 to enable; unset => baseline.
-    if (process.env.VIEWER_BENCHMARK_SHARD_SCAN === '1') {
+    // Sharded pre-pass A/B knob. The app DEFAULT is ON, so a serial baseline
+    // must inject the kill switch: VIEWER_BENCHMARK_SHARD_SCAN=0 (or "off")
+    // => 0; =1 or unset => app default (on).
+    const shardScanEnv = process.env.VIEWER_BENCHMARK_SHARD_SCAN;
+    if (shardScanEnv === '0' || shardScanEnv === 'off') {
+      await this.page.addInitScript(() => {
+        (globalThis as unknown as { __IFC_LITE_SHARD_SCAN?: number }).__IFC_LITE_SHARD_SCAN = 0;
+      });
+      console.log('[Benchmark] sharded pre-pass: OFF (kill switch)');
+    } else if (shardScanEnv === '1') {
       await this.page.addInitScript(() => {
         (globalThis as unknown as { __IFC_LITE_SHARD_SCAN?: number }).__IFC_LITE_SHARD_SCAN = 1;
       });
-      console.log('[Benchmark] sharded entity-index scan: ON');
+      console.log('[Benchmark] sharded pre-pass: ON (explicit)');
     }
 
     // Optional contribution-culling override for A/B runs (issue #1682).


### PR DESCRIPTION
## Problem

Time-to-first-geometry on large fresh loads is gated by the serial pre-pass. On an 883 MB / 19.1M-entity CATIA model: meta 5.9s (RTC ladder full-index detour) → entity index 7.3s → **styles resolution 4.2s over 4.35M styled items — the actual job-dispatch gate** (mesh chunks queue in JS until styles arrive so colors are correct) → first jobs 11.5s → first visible geometry at 14-16s.

## Fix — sharded pre-pass (Path C of the May streaming-load design, dd56ea9e)

ON by default; `__IFC_LITE_SHARD_SCAN = 0` (env `VIEWER_BENCHMARK_SHARD_SCAN`) is the kill switch. Flag off = the serial path, byte-for-byte.

1. **Parallel entity-index scan.** Idle geometry workers each scan a byte shard (`scanEntityIndexShard`, wrapping the byte-identical `scan_shard` primitive from #1589) and the host stitches the full index with the handoff protocol — **19.1M entities in 0.6-0.8s** vs 7.7s serial — delivered immediately to the workers and the parser. Each record also carries a **prepass-class byte** (styled item / colour map / material / voids / fills / aggregates), computed at scan time from the same keyword compares as the serial pre-pass, so every span list is known at stitch time.
2. **Parallel styles resolution.** Styled-item spans resolve as contiguous file-order slices on the workers (`resolveStyledItemsShard` wrapping the extracted `resolve_styled_items_into` — the exact serial loop), merged first-wins in shard order (identical precedence). The canonical flatten (`finalizePrepassStyles`, geometry worker 0) **seeds the merged maps before the material-chain resolution** — inject-after lost material-dependent styles (measured: 1960→1134 styled on FM_ARC_DigitalHub; the seed fix restores exact parity).
3. **Pre-pass with a prebuilt index** (`buildPrePassStreamingSharded`): starts after the stitch (racing it costs +2.7s of memory-bandwidth contention — measured), skips the inline index build and the index export, resolves meta against the full index (single-stage RTC ladder — no mid-scan full-file rescan).
4. **Stream-end defers while chunks are queued** behind the asynchronously finalized styles event (without this, workers completed before the drain and a run produced zero meshes).

## Measured (real Chrome, fresh profile = true cold load)

**CatiaA1.ifc, 883 MB, 19.1M entities, 3 workers (memory tier):**

| | serial (main) | sharded |
|---|---|---|
| entity index | 7.7s | **0.63s** |
| meta | 6.4s | **3.9s** |
| first jobs chunk | 11.7s | **4.2s** |
| styles | 11.7s | **7.6s** |
| **first visible geometry** | **14.3s** | **10.4-11.1s (-23 to -28%)** |
| stream complete | 22.4s | **15.4s (-31%)** |
| final render stats | 2,122 draws / 722.7 MB / 284 batches | identical |

**FM_ARC_DigitalHub.ifc (22 MB, 8 workers):** styles 83ms→93ms, first visible 414ms→412ms — parity within noise, and **exact output parity: 1960 styled / 62 void hosts / 83 draws / 12.7 MB in both modes.**

## Correctness gates

- Styled merge count parity on CatiaA1: 4,355,320 = 4,351,243 geometry + 4,077 orphan — exactly the serial resolver's numbers.
- `scan_shard` byte-identical protocol unchanged (6 dedicated tests incl. boundary-in-quoted-string, record-larger-than-chunk, duplicate-id last-wins); processing crate 51 tests, geometry package 146 tests, API surface snapshot unchanged.
- The seed-before-material-chain requirement is documented on `resolve_prepass_with_style_seeds`.

## Follow-ups charted (recorded in the design doc's Path A track)

Sort-once index delivery (each worker currently argsorts the file-order columns), sharding the styles flatten (~2.4s serial in finalize), and columns-driven pre-pass discovery (the pre-pass would stop scanning bytes entirely; projected ~8s → ~6s first visible).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional sharded pre-pass for large model loads, using parallel entity indexing and style resolution.
  * Improved loading performance while preserving the same output as the standard serial path.
  * Added an optional benchmark switch for evaluating sharded scanning.

* **Bug Fixes**
  * Improved stream completion handling to prevent premature end-of-stream notifications.
  * Added fallback handling for shared-buffer decoding failures.

* **Documentation**
  * Added release notes describing the new sharded pre-pass and measured performance improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->