### PR TITLE
feat(docs): extend PLANKOPF plan-sheet theme to the mkdocs docs site

### DIFF
--- a/docs/javascripts/mermaid-init.js
+++ b/docs/javascripts/mermaid-init.js
@@ -26,13 +26,44 @@
     securityLevel: 'loose'
   });
 
-  // Render mermaid diagrams
+  // Render mermaid diagrams. Stash each diagram's source text before running,
+  // because mermaid replaces the node's content with SVG — the stash lets us
+  // re-render on a palette toggle.
   function renderMermaid() {
     const elements = document.querySelectorAll('.mermaid:not([data-processed])');
     if (elements.length > 0) {
+      elements.forEach(function(el) {
+        if (!el.getAttribute('data-mermaid-source')) {
+          el.setAttribute('data-mermaid-source', el.textContent.trim());
+        }
+      });
       mermaid.run({ nodes: elements });
     }
   }
+
+  // Re-render when the palette is toggled: diagrams carry PLANKOPF red on
+  // carbon, so a stale theme is visible. Reset the processed flag + saved
+  // source, re-initialize with the new theme, and run again.
+  var lastScheme = getTheme();
+  var schemeObserver = new MutationObserver(function() {
+    var next = getTheme();
+    if (next === lastScheme) return;
+    lastScheme = next;
+    mermaid.initialize({
+      startOnLoad: false,
+      theme: next,
+      flowchart: { useMaxWidth: true, htmlLabels: true },
+      securityLevel: 'loose'
+    });
+    document.querySelectorAll('.mermaid[data-processed]').forEach(function(el) {
+      if (el.getAttribute('data-mermaid-source')) {
+        el.innerHTML = el.getAttribute('data-mermaid-source');
+      }
+      el.removeAttribute('data-processed');
+    });
+    renderMermaid();
+  });
+  schemeObserver.observe(document.body, { attributes: true, attributeFilter: ['data-md-color-scheme'] });
 
   // Initial render
   if (document.readyState === 'loading') {

--- a/docs/javascripts/mermaid-init.js
+++ b/docs/javascripts/mermaid-init.js
@@ -56,8 +56,11 @@
       securityLevel: 'loose'
     });
     document.querySelectorAll('.mermaid[data-processed]').forEach(function(el) {
-      if (el.getAttribute('data-mermaid-source')) {
-        el.innerHTML = el.getAttribute('data-mermaid-source');
+      var src = el.getAttribute('data-mermaid-source');
+      if (src) {
+        // Restore as TEXT, not markup — the source must never be reparsed as
+        // DOM (it would let diagram content execute before mermaid rerenders).
+        el.textContent = src;
       }
       el.removeAttribute('data-processed');
     });

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,14 +1,20 @@
+{#
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
 {% extends "base.html" %}
 
 {#-
   PLANKOPF fonts. theme.font is false in mkdocs.yml so Material's `block fonts`
   emits nothing; we load the variable Archivo (needs 400..900 for the plan
-  lettering) and Fragment Mono ourselves, and set the font-family variables
-  Material's stylesheet reads (`--md-text-font` / `--md-code-font`).
+  lettering) and Fragment Mono ourselves, and set both the font-name vars and
+  the full font-family stacks (with generic fallbacks so text is readable
+  during `display=swap` before the web fonts load).
 -#}
 {% block fonts %}
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;800&family=Archivo:wdth,wght@75..125,400..900&family=Fragment+Mono:ital@0;1&display=swap" rel="stylesheet">
-  <style>:root{--md-text-font:"Archivo";--md-code-font:"Fragment Mono"}</style>
+  <style>:root{--md-text-font:"Archivo";--md-code-font:"Fragment Mono";--md-text-font-family:"Archivo",-apple-system,BlinkMacSystemFont,Helvetica,Arial,sans-serif;--md-code-font-family:"Fragment Mono",SFMono-Regular,Consolas,Menlo,monospace}</style>
 {% endblock %}

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,0 +1,14 @@
+{% extends "base.html" %}
+
+{#-
+  PLANKOPF fonts. theme.font is false in mkdocs.yml so Material's `block fonts`
+  emits nothing; we load the variable Archivo (needs 400..900 for the plan
+  lettering) and Fragment Mono ourselves, and set the font-family variables
+  Material's stylesheet reads (`--md-text-font` / `--md-code-font`).
+-#}
+{% block fonts %}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;800&family=Archivo:wdth,wght@75..125,400..900&family=Fragment+Mono:ital@0;1&display=swap" rel="stylesheet">
+  <style>:root{--md-text-font:"Archivo";--md-code-font:"Fragment Mono"}</style>
+{% endblock %}

--- a/docs/overrides/partials/copyright.html
+++ b/docs/overrides/partials/copyright.html
@@ -1,3 +1,8 @@
+{#
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
 {#-
   PLANKOPF title block, mirroring the ifclite.dev landing's fixed sheet header.
   Replaces Material's plain copyright line with hairline-ruled engineering cells.

--- a/docs/overrides/partials/copyright.html
+++ b/docs/overrides/partials/copyright.html
@@ -1,0 +1,22 @@
+{#-
+  PLANKOPF title block, mirroring the ifclite.dev landing's fixed sheet header.
+  Replaces Material's plain copyright line with hairline-ruled engineering cells.
+-#}
+<div class="md-copyright pk-titleblock">
+  <div class="pk-tb-cell">
+    <span class="pk-tb-k">Projekt</span>
+    <span class="pk-tb-v">IFClite · Dokumentation</span>
+  </div>
+  <div class="pk-tb-cell pk-tb-hide">
+    <span class="pk-tb-k">Gez.</span>
+    <span class="pk-tb-v"><a href="https://lt.plus" target="_blank" rel="noopener">L. Trümpler · LTplus AG</a></span>
+  </div>
+  <div class="pk-tb-cell pk-tb-hide">
+    <span class="pk-tb-k">Lizenz</span>
+    <span class="pk-tb-v"><a href="https://github.com/LTplus-AG/ifc-lite/blob/main/LICENSE" target="_blank" rel="noopener">MPL-2.0</a></span>
+  </div>
+  <div class="pk-tb-cell pk-tb-blatt">
+    <span class="pk-tb-k">Blatt</span>
+    <span class="pk-tb-v">Docs · <a href="https://ifclite.dev/">ifclite.dev</a></span>
+  </div>
+</div>

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,126 +1,337 @@
-/* IFC-Lite Documentation Custom Styles */
+/* ══════════════════════════════════════════════════════════════════════
+   IFC-Lite Documentation — "PLANKOPF"
+   Swiss engineering plan-sheet theme, matching ifclite.dev. Two neutrals +
+   one Swiss red. Archivo (text) + Fragment Mono (code) load from
+   docs/overrides/main.html. Palette is `custom` in mkdocs.yml, so Material
+   emits no colour rules and this file fully owns the schemes.
+   Reviewed against mkdocs-material 9.7.x internals.
+   ══════════════════════════════════════════════════════════════════════ */
 
-/* Color scheme adjustments */
-:root {
-  --md-primary-fg-color: #4f46e5;
-  --md-primary-fg-color--light: #6366f1;
-  --md-primary-fg-color--dark: #4338ca;
-  --md-accent-fg-color: #3b82f6;
+/* ── palette: light (default scheme) ── */
+[data-md-color-scheme="default"] {
+  --pk-red: #e30613;
+  --pk-red-hover: #c00510;
+  --pk-paper: #fcfcfa;
+  --pk-ink: #111110;
+  --pk-ink-2: #45443f;
+  --pk-ink-3: #6b6b64;
+  --pk-line: #dcdbd4;
+  --pk-line-2: #c3c2b8;
+  --pk-card: #f8f7f2;
+
+  --md-hue: 40;
+
+  --md-default-bg-color: var(--pk-paper);
+  --md-default-fg-color: var(--pk-ink);
+  /* keep Material's derived tints as ALPHA (they composite over surfaces) */
+  --md-default-fg-color--light: rgba(17, 17, 16, 0.6);
+  --md-default-fg-color--lighter: rgba(17, 17, 16, 0.32);
+  --md-default-fg-color--lightest: rgba(17, 17, 16, 0.07);
+
+  --md-primary-fg-color: var(--pk-ink);          /* header / tabs */
+  --md-primary-fg-color--light: #2a2a26;
+  --md-primary-fg-color--dark: #000;
+  --md-primary-bg-color: var(--pk-paper);
+  --md-primary-bg-color--light: rgba(252, 252, 250, 0.7);
+
+  --md-accent-fg-color: var(--pk-red);
+  --md-accent-fg-color--transparent: color-mix(in srgb, var(--pk-red) 10%, transparent);
+
+  /* links: ink with a red underline — red stays a signature, not the field */
+  --md-typeset-a-color: var(--pk-ink);
+  --md-typeset-mark-color: rgba(227, 6, 19, 0.16);
+  --md-typeset-table-color: var(--pk-line);
+
+  --md-code-bg-color: var(--pk-card);
+  --md-code-fg-color: var(--pk-ink-2);
+  --md-code-hl-color: rgba(227, 6, 19, 0.12);
+  --md-code-hl-keyword-color: var(--pk-ink);
+  --md-code-hl-function-color: var(--pk-ink);
+  --md-code-hl-string-color: #a8552a;
+  --md-code-hl-number-color: #1f7a4d;
+  --md-code-hl-comment-color: var(--pk-ink-3);
+  --md-code-hl-name-color: var(--pk-ink-2);
+  --md-code-hl-operator-color: var(--pk-ink-3);
+  --md-code-hl-punctuation-color: var(--pk-ink-3);
+
+  --md-footer-bg-color: var(--pk-ink);
+  --md-footer-bg-color--dark: #000;
 }
 
-/* Header styling */
+/* ── palette: dark (slate scheme) ── */
+[data-md-color-scheme="slate"] {
+  --pk-red: #ff2d1a;
+  --pk-red-hover: #ff5240;
+  --pk-paper: #0e0e0c;
+  --pk-ink: #ededea;
+  --pk-ink-2: #b4b3ab;
+  --pk-ink-3: #83837a;
+  --pk-line: #26251f;
+  --pk-line-2: #38372f;
+  --pk-card: #141310;
+
+  --md-hue: 40;
+
+  --md-default-bg-color: var(--pk-paper);
+  --md-default-fg-color: var(--pk-ink);
+  --md-default-fg-color--light: rgba(237, 237, 234, 0.62);
+  --md-default-fg-color--lighter: rgba(237, 237, 234, 0.32);
+  --md-default-fg-color--lightest: rgba(237, 237, 234, 0.1);
+  /* elevated surfaces (hover, sidebar fades) — keep them just above carbon */
+  --md-default-bg-color--light: #161613;
+  --md-default-bg-color--lighter: #1b1a16;
+  --md-default-bg-color--lightest: #201f1a;
+
+  --md-primary-fg-color: #060605;
+  --md-primary-fg-color--light: #16150f;
+  --md-primary-fg-color--dark: #000;
+  --md-primary-bg-color: var(--pk-ink);
+  --md-primary-bg-color--light: rgba(237, 237, 234, 0.7);
+
+  --md-accent-fg-color: var(--pk-red);
+  --md-accent-fg-color--transparent: color-mix(in srgb, var(--pk-red) 14%, transparent);
+
+  --md-typeset-a-color: var(--pk-ink);
+  --md-typeset-mark-color: rgba(255, 45, 26, 0.22);
+  --md-typeset-table-color: var(--pk-line-2);
+
+  --md-code-bg-color: var(--pk-card);
+  --md-code-fg-color: var(--pk-ink-2);
+  --md-code-hl-color: rgba(255, 45, 26, 0.14);
+  --md-code-hl-keyword-color: var(--pk-ink);
+  --md-code-hl-function-color: var(--pk-ink);
+  --md-code-hl-string-color: #d98a52;
+  --md-code-hl-number-color: #4fb07e;
+  --md-code-hl-comment-color: var(--pk-ink-3);
+  --md-code-hl-name-color: var(--pk-ink-2);
+  --md-code-hl-operator-color: var(--pk-ink-3);
+  --md-code-hl-punctuation-color: var(--pk-ink-3);
+
+  --md-footer-bg-color: #060605;
+  --md-footer-bg-color--dark: #060605;
+}
+
+/* ── header + tabs (carbon plan-sheet header) ── */
 .md-header {
   background-color: var(--md-primary-fg-color);
+  border-bottom: 1px solid var(--pk-red);
+  box-shadow: none;
 }
-
-/* Navigation tabs */
 .md-tabs {
-  background-color: var(--md-primary-fg-color--dark);
-}
-
-/* Code blocks */
-.highlight code {
-  font-size: 0.85em;
-}
-
-/* Admonitions */
-.admonition.tip {
-  border-color: #22c55e;
-}
-
-.admonition.tip > .admonition-title::before {
-  background-color: #22c55e;
-}
-
-.admonition.warning {
-  border-color: #f59e0b;
-}
-
-.admonition.warning > .admonition-title::before {
-  background-color: #f59e0b;
-}
-
-/* Mermaid diagrams */
-.mermaid {
-  text-align: center;
-  margin: 1rem 0;
-}
-
-/* Tables */
-.md-typeset table:not([class]) {
-  font-size: 0.85em;
-  border: 1px solid var(--md-typeset-table-color);
-}
-
-.md-typeset table:not([class]) th {
   background-color: var(--md-primary-fg-color);
-  color: white;
-  font-weight: 600;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
 }
-
-/* Status badges in tables */
-.md-typeset table td:has(.success) {
-  color: #22c55e;
+.md-header__title { font-weight: 700; letter-spacing: 0.02em; }
+.md-tabs__link {
+  font-family: var(--md-code-font, monospace);
+  font-size: 0.66rem; letter-spacing: 0.08em; text-transform: uppercase;
+  opacity: 0.78;
 }
+.md-tabs__link:hover, .md-tabs__link--active { opacity: 1; }
+.md-tabs__item--active .md-tabs__link { box-shadow: inset 0 -2px var(--pk-red); }
+.md-search__form { border-radius: 1px; background-color: rgba(255, 255, 255, 0.12); }
+.md-search__form:hover { background-color: rgba(255, 255, 255, 0.18); }
+.md-search__output { border-radius: 0 0 1px 1px; }
+.md-search__input::placeholder { color: rgba(255, 255, 255, 0.6); }
 
-/* Cards grid */
-.grid.cards {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-  gap: 1rem;
-  margin: 1rem 0;
-}
-
-.grid.cards > * {
-  padding: 1rem;
-  border: 1px solid var(--md-typeset-table-color);
-  border-radius: 0.5rem;
-  transition: box-shadow 0.2s;
-}
-
-.grid.cards > *:hover {
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
-}
-
-/* Hero section on home */
+/* ── typography ── */
+.md-typeset { font-size: 0.78rem; line-height: 1.65; }
 .md-typeset h1 {
-  font-weight: 700;
+  font-weight: 800; letter-spacing: 0.01em; text-transform: uppercase;
+  color: var(--pk-ink); line-height: 1.06;
+  font-variation-settings: "wght" 800, "wdth" 112;
 }
+.md-typeset h2 {
+  font-weight: 700; letter-spacing: 0.005em; color: var(--pk-ink);
+  margin-top: 2.2em; padding-top: 0.6em; border-top: 1px solid var(--pk-line);
+}
+/* red plan-callout tick before every H2 (in-flow, no margin collision) */
+.md-typeset h2::before {
+  content: ""; display: inline-block; width: 20px; height: 2px;
+  background: var(--pk-red); vertical-align: middle;
+  margin-right: 0.55em; transform: translateY(-0.18em);
+}
+.md-typeset h3, .md-typeset h4 { font-weight: 700; color: var(--pk-ink); }
+.md-typeset h5, .md-typeset h6 {
+  font-family: var(--md-code-font, monospace);
+  text-transform: uppercase; letter-spacing: 0.06em; color: var(--pk-ink-3);
+  font-size: 0.72rem;
+}
+/* identifiers in headings must never be uppercased/tracked or mono-cased */
+.md-typeset h1 code, .md-typeset h2 code,
+.md-typeset h3 code, .md-typeset h4 code,
+.md-typeset h5 code, .md-typeset h6 code {
+  text-transform: none; letter-spacing: normal;
+  font-family: var(--md-code-font, monospace);
+}
+.md-typeset h2 code::before { content: none; }
 
-/* Code tabs */
+/* links: ink body links with a red underline, full red on hover */
+.md-typeset a {
+  text-decoration: underline;
+  text-decoration-color: var(--pk-red);
+  text-decoration-thickness: 1px;
+  text-underline-offset: 2px;
+}
+.md-typeset a:hover { color: var(--pk-red-hover); text-decoration-color: var(--pk-red-hover); }
+
+/* ── sharp corners everywhere ── */
+.md-typeset pre > code,
+.md-typeset .highlight,
+.md-typeset > .highlighttable,
+.md-typeset code,
+.md-typeset .admonition,
+.md-typeset details,
+.md-typeset table:not([class]),
+.md-button,
+.grid.cards > *,
+.md-typeset .tabbed-content,
+.md-typeset .tabbed-labels > label,
+.md-typeset .tabbed-block { border-radius: 1px !important; }
+
+/* ── code ── */
+.highlight code, .md-typeset code { font-size: 0.82em; }
+.md-typeset pre > code { border: 1px solid var(--pk-line); }
+.md-typeset code:not(pre code) {
+  border: 1px solid var(--pk-line); padding: 0.05em 0.35em;
+  color: var(--pk-ink);
+}
+.md-clipboard { color: var(--pk-ink-3); }
+.md-clipboard:hover { color: var(--pk-red); }
+
+/* ── tables (schedule of quantities) ── */
+.md-typeset table:not([class]) { font-size: 0.8em; border: 1px solid var(--pk-ink); }
+.md-typeset table:not([class]) th {
+  background-color: var(--pk-ink); color: var(--pk-paper);
+  font-family: var(--md-code-font, monospace);
+  font-weight: 500; text-transform: uppercase; letter-spacing: 0.06em;
+  font-size: 0.64rem;
+}
+.md-typeset table:not([class]) td { border-top: 1px solid var(--pk-line); }
+.md-typeset table:not([class]) tr:hover { background: var(--pk-card); }
+
+/* ── admonitions (spend red only on `note` = the DETAIL callout) ── */
+.md-typeset .admonition, .md-typeset details {
+  border: 1px solid var(--pk-line); border-left-width: 3px;
+  box-shadow: none; font-size: 0.76rem;
+}
+.md-typeset .admonition-title, .md-typeset summary {
+  font-family: var(--md-code-font, monospace);
+  text-transform: uppercase; letter-spacing: 0.04em; font-size: 0.7rem;
+  background: var(--pk-card);
+}
+.md-typeset .admonition.note { border-left-color: var(--pk-red); }
+.md-typeset .note > .admonition-title::before { background-color: var(--pk-red); }
+.md-typeset .admonition.info, .md-typeset .admonition.abstract,
+.md-typeset .admonition.example, .md-typeset .admonition.quote {
+  border-left-color: var(--pk-ink-2);
+}
+.md-typeset .info > .admonition-title::before,
+.md-typeset .abstract > .admonition-title::before,
+.md-typeset .example > .admonition-title::before,
+.md-typeset .quote > .admonition-title::before { background-color: var(--pk-ink-2); }
+.md-typeset .admonition.tip, .md-typeset .admonition.success { border-left-color: #1f7a4d; }
+.md-typeset .tip > .admonition-title::before,
+.md-typeset .success > .admonition-title::before { background-color: #1f7a4d; }
+.md-typeset .admonition.warning { border-left-color: #a86b0d; }
+.md-typeset .warning > .admonition-title::before { background-color: #a86b0d; }
+.md-typeset .admonition.danger, .md-typeset .admonition.bug,
+.md-typeset .admonition.failure { border-left-color: var(--pk-red); }
+.md-typeset .danger > .admonition-title::before,
+.md-typeset .bug > .admonition-title::before,
+.md-typeset .failure > .admonition-title::before { background-color: var(--pk-red); }
+
+/* ── content tabs ── */
 .md-typeset .tabbed-labels > label {
-  font-weight: 500;
+  font-family: var(--md-code-font, monospace);
+  font-weight: 500; text-transform: uppercase; letter-spacing: 0.03em;
+  font-size: 0.68rem;
+}
+.md-typeset .tabbed-set > input:checked + label { color: var(--pk-red); }
+.js .md-typeset .tabbed-labels::before { background: var(--pk-red); }
+
+/* ── navigation (red reserved for the ACTIVE item) ── */
+.md-nav__link:hover, .md-nav__link:focus { color: var(--pk-red); }
+.md-nav__link--active, .md-nav__item .md-nav__link--active {
+  color: var(--pk-red); font-weight: 600;
+}
+.md-nav__title {
+  font-family: var(--md-code-font, monospace);
+  text-transform: uppercase; letter-spacing: 0.06em; font-size: 0.62rem;
+}
+.md-sidebar--secondary .md-nav__link--active {
+  border-left: 2px solid var(--pk-red); padding-left: 0.6rem;
+}
+/* breadcrumbs (navigation.path) as plan-sheet zone labels */
+.md-nav__path { font-family: var(--md-code-font, monospace); text-transform: uppercase; letter-spacing: 0.04em; }
+
+/* ── buttons ── */
+.md-typeset .md-button {
+  border: 1px solid var(--pk-line-2); border-radius: 1px;
+  font-family: var(--md-code-font, monospace); text-transform: uppercase;
+  letter-spacing: 0.03em; font-size: 0.7rem;
+}
+.md-typeset .md-button:hover { border-color: var(--pk-red); color: var(--pk-red); background: transparent; }
+.md-typeset .md-button--primary {
+  background: var(--pk-ink); color: var(--pk-paper); border-color: var(--pk-ink);
+}
+.md-typeset .md-button--primary:hover { background: var(--pk-red); border-color: var(--pk-red); color: #fff; }
+
+/* ── cards grid (single bordered block, hairline cell dividers) ── */
+.grid.cards {
+  display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 0; border: 1px solid var(--pk-ink); margin: 1.4rem 0;
+}
+.grid.cards > * {
+  padding: 1.1rem 1.2rem; border: 0;
+  border-right: 1px solid var(--pk-line); border-bottom: 1px solid var(--pk-line);
+  border-radius: 0 !important; box-shadow: none; transition: background 0.18s;
+}
+.grid.cards > *:hover { box-shadow: none; background: var(--pk-card); }
+.md-typeset .grid.cards > ul > li:hover { box-shadow: none; }
+
+/* ── title-block footer (mirrors the landing's fixed sheet header) ── */
+.pk-titleblock {
+  display: grid;
+  grid-template-columns: minmax(0, 1.5fr) minmax(0, 1.5fr) minmax(0, 1fr) minmax(0, 1.2fr);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  font-family: var(--md-code-font, monospace);
+  max-width: 100%;
+}
+.pk-tb-cell {
+  border-right: 1px solid rgba(255, 255, 255, 0.1);
+  padding: 0.5rem 0.9rem; display: flex; flex-direction: column; gap: 1px;
+  min-width: 0; overflow: hidden;
+}
+.pk-tb-cell:last-child { border-right: 0; }
+.pk-tb-k { font-size: 0.5rem; letter-spacing: 0.16em; text-transform: uppercase; opacity: 0.55; }
+.pk-tb-v { font-size: 0.68rem; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.pk-tb-v a { color: inherit; text-decoration: none; }
+.pk-tb-v a:hover { color: var(--pk-red); }
+.pk-tb-blatt { border-left: 3px solid var(--pk-red); }
+.pk-tb-blatt .pk-tb-v { color: var(--pk-red); }
+.pk-tb-blatt .pk-tb-v a { color: var(--pk-red); }
+@media screen and (max-width: 44.9375em) {
+  .pk-titleblock { grid-template-columns: 1fr auto; }
+  .pk-tb-cell.pk-tb-hide { display: none; }
 }
 
-/* Custom icons */
-.lg.middle {
-  font-size: 2rem;
-  vertical-align: middle;
-  margin-right: 0.5rem;
-}
+/* ── mermaid ── */
+.mermaid { text-align: center; margin: 1rem 0; }
+.md-typeset .mermaid .xychart-bar { fill: var(--pk-red); }
 
-/* Feature comparison checkmarks */
-.success {
-  color: #22c55e;
-}
+/* ── misc kept from the original ── */
+.lg.middle { font-size: 2rem; vertical-align: middle; margin-right: 0.5rem; }
+.success { color: #1f7a4d; }
+.md-typeset table td:has(.success) { color: #1f7a4d; }
 
-/* XY Chart styling */
-.md-typeset .mermaid .xychart-bar {
-  fill: var(--md-primary-fg-color);
-}
-
-/* Responsive adjustments */
+/* ── responsive ── */
 @media screen and (max-width: 76.1875em) {
-  .grid.cards {
-    grid-template-columns: 1fr;
-  }
+  .grid.cards { grid-template-columns: 1fr; }
+  .grid.cards > * { border-right: 0; }
 }
 
-/* Print styles */
+/* ── print ── */
 @media print {
-  .md-sidebar,
-  .md-header,
-  .md-tabs {
-    display: none;
-  }
+  .md-sidebar, .md-header, .md-tabs { display: none; }
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,18 +11,24 @@ theme:
   name: material
   custom_dir: docs/overrides
   logo: assets/logo.png
+  # PLANKOPF: Swiss engineering plan-sheet identity, matching ifclite.dev.
+  # font:false so Material skips its legacy Fonts API (no variable weights) —
+  # docs/overrides/main.html loads variable Archivo + Fragment Mono instead.
+  # primary/accent:custom so Material emits no colour rules; the carbon header
+  # + Swiss-red accents are fully owned by docs/stylesheets/extra.css.
+  font: false
   palette:
     - media: "(prefers-color-scheme: light)"
       scheme: default
-      primary: indigo
-      accent: blue
+      primary: custom
+      accent: custom
       toggle:
         icon: material/brightness-7
         name: Switch to dark mode
     - media: "(prefers-color-scheme: dark)"
       scheme: slate
-      primary: indigo
-      accent: blue
+      primary: custom
+      accent: custom
       toggle:
         icon: material/brightness-4
         name: Switch to light mode


### PR DESCRIPTION
Extends the PLANKOPF Swiss engineering plan-sheet identity (shipped for the landing in #1753) to the **mkdocs-material docs site** at ifclite.dev/docs, so the two surfaces read as one system.

## What changed
- **Fonts** — Archivo (text) + Fragment Mono (code). `theme.font: false` disables Material's legacy Fonts API (which only loads 300/400/700 and would faux-synthesize Archivo 800 / bold mono); `docs/overrides/main.html` loads the variable Archivo (400..900) + Fragment Mono and sets `--md-text-font`/`--md-code-font`.
- **Palette** — `primary`/`accent: custom` so Material emits no colour rules. This avoids two real conflicts verified against Material 9.7.x internals: the special-cased `primary: black` header paint, and `[data-md-color-scheme=slate][data-md-color-primary=black]{--md-typeset-a-color:#5e8bde}` at `(0,2,0)` that would beat scheme overrides. `extra.css` now fully owns both schemes (paper/carbon, one Swiss red, alpha-preserving `--light/--lighter/--lightest` tints, warm `--md-hue`, retuned near-monochrome code tokens).
- **Type** — Archivo uppercase H1, red DETAIL tick + hairline rule on H2, mono-uppercase micro-headings and nav/tab/table labels. Identifiers in headings (`h* code`) exempted from casing so API symbols stay verbatim.
- **Red economy** — links are ink with a red underline; solid red is reserved for `note` admonitions, the active nav/toc item, H2 ticks, and the BLATT cell.
- **Signature move** — a title-block footer (`partials/copyright.html`) mirroring the landing's fixed sheet header (PROJEKT / GEZ. / LIZENZ / BLATT).
- **Mermaid** — diagrams now carry brand colours, so `mermaid-init.js` re-initialises and re-renders on palette toggle (stashing each diagram's source first).

## Process
Planned with an adversarial review (grounded against the installed Material 9.7.1 CSS) that caught the `primary: black` / slate-link specificity bugs, the alpha-tint requirement, the font-weight gap, and a red-overspend before implementation.

## Verification
`mkdocs build --strict` passes; Archivo 800 (real, variable) + Fragment Mono confirmed loaded; light + dark both render coherently (header, cards, tables, admonitions, code, nav, title-block footer). Only local 404 is `/versions.json` (pre-existing `mike` version provider, generated on deploy).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Mermaid diagrams now automatically re-render when switching between light and dark themes.
  - Documentation pages now use custom Archivo and Fragment Mono fonts.
  - Added a structured documentation title block with project, author, license, and document information.

- **Style**
  - Introduced a refreshed light and dark visual theme with updated colors, typography, code blocks, tables, cards, navigation, buttons, and admonitions.
  - Improved responsive and print-friendly layouts.
  - Updated theme configuration to support the custom visual identity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->