### PR TITLE
feat(viewer,merge): merge refs in the viewer — conflict queue with per-conflict resolutions (#1717 V3)

### DIFF
--- a/apps/viewer/src/components/viewer/layers/LayerMergeSection.tsx
+++ b/apps/viewer/src/components/viewer/layers/LayerMergeSection.tsx
@@ -138,6 +138,14 @@ export function LayerMergeSection() {
     void refresh();
   }, [refresh, layerStack]);
 
+  // A previewed plan is only valid for the (candidate, target) it was
+  // computed for — a stale conflicts+choices pair against a new pair
+  // would silently auto-resolve conflicts the user never reviewed.
+  useEffect(() => {
+    setResult(null);
+    setChoices(new Map());
+  }, [candidateId, targetKey]);
+
   const target = useMemo<MergeTarget | null>(() => {
     // Ref names may themselves contain ':' — slice on the FIRST separator
     // only, never split (a ref like 'release:2026' must stay intact).

--- a/apps/viewer/src/components/viewer/layers/LayerMergeSection.tsx
+++ b/apps/viewer/src/components/viewer/layers/LayerMergeSection.tsx
@@ -1,0 +1,317 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Merge section of the Layers panel (#1717 V3, 08-review.md §8.3): pick a
+ * published candidate and a target ref, preview the three-way plan, work
+ * the conflict queue (ours/theirs per conflict; subtree deletes carry
+ * their descendants as ONE decision), and execute once the queue is
+ * empty. Local refs merge in-process; registry refs merge on the server
+ * where policies and approvals are enforced.
+ */
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { GitMerge, RefreshCw } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { useViewerStore } from '@/store';
+import { useIfc } from '@/hooks/useIfc';
+import { toast } from '@/components/ui/toast';
+import type { MergeConflict, ResolutionInput } from '@ifc-lite/merge';
+import { getBrowserLayerStore, DEFAULT_LOCAL_REF } from '@/lib/layers/browser-store';
+import { LayerRegistryClient } from '@/lib/layers/registry-client';
+import {
+  candidateLabel,
+  executeMergeInto,
+  previewMergeInto,
+  refStackFiles,
+  type MergeTarget,
+  type ViewerMergeResult,
+} from '@/lib/layers/merge';
+import { pathTail } from '@/lib/layers/stack';
+
+type Choice = 'ours' | 'theirs';
+
+function conflictKey(c: MergeConflict): string {
+  return c.componentKey === undefined ? c.path : `${c.path}::${c.componentKey}`;
+}
+
+function valueSummary(attrs: Record<string, unknown> | undefined): string {
+  if (!attrs) return 'removed';
+  const json = JSON.stringify(attrs);
+  return json.length > 60 ? `${json.slice(0, 57)}…` : json;
+}
+
+function ConflictRow({
+  conflict,
+  choice,
+  onChoose,
+}: {
+  conflict: MergeConflict;
+  choice: Choice | undefined;
+  onChoose: (choice: Choice) => void;
+}) {
+  const isDelete = conflict.kind === 'modify-vs-delete' || conflict.kind === 'delete-vs-modify';
+  return (
+    <div className="rounded border bg-card/40 px-1.5 py-1">
+      <div className="flex items-center gap-1.5">
+        <span className="truncate text-[11px] font-medium" title={conflict.path}>
+          {pathTail(conflict.path)}
+        </span>
+        <span className="truncate text-[10px] text-muted-foreground">
+          {conflict.componentKey ?? conflict.kind}
+        </span>
+        <span className="ml-auto inline-flex overflow-hidden rounded border">
+          {(['ours', 'theirs'] as const).map((option) => (
+            <button
+              key={option}
+              type="button"
+              onClick={() => onChoose(option)}
+              className={`px-1.5 py-px text-[10px] font-medium transition-colors ${
+                choice === option ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:bg-muted/60'
+              }`}
+            >
+              {option}
+            </button>
+          ))}
+        </span>
+      </div>
+      <div className="grid grid-cols-2 gap-1 pt-0.5 text-[10px] text-muted-foreground">
+        <span className="truncate" title={valueSummary(conflict.ours?.attributes as Record<string, unknown>)}>
+          ours: {valueSummary(conflict.ours?.attributes as Record<string, unknown>)}
+        </span>
+        <span className="truncate" title={valueSummary(conflict.theirs?.attributes as Record<string, unknown>)}>
+          theirs: {valueSummary(conflict.theirs?.attributes as Record<string, unknown>)}
+        </span>
+      </div>
+      {isDelete && conflict.subtree && conflict.subtree.length > 0 && (
+        <p className="pt-0.5 text-[10px] text-amber-600 dark:text-amber-300">
+          Delete decision carries {conflict.subtree.length} touched descendant
+          {conflict.subtree.length === 1 ? '' : 's'}: {conflict.subtree.map(pathTail).join(', ')}
+        </p>
+      )}
+    </div>
+  );
+}
+
+export function LayerMergeSection() {
+  const { loadFederatedIfcx } = useIfc();
+  const layerStack = useViewerStore((s) => s.layerStack);
+
+  const [candidates, setCandidates] = useState<Array<{ id: string; label: string }>>([]);
+  const [localRefs, setLocalRefs] = useState<string[]>([]);
+  const [registryRefs, setRegistryRefs] = useState<string[]>([]);
+  const [candidateId, setCandidateId] = useState<string>('');
+  const [targetKey, setTargetKey] = useState<string>(`local:${DEFAULT_LOCAL_REF}`);
+  const [result, setResult] = useState<ViewerMergeResult | null>(null);
+  const [choices, setChoices] = useState<Map<string, Choice>>(new Map());
+  const [busy, setBusy] = useState(false);
+
+  const registryClient = useMemo(() => LayerRegistryClient.fromCollabConfig(), []);
+
+  const refresh = useCallback(async () => {
+    const store = await getBrowserLayerStore();
+    const refs = Object.keys(store.listRefs());
+    setLocalRefs(refs.length > 0 ? refs : [DEFAULT_LOCAL_REF]);
+    setCandidates(store.listLayers().map((id) => ({ id, label: candidateLabel(store, id) })));
+    if (registryClient) {
+      try {
+        const remote = await registryClient.listRefs();
+        setRegistryRefs(Object.keys(remote.refs));
+      } catch {
+        setRegistryRefs([]);
+      }
+    }
+  }, [registryClient]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh, layerStack]);
+
+  const target = useMemo<MergeTarget | null>(() => {
+    const [kind, refName] = targetKey.split(':', 2);
+    if (kind === 'local') return { kind: 'local', refName };
+    if (kind === 'registry' && registryClient) return { kind: 'registry', refName, client: registryClient };
+    return null;
+  }, [targetKey, registryClient]);
+
+  const preview = useCallback(async () => {
+    if (!target || !candidateId) return;
+    setBusy(true);
+    setChoices(new Map());
+    try {
+      const store = await getBrowserLayerStore();
+      setResult(await previewMergeInto(target, store, candidateId));
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  }, [target, candidateId]);
+
+  const execute = useCallback(async () => {
+    if (!target || !candidateId || !result) return;
+    setBusy(true);
+    try {
+      const store = await getBrowserLayerStore();
+      const resolutions: ResolutionInput[] = result.conflicts.map((conflict) => ({
+        path: conflict.path,
+        ...(conflict.componentKey !== undefined ? { componentKey: conflict.componentKey } : {}),
+        choice: choices.get(conflictKey(conflict)) as Choice,
+      }));
+      const resolver =
+        (typeof window !== 'undefined' && window.localStorage.getItem('ifc-lite:layer-author')) || 'viewer-user';
+      const outcome = await executeMergeInto(target, store, candidateId, resolutions, resolver);
+      setResult(outcome);
+      if (outcome.status === 'merged' || outcome.status === 'fast-forward') {
+        toast.success(
+          outcome.status === 'merged'
+            ? `Merged into '${target.refName}' (${outcome.mergeLayerId?.slice(0, 15)}…).`
+            : `Fast-forwarded '${target.refName}'.`,
+        );
+        await refresh();
+      } else if (outcome.status === 'policy-failure') {
+        toast.error(`Policy: ${outcome.reason}`);
+      }
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  }, [target, candidateId, result, choices, refresh]);
+
+  const loadMergedRef = useCallback(async () => {
+    if (!target || target.kind !== 'local') return;
+    setBusy(true);
+    try {
+      const store = await getBrowserLayerStore();
+      const files = refStackFiles(store, target.refName).map(
+        (file, i) => new File([JSON.stringify(file)], `${target.refName}-${i}.ifcx`, { type: 'application/json' }),
+      );
+      await loadFederatedIfcx(files);
+      toast.success(`Loaded ref '${target.refName}' (${files.length} layers).`);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  }, [target, loadFederatedIfcx]);
+
+  if (candidates.length === 0) return null;
+
+  const allResolved = result !== null && result.conflicts.every((c) => choices.has(conflictKey(c)));
+  const mergeDone = result?.status === 'merged' || result?.status === 'fast-forward';
+
+  return (
+    <div className="rounded-md border border-dashed bg-card/30 p-2">
+      <div className="flex items-center gap-1.5 pb-1.5 text-[11px] font-medium">
+        <GitMerge className="size-3" aria-hidden />
+        <span>Merge</span>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="ml-auto h-5 px-1"
+          onClick={() => void refresh()}
+          aria-label="Refresh refs and candidates"
+        >
+          <RefreshCw className="size-3" aria-hidden />
+        </Button>
+      </div>
+      <div className="flex flex-col gap-1.5">
+        <Select value={candidateId} onValueChange={setCandidateId}>
+          <SelectTrigger className="h-7 text-xs" aria-label="Candidate layer">
+            <SelectValue placeholder="Candidate layer" />
+          </SelectTrigger>
+          <SelectContent>
+            {candidates.map((c) => (
+              <SelectItem key={c.id} value={c.id} className="text-xs">
+                {c.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <div className="flex items-center gap-1.5">
+          <Select value={targetKey} onValueChange={setTargetKey}>
+            <SelectTrigger className="h-7 flex-1 text-xs" aria-label="Target ref">
+              <SelectValue placeholder="Target ref" />
+            </SelectTrigger>
+            <SelectContent>
+              {localRefs.map((name) => (
+                <SelectItem key={`local:${name}`} value={`local:${name}`} className="text-xs">
+                  {name} (local)
+                </SelectItem>
+              ))}
+              {registryRefs.map((name) => (
+                <SelectItem key={`registry:${name}`} value={`registry:${name}`} className="text-xs">
+                  {name} (registry)
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Button
+            size="sm"
+            variant="outline"
+            className="h-7 px-2 text-[11px]"
+            disabled={busy || !candidateId || !target}
+            onClick={() => void preview()}
+          >
+            Preview
+          </Button>
+        </div>
+
+        {result && (
+          <div className="flex flex-col gap-1">
+            <p className="text-[11px] text-muted-foreground">
+              {result.status === 'preview' &&
+                `${result.stats?.autoMerged ?? 0} auto-merged, ${result.conflicts.length} conflict${result.conflicts.length === 1 ? '' : 's'}.`}
+              {result.status === 'conflicts' && `${result.conflicts.length} unresolved conflict${result.conflicts.length === 1 ? '' : 's'}.`}
+              {result.status === 'fast-forward' && 'Fast-forwarded.'}
+              {result.status === 'merged' && `Merged as ${result.mergeLayerId?.slice(0, 15)}…`}
+              {result.status === 'policy-failure' && `Blocked by ref policy: ${result.reason}`}
+              {result.status === 'unrelated-base' && `Unrelated base: ${result.reason}`}
+            </p>
+            {result.conflicts.map((conflict) => (
+              <ConflictRow
+                key={conflictKey(conflict)}
+                conflict={conflict}
+                choice={choices.get(conflictKey(conflict))}
+                onChoose={(choice) =>
+                  setChoices((prev) => new Map(prev).set(conflictKey(conflict), choice))
+                }
+              />
+            ))}
+            {!mergeDone && (result.status === 'preview' || result.status === 'conflicts') && (
+              <Button
+                size="sm"
+                className="h-7 gap-1 self-end px-2 text-[11px]"
+                disabled={busy || !allResolved}
+                onClick={() => void execute()}
+              >
+                <GitMerge className="size-3" aria-hidden />
+                {result.conflicts.length > 0 ? 'Merge with resolutions' : 'Merge'}
+              </Button>
+            )}
+            {mergeDone && target?.kind === 'local' && (
+              <Button
+                size="sm"
+                variant="outline"
+                className="h-7 self-end px-2 text-[11px]"
+                disabled={busy}
+                onClick={() => void loadMergedRef()}
+              >
+                Load merged ref
+              </Button>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/viewer/src/components/viewer/layers/LayerMergeSection.tsx
+++ b/apps/viewer/src/components/viewer/layers/LayerMergeSection.tsx
@@ -104,6 +104,9 @@ function ConflictRow({
 export function LayerMergeSection() {
   const { loadFederatedIfcx } = useIfc();
   const layerStack = useViewerStore((s) => s.layerStack);
+  // Authenticated deployments guard /api/v1 with the same bearer token as
+  // the websocket; an unbound client would 401 on every registry call.
+  const collabToken = useViewerStore((s) => s.collabSelfToken);
 
   const [candidates, setCandidates] = useState<Array<{ id: string; label: string }>>([]);
   const [localRefs, setLocalRefs] = useState<string[]>([]);
@@ -114,7 +117,7 @@ export function LayerMergeSection() {
   const [choices, setChoices] = useState<Map<string, Choice>>(new Map());
   const [busy, setBusy] = useState(false);
 
-  const registryClient = useMemo(() => LayerRegistryClient.fromCollabConfig(), []);
+  const registryClient = useMemo(() => LayerRegistryClient.fromCollabConfig(collabToken ?? undefined), [collabToken]);
 
   const refresh = useCallback(async () => {
     const store = await getBrowserLayerStore();
@@ -136,7 +139,13 @@ export function LayerMergeSection() {
   }, [refresh, layerStack]);
 
   const target = useMemo<MergeTarget | null>(() => {
-    const [kind, refName] = targetKey.split(':', 2);
+    // Ref names may themselves contain ':' — slice on the FIRST separator
+    // only, never split (a ref like 'release:2026' must stay intact).
+    const sep = targetKey.indexOf(':');
+    if (sep < 0) return null;
+    const kind = targetKey.slice(0, sep);
+    const refName = targetKey.slice(sep + 1);
+    if (refName.length === 0) return null;
     if (kind === 'local') return { kind: 'local', refName };
     if (kind === 'registry' && registryClient) return { kind: 'registry', refName, client: registryClient };
     return null;

--- a/apps/viewer/src/components/viewer/layers/LayersPanel.tsx
+++ b/apps/viewer/src/components/viewer/layers/LayersPanel.tsx
@@ -25,6 +25,7 @@ import type { LayerAuthorKind, LayerStackEntry } from '@/store/slices/layerStack
 import { computeLayerContribution, shortContentId } from '@/lib/layers/stack';
 import { LayerDiffView } from './LayerDiffView';
 import { LayerDraftSection } from './LayerDraftSection';
+import { LayerMergeSection } from './LayerMergeSection';
 
 interface LayersPanelProps {
   onClose: () => void;
@@ -230,6 +231,7 @@ export function LayersPanel(_props: LayersPanelProps) {
       <ScrollArea className="min-h-0 flex-1">
         <div className="flex flex-col gap-1 px-2 pb-2">
           <LayerDraftSection />
+          <LayerMergeSection />
           {strata.map((entry, i) => (
             <LayerStratum
               key={entry.id}

--- a/apps/viewer/src/lib/layers/merge.test.ts
+++ b/apps/viewer/src/lib/layers/merge.test.ts
@@ -1,0 +1,92 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { computeLayerId, computeStackHash, createProvenanceManifest, setProvenance } from '@ifc-lite/ifcx';
+import type { IfcxFile, IfcxNode } from '@ifc-lite/ifcx';
+import { extractStackState } from '@ifc-lite/merge';
+import { BrowserLayerStore } from './browser-store.js';
+import { executeMergeInto, previewMergeInto, refStackFiles, candidateLabel } from './merge.js';
+
+const FIRE = 'bsi::ifc::v5a::Pset_FireSafety::FireRating';
+
+function publishable(data: IfcxNode[], intent: string, baseIds: string[] | null): IfcxFile {
+  const bare: IfcxFile = {
+    header: { id: '', ifcxVersion: 'ifcx_alpha', dataVersion: '1.0.0', author: 't', timestamp: '2026-07-11T00:00:00Z' },
+    imports: [],
+    schemas: {},
+    data,
+  };
+  const manifest = createProvenanceManifest({
+    author: { kind: 'human', principal: 'alice' },
+    intent,
+    base: baseIds === null ? null : { kind: 'stack', id: computeStackHash(baseIds) },
+    created: '2026-07-11T00:00:00Z',
+  });
+  const withManifest = setProvenance(bare, manifest);
+  const id = computeLayerId(withManifest);
+  return { ...withManifest, header: { ...withManifest.header, id } };
+}
+
+describe('viewer merge orchestration over the local store (#1717 V3)', () => {
+  it('preview surfaces the conflict; per-conflict resolutions complete the merge', async () => {
+    const store = await BrowserLayerStore.open();
+    const base = publishable(
+      [{ path: 'wall-1', attributes: { 'bsi::ifc::class': { code: 'IfcWall', uri: 'u' }, [FIRE]: 'REI60' } }],
+      'Base model',
+      null,
+    );
+    store.storeLayer(base);
+    const ours = publishable([{ path: 'wall-1', attributes: { [FIRE]: 'REI90' } }], 'Ours edit', [base.header.id]);
+    store.storeLayer(ours);
+    store.setRef('main', { layers: [base.header.id, ours.header.id] });
+    const candidate = publishable([{ path: 'wall-1', attributes: { [FIRE]: 'REI120' } }], 'Raise to REI120', [
+      base.header.id,
+    ]);
+    store.storeLayer(candidate);
+
+    const target = { kind: 'local', refName: 'main' } as const;
+    const preview = await previewMergeInto(target, store, candidate.header.id);
+    assert.strictEqual(preview.status, 'preview');
+    assert.strictEqual(preview.conflicts.length, 1);
+    assert.strictEqual(preview.conflicts[0].componentKey, 'pset:Pset_FireSafety');
+
+    const merged = await executeMergeInto(
+      target,
+      store,
+      candidate.header.id,
+      [{ path: 'wall-1', componentKey: 'pset:Pset_FireSafety', choice: 'theirs' }],
+      'louis',
+    );
+    assert.strictEqual(merged.status, 'merged');
+    assert.ok(merged.mergeLayerId?.startsWith('blake3:'));
+
+    const state = extractStackState(refStackFiles(store, 'main'));
+    assert.strictEqual(state.get('wall-1')?.components.get('pset:Pset_FireSafety')?.[FIRE], 'REI120');
+  });
+
+  it('an unaddressed conflict refuses to merge', async () => {
+    const store = await BrowserLayerStore.open();
+    const base = publishable([{ path: 'wall-1', attributes: { [FIRE]: 'REI60' } }], 'Base', null);
+    store.storeLayer(base);
+    const ours = publishable([{ path: 'wall-1', attributes: { [FIRE]: 'REI90' } }], 'Ours', [base.header.id]);
+    store.storeLayer(ours);
+    store.setRef('main', { layers: [base.header.id, ours.header.id] });
+    const candidate = publishable([{ path: 'wall-1', attributes: { [FIRE]: 'REI120' } }], 'Theirs', [base.header.id]);
+    store.storeLayer(candidate);
+
+    const outcome = await executeMergeInto({ kind: 'local', refName: 'main' }, store, candidate.header.id, [], 'louis');
+    assert.strictEqual(outcome.status, 'conflicts');
+    assert.strictEqual(outcome.conflicts.length, 1);
+  });
+
+  it('candidateLabel prefers the manifest intent', async () => {
+    const store = await BrowserLayerStore.open();
+    const layer = publishable([{ path: 'a', attributes: { [FIRE]: 'X' } }], 'My intent line', null);
+    store.storeLayer(layer);
+    assert.strictEqual(candidateLabel(store, layer.header.id), 'My intent line');
+    assert.strictEqual(candidateLabel(store, 'blake3:unknown-layer-id'), 'blake3:unknown-');
+  });
+});

--- a/apps/viewer/src/lib/layers/merge.ts
+++ b/apps/viewer/src/lib/layers/merge.ts
@@ -1,0 +1,152 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Merge orchestration for the Layers panel (#1717 V3): one preview /
+ * execute surface over the two ref backends. Local refs run the shared
+ * engine in-process (the browser store satisfies the sync
+ * `LayerRefStore`); registry refs merge SERVER-side, where ref policies
+ * and approvals are enforced — the candidate is pushed first so the
+ * server can load it.
+ */
+
+import type { IfcxFile } from '@ifc-lite/ifcx';
+import { getProvenance } from '@ifc-lite/ifcx';
+import { mergeIntoRef } from '@ifc-lite/merge';
+import type { MergeConflict, MergeOutcome, ResolutionInput } from '@ifc-lite/merge';
+import type { BrowserLayerStore } from './browser-store';
+import { LayerRegistryClient, RegistryError } from './registry-client';
+import type { RegistryMergeOutcome } from './registry-client';
+
+export type MergeTarget =
+  | { kind: 'local'; refName: string }
+  | { kind: 'registry'; refName: string; client: LayerRegistryClient };
+
+/** The panel's normalized view of both backends' outcomes. */
+export interface ViewerMergeResult {
+  status: MergeOutcome['status'];
+  conflicts: MergeConflict[];
+  /** Ref layer ids after a completed merge / fast-forward. */
+  refLayers?: string[];
+  mergeLayerId?: string;
+  reason?: string;
+  /** Plan stats for previews. */
+  stats?: { autoMerged: number; conflicting: number };
+}
+
+function fromRegistry(outcome: RegistryMergeOutcome): ViewerMergeResult {
+  return {
+    status: outcome.status,
+    conflicts: outcome.conflicts ?? outcome.plan?.conflicts ?? [],
+    refLayers: outcome.layers,
+    mergeLayerId: outcome.merge_layer,
+    reason: outcome.reason,
+    ...(outcome.plan
+      ? { stats: { autoMerged: outcome.plan.stats.autoMerged, conflicting: outcome.plan.stats.conflicting } }
+      : {}),
+  };
+}
+
+function fromLocal(outcome: MergeOutcome): ViewerMergeResult {
+  switch (outcome.status) {
+    case 'preview':
+      return {
+        status: 'preview',
+        conflicts: outcome.plan.conflicts,
+        stats: { autoMerged: outcome.plan.stats.autoMerged, conflicting: outcome.plan.stats.conflicting },
+      };
+    case 'conflicts':
+      return { status: 'conflicts', conflicts: outcome.conflicts };
+    case 'fast-forward':
+      return { status: 'fast-forward', conflicts: [], refLayers: outcome.refLayers };
+    case 'merged':
+      return { status: 'merged', conflicts: [], refLayers: outcome.refLayers, mergeLayerId: outcome.mergeLayerId };
+    case 'policy-failure':
+      return { status: 'policy-failure', conflicts: [], reason: outcome.reason };
+    case 'unrelated-base':
+      return { status: 'unrelated-base', conflicts: [], reason: `declared base ${outcome.declaredBase.id} matches nothing on the ref` };
+  }
+}
+
+async function ensureCandidateOnRegistry(
+  client: LayerRegistryClient,
+  store: BrowserLayerStore,
+  candidateId: string,
+): Promise<void> {
+  try {
+    await client.pushLayer(store.loadLayer(candidateId));
+  } catch (err) {
+    // An identical re-push is idempotent (201); a content-conflict means
+    // the id exists with the same canonical bytes but different
+    // non-canonical ones — the server copy wins, merging can proceed.
+    if (err instanceof RegistryError && err.status === 409) return;
+    throw err;
+  }
+}
+
+export async function previewMergeInto(
+  target: MergeTarget,
+  store: BrowserLayerStore,
+  candidateId: string,
+): Promise<ViewerMergeResult> {
+  if (target.kind === 'local') {
+    return fromLocal(mergeIntoRef(store, { candidateId, into: target.refName, preview: true }));
+  }
+  await ensureCandidateOnRegistry(target.client, store, candidateId);
+  return fromRegistry(await target.client.mergeRef(target.refName, { candidate: candidateId, preview: true }));
+}
+
+export async function executeMergeInto(
+  target: MergeTarget,
+  store: BrowserLayerStore,
+  candidateId: string,
+  resolutions: ResolutionInput[],
+  resolver: string,
+): Promise<ViewerMergeResult> {
+  if (target.kind === 'local') {
+    return fromLocal(
+      mergeIntoRef(store, {
+        candidateId,
+        into: target.refName,
+        principal: resolver,
+        ...(resolutions.length > 0 ? { resolutions } : {}),
+      }),
+    );
+  }
+  await ensureCandidateOnRegistry(target.client, store, candidateId);
+  return fromRegistry(
+    await target.client.mergeRef(target.refName, {
+      candidate: candidateId,
+      ...(resolutions.length > 0
+        ? {
+            resolutions: resolutions
+              .filter((r): r is ResolutionInput & { choice: 'ours' | 'theirs' } => r.choice !== 'edited')
+              .map((r) => ({
+                path: r.path,
+                choice: r.choice,
+                ...(r.componentKey !== undefined ? { component_key: r.componentKey } : {}),
+              })),
+          }
+        : {}),
+    }),
+  );
+}
+
+/** Short human label for a candidate layer (intent, else id prefix). */
+export function candidateLabel(store: BrowserLayerStore, layerId: string): string {
+  try {
+    const manifest = getProvenance(store.loadLayer(layerId));
+    if (manifest?.intent) return manifest.intent;
+  } catch {
+    // fall through to the id prefix
+  }
+  return layerId.slice(0, 15);
+}
+
+/** The files composing a ref's stack, for loading into the viewer. */
+export function refStackFiles(store: BrowserLayerStore, refName: string): IfcxFile[] {
+  const entry = store.getRef(refName);
+  if (!entry) throw new Error(`No local ref '${refName}'`);
+  return entry.layers.map((id) => store.loadLayer(id));
+}

--- a/apps/viewer/src/lib/layers/merge.ts
+++ b/apps/viewer/src/lib/layers/merge.ts
@@ -41,7 +41,11 @@ function fromRegistry(outcome: RegistryMergeOutcome): ViewerMergeResult {
     conflicts: outcome.conflicts ?? outcome.plan?.conflicts ?? [],
     refLayers: outcome.layers,
     mergeLayerId: outcome.merge_layer,
-    reason: outcome.reason,
+    reason:
+      outcome.reason ??
+      (outcome.declared_base
+        ? `declared base ${outcome.declared_base.id} matches nothing on the ref`
+        : undefined),
     ...(outcome.plan
       ? { stats: { autoMerged: outcome.plan.stats.autoMerged, conflicting: outcome.plan.stats.conflicting } }
       : {}),

--- a/apps/viewer/src/lib/layers/registry-client.ts
+++ b/apps/viewer/src/lib/layers/registry-client.ts
@@ -1,0 +1,115 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Layer-registry client (#1717 V3): a thin fetch wrapper over the
+ * collab-server registry (`/api/v1/layers|refs|reviews`, 10-registry.md).
+ * Derives its HTTP base from the collab websocket URL like the blob
+ * store, and authenticates Bearer-only (the registry rejects `?token=`).
+ *
+ * Registry merges run SERVER-side (that is where ref policies and
+ * approvals are enforced) — the client only ferries the candidate id,
+ * preview flag, and per-conflict resolutions.
+ */
+
+import type { IfcxFile } from '@ifc-lite/ifcx';
+import type { MergeConflict, MergePlan, RefEntry } from '@ifc-lite/merge';
+import { collabServerUrl } from '@/lib/collab/config';
+
+export interface RegistryMergeOutcome {
+  status: 'fast-forward' | 'merged' | 'preview' | 'conflicts' | 'policy-failure' | 'unrelated-base';
+  layers?: string[];
+  merge_layer?: string;
+  plan?: MergePlan;
+  conflicts?: MergeConflict[];
+  reason?: string;
+}
+
+export interface RegistryResolutionInput {
+  path: string;
+  component_key?: string;
+  choice: 'ours' | 'theirs';
+}
+
+export class RegistryError extends Error {
+  readonly status: number;
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = 'RegistryError';
+    this.status = status;
+  }
+}
+
+export class LayerRegistryClient {
+  private readonly base: string;
+  private readonly token?: string;
+
+  constructor(baseUrl: string, token?: string) {
+    this.base = `${baseUrl.replace(/\/$/, '')}/api/v1`;
+    this.token = token;
+  }
+
+  /** Client bound to the configured collab server, or null when off. */
+  static fromCollabConfig(token?: string): LayerRegistryClient | null {
+    const ws = collabServerUrl();
+    if (!ws) return null;
+    return new LayerRegistryClient(ws.replace(/^ws/, 'http'), token);
+  }
+
+  private async request<T>(method: string, path: string, body?: unknown): Promise<T> {
+    const res = await fetch(`${this.base}${path}`, {
+      method,
+      headers: {
+        ...(body !== undefined ? { 'content-type': 'application/json' } : {}),
+        ...(this.token ? { authorization: `Bearer ${this.token}` } : {}),
+      },
+      ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+    });
+    const text = await res.text();
+    let parsed: unknown;
+    try {
+      parsed = text ? JSON.parse(text) : {};
+    } catch {
+      parsed = { error: text };
+    }
+    // Merge outcomes ride non-2xx codes (409 conflicts, 403 policy) with
+    // a structured body — surface those to the caller, not as errors.
+    if (!res.ok && !(parsed && typeof parsed === 'object' && 'status' in (parsed as object))) {
+      const message = (parsed as { error?: string })?.error ?? `registry request failed (${res.status})`;
+      throw new RegistryError(res.status, message);
+    }
+    return parsed as T;
+  }
+
+  listLayers(): Promise<{ layers: string[] }> {
+    return this.request('GET', '/layers');
+  }
+
+  pullLayer(id: string): Promise<IfcxFile> {
+    return this.request('GET', `/layers/${encodeURIComponent(id)}`);
+  }
+
+  pushLayer(file: IfcxFile): Promise<{ id: string }> {
+    return this.request('POST', '/layers', file);
+  }
+
+  listRefs(): Promise<{ refs: Record<string, RefEntry> }> {
+    return this.request('GET', '/refs');
+  }
+
+  getRef(name: string): Promise<{ ref: string } & RefEntry> {
+    return this.request('GET', `/refs/${encodeURIComponent(name)}`);
+  }
+
+  putRef(name: string, entry: { layers?: string[]; policy?: RefEntry['policy'] }): Promise<{ ref: string } & RefEntry> {
+    return this.request('PUT', `/refs/${encodeURIComponent(name)}`, entry);
+  }
+
+  mergeRef(
+    name: string,
+    init: { candidate: string; preview?: boolean; resolutions?: RegistryResolutionInput[] },
+  ): Promise<RegistryMergeOutcome> {
+    return this.request('POST', `/refs/${encodeURIComponent(name)}/merge`, init);
+  }
+}

--- a/apps/viewer/src/lib/layers/registry-client.ts
+++ b/apps/viewer/src/lib/layers/registry-client.ts
@@ -24,6 +24,8 @@ export interface RegistryMergeOutcome {
   plan?: MergePlan;
   conflicts?: MergeConflict[];
   reason?: string;
+  /** Sent on unrelated-base outcomes instead of `reason`. */
+  declared_base?: { kind: string; id: string };
 }
 
 export interface RegistryResolutionInput {

--- a/packages/collab-server/src/layer-registry-route.ts
+++ b/packages/collab-server/src/layer-registry-route.ts
@@ -324,6 +324,7 @@ export async function handleLayerRegistryRequest(
             candidate?: string;
             preview?: boolean;
             resolve?: 'ours' | 'theirs';
+            resolutions?: unknown[];
             waivers?: Waiver[];
             allow_unrelated?: boolean;
           }
@@ -335,6 +336,33 @@ export async function handleLayerRegistryRequest(
       const init: MergeInit = { candidateId: body.candidate, into: segments[1] };
       if (body.preview) init.preview = true;
       if (body.resolve === 'ours' || body.resolve === 'theirs') init.resolve = body.resolve;
+      // Per-conflict resolutions from the review UI: strictly-shaped
+      // ours/theirs decisions ('edited' stays a local-flow feature).
+      if (body.resolutions !== undefined) {
+        if (!Array.isArray(body.resolutions)) {
+          return json(res, 400, { error: 'resolutions must be an array of { path, component_key?, choice }' });
+        }
+        const parsedResolutions: NonNullable<MergeInit['resolutions']> = [];
+        for (const item of body.resolutions) {
+          if (typeof item !== 'object' || item === null) {
+            return json(res, 400, { error: 'each resolution must be { path, component_key?, choice: "ours" | "theirs" }' });
+          }
+          const raw = item as Record<string, unknown>;
+          const choice = raw.choice;
+          if (typeof raw.path !== 'string' || (choice !== 'ours' && choice !== 'theirs')) {
+            return json(res, 400, { error: 'each resolution must be { path, component_key?, choice: "ours" | "theirs" }' });
+          }
+          if (raw.component_key !== undefined && typeof raw.component_key !== 'string') {
+            return json(res, 400, { error: 'component_key must be a string when present' });
+          }
+          parsedResolutions.push({
+            path: raw.path,
+            choice,
+            ...(raw.component_key !== undefined ? { componentKey: raw.component_key as string } : {}),
+          });
+        }
+        init.resolutions = parsedResolutions;
+      }
       if (Array.isArray(body.waivers)) init.waivers = body.waivers;
       if (body.allow_unrelated) init.allowUnrelated = true;
       if (principal) init.principal = principal.userId;

--- a/packages/collab-server/test/layer-registry.test.ts
+++ b/packages/collab-server/test/layer-registry.test.ts
@@ -681,6 +681,68 @@ describe('layer registry route', () => {
     }
   });
 
+  it('merges with per-conflict resolutions from the review UI', async () => {
+    const server = await startCollabServer({ port: 0, layerRegistry: true });
+    try {
+      const port = (server.httpServer.address() as { port: number }).port;
+      const url = `http://127.0.0.1:${port}/api/v1`;
+      const post = (path: string, body: unknown) =>
+        fetch(`${url}${path}`, { method: 'POST', body: JSON.stringify(body) });
+
+      const SOUND = 'bsi::ifc::v5a::Pset_Acoustic::Rw';
+      const root = publishable(
+        [{ path: 'wall-1', attributes: { [CLASS]: { code: 'IfcWall', uri: 'u' }, [FIRE]: 'REI60', [SOUND]: 40 } }],
+        'Import',
+        null
+      );
+      await post('/layers', root);
+      const ours = publishable(
+        [{ path: 'wall-1', attributes: { [FIRE]: 'REI90', [SOUND]: 45 } }],
+        'Ours',
+        { kind: 'stack', id: computeStackHash([root.header.id]) }
+      );
+      await post('/layers', ours);
+      await fetch(`${url}/refs/main`, {
+        method: 'PUT',
+        body: JSON.stringify({ layers: [root.header.id, ours.header.id] }),
+      });
+      const candidate = publishable(
+        [{ path: 'wall-1', attributes: { [FIRE]: 'REI120', [SOUND]: 50 } }],
+        'Theirs',
+        { kind: 'stack', id: computeStackHash([root.header.id]) }
+      );
+      await post('/layers', candidate);
+
+      // Without resolutions the conflicts surface as 409.
+      const conflicted = await post('/refs/main/merge', { candidate: candidate.header.id });
+      expect(conflicted.status).toBe(409);
+      const body409 = (await conflicted.json()) as { conflicts: Array<{ componentKey?: string }> };
+      expect(body409.conflicts).toHaveLength(2);
+
+      // Malformed resolutions are rejected with a clear 400.
+      const malformed = await post('/refs/main/merge', {
+        candidate: candidate.header.id,
+        resolutions: [{ path: 'wall-1', choice: 'nuke' }],
+      });
+      expect(malformed.status).toBe(400);
+
+      // Mixed per-conflict choices complete the merge server-side.
+      const merged = await post('/refs/main/merge', {
+        candidate: candidate.header.id,
+        resolutions: [
+          { path: 'wall-1', component_key: 'pset:Pset_FireSafety', choice: 'theirs' },
+          { path: 'wall-1', component_key: 'pset:Pset_Acoustic', choice: 'ours' },
+        ],
+      });
+      expect(merged.status).toBe(200);
+      const outcome = (await merged.json()) as { status: string; merge_layer?: string };
+      expect(outcome.status).toBe('merged');
+      expect(outcome.merge_layer?.startsWith('blake3:')).toBe(true);
+    } finally {
+      await server.stop();
+    }
+  });
+
   it('binds the manifest author to the push credential', async () => {
     const server = await startCollabServer({
       port: 0,

--- a/packages/merge/src/ref-flow-resolutions.test.ts
+++ b/packages/merge/src/ref-flow-resolutions.test.ts
@@ -1,0 +1,135 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Per-conflict resolutions through the shared ref-merge flow (#1717 V3):
+ * the review-UI loop is preview → decide each conflict → execute with
+ * `MergeInit.resolutions`. Blanket `resolve` keeps its semantics;
+ * partially-addressed plans surface the leftovers as conflicts.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { computeLayerId, computeStackHash, createProvenanceManifest, setProvenance } from '@ifc-lite/ifcx';
+import type { IfcxFile, IfcxNode } from '@ifc-lite/ifcx';
+import { extractStackState } from './component-state.js';
+import { mergeIntoRef } from './ref-flow.js';
+import type { LayerRefStore, RefEntry } from './ref-flow.js';
+
+const FIRE = 'bsi::ifc::v5a::Pset_FireSafety::FireRating';
+const SOUND = 'bsi::ifc::v5a::Pset_Acoustic::Rw';
+
+class MemoryStore implements LayerRefStore {
+  private layers = new Map<string, IfcxFile>();
+  private refs = new Map<string, RefEntry>();
+  storeLayer(file: IfcxFile): string {
+    this.layers.set(file.header.id, structuredClone(file));
+    return file.header.id;
+  }
+  loadLayer(id: string): IfcxFile {
+    const f = this.layers.get(id);
+    if (!f) throw new Error(`no layer ${id}`);
+    return structuredClone(f);
+  }
+  getRef(name: string): RefEntry | undefined {
+    const e = this.refs.get(name);
+    return e ? structuredClone(e) : undefined;
+  }
+  setRef(name: string, entry: RefEntry): void {
+    this.refs.set(name, structuredClone(entry));
+  }
+}
+
+function publishable(data: IfcxNode[], intent: string, baseIds: string[] | null): IfcxFile {
+  const bare: IfcxFile = {
+    header: { id: '', ifcxVersion: 'ifcx_alpha', dataVersion: '1.0.0', author: 't', timestamp: '2026-07-11T00:00:00Z' },
+    imports: [],
+    schemas: {},
+    data,
+  };
+  const manifest = createProvenanceManifest({
+    author: { kind: 'human', principal: 'alice' },
+    intent,
+    base: baseIds === null ? null : { kind: 'stack', id: computeStackHash(baseIds) },
+    created: '2026-07-11T00:00:00Z',
+  });
+  const withManifest = setProvenance(bare, manifest);
+  const id = computeLayerId(withManifest);
+  return { ...withManifest, header: { ...withManifest.header, id } };
+}
+
+/** Store with a two-conflict setup: ours and theirs edit FIRE and SOUND divergently. */
+function conflictingSetup() {
+  const store = new MemoryStore();
+  const base = publishable(
+    [{ path: 'wall-1', attributes: { 'bsi::ifc::class': { code: 'IfcWall', uri: 'u' }, [FIRE]: 'REI60', [SOUND]: 40 } }],
+    'Base',
+    null,
+  );
+  store.storeLayer(base);
+  const ours = publishable([{ path: 'wall-1', attributes: { [FIRE]: 'REI90', [SOUND]: 45 } }], 'Ours', [base.header.id]);
+  store.storeLayer(ours);
+  store.setRef('main', { layers: [base.header.id, ours.header.id] });
+  const candidate = publishable([{ path: 'wall-1', attributes: { [FIRE]: 'REI120', [SOUND]: 50 } }], 'Theirs', [base.header.id]);
+  store.storeLayer(candidate);
+  return { store, base, candidate };
+}
+
+describe('MergeInit.resolutions (per-conflict, review-UI flow)', () => {
+  it('previews conflicts, then merges with mixed per-conflict choices', () => {
+    const { store, candidate } = conflictingSetup();
+
+    const preview = mergeIntoRef(store, { candidateId: candidate.header.id, into: 'main', preview: true });
+    expect(preview.status).toBe('preview');
+    if (preview.status !== 'preview') return;
+    expect(preview.plan.conflicts).toHaveLength(2);
+
+    const outcome = mergeIntoRef(store, {
+      candidateId: candidate.header.id,
+      into: 'main',
+      created: '2026-07-11T01:00:00Z',
+      resolutions: [
+        { path: 'wall-1', componentKey: 'pset:Pset_FireSafety', choice: 'theirs' },
+        { path: 'wall-1', componentKey: 'pset:Pset_Acoustic', choice: 'ours' },
+      ],
+    });
+    expect(outcome.status).toBe('merged');
+    if (outcome.status !== 'merged') return;
+
+    const state = extractStackState(outcome.refLayers.map((id) => store.loadLayer(id)));
+    const wall = state.get('wall-1');
+    expect(wall?.components.get('pset:Pset_FireSafety')?.[FIRE]).toBe('REI120'); // theirs
+    expect(wall?.components.get('pset:Pset_Acoustic')?.[SOUND]).toBe(45); // ours
+  });
+
+  it('surfaces unaddressed conflicts instead of merging past them', () => {
+    const { store, candidate } = conflictingSetup();
+    const outcome = mergeIntoRef(store, {
+      candidateId: candidate.header.id,
+      into: 'main',
+      resolutions: [{ path: 'wall-1', componentKey: 'pset:Pset_FireSafety', choice: 'theirs' }],
+    });
+    expect(outcome.status).toBe('conflicts');
+    if (outcome.status !== 'conflicts') return;
+    expect(outcome.conflicts).toHaveLength(1);
+    expect(outcome.conflicts[0].componentKey).toBe('pset:Pset_Acoustic');
+  });
+
+  it('per-conflict resolutions take precedence over a blanket resolve', () => {
+    const { store, candidate } = conflictingSetup();
+    const outcome = mergeIntoRef(store, {
+      candidateId: candidate.header.id,
+      into: 'main',
+      created: '2026-07-11T01:00:00Z',
+      resolve: 'ours',
+      resolutions: [
+        { path: 'wall-1', componentKey: 'pset:Pset_FireSafety', choice: 'theirs' },
+        { path: 'wall-1', componentKey: 'pset:Pset_Acoustic', choice: 'theirs' },
+      ],
+    });
+    expect(outcome.status).toBe('merged');
+    if (outcome.status !== 'merged') return;
+    const state = extractStackState(outcome.refLayers.map((id) => store.loadLayer(id)));
+    expect(state.get('wall-1')?.components.get('pset:Pset_FireSafety')?.[FIRE]).toBe('REI120');
+  });
+});

--- a/packages/merge/src/ref-flow.ts
+++ b/packages/merge/src/ref-flow.ts
@@ -123,6 +123,12 @@ export interface MergeInit {
   into: string;
   preview?: boolean;
   resolve?: 'ours' | 'theirs';
+  /**
+   * Per-conflict resolutions (the review-UI flow: preview, decide each
+   * conflict, execute). Takes precedence over the blanket `resolve`;
+   * conflicts left unaddressed surface as a `conflicts` outcome.
+   */
+  resolutions?: ResolutionInput[];
   waivers?: Waiver[];
   approvedBy?: string;
   principal?: string;
@@ -220,15 +226,18 @@ export function mergeIntoRef(store: LayerRefStore, init: MergeInit): MergeOutcom
 
   let resolutionInputs: ResolutionInput[] = [];
   if (plan.conflicts.length > 0) {
-    if (!init.resolve) {
+    if (init.resolutions !== undefined && init.resolutions.length > 0) {
+      resolutionInputs = init.resolutions;
+    } else if (init.resolve) {
+      const choice = init.resolve;
+      resolutionInputs = plan.conflicts.map((conflict) => {
+        const input: ResolutionInput = { path: conflict.path, choice };
+        if (conflict.componentKey !== undefined) input.componentKey = conflict.componentKey;
+        return input;
+      });
+    } else {
       return { status: 'conflicts', conflicts: plan.conflicts, ancestorMatched: ancestor.matched };
     }
-    const choice = init.resolve;
-    resolutionInputs = plan.conflicts.map((conflict) => {
-      const input: ResolutionInput = { path: conflict.path, choice };
-      if (conflict.componentKey !== undefined) input.componentKey = conflict.componentKey;
-      return input;
-    });
   }
   const applied = applyResolutions(plan, resolutionInputs);
   if (applied.unresolved.length > 0) {


### PR DESCRIPTION
## Summary

Phase V3 of #1717: merge in the viewer. A published candidate merges into a ref — local (in-process engine over the IndexedDB store) or registry (server-side, where policies and approvals are enforced) — with a preview, a conflict queue, and per-conflict ours/theirs resolutions per 08-review.md §8.3. Stacked on #1719 → #1718 → #1027; merge in that order.

## Engine + registry groundwork (shared, not viewer-only)

- **`MergeInit.resolutions`** (`@ifc-lite/merge`): per-conflict `ResolutionInput[]` through the shared ref-merge flow — the review-UI loop is preview → decide each conflict → execute. Takes precedence over the blanket `resolve`; unaddressed conflicts surface as a `conflicts` outcome instead of merging past them. (Previously only blanket ours/theirs existed, which cannot express a real review.)
- **Registry merge endpoint** accepts `resolutions: [{ path, component_key?, choice }]` with strict shape validation (400 on malformed) and feeds them to the same flow. E2E-tested: 409 with both conflicts → 400 on garbage → 200 merged with mixed choices.

## Viewer

- **`LayerRegistryClient`** (`lib/layers/registry-client.ts`): thin fetch wrapper over `/api/v1/layers|refs|merge`, HTTP base derived from `collabServerUrl()` like the blob store, Bearer-only. Merge outcomes ride non-2xx codes (409 conflicts / 403 policy) as structured results, not errors.
- **Merge orchestration** (`lib/layers/merge.ts`): one preview/execute surface over both backends. Local refs run `mergeIntoRef` in-process; registry refs push the candidate first (409 = already there) and merge server-side.
- **Merge section** in the Layers panel: candidate picker (labeled by manifest intent), target ref picker (local + registry refs), preview stats, conflict queue — path, componentKey, ours/theirs value summaries, subtree-delete warnings ("delete decision carries N touched descendants"), per-row ours/theirs toggle — and an execute button gated on every conflict having a decision. After a local merge: "Load merged ref" recomposes the ref's stack into the viewer.

## Verification

- `@ifc-lite/merge`: 3 new tests (mixed per-conflict merge with composed-state assertions, unaddressed-conflict refusal, precedence over blanket resolve). `collab-server`: resolutions e2e (89 total). Viewer: orchestration round-trip over the browser store + full suite green.
- Localhost: seeded a real divergence (base REI60, ours REI90 on `main`, candidate REI150), drove the UI — preview showed "0 auto-merged, 1 conflict" with the queue row, merge stayed disabled until "theirs" was chosen, merged as a blake3 merge layer, "Load merged ref" composed 3 strata with the merge layer strongest (GitMerge marker), and the effective state resolved to REI150.

## Notes
- Registry merges of `edited` resolutions are intentionally not ferried (local-flow feature; the route accepts ours/theirs only).
- Checks panel, provenance detail panel, author-kind lens, and BCF-bound review comments remain for the L4 completion pass (#1717).
