### PR TITLE
feat(layers): geometry-affecting edit publishing — session placement layers, retype opinions, no silent drops

### DIFF
--- a/.changeset/retype-and-skipped-ops.md
+++ b/.changeset/retype-and-skipped-ops.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/mutations": minor
+---
+
+`changeSetToOps` serializes entity retypes (`UPDATE_ENTITY_TYPE` → a `bsi::ifc::class` opinion, with `PredefinedType` on the core-attribute channel) instead of silently dropping them, and reports unrepresentable mutation types in a new `skipped` result field so callers can warn instead of under-publishing.

--- a/apps/viewer/src/components/viewer/layers/LayerDraftSection.tsx
+++ b/apps/viewer/src/components/viewer/layers/LayerDraftSection.tsx
@@ -99,18 +99,22 @@ export function LayerDraftSection() {
         authorPrincipal: trimmedAuthor,
         refName: DEFAULT_LOCAL_REF,
       });
-      if (result.skippedCount > 0) {
-        toast.info(
-          `${result.skippedCount} edit${result.skippedCount === 1 ? '' : 's'} had no layer representation and stayed out of the published layer.`,
-        );
-      }
-      if (result.unresolved.length > 0) {
-        // A partial publish must not recompose: the federation reload
-        // resets viewer state, which would erase the very edits we
+      if (result.unresolved.length > 0 || result.skippedCount > 0) {
+        // A partial publish must not recompose OR clear: the federation
+        // reload resets viewer state and clearAllMutations would drop the
+        // very edits (unresolved identity / no layer representation) we
         // promise to keep. The layer is on the ref; stack it after the
-        // identities are fixed (re-publishing folds idempotently).
+        // leftovers are dealt with (re-publishing folds idempotently).
+        const parts = [
+          result.unresolved.length > 0
+            ? `${result.unresolved.length} edited ${result.unresolved.length === 1 ? 'entity' : 'entities'} had no stable identity`
+            : null,
+          result.skippedCount > 0
+            ? `${result.skippedCount} edit${result.skippedCount === 1 ? '' : 's'} had no layer representation`
+            : null,
+        ].filter(Boolean);
         toast.info(
-          `Published to '${DEFAULT_LOCAL_REF}', but ${result.unresolved.length} edited ${result.unresolved.length === 1 ? 'entity' : 'entities'} had no stable identity and stayed out. Pending edits were kept; the layer was not stacked.`,
+          `Published to '${DEFAULT_LOCAL_REF}', but ${parts.join(' and ')} and stayed out. Pending edits were kept; the layer was not stacked.`,
         );
         setIntent('');
         return;

--- a/apps/viewer/src/components/viewer/layers/LayerDraftSection.tsx
+++ b/apps/viewer/src/components/viewer/layers/LayerDraftSection.tsx
@@ -99,6 +99,11 @@ export function LayerDraftSection() {
         authorPrincipal: trimmedAuthor,
         refName: DEFAULT_LOCAL_REF,
       });
+      if (result.skippedCount > 0) {
+        toast.info(
+          `${result.skippedCount} edit${result.skippedCount === 1 ? '' : 's'} had no layer representation and stayed out of the published layer.`,
+        );
+      }
       if (result.unresolved.length > 0) {
         // A partial publish must not recompose: the federation reload
         // resets viewer state, which would erase the very edits we

--- a/apps/viewer/src/lib/layers/collab-publish.test.ts
+++ b/apps/viewer/src/lib/layers/collab-publish.test.ts
@@ -5,7 +5,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
 import { getProvenance } from '@ifc-lite/ifcx';
-import { createCollabSession, createEntity, setAttribute } from '@ifc-lite/collab';
+import { createCollabSession, createEntity, setAttribute, setEntityPlacement } from '@ifc-lite/collab';
 import { extractStackState } from '@ifc-lite/merge';
 import { BrowserLayerStore } from './browser-store.js';
 import { publishCollabDraft } from './publish.js';
@@ -80,6 +80,26 @@ describe('collab session draft publishing (#1717)', () => {
       assert.deepStrictEqual(store.getRef('local')?.layers, [result.layerId, second.layerId]);
       const composed = extractStackState([result.file, second.file]);
       assert.strictEqual(composed.get('wall-guid-1')?.components.get('pset:Pset_FireSafety')?.[FIRE], 'REI120');
+
+      // Geometry-affecting session edits publish too: a placement move
+      // rides the doc as `usd::xformop` and freezes into the layer delta.
+      const forkForMove = session.captureDocState();
+      setEntityPlacement(session.doc, 'wall-guid-1', { location: [2, 0, 0] });
+      const moved = await publishCollabDraft({
+        store,
+        doc: session.doc,
+        baseline: forkForMove,
+        stackFiles: [result.file, second.file],
+        intent: 'Shift wall 2m east',
+        authorPrincipal: 'alice',
+        hybrid: false,
+        refName: 'local',
+      });
+      const movedNode = moved.file.data.find((n) => n.path === 'wall-guid-1');
+      const xform = movedNode?.attributes?.['usd::xformop'] as { transform?: number[][] } | undefined;
+      assert.ok(xform?.transform, 'placement edit must serialize as usd::xformop');
+      // Row-vector convention: translation is the fourth row.
+      assert.strictEqual(xform.transform?.[3]?.[0], 2);
     } finally {
       session.dispose();
     }

--- a/apps/viewer/src/lib/layers/publish.test.ts
+++ b/apps/viewer/src/lib/layers/publish.test.ts
@@ -139,6 +139,45 @@ describe('publishViewerDraft (#1717 V2)', () => {
   });
 });
 
+describe('publishViewerDraft retype + skipped reporting (#1717 geometry pass)', () => {
+  it('serializes a retype as a class opinion with PredefinedType on the core channel', async () => {
+    const store = await BrowserLayerStore.open();
+    const result = publishViewerDraft({
+      store,
+      stackFiles: [makeBase()],
+      mutations: [
+        mutation({ type: 'UPDATE_ENTITY_TYPE', entityType: 'IfcColumn', predefinedType: 'COLUMN' }),
+      ],
+      pathOf: (id) => (id === 7 ? 'wall-guid-1' : undefined),
+      intent: 'Retype to column',
+      authorPrincipal: 'alice',
+      refName: 'local',
+    });
+    assert.strictEqual(result.skippedCount, 0);
+    const node = result.file.data.find((n) => n.path === 'wall-guid-1');
+    assert.deepStrictEqual(node?.attributes?.['bsi::ifc::class'], { code: 'IfcColumn' });
+    assert.strictEqual(node?.attributes?.['bsi::ifc::prop::PredefinedType'], 'COLUMN');
+  });
+
+  it('reports edits with no layer representation instead of dropping them silently', async () => {
+    const store = await BrowserLayerStore.open();
+    const result = publishViewerDraft({
+      store,
+      stackFiles: [makeBase()],
+      mutations: [
+        mutation({ psetName: 'Pset_FireSafety', propName: 'FireRating', newValue: 'REI90' }),
+        mutation({ id: 'm-future', type: 'SOME_FUTURE_TYPE' as Mutation['type'] }),
+      ],
+      pathOf: (id) => (id === 7 ? 'wall-guid-1' : undefined),
+      intent: 'Mixed edits',
+      authorPrincipal: 'alice',
+      refName: 'local',
+    });
+    assert.strictEqual(result.skippedCount, 1);
+    assert.strictEqual(result.opCount, 1);
+  });
+});
+
 describe('BrowserLayerStore integrity', () => {
   it('refuses a header id that does not match the content address', async () => {
     const store = await BrowserLayerStore.open();

--- a/apps/viewer/src/lib/layers/publish.ts
+++ b/apps/viewer/src/lib/layers/publish.ts
@@ -68,6 +68,11 @@ function wireEntry(
     // a plain string — a typed record would compose but never display.
     return { key: `${ATTR.PROP_PREFIX}${member}`, value };
   }
+  if (componentKey === 'attr:class' && member === 'code') {
+    // Retype (UPDATE_ENTITY_TYPE): a class opinion, code-only like the
+    // add-entity path.
+    return { key: ATTR.CLASS, value: value === null ? null : { code: value } };
+  }
   return null;
 }
 
@@ -149,6 +154,8 @@ export interface PublishDraftResult {
   opCount: number;
   /** expressIds with no resolvable identity — excluded from the layer. */
   unresolved: number[];
+  /** Mutations with no component representation — excluded, never silent. */
+  skippedCount: number;
 }
 
 /** Freeze pending edits into a published layer on the local store. */
@@ -160,7 +167,7 @@ export function publishViewerDraft(init: PublishDraftInit): PublishDraftResult {
     mutations: [...init.mutations],
     applied: true,
   };
-  const { ops, identityMap, unresolved } = changeSetToOps(changeSet, {
+  const { ops, identityMap, unresolved, skipped } = changeSetToOps(changeSet, {
     globalIdOf: (expressId) => init.pathOf(expressId),
   });
   const data = buildDeltaNodes(ops, init.stackFiles);
@@ -196,7 +203,7 @@ export function publishViewerDraft(init: PublishDraftInit): PublishDraftResult {
   const existing = init.store.getRef(init.refName);
   init.store.setRef(init.refName, { layers: [...(existing?.layers ?? []), layerId] });
 
-  return { layerId, file, opCount: ops.length, unresolved };
+  return { layerId, file, opCount: ops.length, unresolved, skippedCount: skipped.length };
 }
 
 export interface CollabPublishInit {

--- a/packages/mutations/src/change-set-to-ops.test.ts
+++ b/packages/mutations/src/change-set-to-ops.test.ts
@@ -134,4 +134,33 @@ describe('changeSetToOps', () => {
     const add = result.ops.find((op) => op.op === 'add-entity');
     expect(add).toMatchObject({ ifcType: 'IfcWall' });
   });
+
+  it('serializes a retype as a class opinion and rides PredefinedType on the core channel', () => {
+    const result = changeSetToOps(
+      changeSet([
+        mutation('UPDATE_ENTITY_TYPE', 42, { entityType: 'IfcColumn', predefinedType: 'COLUMN' }),
+      ]),
+      resolver
+    );
+    expect(result.skipped).toEqual([]);
+    expect(result.ops).toContainEqual({
+      op: 'set-component',
+      entity: '3fAx$GlobalId42',
+      componentKey: 'attr:class',
+      values: { code: 'IfcColumn' },
+    });
+    expect(result.ops).toContainEqual({
+      op: 'set-component',
+      entity: '3fAx$GlobalId42',
+      componentKey: 'attr:core',
+      values: { PredefinedType: 'COLUMN' },
+    });
+  });
+
+  it('reports unrepresentable mutation types instead of silently dropping them', () => {
+    const foreign = mutation('SOME_FUTURE_TYPE' as MutationType, 42, {});
+    const result = changeSetToOps(changeSet([foreign]), resolver);
+    expect(result.ops).toEqual([]);
+    expect(result.skipped).toEqual([foreign]);
+  });
 });

--- a/packages/mutations/src/change-set-to-ops.ts
+++ b/packages/mutations/src/change-set-to-ops.ts
@@ -66,6 +66,11 @@ export interface ChangeSetOpsResult {
   identityMap: DerivedIdentityEntry[];
   /** expressIds for which no identity could be established at all. */
   unresolved: number[];
+  /**
+   * Mutations with no component representation (unknown/future types).
+   * Reported so callers can warn instead of silently under-publishing.
+   */
+  skipped: Mutation[];
 }
 
 const textEncoder = new TextEncoder();
@@ -141,10 +146,11 @@ export function changeSetToOps(
     perEntity.set(componentKey, values);
   };
 
+  const skipped: Mutation[] = [];
   for (const mutation of changeSet.mutations) {
     const entity = identityOf(mutation.entityId);
     if (entity === undefined) continue;
-    applyMutation(mutation, entity, setMember, componentFor, entityOps, resolver);
+    applyMutation(mutation, entity, setMember, componentFor, entityOps, resolver, skipped);
   }
 
   const ops: ChangeSetOp[] = [...entityOps.values()];
@@ -158,7 +164,7 @@ export function changeSetToOps(
     }
   }
 
-  return { ops, identityMap, unresolved };
+  return { ops, identityMap, unresolved, skipped };
 }
 
 function applyMutation(
@@ -167,7 +173,8 @@ function applyMutation(
   setMember: (entity: string, componentKey: string, member: string, value: PropertyValue | null) => void,
   componentFor: (entity: string, componentKey: string) => Map<string, Record<string, PropertyValue | null> | null>,
   entityOps: Map<string, ChangeSetOp>,
-  resolver: EntityIdentityResolver
+  resolver: EntityIdentityResolver,
+  skipped: Mutation[]
 ): void {
   switch (mutation.type) {
     case 'CREATE_PROPERTY':
@@ -218,6 +225,22 @@ function applyMutation(
       break;
     case 'DELETE_ENTITY':
       entityOps.set(entity, { op: 'tombstone-entity', entity });
+      break;
+    case 'UPDATE_ENTITY_TYPE':
+      // Retype = a class-component opinion; the wire layer serializes it
+      // as `bsi::ifc::class` (code only, like add-entity). PredefinedType
+      // rides the core-attribute channel; explicit null clears it.
+      if (mutation.entityType) {
+        setMember(entity, 'attr:class', 'code', mutation.entityType);
+        if (mutation.predefinedType !== undefined) {
+          setMember(entity, 'attr:core', 'PredefinedType', mutation.predefinedType);
+        }
+      }
+      break;
+    default:
+      // Runtime data may carry mutation types this build does not know
+      // (forward compat): report, never silently under-publish.
+      skipped.push(mutation);
       break;
   }
 }


### PR DESCRIPTION
PR 6 of the #1717 completion pass: the "geometry-affecting edit publishing" leftover. Stacked on #1730 → #1729 → #1728 → #1727 → #1726; merge the chain in order.

## What the audit actually found

Three distinct gaps hid under "geometry edits are silently skipped":

1. **Placement edits in IFCX compositions are collab-native** (`usd::xformop` on the Y.Doc) — and the session publish path from #1730 already freezes them, but nothing pinned that behavior.
2. **`UPDATE_ENTITY_TYPE` (retype) was the one mutation type that genuinely fell through `changeSetToOps` silently** — a retyped entity published a layer that did not carry the retype.
3. **Nothing reported unrepresentable mutations**: a future/unknown type would vanish without a trace. (Local STEP placement moves, which write positional attributes on the placement chain's `IfcCartesianPoint`, already surface honestly through the existing `unresolved` reporting — sub-entities have no GUID identity by design.)

## Changes

- **@ifc-lite/mutations**: `UPDATE_ENTITY_TYPE` serializes as a class opinion (`attr:class` → `bsi::ifc::class { code }`), with `PredefinedType` riding the core-attribute channel (explicit null clears). New `skipped: Mutation[]` on the result reports anything with no component representation — the switch keeps a defensive default so runtime data from newer builds degrades loudly, never silently.
- **Viewer**: the wire layer maps the class opinion; `publishViewerDraft` returns `skippedCount` and the Draft section toasts when edits stayed out of a published layer.
- **Session placement publishing pinned by test**: a `setEntityPlacement` move on the live doc freezes into the layer delta as `usd::xformop` (row-vector 4×4, translation verified), composing onto the stack like any other opinion.

## Verification

- New tests: mutations (retype → class + PredefinedType ops, unknown type → `skipped`), viewer publish (retype wire form `bsi::ifc::class {code}` + `prop::PredefinedType`, mixed edits report `skippedCount` while publishing the representable rest), collab publish (placement move → `usd::xformop` in the delta with the exact translation).
- Suites: mutations 73, viewer 1690, typecheck + api-surface green.

## Notes

- Mesh-level edit publishing (beyond placement) stays out: there is no IFCX opinion form for mesh deltas yet; the collab geometry channel (content-addressed blobs) is the substrate a future spike would build on.
- Remaining #1717 scope after this: webhooks + auto-merge policies (PR 7, last one).