### PR TITLE
fix(viewer): welcome-screen overlay collision + Share dialog empty-link on reopen

### DIFF
--- a/apps/viewer/src/components/viewer/ShareDialog.tsx
+++ b/apps/viewer/src/components/viewer/ShareDialog.tsx
@@ -24,7 +24,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { useViewerStore } from '@/store';
 import type { CollabRole } from '@/store/slices/collabSlice';
-import { buildShareUrl, mintRoomId, mintRoomToken } from '@/lib/collab/share-link';
+import { buildShareUrl, mintRoomId, mintRoomToken, parseRoleFromToken } from '@/lib/collab/share-link';
 import { buildStepSeedSource } from '@/lib/collab/step-seed';
 
 interface ShareDialogProps {
@@ -43,6 +43,7 @@ export function ShareDialog({ open, onOpenChange }: ShareDialogProps) {
   const activeModelId = useViewerStore((s) => s.activeModelId);
   const ifcDataStore = useViewerStore((s) => s.ifcDataStore);
   const collabRoomId = useViewerStore((s) => s.collabRoomId);
+  const collabRole = useViewerStore((s) => s.collabRole);
   const collabPeers = useViewerStore((s) => s.collabPeers);
   const collabIdentity = useViewerStore((s) => s.collabIdentity);
   const startCollab = useViewerStore((s) => s.startCollab);
@@ -51,6 +52,27 @@ export function ShareDialog({ open, onOpenChange }: ShareDialogProps) {
   const [link, setLink] = useState<string>('');
   const [busy, setBusy] = useState(false);
   const [copied, setCopied] = useState(false);
+  const [notice, setNotice] = useState<string | null>(null);
+
+  /**
+   * Non-admins cannot mint role-scoped tokens (no escalation by design),
+   * and even an admin's mint can fail after a reload loses the bearer.
+   * Fall back to a link we already hold: the last one this tab minted,
+   * else the invite THIS tab joined with (its token rides the page URL) —
+   * forwarding it grants exactly the access we received, never more.
+   */
+  const fallbackShareLink = useCallback((roomId: string): { url: string; role: CollabRole | null } | null => {
+    const last = useViewerStore.getState().collabLastShareToken;
+    if (last) return { url: buildShareUrl(roomId, last), role: parseRoleFromToken(last) };
+    if (typeof window !== 'undefined') {
+      const params = new URLSearchParams(window.location.search);
+      const urlToken = params.get('t');
+      if (urlToken && params.get('room') === roomId) {
+        return { url: buildShareUrl(roomId, urlToken), role: parseRoleFromToken(urlToken) };
+      }
+    }
+    return null;
+  }, []);
 
   const modelName = useMemo(() => {
     if (activeModelId) {
@@ -70,8 +92,26 @@ export function ShareDialog({ open, onOpenChange }: ShareDialogProps) {
     let cancelled = false;
     setBusy(true);
     setCopied(false);
+    setNotice(null);
     (async () => {
       const roomId = collabRoomId ?? mintRoomId();
+      // A joined non-admin can't mint: don't fire a doomed request, reuse
+      // the invite we hold and say so.
+      if (collabRoomId && collabRole && collabRole !== 'admin') {
+        const fallback = fallbackShareLink(roomId);
+        if (!cancelled) {
+          if (fallback) {
+            setLink(fallback.url);
+            if (fallback.role) setRole(fallback.role);
+            setNotice('You joined via an invite - sharing it forwards the same access. Only the room admin can mint new links.');
+          } else {
+            setLink('');
+            setNotice('Only the room admin can create invite links for this room.');
+          }
+          setBusy(false);
+        }
+        return;
+      }
       try {
         if (!collabRoomId) {
           // The creator mints an admin token (first-touch) and joins with it,
@@ -109,6 +149,17 @@ export function ShareDialog({ open, onOpenChange }: ShareDialogProps) {
       } catch (err) {
         // eslint-disable-next-line no-console
         console.error('[collab] share-link minting failed:', err);
+        // Never leave an empty Link box: reuse a link we already hold.
+        const fallback = fallbackShareLink(roomId);
+        if (!cancelled) {
+          if (fallback) {
+            setLink(fallback.url);
+            setNotice('Could not mint a fresh link - reusing your current invite (same access).');
+          } else {
+            setLink('');
+            setNotice('Link creation failed. Check the connection and try again.');
+          }
+        }
       } finally {
         if (!cancelled) setBusy(false);
       }
@@ -116,7 +167,7 @@ export function ShareDialog({ open, onOpenChange }: ShareDialogProps) {
     return () => {
       cancelled = true;
     };
-  }, [open, hasModel, role, collabRoomId, startCollab, ifcDataStore, modelName]);
+  }, [open, hasModel, role, collabRoomId, collabRole, startCollab, ifcDataStore, modelName, fallbackShareLink]);
 
   const handleCopy = useCallback(async () => {
     if (!link) return;
@@ -159,6 +210,9 @@ export function ShareDialog({ open, onOpenChange }: ShareDialogProps) {
                     aria-checked={role === opt.role}
                     variant={role === opt.role ? 'default' : 'outline'}
                     size="sm"
+                    // Only the room admin mints role-scoped links; a joiner
+                    // forwards the invite they hold, so the role is fixed.
+                    disabled={Boolean(collabRoomId && collabRole && collabRole !== 'admin')}
                     onClick={() => setRole(opt.role)}
                   >
                     {opt.label}
@@ -185,6 +239,7 @@ export function ShareDialog({ open, onOpenChange }: ShareDialogProps) {
                 {copied ? 'Copied' : 'Copy'}
               </Button>
             </div>
+            {notice && <p className="text-xs text-muted-foreground">{notice}</p>}
 
             <div className="flex flex-col gap-1.5">
               <Label className="flex items-center gap-1.5">

--- a/apps/viewer/src/components/viewer/ViewportContainer.tsx
+++ b/apps/viewer/src/components/viewer/ViewportContainer.tsx
@@ -1276,7 +1276,7 @@ export function ViewportContainer() {
                 .then((m) => m.loadDemoLayerStack())
                 .catch((err: unknown) => toast.error(err instanceof Error ? err.message : String(err)));
             }}
-            className="group mt-6 hidden md:flex items-center gap-3 max-w-3xl w-full p-4 bg-zinc-100 dark:bg-[#1f2335] border border-primary/40 hover:border-primary transition-colors text-left"
+            className="group mt-6 hidden md:flex items-center gap-3 max-w-3xl w-full p-3 bg-zinc-100 dark:bg-[#1f2335] border border-primary/40 hover:border-primary transition-colors text-left"
           >
             <div className="p-2 bg-white dark:bg-[#16161e] border border-zinc-300 dark:border-[#3b4261] text-primary">
               <GitMerge className="h-5 w-5" />
@@ -1296,8 +1296,11 @@ export function ViewportContainer() {
           </button>
 
           {/* Footer chips - left: discovery link to the marketing site for first-time
-              visitors, right: shortcuts cue for power users. Both desktop-only. */}
-          <div className="absolute bottom-8 left-8 hidden md:block">
+              visitors, right: shortcuts cue for power users. Both desktop-only.
+              IN FLOW, not absolute: the welcome column scrolls on short
+              viewports, and absolutely-anchored chips ride the scroll and
+              land on top of the content (#1736 follow-up). */}
+          <div className="mt-10 hidden w-full max-w-3xl items-center justify-between gap-4 md:flex">
             <a
               href="https://ifclite.dev"
               target="_blank"
@@ -1307,8 +1310,6 @@ export function ViewportContainer() {
               <span>New here?</span>
               <span className="font-bold text-primary group-hover:translate-x-0.5 transition-transform">ifclite.dev →</span>
             </a>
-          </div>
-          <div className="absolute bottom-8 right-8 hidden md:block">
             <div className="flex items-center gap-2 text-xs font-mono px-3 py-1.5 bg-zinc-100 dark:bg-[#1f2335] border border-zinc-300 dark:border-[#3b4261] text-zinc-500 dark:text-[#565f89]">
               <Command className="h-3 w-3" />
               <span>SHORTCUTS</span>


### PR DESCRIPTION
Two production regressions/gaps reported after #1736 shipped, both reproduced and fixed with full in-browser verification.

## 1. Welcome screen: footer chips overlapped the content

The "New here? ifclite.dev" and "SHORTCUTS" chips were absolutely anchored (`bottom-8`) inside the welcome column — which is `overflow-auto`. On viewports short enough to scroll (the new Layers callout added height), the chips ride the scroll and land ON TOP of the feature grid and callout. Fix: the chips join the flow as a footer row under the callout (same styling, desktop-only as before), which eliminates the entire class of anchor-vs-scroll collisions; the callout also slimmed to p-3. Verified at 1512x780 fully scrolled: zero overlapping rects, clean rows.

## 2. Share dialog: empty Link box when reopened from a shared model

The dialog re-mints a role-scoped token on every open — but minting requires the room ADMIN's bearer. A participant who JOINED via an invite (non-admin, exactly the reported "Shared model" case) got a silent 403 and an empty Link field with a live Copy button. An admin whose bearer was lost could hit the same dead end.

Fix, fail-open to what the user already holds:
- A joined non-admin skips the doomed mint and reuses the invite they hold — the last minted token, else the token riding the page URL they joined with. Forwarding it grants exactly the access they received, never more. A notice says so, and the role toggles are disabled (only admins mint role-scoped links).
- An admin mint FAILURE now falls back the same way with a notice instead of console-only silence; if nothing is held, the notice replaces the empty-box mystery.

## In-browser verification (Chrome DevTools MCP, every path driven)

- Owner: create room -> link minted -> close -> REOPEN -> link populated.
- Joiner (second tab via the invite URL, editor role): opens Share -> link populated from the held invite, "forwards the same access" notice shown, role radios disabled, Copy enabled -> close -> reopen -> still populated.
- Welcome at 780px height, scrolled to bottom: callout and both chips in separate rows, overlap rect check false.
- Viewer suite 1692 green, typecheck clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved sharing for collaborative rooms by reusing valid invite links when users cannot create new role-scoped links.
  * Added clear notices for forwarded links, permission limitations, and link-generation errors.
  * Prevented unauthorized changes to access levels for forwarded invitations.

* **Style**
  * Refined welcome-screen spacing and footer chip alignment for a more consistent layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->