### PR TITLE
perf(stream): sharded pre-pass stage 2 — columns-driven discovery + column-based flatten

### DIFF
--- a/.changeset/sharded-prepass-stage2.md
+++ b/.changeset/sharded-prepass-stage2.md
@@ -1,8 +1,8 @@
 ---
 "@ifc-lite/geometry": minor
-"@ifc-lite/wasm": minor
+"@ifc-lite/wasm": major
 ---
 
 Sharded pre-pass stage 2: columns-driven discovery + column-based styles flatten.
 
-The shard scan now classifies every record (geometry job, type candidate, project/site, all support-span kinds), so the pre-pass fills its collectors from the stitched class columns in ~100ms and never byte-scans the file — meta and ALL job chunks arrive right after the stitch instead of behind a multi-second scan. The styles finalize keeps the shard-merged geometry styles as columns end to end (`flat_styles_rgba8_from_geometry_columns`): no 4M-entry hashmap seed, no hashmap rebuild in the flatten, byte-identical wire output. Same flag (`__IFC_LITE_SHARD_SCAN`), same serial fallback.
+The shard scan now classifies every record (geometry job, type candidate, project/site, all support-span kinds), so the pre-pass fills its collectors from the stitched class columns in ~100ms and never byte-scans the file — meta and ALL job chunks arrive right after the stitch instead of behind a multi-second scan. The styles finalize keeps the shard-merged geometry styles as columns end to end (`flat_styles_rgba8_from_geometry_columns`): no 4M-entry hashmap seed, no hashmap rebuild in the flatten, byte-identical wire output. Same flag (`__IFC_LITE_SHARD_SCAN`), same serial fallback. BREAKING (@ifc-lite/wasm): `buildPrePassStreamingSharded` gains a required `index_classes` parameter (the class column is what makes columns discovery possible).

--- a/.changeset/sharded-prepass-stage2.md
+++ b/.changeset/sharded-prepass-stage2.md
@@ -1,0 +1,8 @@
+---
+"@ifc-lite/geometry": minor
+"@ifc-lite/wasm": minor
+---
+
+Sharded pre-pass stage 2: columns-driven discovery + column-based styles flatten.
+
+The shard scan now classifies every record (geometry job, type candidate, project/site, all support-span kinds), so the pre-pass fills its collectors from the stitched class columns in ~100ms and never byte-scans the file — meta and ALL job chunks arrive right after the stitch instead of behind a multi-second scan. The styles finalize keeps the shard-merged geometry styles as columns end to end (`flat_styles_rgba8_from_geometry_columns`): no 4M-entry hashmap seed, no hashmap rebuild in the flatten, byte-identical wire output. Same flag (`__IFC_LITE_SHARD_SCAN`), same serial fallback.

--- a/packages/geometry/src/geometry-parallel.ts
+++ b/packages/geometry/src/geometry-parallel.ts
@@ -413,7 +413,7 @@ export async function* processParallel(
   // synchronous setup, long before any shard result can arrive).
   let startPrepass: (
     sharded: boolean,
-    indexColumns?: { ids: Uint32Array; starts: Uint32Array; lengths: Uint32Array },
+    indexColumns?: { ids: Uint32Array; starts: Uint32Array; lengths: Uint32Array; classes: Uint8Array },
   ) => void = () => {};
 
   // Content-affinity routing (#1130 follow-up): the pre-pass tags every job with
@@ -1029,8 +1029,10 @@ export async function* processParallel(
       );
     }
 
-    // Start the sharded pre-pass with the stitched index columns.
-    startPrepass(true, { ids, starts, lengths });
+    // Start the sharded pre-pass with the stitched index columns + classes
+    // (stage 2: the pre-pass discovers jobs/spans from the class column and
+    // never byte-scans the file).
+    startPrepass(true, { ids, starts, lengths, classes: classes.slice() });
   };
 
   /**
@@ -1416,7 +1418,7 @@ export async function* processParallel(
   }
   startPrepass = (
     sharded: boolean,
-    indexColumns?: { ids: Uint32Array; starts: Uint32Array; lengths: Uint32Array },
+    indexColumns?: { ids: Uint32Array; starts: Uint32Array; lengths: Uint32Array; classes: Uint8Array },
   ) => {
     if (sharded && indexColumns) {
       prepassWorker.postMessage({
@@ -1428,6 +1430,7 @@ export async function* processParallel(
         indexIds: indexColumns.ids,
         indexStarts: indexColumns.starts,
         indexLengths: indexColumns.lengths,
+        indexClasses: indexColumns.classes,
       }, [
         // TRANSFER the ~230MB of stitched columns (deliverEntityIndex already
         // copied them into SABs for the other consumers) — a structured clone
@@ -1435,6 +1438,7 @@ export async function* processParallel(
         indexColumns.ids.buffer,
         indexColumns.starts.buffer,
         indexColumns.lengths.buffer,
+        indexColumns.classes.buffer,
       ]);
     } else {
       prepassWorker.postMessage({

--- a/packages/geometry/src/geometry.worker.ts
+++ b/packages/geometry/src/geometry.worker.ts
@@ -301,6 +301,8 @@ export interface GeometryWorkerPrePassShardedMessage {
   indexIds: Uint32Array;
   indexStarts: Uint32Array;
   indexLengths: Uint32Array;
+  /** Per-record prepass classes — drives columns discovery (no byte scan). */
+  indexClasses: Uint8Array;
 }
 
 /**
@@ -1292,7 +1294,7 @@ async function handleMessage(e: MessageEvent<GeometryWorkerRequest>): Promise<vo
       // Sharded pre-pass main call: prebuilt (stitched) index, external styles.
       const ifcApi = await ensureInit();
       (self as unknown as Worker).postMessage({ type: 'prepass-progress', phase: 'parsing' });
-      const { sharedBuffer, indexIds, indexStarts, indexLengths } = e.data;
+      const { sharedBuffer, indexIds, indexStarts, indexLengths, indexClasses } = e.data;
       const chunkSize = e.data.chunkSize ?? 50_000;
       const disabledTypes = e.data.disabledTypes ?? undefined;
       const skipTypeGeometry = e.data.skipTypeGeometry === true;
@@ -1304,11 +1306,11 @@ async function handleMessage(e: MessageEvent<GeometryWorkerRequest>): Promise<vo
           buildPrePassStreamingSharded: (
             data: Uint8Array, onEvent: (e: unknown) => void, chunkSize: number,
             disabledTypes: string[] | undefined, skipTypeGeometry: boolean,
-            ids: Uint32Array, starts: Uint32Array, lengths: Uint32Array,
+            ids: Uint32Array, starts: Uint32Array, lengths: Uint32Array, classes: Uint8Array,
           ) => unknown;
         }).buildPrePassStreamingSharded(
           bytes, onEvent, chunkSize, disabledTypes, skipTypeGeometry,
-          indexIds, indexStarts, indexLengths,
+          indexIds, indexStarts, indexLengths, indexClasses,
         );
       try {
         run(viewSharedBytes(sharedBuffer));

--- a/packages/wasm/pkg/ifc-lite.d.ts
+++ b/packages/wasm/pkg/ifc-lite.d.ts
@@ -209,7 +209,7 @@ export class IfcAPI {
    *     styles payload the serial path emits. NO `styles` event is emitted
    *     here.
    */
-  buildPrePassStreamingSharded(data: Uint8Array, on_event: Function, chunk_size: number, disabled_type_names: string[] | null | undefined, skip_type_geometry: boolean, index_ids: Uint32Array, index_starts: Uint32Array, index_lengths: Uint32Array): any;
+  buildPrePassStreamingSharded(data: Uint8Array, on_event: Function, chunk_size: number, disabled_type_names: string[] | null | undefined, skip_type_geometry: boolean, index_ids: Uint32Array, index_starts: Uint32Array, index_lengths: Uint32Array, index_classes: Uint8Array): any;
   /**
    * Store the whole IFC source file ONCE per load so the `*FromSource` batch
    * variants can read it from the wasm heap instead of re-copying it per call.
@@ -1294,7 +1294,7 @@ export interface InitOutput {
   readonly gridaxisjs_tag: (a: number, b: number) => void;
   readonly ifcapi_buildPrePassOnce: (a: number, b: number, c: number) => number;
   readonly ifcapi_buildPrePassStreaming: (a: number, b: number, c: number, d: number, e: number, f: number, g: number, h: number, i: number) => void;
-  readonly ifcapi_buildPrePassStreamingSharded: (a: number, b: number, c: number, d: number, e: number, f: number, g: number, h: number, i: number, j: number, k: number, l: number, m: number, n: number, o: number) => void;
+  readonly ifcapi_buildPrePassStreamingSharded: (a: number, b: number, c: number, d: number, e: number, f: number, g: number, h: number, i: number, j: number, k: number, l: number, m: number, n: number, o: number, p: number, q: number) => void;
   readonly ifcapi_clearPrePassCache: (a: number) => void;
   readonly ifcapi_diagnoseGeometry: (a: number, b: number, c: number) => number;
   readonly ifcapi_exportCsv: (a: number, b: number, c: number, d: number, e: number, f: number, g: number, h: number, i: number) => void;

--- a/rust/processing/src/lib.rs
+++ b/rust/processing/src/lib.rs
@@ -12,9 +12,13 @@ pub(crate) mod parallel_scan;
 mod shard_classes;
 pub use parallel_scan::{build_entity_index_parallel, scan_shard, ShardRecords};
 pub use shard_classes::{
-    scan_shard_classified, PREPASS_CLASS_INDEXED_COLOUR_MAP, PREPASS_CLASS_MATERIAL_DEF_REPR,
-    PREPASS_CLASS_NONE, PREPASS_CLASS_REL_AGGREGATES, PREPASS_CLASS_REL_ASSOCIATES_MATERIAL,
-    PREPASS_CLASS_REL_FILLS, PREPASS_CLASS_REL_VOIDS, PREPASS_CLASS_STYLED_ITEM,
+    classify_type_name, scan_shard_classified, PREPASS_CLASS_CODE_MASK,
+    PREPASS_CLASS_FLAG_GEOMETRY_JOB, PREPASS_CLASS_FLAG_TYPE_CANDIDATE,
+    PREPASS_CLASS_INDEXED_COLOUR_MAP, PREPASS_CLASS_MATERIAL_DEF_REPR,
+    PREPASS_CLASS_MAPPED_ITEM, PREPASS_CLASS_MATERIAL_LAYER_SET, PREPASS_CLASS_NONE,
+    PREPASS_CLASS_PROJECT, PREPASS_CLASS_REL_DEFINES_BY_TYPE,
+    PREPASS_CLASS_REL_AGGREGATES, PREPASS_CLASS_REL_ASSOCIATES_MATERIAL, PREPASS_CLASS_REL_FILLS,
+    PREPASS_CLASS_REL_VOIDS, PREPASS_CLASS_SITE, PREPASS_CLASS_STYLED_ITEM,
 };
 // `determinism::diff_report` unit tests (#1549) live in this sibling
 // `_tests.rs` file, declared from here rather than inside `determinism.rs`,
@@ -32,6 +36,7 @@ mod georeferencing;
 pub mod pipeline_diagnostics;
 pub mod prepass;
 mod prepass_styled;
+pub use prepass_styled::flat_styles_rgba8_from_geometry_columns;
 mod processor;
 pub mod stream_meta;
 pub mod style;

--- a/rust/processing/src/parallel_scan.rs
+++ b/rust/processing/src/parallel_scan.rs
@@ -52,7 +52,7 @@
 //! parallel driver buys nothing and only adds merge overhead — the wasm build
 //! delegates straight to the serial scanner and is unchanged.
 
-use ifc_lite_core::EntityIndex;
+use ifc_lite_core::{EntityIndex, EntityScanner};
 
 /// One shard's speculative scan over `[range_start, range_end)`.
 ///
@@ -78,8 +78,25 @@ pub fn scan_shard(
     range_start: usize,
     range_end: usize,
 ) -> (ShardRecords, Option<usize>) {
-    let (records, _classes, handoff) =
-        crate::shard_classes::scan_shard_classified(content, range_start, range_end);
+    // Deliberately NOT delegating to `scan_shard_classified`: index-only
+    // callers (native exporters / georeferencing via
+    // `build_entity_index_parallel`) would pay a per-entity keyword
+    // classification — string matches + the `has_geometry_by_name` cache —
+    // across every record for a column they never read.
+    let mut scanner = if range_start == 0 {
+        EntityScanner::new(content)
+    } else {
+        EntityScanner::new_at(content, range_start)
+    };
+    let mut records = Vec::new();
+    let mut handoff = None;
+    while let Some((id, _type_name, start, entity_end)) = scanner.next_entity() {
+        if start >= range_end {
+            handoff = Some(start);
+            break;
+        }
+        records.push((id, start, entity_end));
+    }
     (records, handoff)
 }
 

--- a/rust/processing/src/prepass_styled.rs
+++ b/rust/processing/src/prepass_styled.rs
@@ -54,3 +54,77 @@ pub fn resolve_styled_items_into(
     }
 }
 
+
+/// [`crate::prepass::flat_styles_rgba8`] with the (dominant) geometry-style
+/// source supplied as PRE-MERGED columns instead of a map — the sharded
+/// finalize path. `geom_ids` are unique (the host merged shard results
+/// first-wins) with `geom_colors` as rgba f32 quads; `resolved` carries the
+/// support resolution (indexed colours, materials, element colours) and MUST
+/// have an empty `geometry_style_index`. Output is byte-identical to the
+/// serial flatten: same precedence (geometry > indexed colour > material >
+/// element material), same id-ascending wire order, same rgba8 conversion —
+/// without ever building the 4M-entry geometry hashmap.
+pub fn flat_styles_rgba8_from_geometry_columns(
+    geom_ids: &[u32],
+    geom_colors: &[f32],
+    resolved: &crate::prepass::ResolvedPrepass,
+    decoder: &mut EntityDecoder,
+) -> (Vec<u32>, Vec<u8>) {
+    debug_assert!(resolved.geometry_style_index.is_empty());
+    // Overlay sources in serial precedence order, or_insert among themselves.
+    let mut overlay: FxHashMap<u32, [f32; 4]> = FxHashMap::default();
+    for (&geometry_id, &color) in &resolved.indexed_colour_index {
+        overlay.entry(geometry_id).or_insert(color);
+    }
+    let material_styles = crate::style::build_material_style_index(
+        &resolved.material_def_reprs,
+        &resolved.orphan_styled_items,
+        decoder,
+    );
+    for (&mat_id, &color) in crate::style::flatten_material_color_index(&material_styles).iter() {
+        overlay.entry(mat_id).or_insert(color);
+    }
+    for (&element_id, colors) in &resolved.element_material_colors {
+        if let Some(&color) = colors.first() {
+            overlay.entry(element_id).or_insert(color);
+        }
+    }
+
+    // Sort both sides by id and merge, geometry winning on ties.
+    let mut geom_order: Vec<u32> = (0..geom_ids.len() as u32).collect();
+    geom_order.sort_unstable_by_key(|&i| geom_ids[i as usize]);
+    let mut overlay_sorted: Vec<(u32, [f32; 4])> = overlay.into_iter().collect();
+    overlay_sorted.sort_unstable_by_key(|&(id, _)| id);
+
+    let mut ids: Vec<u32> = Vec::with_capacity(geom_ids.len() + overlay_sorted.len());
+    let mut rgba: Vec<u8> = Vec::with_capacity((geom_ids.len() + overlay_sorted.len()) * 4);
+    let push = |id: u32, color: [f32; 4], ids: &mut Vec<u32>, rgba: &mut Vec<u8>| {
+        ids.push(id);
+        rgba.extend_from_slice(&crate::style::Rgba::from_array(color).to_rgba8());
+    };
+    let mut oi = 0;
+    for &gi in &geom_order {
+        let id = geom_ids[gi as usize];
+        while oi < overlay_sorted.len() && overlay_sorted[oi].0 < id {
+            let (oid, oc) = overlay_sorted[oi];
+            push(oid, oc, &mut ids, &mut rgba);
+            oi += 1;
+        }
+        if oi < overlay_sorted.len() && overlay_sorted[oi].0 == id {
+            oi += 1; // geometry wins the tie, overlay entry dropped
+        }
+        let c = gi as usize * 4;
+        push(
+            id,
+            [geom_colors[c], geom_colors[c + 1], geom_colors[c + 2], geom_colors[c + 3]],
+            &mut ids,
+            &mut rgba,
+        );
+    }
+    while oi < overlay_sorted.len() {
+        let (oid, oc) = overlay_sorted[oi];
+        push(oid, oc, &mut ids, &mut rgba);
+        oi += 1;
+    }
+    (ids, rgba)
+}

--- a/rust/processing/src/shard_classes.rs
+++ b/rust/processing/src/shard_classes.rs
@@ -33,6 +33,25 @@ pub const PREPASS_CLASS_REL_VOIDS: u8 = 8;
 pub const PREPASS_CLASS_REL_FILLS: u8 = 9;
 /// `IFCRELAGGREGATES`.
 pub const PREPASS_CLASS_REL_AGGREGATES: u8 = 10;
+/// `IFCPROJECT`.
+pub const PREPASS_CLASS_PROJECT: u8 = 2;
+/// `IFCSITE` (also a geometry job — the pre-pass buffers it like one).
+pub const PREPASS_CLASS_SITE: u8 = 3;
+/// `IFCMATERIALLAYERSET` / `IFCMATERIALLAYERSETUSAGE` (arms the layer index).
+pub const PREPASS_CLASS_MATERIAL_LAYER_SET: u8 = 13;
+/// FLAG bit: geometry-bearing entity (`has_geometry_by_name`) — a pre-pass
+/// geometry job. Composes with the named codes' nibble range (2..=13) and
+/// with [`PREPASS_CLASS_FLAG_TYPE_CANDIDATE`].
+pub const PREPASS_CLASS_FLAG_GEOMETRY_JOB: u8 = 0x80;
+/// FLAG bit: `IfcTypeProduct` subtype candidate (name ends TYPE/STYLE) for the
+/// #957 orphan type-geometry pass.
+pub const PREPASS_CLASS_FLAG_TYPE_CANDIDATE: u8 = 0x40;
+/// `IFCMAPPEDITEM` (#957/#1623 repmap plans).
+pub const PREPASS_CLASS_MAPPED_ITEM: u8 = 11;
+/// `IFCRELDEFINESBYTYPE` (#957 instantiated-type ids).
+pub const PREPASS_CLASS_REL_DEFINES_BY_TYPE: u8 = 12;
+/// Mask extracting the named-arm code from a class byte (drops the flag bits).
+pub const PREPASS_CLASS_CODE_MASK: u8 = 0x3F;
 
 /// [`scan_shard`] plus a parallel per-record class column (see the
 /// `PREPASS_CLASS_*` codes). Same records, same handoff; the class byte lets
@@ -57,16 +76,48 @@ pub fn scan_shard_classified(
             break;
         }
         records.push((id, start, entity_end));
-        classes.push(match type_name {
-            "IFCSTYLEDITEM" => PREPASS_CLASS_STYLED_ITEM,
-            "IFCINDEXEDCOLOURMAP" => PREPASS_CLASS_INDEXED_COLOUR_MAP,
-            "IFCMATERIALDEFINITIONREPRESENTATION" => PREPASS_CLASS_MATERIAL_DEF_REPR,
-            "IFCRELASSOCIATESMATERIAL" => PREPASS_CLASS_REL_ASSOCIATES_MATERIAL,
-            "IFCRELVOIDSELEMENT" => PREPASS_CLASS_REL_VOIDS,
-            "IFCRELFILLSELEMENT" => PREPASS_CLASS_REL_FILLS,
-            "IFCRELAGGREGATES" => PREPASS_CLASS_REL_AGGREGATES,
-            _ => PREPASS_CLASS_NONE,
-        });
+        classes.push(classify_type_name(type_name));
     }
     (records, classes, handoff)
+}
+
+/// Classify a scanned STEP keyword into the prepass class byte: a named-arm
+/// code for the exact keywords the serial pre-pass matches, plus the
+/// geometry-job / type-candidate FLAG bits from the same helpers it calls
+/// (`has_geometry_by_name`, `IfcType::is_subtype_of`). Byte-identical span
+/// collection and job discovery follow from using the identical predicates at
+/// scan time.
+pub fn classify_type_name(type_name: &str) -> u8 {
+    use ifc_lite_core::{has_geometry_by_name, IfcType};
+    let named = match type_name {
+        "IFCPROJECT" => PREPASS_CLASS_PROJECT,
+        "IFCSITE" => return PREPASS_CLASS_SITE, // site is job + site-record; flags implied
+        "IFCSTYLEDITEM" => PREPASS_CLASS_STYLED_ITEM,
+        "IFCINDEXEDCOLOURMAP" => PREPASS_CLASS_INDEXED_COLOUR_MAP,
+        "IFCMATERIALDEFINITIONREPRESENTATION" => PREPASS_CLASS_MATERIAL_DEF_REPR,
+        "IFCRELASSOCIATESMATERIAL" => PREPASS_CLASS_REL_ASSOCIATES_MATERIAL,
+        "IFCRELVOIDSELEMENT" => PREPASS_CLASS_REL_VOIDS,
+        "IFCRELFILLSELEMENT" => PREPASS_CLASS_REL_FILLS,
+        "IFCRELAGGREGATES" => PREPASS_CLASS_REL_AGGREGATES,
+        "IFCMAPPEDITEM" => PREPASS_CLASS_MAPPED_ITEM,
+        "IFCRELDEFINESBYTYPE" => PREPASS_CLASS_REL_DEFINES_BY_TYPE,
+        "IFCMATERIALLAYERSET" | "IFCMATERIALLAYERSETUSAGE" => PREPASS_CLASS_MATERIAL_LAYER_SET,
+        _ => PREPASS_CLASS_NONE,
+    };
+    if named != PREPASS_CLASS_NONE {
+        // The named keywords are mutually exclusive with the flag predicates in
+        // the serial match (its arms return before the `_` arm runs them).
+        return named;
+    }
+    let mut class = PREPASS_CLASS_NONE;
+    if type_name.ends_with("TYPE") || type_name.ends_with("STYLE") {
+        let ty = IfcType::from_str(type_name);
+        if ty.is_subtype_of(IfcType::IfcTypeProduct) {
+            class |= PREPASS_CLASS_FLAG_TYPE_CANDIDATE;
+        }
+    }
+    if has_geometry_by_name(type_name) {
+        class |= PREPASS_CLASS_FLAG_GEOMETRY_JOB;
+    }
+    class
 }

--- a/rust/wasm-bindings/src/api/gpu_meshes/mod.rs
+++ b/rust/wasm-bindings/src/api/gpu_meshes/mod.rs
@@ -11,5 +11,6 @@ mod batch;
 mod batch_from_source;
 mod instancing;
 pub(crate) mod prepass;
+mod prepass_discovery;
 mod prepass_sharded;
 mod void_index;

--- a/rust/wasm-bindings/src/api/gpu_meshes/prepass.rs
+++ b/rust/wasm-bindings/src/api/gpu_meshes/prepass.rs
@@ -186,9 +186,11 @@ impl IfcAPI {
             skip_type_geometry,
             None,
             false,
+            None,
         )
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn pre_pass_streaming_impl(
         &self,
         data: &[u8],
@@ -198,6 +200,7 @@ impl IfcAPI {
         skip_type_geometry: bool,
         prebuilt: Option<ifc_lite_core::ColumnarEntityIndex>,
         external_styles: bool,
+        columns: Option<super::prepass_discovery::IndexColumns<'_>>,
     ) -> Result<JsValue, JsValue> {
         let prebuilt_arc: Option<std::sync::Arc<ifc_lite_core::ColumnarEntityIndex>> =
             prebuilt.map(std::sync::Arc::new);
@@ -312,11 +315,25 @@ impl IfcAPI {
         // resolver the native pipeline and `buildPrePassOnce` run.
         let mut prepass_spans = ifc_lite_processing::prepass::PrepassSpans::default();
 
+        // STAGE 2: fill collectors from the class columns; no byte scan.
+        if let Some((cids, cstarts, clengths, cclasses)) = columns {
+            let d = super::prepass_discovery::discover_from_columns(
+                content, cids, cstarts, clengths, cclasses, &disabled_types,
+            );
+            buffered_jobs = d.buffered_jobs;
+            total_jobs = d.total_jobs;
+            project_id = d.project_id;
+            site_position = d.site_position;
+            prepass_spans = d.prepass_spans;
+            prepass_spans.styled_items = Vec::new(); // shards resolve styles
+            mapped_item_spans = d.mapped_item_spans;
+            rel_defines_by_type_spans = d.rel_defines_by_type_spans;
+            type_candidate_spans = d.type_candidate_spans;
+            has_layer_set = d.has_layer_set;
+        } else {
         while let Some((id, type_name, start, end)) = scanner.next_entity() {
-            // Build entity index inline (prebuilt/sharded mode: map stays
-            // empty; decoders use the prebuilt columnar index instead).
             if prebuilt_arc.is_none() {
-                entity_index.insert(id, (start, end));
+                entity_index.insert(id, (start, end)); // prebuilt mode: map unused
             }
 
             match type_name {
@@ -444,24 +461,23 @@ impl IfcAPI {
                 super::prepass_sharded::set_stream_meta_props(&meta, &meta_res);
                 on_event.call1(&JsValue::NULL, &meta.into())?;
                 meta_emitted = true;
-                // NOTE: jobs are NOT drained here. They are buffered through the
-                // whole scan and emitted post-scan with an exact geometry-hash
-                // affinity key (which needs the COMPLETE entity index). Deferring
-                // is free: workers gate on the styles + entity-index events, both
-                // of which are themselves post-scan.
+                // Jobs stay buffered through the scan; the post-scan pass
+                // emits them with exact geometry-hash affinity keys (workers
+                // gate on post-scan events anyway, so deferring is free).
                 continue;
             }
         }
 
-        // Tail: if we never hit the meta threshold (very small file with
-        // <50 geometry jobs), emit meta now with whatever data we have so
-        // workers can still process the trailing buffer.
+        }
+
+        // Tail meta: small files (scan path) + every columns-path file.
         if !meta_emitted {
             // Build a decoder lazily for unit/RTC/site lookups. With a
             // sub-50-job file the scan is essentially instant anyway, so the
             // full entity index is already complete here — the single-stage
             // `SmallFileSingle` ladder (one detect_rtc_offset_with_fallback) is
             // correct, sharing its resolution with `buildPrePassOnce`.
+            let meta_jobs = &buffered_jobs[..buffered_jobs.len().min(RTC_SAMPLE_THRESHOLD)];
             let meta_res = if let Some(pi) = &prebuilt_arc {
                 let mut decoder = EntityDecoder::with_arc_columnar_index(content, pi.clone());
                 resolve_stream_meta(
@@ -469,7 +485,7 @@ impl IfcAPI {
                     content,
                     project_id,
                     site_position,
-                    &buffered_jobs,
+                    meta_jobs,
                     &mut decoder,
                 )
             } else {

--- a/rust/wasm-bindings/src/api/gpu_meshes/prepass_discovery.rs
+++ b/rust/wasm-bindings/src/api/gpu_meshes/prepass_discovery.rs
@@ -1,0 +1,147 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Columns-driven pre-pass discovery (stage 2 of the sharded pre-pass):
+//! reproduces the serial scan loop's job/span collection from the shard
+//! class columns, so the pre-pass never byte-scans the file.
+
+/// The stitched index + class columns handed to the columns-discovery walk.
+pub(super) type IndexColumns<'a> = (&'a [u32], &'a [u32], &'a [u32], &'a [u8]);
+
+/// Everything the pre-pass scan loop discovers, filled from the shard class
+/// columns instead of a byte scan (stage 2 of the sharded pre-pass). The
+/// class byte was computed at shard-scan time from the SAME predicates the
+/// serial loop matches on, so filling these from the columns reproduces the
+/// serial discovery byte-for-byte — without re-walking the file.
+pub(super) struct ColumnsDiscovery {
+    pub buffered_jobs: Vec<(u32, usize, usize, ifc_lite_core::IfcType)>,
+    pub total_jobs: u32,
+    pub project_id: Option<u32>,
+    pub site_position: Option<(u32, usize, usize)>,
+    pub prepass_spans: ifc_lite_processing::prepass::PrepassSpans,
+    pub mapped_item_spans: Vec<(u32, usize, usize)>,
+    pub rel_defines_by_type_spans: Vec<(u32, usize, usize)>,
+    pub type_candidate_spans: Vec<(u32, usize, usize, ifc_lite_core::IfcType)>,
+    pub has_layer_set: bool,
+}
+
+/// Parse the raw STEP keyword at a record start (`#id=KEYWORD(...`). Only
+/// called for the few records that need it (geometry jobs + type candidates),
+/// never for the 19M-entity bulk.
+fn keyword_at(content: &[u8], start: usize, end: usize) -> &str {
+    let span = &content[start..end.min(content.len())];
+    let eq = span.iter().position(|&b| b == b'=').map(|p| p + 1).unwrap_or(0);
+    let kw_end = span[eq..]
+        .iter()
+        .position(|&b| b == b'(')
+        .map(|p| eq + p)
+        .unwrap_or(span.len());
+    std::str::from_utf8(&span[eq..kw_end]).unwrap_or("").trim()
+}
+
+/// Walk the stitched (file-ordered) class columns and reproduce the serial
+/// pre-pass scan's discovery. `disabled_types` (rare) forces a keyword parse
+/// per flagged geometry record; the empty default never touches the bytes.
+pub(super) fn discover_from_columns(
+    content: &[u8],
+    ids: &[u32],
+    starts: &[u32],
+    lengths: &[u32],
+    classes: &[u8],
+    disabled_types: &rustc_hash::FxHashSet<String>,
+) -> ColumnsDiscovery {
+    use ifc_lite_processing as p;
+    let mut d = ColumnsDiscovery {
+        buffered_jobs: Vec::new(),
+        total_jobs: 0,
+        project_id: None,
+        site_position: None,
+        prepass_spans: p::prepass::PrepassSpans::default(),
+        mapped_item_spans: Vec::new(),
+        rel_defines_by_type_spans: Vec::new(),
+        type_candidate_spans: Vec::new(),
+        has_layer_set: false,
+    };
+    for i in 0..ids.len() {
+        let class = classes[i];
+        if class == p::PREPASS_CLASS_NONE {
+            continue;
+        }
+        let id = ids[i];
+        let start = starts[i] as usize;
+        let end = start + lengths[i] as usize;
+        match class & p::PREPASS_CLASS_CODE_MASK {
+            c if c == p::PREPASS_CLASS_PROJECT => {
+                if d.project_id.is_none() {
+                    d.project_id = Some(id);
+                }
+                continue;
+            }
+            c if c == p::PREPASS_CLASS_SITE => {
+                if d.site_position.is_none() {
+                    d.site_position = Some((id, start, end));
+                }
+                d.buffered_jobs.push((id, start, end, ifc_lite_core::IfcType::IfcSite));
+                d.total_jobs += 1;
+                continue;
+            }
+            c if c == p::PREPASS_CLASS_STYLED_ITEM => {
+                d.prepass_spans.styled_items.push((id, start, end));
+                continue;
+            }
+            c if c == p::PREPASS_CLASS_INDEXED_COLOUR_MAP => {
+                d.prepass_spans.indexed_colour_maps.push((id, start, end));
+                continue;
+            }
+            c if c == p::PREPASS_CLASS_MATERIAL_DEF_REPR => {
+                d.prepass_spans.material_def_reprs.push((id, start, end));
+                continue;
+            }
+            c if c == p::PREPASS_CLASS_REL_ASSOCIATES_MATERIAL => {
+                d.prepass_spans.rel_associates_material.push((id, start, end));
+                continue;
+            }
+            c if c == p::PREPASS_CLASS_REL_VOIDS => {
+                d.prepass_spans.void_rels.push((id, start, end));
+                continue;
+            }
+            c if c == p::PREPASS_CLASS_REL_FILLS => {
+                d.prepass_spans.fills_rels.push((id, start, end));
+                continue;
+            }
+            c if c == p::PREPASS_CLASS_REL_AGGREGATES => {
+                d.prepass_spans.aggregate_rels.push((id, start, end));
+                continue;
+            }
+            c if c == p::PREPASS_CLASS_MATERIAL_LAYER_SET => {
+                d.has_layer_set = true;
+                continue;
+            }
+            c if c == p::PREPASS_CLASS_MAPPED_ITEM => {
+                d.mapped_item_spans.push((id, start, end));
+                continue;
+            }
+            c if c == p::PREPASS_CLASS_REL_DEFINES_BY_TYPE => {
+                d.rel_defines_by_type_spans.push((id, start, end));
+                continue;
+            }
+            _ => {}
+        }
+        // Flag bits (the serial `_` arm): type candidate and/or geometry job.
+        if class & p::PREPASS_CLASS_FLAG_TYPE_CANDIDATE != 0 {
+            let kw = keyword_at(content, start, end);
+            d.type_candidate_spans
+                .push((id, start, end, ifc_lite_core::IfcType::from_str(kw)));
+        }
+        if class & p::PREPASS_CLASS_FLAG_GEOMETRY_JOB != 0 {
+            let kw = keyword_at(content, start, end);
+            if disabled_types.is_empty() || !disabled_types.contains(kw) {
+                d.buffered_jobs
+                    .push((id, start, end, ifc_lite_core::IfcType::from_str(kw)));
+                d.total_jobs += 1;
+            }
+        }
+    }
+    d
+}

--- a/rust/wasm-bindings/src/api/gpu_meshes/prepass_sharded.rs
+++ b/rust/wasm-bindings/src/api/gpu_meshes/prepass_sharded.rs
@@ -62,6 +62,7 @@ impl IfcAPI {
         index_ids: &[u32],
         index_starts: &[u32],
         index_lengths: &[u32],
+        index_classes: &[u8],
     ) -> Result<JsValue, JsValue> {
         let prebuilt = ifc_lite_core::ColumnarEntityIndex::from_columns(
             index_ids,
@@ -76,6 +77,7 @@ impl IfcAPI {
             skip_type_geometry,
             Some(prebuilt),
             true,
+            Some((index_ids, index_starts, index_lengths, index_classes)),
         )
     }
 
@@ -265,29 +267,26 @@ impl IfcAPI {
                 orphan_colors[i * 4 + 3],
             ]);
         }
-        let mut geom_seed = rustc_hash::FxHashMap::default();
-        for (i, &id) in geom_ids.iter().enumerate() {
-            geom_seed.insert(
-                id,
-                ifc_lite_processing::style::GeometryStyleInfo::from_color([
-                    geom_colors[i * 4],
-                    geom_colors[i * 4 + 1],
-                    geom_colors[i * 4 + 2],
-                    geom_colors[i * 4 + 3],
-                ]),
-            );
-        }
-        let mut resolved = ifc_lite_processing::prepass::resolve_prepass_with_style_seeds(
+        // Geometry styles stay as COLUMNS (stage 2): the support resolution
+        // only consults the ORPHAN map (material chain), and the column-based
+        // flatten below never builds the 4M-entry geometry hashmap.
+        let resolved = ifc_lite_processing::prepass::resolve_prepass_with_style_seeds(
             &stashed_support,
             &mut decoder,
             ifc_lite_processing::prepass::ResolveOptions {
                 collect_indexed_colour_full: false,
                 defer_attached_styles: false,
             },
-            Some((orphan_seed, geom_seed)),
+            Some((orphan_seed, rustc_hash::FxHashMap::default())),
+        );
+        let flat = ifc_lite_processing::flat_styles_rgba8_from_geometry_columns(
+            geom_ids,
+            geom_colors,
+            &resolved,
+            &mut decoder,
         );
 
-        Ok(styles_payload(&resolved, &mut decoder).into())
+        Ok(styles_payload_with_flat(flat, &resolved).into())
     }
 }
 
@@ -299,8 +298,16 @@ pub(super) fn styles_payload(
     resolved: &ifc_lite_processing::prepass::ResolvedPrepass,
     decoder: &mut ifc_lite_core::EntityDecoder,
 ) -> js_sys::Object {
-    let (style_ids_vec, style_colors_vec) =
-        ifc_lite_processing::prepass::flat_styles_rgba8(resolved, decoder);
+    let flat = ifc_lite_processing::prepass::flat_styles_rgba8(resolved, decoder);
+    styles_payload_with_flat(flat, resolved)
+}
+
+/// [`styles_payload`] with the style columns precomputed (the sharded
+/// finalize computes them via the column-based flatten).
+pub(super) fn styles_payload_with_flat(
+    (style_ids_vec, style_colors_vec): (Vec<u32>, Vec<u8>),
+    resolved: &ifc_lite_processing::prepass::ResolvedPrepass,
+) -> js_sys::Object {
     let (void_keys_vec, void_counts_vec, void_values_vec) =
         ifc_lite_processing::prepass::flat_voids(&resolved.void_index);
     let (mat_ids_vec, mat_counts_vec, mat_colors_vec) =
@@ -316,5 +323,3 @@ pub(super) fn styles_payload(
     crate::api::set_js_prop(&result, "materialColors", &js_sys::Uint8Array::from(mat_colors_vec.as_slice()));
     result
 }
-
-


### PR DESCRIPTION
## What

Stage 2 of #1720: the pre-pass never byte-scans the file, and the styles flatten never builds the 4M-entry hashmap.

1. **Columns-driven discovery**: the shard scan classifies every record (`classify_type_name` — same predicates as the serial match: geometry job, type candidate, project/site, all support-span kinds). `buildPrePassStreamingSharded` fills its collectors from the class columns in ~100ms (`prepass_discovery.rs`) — meta + the first jobs chunk arrive right after the stitch.
2. **Column-based styles flatten**: `flat_styles_rgba8_from_geometry_columns` merges the small overlay sources into the shard-merged geometry columns (identical precedence, id order, rgba8 conversion) — finalize dropped from 2.7s to 0.78s.

Same flag (`__IFC_LITE_SHARD_SCAN`), serial path untouched.

## Measured (CatiaA1.ifc, 883MB, cold, 3 workers)

| | serial | stage 1 (#1720) | stage 2 |
|---|---|---|---|
| first jobs chunk | 11.7s | 7.5s | **4.0s** |
| styles | 11.7s | 9.7-10.2s | **8.2s** |
| **first visible** | **14.3s** | 10.4-11.1s | **9.9s (-31%)** |

Render-stats parity exact on CatiaA1 (2,122 draws / 722.7MB / 284 batches) and FM_ARC_DigitalHub (1960 styled / 62 voids / 83 draws).

## Gates
Ratchet green (discovery in its own module), clippy -D warnings clean, 51 processing lib tests, API surface unchanged, changeset added.

Recorded follow-up (stage 3): sort-once index delivery — the remaining ~2s argsort inside the sharded pre-pass call and per style-slice worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved sharded model processing by using column-based discovery instead of scanning file content.
  * Faster pre-pass collection and style finalization, with results produced in approximately 100 ms.
* **Bug Fixes**
  * Improved classification of geometry jobs, type candidates, project/site records, and related entities.
  * Preserved existing fallback behavior for non-sharded processing and shard-scan configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->