### PR TITLE
fix(merge,viewer): no-op merge for layers already on the ref; diff ghost ownership

### DIFF
--- a/.changeset/merge-noop-already-on-ref.md
+++ b/.changeset/merge-noop-already-on-ref.md
@@ -1,0 +1,6 @@
+---
+"@ifc-lite/merge": patch
+"@ifc-lite/collab-server": patch
+---
+
+Merging a candidate that is already on the target ref now no-ops (fast-forward with the ref unchanged) instead of refusing with unrelated-base. Published drafts land on their home ref with a declared base equal to the composition they were authored against, which need not be representable on the ref, so re-merging them previously dead-ended. Registry merge previews now also report `ancestor_matched` so clients can warn before an execute would be refused.

--- a/apps/viewer/src/components/viewer/layers/LayerDiffView.tsx
+++ b/apps/viewer/src/components/viewer/layers/LayerDiffView.tsx
@@ -89,8 +89,11 @@ export function LayerDiffView({ entry, diff }: { entry: LayerStackEntry; diff: S
         if (id !== undefined) ids.add(id);
       }
       if (ids.size === 0) return false;
-      ownedGhostSet.current = ids;
       state.setGhostExceptEntities(ids);
+      // The slice stores a defensive COPY of the set — own THAT copy, or
+      // the identity checks below (and the unmount cleanup) never match
+      // and the ghost leaks until "Show All".
+      ownedGhostSet.current = useViewerStore.getState().ghostExceptEntities;
       return true;
     });
   }, [diff]);

--- a/apps/viewer/src/components/viewer/layers/LayerMergeSection.tsx
+++ b/apps/viewer/src/components/viewer/layers/LayerMergeSection.tsx
@@ -421,6 +421,12 @@ export function LayerMergeSection() {
               {result.status === 'policy-failure' && `Blocked by ref policy: ${result.reason}`}
               {result.status === 'unrelated-base' && `Unrelated base: ${result.reason}`}
             </p>
+            {result.status === 'preview' && result.ancestorMatched === false && (
+              <p className="text-[11px] text-amber-600 dark:text-amber-500">
+                No shared base on this ref: the plan treats every candidate op as new. Candidates
+                that declare a base from another history will be refused at merge.
+              </p>
+            )}
             {requiredChecks.length > 0 && !mergeDone && (
               <div className="flex flex-col gap-0.5 rounded border bg-card/40 px-1.5 py-1">
                 <span className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">

--- a/apps/viewer/src/lib/layers/merge.ts
+++ b/apps/viewer/src/lib/layers/merge.ts
@@ -33,6 +33,12 @@ export interface ViewerMergeResult {
   reason?: string;
   /** Plan stats for previews. */
   stats?: { autoMerged: number; conflicting: number };
+  /**
+   * False on previews planned against an empty ancestor because the
+   * candidate's declared base matched nothing on the ref — executing
+   * such a merge will be refused (unrelated-base), so the panel warns.
+   */
+  ancestorMatched?: boolean;
 }
 
 function fromRegistry(outcome: RegistryMergeOutcome): ViewerMergeResult {
@@ -49,6 +55,7 @@ function fromRegistry(outcome: RegistryMergeOutcome): ViewerMergeResult {
     ...(outcome.plan
       ? { stats: { autoMerged: outcome.plan.stats.autoMerged, conflicting: outcome.plan.stats.conflicting } }
       : {}),
+    ...(outcome.ancestor_matched !== undefined ? { ancestorMatched: outcome.ancestor_matched } : {}),
   };
 }
 
@@ -59,6 +66,7 @@ function fromLocal(outcome: MergeOutcome): ViewerMergeResult {
         status: 'preview',
         conflicts: outcome.plan.conflicts,
         stats: { autoMerged: outcome.plan.stats.autoMerged, conflicting: outcome.plan.stats.conflicting },
+        ancestorMatched: outcome.ancestorMatched,
       };
     case 'conflicts':
       return { status: 'conflicts', conflicts: outcome.conflicts };

--- a/apps/viewer/src/lib/layers/registry-client.ts
+++ b/apps/viewer/src/lib/layers/registry-client.ts
@@ -26,6 +26,8 @@ export interface RegistryMergeOutcome {
   reason?: string;
   /** Sent on unrelated-base outcomes instead of `reason`. */
   declared_base?: { kind: string; id: string };
+  /** On previews/merges: whether the candidate's declared base was found on the ref. */
+  ancestor_matched?: boolean;
 }
 
 export interface RegistryResolutionInput {

--- a/packages/collab-server/src/layer-registry-route.ts
+++ b/packages/collab-server/src/layer-registry-route.ts
@@ -589,7 +589,11 @@ export async function handleLayerRegistryRequest(
             ancestor_matched: outcome.ancestorMatched,
           });
         case 'preview':
-          return json(res, 200, { status: outcome.status, plan: outcome.plan });
+          return json(res, 200, {
+            status: outcome.status,
+            plan: outcome.plan,
+            ancestor_matched: outcome.ancestorMatched,
+          });
         case 'conflicts':
           return json(res, 409, { status: outcome.status, conflicts: outcome.conflicts });
         case 'policy-failure':

--- a/packages/merge/src/ref-flow-resolutions.test.ts
+++ b/packages/merge/src/ref-flow-resolutions.test.ts
@@ -133,3 +133,56 @@ describe('MergeInit.resolutions (per-conflict, review-UI flow)', () => {
     expect(state.get('wall-1')?.components.get('pset:Pset_FireSafety')?.[FIRE]).toBe('REI120');
   });
 });
+
+describe('candidate already on the ref (published drafts re-merged into their home ref)', () => {
+  /**
+   * Publishing appends the draft to its home ref, and the draft's declared
+   * base is the COMPOSITION it was authored against — a stack that need
+   * not be representable on the ref (e.g. URI-id base files fail the
+   * content-address gate). Re-merging that layer into the same ref must
+   * no-op, not refuse as unrelated-base.
+   */
+  function publishedOntoRef() {
+    const store = new MemoryStore();
+    // Base declared against a stack hash that matches nothing on the ref.
+    const candidate = publishable(
+      [{ path: 'wall-1', attributes: { [FIRE]: 'REI180' } }],
+      'Draft',
+      ['uri:not-on-any-ref'],
+    );
+    store.storeLayer(candidate);
+    store.setRef('local', { layers: [candidate.header.id] });
+    return { store, candidate };
+  }
+
+  it('previews as an empty plan with a matched ancestor', () => {
+    const { store, candidate } = publishedOntoRef();
+    const outcome = mergeIntoRef(store, { candidateId: candidate.header.id, into: 'local', preview: true });
+    expect(outcome.status).toBe('preview');
+    if (outcome.status !== 'preview') return;
+    expect(outcome.plan.conflicts).toHaveLength(0);
+    expect(outcome.plan.stats.touched).toBe(0);
+    expect(outcome.ancestorMatched).toBe(true);
+  });
+
+  it('executes as a no-op fast-forward with the ref unchanged', () => {
+    const { store, candidate } = publishedOntoRef();
+    const outcome = mergeIntoRef(store, { candidateId: candidate.header.id, into: 'local' });
+    expect(outcome.status).toBe('fast-forward');
+    if (outcome.status !== 'fast-forward') return;
+    expect(outcome.refLayers).toEqual([candidate.header.id]);
+    expect(store.getRef('local')?.layers).toEqual([candidate.header.id]);
+  });
+
+  it('still refuses a genuinely unrelated candidate NOT on the ref', () => {
+    const { store } = publishedOntoRef();
+    const stranger = publishable(
+      [{ path: 'wall-2', attributes: { [FIRE]: 'REI30' } }],
+      'Stranger',
+      ['uri:some-other-history'],
+    );
+    store.storeLayer(stranger);
+    const outcome = mergeIntoRef(store, { candidateId: stranger.header.id, into: 'local' });
+    expect(outcome.status).toBe('unrelated-base');
+  });
+});

--- a/packages/merge/src/ref-flow.ts
+++ b/packages/merge/src/ref-flow.ts
@@ -192,6 +192,22 @@ export function mergeIntoRef(store: LayerRefStore, init: MergeInit): MergeOutcom
   const waivers = init.waivers ?? [];
   const resolver = init.principal ?? 'unknown';
 
+  // A candidate already ON the ref is a completed merge, not a mismatch:
+  // publishing appends the draft to its home ref, so re-merging that
+  // layer into the same ref must no-op instead of refusing as
+  // unrelated-base (its declared base is the composition it was authored
+  // against, which need not be representable on the ref).
+  if (oursIds.includes(candidateId)) {
+    if (init.preview) {
+      return {
+        status: 'preview',
+        plan: { autoOps: [], conflicts: [], stats: { touched: 0, autoMerged: 0, conflicting: 0 } },
+        ancestorMatched: true,
+      };
+    }
+    return { status: 'fast-forward', refLayers: oursIds, ancestorMatched: true };
+  }
+
   // Fast path: candidate authored against the ref's current stack. A
   // merge that consumes a waiver falls through to the three-way path so
   // the waiver is durably recorded on a merge layer.


### PR DESCRIPTION
Found while running the full Layer PRs feature through the browser after #1736/#1741.

## Bug 1: publish-then-merge dead-ends with "Unrelated base"

The primary happy path - load a stack, edit a property, publish the draft, merge it into the local ref - refused with \`Unrelated base: declared base blake3:... matches nothing on the ref\`, immediately after Preview reported a clean plan (0 conflicts).

Root cause: publishing appends the draft to its home ref, and the draft's declared base is the composition it was authored against. That composition need not be representable on the ref at all (the demo stack's base file has a URI \`header.id\`, which the content-address gate on both stores correctly refuses), so \`resolveAncestor\` can never match and the unrelated-base guard fires on a layer that is *already a member of the target ref*.

Fixes:
- \`mergeIntoRef\` treats a candidate already on the ref as a completed merge: preview returns an empty plan with \`ancestorMatched: true\`, execute returns a no-op fast-forward with the ref unchanged. A genuinely unrelated candidate NOT on the ref is still refused (covered by test).
- Registry merge previews now include \`ancestor_matched\` on the wire; the viewer threads it through \`ViewerMergeResult\`, and the merge panel shows a warning when a plan was computed against an empty ancestor - so preview and execute no longer disagree silently.

Verified live: preview 0/0 -> Merge -> "Fast-forwarded." -> Load merged ref works, no console errors.

## Bug 2: diff-view ghost leaks after closing the diff

\`visibilitySlice.setGhostExceptEntities\` stores a defensive **copy** of the set, but \`LayerDiffView\` kept the pre-copy reference as its ownership token - the identity checks (toggle-off, unmount cleanup) never matched, so ghosting stuck until Show All. The view now reads the store's copy back as its owned reference.

## Tests
- 3 new cases in \`ref-flow-resolutions.test.ts\` (preview no-op, execute no-op, unrelated stranger still refused); merge suite 69/69, collab-server 113/113, viewer suite green, api-surface unchanged.
- Changeset: patch for \`@ifc-lite/merge\` + \`@ifc-lite/collab-server\`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Re-merging a candidate already on a ref now completes as a no-op without changing the ref.
  * Draft merges now publish correctly to their home ref, even when their original base is unavailable.
  * Merge previews now indicate whether a shared ancestor was found.

* **Bug Fixes**
  * Added a warning when a merge preview has no shared base.
  * Improved layer ghost-isolation cleanup when viewing layer differences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->