### PR TITLE
feat(layers): conflict queue completion — edited resolutions, edit-in-place editor, bulk actions

### DIFF
--- a/.changeset/edited-resolutions-registry.md
+++ b/.changeset/edited-resolutions-registry.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/collab-server": patch
+---
+
+The registry merge route accepts edit-in-place resolutions (`{ path, component_key, choice: "edited", attributes }`), strictly validated, with the engine's edited-target rules surfaced as 400s. Completes the conflict-queue spec (08-review.md §8.3) alongside the viewer's new edit choice and bulk actions.

--- a/apps/viewer/src/components/viewer/layers/LayerMergeSection.tsx
+++ b/apps/viewer/src/components/viewer/layers/LayerMergeSection.tsx
@@ -29,6 +29,7 @@ import { getBrowserLayerStore, DEFAULT_LOCAL_REF } from '@/lib/layers/browser-st
 import { LayerRegistryClient } from '@/lib/layers/registry-client';
 import {
   candidateLabel,
+  editedWithRemovals,
   executeMergeInto,
   previewMergeInto,
   refStackFiles,
@@ -243,7 +244,12 @@ export function LayerMergeSection() {
           ...(conflict.componentKey !== undefined ? { componentKey: conflict.componentKey } : {}),
           choice,
           ...(choice === 'edited'
-            ? { attributes: parseEditedAttributes(editedTexts.get(conflictKey(conflict)) ?? '') }
+            ? {
+                attributes: editedWithRemovals(
+                  conflict,
+                  parseEditedAttributes(editedTexts.get(conflictKey(conflict)) ?? '') ?? {},
+                ),
+              }
             : {}),
         };
       });

--- a/apps/viewer/src/components/viewer/layers/LayerMergeSection.tsx
+++ b/apps/viewer/src/components/viewer/layers/LayerMergeSection.tsx
@@ -40,10 +40,34 @@ import {
 import { pathTail } from '@/lib/layers/stack';
 import { CheckCircle2, XCircle } from 'lucide-react';
 
-type Choice = 'ours' | 'theirs';
+type Choice = 'ours' | 'theirs' | 'edited';
 
 function conflictKey(c: MergeConflict): string {
   return c.componentKey === undefined ? c.path : `${c.path}::${c.componentKey}`;
+}
+
+/** Edit-in-place applies as a set-component: only componentKey-scoped,
+ *  non-relation conflicts can take one (mirrors `applyResolutions`). */
+function isEditable(c: MergeConflict): boolean {
+  return (
+    c.componentKey !== undefined &&
+    !c.componentKey.startsWith('child:') &&
+    !c.componentKey.startsWith('inherit:')
+  );
+}
+
+/** Parsed replacement attributes for an edited conflict, or undefined
+ *  while the JSON is not (yet) a plain object. */
+function parseEditedAttributes(text: string): Record<string, unknown> | undefined {
+  try {
+    const parsed: unknown = JSON.parse(text);
+    if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+  } catch {
+    // fall through
+  }
+  return undefined;
 }
 
 function valueSummary(attrs: Record<string, unknown> | undefined): string {
@@ -56,12 +80,18 @@ function ConflictRow({
   conflict,
   choice,
   onChoose,
+  editedText,
+  onEditText,
 }: {
   conflict: MergeConflict;
   choice: Choice | undefined;
   onChoose: (choice: Choice) => void;
+  editedText: string;
+  onEditText: (text: string) => void;
 }) {
   const isDelete = conflict.kind === 'modify-vs-delete' || conflict.kind === 'delete-vs-modify';
+  const options: Choice[] = isEditable(conflict) ? ['ours', 'theirs', 'edited'] : ['ours', 'theirs'];
+  const editedValid = choice !== 'edited' || parseEditedAttributes(editedText) !== undefined;
   return (
     <div className="rounded border bg-card/40 px-1.5 py-1">
       <div className="flex items-center gap-1.5">
@@ -72,7 +102,7 @@ function ConflictRow({
           {conflict.componentKey ?? conflict.kind}
         </span>
         <span className="ml-auto inline-flex overflow-hidden rounded border">
-          {(['ours', 'theirs'] as const).map((option) => (
+          {options.map((option) => (
             <button
               key={option}
               type="button"
@@ -81,7 +111,7 @@ function ConflictRow({
                 choice === option ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:bg-muted/60'
               }`}
             >
-              {option}
+              {option === 'edited' ? 'edit' : option}
             </button>
           ))}
         </span>
@@ -94,6 +124,23 @@ function ConflictRow({
           theirs: {valueSummary(conflict.theirs?.attributes as Record<string, unknown>)}
         </span>
       </div>
+      {choice === 'edited' && (
+        <div className="flex flex-col gap-0.5 pt-0.5">
+          <textarea
+            value={editedText}
+            onChange={(e) => onEditText(e.target.value)}
+            rows={2}
+            spellCheck={false}
+            aria-label={`Replacement attributes for ${conflict.path}`}
+            className={`w-full resize-y rounded border bg-background px-1.5 py-1 font-mono text-[10px] ${
+              editedValid ? '' : 'border-red-500'
+            }`}
+          />
+          {!editedValid && (
+            <span className="text-[10px] text-red-500">Replacement must be a JSON object of attributes.</span>
+          )}
+        </div>
+      )}
       {isDelete && conflict.subtree && conflict.subtree.length > 0 && (
         <p className="pt-0.5 text-[10px] text-amber-600 dark:text-amber-300">
           Delete decision carries {conflict.subtree.length} touched descendant
@@ -118,6 +165,7 @@ export function LayerMergeSection() {
   const [targetKey, setTargetKey] = useState<string>(`local:${DEFAULT_LOCAL_REF}`);
   const [result, setResult] = useState<ViewerMergeResult | null>(null);
   const [choices, setChoices] = useState<Map<string, Choice>>(new Map());
+  const [editedTexts, setEditedTexts] = useState<Map<string, string>>(new Map());
   const [requiredChecks, setRequiredChecks] = useState<RequiredCheckStatus[]>([]);
   const [waiverReasons, setWaiverReasons] = useState<Map<string, string>>(new Map());
   const [busy, setBusy] = useState(false);
@@ -149,6 +197,7 @@ export function LayerMergeSection() {
   useEffect(() => {
     setResult(null);
     setChoices(new Map());
+    setEditedTexts(new Map());
     setRequiredChecks([]);
     setWaiverReasons(new Map());
   }, [candidateId, targetKey]);
@@ -170,6 +219,7 @@ export function LayerMergeSection() {
     if (!target || !candidateId) return;
     setBusy(true);
     setChoices(new Map());
+    setEditedTexts(new Map());
     try {
       const store = await getBrowserLayerStore();
       setResult(await previewMergeInto(target, store, candidateId));
@@ -186,11 +236,17 @@ export function LayerMergeSection() {
     setBusy(true);
     try {
       const store = await getBrowserLayerStore();
-      const resolutions: ResolutionInput[] = result.conflicts.map((conflict) => ({
-        path: conflict.path,
-        ...(conflict.componentKey !== undefined ? { componentKey: conflict.componentKey } : {}),
-        choice: choices.get(conflictKey(conflict)) as Choice,
-      }));
+      const resolutions: ResolutionInput[] = result.conflicts.map((conflict) => {
+        const choice = choices.get(conflictKey(conflict)) as Choice;
+        return {
+          path: conflict.path,
+          ...(conflict.componentKey !== undefined ? { componentKey: conflict.componentKey } : {}),
+          choice,
+          ...(choice === 'edited'
+            ? { attributes: parseEditedAttributes(editedTexts.get(conflictKey(conflict)) ?? '') }
+            : {}),
+        };
+      });
       const resolver =
         (typeof window !== 'undefined' && window.localStorage.getItem('ifc-lite:layer-author')) || 'viewer-user';
       // A waiver without a reason is not a waiver (08-review.md §8.4: waiving
@@ -215,7 +271,7 @@ export function LayerMergeSection() {
     } finally {
       setBusy(false);
     }
-  }, [target, candidateId, result, choices, waiverReasons, refresh]);
+  }, [target, candidateId, result, choices, editedTexts, waiverReasons, refresh]);
 
   const loadMergedRef = useCallback(async () => {
     if (!target || target.kind !== 'local') return;
@@ -236,7 +292,53 @@ export function LayerMergeSection() {
 
   if (candidates.length === 0) return null;
 
-  const allResolved = result !== null && result.conflicts.every((c) => choices.has(conflictKey(c)));
+  // Every conflict needs a decision, and an edit-in-place needs valid
+  // replacement attributes before the merge can execute.
+  const allResolved =
+    result !== null &&
+    result.conflicts.every((c) => {
+      const choice = choices.get(conflictKey(c));
+      if (choice === undefined) return false;
+      if (choice !== 'edited') return true;
+      return parseEditedAttributes(editedTexts.get(conflictKey(c)) ?? '') !== undefined;
+    });
+
+  const choose = (conflict: MergeConflict, choice: Choice) => {
+    const key = conflictKey(conflict);
+    setChoices((prev) => new Map(prev).set(key, choice));
+    if (choice === 'edited') {
+      // Seed the editor with the current winner so edits start from a
+      // real value instead of an empty object.
+      setEditedTexts((prev) => {
+        if (prev.has(key)) return prev;
+        const seed = (conflict.ours?.attributes ?? conflict.theirs?.attributes ?? {}) as Record<string, unknown>;
+        return new Map(prev).set(key, JSON.stringify(seed));
+      });
+    }
+  };
+
+  const chooseAll = (choice: 'ours' | 'theirs', filter?: (c: MergeConflict) => boolean) => {
+    if (!result) return;
+    setChoices((prev) => {
+      const next = new Map(prev);
+      for (const conflict of result.conflicts) {
+        if (filter && !filter(conflict)) continue;
+        next.set(conflictKey(conflict), choice);
+      }
+      return next;
+    });
+  };
+
+  // Bulk selectors (08-review.md §8.3, "theirs for all Pset_X"): offer a
+  // per-componentKey group action when several conflicts share a key.
+  const bulkGroups =
+    result === null
+      ? []
+      : [...result.conflicts.reduce((acc, c) => {
+          if (c.componentKey === undefined) return acc;
+          acc.set(c.componentKey, (acc.get(c.componentKey) ?? 0) + 1);
+          return acc;
+        }, new Map<string, number>())].filter(([, count]) => count > 1);
   // Spec 08-review.md §8.3: merge enables on empty queue + green checks;
   // a failing required check needs a waiver reason (§8.4) to proceed.
   const checksSatisfied = requiredChecks.every(
@@ -343,13 +445,46 @@ export function LayerMergeSection() {
                 ))}
               </div>
             )}
+            {!mergeDone && result.conflicts.length > 1 && (
+              <div className="flex flex-wrap items-center gap-1 text-[10px] text-muted-foreground">
+                <span>Bulk:</span>
+                <button type="button" onClick={() => chooseAll('ours')} className="rounded border px-1.5 py-px hover:bg-muted/60">
+                  all ours
+                </button>
+                <button type="button" onClick={() => chooseAll('theirs')} className="rounded border px-1.5 py-px hover:bg-muted/60">
+                  all theirs
+                </button>
+                {bulkGroups.map(([key, count]) => (
+                  <span key={key} className="inline-flex items-center gap-0.5">
+                    <span className="truncate font-mono" title={key}>{key.split(':').pop()}</span>
+                    <span>×{count}:</span>
+                    <button
+                      type="button"
+                      onClick={() => chooseAll('ours', (c) => c.componentKey === key)}
+                      className="rounded border px-1 py-px hover:bg-muted/60"
+                    >
+                      ours
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => chooseAll('theirs', (c) => c.componentKey === key)}
+                      className="rounded border px-1 py-px hover:bg-muted/60"
+                    >
+                      theirs
+                    </button>
+                  </span>
+                ))}
+              </div>
+            )}
             {result.conflicts.map((conflict) => (
               <ConflictRow
                 key={conflictKey(conflict)}
                 conflict={conflict}
                 choice={choices.get(conflictKey(conflict))}
-                onChoose={(choice) =>
-                  setChoices((prev) => new Map(prev).set(conflictKey(conflict), choice))
+                onChoose={(choice) => choose(conflict, choice)}
+                editedText={editedTexts.get(conflictKey(conflict)) ?? ''}
+                onEditText={(text) =>
+                  setEditedTexts((prev) => new Map(prev).set(conflictKey(conflict), text))
                 }
               />
             ))}

--- a/apps/viewer/src/lib/layers/merge.test.ts
+++ b/apps/viewer/src/lib/layers/merge.test.ts
@@ -15,6 +15,7 @@ import type { IfcxFile, IfcxNode, ProvenanceCheck } from '@ifc-lite/ifcx';
 import { extractStackState } from '@ifc-lite/merge';
 import { BrowserLayerStore } from './browser-store.js';
 import {
+  editedWithRemovals,
   executeMergeInto,
   previewMergeInto,
   refStackFiles,
@@ -131,6 +132,41 @@ describe('viewer merge orchestration over the local store (#1717 V3)', () => {
     assert.deepStrictEqual(manifest?.merge?.resolutions, [
       { entity: 'wall-1', choice: 'edited', componentKey: 'pset:Pset_FireSafety' },
     ]);
+  });
+
+  it('an edited resolution tombstones the keys the reviewer removed (LWW would resurrect them)', async () => {
+    const EXIT = 'bsi::ifc::v5a::Pset_FireSafety::FireExit';
+    const store = await BrowserLayerStore.open();
+    const base = publishable([{ path: 'wall-1', attributes: { [FIRE]: 'REI60', [EXIT]: 'EX-1' } }], 'Base', null);
+    store.storeLayer(base);
+    const ours = publishable([{ path: 'wall-1', attributes: { [FIRE]: 'REI90' } }], 'Ours', [base.header.id]);
+    store.storeLayer(ours);
+    store.setRef('main', { layers: [base.header.id, ours.header.id] });
+    const candidate = publishable([{ path: 'wall-1', attributes: { [FIRE]: 'REI120' } }], 'Theirs', [base.header.id]);
+    store.storeLayer(candidate);
+
+    const preview = await previewMergeInto({ kind: 'local', refName: 'main' }, store, candidate.header.id);
+    const conflict = preview.conflicts[0];
+    // The reviewer's edited object keeps FIRE only — the helper must null
+    // every union key they dropped so composition cannot resurrect it.
+    const attributes = editedWithRemovals(conflict, { [FIRE]: 'REI180' });
+    assert.strictEqual(attributes[FIRE], 'REI180');
+    for (const [key, value] of Object.entries(attributes)) {
+      if (key !== FIRE) assert.strictEqual(value, null, `expected null tombstone for ${key}`);
+    }
+
+    const merged = await executeMergeInto(
+      { kind: 'local', refName: 'main' },
+      store,
+      candidate.header.id,
+      [{ path: 'wall-1', componentKey: 'pset:Pset_FireSafety', choice: 'edited', attributes }],
+      'louis',
+    );
+    assert.strictEqual(merged.status, 'merged');
+    const state = extractStackState(refStackFiles(store, 'main'));
+    const component = state.get('wall-1')?.components.get('pset:Pset_FireSafety');
+    assert.strictEqual(component?.[FIRE], 'REI180');
+    assert.ok(!(EXIT in (component ?? {})) || component?.[EXIT] == null, 'removed key must not survive the merge');
   });
 
   it('scores required checks against the candidate and merges past a failure only with a waiver', async () => {

--- a/apps/viewer/src/lib/layers/merge.test.ts
+++ b/apps/viewer/src/lib/layers/merge.test.ts
@@ -100,6 +100,39 @@ describe('viewer merge orchestration over the local store (#1717 V3)', () => {
     assert.strictEqual(outcome.conflicts.length, 1);
   });
 
+  it('an edited resolution replaces the conflicting component with reviewer-typed attributes', async () => {
+    const store = await BrowserLayerStore.open();
+    const base = publishable([{ path: 'wall-1', attributes: { [FIRE]: 'REI60' } }], 'Base', null);
+    store.storeLayer(base);
+    const ours = publishable([{ path: 'wall-1', attributes: { [FIRE]: 'REI90' } }], 'Ours', [base.header.id]);
+    store.storeLayer(ours);
+    store.setRef('main', { layers: [base.header.id, ours.header.id] });
+    const candidate = publishable([{ path: 'wall-1', attributes: { [FIRE]: 'REI120' } }], 'Theirs', [base.header.id]);
+    store.storeLayer(candidate);
+
+    const merged = await executeMergeInto(
+      { kind: 'local', refName: 'main' },
+      store,
+      candidate.header.id,
+      [
+        {
+          path: 'wall-1',
+          componentKey: 'pset:Pset_FireSafety',
+          choice: 'edited',
+          attributes: { [FIRE]: 'REI180' },
+        },
+      ],
+      'louis',
+    );
+    assert.strictEqual(merged.status, 'merged');
+    const state = extractStackState(refStackFiles(store, 'main'));
+    assert.strictEqual(state.get('wall-1')?.components.get('pset:Pset_FireSafety')?.[FIRE], 'REI180');
+    const manifest = getProvenance(store.loadLayer(merged.mergeLayerId ?? ''));
+    assert.deepStrictEqual(manifest?.merge?.resolutions, [
+      { entity: 'wall-1', choice: 'edited', componentKey: 'pset:Pset_FireSafety' },
+    ]);
+  });
+
   it('scores required checks against the candidate and merges past a failure only with a waiver', async () => {
     const store = await BrowserLayerStore.open();
     const base = publishable([{ path: 'wall-1', attributes: { [FIRE]: 'REI60' } }], 'Base', null);

--- a/apps/viewer/src/lib/layers/merge.ts
+++ b/apps/viewer/src/lib/layers/merge.ts
@@ -126,13 +126,12 @@ export async function executeMergeInto(
       candidate: candidateId,
       ...(resolutions.length > 0
         ? {
-            resolutions: resolutions
-              .filter((r): r is ResolutionInput & { choice: 'ours' | 'theirs' } => r.choice !== 'edited')
-              .map((r) => ({
-                path: r.path,
-                choice: r.choice,
-                ...(r.componentKey !== undefined ? { component_key: r.componentKey } : {}),
-              })),
+            resolutions: resolutions.map((r) => ({
+              path: r.path,
+              choice: r.choice,
+              ...(r.componentKey !== undefined ? { component_key: r.componentKey } : {}),
+              ...(r.choice === 'edited' && r.attributes !== undefined ? { attributes: r.attributes } : {}),
+            })),
           }
         : {}),
       ...(waivers.length > 0 ? { waivers } : {}),

--- a/apps/viewer/src/lib/layers/merge.ts
+++ b/apps/viewer/src/lib/layers/merge.ts
@@ -139,6 +139,27 @@ export async function executeMergeInto(
   );
 }
 
+/**
+ * Composition is per-attribute LWW: a key the reviewer DELETED from an
+ * edited resolution must become an explicit `null` opinion, or the old
+ * value silently shines through the merge. Fill removals against the
+ * union of both sides' keys.
+ */
+export function editedWithRemovals(
+  conflict: MergeConflict,
+  edited: Record<string, unknown>,
+): Record<string, unknown> {
+  const union = new Set([
+    ...Object.keys((conflict.ours?.attributes as Record<string, unknown> | undefined) ?? {}),
+    ...Object.keys((conflict.theirs?.attributes as Record<string, unknown> | undefined) ?? {}),
+  ]);
+  const out: Record<string, unknown> = { ...edited };
+  for (const key of union) {
+    if (!(key in out)) out[key] = null;
+  }
+  return out;
+}
+
 /** A target ref's required checks scored against the candidate manifest. */
 export interface RequiredCheckStatus {
   spec: string;

--- a/apps/viewer/src/lib/layers/registry-client.ts
+++ b/apps/viewer/src/lib/layers/registry-client.ts
@@ -31,7 +31,9 @@ export interface RegistryMergeOutcome {
 export interface RegistryResolutionInput {
   path: string;
   component_key?: string;
-  choice: 'ours' | 'theirs';
+  choice: 'ours' | 'theirs' | 'edited';
+  /** Replacement component attributes; required when `choice === 'edited'`. */
+  attributes?: Record<string, unknown>;
 }
 
 export class RegistryError extends Error {

--- a/docs/architecture/layer-prs/12-roadmap.md
+++ b/docs/architecture/layer-prs/12-roadmap.md
@@ -48,7 +48,7 @@ Feature flag: `layers.enabled`. Every phase lands on `main` only with green exit
 ## Phase L4: Review UI (5-6 weeks, scheduled post-Grobkonzept)
 
 - ◐ Viewer diff mode — SHIPPED in `apps/viewer` (#1717 V1/V4): Layers panel with per-layer contribution diff (shared StackDiff JSON) and "Ghost others" 3D isolation; diff-state + author-kind lenses via `@ifc-lite/lens` pending
-- ◐ Conflict queue — SHIPPED (#1717 V3): per-conflict ours/theirs resolutions through `MergeInit.resolutions` (shared flow, registry passthrough), subtree deletes as one decision, merge gated on an empty queue; bulk resolution + `edited` in the UI pending
+- ☑ Conflict queue — per-conflict ours/theirs/edited resolutions through `MergeInit.resolutions` (shared flow; the registry route validates and ferries `edited` with replacement attributes), subtree deletes as one decision, merge gated on an empty queue + green-or-waived checks, bulk actions (all-ours/all-theirs and per-componentKey groups), edit-in-place with a JSON attribute editor for componentKey-scoped non-relation conflicts
 - ☑ Checks panel with IDS deep links; waiver flow — check evidence is fetchable from the registry (`/api/v1/reports/<digest>`, blake3-verified; `ifc layer push` uploads it), provenance check rows expand into the report's entity failures with 3D deep links, and merge offers waive-with-reason for failing required checks (recorded in the merge manifest)
 - ◐ Provenance panel — SHIPPED (#1717 V4): full manifest per stratum (author kind, intent, base, scope claims, check evidence, merge record, signatures); BCF topics as review comments pending
 - ☐ BCF Time Machine on the layer DAG (scrub, branch nodes, open-historical-state)

--- a/packages/collab-server/src/layer-registry-route.ts
+++ b/packages/collab-server/src/layer-registry-route.ts
@@ -376,7 +376,9 @@ export async function handleLayerRegistryRequest(
       if (body.preview) init.preview = true;
       if (body.resolve === 'ours' || body.resolve === 'theirs') init.resolve = body.resolve;
       // Per-conflict resolutions from the review UI: strictly-shaped
-      // ours/theirs decisions ('edited' stays a local-flow feature).
+      // ours/theirs decisions, or edit-in-place with the replacement
+      // attributes (08-review.md §8.3). The engine re-validates edited
+      // targets (componentKey-scoped, non-relation) when applying.
       if (body.resolutions !== undefined) {
         if (!Array.isArray(body.resolutions)) {
           return json(res, 400, { error: 'resolutions must be an array of { path, component_key?, choice }' });
@@ -384,20 +386,35 @@ export async function handleLayerRegistryRequest(
         const parsedResolutions: NonNullable<MergeInit['resolutions']> = [];
         for (const item of body.resolutions) {
           if (typeof item !== 'object' || item === null) {
-            return json(res, 400, { error: 'each resolution must be { path, component_key?, choice: "ours" | "theirs" }' });
+            return json(res, 400, { error: 'each resolution must be { path, component_key?, choice: "ours" | "theirs" | "edited" }' });
           }
           const raw = item as Record<string, unknown>;
           const choice = raw.choice;
-          if (typeof raw.path !== 'string' || (choice !== 'ours' && choice !== 'theirs')) {
-            return json(res, 400, { error: 'each resolution must be { path, component_key?, choice: "ours" | "theirs" }' });
+          if (typeof raw.path !== 'string' || (choice !== 'ours' && choice !== 'theirs' && choice !== 'edited')) {
+            return json(res, 400, { error: 'each resolution must be { path, component_key?, choice: "ours" | "theirs" | "edited" }' });
           }
           if (raw.component_key !== undefined && typeof raw.component_key !== 'string') {
             return json(res, 400, { error: 'component_key must be a string when present' });
+          }
+          if (choice === 'edited') {
+            if (
+              typeof raw.component_key !== 'string' ||
+              typeof raw.attributes !== 'object' ||
+              raw.attributes === null ||
+              Array.isArray(raw.attributes)
+            ) {
+              return json(res, 400, {
+                error: 'an edited resolution must be { path, component_key, choice: "edited", attributes: { ... } }',
+              });
+            }
           }
           parsedResolutions.push({
             path: raw.path,
             choice,
             ...(raw.component_key !== undefined ? { componentKey: raw.component_key as string } : {}),
+            ...(choice === 'edited'
+              ? { attributes: raw.attributes as Record<string, unknown> }
+              : {}),
           });
         }
         init.resolutions = parsedResolutions;
@@ -461,6 +478,11 @@ export async function handleLayerRegistryRequest(
       } catch (err) {
         const handled = handlePushError(res, err);
         if (handled) return handled;
+        // The engine refuses malformed edited resolutions (entity-level
+        // conflict, relation pseudo-component): a client error, not 500.
+        if (err instanceof Error && err.message.includes('edited resolution')) {
+          return json(res, 400, { error: err.message });
+        }
         throw err;
       }
       switch (outcome.status) {

--- a/packages/collab-server/test/layer-registry-edited.test.ts
+++ b/packages/collab-server/test/layer-registry-edited.test.ts
@@ -1,0 +1,145 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Edit-in-place resolutions over the registry merge route (08-review.md
+ * §8.3): the review UI can replace a conflicting component with typed
+ * attributes instead of picking a side. Malformed shapes are 400s, and
+ * the engine's edited-target rules surface as client errors, not 500s.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import {
+  computeLayerId,
+  computeStackHash,
+  createProvenanceManifest,
+  setProvenance,
+} from '@ifc-lite/ifcx';
+import type { IfcxFile, IfcxNode, ProvenanceBase } from '@ifc-lite/ifcx';
+import { extractStackState } from '@ifc-lite/merge';
+import { startCollabServer, type CollabServerHandle } from '../src/index.js';
+
+const FIRE = 'bsi::ifc::v5a::Pset_FireSafety::FireRating';
+const CLASS = 'bsi::ifc::class';
+
+function publishable(nodes: IfcxNode[], intent: string, base: ProvenanceBase | null): IfcxFile {
+  const bare: IfcxFile = {
+    header: {
+      id: '',
+      ifcxVersion: 'ifcx_alpha',
+      dataVersion: '1.0.0',
+      author: 'test',
+      timestamp: '2026-06-10T00:00:00.000Z',
+    },
+    imports: [],
+    schemas: {},
+    data: nodes,
+  };
+  const manifest = createProvenanceManifest({
+    author: { kind: 'human', principal: 'alice' },
+    intent,
+    base,
+    created: '2026-06-10T00:00:00.000Z',
+  });
+  const withManifest = setProvenance(bare, manifest);
+  const id = computeLayerId(withManifest);
+  return { ...withManifest, header: { ...withManifest.header, id } };
+}
+
+describe('edited resolutions over the merge route', () => {
+  let handle: CollabServerHandle;
+  let api: string;
+
+  beforeAll(async () => {
+    handle = await startCollabServer({ port: 0, layerRegistry: true });
+    const port = (handle.httpServer.address() as { port: number }).port;
+    api = `http://127.0.0.1:${port}/api/v1`;
+  });
+
+  afterAll(async () => {
+    await handle.stop();
+  });
+
+  it('merges a conflict with reviewer-typed replacement attributes', async () => {
+    const base = publishable(
+      [{ path: 'wall-1', attributes: { [CLASS]: { code: 'IfcWall', uri: 'u' }, [FIRE]: 'REI60' } }],
+      'Base',
+      null
+    );
+    const ours = publishable(
+      [{ path: 'wall-1', attributes: { [FIRE]: 'REI90' } }],
+      'Ours',
+      { kind: 'stack', id: computeStackHash([base.header.id]) }
+    );
+    const candidate = publishable(
+      [{ path: 'wall-1', attributes: { [FIRE]: 'REI120' } }],
+      'Theirs',
+      { kind: 'stack', id: computeStackHash([base.header.id]) }
+    );
+    for (const layer of [base, ours, candidate]) {
+      expect((await fetch(`${api}/layers`, { method: 'POST', body: JSON.stringify(layer) })).status).toBe(201);
+    }
+    expect(
+      (
+        await fetch(`${api}/refs/main`, {
+          method: 'PUT',
+          body: JSON.stringify({ layers: [base.header.id, ours.header.id] }),
+        })
+      ).status
+    ).toBe(201);
+
+    // Unresolved: conflicts ride a 409.
+    const conflicted = await fetch(`${api}/refs/main/merge`, {
+      method: 'POST',
+      body: JSON.stringify({ candidate: candidate.header.id }),
+    });
+    expect(conflicted.status).toBe(409);
+
+    // Malformed edited shapes are client errors.
+    const missingAttrs = await fetch(`${api}/refs/main/merge`, {
+      method: 'POST',
+      body: JSON.stringify({
+        candidate: candidate.header.id,
+        resolutions: [{ path: 'wall-1', component_key: 'pset:Pset_FireSafety', choice: 'edited' }],
+      }),
+    });
+    expect(missingAttrs.status).toBe(400);
+    const arrayAttrs = await fetch(`${api}/refs/main/merge`, {
+      method: 'POST',
+      body: JSON.stringify({
+        candidate: candidate.header.id,
+        resolutions: [
+          { path: 'wall-1', component_key: 'pset:Pset_FireSafety', choice: 'edited', attributes: [1, 2] },
+        ],
+      }),
+    });
+    expect(arrayAttrs.status).toBe(400);
+
+    // A reviewer-typed value that is neither side wins the merge.
+    const merged = await fetch(`${api}/refs/main/merge`, {
+      method: 'POST',
+      body: JSON.stringify({
+        candidate: candidate.header.id,
+        resolutions: [
+          {
+            path: 'wall-1',
+            component_key: 'pset:Pset_FireSafety',
+            choice: 'edited',
+            attributes: { [FIRE]: 'REI180' },
+          },
+        ],
+      }),
+    });
+    expect(merged.status).toBe(200);
+    const outcome = (await merged.json()) as { status: string; layers: string[] };
+    expect(outcome.status).toBe('merged');
+
+    const files: IfcxFile[] = [];
+    for (const id of outcome.layers) {
+      files.push((await (await fetch(`${api}/layers/${id}`)).json()) as IfcxFile);
+    }
+    const state = extractStackState(files);
+    expect(state.get('wall-1')?.components.get('pset:Pset_FireSafety')).toEqual({ [FIRE]: 'REI180' });
+  });
+});


### PR DESCRIPTION
PR 3 of the #1717 completion pass, finishing the 08-review.md §8.3 conflict queue. Stacked on #1727 (which stacks on #1726) — merge the chain in order, retargeting as each lands.

## What was missing

The merge engine has supported `choice: 'edited'` (reviewer-typed replacement attributes) since #1027, but it was structurally unreachable: the viewer offered only ours/theirs, the orchestration explicitly filtered `edited` out of registry calls, and the registry route rejected it. Bulk resolution did not exist at all.

## Registry (collab-server)

- The merge route accepts `{ path, component_key, choice: "edited", attributes }` with strict shape validation (missing/array attributes are 400s). The engine's edited-target rules (componentKey-scoped only, no relation pseudo-components) surface as 400s instead of 500s.

## Viewer

- **Edit-in-place**: componentKey-scoped, non-relation conflicts gain an "edit" choice that opens a JSON attribute editor seeded with the current winner. Invalid JSON marks the row and disables the merge button until fixed. The parsed attributes ride `ResolutionInput.attributes` through both backends (the registry filter is gone).
- **Bulk actions**: "all ours" / "all theirs" over the whole queue, plus per-componentKey group actions ("Pset_FireSafety ×2: ours | theirs") whenever several conflicts share a key — the spec's bulk-by-selector, scoped to what the queue actually shows. Per-row choices still override.

## Verification

- New tests: collab-server e2e (conflicts 409 → malformed edited 400s → merged 200 with a reviewer-typed value composing over both sides), viewer orchestration (edited resolution merges locally, custom value wins composition, merge manifest records `choice: 'edited'`). Suites: collab-server 103, viewer 1687, typecheck + api-surface green.
- Localhost (vite + Chrome DevTools MCP): seeded a 3-conflict divergence (two walls on Pset_FireSafety, one on Pset_Acoustic). The bulk row and the ×2 group selector rendered; group-"theirs" resolved both fire conflicts; "edit" on the acoustic conflict seeded the editor with the current value; broken JSON disabled merge and showed the hint; after fixing, the merge produced a 3-layer ref whose composed state had REI120 on both walls and the custom Rw 47 (neither ours 45 nor theirs 50).

## Notes

- Remaining #1717 scope after this: BCF review comments, Y.Doc drafts, geometry-edit publishing, webhooks + auto-merge.