### PR TITLE
feat(layers): live-session Y.Doc draft publishing

### DIFF
--- a/.changeset/collab-capture-doc-state.md
+++ b/.changeset/collab-capture-doc-state.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/collab": minor
+---
+
+`CollabSession.captureDocState()`: full-state fork point (`Y.encodeStateAsUpdate`) for whole-doc layer publishing via `publishLayer`, distinct from `captureBaseline()`'s state vector for the per-user `extractUserLayer` path. Backs the viewer's live-session draft publishing (#1717).

--- a/apps/viewer/src/components/viewer/layers/LayerDraftSection.tsx
+++ b/apps/viewer/src/components/viewer/layers/LayerDraftSection.tsx
@@ -146,8 +146,9 @@ export function LayerDraftSection() {
         stackFiles: state.layerStack.map((e) => e.file),
         intent: trimmedIntent,
         authorPrincipal: trimmedAuthor,
-        // Peers in the room means the doc may carry their edits too.
-        hybrid: state.collabPeers.length > 0,
+        // Anyone present since the baseline may have edits in the doc —
+        // including peers who already left.
+        hybrid: state.collabPeers.length > 0 || state.collabPeersSinceBaseline,
         refName: DEFAULT_LOCAL_REF,
       });
       // The published layer absorbed everything since the fork point;

--- a/apps/viewer/src/components/viewer/layers/LayerDraftSection.tsx
+++ b/apps/viewer/src/components/viewer/layers/LayerDraftSection.tsx
@@ -17,8 +17,9 @@ import { useViewerStore } from '@/store';
 import { useIfc } from '@/hooks/useIfc';
 import { toast } from '@/components/ui/toast';
 import { getBrowserLayerStore, DEFAULT_LOCAL_REF } from '@/lib/layers/browser-store';
-import { publishViewerDraft } from '@/lib/layers/publish';
+import { publishCollabDraft, publishViewerDraft } from '@/lib/layers/publish';
 import type { Mutation } from '@ifc-lite/mutations';
+import { Users } from 'lucide-react';
 
 const AUTHOR_STORAGE_KEY = 'ifc-lite:layer-author';
 
@@ -64,6 +65,9 @@ export function LayerDraftSection() {
   // mutationVersion drives the pending count; layerStack drives eligibility.
   const mutationVersion = useViewerStore((s) => s.mutationVersion);
   const stackSize = useViewerStore((s) => s.layerStack.length);
+  const collabSession = useViewerStore((s) => s.collabSession);
+  const collabDraftBaseline = useViewerStore((s) => s.collabDraftBaseline);
+  const collabPeers = useViewerStore((s) => s.collabPeers);
   const [intent, setIntent] = useState('');
   const [author, setAuthor] = useState(storedAuthor);
   const [busy, setBusy] = useState(false);
@@ -124,7 +128,50 @@ export function LayerDraftSection() {
     }
   }, [intent, author, addIfcxOverlays]);
 
+  const publishSession = useCallback(async () => {
+    const state = useViewerStore.getState();
+    const session = state.collabSession;
+    const baseline = state.collabDraftBaseline;
+    const trimmedIntent = intent.trim();
+    const trimmedAuthor = author.trim() || 'viewer-user';
+    if (!session || !baseline || !trimmedIntent) return;
+    window.localStorage.setItem(AUTHOR_STORAGE_KEY, trimmedAuthor);
+    setBusy(true);
+    try {
+      const store = await getBrowserLayerStore();
+      const result = await publishCollabDraft({
+        store,
+        doc: session.doc,
+        baseline,
+        stackFiles: state.layerStack.map((e) => e.file),
+        intent: trimmedIntent,
+        authorPrincipal: trimmedAuthor,
+        // Peers in the room means the doc may carry their edits too.
+        hybrid: state.collabPeers.length > 0,
+        refName: DEFAULT_LOCAL_REF,
+      });
+      // The published layer absorbed everything since the fork point;
+      // move the fork forward so the next publish is delta-only. Local
+      // pending mutations are part of that layer, so clear them too.
+      useViewerStore.getState().resetCollabDraftBaseline();
+      useViewerStore.getState().clearAllMutations();
+      const json = JSON.stringify(result.file);
+      const fileName = `${trimmedIntent.slice(0, 40).replace(/[^\w-]+/g, '-') || 'session-layer'}.ifcx`;
+      await addIfcxOverlays([new File([json], fileName, { type: 'application/json' })]);
+      setIntent('');
+      toast.success(
+        `Published session draft ${result.layerId.slice(0, 15)}… to '${DEFAULT_LOCAL_REF}' (${result.opCount} ops).`,
+      );
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  }, [intent, author, addIfcxOverlays]);
+
   if (stackSize === 0) return null;
+
+  const sessionReady = collabSession !== null && collabDraftBaseline !== null;
 
   return (
     <div className="rounded-md border border-dashed bg-card/30 p-2">
@@ -141,7 +188,7 @@ export function LayerDraftSection() {
           {pendingCount} pending {pendingCount === 1 ? 'edit' : 'edits'}
         </span>
       </div>
-      {pendingCount === 0 ? (
+      {pendingCount === 0 && !sessionReady ? (
         <p className="text-[11px] text-muted-foreground">
           Edit properties in the model, then freeze the changes here as a new layer.
         </p>
@@ -162,20 +209,45 @@ export function LayerDraftSection() {
               className="h-7 flex-1 text-xs"
               disabled={busy}
             />
-            <Button
-              size="sm"
-              className="h-7 gap-1 px-2 text-[11px]"
-              disabled={busy || intent.trim().length === 0}
-              onClick={() => void publish()}
-            >
-              <UploadCloud className="size-3" aria-hidden />
-              {busy ? 'Publishing…' : 'Publish'}
-            </Button>
+            {pendingCount > 0 && (
+              <Button
+                size="sm"
+                className="h-7 gap-1 px-2 text-[11px]"
+                disabled={busy || intent.trim().length === 0}
+                onClick={() => void publish()}
+              >
+                <UploadCloud className="size-3" aria-hidden />
+                {busy ? 'Publishing…' : 'Publish'}
+              </Button>
+            )}
           </div>
-          <p className="text-[10px] text-muted-foreground">
-            Freezes the pending edits as a content-addressed layer on the local ref
-            &apos;{DEFAULT_LOCAL_REF}&apos; and stacks it onto the composition.
-          </p>
+          {pendingCount > 0 && (
+            <p className="text-[10px] text-muted-foreground">
+              Freezes the pending edits as a content-addressed layer on the local ref
+              &apos;{DEFAULT_LOCAL_REF}&apos; and stacks it onto the composition.
+            </p>
+          )}
+          {sessionReady && (
+            <>
+              <Button
+                size="sm"
+                variant="outline"
+                className="h-7 gap-1 self-start px-2 text-[11px]"
+                disabled={busy || intent.trim().length === 0}
+                onClick={() => void publishSession()}
+              >
+                <Users className="size-3" aria-hidden />
+                {busy ? 'Publishing…' : 'Publish session edits'}
+              </Button>
+              <p className="text-[10px] text-muted-foreground">
+                Freezes the live session&apos;s Y.Doc edits since {collabPeers.length > 0 ? 'joining' : 'the last publish'}
+                {collabPeers.length > 0
+                  ? ` — including ${collabPeers.length} peer${collabPeers.length === 1 ? "'s" : "s'"} edits (author kind: hybrid)`
+                  : ''}
+                .
+              </p>
+            </>
+          )}
         </div>
       )}
     </div>

--- a/apps/viewer/src/lib/layers/collab-publish.test.ts
+++ b/apps/viewer/src/lib/layers/collab-publish.test.ts
@@ -1,0 +1,87 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { getProvenance } from '@ifc-lite/ifcx';
+import { createCollabSession, createEntity, setAttribute } from '@ifc-lite/collab';
+import { extractStackState } from '@ifc-lite/merge';
+import { BrowserLayerStore } from './browser-store.js';
+import { publishCollabDraft } from './publish.js';
+
+const FIRE = 'bsi::ifc::v5a::Pset_FireSafety::FireRating';
+
+describe('collab session draft publishing (#1717)', () => {
+  it('freezes Y.Doc edits since the fork point into a hybrid-authored layer on the local ref', async () => {
+    const session = await createCollabSession({
+      roomId: 'test-room',
+      user: { id: 'u1', name: 'alice' },
+      provider: 'memory',
+    });
+    try {
+      createEntity(session.doc, 'wall-guid-1', { ifcClass: 'IfcWall' });
+      const baseline = session.captureDocState();
+      setAttribute(session.doc, 'wall-guid-1', FIRE, 'REI90');
+
+      const store = await BrowserLayerStore.open();
+      const result = await publishCollabDraft({
+        store,
+        doc: session.doc,
+        baseline,
+        stackFiles: [],
+        intent: 'Session fire-rating pass',
+        authorPrincipal: 'alice',
+        hybrid: true,
+        refName: 'local',
+      });
+      assert.ok(result.layerId.startsWith('blake3:'));
+      assert.ok(result.opCount > 0);
+      // Stored, appended to the ref, and provenance-stamped as hybrid.
+      assert.deepStrictEqual(store.getRef('local')?.layers, [result.layerId]);
+      const manifest = getProvenance(store.loadLayer(result.layerId));
+      assert.strictEqual(manifest?.author.kind, 'hybrid');
+      assert.strictEqual(manifest?.intent, 'Session fire-rating pass');
+      // The delta carries ONLY the post-baseline edit, on the GUID path.
+      const state = extractStackState([result.file]);
+      assert.strictEqual(state.get('wall-guid-1')?.components.get('pset:Pset_FireSafety')?.[FIRE], 'REI90');
+
+      // Nothing new since the last fork point: refuse an empty layer.
+      const forward = session.captureDocState();
+      await assert.rejects(
+        publishCollabDraft({
+          store,
+          doc: session.doc,
+          baseline: forward,
+          stackFiles: [],
+          intent: 'Nothing changed',
+          authorPrincipal: 'alice',
+          hybrid: false,
+          refName: 'local',
+        }),
+        /No session edits/,
+      );
+
+      // A fresh edit after the moved fork point publishes delta-only.
+      setAttribute(session.doc, 'wall-guid-1', FIRE, 'REI120');
+      const second = await publishCollabDraft({
+        store,
+        doc: session.doc,
+        baseline: forward,
+        stackFiles: [result.file],
+        intent: 'Bump to REI120',
+        authorPrincipal: 'alice',
+        hybrid: false,
+        refName: 'local',
+      });
+      const secondManifest = getProvenance(store.loadLayer(second.layerId));
+      assert.strictEqual(secondManifest?.author.kind, 'human');
+      assert.strictEqual(secondManifest?.base?.kind, 'stack');
+      assert.deepStrictEqual(store.getRef('local')?.layers, [result.layerId, second.layerId]);
+      const composed = extractStackState([result.file, second.file]);
+      assert.strictEqual(composed.get('wall-guid-1')?.components.get('pset:Pset_FireSafety')?.[FIRE], 'REI120');
+    } finally {
+      session.dispose();
+    }
+  });
+});

--- a/apps/viewer/src/lib/layers/publish.ts
+++ b/apps/viewer/src/lib/layers/publish.ts
@@ -198,3 +198,53 @@ export function publishViewerDraft(init: PublishDraftInit): PublishDraftResult {
 
   return { layerId, file, opCount: ops.length, unresolved };
 }
+
+export interface CollabPublishInit {
+  store: BrowserLayerStore;
+  /** The live session's Y.Doc (opaque here; typed by @ifc-lite/collab). */
+  doc: unknown;
+  /** Full-state fork point (`session.captureDocState()` at join/last publish). */
+  baseline: Uint8Array;
+  stackFiles: IfcxFile[];
+  intent: string;
+  authorPrincipal: string;
+  /** True when peers contributed to the doc (author.kind becomes hybrid). */
+  hybrid: boolean;
+  refName: string;
+  created?: string;
+}
+
+export interface CollabPublishResult {
+  layerId: string;
+  file: IfcxFile;
+  opCount: number;
+}
+
+/**
+ * Freeze a live collab session's edits (everyone's, since `baseline`) into
+ * a published layer on the local store — the Y.Doc source counterpart to
+ * `publishViewerDraft`. Identity is shared by construction: collab docs
+ * address entities by GUID path, the same paths the composition uses.
+ * `@ifc-lite/collab` loads dynamically: in a live session it is already
+ * resident, and the Layers panel chunk must not pull in Yjs otherwise.
+ */
+export async function publishCollabDraft(init: CollabPublishInit): Promise<CollabPublishResult> {
+  const collab = await import('@ifc-lite/collab');
+  const published = collab.publishLayer(init.doc as Parameters<typeof collab.publishLayer>[0], {
+    intent: init.intent,
+    author: { kind: init.hybrid ? 'hybrid' : 'human', principal: init.authorPrincipal },
+    baseline: init.baseline,
+    base:
+      init.stackFiles.length > 0
+        ? { kind: 'stack', id: computeStackHash(init.stackFiles.map((f) => f.header.id)) }
+        : null,
+    ...(init.created !== undefined ? { created: init.created } : {}),
+  });
+  if (published.opCount === 0) {
+    throw new Error('No session edits since the last publish.');
+  }
+  init.store.storeLayer(published.file);
+  const existing = init.store.getRef(init.refName);
+  init.store.setRef(init.refName, { layers: [...(existing?.layers ?? []), published.layerId] });
+  return { layerId: published.layerId, file: published.file, opCount: published.opCount };
+}

--- a/apps/viewer/src/store/slices/collabSlice.ts
+++ b/apps/viewer/src/store/slices/collabSlice.ts
@@ -138,6 +138,13 @@ export interface CollabSlice {
    * the next layer carries only new edits.
    */
   collabDraftBaseline: Uint8Array | null;
+  /**
+   * True when peers were present at ANY point since the draft baseline —
+   * a peer who edited and left must still stamp the published layer
+   * `author.kind: hybrid`; sampling live presence at publish time would
+   * misattribute their edits.
+   */
+  collabPeersSinceBaseline: boolean;
   /** True while a session is being established. */
   collabConnecting: boolean;
   /** The room token this client joined with (admin for the owner). For minting + revoking links. */
@@ -432,6 +439,7 @@ export const createCollabSlice: StateCreator<ViewerState, [], [], CollabSlice> =
   collabStatus: 'disconnected',
   collabRoomId: null,
   collabDraftBaseline: null,
+  collabPeersSinceBaseline: false,
   collabRole: null,
   collabIdentity: loadOrCreateIdentity(),
   collabPeers: [],
@@ -538,7 +546,11 @@ export const createCollabSlice: StateCreator<ViewerState, [], [], CollabSlice> =
 
     const selfClientId = session.clientId;
     session.presence.onUpdate((peers) => {
-      set({ collabPeers: remotePeers(peers, selfClientId) });
+      const remote = remotePeers(peers, selfClientId);
+      set((state) => ({
+        collabPeers: remote,
+        collabPeersSinceBaseline: state.collabPeersSinceBaseline || remote.length > 0,
+      }));
     });
     session.onStatus((status) => set({ collabStatus: status }));
     // Broadcast our role so peers can show it in the roster (advisory; the
@@ -866,6 +878,7 @@ export const createCollabSlice: StateCreator<ViewerState, [], [], CollabSlice> =
       // Fork point for session-draft publishing: the doc is synced (and
       // seeded, for owners) by the time the session is committed.
       collabDraftBaseline: session.captureDocState(),
+      collabPeersSinceBaseline: get().collabPeers.length > 0,
     });
   },
 
@@ -916,6 +929,7 @@ export const createCollabSlice: StateCreator<ViewerState, [], [], CollabSlice> =
       collabStatus: 'disconnected',
       collabRoomId: null,
       collabDraftBaseline: null,
+      collabPeersSinceBaseline: false,
       collabRole: null,
       collabPeers: [],
       collabConnecting: false,
@@ -927,7 +941,12 @@ export const createCollabSlice: StateCreator<ViewerState, [], [], CollabSlice> =
 
   resetCollabDraftBaseline: () => {
     const session = get().collabSession;
-    if (session) set({ collabDraftBaseline: session.captureDocState() });
+    if (session) {
+      set({
+        collabDraftBaseline: session.captureDocState(),
+        collabPeersSinceBaseline: get().collabPeers.length > 0,
+      });
+    }
   },
 
   setCollabLastShareToken: (token) => set({ collabLastShareToken: token }),

--- a/apps/viewer/src/store/slices/collabSlice.ts
+++ b/apps/viewer/src/store/slices/collabSlice.ts
@@ -132,6 +132,12 @@ export interface CollabSlice {
   collabIdentity: EphemeralIdentity;
   /** Remote peers currently present (excludes self). */
   collabPeers: PresenceState[];
+  /**
+   * Full-doc fork point for session-draft publishing (#1717): captured
+   * once the session is synced/seeded, re-captured after each publish so
+   * the next layer carries only new edits.
+   */
+  collabDraftBaseline: Uint8Array | null;
   /** True while a session is being established. */
   collabConnecting: boolean;
   /** The room token this client joined with (admin for the owner). For minting + revoking links. */
@@ -149,6 +155,8 @@ export interface CollabSlice {
   startCollab: (opts: StartCollabOptions) => Promise<void>;
   /** Leave the current room and tear everything down. */
   stopCollab: () => void;
+  /** Re-capture the session-draft fork point (after a publish). */
+  resetCollabDraftBaseline: () => void;
   /** Record the latest minted share link token (for later revocation). */
   setCollabLastShareToken: (token: string | null) => void;
   /** Admin: invalidate the most recently minted share link. Returns success. */
@@ -423,6 +431,7 @@ export const createCollabSlice: StateCreator<ViewerState, [], [], CollabSlice> =
   collabSession: null,
   collabStatus: 'disconnected',
   collabRoomId: null,
+  collabDraftBaseline: null,
   collabRole: null,
   collabIdentity: loadOrCreateIdentity(),
   collabPeers: [],
@@ -854,6 +863,9 @@ export const createCollabSlice: StateCreator<ViewerState, [], [], CollabSlice> =
       collabStatus: session.status(),
       collabConnecting: false,
       collabSelfToken: token ?? null,
+      // Fork point for session-draft publishing: the doc is synced (and
+      // seeded, for owners) by the time the session is committed.
+      collabDraftBaseline: session.captureDocState(),
     });
   },
 
@@ -903,6 +915,7 @@ export const createCollabSlice: StateCreator<ViewerState, [], [], CollabSlice> =
       collabSession: null,
       collabStatus: 'disconnected',
       collabRoomId: null,
+      collabDraftBaseline: null,
       collabRole: null,
       collabPeers: [],
       collabConnecting: false,
@@ -910,6 +923,11 @@ export const createCollabSlice: StateCreator<ViewerState, [], [], CollabSlice> =
       collabLastShareToken: null,
       collabPanelVisible: false,
     });
+  },
+
+  resetCollabDraftBaseline: () => {
+    const session = get().collabSession;
+    if (session) set({ collabDraftBaseline: session.captureDocState() });
   },
 
   setCollabLastShareToken: (token) => set({ collabLastShareToken: token }),

--- a/packages/collab/src/session.ts
+++ b/packages/collab/src/session.ts
@@ -95,6 +95,13 @@ export interface CollabSession {
   snapshot(options?: SnapshotOptions): IfcxFile;
   /** Capture a baseline state vector for later layer extraction. */
   captureBaseline(): Uint8Array;
+  /**
+   * Capture the doc's FULL state (`Y.encodeStateAsUpdate`) as the fork
+   * point for whole-doc publishing (`publishLayer`'s `baseline`). Distinct
+   * from `captureBaseline`, which returns a state VECTOR for the per-user
+   * `extractUserLayer` path.
+   */
+  captureDocState(): Uint8Array;
   /** Extract a per-user layer (defaults to *this* peer). */
   extractUserLayer(baseline: Uint8Array, clientId?: number, snapshot?: SnapshotOptions): IfcxFile;
   /** Wrap edits in a Yjs transaction tagged with our local origin. */
@@ -180,6 +187,9 @@ export async function createCollabSession(opts: CollabSessionOptions): Promise<C
     },
     captureBaseline() {
       return captureBaselineSV(doc);
+    },
+    captureDocState() {
+      return Y.encodeStateAsUpdate(doc);
     },
     extractUserLayer(baseline, clientId, snapshot) {
       return extractLayerForClient(doc, baseline, {


### PR DESCRIPTION
PR 5 of the #1717 completion pass: the Layers panel's Draft section can freeze a LIVE collab session's edits into a published layer — the "collab Y.Doc drafts" leftover. Stacked on #1729 → #1728 → #1727 → #1726; merge the chain in order.

## What was missing

`@ifc-lite/collab` has had `publishLayer(doc, ...)` (CRDT session → frozen, provenance-stamped layer) since #1027, but the viewer never called it: viewer publishing read the LOCAL undo stacks only, so peers' edits in a live session were unpublishable, and there was no fork point to diff the doc against.

## @ifc-lite/collab

- **`CollabSession.captureDocState()`**: full-state fork point (`Y.encodeStateAsUpdate`). The existing `captureBaseline()` returns a state VECTOR (for the per-user `extractUserLayer` filter) which `publishLayer`'s minimal-layer diff cannot replay — this was the missing seam.

## Viewer

- **`collabDraftBaseline`** on the collab slice: captured when the session commits (after sync + owner seeding, so joining a populated room does not read its history as "edits"), cleared on stop, and re-captured after each publish so every session layer is delta-only.
- **`publishCollabDraft`** (`lib/layers/publish.ts`): the Y.Doc-source counterpart to `publishViewerDraft` — same local-ref append and recompose flow. Identity is shared by construction: collab docs address entities by GUID path, the same paths the composition uses. `author.kind` becomes `hybrid` when peers are present (their edits are in the doc too), `human` when solo. An empty delta refuses with "No session edits since the last publish" instead of minting an empty layer. `@ifc-lite/collab` loads dynamically, so Yjs stays out of the Layers panel chunk when no session exists.
- **Draft section**: in a session it grows a "Publish session edits" action (with a peers/hybrid hint) alongside the local-edits publish; local pending mutations clear on session publish since the doc already carries them (the mutation bridge mirrors every local edit).

## Verification

- New viewer test: memory-provider session end to end — hybrid-authored delta layer on the local ref with only post-baseline edits, empty-delta refusal, then a second delta-only publish (`human`, stack base) composing to the final value. Suites: collab 170, viewer 1688, typecheck + api-surface green.
- Localhost (vite, `VITE_COLLAB_ENABLED=true`, local-only IndexedDB session + Chrome DevTools MCP): loaded a 2-layer stack, started a session (baseline auto-captured), applied session edits directly on the live Y.Doc, published from the panel — stack grew to 3 with the session layer strongest and intent + identity-derived author on its manifest, composed FireRating took the session value, the baseline advanced, and an immediate re-publish with no new edits was refused (no empty layer on the ref).

## Notes

- Publishing only one peer's edits (`extractUserLayer`) stays a follow-up; the whole-doc + hybrid stamp matches how sessions are actually co-edited.
- Remaining #1717 scope after this: geometry-edit publishing, webhooks + auto-merge policies.