### PR TITLE
feat(viewer): add plain OSM slippy-map base for the 3D world context

### DIFF
--- a/apps/viewer/src/components/viewer/CesiumOverlay.tsx
+++ b/apps/viewer/src/components/viewer/CesiumOverlay.tsx
@@ -261,7 +261,21 @@ export function CesiumOverlay({
         scene.globe.showGroundAtmosphere = false;
         scene.backgroundColor = Cesium.Color.TRANSPARENT;
         scene.globe.baseColor = Cesium.Color.TRANSPARENT;
-        if (dataSource === 'osm-buildings') {
+        if (dataSource === 'osm-map') {
+          // Plain OpenStreetMap slippy map: a simple, uncluttered flat base
+          // map (no satellite imagery, no 3D massing) for users who find the
+          // photorealistic globe overwhelming (#1744). The globe drapes the
+          // OSM tiles (over terrain when enabled) and receives cast shadows.
+          scene.globe.show = true;
+          scene.globe.shadows = Cesium.ShadowMode.RECEIVE_ONLY;
+          try {
+            // maximumLevel 19 = OSM's deepest tile zoom; conforms to the
+            // OpenStreetMap tile usage policy and avoids 404s past z19.
+            // The provider carries OSM's attribution credit automatically.
+            const osm = new Cesium.OpenStreetMapImageryProvider({ maximumLevel: 19 });
+            if (!cancelled) viewer.imageryLayers.addImageryProvider(osm);
+          } catch (e) { console.warn('[CesiumOverlay] OSM base map unavailable:', e); }
+        } else if (dataSource === 'osm-buildings') {
           // OSM massing context: keep the globe with the satellite base map —
           // the extruded buildings sit ON TOP of the imagery, and the globe
           // is what receives their cast shadows during a sun study.
@@ -865,6 +879,12 @@ async function addDataSourceLayer(
 ): Promise<InstanceType<typeof import('cesium').Cesium3DTileset> | null> {
   try {
     switch (dataSource) {
+      case 'osm-map': {
+        // Plain OSM base map: the imagery layer is the whole context (added in
+        // Effect 1). There is no 3D tileset to place — return null so solar
+        // shadows fall on the globe alone.
+        return null;
+      }
       case 'osm-buildings': {
         // OpenStreetMap Buildings — flat-shaded extruded footprints, the grey
         // massing context used for sun-path / overshadowing studies.

--- a/apps/viewer/src/components/viewer/CesiumOverlay.tsx
+++ b/apps/viewer/src/components/viewer/CesiumOverlay.tsx
@@ -271,8 +271,16 @@ export function CesiumOverlay({
           try {
             // maximumLevel 19 = OSM's deepest tile zoom; conforms to the
             // OpenStreetMap tile usage policy and avoids 404s past z19.
-            // The provider carries OSM's attribution credit automatically.
-            const osm = new Cesium.OpenStreetMapImageryProvider({ maximumLevel: 19 });
+            // Pass an explicit `credit`: Cesium's default OSM credit is the
+            // outdated "MapQuest … CC-BY-SA" string, but the OSMF tile policy
+            // requires a visible "© OpenStreetMap contributors" attribution
+            // linking to the copyright page. Cesium renders credit HTML, so the
+            // anchor is clickable in the on-canvas attribution.
+            const osm = new Cesium.OpenStreetMapImageryProvider({
+              maximumLevel: 19,
+              credit:
+                '© <a href="https://www.openstreetmap.org/copyright" target="_blank" rel="noopener">OpenStreetMap</a> contributors',
+            });
             if (!cancelled) viewer.imageryLayers.addImageryProvider(osm);
           } catch (e) { console.warn('[CesiumOverlay] OSM base map unavailable:', e); }
         } else if (dataSource === 'osm-buildings') {

--- a/apps/viewer/src/components/viewer/SunSkyPanel.tsx
+++ b/apps/viewer/src/components/viewer/SunSkyPanel.tsx
@@ -36,6 +36,7 @@ import {
 } from '@/lib/solar-time';
 
 const CONTEXT_SOURCES: Array<{ value: CesiumDataSource; label: string; hint: string }> = [
+  { value: 'osm-map', label: 'OSM Map', hint: 'Plain OpenStreetMap tiles — a simple flat base map' },
   { value: 'osm-buildings', label: 'OSM Buildings', hint: 'Extruded footprints over the satellite base map' },
   { value: 'google-photorealistic', label: 'Photorealistic', hint: 'Google 3D Tiles — textured real-world context' },
 ];
@@ -129,17 +130,37 @@ export function SunSkyPanel() {
               lit by Cesium's sun instead, so the choice becomes a single
               Atmosphere switch. */}
           {cesiumEnabled ? (
-            <div className="flex items-center gap-1">
-              <ToggleChip
-                label="Atmosphere"
-                active={skyEnabled}
-                onClick={() => setSkyEnabled(!skyEnabled)}
-                title="Sky, sun disc and haze in the world context"
-              />
-              <span className="flex-1 px-1 text-[9px] leading-tight text-muted-foreground">
-                Lighting follows the sun &amp; atmosphere
-              </span>
-            </div>
+            <>
+              <div className="flex items-center gap-1">
+                <ToggleChip
+                  label="Atmosphere"
+                  active={skyEnabled}
+                  onClick={() => setSkyEnabled(!skyEnabled)}
+                  title="Sky, sun disc and haze in the world context"
+                />
+                <span className="flex-1 px-1 text-[9px] leading-tight text-muted-foreground">
+                  Lighting follows the sun &amp; atmosphere
+                </span>
+              </div>
+              {/* Base map — pick the real-world backdrop. Photorealistic can
+                  be overwhelming; the plain OSM map is a simple flat
+                  alternative (#1744). Lives here (not just in the sun study)
+                  so the choice is available whenever the world context is on. */}
+              <label className="flex flex-col gap-0.5">
+                <span className="text-[9px] uppercase tracking-wider text-muted-foreground">Base map</span>
+                <select
+                  aria-label="World context base map"
+                  value={dataSource}
+                  onChange={(e) => setDataSource(e.target.value as CesiumDataSource)}
+                  title={CONTEXT_SOURCES.find((s) => s.value === dataSource)?.hint}
+                  className="w-full bg-muted/40 rounded px-1.5 py-1 border text-foreground text-[10px]"
+                >
+                  {CONTEXT_SOURCES.map((src) => (
+                    <option key={src.value} value={src.value}>{src.label}</option>
+                  ))}
+                </select>
+              </label>
+            </>
           ) : (
             <label className="flex flex-col gap-0.5">
               <span className="text-[9px] uppercase tracking-wider text-muted-foreground">Environment</span>
@@ -295,33 +316,14 @@ export function SunSkyPanel() {
                     ))}
                   </div>
 
-                  {/* World-context extras: dome + shadows + context source */}
+                  {/* World-context extras: dome + shadows. The base-map
+                      picker lives above (visible whenever the world context is
+                      on), so the sun study only adds its dome/shadow toggles. */}
                   {cesiumEnabled ? (
-                    <>
-                      <div className="flex gap-1">
-                        <ToggleChip className="flex-1" label="Dome" active={showSunPath} onClick={() => setShowSunPath(!showSunPath)} />
-                        <ToggleChip className="flex-1" label="Shadows" active={showShadows} onClick={() => setShowShadows(!showShadows)} />
-                      </div>
-                      <div className="flex gap-1">
-                        {CONTEXT_SOURCES.map((src) => (
-                          <button
-                            key={src.value}
-                            type="button"
-                            title={src.hint}
-                            aria-pressed={dataSource === src.value}
-                            onClick={() => setDataSource(src.value)}
-                            className={cn(
-                              'flex-1 px-1.5 py-1 rounded text-[10px] transition-colors',
-                              dataSource === src.value
-                                ? 'bg-teal-600 text-white'
-                                : 'text-muted-foreground hover:bg-muted hover:text-foreground',
-                            )}
-                          >
-                            {src.label}
-                          </button>
-                        ))}
-                      </div>
-                    </>
+                    <div className="flex gap-1">
+                      <ToggleChip className="flex-1" label="Dome" active={showSunPath} onClick={() => setShowSunPath(!showSunPath)} />
+                      <ToggleChip className="flex-1" label="Shadows" active={showShadows} onClick={() => setShowShadows(!showShadows)} />
+                    </div>
                   ) : (
                     <button
                       type="button"

--- a/apps/viewer/src/store/slices/cesiumSlice.ts
+++ b/apps/viewer/src/store/slices/cesiumSlice.ts
@@ -19,7 +19,7 @@ import type { MapConversion } from '@ifc-lite/parser';
 
 import { clearTerrainElevationCache } from '@/lib/geo/terrain-elevation';
 
-export type CesiumDataSource = 'google-photorealistic' | 'osm-buildings';
+export type CesiumDataSource = 'google-photorealistic' | 'osm-buildings' | 'osm-map';
 
 export interface CesiumPlacementDraft {
   eastings: number;
@@ -153,7 +153,9 @@ function saveToStorage(key: string, value: string): void {
 
 function loadDataSource(): CesiumDataSource {
   const stored = loadFromStorage(STORAGE_KEY_DATA_SOURCE, 'google-photorealistic');
-  return stored === 'osm-buildings' ? 'osm-buildings' : 'google-photorealistic';
+  return stored === 'osm-buildings' || stored === 'osm-map'
+    ? stored
+    : 'google-photorealistic';
 }
 
 /** Resolve the Cesium ion token: user override > build-time default */

--- a/apps/viewer/vite-plugins/cesium-assets.ts
+++ b/apps/viewer/vite-plugins/cesium-assets.ts
@@ -76,6 +76,17 @@ export function cesiumStaticAssets(): Plugin {
           CESIUM_DEV_MIME[path.extname(filePath).toLowerCase()] ??
             'application/octet-stream',
         );
+        // Mirror the app's cross-origin isolation headers. Vite injects
+        // `server.headers` (COOP/COEP) into its own responses, but this custom
+        // connect middleware writes the response itself and bypasses that, so
+        // /cesium/* would ship without COEP. Under cross-origin isolation a
+        // dedicated worker script (Cesium spawns several from /cesium/Workers/*)
+        // must itself carry COEP or Chrome blocks it with ERR_BLOCKED_BY_RESPONSE
+        // — killing every Cesium worker and leaving the globe (terrain + imagery,
+        // including the OSM base map) black in dev. Prod is unaffected: vercel.json
+        // applies these to `/(.*)`. Keep these in lockstep with server.headers.
+        res.setHeader('Cross-Origin-Opener-Policy', 'same-origin');
+        res.setHeader('Cross-Origin-Embedder-Policy', 'credentialless');
         if (req.method === 'HEAD') return res.end();
         // Guard the TOCTOU window between existsSync and the stream open: an
         // unhandled 'error' would otherwise crash the dev server.


### PR DESCRIPTION
Closes #1744.

## What
Adds a third **"OSM Map"** base map to the 3D world context, alongside Photorealistic (Google 3D Tiles) and OSM Buildings. It drapes plain OpenStreetMap tiles over the globe — a simple, uncluttered flat map for when the photorealistic globe is overwhelming (exactly what the issue asked for).

The base-map picker is also lifted out of the sun study into a **"Base map" dropdown** shown whenever the world context is enabled, so users can switch backgrounds without starting a sun study.

## How
- **`cesiumSlice`**: `CesiumDataSource` gains `'osm-map'`; the value is persisted/validated like the others.
- **`CesiumOverlay`**: for `osm-map`, show the globe with a `OpenStreetMapImageryProvider` layer (`tile.openstreetmap.org`, capped at `maximumLevel: 19` per the OSM tile usage policy, attribution credit carried automatically), `RECEIVE_ONLY` shadows like osm-buildings, and no 3D tileset.
- **`SunSkyPanel`**: the three-way source picker becomes a labeled `Base map` `<select>` in the world-context block.

## Incidental fix (dev-only)
While verifying, the OSM map (and the existing OSM-Buildings satellite base) rendered **black in dev**. Root cause: the `/cesium/*` dev middleware writes its own responses and never mirrored the app's COOP/COEP headers, so under cross-origin isolation Chrome blocked every Cesium worker (`ERR_BLOCKED_BY_RESPONSE`), killing the globe's terrain + imagery. The middleware now emits the same `Cross-Origin-Opener-Policy` / `Cross-Origin-Embedder-Policy` that `server.headers` (dev) and `vercel.json`'s `/(.*)` rule (prod) already apply. **Prod was never affected** — this only ever broke `pnpm dev`.

## Verification
Loaded a georeferenced sample (`building-architecture.ifc`, UTM 60S) in a real browser and drove the UI:

| Base map | Result |
|---|---|
| OSM Map | Flat OSM slippy map renders (land/sea/coastline/vegetation), model placed correctly |
| OSM Buildings | Satellite base renders (no longer black) |
| Photorealistic | Google 3D tiles render |

No console errors across all three; switching is durable. Typecheck clean on touched files; existing `cesium-*` unit tests pass (19/19).

<sub>Note: `apps/viewer` is `private: true` (not npm-published), so no changeset.</sub>