### PR TITLE
feat(viewer): provenance detail, layer ghosting, lazy Layers panel (#1717 V4)

### DIFF
--- a/apps/viewer/src/components/viewer/layers/LayerDiffView.tsx
+++ b/apps/viewer/src/components/viewer/layers/LayerDiffView.tsx
@@ -9,7 +9,7 @@
  * expressId bridge when the path resolves to a meshed entity.
  */
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { StackDiff } from '@ifc-lite/merge';
 import { useViewerStore } from '@/store';
 import type { LayerStackEntry } from '@/store/slices/layerStackSlice';
@@ -53,6 +53,9 @@ const ROW_LIMIT = 200;
 export function LayerDiffView({ entry, diff }: { entry: LayerStackEntry; diff: StackDiff }) {
   const [kindFilter, setKindFilter] = useState<ChangeKind | null>(null);
   const [ghosting, setGhosting] = useState(false);
+  // The exact Set THIS view installed — the ghost channel is shared with
+  // other features (clash focus etc.), so cleanup must only remove ours.
+  const ownedGhostSet = useRef<Set<number> | null>(null);
 
   const rows = useMemo<DiffRow[]>(() => {
     const out: DiffRow[] = [];
@@ -73,7 +76,10 @@ export function LayerDiffView({ entry, diff }: { entry: LayerStackEntry; diff: S
     const state = useViewerStore.getState();
     setGhosting((prev) => {
       if (prev) {
-        state.setGhostExceptEntities(null);
+        if (state.ghostExceptEntities === ownedGhostSet.current) {
+          state.setGhostExceptEntities(null);
+        }
+        ownedGhostSet.current = null;
         return false;
       }
       const ids = new Set<number>();
@@ -82,17 +88,21 @@ export function LayerDiffView({ entry, diff }: { entry: LayerStackEntry; diff: S
         if (id !== undefined) ids.add(id);
       }
       if (ids.size === 0) return false;
+      ownedGhostSet.current = ids;
       state.setGhostExceptEntities(ids);
       return true;
     });
   }, [diff]);
 
   useEffect(() => {
-    // Leaving the diff (or swapping layers) drops the isolation.
+    // Leaving the diff (or swapping layers) drops OUR isolation only —
+    // never a ghost set some other panel installed.
     return () => {
-      if (useViewerStore.getState().ghostExceptEntities !== null) {
-        useViewerStore.getState().setGhostExceptEntities(null);
+      const state = useViewerStore.getState();
+      if (ownedGhostSet.current !== null && state.ghostExceptEntities === ownedGhostSet.current) {
+        state.setGhostExceptEntities(null);
       }
+      ownedGhostSet.current = null;
     };
   }, [diff]);
 

--- a/apps/viewer/src/components/viewer/layers/LayerDiffView.tsx
+++ b/apps/viewer/src/components/viewer/layers/LayerDiffView.tsx
@@ -9,11 +9,12 @@
  * expressId bridge when the path resolves to a meshed entity.
  */
 
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import type { StackDiff } from '@ifc-lite/merge';
 import { useViewerStore } from '@/store';
 import type { LayerStackEntry } from '@/store/slices/layerStackSlice';
 import { pathTail } from '@/lib/layers/stack';
+import { Ghost } from 'lucide-react';
 
 type ChangeKind = 'added' | 'deleted' | 'modified';
 
@@ -51,6 +52,7 @@ const ROW_LIMIT = 200;
 
 export function LayerDiffView({ entry, diff }: { entry: LayerStackEntry; diff: StackDiff }) {
   const [kindFilter, setKindFilter] = useState<ChangeKind | null>(null);
+  const [ghosting, setGhosting] = useState(false);
 
   const rows = useMemo<DiffRow[]>(() => {
     const out: DiffRow[] = [];
@@ -63,6 +65,36 @@ export function LayerDiffView({ entry, diff }: { entry: LayerStackEntry; diff: S
   }, [diff]);
 
   const visible = kindFilter ? rows.filter((r) => r.kind === kindFilter) : rows;
+
+  // 3D isolation (08-review.md diff mode): ghost everything this layer
+  // did not touch. Deleted paths have no mesh; added/modified resolve
+  // through the composition bridge. Cleared on unmount / diff change.
+  const toggleGhost = useCallback(() => {
+    const state = useViewerStore.getState();
+    setGhosting((prev) => {
+      if (prev) {
+        state.setGhostExceptEntities(null);
+        return false;
+      }
+      const ids = new Set<number>();
+      for (const path of [...diff.added, ...diff.modified.map((m) => m.path)]) {
+        const id = state.layerStackPathToId?.get(path);
+        if (id !== undefined) ids.add(id);
+      }
+      if (ids.size === 0) return false;
+      state.setGhostExceptEntities(ids);
+      return true;
+    });
+  }, [diff]);
+
+  useEffect(() => {
+    // Leaving the diff (or swapping layers) drops the isolation.
+    return () => {
+      if (useViewerStore.getState().ghostExceptEntities !== null) {
+        useViewerStore.getState().setGhostExceptEntities(null);
+      }
+    };
+  }, [diff]);
 
   const selectPath = useCallback((path: string) => {
     const state = useViewerStore.getState();
@@ -82,6 +114,19 @@ export function LayerDiffView({ entry, diff }: { entry: LayerStackEntry; diff: S
         <span className="truncate text-[11px] font-medium" title={entry.name}>
           Changes by {entry.name}
         </span>
+        <button
+          type="button"
+          onClick={toggleGhost}
+          aria-pressed={ghosting}
+          className={`inline-flex shrink-0 items-center gap-1 rounded-full border px-1.5 py-px text-[10px] font-medium leading-none transition-colors ${
+            ghosting
+              ? 'border-sky-500/30 bg-sky-500/10 text-sky-600 dark:text-sky-300'
+              : 'border-border text-muted-foreground hover:bg-muted/60'
+          }`}
+        >
+          <Ghost className="size-2.5" aria-hidden />
+          {ghosting ? 'Ghosting others' : 'Ghost others'}
+        </button>
       </div>
       <div className="flex items-center gap-1 pb-1.5">
         {counts.map(({ kind, count }) => {

--- a/apps/viewer/src/components/viewer/layers/LayerDiffView.tsx
+++ b/apps/viewer/src/components/viewer/layers/LayerDiffView.tsx
@@ -96,13 +96,15 @@ export function LayerDiffView({ entry, diff }: { entry: LayerStackEntry; diff: S
 
   useEffect(() => {
     // Leaving the diff (or swapping layers) drops OUR isolation only —
-    // never a ghost set some other panel installed.
+    // never a ghost set some other panel installed — and resyncs the
+    // toggle so the button never claims ghosting that no longer exists.
     return () => {
       const state = useViewerStore.getState();
       if (ownedGhostSet.current !== null && state.ghostExceptEntities === ownedGhostSet.current) {
         state.setGhostExceptEntities(null);
       }
       ownedGhostSet.current = null;
+      setGhosting(false);
     };
   }, [diff]);
 

--- a/apps/viewer/src/components/viewer/layers/LayerProvenanceDetail.tsx
+++ b/apps/viewer/src/components/viewer/layers/LayerProvenanceDetail.tsx
@@ -1,0 +1,123 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Provenance detail for one stratum (#1717 V4, 08-review.md §8.5): the
+ * full manifest — author, base, scope claims, check evidence, merge
+ * record, identity map — rendered from the layer document itself.
+ */
+
+import { getProvenance } from '@ifc-lite/ifcx';
+import type { IfcxFile, ProvenanceManifest } from '@ifc-lite/ifcx';
+import { CheckCircle2, XCircle } from 'lucide-react';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { shortContentId } from '@/lib/layers/stack';
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="flex items-start gap-1.5">
+      <span className="w-16 shrink-0 text-[10px] uppercase tracking-wide text-muted-foreground">{label}</span>
+      <span className="min-w-0 flex-1 text-[11px]">{children}</span>
+    </div>
+  );
+}
+
+function ChecksList({ manifest }: { manifest: ProvenanceManifest }) {
+  if (manifest.checks.length === 0) return <span className="text-muted-foreground">none attached</span>;
+  return (
+    <span className="flex flex-col gap-0.5">
+      {manifest.checks.map((check, i) => (
+        <span key={`${check.spec ?? check.tool}-${i}`} className="flex items-center gap-1">
+          {check.result === 'pass' ? (
+            <CheckCircle2 className="size-3 shrink-0 text-emerald-500" aria-label="pass" />
+          ) : (
+            <XCircle className="size-3 shrink-0 text-red-500" aria-label="fail" />
+          )}
+          <span className="truncate">{check.spec ?? check.tool}</span>
+          {check.report && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span className="rounded bg-muted px-1 font-mono text-[10px]">{shortContentId(check.report)}</span>
+              </TooltipTrigger>
+              <TooltipContent side="top" className="font-mono text-[10px]">
+                evidence report {check.report}
+              </TooltipContent>
+            </Tooltip>
+          )}
+        </span>
+      ))}
+    </span>
+  );
+}
+
+export function LayerProvenanceDetail({ file }: { file: IfcxFile }) {
+  const manifest = getProvenance(file);
+  if (!manifest) {
+    return (
+      <p className="px-1 py-1 text-[11px] text-muted-foreground">
+        No provenance manifest — this layer is unsigned raw IFCX (an import or a foreign file).
+      </p>
+    );
+  }
+  return (
+    <div className="flex flex-col gap-1 rounded border bg-muted/20 p-1.5">
+      <Field label="Author">
+        {manifest.author.kind} · {manifest.author.principal}
+        {manifest.author.tool ? ` · ${manifest.author.tool}` : ''}
+      </Field>
+      <Field label="Intent">{manifest.intent}</Field>
+      <Field label="Created">{manifest.created}</Field>
+      <Field label="Base">
+        {manifest.base ? (
+          <span className="font-mono text-[10px]">{`${manifest.base.kind}:${shortContentId(manifest.base.id)}`}</span>
+        ) : (
+          <span className="text-muted-foreground">none (base/import layer)</span>
+        )}
+      </Field>
+      <Field label="Scope">
+        {manifest.scope_claim.length > 0 ? (
+          <span className="flex flex-wrap gap-1">
+            {manifest.scope_claim.map((claim) => (
+              <span key={claim} className="rounded bg-muted px-1 font-mono text-[10px]">
+                {claim}
+              </span>
+            ))}
+          </span>
+        ) : (
+          <span className="text-muted-foreground">unrestricted</span>
+        )}
+      </Field>
+      <Field label="Checks">
+        <ChecksList manifest={manifest} />
+      </Field>
+      {manifest.merge && (
+        <Field label="Merge">
+          <span className="flex flex-col gap-0.5">
+            <span>
+              <span className="font-mono text-[10px]">{shortContentId(manifest.merge.candidate)}</span>
+              {' into '}
+              {manifest.merge.into} by {manifest.merge.resolver}
+            </span>
+            <span className="text-muted-foreground">
+              {manifest.merge.resolutions.length} resolution{manifest.merge.resolutions.length === 1 ? '' : 's'}
+              {manifest.merge.waived_checks.length > 0
+                ? `, ${manifest.merge.waived_checks.length} waived check${manifest.merge.waived_checks.length === 1 ? '' : 's'}`
+                : ''}
+            </span>
+          </span>
+        </Field>
+      )}
+      {manifest.identity_map.length > 0 && (
+        <Field label="Identity">
+          {manifest.identity_map.length} content-derived entit{manifest.identity_map.length === 1 ? 'y' : 'ies'}
+        </Field>
+      )}
+      {manifest.signatures.length > 0 && (
+        <Field label="Signed">
+          {manifest.signatures.length} signature{manifest.signatures.length === 1 ? '' : 's'}
+        </Field>
+      )}
+    </div>
+  );
+}

--- a/apps/viewer/src/components/viewer/layers/LayerProvenanceDetail.tsx
+++ b/apps/viewer/src/components/viewer/layers/LayerProvenanceDetail.tsx
@@ -8,7 +8,7 @@
  * record, identity map — rendered from the layer document itself.
  */
 
-import { getProvenance } from '@ifc-lite/ifcx';
+import { getProvenance, validateProvenance } from '@ifc-lite/ifcx';
 import type { IfcxFile, ProvenanceManifest } from '@ifc-lite/ifcx';
 import { CheckCircle2, XCircle } from 'lucide-react';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
@@ -57,6 +57,22 @@ export function LayerProvenanceDetail({ file }: { file: IfcxFile }) {
     return (
       <p className="px-1 py-1 text-[11px] text-muted-foreground">
         No provenance manifest — this layer is unsigned raw IFCX (an import or a foreign file).
+      </p>
+    );
+  }
+  // IFCX is foreign JSON: a manifest-shaped value missing mandatory
+  // fields must degrade to a message, not crash the panel on deref.
+  let manifestErrors: string[];
+  try {
+    manifestErrors = validateProvenance(manifest);
+  } catch {
+    manifestErrors = ['unreadable manifest'];
+  }
+  if (manifestErrors.length > 0) {
+    return (
+      <p className="px-1 py-1 text-[11px] text-muted-foreground">
+        Provenance manifest present but malformed ({manifestErrors.length} issue
+        {manifestErrors.length === 1 ? '' : 's'}) — treating this layer as unsigned.
       </p>
     );
   }

--- a/apps/viewer/src/components/viewer/layers/LayersPanel.tsx
+++ b/apps/viewer/src/components/viewer/layers/LayersPanel.tsx
@@ -15,7 +15,7 @@
  * composition's `layerStackPathToId` bridge and nothing here persists ids.
  */
 
-import { useCallback } from 'react';
+import { useCallback, useState } from 'react';
 import { Bot, GitMerge, Layers, User, Users2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { ScrollArea } from '@/components/ui/scroll-area';
@@ -24,6 +24,7 @@ import { useViewerStore } from '@/store';
 import type { LayerAuthorKind, LayerStackEntry } from '@/store/slices/layerStackSlice';
 import { computeLayerContribution, shortContentId } from '@/lib/layers/stack';
 import { LayerDiffView } from './LayerDiffView';
+import { LayerProvenanceDetail } from './LayerProvenanceDetail';
 import { LayerDraftSection } from './LayerDraftSection';
 import { LayerMergeSection } from './LayerMergeSection';
 
@@ -90,15 +91,19 @@ function LayerStratum({
   position,
   total,
   active,
+  expanded,
   busy,
   onInspect,
+  onToggleDetail,
 }: {
   entry: LayerStackEntry;
   position: number;
   total: number;
   active: boolean;
+  expanded: boolean;
   busy: boolean;
   onInspect: () => void;
+  onToggleDetail: () => void;
 }) {
   const created = entry.created ? entry.created.slice(0, 10) : undefined;
   const subParts: string[] = [];
@@ -115,7 +120,13 @@ function LayerStratum({
     >
       {/* Stratum accent: author-kind tinted, the panel's one signature detail. */}
       <span className={`w-[3px] shrink-0 self-stretch rounded-full ${accentClass(entry.authorKind)}`} aria-hidden />
-      <div className="min-w-0 flex-1">
+      <button
+        type="button"
+        className="min-w-0 flex-1 text-left"
+        onClick={onToggleDetail}
+        aria-expanded={expanded}
+        aria-label={`Provenance of ${entry.name}`}
+      >
         <div className="flex items-center gap-1.5">
           <span className="shrink-0 rounded bg-muted px-1 font-mono text-[10px] leading-4 text-muted-foreground">
             {total - position + 1}
@@ -164,7 +175,7 @@ function LayerStratum({
             </Tooltip>
           )}
         </div>
-      </div>
+      </button>
       <Button
         variant="ghost"
         size="sm"
@@ -182,6 +193,7 @@ export function LayersPanel(_props: LayersPanelProps) {
   const layerStack = useViewerStore((s) => s.layerStack);
   const layerStackDiff = useViewerStore((s) => s.layerStackDiff);
   const layerDiffBusy = useViewerStore((s) => s.layerDiffBusy);
+  const [expandedId, setExpandedId] = useState<string | null>(null);
 
   const inspect = useCallback(
     async (layerId: string) => {
@@ -233,15 +245,19 @@ export function LayersPanel(_props: LayersPanelProps) {
           <LayerDraftSection />
           <LayerMergeSection />
           {strata.map((entry, i) => (
-            <LayerStratum
-              key={entry.id}
-              entry={entry}
-              position={i + 1}
-              total={strata.length}
-              active={layerStackDiff?.layerId === entry.id}
-              busy={layerDiffBusy}
-              onInspect={() => void inspect(entry.id)}
-            />
+            <div key={entry.id} className="flex flex-col gap-1">
+              <LayerStratum
+                entry={entry}
+                position={i + 1}
+                total={strata.length}
+                active={layerStackDiff?.layerId === entry.id}
+                expanded={expandedId === entry.id}
+                busy={layerDiffBusy}
+                onInspect={() => void inspect(entry.id)}
+                onToggleDetail={() => setExpandedId((prev) => (prev === entry.id ? null : entry.id))}
+              />
+              {expandedId === entry.id && <LayerProvenanceDetail file={entry.file} />}
+            </div>
           ))}
           {layerDiffBusy && (
             <p className="px-1 py-2 text-center text-[11px] text-muted-foreground">Computing changes…</p>

--- a/apps/viewer/src/lib/panels/renderPanelBody.tsx
+++ b/apps/viewer/src/lib/panels/renderPanelBody.tsx
@@ -11,7 +11,7 @@
  * hosts stay in lock-step.
  */
 
-import type { ReactNode } from 'react';
+import { lazy, Suspense, type ReactNode } from 'react';
 import type { WorkspacePanelId } from './registry';
 import { HierarchyPanel } from '@/components/viewer/HierarchyPanel';
 import { PropertiesPanel } from '@/components/viewer/PropertiesPanel';
@@ -25,7 +25,11 @@ import { ScriptPanel } from '@/components/viewer/ScriptPanel';
 import { GanttPanel } from '@/components/viewer/schedule/GanttPanel';
 import { ListPanel } from '@/components/viewer/lists/ListPanel';
 import { RoomPanel } from '@/components/viewer/RoomPanel';
-import { LayersPanel } from '@/components/viewer/layers/LayersPanel';
+// Lazy: the Layers panel pulls in @ifc-lite/merge (engine + blake3); a
+// dynamic chunk keeps it out of the initial bundle until first opened.
+const LayersPanel = lazy(() =>
+  import('@/components/viewer/layers/LayersPanel').then((m) => ({ default: m.LayersPanel })),
+);
 
 /**
  * Render the body for a workspace panel. `onClose` is the host's "close this
@@ -48,6 +52,10 @@ export function renderPanelBody(id: WorkspacePanelId, onClose: () => void): Reac
     case 'gantt': return <GanttPanel onClose={onClose} />;
     case 'lists': return <ListPanel onClose={onClose} />;
     case 'collab': return <RoomPanel onClose={onClose} />;
-    case 'layers': return <LayersPanel onClose={onClose} />;
+    case 'layers': return (
+      <Suspense fallback={null}>
+        <LayersPanel onClose={onClose} />
+      </Suspense>
+    );
   }
 }


### PR DESCRIPTION
## Summary

Phase V4 of #1717 — the L4 completion pass on the Layers panel. Stacked on #1721 (V3); merge the chain in order #1027 -> #1718 -> #1719 -> #1721 -> this.

## What it adds

- **Provenance detail** (08-review.md §8.5): clicking a stratum expands its full manifest — author kind/principal/tool, intent, created, base stack hash, scope claims (or "unrestricted"), check evidence with pass/fail icons and report digests, the merge record on merge layers (candidate, target, resolver, resolution/waiver counts), identity-map and signature summaries. Unsigned layers state it plainly.
- **"Ghost others"** on the contribution diff — the diff-mode isolation from the spec: everything the layer did not touch ghosts in 3D via `ghostExceptEntities`, resolved through the composition path bridge. Clears on toggle, on closing the diff, and on unmount.
- **Lazy panel**: the Layers panel body loads through `React.lazy`, keeping `@ifc-lite/merge` + the blake3 path out of the initial bundle until the panel first opens.

## Verification

- Localhost: published a signed layer, expanded its provenance card (all fields render), ran its diff, toggled Ghost others — `ghostExceptEntities` isolates the changed wall and clears on close.
- Viewer suite 1679 green; lint and typecheck clean.

## Remaining from #1717 (deliberately out)
- IDS check reports as fetchable evidence (needs a registry blob route for report digests).
- BCF-bound review comments (topic bound to review/entity/componentKey — builds on `BcfFromChange`).
- Collab Y.Doc drafts and geometry-affecting edit publishing.
