### PR TITLE
fix(parser): By Material tab misses materials associated to TYPE entities (#1755)

### DIFF
--- a/.changeset/lucky-materials-1755.md
+++ b/.changeset/lucky-materials-1755.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/parser": patch
+---
+
+Fix By Material tab / material totals missing materials associated to TYPE entities (#1755). `buildMaterialUsageIndex` now expands `IfcRelAssociatesMaterial` targets that are type entities (e.g. `IfcDoorType`) to their occurrences via forward `IfcRelDefinesByType` edges, with occurrence-level associations taking precedence (IFC semantics) and no double counting. Previously the usage index keyed such materials to the type entity itself, which the viewer's By Material tree dropped via its geometry filter and the totals panel mis-attributed.

--- a/apps/viewer/src/components/viewer/hierarchy/treeDataBuilder.test.ts
+++ b/apps/viewer/src/components/viewer/hierarchy/treeDataBuilder.test.ts
@@ -21,6 +21,7 @@ import {
   buildUnifiedStoreys,
   compareStoreyEntries,
   buildGroupTree,
+  buildMaterialTree,
   resolveMemberGeometry,
   groupMatchesSubFilter,
   GROUP_ENTITY_TYPES,
@@ -1088,5 +1089,73 @@ describe('buildGroupTree — IFCX-shaped store (empty entityIndex)', () => {
     const nodes = buildGroupTree(models, null, new Set(), true, new Set([2, 3]));
     const systems = nodes.filter((n) => n.type === 'group' && n.ifcType === 'IfcDistributionSystem');
     assert.strictEqual(systems.length, 1, 'the shared store must not duplicate group rows per layer');
+  });
+});
+
+// ============================================================================
+// Issue #1755 — By Material tab must surface materials associated to TYPE
+// entities (IfcDoorType). Before the fix the usage index keyed those entries
+// to the type entity, which the geometricIds filter silently dropped.
+// ============================================================================
+
+/** STEP-lines store: doors #1/#2 typed by IfcDoorType #5 (constituent set
+ *  wood1/wood2 on the TYPE), wall #3 with occurrence-level 'Unknown'. */
+function createTypedMaterialDataStore(): IfcDataStore {
+  const lines = [
+    `#1=IFCDOOR('d1',$,'Door',$,$,$,$,$,2.,0.9,$,$,$);`,
+    `#2=IFCDOOR('d2',$,'Door',$,$,$,$,$,2.,0.9,$,$,$);`,
+    `#3=IFCWALL('w1',$,'Wall',$,$,$,$,$,$);`,
+    `#5=IFCDOORTYPE('t1',$,'DoorType',$,$,$,$,$,$,.DOOR.,.SINGLE_SWING_LEFT.,$);`,
+    `#10=IFCMATERIAL('wood1',$,$);`,
+    `#11=IFCMATERIAL('wood2',$,$);`,
+    `#12=IFCMATERIAL('Unknown',$,$);`,
+    `#20=IFCMATERIALCONSTITUENT('Lining',$,#10,0.6,$);`,
+    `#21=IFCMATERIALCONSTITUENT('Framing',$,#11,0.4,$);`,
+    `#22=IFCMATERIALCONSTITUENTSET('Unnamed',$,(#20,#21));`,
+  ];
+  const text = lines.join('\n');
+  const byId = new Map<number, { expressId: number; type: string; byteOffset: number; byteLength: number; lineNumber: number }>();
+  let cursor = 0;
+  for (const line of lines) {
+    const start = text.indexOf(line, cursor);
+    const match = line.match(/^#(\d+)\s*=\s*(\w+)\(/)!;
+    byId.set(parseInt(match[1], 10), {
+      expressId: parseInt(match[1], 10),
+      type: match[2],
+      byteOffset: start,
+      byteLength: line.length,
+      lineNumber: 1,
+    });
+    cursor = start + line.length;
+  }
+
+  const relBuilder = new RelationshipGraphBuilder();
+  relBuilder.addEdge(5, 1, RelationshipType.DefinesByType, 100);
+  relBuilder.addEdge(5, 2, RelationshipType.DefinesByType, 100);
+
+  return {
+    source: new TextEncoder().encode(text),
+    entityIndex: { byId, byType: new Map() },
+    onDemandMaterialMap: new Map([[5, 22], [3, 12]]),
+    relationships: relBuilder.build(),
+  } as unknown as IfcDataStore;
+}
+
+describe('buildMaterialTree — type-level material expansion (#1755)', () => {
+  it('surfaces type-associated materials as rows carrying the occurrence ids', () => {
+    const ds = createTypedMaterialDataStore();
+    // Geometry filter ON with only wall+doors rendered — types must survive it.
+    const nodes = buildMaterialTree(new Map(), ds, new Set(), false, new Set([1, 2, 3]));
+
+    const byName = new Map(nodes.map((n) => [n.name, n]));
+    assert.deepStrictEqual(
+      [...byName.keys()].sort(),
+      ['Unknown', 'wood1', 'wood2'],
+      'all three materials must appear (wood1/wood2 hang off the IfcDoorType)',
+    );
+    assert.deepStrictEqual([...byName.get('wood1')!.globalIds].sort(), [1, 2], 'click-to-isolate targets the doors, not the type');
+    assert.deepStrictEqual([...byName.get('wood2')!.globalIds].sort(), [1, 2]);
+    assert.strictEqual(byName.get('wood1')!.elementCount, 2);
+    assert.deepStrictEqual(byName.get('Unknown')!.globalIds, [3], 'occurrence-level association untouched');
   });
 });

--- a/packages/parser/src/material-resolver.ts
+++ b/packages/parser/src/material-resolver.ts
@@ -11,6 +11,7 @@
 import { EntityExtractor } from './entity-extractor.js';
 import { RelationshipType } from '@ifc-lite/data';
 import type { IfcDataStore } from './columnar-parser.js';
+import { isIfcTypeLikeEntity } from './columnar-parser-indexes.js';
 
 export interface MaterialInfo {
     type: 'Material' | 'MaterialLayerSet' | 'MaterialProfileSet' | 'MaterialConstituentSet' | 'MaterialList';
@@ -587,7 +588,33 @@ export function buildMaterialUsageIndex(store: IfcDataStore): Map<number, Materi
     const usage = new Map<number, MaterialUsage>();
     const forward = store.onDemandMaterialMap;
     if (forward && store.source?.length) {
+        // Guards against a malformed model double-typing one occurrence
+        // (two IfcRelDefinesByType rels → duplicate forward edges), which
+        // would otherwise double-count it in the totals panel.
+        const seenPerMaterial = new Map<number, Set<number>>();
         for (const [entityId, defId] of forward) {
+            // IfcRelAssociatesMaterial commonly targets the TYPE entity
+            // (IfcDoorType etc.). The tab/totals need occurrences — a type
+            // has no geometry, so a type-keyed entry is invisible in the
+            // By Material tree (geom filter) and mis-attributes quantities
+            // (#1755). Expand type keys to their instances via forward
+            // DefinesByType edges; occurrences with their OWN association
+            // are skipped (IFC precedence: occurrence overrides type — they
+            // get their entry from their own map iteration). The type keeps
+            // no entry of its own: a zero-instance type would only produce
+            // dead rows. Stores without a relationship graph (minimal test
+            // stores) keep the old verbatim behavior.
+            const ref = getRef(store, entityId);
+            let targets: readonly number[];
+            if (ref && store.relationships && isIfcTypeLikeEntity(ref.type.toUpperCase())) {
+                targets = store.relationships
+                    .getRelated(entityId, RelationshipType.DefinesByType, 'forward')
+                    .filter((occId) => !forward.has(occId));
+            } else {
+                targets = [entityId];
+            }
+            if (targets.length === 0) continue;
+
             const leaves = collectMaterialLeaves(store, defId);
             for (const leaf of leaves) {
                 let entry = usage.get(leaf.id);
@@ -602,7 +629,13 @@ export function buildMaterialUsageIndex(store: IfcDataStore): Map<number, Materi
                     };
                     usage.set(leaf.id, entry);
                 }
-                entry.entries.push({ entityId, weight: leaf.weight });
+                let seen = seenPerMaterial.get(leaf.id);
+                if (!seen) { seen = new Set(); seenPerMaterial.set(leaf.id, seen); }
+                for (const target of targets) {
+                    if (seen.has(target)) continue;
+                    seen.add(target);
+                    entry.entries.push({ entityId: target, weight: leaf.weight });
+                }
             }
         }
     }

--- a/packages/parser/test/material-usage-type-expansion.test.ts
+++ b/packages/parser/test/material-usage-type-expansion.test.ts
@@ -1,0 +1,90 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Integration regression for issue #1755 — the viewer's "By Material" tab
+ * showed a single row for a model whose door materials were associated to the
+ * IfcDoorType. `buildMaterialUsageIndex` iterated `onDemandMaterialMap`
+ * verbatim, so type-associated materials were keyed to the TYPE entity, which
+ * the tab's geometry filter then dropped. This exercises the FULL pipeline
+ * (scan → parseLite → usage index) so the forward IfcRelDefinesByType edge
+ * direction is validated against the real relationship graph, not hand-built
+ * test edges.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { StepTokenizer } from '../src/tokenizer.js';
+import { ColumnarParser } from '../src/columnar-parser.js';
+import { buildMaterialUsageIndex, extractMaterialsOnDemand } from '../src/material-resolver.js';
+import type { EntityRef } from '../src/types.js';
+
+function scan(ifc: string): { source: Uint8Array; entityRefs: EntityRef[] } {
+    const source = new TextEncoder().encode(ifc);
+    const tokenizer = new StepTokenizer(source);
+    const entityRefs: EntityRef[] = [];
+    for (const ref of tokenizer.scanEntitiesFast()) {
+        entityRefs.push({
+            expressId: ref.expressId,
+            type: ref.type,
+            byteOffset: ref.offset,
+            byteLength: ref.length,
+            lineNumber: ref.line,
+        });
+    }
+    return { source, entityRefs };
+}
+
+// Mirrors the #1755 report: wall with an occurrence-level IfcMaterial
+// ('Unknown'), two doors whose constituent sets (wood1 / wood2) hang off
+// their IfcDoorTypes via IfcRelAssociatesMaterial.
+const IFC = `#1=IFCPROJECT('0Project00000000000001',$,'Repro 1755',$,$,$,$,$,$);
+#100=IFCWALL('0Wall00000000000000001',$,'Wall',$,$,$,$,$,$);
+#110=IFCDOOR('0Door00000000000000001',$,'Door',$,$,$,$,$,2.,0.9,$,$,$);
+#120=IFCDOOR('0Door00000000000000002',$,'Door',$,$,$,$,$,2.,0.9,$,$,$);
+#200=IFCDOORTYPE('0DoorType0000000000001',$,'DoorType-wood1',$,$,$,$,$,$,.DOOR.,.SINGLE_SWING_LEFT.,$);
+#201=IFCDOORTYPE('0DoorType0000000000002',$,'DoorType-wood2',$,$,$,$,$,$,.DOOR.,.SINGLE_SWING_LEFT.,$);
+#210=IFCRELDEFINESBYTYPE('0RelType00000000000001',$,$,$,(#110),#200);
+#211=IFCRELDEFINESBYTYPE('0RelType00000000000002',$,$,$,(#120),#201);
+#300=IFCMATERIAL('Unknown',$,$);
+#301=IFCMATERIAL('wood1',$,$);
+#302=IFCMATERIAL('wood2',$,$);
+#310=IFCMATERIALCONSTITUENT('Lining',$,#301,$,$);
+#311=IFCMATERIALCONSTITUENT('Framing',$,#301,$,$);
+#312=IFCMATERIALCONSTITUENTSET('Unnamed',$,(#310,#311));
+#320=IFCMATERIALCONSTITUENT('Lining',$,#302,$,$);
+#321=IFCMATERIALCONSTITUENT('Framing',$,#302,$,$);
+#322=IFCMATERIALCONSTITUENTSET('Unnamed',$,(#320,#321));
+#330=IFCRELASSOCIATESMATERIAL('0RelMat000000000000001',$,$,$,(#100),#300);
+#331=IFCRELASSOCIATESMATERIAL('0RelMat000000000000002',$,$,$,(#200),#312);
+#332=IFCRELASSOCIATESMATERIAL('0RelMat000000000000003',$,$,$,(#201),#322);`;
+
+describe('buildMaterialUsageIndex end-to-end type expansion (#1755)', () => {
+    it('attributes type-associated constituent materials to door occurrences', async () => {
+        const { source, entityRefs } = scan(IFC);
+        const parser = new ColumnarParser();
+        const store = await parser.parseLite(source.buffer.slice(0) as ArrayBuffer, entityRefs, {});
+
+        // Sanity: the parser keyed the associations to the TYPE entities.
+        expect(store.onDemandMaterialMap?.get(200)).toBe(312);
+        expect(store.onDemandMaterialMap?.get(201)).toBe(322);
+
+        const usage = buildMaterialUsageIndex(store);
+        const byName = new Map([...usage.values()].map((u) => [u.name, u]));
+
+        // wood1/wood2 rows must exist and reference the DOOR occurrences.
+        expect(byName.get('wood1')!.entries.map((e) => e.entityId)).toEqual([110]);
+        expect(byName.get('wood2')!.entries.map((e) => e.entityId)).toEqual([120]);
+        // Occurrence-level wall material untouched.
+        expect(byName.get('Unknown')!.entries.map((e) => e.entityId)).toEqual([100]);
+        // No usage entry may reference a type entity.
+        for (const u of usage.values()) {
+            for (const e of u.entries) expect([200, 201]).not.toContain(e.entityId);
+        }
+
+        // The per-element path (properties panel) keeps its type fallback.
+        const info = extractMaterialsOnDemand(store, 110);
+        expect(info?.type).toBe('MaterialConstituentSet');
+        expect(info?.constituents?.map((c) => c.materialName)).toEqual(['wood1', 'wood1']);
+    });
+});

--- a/packages/parser/test/on-demand-material-properties.test.ts
+++ b/packages/parser/test/on-demand-material-properties.test.ts
@@ -19,9 +19,16 @@ import {
 } from '../src/columnar-parser.js';
 import type { IfcDataStore } from '../src/columnar-parser.js';
 import type { EntityRef } from '../src/types.js';
+import { RelationshipGraphBuilder, RelationshipType } from '@ifc-lite/data';
 
-/** Build a minimal IfcDataStore from STEP lines + an element→material map. */
-function buildStore(lines: string[], materialMap?: Map<number, number>): IfcDataStore {
+/** Build a minimal IfcDataStore from STEP lines + an element→material map.
+ *  `definesByType` adds forward IfcRelDefinesByType edges (type → occurrences)
+ *  so the type-level material expansion in buildMaterialUsageIndex is testable. */
+function buildStore(
+  lines: string[],
+  materialMap?: Map<number, number>,
+  definesByType?: Array<[number, number[]]>,
+): IfcDataStore {
   const text = lines.join('\n');
   const source = new TextEncoder().encode(text);
 
@@ -51,10 +58,23 @@ function buildStore(lines: string[], materialMap?: Map<number, number>): IfcData
     cursor = start + line.length;
   }
 
+  let relationships: unknown;
+  if (definesByType) {
+    const builder = new RelationshipGraphBuilder();
+    let relId = 90000;
+    for (const [typeId, occIds] of definesByType) {
+      for (const occId of occIds) {
+        builder.addEdge(typeId, occId, RelationshipType.DefinesByType, relId++);
+      }
+    }
+    relationships = builder.build();
+  }
+
   return {
     source,
     entityIndex: { byId, byType },
     onDemandMaterialMap: materialMap,
+    relationships,
   } as unknown as IfcDataStore;
 }
 
@@ -196,5 +216,110 @@ describe('buildMaterialUsageIndex', () => {
     expect(insulation.entries).toHaveLength(1);
     expect(insulation.entries[0]).toMatchObject({ entityId: 2 });
     expect(insulation.entries[0].weight).toBeCloseTo(0.2, 6);
+  });
+});
+
+// Issue #1755 — IfcRelAssociatesMaterial commonly targets the TYPE entity
+// (IfcDoorType). The usage index must attribute those materials to the
+// occurrences (types have no geometry, so the By Material tab filtered them
+// out and the totals panel mis-attributed quantities).
+describe('buildMaterialUsageIndex — type-level material expansion (#1755)', () => {
+  // Doors #1/#2 typed by IfcDoorType #5; wall #3 with its own material.
+  // Type #5 carries a two-constituent set (wood1/wood2).
+  const TYPED = [
+    `#1=IFCDOOR('d1',$,'Door',$,$,$,$,$,2.,0.9,$,$,$);`,
+    `#2=IFCDOOR('d2',$,'Door',$,$,$,$,$,2.,0.9,$,$,$);`,
+    `#3=IFCWALL('w1',$,'Wall',$,$,$,$,$,$);`,
+    `#5=IFCDOORTYPE('t1',$,'DoorType',$,$,$,$,$,$,.DOOR.,.SINGLE_SWING_LEFT.,$);`,
+    `#10=IFCMATERIAL('wood1',$,$);`,
+    `#11=IFCMATERIAL('wood2',$,$);`,
+    `#12=IFCMATERIAL('Unknown',$,$);`,
+    `#20=IFCMATERIALCONSTITUENT('Lining',$,#10,0.6,$);`,
+    `#21=IFCMATERIALCONSTITUENT('Framing',$,#11,0.4,$);`,
+    `#22=IFCMATERIALCONSTITUENTSET('Unnamed',$,(#20,#21));`,
+  ];
+
+  it('attributes a type-associated material to the occurrences, not the type', () => {
+    const store = buildStore(
+      TYPED,
+      new Map([[5, 22], [3, 12]]),
+      [[5, [1, 2]]],
+    );
+    const usage = buildMaterialUsageIndex(store);
+
+    const wood1 = usage.get(10)!;
+    expect(wood1.entries.map((e) => e.entityId).sort()).toEqual([1, 2]);
+    for (const e of wood1.entries) expect(e.weight).toBeCloseTo(0.6, 6);
+
+    const wood2 = usage.get(11)!;
+    expect(wood2.entries.map((e) => e.entityId).sort()).toEqual([1, 2]);
+    for (const e of wood2.entries) expect(e.weight).toBeCloseTo(0.4, 6);
+
+    // The type entity itself must NOT appear (dead row in the tab, phantom
+    // element in the totals panel).
+    for (const u of usage.values()) {
+      expect(u.entries.some((e) => e.entityId === 5)).toBe(false);
+    }
+
+    // Occurrence-level association untouched.
+    expect(usage.get(12)!.entries).toEqual([{ entityId: 3, weight: 1 }]);
+  });
+
+  it('occurrence-level association overrides the type-level one (no double count)', () => {
+    // Door #1 has its OWN material (wood2 direct); #2 inherits from the type.
+    const store = buildStore(
+      TYPED,
+      new Map([[5, 22], [1, 11]]),
+      [[5, [1, 2]]],
+    );
+    const usage = buildMaterialUsageIndex(store);
+
+    // #1 appears exactly once across all usages — under its own wood2.
+    const appearances: number[] = [];
+    for (const u of usage.values()) {
+      for (const e of u.entries) if (e.entityId === 1) appearances.push(u.id);
+    }
+    expect(appearances).toEqual([11]);
+    expect(usage.get(11)!.entries.find((e) => e.entityId === 1)!.weight).toBeCloseTo(1, 6);
+
+    // #2 still inherits both constituents from the type.
+    expect(usage.get(10)!.entries.map((e) => e.entityId)).toEqual([2]);
+  });
+
+  it('per-occurrence weights across usages sum to ~1', () => {
+    const store = buildStore(TYPED, new Map([[5, 22]]), [[5, [1, 2]]]);
+    const usage = buildMaterialUsageIndex(store);
+    for (const occId of [1, 2]) {
+      let sum = 0;
+      for (const u of usage.values()) {
+        for (const e of u.entries) if (e.entityId === occId) sum += e.weight;
+      }
+      expect(sum).toBeCloseTo(1, 6);
+    }
+  });
+
+  it('a type with zero occurrences yields no entries (no dead rows)', () => {
+    const store = buildStore(TYPED, new Map([[5, 22]]), [[5, []]]);
+    const usage = buildMaterialUsageIndex(store);
+    expect(usage.size).toBe(0);
+  });
+
+  it('keeps the verbatim type-keyed entry when the store has no relationship graph', () => {
+    // Minimal stores (this harness without definesByType) have no graph —
+    // fall back to the old behavior rather than dropping data.
+    const store = buildStore(TYPED, new Map([[5, 22]]));
+    const usage = buildMaterialUsageIndex(store);
+    expect(usage.get(10)!.entries.map((e) => e.entityId)).toEqual([5]);
+  });
+
+  it('dedupes a double-typed occurrence (malformed duplicate DefinesByType edges)', () => {
+    const store = buildStore(
+      TYPED,
+      new Map([[5, 22]]),
+      [[5, [1, 1, 2]]],
+    );
+    const usage = buildMaterialUsageIndex(store);
+    const wood1Ids = usage.get(10)!.entries.map((e) => e.entityId).sort();
+    expect(wood1Ids).toEqual([1, 2]);
   });
 });


### PR DESCRIPTION
Fixes #1755.

## Root cause

The By Material sidebar tab showed a single "Unknown" row for models where door materials hang off the **IfcDoorType** via `IfcRelAssociatesMaterial` (standard practice for doors/windows):

- `buildMaterialUsageIndex` iterated `onDemandMaterialMap` verbatim, so type-associated materials were keyed to the **type entity**.
- `buildMaterialTree` then dropped those entries via its `geometricIds` filter — type entities render no geometry — so the wood1/wood2 rows vanished. Only the wall's occurrence-level material survived.
- The properties panel was unaffected (`extractMaterialsOnDemand` already falls back occurrence→type), which is why the panel showed the constituent sets while the tab showed nothing.

Not a layer/constituent-set resolution bug: sets fan out correctly. The missing piece was expanding **type-level associations to occurrences** in the usage index.

## Fix

`buildMaterialUsageIndex` now expands type-entity keys (`isIfcTypeLikeEntity`, covers IFC2x3 `*Style`) to their occurrences via forward `IfcRelDefinesByType` edges:

- **Occurrence wins**: instances carrying their own association are skipped during expansion (IFC precedence), no double counting.
- **No phantom rows**: the type entity keeps no entry of its own; a zero-instance type emits nothing.
- **Dedupe** guards against malformed double-typed occurrences.
- Stores without a relationship graph keep the previous verbatim behavior.

This transitively fixes both consumers: the By Material tree (rows appear, click-to-isolate targets the doors) and the material totals panel (element counts/By Class now attribute to occurrences — previously `IfcDoorType` was counted as the element and occurrence Qto sets were never summed).

## Verification

- 7 new parser unit tests (type-only, occurrence-only, precedence, weight sums, no-graph back-compat, zero-occurrence type, double-typing dedupe) + 1 end-to-end `scan → parseLite → index` integration test validating the real edge direction. Parser suite: 261 passing.
- New `buildMaterialTree` viewer test: type-associated materials survive the geometry filter and carry occurrence ids. Tree suite: 42 passing.
- Verified live on localhost with a repro model (wall + 2 doors, constituent sets wood1/wood2 on the door types): By Material shows Unknown/wood1/wood2; clicking each row isolates the correct element; totals panel reports `IFCDOOR`, not `IFCDOORTYPE`.
- API surface unchanged; changeset included (`@ifc-lite/parser` patch).

## Adjacent findings (out of scope, from the adversarial sweep)

1. `onDemandMaterialMap` is last-wins (`Map<number, number>`): multiple `IfcRelAssociatesMaterial` per object lose all but one, and the cache-rebuild path can pick a *different* survivor than a fresh parse.
2. Server-loaded stores (no on-demand map) yield an empty usage index → By Material tab empty on that path.
3. Constituent sets with partial fractions weight fraction-less siblings at 0 in totals.
4. Totals panel never consults type-level Qto sets (`extractTypeQuantitiesOnDemand`, #1745 territory) — typed materials with type-held quantities still total 0 volume.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed the **By Material** view so materials assigned through IFC type entities appear correctly on rendered elements.
  - Corrected material totals and element counts by preventing duplicate material assignments.
  - Preserved occurrence-level material assignments when they override type-level assignments.
  - Improved handling for models with missing or incomplete relationship data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->