### PR TITLE
feat(viewer): first-class exposure for Layer PRs and collab — launchpad, demo stack, tour, badges, menus

### DIFF
--- a/apps/viewer/public/samples/hello-wall.ifcx
+++ b/apps/viewer/public/samples/hello-wall.ifcx
@@ -1,0 +1,2193 @@
+{
+  "header": {
+    "id": "ifc5.technical.buildingsmart.org/examples/Hello Wall/hello-wall.ifcx",
+    "ifcxVersion": "ifcx_alpha",
+    "dataVersion": "1.0.0",
+    "author": "technical@buildingsmart.org",
+    "timestamp": "time string"
+  },
+  "imports": [
+    { "uri": "https://ifcx.dev/@standards.buildingsmart.org/ifc/core/ifc@v5a.ifcx" },
+    { "uri": "https://ifcx.dev/@standards.buildingsmart.org/ifc/core/prop@v5a.ifcx" },
+    { "uri": "https://ifcx.dev/@standards.buildingsmart.org/ifc/ifc-mat/ifc-mat@v1.0.0.ifcx" },
+    { "uri": "https://ifcx.dev/@openusd.org/usd@v1.ifcx" },
+    { "uri": "https://ifcx.dev/@nlsfb/nlsfb@v1.ifcx" }
+  ],
+  "schemas": {
+    "customdata": {
+      "value": {
+        "dataType": "Object",
+        "objectRestrictions": {
+          "values": {
+            "originalStepInstance": {
+              "dataType": "String"
+            }
+          }
+        }
+      }
+    }
+  },
+  "data": [
+    {
+      "path": "25503984-6605-43a1-8597-eae657ff5bea",
+      "children": {
+        "Void": "8fada721-cff8-590b-8d0b-9300b5fe8e18",
+        "Frame": "08f06095-3f32-55b9-a353-61c9aca5cc4d",
+        "Glazing": "5ad6f475-c04c-5628-8b9d-75d0bab0c0e5"
+      }
+    },
+    {
+      "path": "14adb22b-d474-48a2-8e8f-6d4c067c1953",
+      "children": {
+        "My_Site": "e0834921-e095-40f0-8874-3c6bd1ec699e"
+      }
+    },
+    {
+      "path": "ab143723-f7b1-5368-b106-55896e88d768",
+      "children": {
+        "My_Project": "14adb22b-d474-48a2-8e8f-6d4c067c1953"
+      }
+    },
+    {
+      "path": "e0834921-e095-40f0-8874-3c6bd1ec699e",
+      "children": {
+        "My_Building": "e84dc79e-fe9d-4781-9f4b-54dd435cca91"
+      }
+    },
+    {
+      "path": "e84dc79e-fe9d-4781-9f4b-54dd435cca91",
+      "children": {
+        "My_Storey": "44af358b-3160-4063-8a89-a868335ff3b5"
+      }
+    },
+    {
+      "path": "44af358b-3160-4063-8a89-a868335ff3b5",
+      "children": {
+        "My_Space": "e3035b71-bd9f-4cdc-86fd-b56e2f4605b6",
+        "Wall": "93791d5d-5beb-437b-b8ec-2f1f0ba4bf3b"
+      }
+    },
+    {
+      "path": "e3035b71-bd9f-4cdc-86fd-b56e2f4605b6",
+      "children": {
+        "Body": "15289df1-5ae0-5fc9-8399-19de1fbb87a0",
+        "Boundary_Wall": "c8ecbf4c-e37a-4489-9133-15163b8a904e",
+        "Boundary_Window": "cc40ef6e-950e-4b79-a802-4cc710294e3a",
+        "Boundary_Window_001": "7f2a3284-bf01-4b0a-85e4-e48d92ba56dd"
+      }
+    },
+    {
+      "path": "93791d5d-5beb-437b-b8ec-2f1f0ba4bf3b",
+      "children": {
+        "Body": "634f90c3-831e-5f29-a9b2-fa69b207821e",
+        "Axis": "8407e490-ceaa-56e5-96df-2351d9110668",
+        "Directrix": "9d1fce89-e179-5076-9a3b-1b40eef3524b",
+        "Basis": "367f7f7d-b4c5-50fe-829a-6bbced170dd1",
+        "Window": "2c2d549f-f9fe-4e22-8590-562fda81a690",
+        "Window_001": "592504dc-469a-44d6-9ae8-c801b591679b"
+      }
+    },
+    {
+      "path": "2c2d549f-f9fe-4e22-8590-562fda81a690",
+      "inherits": {
+        "windowType": "25503984-6605-43a1-8597-eae657ff5bea"
+      }
+    },
+    {
+      "path": "592504dc-469a-44d6-9ae8-c801b591679b",
+      "inherits": {
+        "windowType": "25503984-6605-43a1-8597-eae657ff5bea"
+      }
+    },
+    {
+      "path": "c8ecbf4c-e37a-4489-9133-15163b8a904e",
+      "children": {
+        "Body": "911155b7-f688-51ee-8e3e-b97475be2452"
+      }
+    },
+    {
+      "path": "cc40ef6e-950e-4b79-a802-4cc710294e3a",
+      "children": {
+        "Body": "f3aa8991-7481-5d6b-8dae-f98c372f4a98"
+      }
+    },
+    {
+      "path": "7f2a3284-bf01-4b0a-85e4-e48d92ba56dd",
+      "children": {
+        "Body": "126781f3-6465-5c39-9216-81cc636eeb39"
+      }
+    },
+    {
+      "path": "7a187a90-3dcf-58cc-b3a6-51a9a407c55a",
+      "attributes": {
+        "bsi::ifc::presentation::diffuseColor": [
+          0.5,
+          0.5,
+          0.5
+        ],
+        "bsi::ifc::presentation::opacity": 1,
+        "bsi::ifc::material": {
+          "code": "CONCRETE",
+          "uri": "https://identifier.buildingsmart.org/uri/fish/midas-materials/26/class/CONCRETE"
+        }
+      }
+    },
+    {
+      "path": "25503984-6605-43a1-8597-eae657ff5bea",
+      "attributes": {
+        "customdata": {
+          "originalStepInstance": "#459=IfcWindowType('0bK3c4PWL3eOMNwkPN$rlg',$,'WT01',$,$,$,(#436,#458),$,$,.NOTDEFINED.,.NOTDEFINED.,$,$)"
+        }
+      }
+    },
+    {
+      "path": "25503984-6605-43a1-8597-eae657ff5bea",
+      "attributes": {
+        "bsi::ifc::class": {
+          "code": "IfcWindow",
+          "uri": "https://identifier.buildingsmart.org/uri/buildingsmart/ifc/4.3/class/IfcWindow"
+        }
+      }
+    },
+    {
+      "path": "25503984-6605-43a1-8597-eae657ff5bea",
+      "attributes": {
+        "bsi::ifc::prop::TypeName": "WT01"
+      }
+    },
+    {
+      "path": "8fada721-cff8-590b-8d0b-9300b5fe8e18",
+      "attributes": {
+        "usd::usdgeom::mesh": {
+          "faceVertexIndices": [
+            3,
+            0,
+            1,
+            3,
+            1,
+            2,
+            7,
+            4,
+            5,
+            7,
+            5,
+            6,
+            11,
+            8,
+            9,
+            11,
+            9,
+            10,
+            15,
+            12,
+            13,
+            15,
+            13,
+            14,
+            18,
+            16,
+            17,
+            18,
+            19,
+            16,
+            21,
+            20,
+            22,
+            20,
+            23,
+            22
+          ],
+          "points": [
+            [
+              0,
+              -0.6,
+              0
+            ],
+            [
+              0,
+              0.59999996,
+              0
+            ],
+            [
+              0.9,
+              0.59999996,
+              0
+            ],
+            [
+              0.9,
+              -0.6,
+              0
+            ],
+            [
+              0.9,
+              -0.6,
+              0
+            ],
+            [
+              0.9,
+              0.59999996,
+              0
+            ],
+            [
+              0.9,
+              0.59999996,
+              1.2
+            ],
+            [
+              0.9,
+              -0.6,
+              1.2
+            ],
+            [
+              0.9,
+              -0.6,
+              1.2
+            ],
+            [
+              0.9,
+              0.59999996,
+              1.2
+            ],
+            [
+              0,
+              0.59999996,
+              1.2
+            ],
+            [
+              0,
+              -0.6,
+              1.2
+            ],
+            [
+              0,
+              -0.6,
+              1.2
+            ],
+            [
+              0,
+              0.59999996,
+              1.2
+            ],
+            [
+              0,
+              0.59999996,
+              0
+            ],
+            [
+              0,
+              -0.6,
+              0
+            ],
+            [
+              0,
+              -0.6,
+              0
+            ],
+            [
+              0.9,
+              -0.6,
+              0
+            ],
+            [
+              0.9,
+              -0.6,
+              1.2
+            ],
+            [
+              0,
+              -0.6,
+              1.2
+            ],
+            [
+              0,
+              0.59999996,
+              0
+            ],
+            [
+              0.9,
+              0.59999996,
+              0
+            ],
+            [
+              0.9,
+              0.59999996,
+              1.2
+            ],
+            [
+              0,
+              0.59999996,
+              1.2
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "path": "8fada721-cff8-590b-8d0b-9300b5fe8e18",
+      "attributes": {
+        "usd::usdgeom::visibility": {
+          "visibility": "invisible"
+        }
+      }
+    },
+    {
+      "path": "14adb22b-d474-48a2-8e8f-6d4c067c1953",
+      "attributes": {
+        "customdata": {
+          "originalStepInstance": "#1=IfcProject('0KhR8hr7H8eewFRKm6V1bJ',$,'My Project',$,$,$,$,(#14,#26),#9)"
+        }
+      }
+    },
+    {
+      "path": "14adb22b-d474-48a2-8e8f-6d4c067c1953",
+      "attributes": {
+        "bsi::ifc::class": {
+          "code": "IfcProject",
+          "uri": "https://identifier.buildingsmart.org/uri/buildingsmart/ifc/4.3/class/IfcProject"
+        }
+      }
+    },
+    {
+      "path": "e0834921-e095-40f0-8874-3c6bd1ec699e",
+      "attributes": {
+        "customdata": {
+          "originalStepInstance": "#30=IfcSite('3WWqaXu9L0y8XqF6lHx6cU',$,'My Site',$,$,#53,$,$,$,$,$,$,$,$)"
+        }
+      }
+    },
+    {
+      "path": "e0834921-e095-40f0-8874-3c6bd1ec699e",
+      "attributes": {
+        "bsi::ifc::class": {
+          "code": "IfcSite",
+          "uri": "https://identifier.buildingsmart.org/uri/buildingsmart/ifc/4.3/class/IfcSite"
+        }
+      }
+    },
+    {
+      "path": "e84dc79e-fe9d-4781-9f4b-54dd435cca91",
+      "attributes": {
+        "customdata": {
+          "originalStepInstance": "#36=IfcBuilding('3eJSUU$fr7WPzBLDr3NCgH',$,'My Building',$,$,#59,$,$,$,$,$,$)"
+        }
+      }
+    },
+    {
+      "path": "e84dc79e-fe9d-4781-9f4b-54dd435cca91",
+      "attributes": {
+        "bsi::ifc::class": {
+          "code": "IfcBuilding",
+          "uri": "https://identifier.buildingsmart.org/uri/buildingsmart/ifc/4.3/class/IfcBuilding"
+        }
+      }
+    },
+    {
+      "path": "44af358b-3160-4063-8a89-a868335ff3b5",
+      "attributes": {
+        "customdata": {
+          "originalStepInstance": "#42=IfcBuildingStorey('14hpMBCM10Oug9g6WpN$Er',$,'My Storey',$,$,#65,$,$,$,$)"
+        }
+      }
+    },
+    {
+      "path": "44af358b-3160-4063-8a89-a868335ff3b5",
+      "attributes": {
+        "bsi::ifc::class": {
+          "code": "IfcBuildingStorey",
+          "uri": "https://identifier.buildingsmart.org/uri/buildingsmart/ifc/4.3/class/IfcBuildingStorey"
+        }
+      }
+    },
+    {
+      "path": "e3035b71-bd9f-4cdc-86fd-b56e2f4605b6",
+      "attributes": {
+        "customdata": {
+          "originalStepInstance": "#1494=IfcSpace('3Z0rjnlPzCt8RzjMulHWMs',$,'My Space',$,$,#1515,#1509,$,$,.SPACE.,$)"
+        }
+      }
+    },
+    {
+      "path": "e3035b71-bd9f-4cdc-86fd-b56e2f4605b6",
+      "attributes": {
+        "bsi::ifc::class": {
+          "code": "IfcSpace",
+          "uri": "https://identifier.buildingsmart.org/uri/buildingsmart/ifc/4.3/class/IfcSpace"
+        }
+      }
+    },
+    {
+      "path": "e3035b71-bd9f-4cdc-86fd-b56e2f4605b6",
+      "attributes": {
+        "bsi::ifc::presentation::diffuseColor": [
+          0.6,
+          0.7,
+          0.8
+        ],
+        "bsi::ifc::presentation::opacity": 0.3
+      }
+    },
+    {
+      "path": "e3035b71-bd9f-4cdc-86fd-b56e2f4605b6",
+      "attributes": {
+        "usd::xformop": {
+          "transform": [
+            [
+              1,
+              0,
+              0,
+              0
+            ],
+            [
+              0,
+              1,
+              0,
+              0
+            ],
+            [
+              0,
+              0,
+              1,
+              0
+            ],
+            [
+              0,
+              0.100000023841858,
+              0,
+              1
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "path": "15289df1-5ae0-5fc9-8399-19de1fbb87a0",
+      "attributes": {
+        "usd::usdgeom::mesh": {
+          "faceVertexIndices": [
+            0,
+            1,
+            2,
+            0,
+            2,
+            3,
+            6,
+            5,
+            4,
+            6,
+            7,
+            5,
+            10,
+            9,
+            8,
+            10,
+            11,
+            9,
+            13,
+            12,
+            14,
+            13,
+            14,
+            15,
+            16,
+            17,
+            18,
+            16,
+            18,
+            19,
+            21,
+            20,
+            22,
+            21,
+            22,
+            23
+          ],
+          "points": [
+            [
+              0,
+              0,
+              0
+            ],
+            [
+              0,
+              0,
+              3
+            ],
+            [
+              0,
+              4,
+              3
+            ],
+            [
+              0,
+              4,
+              0
+            ],
+            [
+              0,
+              4,
+              3
+            ],
+            [
+              0,
+              4,
+              0
+            ],
+            [
+              10,
+              4,
+              3
+            ],
+            [
+              10,
+              4,
+              0
+            ],
+            [
+              10,
+              4,
+              3
+            ],
+            [
+              10,
+              4,
+              0
+            ],
+            [
+              10,
+              0,
+              3
+            ],
+            [
+              10,
+              0,
+              0
+            ],
+            [
+              10,
+              0,
+              3
+            ],
+            [
+              10,
+              0,
+              0
+            ],
+            [
+              0,
+              0,
+              3
+            ],
+            [
+              0,
+              0,
+              0
+            ],
+            [
+              0,
+              4,
+              0
+            ],
+            [
+              10,
+              4,
+              0
+            ],
+            [
+              10,
+              0,
+              0
+            ],
+            [
+              0,
+              0,
+              0
+            ],
+            [
+              0,
+              4,
+              3
+            ],
+            [
+              10,
+              4,
+              3
+            ],
+            [
+              0,
+              0,
+              3
+            ],
+            [
+              10,
+              0,
+              3
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "path": "93791d5d-5beb-437b-b8ec-2f1f0ba4bf3b",
+      "attributes": {
+        "customdata": {
+          "originalStepInstance": "#1222=IfcWall('2JUHrTM_j3UxZiBnyBfByx',$,'Wall',$,$,#1235,#1230,$,$)"
+        }
+      }
+    },
+    {
+      "path": "93791d5d-5beb-437b-b8ec-2f1f0ba4bf3b",
+      "attributes": {
+        "bsi::ifc::class": {
+          "code": "IfcWall",
+          "uri": "https://identifier.buildingsmart.org/uri/buildingsmart/ifc/4.3/class/IfcWall"
+        }
+      }
+    },
+    {
+      "path": "93791d5d-5beb-437b-b8ec-2f1f0ba4bf3b",
+      "attributes": {
+        "bsi::ifc::prop::IsExternal": true
+      }
+    },
+    {
+      "path": "93791d5d-5beb-437b-b8ec-2f1f0ba4bf3b",
+      "inherits": {
+        "material": "7a187a90-3dcf-58cc-b3a6-51a9a407c55a"
+      }
+    },
+    {
+      "path": "93791d5d-5beb-437b-b8ec-2f1f0ba4bf3b",
+      "attributes": {
+        "nlsfb::class": {
+          "code": "21.21",
+          "uri": "https://identifier.buildingsmart.org/uri/nlsfb/nlsfb2005/2.2/class/21.21"
+        }
+      }
+    },
+    {
+      "path": "634f90c3-831e-5f29-a9b2-fa69b207821e",
+      "attributes": {
+        "usd::usdgeom::mesh": {
+          "faceVertexIndices": [
+            3,
+            0,
+            1,
+            3,
+            1,
+            2,
+            5,
+            4,
+            7,
+            6,
+            5,
+            7,
+            9,
+            8,
+            10,
+            10,
+            8,
+            11,
+            14,
+            12,
+            13,
+            15,
+            12,
+            14,
+            17,
+            16,
+            19,
+            18,
+            17,
+            19,
+            21,
+            20,
+            23,
+            22,
+            21,
+            23,
+            25,
+            24,
+            27,
+            26,
+            25,
+            27,
+            29,
+            28,
+            31,
+            30,
+            29,
+            31,
+            33,
+            32,
+            35,
+            34,
+            33,
+            35,
+            37,
+            36,
+            39,
+            38,
+            37,
+            39,
+            41,
+            40,
+            43,
+            42,
+            41,
+            43,
+            45,
+            44,
+            47,
+            46,
+            45,
+            47,
+            54,
+            50,
+            52,
+            53,
+            50,
+            51,
+            53,
+            52,
+            50,
+            55,
+            53,
+            51,
+            57,
+            54,
+            55,
+            57,
+            56,
+            54,
+            57,
+            55,
+            51,
+            49,
+            58,
+            59,
+            48,
+            49,
+            59,
+            49,
+            50,
+            56,
+            56,
+            50,
+            54,
+            49,
+            56,
+            58,
+            51,
+            48,
+            59,
+            51,
+            59,
+            57,
+            64,
+            62,
+            66,
+            63,
+            62,
+            65,
+            62,
+            64,
+            65,
+            63,
+            65,
+            67,
+            67,
+            66,
+            69,
+            66,
+            68,
+            69,
+            63,
+            67,
+            69,
+            71,
+            70,
+            61,
+            71,
+            61,
+            60,
+            68,
+            62,
+            61,
+            66,
+            62,
+            68,
+            70,
+            68,
+            61,
+            71,
+            60,
+            63,
+            69,
+            71,
+            63
+          ],
+          "points": [
+            [
+              10,
+              0,
+              0
+            ],
+            [
+              10,
+              0.1,
+              0
+            ],
+            [
+              10,
+              0.1,
+              3
+            ],
+            [
+              10,
+              0,
+              3
+            ],
+            [
+              0,
+              0,
+              0
+            ],
+            [
+              0,
+              0.1,
+              0
+            ],
+            [
+              0,
+              0.1,
+              3
+            ],
+            [
+              0,
+              0,
+              3
+            ],
+            [
+              10,
+              0,
+              0
+            ],
+            [
+              10,
+              0.1,
+              0
+            ],
+            [
+              0,
+              0.1,
+              0
+            ],
+            [
+              0,
+              0,
+              0
+            ],
+            [
+              10,
+              0,
+              3
+            ],
+            [
+              10,
+              0.1,
+              3
+            ],
+            [
+              0,
+              0.1,
+              3
+            ],
+            [
+              0,
+              0,
+              3
+            ],
+            [
+              1.7676749,
+              0,
+              1
+            ],
+            [
+              1.7676749,
+              0.1,
+              1
+            ],
+            [
+              2.667675,
+              0.1,
+              1
+            ],
+            [
+              2.667675,
+              0,
+              1
+            ],
+            [
+              2.667675,
+              0,
+              1
+            ],
+            [
+              2.667675,
+              0.1,
+              1
+            ],
+            [
+              2.667675,
+              0.1,
+              2.2
+            ],
+            [
+              2.667675,
+              0,
+              2.2
+            ],
+            [
+              2.667675,
+              0,
+              2.2
+            ],
+            [
+              2.667675,
+              0.1,
+              2.2
+            ],
+            [
+              1.7676749,
+              0.1,
+              2.2
+            ],
+            [
+              1.7676749,
+              0,
+              2.2
+            ],
+            [
+              1.7676749,
+              0,
+              2.2
+            ],
+            [
+              1.7676749,
+              0.1,
+              2.2
+            ],
+            [
+              1.7676749,
+              0.1,
+              1
+            ],
+            [
+              1.7676749,
+              0,
+              1
+            ],
+            [
+              4.9466066,
+              0,
+              1
+            ],
+            [
+              4.9466066,
+              0.1,
+              1
+            ],
+            [
+              5.8466067,
+              0.1,
+              1
+            ],
+            [
+              5.8466067,
+              0,
+              1
+            ],
+            [
+              5.8466067,
+              0,
+              1
+            ],
+            [
+              5.8466067,
+              0.1,
+              1
+            ],
+            [
+              5.8466067,
+              0.1,
+              2.2
+            ],
+            [
+              5.8466067,
+              0,
+              2.2
+            ],
+            [
+              5.8466067,
+              0,
+              2.2
+            ],
+            [
+              5.8466067,
+              0.1,
+              2.2
+            ],
+            [
+              4.9466066,
+              0.1,
+              2.2
+            ],
+            [
+              4.9466066,
+              0,
+              2.2
+            ],
+            [
+              4.9466066,
+              0,
+              2.2
+            ],
+            [
+              4.9466066,
+              0.1,
+              2.2
+            ],
+            [
+              4.9466066,
+              0.1,
+              1
+            ],
+            [
+              4.9466066,
+              0,
+              1
+            ],
+            [
+              10,
+              0,
+              0
+            ],
+            [
+              10,
+              0,
+              3
+            ],
+            [
+              0,
+              0,
+              3
+            ],
+            [
+              0,
+              0,
+              0
+            ],
+            [
+              1.7676749,
+              0,
+              2.2
+            ],
+            [
+              1.7676749,
+              0,
+              1
+            ],
+            [
+              2.667675,
+              0,
+              2.2
+            ],
+            [
+              2.667675,
+              0,
+              1
+            ],
+            [
+              4.9466066,
+              0,
+              2.2
+            ],
+            [
+              4.9466066,
+              0,
+              1
+            ],
+            [
+              5.8466067,
+              0,
+              2.2
+            ],
+            [
+              5.8466067,
+              0,
+              1
+            ],
+            [
+              10,
+              0.1,
+              0
+            ],
+            [
+              10,
+              0.1,
+              3
+            ],
+            [
+              0,
+              0.1,
+              3
+            ],
+            [
+              0,
+              0.1,
+              0
+            ],
+            [
+              1.7676749,
+              0.1,
+              2.2
+            ],
+            [
+              1.7676749,
+              0.1,
+              1
+            ],
+            [
+              2.667675,
+              0.1,
+              2.2
+            ],
+            [
+              2.667675,
+              0.1,
+              1
+            ],
+            [
+              4.9466066,
+              0.1,
+              2.2
+            ],
+            [
+              4.9466066,
+              0.1,
+              1
+            ],
+            [
+              5.8466067,
+              0.1,
+              2.2
+            ],
+            [
+              5.8466067,
+              0.1,
+              1
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "path": "8407e490-ceaa-56e5-96df-2351d9110668",
+      "attributes": {
+        "usd::usdgeom::basiscurves": {
+          "points": [
+            [
+              0,
+              0,
+              0
+            ],
+            [
+              10,
+              0,
+              0
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "path": "9d1fce89-e179-5076-9a3b-1b40eef3524b",
+      "attributes": {
+        "usd::usdgeom::basiscurves": {
+          "points": [
+            [
+              0,
+              0,
+              0
+            ],
+            [
+              0,
+              0,
+              3
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "path": "367f7f7d-b4c5-50fe-829a-6bbced170dd1",
+      "attributes": {
+        "usd::usdgeom::mesh": {
+          "faceVertexIndices": [
+            0,
+            1,
+            3,
+            2,
+            3,
+            1
+          ],
+          "points": [
+            [
+              0,
+              0,
+              0
+            ],
+            [
+              0,
+              0.1,
+              0
+            ],
+            [
+              10,
+              0.1,
+              0
+            ],
+            [
+              10,
+              0,
+              0
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "path": "2c2d549f-f9fe-4e22-8590-562fda81a690",
+      "attributes": {
+        "customdata": {
+          "originalStepInstance": "#1262=IfcWindow('0iBLIV_VvE8eMGLY$QWQQG',$,'Window',$,$,#1349,#1291,$,$,$,$,$,$)"
+        }
+      }
+    },
+    {
+      "path": "2c2d549f-f9fe-4e22-8590-562fda81a690",
+      "attributes": {
+        "bsi::ifc::class": {
+          "code": "IfcWindow",
+          "uri": "https://identifier.buildingsmart.org/uri/buildingsmart/ifc/4.3/class/IfcWindow"
+        }
+      }
+    },
+    {
+      "path": "2c2d549f-f9fe-4e22-8590-562fda81a690",
+      "attributes": {
+        "bsi::ifc::prop::IsExternal": true
+      }
+    },
+    {
+      "path": "2c2d549f-f9fe-4e22-8590-562fda81a690",
+      "attributes": {
+        "usd::xformop": {
+          "transform": [
+            [
+              1,
+              0,
+              0,
+              0
+            ],
+            [
+              0,
+              1,
+              0,
+              0
+            ],
+            [
+              0,
+              0,
+              1,
+              0
+            ],
+            [
+              1.76767492294312,
+              0,
+              1,
+              1
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "path": "592504dc-469a-44d6-9ae8-c801b591679b",
+      "attributes": {
+        "customdata": {
+          "originalStepInstance": "#1407=IfcWindow('1P9GJSHff4rfheo06raMUR',$,'Window',$,$,#1478,#1435,$,$,$,$,$,$)"
+        }
+      }
+    },
+    {
+      "path": "592504dc-469a-44d6-9ae8-c801b591679b",
+      "attributes": {
+        "bsi::ifc::class": {
+          "code": "IfcWindow",
+          "uri": "https://identifier.buildingsmart.org/uri/buildingsmart/ifc/4.3/class/IfcWindow"
+        }
+      }
+    },
+    {
+      "path": "592504dc-469a-44d6-9ae8-c801b591679b",
+      "attributes": {
+        "bsi::ifc::prop::IsExternal": true
+      }
+    },
+    {
+      "path": "592504dc-469a-44d6-9ae8-c801b591679b",
+      "attributes": {
+        "usd::xformop": {
+          "transform": [
+            [
+              1,
+              0,
+              0,
+              0
+            ],
+            [
+              0,
+              1,
+              0,
+              0
+            ],
+            [
+              0,
+              0,
+              1,
+              0
+            ],
+            [
+              4.94660663604736,
+              0,
+              1,
+              1
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "path": "c8ecbf4c-e37a-4489-9133-15163b8a904e",
+      "attributes": {
+        "bsi::ifc::spaceBoundary": {
+          "relatedelement": {
+            "ref": "93791d5d-5beb-437b-b8ec-2f1f0ba4bf3b"
+          },
+          "relatingspace": {
+            "ref": "e3035b71-bd9f-4cdc-86fd-b56e2f4605b6"
+          }
+        }
+      }
+    },
+    {
+      "path": "911155b7-f688-51ee-8e3e-b97475be2452",
+      "attributes": {
+        "usd::usdgeom::mesh": {
+          "faceVertexIndices": [
+            2,
+            0,
+            1,
+            2,
+            3,
+            0
+          ],
+          "points": [
+            [
+              0,
+              -2.3841858e-08,
+              0
+            ],
+            [
+              0,
+              -2.3841858e-08,
+              3
+            ],
+            [
+              10,
+              -2.3841858e-08,
+              3
+            ],
+            [
+              10,
+              -2.3841858e-08,
+              0
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "path": "cc40ef6e-950e-4b79-a802-4cc710294e3a",
+      "attributes": {
+        "bsi::ifc::spaceBoundary": {
+          "relatedelement": {
+            "ref": "2c2d549f-f9fe-4e22-8590-562fda81a690"
+          },
+          "relatingspace": {
+            "ref": "e3035b71-bd9f-4cdc-86fd-b56e2f4605b6"
+          }
+        }
+      }
+    },
+    {
+      "path": "f3aa8991-7481-5d6b-8dae-f98c372f4a98",
+      "attributes": {
+        "usd::usdgeom::mesh": {
+          "faceVertexIndices": [
+            3,
+            0,
+            1,
+            3,
+            1,
+            2
+          ],
+          "points": [
+            [
+              2.667675,
+              -2.3841858e-08,
+              1
+            ],
+            [
+              1.7676749,
+              -2.3841858e-08,
+              1
+            ],
+            [
+              1.7676749,
+              -2.3841858e-08,
+              2.2
+            ],
+            [
+              2.667675,
+              -2.3841858e-08,
+              2.2
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "path": "7f2a3284-bf01-4b0a-85e4-e48d92ba56dd",
+      "attributes": {
+        "bsi::ifc::spaceBoundary": {
+          "relatedelement": {
+            "ref": "592504dc-469a-44d6-9ae8-c801b591679b"
+          },
+          "relatingspace": {
+            "ref": "e3035b71-bd9f-4cdc-86fd-b56e2f4605b6"
+          }
+        }
+      }
+    },
+    {
+      "path": "126781f3-6465-5c39-9216-81cc636eeb39",
+      "attributes": {
+        "usd::usdgeom::mesh": {
+          "faceVertexIndices": [
+            1,
+            2,
+            3,
+            1,
+            3,
+            0
+          ],
+          "points": [
+            [
+              4.9466066,
+              -2.3841858e-08,
+              2.2
+            ],
+            [
+              5.8466067,
+              -2.3841858e-08,
+              2.2
+            ],
+            [
+              5.8466067,
+              -2.3841858e-08,
+              1
+            ],
+            [
+              4.9466066,
+              -2.3841858e-08,
+              1
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "path": "25503984-6605-43a1-8597-eae657ff5bea",
+      "attributes": {
+        "bsi::ifc::prop::Volume": 0.025999999592,
+        "bsi::ifc::prop::Height": 1.2
+      }
+    },
+    {
+      "path": "e3035b71-bd9f-4cdc-86fd-b56e2f4605b6",
+      "attributes": {
+        "bsi::ifc::prop::Volume": 120.0,
+        "bsi::ifc::prop::Height": 3.0
+      }
+    },
+    {
+      "path": "93791d5d-5beb-437b-b8ec-2f1f0ba4bf3b",
+      "attributes": {
+        "bsi::ifc::prop::Volume": 2.783999976,
+        "bsi::ifc::prop::Height": 3.0
+      }
+    },
+    {
+      "path": "4549bada-a37e-5044-bb70-456516cca5a8",
+      "attributes": {
+        "bsi::ifc::material": {
+          "code": "WOOD",
+          "uri": "https://identifier.buildingsmart.org/uri/fish/midas-materials/26/class/WOOD"
+        },
+        "bsi::ifc::presentation::diffuseColor": [
+          0.8,
+          0.7,
+          0.6
+        ],
+        "bsi::ifc-mat::prop::StrengthClass": "C24",
+        "bsi::ifc-mat::prop::MoistureContent": 0.56,
+        "bsi::ifc-mat::prop::MassDensity": 529.0,
+        "bsi::ifc-mat::prop::GWP": {
+          "A1-A3": -629.4,
+          "A4": 0,
+          "A5": 0,
+          "C2": 1.802,
+          "C3": 863,
+          "D": -274.8
+        }
+      }
+    },
+    {
+      "path": "08f06095-3f32-55b9-a353-61c9aca5cc4d",
+      "attributes": {
+        "usd::usdgeom::mesh": {
+          "faceVertexIndices": [
+            3,
+            0,
+            1,
+            2,
+            3,
+            1,
+            7,
+            4,
+            5,
+            7,
+            5,
+            6,
+            10,
+            11,
+            8,
+            10,
+            8,
+            9,
+            14,
+            15,
+            12,
+            13,
+            14,
+            12,
+            19,
+            17,
+            16,
+            19,
+            16,
+            18,
+            21,
+            22,
+            23,
+            21,
+            23,
+            20,
+            26,
+            25,
+            24,
+            26,
+            27,
+            25,
+            28,
+            30,
+            31,
+            29,
+            28,
+            31,
+            32,
+            34,
+            35,
+            32,
+            35,
+            33,
+            39,
+            36,
+            37,
+            39,
+            37,
+            38,
+            41,
+            42,
+            43,
+            41,
+            43,
+            40,
+            47,
+            44,
+            45,
+            47,
+            45,
+            46,
+            49,
+            50,
+            51,
+            49,
+            51,
+            48,
+            55,
+            53,
+            52,
+            55,
+            52,
+            54,
+            56,
+            58,
+            59,
+            56,
+            59,
+            57,
+            63,
+            61,
+            60,
+            63,
+            60,
+            62
+          ],
+          "points": [
+            [
+              0.099999994,
+              0.05,
+              0.099999994
+            ],
+            [
+              0.0,
+              0.05,
+              0.0
+            ],
+            [
+              0.0,
+              0.05,
+              1.2
+            ],
+            [
+              0.099999994,
+              0.05,
+              1.1
+            ],
+            [
+              0.099999994,
+              0.0,
+              0.099999994
+            ],
+            [
+              0.099999994,
+              0.0,
+              1.1
+            ],
+            [
+              0.0,
+              0.0,
+              1.2
+            ],
+            [
+              0.0,
+              0.0,
+              0.0
+            ],
+            [
+              0.8,
+              0.0,
+              1.1
+            ],
+            [
+              0.8,
+              0.0,
+              0.099999994
+            ],
+            [
+              0.9,
+              0.0,
+              0.0
+            ],
+            [
+              0.9,
+              0.0,
+              1.2
+            ],
+            [
+              0.099999994,
+              0.0,
+              1.1
+            ],
+            [
+              0.8,
+              0.0,
+              1.1
+            ],
+            [
+              0.9,
+              0.0,
+              1.2
+            ],
+            [
+              0.0,
+              0.0,
+              1.2
+            ],
+            [
+              0.099999994,
+              0.0,
+              0.099999994
+            ],
+            [
+              0.8,
+              0.0,
+              0.099999994
+            ],
+            [
+              0.0,
+              0.0,
+              0.0
+            ],
+            [
+              0.9,
+              0.0,
+              0.0
+            ],
+            [
+              0.8,
+              0.05,
+              1.1
+            ],
+            [
+              0.9,
+              0.05,
+              1.2
+            ],
+            [
+              0.9,
+              0.05,
+              0.0
+            ],
+            [
+              0.8,
+              0.05,
+              0.099999994
+            ],
+            [
+              0.0,
+              0.05,
+              1.2
+            ],
+            [
+              0.099999994,
+              0.05,
+              1.1
+            ],
+            [
+              0.9,
+              0.05,
+              1.2
+            ],
+            [
+              0.8,
+              0.05,
+              1.1
+            ],
+            [
+              0.9,
+              0.05,
+              0.0
+            ],
+            [
+              0.8,
+              0.05,
+              0.099999994
+            ],
+            [
+              0.0,
+              0.05,
+              0.0
+            ],
+            [
+              0.099999994,
+              0.05,
+              0.099999994
+            ],
+            [
+              0.0,
+              0.05,
+              0.0
+            ],
+            [
+              0.0,
+              0.0,
+              0.0
+            ],
+            [
+              0.9,
+              0.05,
+              0.0
+            ],
+            [
+              0.9,
+              0.0,
+              0.0
+            ],
+            [
+              0.9,
+              0.0,
+              0.0
+            ],
+            [
+              0.9,
+              0.05,
+              0.0
+            ],
+            [
+              0.9,
+              0.05,
+              1.2
+            ],
+            [
+              0.9,
+              0.0,
+              1.2
+            ],
+            [
+              0.8,
+              0.0,
+              0.099999994
+            ],
+            [
+              0.8,
+              0.05,
+              0.099999994
+            ],
+            [
+              0.099999994,
+              0.05,
+              0.099999994
+            ],
+            [
+              0.099999994,
+              0.0,
+              0.099999994
+            ],
+            [
+              0.8,
+              0.0,
+              1.1
+            ],
+            [
+              0.8,
+              0.05,
+              1.1
+            ],
+            [
+              0.8,
+              0.05,
+              0.099999994
+            ],
+            [
+              0.8,
+              0.0,
+              0.099999994
+            ],
+            [
+              0.9,
+              0.0,
+              1.2
+            ],
+            [
+              0.9,
+              0.05,
+              1.2
+            ],
+            [
+              0.0,
+              0.05,
+              1.2
+            ],
+            [
+              0.0,
+              0.0,
+              1.2
+            ],
+            [
+              0.0,
+              0.05,
+              1.2
+            ],
+            [
+              0.0,
+              0.0,
+              1.2
+            ],
+            [
+              0.0,
+              0.05,
+              0.0
+            ],
+            [
+              0.0,
+              0.0,
+              0.0
+            ],
+            [
+              0.099999994,
+              0.05,
+              1.1
+            ],
+            [
+              0.099999994,
+              0.0,
+              1.1
+            ],
+            [
+              0.8,
+              0.05,
+              1.1
+            ],
+            [
+              0.8,
+              0.0,
+              1.1
+            ],
+            [
+              0.099999994,
+              0.05,
+              0.099999994
+            ],
+            [
+              0.099999994,
+              0.0,
+              0.099999994
+            ],
+            [
+              0.099999994,
+              0.05,
+              1.1
+            ],
+            [
+              0.099999994,
+              0.0,
+              1.1
+            ]
+          ]
+        }
+      },
+      "inherits": {
+        "material": "4549bada-a37e-5044-bb70-456516cca5a8"
+      }
+    },
+    {
+      "path": "d10e4eb4-6a35-5fbe-9491-7a6fb93f1691",
+      "attributes": {
+        "bsi::ifc::material": {
+          "code": "GLASS",
+          "uri": "https://identifier.buildingsmart.org/uri/fish/midas-materials/26/class/GLASS"
+        },
+        "bsi::ifc::presentation::diffuseColor": [
+          0.5,
+          0.8,
+          0.6
+        ],
+        "bsi::ifc::presentation::opacity": 0.3
+      }
+    },
+    {
+      "path": "5ad6f475-c04c-5628-8b9d-75d0bab0c0e5",
+      "attributes": {
+        "usd::usdgeom::mesh": {
+          "faceVertexIndices": [
+            0,
+            1,
+            2,
+            0,
+            2,
+            3,
+            7,
+            4,
+            5,
+            7,
+            5,
+            6,
+            9,
+            10,
+            11,
+            9,
+            11,
+            8,
+            15,
+            12,
+            13,
+            15,
+            13,
+            14,
+            17,
+            18,
+            19,
+            17,
+            19,
+            16,
+            23,
+            20,
+            21,
+            23,
+            21,
+            22
+          ],
+          "points": [
+            [
+              0.8,
+              0.02,
+              0.099999994
+            ],
+            [
+              0.8,
+              0.02,
+              1.1
+            ],
+            [
+              0.099999994,
+              0.02,
+              1.1
+            ],
+            [
+              0.099999994,
+              0.02,
+              0.099999994
+            ],
+            [
+              0.8,
+              0.03,
+              0.099999994
+            ],
+            [
+              0.099999994,
+              0.03,
+              0.099999994
+            ],
+            [
+              0.099999994,
+              0.03,
+              1.1
+            ],
+            [
+              0.8,
+              0.03,
+              1.1
+            ],
+            [
+              0.8,
+              0.02,
+              1.1
+            ],
+            [
+              0.8,
+              0.03,
+              1.1
+            ],
+            [
+              0.099999994,
+              0.03,
+              1.1
+            ],
+            [
+              0.099999994,
+              0.02,
+              1.1
+            ],
+            [
+              0.099999994,
+              0.02,
+              1.1
+            ],
+            [
+              0.099999994,
+              0.03,
+              1.1
+            ],
+            [
+              0.099999994,
+              0.03,
+              0.099999994
+            ],
+            [
+              0.099999994,
+              0.02,
+              0.099999994
+            ],
+            [
+              0.099999994,
+              0.02,
+              0.099999994
+            ],
+            [
+              0.099999994,
+              0.03,
+              0.099999994
+            ],
+            [
+              0.8,
+              0.03,
+              0.099999994
+            ],
+            [
+              0.8,
+              0.02,
+              0.099999994
+            ],
+            [
+              0.8,
+              0.02,
+              0.099999994
+            ],
+            [
+              0.8,
+              0.03,
+              0.099999994
+            ],
+            [
+              0.8,
+              0.03,
+              1.1
+            ],
+            [
+              0.8,
+              0.02,
+              1.1
+            ]
+          ]
+        }
+      },
+      "inherits": {
+        "material": "d10e4eb4-6a35-5fbe-9491-7a6fb93f1691"
+      }
+    }
+  ]
+}

--- a/apps/viewer/src/components/tours/TourHost.tsx
+++ b/apps/viewer/src/components/tours/TourHost.tsx
@@ -24,6 +24,7 @@ import { TourStepCard } from './TourStepCard';
 function PrereqCard({ tour }: { tour: TourDefinition }) {
   const demoLoading = useTourStore((s) => s.demoLoading);
   const needsSecond = Boolean(tour.prerequisites?.secondModel);
+  const needsStack = Boolean(tour.prerequisites?.layerStack);
   return (
     <div
       role="dialog"
@@ -32,9 +33,11 @@ function PrereqCard({ tour }: { tour: TourDefinition }) {
     >
       <div className="text-sm font-semibold">{tour.title}</div>
       <p className="mt-1 text-[13px] leading-relaxed text-muted-foreground">
-        {needsSecond
-          ? 'This tour needs two loaded revisions of a model. Load the demo project to follow along.'
-          : 'This tour needs a loaded model. Load the demo project to follow along, or open your own IFC file first.'}
+        {needsStack
+          ? 'This tour needs a composed layer stack. Load the demo stack (three tiny layers) to follow along.'
+          : needsSecond
+            ? 'This tour needs two loaded revisions of a model. Load the demo project to follow along.'
+            : 'This tour needs a loaded model. Load the demo project to follow along, or open your own IFC file first.'}
       </p>
       <div className="mt-3 flex items-center justify-end gap-1.5">
         <Button variant="ghost" size="sm" className="text-muted-foreground" onClick={cancelPrereq} disabled={demoLoading}>
@@ -42,7 +45,7 @@ function PrereqCard({ tour }: { tour: TourDefinition }) {
         </Button>
         <Button size="sm" disabled={demoLoading} onClick={() => void confirmPrereqWithDemo()}>
           {demoLoading && <Loader2 className="animate-spin" />}
-          Load demo project
+          {needsStack ? 'Load demo stack' : 'Load demo project'}
         </Button>
       </div>
     </div>

--- a/apps/viewer/src/components/viewer/CommandPalette.tsx
+++ b/apps/viewer/src/components/viewer/CommandPalette.tsx
@@ -65,6 +65,7 @@ import {
   Slice,
   Layers,
   Layers3,
+  Users,
   SquareStack,
   ChevronsUpDown,
   PanelRight,
@@ -72,6 +73,7 @@ import {
   ChevronsRight,
   GraduationCap,
 } from 'lucide-react';
+import { isCollabEnabled } from '@/lib/collab/config';
 import { cn } from '@/lib/utils';
 import { useViewerStore } from '@/store';
 import { applyLevelDisplayMode } from '@/store/levelDisplay';
@@ -217,7 +219,7 @@ function recordUsage(id: string) {
  *  analysis extension first preserves the prior "panels win the slot" behavior.
  *  Kept as two thin helpers so every existing command action keeps its call
  *  site (the `'list'` legacy id maps to the registry's `'lists'`). */
-function activateRightPanel(panel: 'bcf' | 'ids' | 'lens' | 'clash' | 'compare' | 'extensions' | 'layers') {
+function activateRightPanel(panel: 'bcf' | 'ids' | 'lens' | 'clash' | 'compare' | 'extensions' | 'layers' | 'collab') {
   closeActiveAnalysisExtension();
   useViewerStore.getState().toggleWorkspacePanel(panel);
 }
@@ -446,6 +448,10 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
         action: () => { activateRightPanel('lens'); } },
       { id: 'panel:layers', label: 'Layer Stack', keywords: 'ifcx layers federation draft publish merge review provenance registry version overlay', category: 'Panels', icon: Layers,
         action: () => { activateRightPanel('layers'); } },
+      ...(isCollabEnabled()
+        ? [{ id: 'panel:collab', label: 'Collaboration Room', keywords: 'share invite live multiplayer presence room realtime sync', category: 'Panels' as const, icon: Users,
+            action: () => { activateRightPanel('collab'); } }]
+        : []),
       { id: 'panel:extensions', label: 'Extensions', keywords: 'extension plugin install manage iflx', category: 'Panels', icon: Puzzle,
         action: () => { activateRightPanel('extensions'); } },
       // ── Customization entry points — first-class discoverability

--- a/apps/viewer/src/components/viewer/CommandPalette.tsx
+++ b/apps/viewer/src/components/viewer/CommandPalette.tsx
@@ -63,6 +63,7 @@ import {
   Pencil,
   PenLine,
   Slice,
+  Layers,
   Layers3,
   SquareStack,
   ChevronsUpDown,
@@ -216,7 +217,7 @@ function recordUsage(id: string) {
  *  analysis extension first preserves the prior "panels win the slot" behavior.
  *  Kept as two thin helpers so every existing command action keeps its call
  *  site (the `'list'` legacy id maps to the registry's `'lists'`). */
-function activateRightPanel(panel: 'bcf' | 'ids' | 'lens' | 'clash' | 'compare' | 'extensions') {
+function activateRightPanel(panel: 'bcf' | 'ids' | 'lens' | 'clash' | 'compare' | 'extensions' | 'layers') {
   closeActiveAnalysisExtension();
   useViewerStore.getState().toggleWorkspacePanel(panel);
 }
@@ -443,6 +444,8 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
         action: () => { activateBottomPanel('gantt'); } },
       { id: 'panel:lens', label: 'Lens Rules', keywords: 'color filter highlight', category: 'Panels', icon: Palette,
         action: () => { activateRightPanel('lens'); } },
+      { id: 'panel:layers', label: 'Layer Stack', keywords: 'ifcx layers federation draft publish merge review provenance registry version overlay', category: 'Panels', icon: Layers,
+        action: () => { activateRightPanel('layers'); } },
       { id: 'panel:extensions', label: 'Extensions', keywords: 'extension plugin install manage iflx', category: 'Panels', icon: Puzzle,
         action: () => { activateRightPanel('extensions'); } },
       // ── Customization entry points — first-class discoverability

--- a/apps/viewer/src/components/viewer/MainToolbar.tsx
+++ b/apps/viewer/src/components/viewer/MainToolbar.tsx
@@ -327,6 +327,7 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
   const collabPeerCount = useViewerStore((s) => s.collabPeers.length);
   const collabRoomId = useViewerStore((s) => s.collabRoomId);
   const collabPanelVisible = useViewerStore((s) => s.collabPanelVisible);
+  const layersPanelVisible = useViewerStore((s) => s.layersPanelVisible);
   const {
     loadFile,
     loading,
@@ -754,7 +755,7 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
     setScriptPanelVisible,
   ]);
 
-  const handleToggleRightPanel = useCallback((panel: 'bcf' | 'ids' | 'lens' | 'clash' | 'compare' | 'addElement' | 'extensions' | 'layers' | 'collab') => {
+  const handleToggleRightPanel = useCallback((panel: 'bcf' | 'ids' | 'lens' | 'clash' | 'compare' | 'addElement' | 'extensions') => {
     if (activeAnalysisExtension?.placement !== 'bottom') {
       closeActiveAnalysisExtension();
     }
@@ -874,12 +875,16 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
     if (comparePanelVisible) panels.add('compare');
     if (extensionsPanelVisible) panels.add('extensions');
     if (activeTool === 'addElement') panels.add('addElement');
+    if (layersPanelVisible) panels.add('layers');
+    if (collabPanelVisible) panels.add('collab');
     if (analysisExtensionState.activeId) panels.add(analysisExtensionState.activeId);
     return panels;
   }, [
     activeTool,
     analysisExtensionState.activeId,
     bcfPanelVisible,
+    collabPanelVisible,
+    layersPanelVisible,
     clashPanelVisible,
     comparePanelVisible,
     extensionsPanelVisible,
@@ -903,6 +908,8 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
     if (activeWorkspacePanels.has('compare')) return 'Compare Models';
     if (activeWorkspacePanels.has('extensions')) return 'Extensions';
     if (activeWorkspacePanels.has('addElement')) return 'Add Element';
+    if (activeWorkspacePanels.has('layers')) return 'Layer Stack';
+    if (activeWorkspacePanels.has('collab')) return 'Collaboration Room';
     return activeAnalysisExtension?.label ?? 'Analysis';
   }, [activeAnalysisExtension?.label, activeWorkspacePanels]);
 
@@ -1291,7 +1298,7 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
           </DropdownMenuCheckboxItem>
           <DropdownMenuCheckboxItem
             checked={activeWorkspacePanels.has('layers')}
-            onCheckedChange={() => handleToggleRightPanel('layers')}
+            onCheckedChange={() => useViewerStore.getState().toggleWorkspacePanel('layers')}
           >
             <Layers className="h-4 w-4 mr-2" />
             Layer Stack
@@ -1299,7 +1306,7 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
           {collabEnabled && (
             <DropdownMenuCheckboxItem
               checked={activeWorkspacePanels.has('collab')}
-              onCheckedChange={() => handleToggleRightPanel('collab')}
+              onCheckedChange={() => useViewerStore.getState().toggleWorkspacePanel('collab')}
             >
               <Users className="h-4 w-4 mr-2" />
               Collaboration Room

--- a/apps/viewer/src/components/viewer/MainToolbar.tsx
+++ b/apps/viewer/src/components/viewer/MainToolbar.tsx
@@ -366,13 +366,18 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
         void loadFederatedIfcx(files as File[]);
       }
     };
+    // Panels (RoomPanel empty state) request the Share dialog this way —
+    // its open state is toolbar-local.
+    const shareHandler = () => setShareDialogOpen(true);
     window.addEventListener('ifc-lite:load-file', handler);
     window.addEventListener('ifc-lite:add-model', addHandler);
     window.addEventListener('ifc-lite:load-layer-stack', stackHandler);
+    window.addEventListener('ifc-lite:open-share-dialog', shareHandler);
     return () => {
       window.removeEventListener('ifc-lite:load-file', handler);
       window.removeEventListener('ifc-lite:add-model', addHandler);
       window.removeEventListener('ifc-lite:load-layer-stack', stackHandler);
+      window.removeEventListener('ifc-lite:open-share-dialog', shareHandler);
     };
   }, [loadFile, addModel, loadFederatedIfcx]);
 
@@ -749,7 +754,7 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
     setScriptPanelVisible,
   ]);
 
-  const handleToggleRightPanel = useCallback((panel: 'bcf' | 'ids' | 'lens' | 'clash' | 'compare' | 'addElement' | 'extensions' | 'layers') => {
+  const handleToggleRightPanel = useCallback((panel: 'bcf' | 'ids' | 'lens' | 'clash' | 'compare' | 'addElement' | 'extensions' | 'layers' | 'collab') => {
     if (activeAnalysisExtension?.placement !== 'bottom') {
       closeActiveAnalysisExtension();
     }
@@ -1291,6 +1296,15 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
             <Layers className="h-4 w-4 mr-2" />
             Layer Stack
           </DropdownMenuCheckboxItem>
+          {collabEnabled && (
+            <DropdownMenuCheckboxItem
+              checked={activeWorkspacePanels.has('collab')}
+              onCheckedChange={() => handleToggleRightPanel('collab')}
+            >
+              <Users className="h-4 w-4 mr-2" />
+              Collaboration Room
+            </DropdownMenuCheckboxItem>
+          )}
           <DropdownMenuSeparator />
           <DropdownMenuLabel className="text-[10px] uppercase tracking-wide text-muted-foreground">
             Author

--- a/apps/viewer/src/components/viewer/MainToolbar.tsx
+++ b/apps/viewer/src/components/viewer/MainToolbar.tsx
@@ -41,6 +41,7 @@ import {
   Palette,
   Orbit,
   Layout,
+  Layers,
   LayoutTemplate,
   FileCode2,
   CalendarClock,
@@ -357,13 +358,23 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
       const file = (e as CustomEvent<unknown>).detail;
       if (file instanceof File) void addModel(file);
     };
+    // Layer-stack variant: load a File[] as a composed .ifcx federation
+    // (the Layers panel demo + tour dispatch this, see lib/layers/demo-stack).
+    const stackHandler = (e: Event) => {
+      const files = (e as CustomEvent<unknown>).detail;
+      if (Array.isArray(files) && files.every((f) => f instanceof File) && files.length > 0) {
+        void loadFederatedIfcx(files as File[]);
+      }
+    };
     window.addEventListener('ifc-lite:load-file', handler);
     window.addEventListener('ifc-lite:add-model', addHandler);
+    window.addEventListener('ifc-lite:load-layer-stack', stackHandler);
     return () => {
       window.removeEventListener('ifc-lite:load-file', handler);
       window.removeEventListener('ifc-lite:add-model', addHandler);
+      window.removeEventListener('ifc-lite:load-layer-stack', stackHandler);
     };
-  }, [loadFile, addModel]);
+  }, [loadFile, addModel, loadFederatedIfcx]);
 
   // Check if we have models loaded (for showing add model button)
   const hasModelsLoaded = models.size > 0 || (geometryResult?.meshes && geometryResult.meshes.length > 0);
@@ -738,7 +749,7 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
     setScriptPanelVisible,
   ]);
 
-  const handleToggleRightPanel = useCallback((panel: 'bcf' | 'ids' | 'lens' | 'clash' | 'compare' | 'addElement' | 'extensions') => {
+  const handleToggleRightPanel = useCallback((panel: 'bcf' | 'ids' | 'lens' | 'clash' | 'compare' | 'addElement' | 'extensions' | 'layers') => {
     if (activeAnalysisExtension?.placement !== 'bottom') {
       closeActiveAnalysisExtension();
     }
@@ -1272,6 +1283,13 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
           >
             <GitCompareArrows className="h-4 w-4 mr-2" />
             Compare Models
+          </DropdownMenuCheckboxItem>
+          <DropdownMenuCheckboxItem
+            checked={activeWorkspacePanels.has('layers')}
+            onCheckedChange={() => handleToggleRightPanel('layers')}
+          >
+            <Layers className="h-4 w-4 mr-2" />
+            Layer Stack
           </DropdownMenuCheckboxItem>
           <DropdownMenuSeparator />
           <DropdownMenuLabel className="text-[10px] uppercase tracking-wide text-muted-foreground">

--- a/apps/viewer/src/components/viewer/RoomPanel.tsx
+++ b/apps/viewer/src/components/viewer/RoomPanel.tsx
@@ -14,7 +14,7 @@
  */
 
 import { useCallback, useMemo, useState } from 'react';
-import { Check, Link2, LocateFixed, LogOut, ShieldOff, UserMinus, Users } from 'lucide-react';
+import { Check, Link2, LocateFixed, LogOut, Share2, ShieldOff, UserMinus, Users } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
@@ -243,10 +243,21 @@ export function RoomPanel({ onClose }: RoomPanelProps) {
     return (
       <div className="flex h-full flex-col items-center justify-center gap-2 p-6 text-center">
         <Users className="size-6 text-muted-foreground" aria-hidden />
-        <p className="text-sm font-medium">Not in a shared room</p>
-        <p className="text-xs text-muted-foreground">
-          Use the Share button in the toolbar to create a room and copy an
-          invite link, or open a link someone shared with you.
+        <p className="text-sm font-medium">Work on this model together</p>
+        <p className="max-w-[30ch] text-xs text-muted-foreground">
+          Create a room to edit live with others: shared cursors, presence,
+          and every edit synced. Invites are one link.
+        </p>
+        <Button
+          size="sm"
+          className="mt-1 h-7 gap-1.5 px-3 text-[11px]"
+          onClick={() => window.dispatchEvent(new CustomEvent('ifc-lite:open-share-dialog'))}
+        >
+          <Share2 className="size-3.5" aria-hidden />
+          Create a room
+        </Button>
+        <p className="max-w-[30ch] text-[10px] text-muted-foreground/70">
+          Got an invite? Just open the link - it lands you in the room.
         </p>
       </div>
     );

--- a/apps/viewer/src/components/viewer/ViewportContainer.tsx
+++ b/apps/viewer/src/components/viewer/ViewportContainer.tsx
@@ -44,7 +44,7 @@ import { toast } from '@/components/ui/toast';
 import { TourInvite } from '@/components/tours/TourInvite';
 import { TOUR_ANCHORS, tourAnchor } from '@/lib/tours/anchors';
 import { describeUnsupportedFormat } from '@/hooks/ingest/pointCloudIngest';
-import { Upload, MousePointer, Layers, Info, Command, AlertTriangle, ChevronDown, ExternalLink, Plus, Clock3, Sparkles, ArrowUpRight, PackagePlus } from 'lucide-react';
+import { Upload, MousePointer, Layers, Info, Command, AlertTriangle, ChevronDown, ExternalLink, Plus, Clock3, Sparkles, ArrowUpRight, PackagePlus , GitMerge } from 'lucide-react';
 import { createBlankIfcFile } from '@/utils/createBlankIfc';
 import type { MeshData, CoordinateInfo, GeometryResult, PointCloudAsset } from '@ifc-lite/geometry';
 import { type IfcDataStore, type MapConversion } from '@ifc-lite/parser';
@@ -1267,7 +1267,33 @@ export function ViewportContainer() {
             ))}
           </div>
 
-          {/* Footer chips — left: discovery link to the marketing site for first-time
+          {/* Moonshot callout (#1717): Layer PRs are brand new - nobody knows
+              to multi-drop .ifcx files, so the welcome screen sells the demo. */}
+          <button
+            type="button"
+            onClick={() => {
+              void import('@/lib/layers/demo-stack').then((m) => m.loadDemoLayerStack());
+            }}
+            className="group mt-6 hidden md:flex items-center gap-3 max-w-3xl w-full p-4 bg-zinc-100 dark:bg-[#1f2335] border border-primary/40 hover:border-primary transition-colors text-left"
+          >
+            <div className="p-2 bg-white dark:bg-[#16161e] border border-zinc-300 dark:border-[#3b4261] text-primary">
+              <GitMerge className="h-5 w-5" />
+            </div>
+            <div className="min-w-0 flex-1">
+              <h3 className="font-bold uppercase text-sm tracking-wide text-zinc-900 dark:text-[#a9b1d6]">
+                <span className="mr-2 rounded-sm bg-primary px-1.5 py-0.5 text-[10px] text-primary-foreground">New</span>
+                Layers
+              </h3>
+              <p className="text-xs font-mono text-zinc-500 dark:text-[#565f89]">
+                Version your model like code: layers, drafts, merges, reviews
+              </p>
+            </div>
+            <span className="text-xs font-mono font-bold text-primary group-hover:translate-x-0.5 transition-transform">
+              Try the demo stack &rarr;
+            </span>
+          </button>
+
+          {/* Footer chips - left: discovery link to the marketing site for first-time
               visitors, right: shortcuts cue for power users. Both desktop-only. */}
           <div className="absolute bottom-8 left-8 hidden md:block">
             <a

--- a/apps/viewer/src/components/viewer/ViewportContainer.tsx
+++ b/apps/viewer/src/components/viewer/ViewportContainer.tsx
@@ -1272,7 +1272,9 @@ export function ViewportContainer() {
           <button
             type="button"
             onClick={() => {
-              void import('@/lib/layers/demo-stack').then((m) => m.loadDemoLayerStack());
+              void import('@/lib/layers/demo-stack')
+                .then((m) => m.loadDemoLayerStack())
+                .catch((err: unknown) => toast.error(err instanceof Error ? err.message : String(err)));
             }}
             className="group mt-6 hidden md:flex items-center gap-3 max-w-3xl w-full p-4 bg-zinc-100 dark:bg-[#1f2335] border border-primary/40 hover:border-primary transition-colors text-left"
           >

--- a/apps/viewer/src/components/viewer/layers/LayerDiffView.tsx
+++ b/apps/viewer/src/components/viewer/layers/LayerDiffView.tsx
@@ -12,6 +12,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { StackDiff } from '@ifc-lite/merge';
 import { useViewerStore } from '@/store';
+import { tourAnchor, TOUR_ANCHORS } from '@/lib/tours/anchors';
 import type { LayerStackEntry } from '@/store/slices/layerStackSlice';
 import { pathTail } from '@/lib/layers/stack';
 import { Ghost } from 'lucide-react';
@@ -121,7 +122,10 @@ export function LayerDiffView({ entry, diff }: { entry: LayerStackEntry; diff: S
   ];
 
   return (
-    <div className="animate-in fade-in slide-in-from-top-1 rounded-md border bg-card/30 p-2">
+    <div
+      className="animate-in fade-in slide-in-from-top-1 rounded-md border bg-card/30 p-2"
+      {...tourAnchor(TOUR_ANCHORS.layersDiff)}
+    >
       <div className="flex items-center justify-between gap-2 pb-1.5">
         <span className="truncate text-[11px] font-medium" title={entry.name}>
           Changes by {entry.name}

--- a/apps/viewer/src/components/viewer/layers/LayerDraftSection.tsx
+++ b/apps/viewer/src/components/viewer/layers/LayerDraftSection.tsx
@@ -18,7 +18,7 @@ import { useIfc } from '@/hooks/useIfc';
 import { toast } from '@/components/ui/toast';
 import { getBrowserLayerStore, DEFAULT_LOCAL_REF } from '@/lib/layers/browser-store';
 import { publishCollabDraft, publishViewerDraft } from '@/lib/layers/publish';
-import type { Mutation } from '@ifc-lite/mutations';
+import { pendingCompositionMutations } from '@/lib/layers/pending';
 import { Users } from 'lucide-react';
 
 const AUTHOR_STORAGE_KEY = 'ifc-lite:layer-author';
@@ -32,32 +32,6 @@ function storedAuthor(): string {
   // of matching it out of the box.
   const identity = useViewerStore.getState().collabIdentity?.name;
   return identity && identity.trim().length > 0 ? identity : 'viewer-user';
-}
-
-/**
- * Pending mutations of the FEDERATED composition only. Reads the UNDO
- * stacks, not the view's mutation history: the history is append-only
- * (undo applies inverse ops without removing the record), so publishing
- * from it would resurrect edits the user explicitly undid.
- *
- * Models outside the composition (a STEP model added alongside) have
- * their own overlapping expressId space — resolving those ids through
- * the composition's path bridge would publish onto unrelated entities,
- * so only models sharing the composed data store contribute. Georef
- * pseudo-mutations (entityId 0, georef.* attribute names) carry no
- * entity identity and are dropped.
- */
-function pendingMutations(): Mutation[] {
-  const state = useViewerStore.getState();
-  const out: Mutation[] = [];
-  for (const [modelId, model] of state.models) {
-    if (model.ifcDataStore !== state.ifcDataStore) continue;
-    for (const mutation of state.undoStacks.get(modelId) ?? []) {
-      if (mutation.attributeName?.startsWith('georef.')) continue;
-      out.push(mutation);
-    }
-  }
-  return out;
 }
 
 export function LayerDraftSection() {
@@ -74,7 +48,7 @@ export function LayerDraftSection() {
 
   const pendingCount = useMemo(() => {
     void mutationVersion;
-    return pendingMutations().length;
+    return pendingCompositionMutations().length;
   }, [mutationVersion]);
 
   const publish = useCallback(async () => {
@@ -93,7 +67,7 @@ export function LayerDraftSection() {
       const result = publishViewerDraft({
         store,
         stackFiles: state.layerStack.map((e) => e.file),
-        mutations: pendingMutations(),
+        mutations: pendingCompositionMutations(),
         pathOf: (expressId) => idToPath.get(expressId),
         intent: trimmedIntent,
         authorPrincipal: trimmedAuthor,

--- a/apps/viewer/src/components/viewer/layers/LayersPanel.tsx
+++ b/apps/viewer/src/components/viewer/layers/LayersPanel.tsx
@@ -15,8 +15,8 @@
  * composition's `layerStackPathToId` bridge and nothing here persists ids.
  */
 
-import { useCallback, useState } from 'react';
-import { Bot, GitMerge, Layers, User, Users2 } from 'lucide-react';
+import { useCallback, useRef, useState } from 'react';
+import { Bot, FolderOpen, GitMerge, Layers, Sparkles, User, Users2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
@@ -27,6 +27,10 @@ import { LayerDiffView } from './LayerDiffView';
 import { LayerProvenanceDetail } from './LayerProvenanceDetail';
 import { LayerDraftSection } from './LayerDraftSection';
 import { LayerMergeSection } from './LayerMergeSection';
+import { useIfc } from '@/hooks/useIfc';
+import { loadDemoLayerStack } from '@/lib/layers/demo-stack';
+import { toast } from '@/components/ui/toast';
+import { tourAnchor, TOUR_ANCHORS } from '@/lib/tours/anchors';
 
 interface LayersPanelProps {
   onClose: () => void;
@@ -194,6 +198,20 @@ export function LayersPanel(_props: LayersPanelProps) {
   const layerStackDiff = useViewerStore((s) => s.layerStackDiff);
   const layerDiffBusy = useViewerStore((s) => s.layerDiffBusy);
   const [expandedId, setExpandedId] = useState<string | null>(null);
+  const { loadFederatedIfcx } = useIfc();
+  const stackInputRef = useRef<HTMLInputElement>(null);
+  const [demoBusy, setDemoBusy] = useState(false);
+
+  const loadDemo = useCallback(async () => {
+    setDemoBusy(true);
+    try {
+      await loadDemoLayerStack();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : String(err));
+    } finally {
+      setDemoBusy(false);
+    }
+  }, []);
 
   const inspect = useCallback(
     async (layerId: string) => {
@@ -215,13 +233,58 @@ export function LayersPanel(_props: LayersPanelProps) {
 
   if (layerStack.length === 0) {
     return (
-      <div className="flex h-full flex-col items-center justify-center gap-2 p-6 text-center">
-        <Layers className="size-8 text-muted-foreground/50" aria-hidden />
-        <p className="text-xs font-medium">No layer stack loaded</p>
-        <p className="max-w-[26ch] text-[11px] text-muted-foreground">
-          Drop several .ifcx files together to load a model as composed layers.
-        </p>
-      </div>
+      <ScrollArea className="h-full">
+        <div className="flex flex-col items-center gap-2 p-6 pt-10 text-center">
+          <Layers className="size-8 text-muted-foreground/50" aria-hidden />
+          <p className="text-xs font-medium">Layers: version your model like code</p>
+          <p className="max-w-[30ch] text-[11px] text-muted-foreground">
+            An IFC5 model composes from immutable layers. Inspect who changed
+            what, publish your edits as new layers, and merge them with
+            reviews, checks, and conflict resolution.
+          </p>
+          <div className="flex flex-col gap-1.5 pt-2">
+            <Button
+              size="sm"
+              className="h-7 gap-1.5 px-3 text-[11px]"
+              onClick={() => void loadDemo()}
+              disabled={demoBusy}
+              {...tourAnchor(TOUR_ANCHORS.layersDemo)}
+            >
+              <Sparkles className="size-3.5" aria-hidden />
+              {demoBusy ? 'Loading…' : 'Load demo stack'}
+            </Button>
+            <Button
+              size="sm"
+              variant="outline"
+              className="h-7 gap-1.5 px-3 text-[11px]"
+              onClick={() => stackInputRef.current?.click()}
+            >
+              <FolderOpen className="size-3.5" aria-hidden />
+              Open .ifcx files
+            </Button>
+            <input
+              ref={stackInputRef}
+              type="file"
+              accept=".ifcx"
+              multiple
+              className="hidden"
+              onChange={(e) => {
+                const files = [...(e.target.files ?? [])];
+                e.target.value = '';
+                if (files.length > 0) void loadFederatedIfcx(files);
+              }}
+            />
+          </div>
+          <p className="max-w-[30ch] pt-1 text-[10px] text-muted-foreground/70">
+            You can also drop several .ifcx files anywhere in the viewer.
+          </p>
+          {/* Local candidates from earlier sessions stay actionable even
+              before a stack is loaded (self-hides when the store is empty). */}
+          <div className="w-full pt-2 text-left">
+            <LayerMergeSection />
+          </div>
+        </div>
+      </ScrollArea>
     );
   }
 
@@ -242,8 +305,13 @@ export function LayersPanel(_props: LayersPanelProps) {
       </div>
       <ScrollArea className="min-h-0 flex-1">
         <div className="flex flex-col gap-1 px-2 pb-2">
-          <LayerDraftSection />
-          <LayerMergeSection />
+          <div {...tourAnchor(TOUR_ANCHORS.layersDraft)}>
+            <LayerDraftSection />
+          </div>
+          <div {...tourAnchor(TOUR_ANCHORS.layersMerge)}>
+            <LayerMergeSection />
+          </div>
+          <div className="flex flex-col gap-1" {...tourAnchor(TOUR_ANCHORS.layersStrata)}>
           {strata.map((entry, i) => (
             <div key={entry.id} className="flex flex-col gap-1">
               <LayerStratum
@@ -259,6 +327,7 @@ export function LayersPanel(_props: LayersPanelProps) {
               {expandedId === entry.id && <LayerProvenanceDetail file={entry.file} />}
             </div>
           ))}
+          </div>
           {layerDiffBusy && (
             <p className="px-1 py-2 text-center text-[11px] text-muted-foreground">Computing changes…</p>
           )}

--- a/apps/viewer/src/components/viewer/sidebar/ActivityBar.tsx
+++ b/apps/viewer/src/components/viewer/sidebar/ActivityBar.tsx
@@ -14,7 +14,7 @@
  * gains an eye toggle inline.
  */
 
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import {
   SlidersHorizontal,
   PanelRightClose,
@@ -38,6 +38,7 @@ import { useViewerStore } from '@/store';
 import { usePanelControls } from '@/hooks/usePanelControls';
 import { WORKSPACE_PANELS, getPanelDef, type WorkspacePanelId } from '@/lib/panels/registry';
 import { isCollabEnabled } from '@/lib/collab/config';
+import { pendingCompositionMutations } from '@/lib/layers/pending';
 import { activityAnchor, tourAnchor } from '@/lib/tours/anchors';
 import { CustomizeSidebar } from './CustomizeSidebar';
 
@@ -58,10 +59,18 @@ export function ActivityBar() {
   const setPanelShownInSidebar = useViewerStore((s) => s.setPanelShownInSidebar);
   const reorder = useViewerStore((s) => s.reorderSidebarPanel);
   const resetLayout = useViewerStore((s) => s.resetSidebarLayout);
-  // Layer-stack panel (#1717) only surfaces while a federated stack is loaded.
-  const hasLayerStack = useViewerStore((s) => s.layerStack.length > 0);
 
   const { isOpen, panelLocation, toggle, openInHome, floatPanel, popOutPanel, activePanel } = usePanelControls();
+
+  // Draft-awareness badge on the Layers icon (#1717 exposure): unpublished
+  // composition edits are the moment the feature becomes relevant — surface
+  // the count where the user already looks, like the Room peers badge.
+  const mutationVersion = useViewerStore((s) => s.mutationVersion);
+  const hasStack = useViewerStore((s) => s.layerStack.length > 0);
+  const pendingLayerEdits = useMemo(() => {
+    void mutationVersion;
+    return hasStack ? pendingCompositionMutations().length : 0;
+  }, [mutationVersion, hasStack]);
 
   const hidden = new Set(hiddenIds);
   const [dragId, setDragId] = useState<WorkspacePanelId | null>(null);
@@ -74,8 +83,7 @@ export function ActivityBar() {
   const visibleIds = order.filter(
     (id) =>
       (!hidden.has(id) || id === 'properties') &&
-      (id !== 'collab' || isCollabEnabled()) &&
-      (id !== 'layers' || hasLayerStack),
+      (id !== 'collab' || isCollabEnabled()),
   );
 
   const onIconClick = (id: WorkspacePanelId) => {
@@ -167,6 +175,15 @@ export function ActivityBar() {
                       <span className="absolute left-0 top-1.5 bottom-1.5 w-0.5 rounded-r bg-primary" aria-hidden />
                     )}
                     <Icon className="h-4 w-4" />
+                    {/* Unpublished-edits badge on the Layers icon. */}
+                    {!customizing && id === 'layers' && pendingLayerEdits > 0 && (
+                      <span
+                        className="absolute -right-1 -top-1 flex h-3.5 min-w-3.5 items-center justify-center rounded-full bg-amber-500 px-1 text-[9px] font-medium text-white ring-1 ring-background"
+                        aria-hidden
+                      >
+                        {pendingLayerEdits > 99 ? '99+' : pendingLayerEdits}
+                      </span>
+                    )}
                     {/* Detached indicator dot — floating (primary) vs popped out (emerald). */}
                     {!customizing && open && loc !== 'docked' && (
                       <span

--- a/apps/viewer/src/hooks/useIfcFederation.ts
+++ b/apps/viewer/src/hooks/useIfcFederation.ts
@@ -455,6 +455,23 @@ export function useIfcFederation(
         [...layers].reverse().map((layer) => layerStackEntry(layer)),
         result.pathToId ?? null,
       );
+      // First composed stack this browser has seen: open the Layers panel
+      // once so the feature introduces itself (#1717 exposure). Never
+      // repeats — after that the rail icon, badge, and menus carry it.
+      if (layers.length >= 2 && typeof window !== 'undefined') {
+        const INTRO_KEY = 'ifc-lite:layers:intro-shown';
+        try {
+          if (!window.localStorage.getItem(INTRO_KEY)) {
+            window.localStorage.setItem(INTRO_KEY, '1');
+            useViewerStore.getState().openWorkspacePanel('layers');
+            toast.info(
+              `Composed ${layers.length} layers - inspect, diff, publish, and merge them in the Layers panel.`,
+            );
+          }
+        } catch {
+          /* private-mode storage failures must never break loading */
+        }
+      }
 
       // Create data store from federated result. Route through the shared
       // IFCX store factory so the lazy accessors (getEntity/getProperties/

--- a/apps/viewer/src/lib/layers/demo-stack.ts
+++ b/apps/viewer/src/lib/layers/demo-stack.ts
@@ -1,0 +1,113 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * One-click demo layer stack (#1717 exposure): the bundled buildingSMART
+ * hello-wall IFC5 sample as the base, plus two authored overlays built
+ * here — an agent-published fire-safety pass (with check evidence and a
+ * scope claim) and a human review bump that overrides it. Composed, the
+ * stack demonstrates strata, provenance badges, contribution diffs,
+ * ghosting, LWW override, and a ready-made merge divergence with ZERO
+ * files or setup from the user.
+ *
+ * Fixed `created` stamps keep every layer id deterministic, so re-loading
+ * the demo never mints new content addresses.
+ */
+
+import type { IfcxFile, IfcxNode, ProvenanceBase } from '@ifc-lite/ifcx';
+import {
+  computeLayerId,
+  computeStackHash,
+  createProvenanceManifest,
+  setProvenance,
+} from '@ifc-lite/ifcx';
+
+/** hello-wall entity paths (IFC5 UUID-style; path IS the identity). */
+const WALL = '93791d5d-5beb-437b-b8ec-2f1f0ba4bf3b';
+const WINDOW_A = '25503984-6605-43a1-8597-eae657ff5bea';
+const WINDOW_B = '2c2d549f-f9fe-4e22-8590-562fda81a690';
+
+const FIRE = 'bsi::ifc::v5a::Pset_FireSafety::FireRating';
+const COMBUSTIBLE = 'bsi::ifc::v5a::Pset_FireSafety::Combustible';
+
+const SAMPLE_PATH = '/samples/hello-wall.ifcx';
+
+/** Load-a-layer-stack request; the listener lives next to the load-file
+ *  one in MainToolbar and routes to `loadFederatedIfcx`. */
+export const EVENT_LOAD_LAYER_STACK = 'ifc-lite:load-layer-stack';
+
+function publishable(
+  nodes: IfcxNode[],
+  intent: string,
+  author: { kind: 'human' | 'agent'; principal: string; tool?: string },
+  base: ProvenanceBase,
+  created: string,
+  extras: Partial<Parameters<typeof createProvenanceManifest>[0]> = {},
+): IfcxFile {
+  const bare: IfcxFile = {
+    header: {
+      id: '',
+      ifcxVersion: 'ifcx_alpha',
+      dataVersion: '1.0.0',
+      author: author.principal,
+      timestamp: created,
+    },
+    imports: [],
+    schemas: {},
+    data: nodes,
+  };
+  const manifest = createProvenanceManifest({ author, intent, base, created, ...extras });
+  const withManifest = setProvenance(bare, manifest);
+  return { ...withManifest, header: { ...withManifest.header, id: computeLayerId(withManifest) } };
+}
+
+/** The three demo files, strongest last (the federation loader treats the
+ *  first file as weakest). Exposed for tests. */
+export async function buildDemoLayerFiles(): Promise<File[]> {
+  const res = await fetch(SAMPLE_PATH);
+  if (!res.ok) throw new Error(`demo stack fetch failed: ${res.status} ${SAMPLE_PATH}`);
+  const baseText = await res.text();
+  const base = JSON.parse(baseText) as IfcxFile;
+  const baseId = base.header.id;
+
+  const agentPass = publishable(
+    [
+      { path: WALL, attributes: { [FIRE]: 'REI90', [COMBUSTIBLE]: false } },
+      { path: WINDOW_A, attributes: { [FIRE]: 'EI30' } },
+      { path: WINDOW_B, attributes: { [FIRE]: 'EI30' } },
+    ],
+    'Classify fire ratings (agent pass)',
+    { kind: 'agent', principal: 'fire-safety-agent', tool: '@ifc-lite/mcp' },
+    { kind: 'stack', id: computeStackHash([baseId]) },
+    '2026-07-01T09:00:00.000Z',
+    {
+      scope_claim: ['model.mutate:Pset_FireSafety*'],
+      checks: [{ tool: '@ifc-lite/ids', spec: 'fire-safety.ids', result: 'pass' }],
+    },
+  );
+
+  const humanReview = publishable(
+    [{ path: WALL, attributes: { [FIRE]: 'REI120' } }],
+    'Review: corridor wall needs REI120',
+    { kind: 'human', principal: 'louis' },
+    { kind: 'stack', id: computeStackHash([baseId, agentPass.header.id]) },
+    '2026-07-02T14:30:00.000Z',
+  );
+
+  const toFile = (doc: IfcxFile | string, name: string) =>
+    new File([typeof doc === 'string' ? doc : JSON.stringify(doc)], name, { type: 'application/json' });
+  return [
+    toFile(baseText, 'hello-wall.ifcx'),
+    toFile(agentPass, 'agent-fire-safety.ifcx'),
+    toFile(humanReview, 'human-review.ifcx'),
+  ];
+}
+
+/** Build the demo files and hand them to the federation loader via the
+ *  window event bus (usable from panels AND the tour's demoFulfil, where
+ *  no hook context exists). */
+export async function loadDemoLayerStack(): Promise<void> {
+  const files = await buildDemoLayerFiles();
+  window.dispatchEvent(new CustomEvent(EVENT_LOAD_LAYER_STACK, { detail: files }));
+}

--- a/apps/viewer/src/lib/layers/pending.ts
+++ b/apps/viewer/src/lib/layers/pending.ts
@@ -1,0 +1,36 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Pending mutations of the FEDERATED composition only. Reads the UNDO
+ * stacks, not the view's mutation history: the history is append-only
+ * (undo applies inverse ops without removing the record), so publishing
+ * from it would resurrect edits the user explicitly undid.
+ *
+ * Models outside the composition (a STEP model added alongside) have
+ * their own overlapping expressId space — resolving those ids through
+ * the composition's path bridge would publish onto unrelated entities,
+ * so only models sharing the composed data store contribute. Georef
+ * pseudo-mutations (entityId 0, georef.* attribute names) carry no
+ * entity identity and are dropped.
+ *
+ * Shared by the Draft section (publish source) and the activity-bar
+ * badge (draft-awareness signal).
+ */
+
+import type { Mutation } from '@ifc-lite/mutations';
+import { useViewerStore } from '@/store';
+
+export function pendingCompositionMutations(): Mutation[] {
+  const state = useViewerStore.getState();
+  const out: Mutation[] = [];
+  for (const [modelId, model] of state.models) {
+    if (model.ifcDataStore !== state.ifcDataStore) continue;
+    for (const mutation of state.undoStacks.get(modelId) ?? []) {
+      if (mutation.attributeName?.startsWith('georef.')) continue;
+      out.push(mutation);
+    }
+  }
+  return out;
+}

--- a/apps/viewer/src/lib/tours/anchors.ts
+++ b/apps/viewer/src/lib/tours/anchors.ts
@@ -52,6 +52,16 @@ export const TOUR_ANCHORS = {
   clashFocusMode: 'clash-focus-mode',
   /** ClashPanel "BCF topic" button in the results toolbar (result with clashes). */
   clashBcf: 'clash-bcf',
+  /** LayersPanel empty-state "Load demo stack" button (only while no stack). */
+  layersDemo: 'layers-demo',
+  /** LayersPanel strata list container (only while a stack is loaded). */
+  layersStrata: 'layers-strata',
+  /** LayersPanel Draft section wrapper (stack loaded). */
+  layersDraft: 'layers-draft',
+  /** LayersPanel Merge section wrapper (stack loaded, candidates exist). */
+  layersMerge: 'layers-merge',
+  /** LayerDiffView root (only while a contribution diff is open). */
+  layersDiff: 'layers-diff',
   /** ComparePanel A/B model-select grid (only with two loaded models). */
   compareAb: 'compare-ab',
   /** ComparePanel "Run comparison" button (only with two loaded models). */

--- a/apps/viewer/src/lib/tours/controller.ts
+++ b/apps/viewer/src/lib/tours/controller.ts
@@ -68,6 +68,7 @@ function prereqsMet(def: TourDefinition, s: ViewerState): boolean {
   if (!p) return true;
   if (p.modelLoaded && !(s.models.size > 0 && !s.loading && !s.geometryStreamingActive)) return false;
   if (p.secondModel && [...s.models.values()].filter((m) => m.ifcDataStore).length < 2) return false;
+  if (p.layerStack && s.layerStack.length < 2) return false;
   return true;
 }
 

--- a/apps/viewer/src/lib/tours/registry.ts
+++ b/apps/viewer/src/lib/tours/registry.ts
@@ -13,6 +13,7 @@ import { BCF_TOUR } from './tours/bcf';
 import { CLASH_TOUR } from './tours/clash';
 import { COMPARE_TOUR } from './tours/compare';
 import { IDS_TOUR } from './tours/ids';
+import { LAYERS_TOUR } from './tours/layers';
 import { LENS_TOUR } from './tours/lens';
 import { MEASURE_SECTION_TOUR } from './tours/measure-section';
 import { SCRIPTING_TOUR } from './tours/scripting';
@@ -25,6 +26,7 @@ export const TOUR_REGISTRY: readonly TourDefinition[] = [
   IDS_TOUR,
   CLASH_TOUR,
   COMPARE_TOUR,
+  LAYERS_TOUR,
   LENS_TOUR,
   SCRIPTING_TOUR,
   BCF_TOUR,

--- a/apps/viewer/src/lib/tours/tours/layers.ts
+++ b/apps/viewer/src/lib/tours/tours/layers.ts
@@ -1,0 +1,130 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Layers tour (#1717): the "Git for buildings" walkthrough. A composed
+ * IFC5 model is a stack of immutable layers - the tour reads the strata,
+ * isolates one layer's contribution in 3D, opens its provenance, and
+ * points at the draft-publish and merge/review loops. The prerequisite
+ * interstitial loads the bundled demo stack (hello-wall base + an
+ * agent-published fire-safety pass + a human review bump), so the tour
+ * runs anywhere with one click and no files. Diff/ghost state is the
+ * outcome, not tour-owned - closing the diff clears the ghost, so there
+ * is nothing to tear down. Target: about 4 minutes.
+ */
+
+import { activityAnchor, TOUR_ANCHORS } from '../anchors';
+import { loadDemoLayerStack } from '@/lib/layers/demo-stack';
+import { getViewerStoreApi } from '@/store';
+import type { TourDefinition } from '../types';
+
+/** Dispatching the load event is fire-and-forget; the interstitial needs
+ *  the COMPOSED stack before the first gated step can ever pass. */
+async function loadDemoStackAndSettle(timeoutMs = 120_000): Promise<void> {
+  await loadDemoLayerStack();
+  const store = getViewerStoreApi();
+  const start = Date.now();
+  await new Promise<void>((resolve, reject) => {
+    const check = () => {
+      const s = store.getState();
+      if (s.layerStack.length >= 2 && !s.loading) {
+        resolve();
+        return;
+      }
+      if (Date.now() - start > timeoutMs) {
+        reject(new Error('demo layer stack did not settle in time'));
+        return;
+      }
+      setTimeout(check, 200);
+    };
+    check();
+  });
+}
+
+export const LAYERS_TOUR: TourDefinition = {
+  id: 'layers',
+  title: 'Layers: version a model like code',
+  description:
+    "Read a composed layer stack, isolate one layer's changes in 3D, check its provenance, and see how edits publish and merge.",
+  minutes: 4,
+  version: 1,
+  panel: 'layers',
+  prerequisites: { layerStack: true },
+  demoFulfil: loadDemoStackAndSettle,
+  steps: [
+    {
+      id: 'open-panel',
+      kind: 'action',
+      anchor: activityAnchor('layers'),
+      placement: 'left',
+      title: 'Open Layers',
+      body: 'Open the Layers panel from the sidebar rail. It shows the composition behind the model: immutable layers, strongest opinion on top.',
+      // Same panel-open truth as the compare tour: docked counts only while
+      // the sidebar is expanded; floating/popped count regardless.
+      gate: {
+        predicate: (s) =>
+          (s.sidebarMode === 'expanded' &&
+            (s.sidebarActivePanel === 'layers' || s.sidebarSecondaryPanel === 'layers')) ||
+          s.floatingPanels.some((p) => p.id === 'layers') ||
+          s.poppedOutIds.includes('layers'),
+      },
+    },
+    {
+      id: 'read-strata',
+      kind: 'passive',
+      anchor: TOUR_ANCHORS.layersStrata,
+      panel: 'layers',
+      placement: 'left',
+      title: 'Every change is a layer',
+      body: 'Each stratum is a content-addressed, immutable layer. The badges show WHO wrote it - human, agent, or a merge - plus its checks and blake3 id. The demo stack has an agent-published fire-safety pass overridden by a human review.',
+    },
+    {
+      id: 'inspect-diff',
+      kind: 'action',
+      anchor: TOUR_ANCHORS.layersStrata,
+      panel: 'layers',
+      placement: 'left',
+      title: 'What did one layer change?',
+      body: 'Click "Changes" on a stratum. The contribution diff lists exactly what that layer added, modified, or deleted - clicking a row selects the entity in 3D.',
+      gate: { predicate: (s) => s.layerStackDiff !== null },
+    },
+    {
+      id: 'ghost-others',
+      kind: 'action',
+      anchor: TOUR_ANCHORS.layersDiff,
+      panel: 'layers',
+      placement: 'left',
+      title: 'Isolate it in 3D',
+      body: 'Toggle "Ghost others": everything the layer did NOT touch fades, so its footprint is unmissable - even in a large model.',
+      gate: { predicate: (s) => s.ghostExceptEntities !== null && s.ghostExceptEntities.size > 0 },
+    },
+    {
+      id: 'provenance',
+      kind: 'passive',
+      anchor: TOUR_ANCHORS.layersStrata,
+      panel: 'layers',
+      placement: 'left',
+      title: 'Provenance, not vibes',
+      body: 'Expand a stratum for the full manifest: author and tool, intent, declared scope, IDS check evidence (fetchable from a registry), signatures, and - on merge layers - who resolved what.',
+    },
+    {
+      id: 'draft',
+      kind: 'passive',
+      anchor: TOUR_ANCHORS.layersDraft,
+      panel: 'layers',
+      placement: 'left',
+      title: 'Your edits become layers',
+      body: "Edit any property in the model and it collects here as a pending draft. Publishing freezes it into a new immutable layer on a local ref - in a live collab session, the whole session's edits can publish together.",
+    },
+    {
+      id: 'merge',
+      kind: 'passive',
+      anchor: TOUR_ANCHORS.layersMerge,
+      panel: 'layers',
+      placement: 'left',
+      title: 'Merge with reviews and checks',
+      body: 'Pick a candidate and a target ref, preview the three-way plan, and work the conflict queue - ours, theirs, or edit-in-place. Registry refs enforce required checks, approvals, and BCF review comments server-side. Model versions, with pull requests.',
+    },
+  ],
+};

--- a/apps/viewer/src/lib/tours/types.ts
+++ b/apps/viewer/src/lib/tours/types.ts
@@ -98,6 +98,8 @@ export interface TourPrerequisites {
   modelLoaded?: boolean;
   /** At least two fully loaded models (compare tour). */
   secondModel?: boolean;
+  /** A composed .ifcx layer stack of 2+ layers (layers tour). */
+  layerStack?: boolean;
 }
 
 /** Snapshot fields a tour may keep applied after a successful finish. */


### PR DESCRIPTION
Layer PRs AND live collaboration shipped as complete features but were effectively invisible: the Layers panel only appeared after multi-dropping .ifcx files, the Room panel was reachable only via the split-panel menu and greeted you with "use the Share button in the toolbar", and neither existed in the Panels menu, palette, or tours. This PR treats both as the moonshots they are.

## Layer PRs

**Reachable everywhere:** activity-rail icon always visible (loaded-stack gate removed); "Layer Stack" in the toolbar Panels menu and the command palette.

**The panel sells itself:** the empty state is a launchpad — what-this-is copy, "Load demo stack", "Open .ifcx files" (native multi-picker), drag-drop hint, and the Merge section stays live for local candidates. The bundled demo stack (43 KB buildingSMART hello-wall + an agent-published fire-safety pass with a passing IDS check + a human review override, deterministic ids) shows strata, Human/Agent badges, checks, LWW override, diffs, and ghosting in one click.

**Moments of relevance:** amber unpublished-edits badge on the rail icon (fed by the same pendingCompositionMutations helper the Draft section counts with, extracted to lib/layers/pending.ts); first composed stack auto-opens the panel once with a toast.

**Learning system:** a guided 7-step "Layers: version a model like code" tour with a new layerStack prerequisite whose interstitial loads the demo stack; steps gate on the real diff and ghost state. New tour anchors on strata, diff view, draft, and merge sections. The welcome screen gains a "NEW — Layers" callout that loads the demo directly.

## Collaboration room

- "Collaboration Room" joins the toolbar Panels menu and the command palette (both gated on the collab feature flag, like the rail icon).
- The Room panel's empty state is actionable: pitch copy plus a "Create a room" button that opens the Share dialog directly (new `ifc-lite:open-share-dialog` event, since the dialog state is toolbar-local), and a note that invite links land you in the room on open.

## Verification

- Viewer suite 1693 green (including the plain-ASCII tour-copy gate, which caught my typographic dashes), typecheck clean.
- Localhost (Chrome DevTools MCP), all driven end to end: welcome callout -> demo stack composes 3 strata with correct badges/checks -> auto-open + toast fire once -> the tour passes every gate (diff click, ghost toggle, finish) -> fresh reload shows rail icon, Panels menu items, palette hits for both features -> the Layers launchpad renders both buttons -> the Room empty state's "Create a room" opens the real Share dialog.

Note: in production the collab surfaces stay dark until `VITE_COLLAB_ENABLED` / `VITE_COLLAB_SERVER_URL` are set on Vercel — that decision stays with @louistrue (the registry + collab server are already live on Railway).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Layer Stack workspace tools for loading, viewing, comparing, merging, and publishing composed IFCX layers, including a guided Layers tour.
  * Added a “Hello Wall” sample and one-click demo Layer Stack with support for opening local .ifcx files.
  * Added pending-edit indicators on the Layers icon and Layers panel.
  * Added collaboration UI, including a “Collaboration Room” panel and a “Create a room” action.

* **Enhancements**
  * Improved Layer Stack tour prerequisites and updated welcome/onboarding actions.
  * Enhanced the demo/loading flow and pending-edit publishing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->