### PR TITLE
fix(viewer): drive SpaceMouse axis parsing from the HID report descriptor (#1677)

### DIFF
--- a/apps/viewer/src/components/viewer/SpaceMousePanel.tsx
+++ b/apps/viewer/src/components/viewer/SpaceMousePanel.tsx
@@ -10,12 +10,38 @@
  * spaceMouse store slice.
  */
 
-import { useRef, useState } from 'react';
-import { ChevronDown, ChevronUp, GripVertical, Unplug } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
+import { Activity, ChevronDown, ChevronUp, Copy, GripVertical, Unplug } from 'lucide-react';
 import { useViewerStore } from '@/store';
 import { useDraggablePanel } from '@/hooks/useDraggablePanel';
 import { cn } from '@/lib/utils';
-import { SENSITIVITY } from '@/lib/spacemouse/constants';
+import { AXIS_FULL_SCALE, SENSITIVITY } from '@/lib/spacemouse/constants';
+import type { SpaceMouseDiagnostics } from '@/lib/spacemouse/device';
+
+const AXIS_KEYS = ['tx', 'ty', 'tz', 'rx', 'ry', 'rz'] as const;
+
+/** One centered axis bar: fill grows left or right of the midline. */
+function AxisBar({ label, value }: { label: string; value: number }) {
+  const fraction = Math.max(-1, Math.min(1, value / AXIS_FULL_SCALE));
+  const half = Math.abs(fraction) * 50;
+  return (
+    <div className="flex items-center gap-1.5">
+      <span className="w-4 shrink-0 font-mono text-[9px] uppercase text-muted-foreground">{label}</span>
+      <div className="relative h-1.5 flex-1 overflow-hidden rounded-full bg-muted">
+        <div className="absolute inset-y-0 left-1/2 w-px bg-muted-foreground/30" />
+        <div
+          className={cn('absolute inset-y-0 bg-teal-500', fraction === 0 && 'opacity-0')}
+          style={fraction >= 0
+            ? { left: '50%', width: `${half}%` }
+            : { right: '50%', width: `${half}%` }}
+        />
+      </div>
+      <span className="w-8 shrink-0 text-right font-mono text-[9px] tabular-nums text-muted-foreground">
+        {Math.round(value)}
+      </span>
+    </div>
+  );
+}
 
 export function SpaceMousePanel() {
   const open = useViewerStore((s) => s.spaceMousePanelOpen);
@@ -28,12 +54,42 @@ export function SpaceMousePanel() {
   const setSensitivity = useViewerStore((s) => s.setSpaceMouseSensitivity);
   const connect = useViewerStore((s) => s.spaceMouseConnect);
   const disconnect = useViewerStore((s) => s.spaceMouseDisconnect);
+  const getDiagnostics = useViewerStore((s) => s.spaceMouseGetDiagnostics);
 
   const [collapsed, setCollapsed] = useState(false);
+  const [diagOpen, setDiagOpen] = useState(false);
+  const [diag, setDiag] = useState<SpaceMouseDiagnostics | null>(null);
+  const [copyState, setCopyState] = useState<'idle' | 'copied' | 'failed'>('idle');
   // Hooks must run unconditionally — keep these ABOVE the `!open` early return
   // (a conditional hook is React error #310).
   const panelRef = useRef<HTMLDivElement>(null);
   const drag = useDraggablePanel(panelRef);
+
+  // Poll the session's diagnostics snapshot at UI rate while the section is
+  // visible. Reports stream at ~125Hz; pushing each one through the store
+  // would be waste, so the panel pulls instead.
+  const diagActive = open && !collapsed && diagOpen && !!getDiagnostics;
+  useEffect(() => {
+    if (!diagActive || !getDiagnostics) {
+      setDiag(null);
+      return;
+    }
+    setDiag(getDiagnostics());
+    const timer = setInterval(() => setDiag(getDiagnostics()), 100);
+    return () => clearInterval(timer);
+  }, [diagActive, getDiagnostics]);
+
+  const copyDump = async () => {
+    const dump = getDiagnostics?.().buildDump();
+    if (!dump) return;
+    try {
+      await navigator.clipboard.writeText(dump);
+      setCopyState('copied');
+    } catch {
+      setCopyState('failed'); // clipboard blocked (permissions / unfocused doc)
+    }
+    setTimeout(() => setCopyState('idle'), 2000);
+  };
 
   if (!open) return null;
 
@@ -140,6 +196,62 @@ export function SpaceMousePanel() {
                 driver is running it may hold the device; quit it before
                 connecting here.
               </p>
+
+              {connected && getDiagnostics && (
+                <div className="flex flex-col gap-1.5 border-t pt-1.5">
+                  <button
+                    type="button"
+                    onClick={() => setDiagOpen(!diagOpen)}
+                    aria-expanded={diagOpen}
+                    className="flex items-center gap-1 text-[9px] uppercase tracking-wider text-muted-foreground transition-colors hover:text-foreground"
+                  >
+                    <Activity className="h-3 w-3" />
+                    Diagnostics
+                    {diagOpen ? <ChevronUp className="h-2.5 w-2.5" /> : <ChevronDown className="h-2.5 w-2.5" />}
+                  </button>
+
+                  {diagOpen && diag && (
+                    <>
+                      <div className="flex flex-col gap-0.5">
+                        {AXIS_KEYS.map((axis) => (
+                          <AxisBar key={axis} label={axis} value={diag.axes[axis]} />
+                        ))}
+                      </div>
+
+                      <div className="font-mono text-[8px] leading-snug text-muted-foreground">
+                        <div>
+                          layout: {diag.layoutSource === 'descriptor'
+                            ? `descriptor (${diag.layoutAxes} axes)`
+                            : 'built-in fallback'}
+                        </div>
+                        {diag.reports.length === 0 ? (
+                          <div>no reports received yet, move the cap</div>
+                        ) : (
+                          diag.reports.map((r) => (
+                            <div key={r.reportId} className="truncate" title={r.lastBytesHex}>
+                              report {r.reportId}: {r.count}x {r.byteLength}B [{r.lastBytesHex}]
+                            </div>
+                          ))
+                        )}
+                      </div>
+
+                      <button
+                        type="button"
+                        onClick={() => { void copyDump(); }}
+                        className="flex items-center justify-center gap-1 rounded border px-1.5 py-1 text-[9px] text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                      >
+                        <Copy className="h-2.5 w-2.5" />
+                        {copyState === 'copied' ? 'Copied' : copyState === 'failed' ? 'Copy failed, try again' : 'Copy device report'}
+                      </button>
+                      <p className="text-[8px] leading-snug text-muted-foreground">
+                        If motion is wrong or dead for your device, copy this
+                        report and paste it into a GitHub issue so the axis
+                        layout can be fixed for your model.
+                      </p>
+                    </>
+                  )}
+                </div>
+              )}
             </>
           )}
         </>

--- a/apps/viewer/src/components/viewer/useSpaceMouseControls.ts
+++ b/apps/viewer/src/components/viewer/useSpaceMouseControls.ts
@@ -133,6 +133,7 @@ export function useSpaceMouseControls(params: UseSpaceMouseControlsParams): void
           const s = useViewerStore.getState();
           s.setSpaceMouseConnected(false);
           s.setSpaceMouseDisconnect(null);
+          s.setSpaceMouseGetDiagnostics(null);
         }
       },
     };
@@ -156,6 +157,7 @@ export function useSpaceMouseControls(params: UseSpaceMouseControlsParams): void
       const s = useViewerStore.getState();
       s.setSpaceMouseConnected(true, next.productName);
       s.setSpaceMouseDisconnect(() => { void next.close(); });
+      s.setSpaceMouseGetDiagnostics(() => next.getDiagnostics());
       startLoop();
     };
 
@@ -206,6 +208,7 @@ export function useSpaceMouseControls(params: UseSpaceMouseControlsParams): void
       const s = useViewerStore.getState();
       s.setSpaceMouseConnect(null);
       s.setSpaceMouseDisconnect(null);
+      s.setSpaceMouseGetDiagnostics(null);
       s.setSpaceMouseConnected(false);
       void session?.close();
       session = null;

--- a/apps/viewer/src/lib/spacemouse/descriptor.test.ts
+++ b/apps/viewer/src/lib/spacemouse/descriptor.test.ts
@@ -284,12 +284,31 @@ test('truncated report keeps previous values for unreadable axes', () => {
   assert.equal(state.tz, 300);
 });
 
-test('a report id covered by the descriptor with unsigned logical range reads unsigned', () => {
+test('unsigned logical ranges are centred on their midpoint (0..700 rests at 350)', () => {
   // Some descriptors declare 0..700 with a 350 midpoint instead of -350..350.
+  // Scaling around zero would turn the resting value into constant drift.
   const field: AxisField = { axis: 'tx', bitOffset: 0, bitSize: 16, logicalMinimum: 0, logicalMaximum: 700 };
-  const view = new DataView(new ArrayBuffer(2));
-  view.setUint16(0, 65000, true); // would be negative as int16
-  const raw = readAxisField(view, field);
-  assert.ok(raw !== null && raw > 0, `unsigned read stays positive, got ${raw}`);
-  assert.equal(raw, AXIS_FULL_SCALE); // clamped after rescale
+  const at = (value: number) => {
+    const view = new DataView(new ArrayBuffer(2));
+    view.setUint16(0, value, true);
+    return readAxisField(view, field);
+  };
+  assert.equal(at(350), 0); // resting midpoint is neutral
+  assert.equal(at(0), -AXIS_FULL_SCALE);
+  assert.equal(at(700), AXIS_FULL_SCALE);
+  assert.equal(at(525), AXIS_FULL_SCALE / 2);
+  // Out-of-range garbage (would be negative as int16) clamps, stays positive.
+  assert.equal(at(65000), AXIS_FULL_SCALE);
+});
+
+test('symmetric signed ranges are unaffected by midpoint centring', () => {
+  const field: AxisField = { axis: 'ty', bitOffset: 0, bitSize: 16, logicalMinimum: -350, logicalMaximum: 350 };
+  const at = (value: number) => {
+    const view = new DataView(new ArrayBuffer(2));
+    view.setInt16(0, value, true);
+    return readAxisField(view, field);
+  };
+  assert.equal(at(0), 0);
+  assert.equal(at(175), 175);
+  assert.equal(at(-350), -AXIS_FULL_SCALE);
 });

--- a/apps/viewer/src/lib/spacemouse/descriptor.test.ts
+++ b/apps/viewer/src/lib/spacemouse/descriptor.test.ts
@@ -1,0 +1,295 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Tests for the HID report-descriptor driven axis layout (#1677 hardware
+ * follow-up). Each case models a real 3Dconnexion descriptor shape: the
+ * classic split-report SpaceNavigator, combined-report devices, different
+ * logical ranges, 8-bit and unaligned fields, padding, rotation-first
+ * ordering, and nested collections.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  buildDeviceLayout,
+  layoutAxisCount,
+  parseReportWithLayout,
+  readAxisField,
+  type AxisField,
+} from './descriptor.js';
+import { zeroSixDof } from './parser.js';
+import { AXIS_FULL_SCALE } from './constants.js';
+
+const GD = 0x01 << 16; // Generic Desktop usage page, extended-usage high bits
+const BTN = 0x09 << 16; // Button usage page
+const [X, Y, Z, RX, RY, RZ] = [GD | 0x30, GD | 0x31, GD | 0x32, GD | 0x33, GD | 0x34, GD | 0x35];
+
+function axisItem(usages: number[], opts: Partial<HIDReportItem> = {}): HIDReportItem {
+  return {
+    usages,
+    reportSize: 16,
+    reportCount: usages.length,
+    logicalMinimum: -350,
+    logicalMaximum: 350,
+    ...opts,
+  };
+}
+
+/** DataView of int16 LE values. */
+function i16(values: number[]): DataView {
+  const view = new DataView(new ArrayBuffer(values.length * 2));
+  values.forEach((v, i) => view.setInt16(i * 2, v, true));
+  return view;
+}
+
+function bytes(values: number[]): DataView {
+  return new DataView(new Uint8Array(values).buffer);
+}
+
+/** Classic SpaceNavigator: report 1 = XYZ, report 2 = RxRyRz, report 3 = buttons. */
+function splitCollections(): HIDCollectionInfo[] {
+  return [{
+    usagePage: 0x01,
+    usage: 0x08,
+    inputReports: [
+      { reportId: 1, items: [axisItem([X, Y, Z])] },
+      { reportId: 2, items: [axisItem([RX, RY, RZ])] },
+      {
+        reportId: 3,
+        items: [{
+          isRange: true,
+          usageMinimum: BTN | 1,
+          usageMaximum: BTN | 2,
+          reportSize: 1,
+          reportCount: 2,
+          logicalMinimum: 0,
+          logicalMaximum: 1,
+        }],
+      },
+    ],
+  }];
+}
+
+test('split-report descriptor maps both reports and the buttons id', () => {
+  const layout = buildDeviceLayout(splitCollections());
+  assert.ok(layout);
+  assert.equal(layoutAxisCount(layout), 6);
+  assert.equal(layout.buttonsReportId, 3);
+
+  const t = layout.reports.get(1);
+  assert.ok(t);
+  assert.deepEqual(t.map((f) => [f.axis, f.bitOffset]), [['tx', 0], ['ty', 16], ['tz', 32]]);
+
+  const state = parseReportWithLayout(t, i16([5, -6, 7]), zeroSixDof());
+  assert.equal(state.tx, 5);
+  assert.equal(state.ty, -6);
+  assert.equal(state.tz, 7);
+
+  const r = layout.reports.get(2);
+  assert.ok(r);
+  const state2 = parseReportWithLayout(r, i16([-9, 10, -11]), state);
+  assert.deepEqual(state2, { tx: 5, ty: -6, tz: 7, rx: -9, ry: 10, rz: -11 });
+});
+
+test('combined-report descriptor maps all six axes in one report', () => {
+  const layout = buildDeviceLayout([{
+    usagePage: 0x01,
+    usage: 0x08,
+    inputReports: [{ reportId: 1, items: [axisItem([X, Y, Z, RX, RY, RZ])] }],
+  }]);
+  assert.ok(layout);
+  const fields = layout.reports.get(1);
+  assert.ok(fields);
+  assert.equal(fields.length, 6);
+  const state = parseReportWithLayout(fields, i16([1, 2, 3, 4, 5, 6]), zeroSixDof());
+  assert.deepEqual(state, { tx: 1, ty: 2, tz: 3, rx: 4, ry: 5, rz: 6 });
+});
+
+test('a wider logical range rescales to the legacy full-scale window', () => {
+  const layout = buildDeviceLayout([{
+    usagePage: 0x01,
+    usage: 0x08,
+    inputReports: [{
+      reportId: 1,
+      items: [axisItem([X, Y, Z], { logicalMinimum: -511, logicalMaximum: 511 })],
+    }],
+  }]);
+  assert.ok(layout);
+  const fields = layout.reports.get(1);
+  assert.ok(fields);
+  const state = parseReportWithLayout(fields, i16([511, -511, 0]), zeroSixDof());
+  assert.equal(state.tx, AXIS_FULL_SCALE);
+  assert.equal(state.ty, -AXIS_FULL_SCALE);
+  assert.equal(state.tz, 0);
+});
+
+test('8-bit combined report parses per byte (the legacy int16 reader cannot)', () => {
+  // A 6-byte, six-axis 8-bit report: read as int16 pairs this smears one
+  // physical axis across two logical ones, which is exactly the class of bug
+  // the descriptor path exists to fix.
+  const layout = buildDeviceLayout([{
+    usagePage: 0x01,
+    usage: 0x08,
+    inputReports: [{
+      reportId: 1,
+      items: [axisItem([X, Y, Z, RX, RY, RZ], { reportSize: 8, logicalMinimum: -127, logicalMaximum: 127 })],
+    }],
+  }]);
+  assert.ok(layout);
+  const fields = layout.reports.get(1);
+  assert.ok(fields);
+  // Tilt only: rx = -64 (0xc0 signed), everything else at rest.
+  const state = parseReportWithLayout(fields, bytes([0, 0, 0, 0xc0, 0, 0]), zeroSixDof());
+  assert.equal(Math.round(state.rx), Math.round((-64 / 127) * AXIS_FULL_SCALE));
+  assert.equal(state.tx, 0);
+  assert.equal(state.ty, 0);
+  assert.equal(state.tz, 0);
+});
+
+test('rotation-first report ordering follows the descriptor, not convention', () => {
+  const layout = buildDeviceLayout([{
+    usagePage: 0x01,
+    usage: 0x08,
+    inputReports: [
+      { reportId: 1, items: [axisItem([RX, RY, RZ])] },
+      { reportId: 2, items: [axisItem([X, Y, Z])] },
+    ],
+  }]);
+  assert.ok(layout);
+  const fields = layout.reports.get(1);
+  assert.ok(fields);
+  const state = parseReportWithLayout(fields, i16([40, 50, 60]), zeroSixDof());
+  assert.deepEqual(state, { tx: 0, ty: 0, tz: 0, rx: 40, ry: 50, rz: 60 });
+});
+
+test('constant padding before the axes shifts their bit offsets', () => {
+  const layout = buildDeviceLayout([{
+    usagePage: 0x01,
+    usage: 0x08,
+    inputReports: [{
+      reportId: 1,
+      items: [
+        { isConstant: true, reportSize: 8, reportCount: 1 },
+        axisItem([X, Y, Z]),
+      ],
+    }],
+  }]);
+  assert.ok(layout);
+  const fields = layout.reports.get(1);
+  assert.ok(fields);
+  assert.deepEqual(fields.map((f) => f.bitOffset), [8, 24, 40]);
+  // 1 padding byte, then tx = 350 (0x5e 0x01 LE).
+  const state = parseReportWithLayout(fields, bytes([0xff, 0x5e, 0x01, 0, 0, 0, 0]), zeroSixDof());
+  assert.equal(state.tx, 350);
+});
+
+test('usage ranges (X..RZ via usageMinimum/Maximum) map like listed usages', () => {
+  const layout = buildDeviceLayout([{
+    usagePage: 0x01,
+    usage: 0x08,
+    inputReports: [{
+      reportId: 1,
+      items: [{
+        isRange: true,
+        usageMinimum: X,
+        usageMaximum: RZ,
+        reportSize: 16,
+        reportCount: 6,
+        logicalMinimum: -350,
+        logicalMaximum: 350,
+      }],
+    }],
+  }]);
+  assert.ok(layout);
+  assert.equal(layoutAxisCount(layout), 6);
+  const fields = layout.reports.get(1);
+  assert.ok(fields);
+  const state = parseReportWithLayout(fields, i16([1, 2, 3, 4, 5, 6]), zeroSixDof());
+  assert.deepEqual(state, { tx: 1, ty: 2, tz: 3, rx: 4, ry: 5, rz: 6 });
+});
+
+test('unaligned 10-bit fields extract and sign-extend correctly', () => {
+  const field: AxisField = { axis: 'tx', bitOffset: 6, bitSize: 10, logicalMinimum: -350, logicalMaximum: 350 };
+  // Value -2 in 10 bits = 0b1111111110, placed at bit offset 6.
+  const buffer = new Uint8Array(2);
+  const value = 0b1111111110;
+  for (let i = 0; i < 10; i++) {
+    if ((value >> i) & 1) buffer[(6 + i) >> 3] |= 1 << ((6 + i) & 7);
+  }
+  assert.equal(readAxisField(new DataView(buffer.buffer), field), -2);
+});
+
+test('nested collections are walked for axes', () => {
+  const layout = buildDeviceLayout([{
+    usagePage: 0x01,
+    usage: 0x08,
+    children: [{
+      usagePage: 0x01,
+      usage: 0x01,
+      inputReports: [{ reportId: 1, items: [axisItem([X, Y, Z])] }],
+    }],
+  }]);
+  assert.ok(layout);
+  assert.equal(layoutAxisCount(layout), 3);
+});
+
+test('descriptors without enough axes fall back to null (legacy parser)', () => {
+  assert.equal(buildDeviceLayout(undefined), null);
+  assert.equal(buildDeviceLayout([]), null);
+  assert.equal(buildDeviceLayout([{ usagePage: 0x01, usage: 0x08 }]), null);
+  // Two axes only: not trustworthy for 6DoF, prefer the legacy layout.
+  assert.equal(
+    buildDeviceLayout([{
+      usagePage: 0x01,
+      usage: 0x08,
+      inputReports: [{ reportId: 1, items: [axisItem([X, Y])] }],
+    }]),
+    null,
+  );
+});
+
+test('malformed items (zero sizes, missing usages) are skipped, never throw', () => {
+  const layout = buildDeviceLayout([{
+    usagePage: 0x01,
+    usage: 0x08,
+    inputReports: [{
+      reportId: 1,
+      items: [
+        { reportSize: 0, reportCount: 3, usages: [X] },
+        { reportSize: 16, reportCount: 0, usages: [X] },
+        {},
+        axisItem([X, Y, Z]),
+      ],
+    }],
+  }]);
+  assert.ok(layout);
+  const fields = layout.reports.get(1);
+  assert.ok(fields);
+  // The malformed items contribute no bits, so axes start at offset 0.
+  assert.deepEqual(fields.map((f) => f.bitOffset), [0, 16, 32]);
+});
+
+test('truncated report keeps previous values for unreadable axes', () => {
+  const layout = buildDeviceLayout(splitCollections());
+  assert.ok(layout);
+  const fields = layout.reports.get(1);
+  assert.ok(fields);
+  const prev = { ...zeroSixDof(), tx: 100, ty: 200, tz: 300 };
+  // Only 3 bytes: tx readable, ty/tz truncated.
+  const state = parseReportWithLayout(fields, bytes([0x0a, 0x00, 0x7f]), prev);
+  assert.equal(state.tx, 10);
+  assert.equal(state.ty, 200);
+  assert.equal(state.tz, 300);
+});
+
+test('a report id covered by the descriptor with unsigned logical range reads unsigned', () => {
+  // Some descriptors declare 0..700 with a 350 midpoint instead of -350..350.
+  const field: AxisField = { axis: 'tx', bitOffset: 0, bitSize: 16, logicalMinimum: 0, logicalMaximum: 700 };
+  const view = new DataView(new ArrayBuffer(2));
+  view.setUint16(0, 65000, true); // would be negative as int16
+  const raw = readAxisField(view, field);
+  assert.ok(raw !== null && raw > 0, `unsigned read stays positive, got ${raw}`);
+  assert.equal(raw, AXIS_FULL_SCALE); // clamped after rescale
+});

--- a/apps/viewer/src/lib/spacemouse/descriptor.ts
+++ b/apps/viewer/src/lib/spacemouse/descriptor.ts
@@ -182,9 +182,14 @@ export function readAxisField(data: DataView, field: AxisField): number | null {
 
   // Rescale the device's declared range to the legacy AXIS_FULL_SCALE window
   // so dead zone and rates keep meaning the same thing on every device.
-  const fullScale = Math.max(Math.abs(field.logicalMinimum), Math.abs(field.logicalMaximum));
+  // Centre on the logical midpoint first: an unsigned 0..700 axis rests at
+  // 350, and scaling it around zero instead would read as constant drift.
   if (!Number.isFinite(raw)) return 0;
-  if (fullScale > 0) raw = (raw / fullScale) * AXIS_FULL_SCALE;
+  const halfRange = (field.logicalMaximum - field.logicalMinimum) / 2;
+  if (halfRange > 0) {
+    const center = (field.logicalMinimum + field.logicalMaximum) / 2;
+    raw = ((raw - center) / halfRange) * AXIS_FULL_SCALE;
+  }
   return clampAxis(raw);
 }
 

--- a/apps/viewer/src/lib/spacemouse/descriptor.ts
+++ b/apps/viewer/src/lib/spacemouse/descriptor.ts
@@ -1,0 +1,207 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * HID report-descriptor driven axis layout for 3Dconnexion devices.
+ *
+ * The legacy parser (parser.ts) hard-codes the classic SpaceNavigator layout
+ * (reportId 1 = three int16 translations, reportId 2 = rotations, >=12 bytes =
+ * combined). Real hardware disagrees: hardware feedback on #1677 showed a
+ * device where only one axis did anything, because its reports do not match
+ * those byte offsets. WebHID exposes the device's own report descriptor via
+ * `HIDDevice.collections`, which names every axis (Generic Desktop X..RZ) with
+ * its exact bit offset, width and logical range, so instead of guessing we
+ * read the layout the device declares:
+ *
+ *   - any report split (translation/rotation separate, combined, or per-axis)
+ *   - any field width (8/16/32-bit, even unaligned bit fields)
+ *   - any axis order, interleaved padding, leading constant fields
+ *   - the device's true full-scale (logicalMax varies: 350, 511, 32767...)
+ *
+ * Values are rescaled to the legacy AXIS_FULL_SCALE window so the downstream
+ * mapping (dead zone, sensitivity) is unchanged. Devices whose descriptor
+ * exposes no axes (or fake test devices) fall back to the legacy parser,
+ * per report id.
+ */
+
+import { AXIS_FULL_SCALE } from './constants.js';
+import { clampAxis, type SixDof } from './parser.js';
+
+/** Generic Desktop usage page and its 6DoF axis usage ids. */
+const USAGE_PAGE_GENERIC_DESKTOP = 0x01;
+const USAGE_PAGE_BUTTON = 0x09;
+
+/** Extended usage (page << 16 | id) -> SixDof axis key. X..RZ = 0x30..0x35. */
+const AXIS_BY_USAGE: ReadonlyMap<number, keyof SixDof> = new Map([
+  [(USAGE_PAGE_GENERIC_DESKTOP << 16) | 0x30, 'tx'],
+  [(USAGE_PAGE_GENERIC_DESKTOP << 16) | 0x31, 'ty'],
+  [(USAGE_PAGE_GENERIC_DESKTOP << 16) | 0x32, 'tz'],
+  [(USAGE_PAGE_GENERIC_DESKTOP << 16) | 0x33, 'rx'],
+  [(USAGE_PAGE_GENERIC_DESKTOP << 16) | 0x34, 'ry'],
+  [(USAGE_PAGE_GENERIC_DESKTOP << 16) | 0x35, 'rz'],
+]);
+
+/** One axis field inside an input report, located by bit position. */
+export interface AxisField {
+  axis: keyof SixDof;
+  /** Bit offset inside the report payload (report-id byte already stripped). */
+  bitOffset: number;
+  bitSize: number;
+  logicalMinimum: number;
+  logicalMaximum: number;
+}
+
+/** Axis layout of one device, derived from its HID report descriptor. */
+export interface DeviceLayout {
+  /** reportId -> axis fields carried by that report. */
+  reports: ReadonlyMap<number, readonly AxisField[]>;
+  /** reportId whose items include Button-page usages, or null if none found. */
+  buttonsReportId: number | null;
+}
+
+/** Total number of axis fields in a layout (a 6DoF device yields 6). */
+export function layoutAxisCount(layout: DeviceLayout): number {
+  let count = 0;
+  for (const fields of layout.reports.values()) count += fields.length;
+  return count;
+}
+
+/**
+ * Derive the axis layout from a device's HID collections. Returns null when
+ * the descriptor names fewer than three axes (nothing trustworthy to drive a
+ * camera with) so callers fall back to the legacy fixed layout. Never throws
+ * on malformed descriptor data.
+ */
+export function buildDeviceLayout(collections: readonly HIDCollectionInfo[] | undefined): DeviceLayout | null {
+  if (!collections || collections.length === 0) return null;
+
+  const reports = new Map<number, AxisField[]>();
+  let buttonsReportId: number | null = null;
+
+  // Chrome lists one HIDReportInfo per (collection, reportId); a report split
+  // across nested collections appears once per collection, in document order,
+  // so a single bit cursor per reportId reconstructs the payload layout.
+  const bitCursor = new Map<number, number>();
+
+  const visit = (collection: HIDCollectionInfo): void => {
+    for (const report of collection.inputReports ?? []) {
+      const reportId = report.reportId ?? 0;
+      let offset = bitCursor.get(reportId) ?? 0;
+      for (const item of report.items ?? []) {
+        const size = item.reportSize ?? 0;
+        const count = item.reportCount ?? 0;
+        if (size <= 0 || count <= 0 || size > 64) {
+          continue; // malformed item: no bits to account for
+        }
+        if (!item.isConstant) {
+          for (let i = 0; i < count; i++) {
+            const usage = usageForIndex(item, i);
+            if (usage === null) continue;
+            const page = usage >>> 16;
+            if (page === USAGE_PAGE_BUTTON && buttonsReportId === null) {
+              buttonsReportId = reportId;
+              continue;
+            }
+            const axis = AXIS_BY_USAGE.get(usage);
+            if (!axis) continue;
+            const fields = reports.get(reportId) ?? [];
+            fields.push({
+              axis,
+              bitOffset: offset + i * size,
+              bitSize: size,
+              logicalMinimum: item.logicalMinimum ?? 0,
+              logicalMaximum: item.logicalMaximum ?? 0,
+            });
+            reports.set(reportId, fields);
+          }
+        }
+        offset += size * count;
+      }
+      bitCursor.set(reportId, offset);
+    }
+    for (const child of collection.children ?? []) visit(child);
+  };
+
+  try {
+    for (const collection of collections) visit(collection);
+  } catch {
+    return null; // hostile / malformed descriptor object: use the legacy path
+  }
+
+  const layout: DeviceLayout = { reports, buttonsReportId };
+  return layoutAxisCount(layout) >= 3 ? layout : null;
+}
+
+/** Extended usage of the `index`-th element of an item, or null. */
+function usageForIndex(item: HIDReportItem, index: number): number | null {
+  if (item.isRange) {
+    const min = item.usageMinimum;
+    const max = item.usageMaximum;
+    if (typeof min !== 'number') return null;
+    const usage = min + index;
+    return typeof max === 'number' && usage > max ? null : usage;
+  }
+  const usages = item.usages;
+  if (!usages || usages.length === 0) return null;
+  // Fewer usages than reportCount: HID repeats the last one.
+  return usages[Math.min(index, usages.length - 1)] ?? null;
+}
+
+/**
+ * Read one little-endian bit field from a report payload. Returns null when
+ * the report is too short (truncated) or the field is unreadable, so the
+ * caller keeps the previous axis value. Sign-extends when the descriptor's
+ * logical range is signed.
+ */
+export function readAxisField(data: DataView, field: AxisField): number | null {
+  const { bitOffset, bitSize } = field;
+  if (bitSize <= 0 || bitOffset < 0) return null;
+  if (bitOffset + bitSize > data.byteLength * 8) return null;
+  const signed = field.logicalMinimum < 0;
+
+  let raw: number;
+  if (bitOffset % 8 === 0 && bitSize === 8) {
+    raw = signed ? data.getInt8(bitOffset / 8) : data.getUint8(bitOffset / 8);
+  } else if (bitOffset % 8 === 0 && bitSize === 16) {
+    raw = signed ? data.getInt16(bitOffset / 8, true) : data.getUint16(bitOffset / 8, true);
+  } else if (bitOffset % 8 === 0 && bitSize === 32) {
+    raw = signed ? data.getInt32(bitOffset / 8, true) : data.getUint32(bitOffset / 8, true);
+  } else if (bitSize < 32) {
+    // Generic unaligned little-endian bit extraction.
+    let value = 0;
+    for (let i = 0; i < bitSize; i++) {
+      const bit = bitOffset + i;
+      if ((data.getUint8(bit >> 3) >> (bit & 7)) & 1) value += 2 ** i;
+    }
+    if (signed && value >= 2 ** (bitSize - 1)) value -= 2 ** bitSize;
+    raw = value;
+  } else {
+    return null; // unaligned >=32-bit fields do not occur on real devices
+  }
+
+  // Rescale the device's declared range to the legacy AXIS_FULL_SCALE window
+  // so dead zone and rates keep meaning the same thing on every device.
+  const fullScale = Math.max(Math.abs(field.logicalMinimum), Math.abs(field.logicalMaximum));
+  if (!Number.isFinite(raw)) return 0;
+  if (fullScale > 0) raw = (raw / fullScale) * AXIS_FULL_SCALE;
+  return clampAxis(raw);
+}
+
+/**
+ * Fold one report into a 6DoF state using the descriptor-derived fields for
+ * its report id. Pure; axes not carried by this report (or truncated away)
+ * keep their previous value.
+ */
+export function parseReportWithLayout(
+  fields: readonly AxisField[],
+  data: DataView,
+  prev: SixDof,
+): SixDof {
+  const next: SixDof = { ...prev };
+  for (const field of fields) {
+    const value = readAxisField(data, field);
+    if (value !== null) next[field.axis] = value;
+  }
+  return next;
+}

--- a/apps/viewer/src/lib/spacemouse/device.test.ts
+++ b/apps/viewer/src/lib/spacemouse/device.test.ts
@@ -1,0 +1,119 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Session-level report routing tests (#1760 review findings). Node's
+ * EventTarget stands in for a HIDDevice; `navigator.hid` is absent here, which
+ * the session already tolerates. The load-bearing property: reports the
+ * device's layout does not map must NOT refresh the input timestamp, or a
+ * periodic status report would keep an earlier deflection latched past the
+ * staleness watchdog and drive the camera forever.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { SpaceMouseSession } from './device.js';
+
+const GD = 0x01 << 16;
+const [X, Y, Z] = [GD | 0x30, GD | 0x31, GD | 0x32];
+
+interface FakeDeviceInit {
+  collections?: unknown[];
+}
+
+function fakeDevice({ collections = [] }: FakeDeviceInit = {}): HIDDevice {
+  const device = new EventTarget() as unknown as Record<string, unknown>;
+  device.vendorId = 0x256f;
+  device.productId = 0xc635;
+  device.productName = 'Fake';
+  device.opened = true;
+  device.collections = collections;
+  device.open = async () => {};
+  device.close = async () => {};
+  return device as unknown as HIDDevice;
+}
+
+function send(device: HIDDevice, reportId: number, bytes: number[]): void {
+  const event = new Event('inputreport') as Event & {
+    reportId: number;
+    data: DataView;
+    device: HIDDevice;
+  };
+  event.reportId = reportId;
+  event.data = new DataView(new Uint8Array(bytes).buffer);
+  event.device = device;
+  (device as unknown as EventTarget).dispatchEvent(event);
+}
+
+/** Descriptor naming X, Y, Z as 16-bit +/-350 fields in report 1. */
+function xyzCollections(): unknown[] {
+  return [{
+    usagePage: 0x01,
+    usage: 0x08,
+    inputReports: [{
+      reportId: 1,
+      items: [{
+        usages: [X, Y, Z],
+        reportSize: 16,
+        reportCount: 3,
+        logicalMinimum: -350,
+        logicalMaximum: 350,
+      }],
+    }],
+  }];
+}
+
+test('descriptor device: mapped report updates state and timestamp', () => {
+  const device = fakeDevice({ collections: xyzCollections() });
+  const session = new SpaceMouseSession(device, {});
+  assert.equal(session.getLastSampleAt(), Number.NEGATIVE_INFINITY);
+  send(device, 1, [0x64, 0x00, 0x00, 0x00, 0x00, 0x00]); // tx = 100
+  assert.equal(session.getState().tx, 100);
+  assert.ok(Number.isFinite(session.getLastSampleAt()));
+  session.detach();
+});
+
+test('descriptor device: unmapped report id neither moves axes nor refreshes the watchdog', () => {
+  const device = fakeDevice({ collections: xyzCollections() });
+  const session = new SpaceMouseSession(device, {});
+  send(device, 1, [0x64, 0x00, 0x00, 0x00, 0x00, 0x00]);
+  const sampleAt = session.getLastSampleAt();
+  // A status/vendor report the descriptor does not map, with bytes that the
+  // legacy parser would happily decode as rotation.
+  send(device, 2, [0x2c, 0x01, 0x00, 0x00, 0x00, 0x00]);
+  send(device, 23, [0xff, 0xff, 0xff, 0xff, 0xff, 0xff]);
+  assert.deepEqual(session.getState(), { tx: 100, ty: 0, tz: 0, rx: 0, ry: 0, rz: 0 });
+  assert.equal(session.getLastSampleAt(), sampleAt, 'unmapped reports must not feed the watchdog');
+  session.detach();
+});
+
+test('legacy device: only the known motion report ids refresh the watchdog', () => {
+  const device = fakeDevice(); // no descriptor: legacy fixed layout
+  const session = new SpaceMouseSession(device, {});
+  send(device, 1, [0x64, 0x00, 0x00, 0x00, 0x00, 0x00]);
+  assert.equal(session.getState().tx, 100);
+  const sampleAt = session.getLastSampleAt();
+  send(device, 9, [0x01, 0x02, 0x03, 0x04]); // unknown vendor report
+  assert.equal(session.getLastSampleAt(), sampleAt);
+  send(device, 2, [0x00, 0x00, 0x2c, 0x01, 0x00, 0x00]); // rotation: ry = 300
+  assert.equal(session.getState().ry, 300);
+  assert.ok(session.getLastSampleAt() >= sampleAt);
+  session.detach();
+});
+
+test('buttons report fires the fit callback on press edges, never motion', () => {
+  const device = fakeDevice({ collections: xyzCollections() });
+  let fits = 0;
+  const session = new SpaceMouseSession(device, { onFitButton: () => { fits++; } });
+  send(device, 1, [0x64, 0x00, 0x00, 0x00, 0x00, 0x00]);
+  const sampleAt = session.getLastSampleAt();
+  send(device, 3, [0x01]); // button 0 down
+  send(device, 3, [0x01]); // held: no second edge
+  send(device, 3, [0x00]); // released
+  send(device, 3, [0x01]); // pressed again
+  assert.equal(fits, 2);
+  assert.deepEqual(session.getState().tx, 100);
+  assert.equal(session.getLastSampleAt(), sampleAt);
+  session.detach();
+});

--- a/apps/viewer/src/lib/spacemouse/device.ts
+++ b/apps/viewer/src/lib/spacemouse/device.ts
@@ -22,6 +22,8 @@ import {
   HID_USAGE_MULTI_AXIS_CONTROLLER,
   HID_USAGE_PAGE_GENERIC_DESKTOP,
   REPORT_ID_BUTTONS,
+  REPORT_ID_ROTATION,
+  REPORT_ID_TRANSLATION,
   SPACEMOUSE_VENDOR_IDS,
 } from './constants.js';
 import {
@@ -163,10 +165,19 @@ export class SpaceMouseSession {
     }
 
     // 6DoF: descriptor-derived fields when the descriptor covers this report,
-    // legacy fixed offsets otherwise (also the fake-device path in e2e tests).
-    this.state = axisFields
-      ? parseReportWithLayout(axisFields, event.data, this.state)
-      : parseSpaceMouseReport(event.reportId, event.data, this.state);
+    // legacy fixed offsets when there is no usable descriptor (also the
+    // fake-device path in e2e tests). Reports neither path understands are
+    // dropped WITHOUT refreshing lastSampleAt: a periodic status report must
+    // not keep an earlier deflection latched past the staleness watchdog.
+    if (axisFields) {
+      this.state = parseReportWithLayout(axisFields, event.data, this.state);
+    } else if (this.layout) {
+      return; // descriptor is authoritative: unmapped report id, not motion
+    } else if (event.reportId === REPORT_ID_TRANSLATION || event.reportId === REPORT_ID_ROTATION) {
+      this.state = parseSpaceMouseReport(event.reportId, event.data, this.state);
+    } else {
+      return;
+    }
     this.lastSampleAt = performance.now();
     this.options.onSample?.(this.state);
   };

--- a/apps/viewer/src/lib/spacemouse/device.ts
+++ b/apps/viewer/src/lib/spacemouse/device.ts
@@ -24,6 +24,12 @@ import {
   REPORT_ID_BUTTONS,
   SPACEMOUSE_VENDOR_IDS,
 } from './constants.js';
+import {
+  buildDeviceLayout,
+  layoutAxisCount,
+  parseReportWithLayout,
+  type DeviceLayout,
+} from './descriptor.js';
 import { parseButtonsReport, parseSpaceMouseReport, zeroSixDof, type SixDof } from './parser.js';
 
 /** True when the browser exposes WebHID (Chromium-based browsers). */
@@ -57,9 +63,47 @@ function isSpaceMouseCandidate(device: HIDDevice): boolean {
  */
 function multiAxisScore(device: HIDDevice): number {
   const collections = device.collections ?? [];
+  // Descriptor-named 6DoF axes outrank the bare Multi-axis Controller usage:
+  // the interface that actually carries X..RZ is the one we want to open.
+  const layout = buildDeviceLayout(collections);
+  if (layout) return 1 + layoutAxisCount(layout);
   return collections.some(
     (c) => c.usagePage === HID_USAGE_PAGE_GENERIC_DESKTOP && c.usage === HID_USAGE_MULTI_AXIS_CONTROLLER,
   ) ? 1 : 0;
+}
+
+/** 0x-prefixed hex string for ids/usages in the diagnostics dump. */
+function hex(value: number, width = 4): string {
+  return `0x${(value >>> 0).toString(16).padStart(width, '0')}`;
+}
+
+/** Per-report tally + last payload, for the diagnostics view. */
+export interface ReportTrace {
+  reportId: number;
+  count: number;
+  byteLength: number;
+  /** Last payload as space-separated hex bytes (report-id byte stripped). */
+  lastBytesHex: string;
+}
+
+/** Snapshot of everything the panel diagnostics section renders. */
+export interface SpaceMouseDiagnostics {
+  productName: string;
+  vendorId: number;
+  productId: number;
+  /** 'descriptor' when the HID report descriptor drives parsing, else 'legacy'. */
+  layoutSource: 'descriptor' | 'legacy';
+  /** Number of 6DoF axes the descriptor names (0 on the legacy path). */
+  layoutAxes: number;
+  /** Latest decoded sample, device counts rescaled to [-350, 350]. */
+  axes: SixDof;
+  /** performance.now() of the last decoded 6DoF report, -Infinity before one. */
+  lastSampleAt: number;
+  buttonsDown: number[];
+  /** Per-report-id traces, ascending by report id. */
+  reports: ReportTrace[];
+  /** Full JSON dump (device + descriptor + recent reports) for bug reports. */
+  buildDump: () => string;
 }
 
 export interface SpaceMouseSessionOptions {
@@ -80,9 +124,33 @@ export class SpaceMouseSession {
   private lastSampleAt = Number.NEGATIVE_INFINITY;
   private buttonsDown = new Set<number>();
   private closed = false;
+  /** Descriptor-derived axis layout, or null to use the legacy fixed layout. */
+  private readonly layout: DeviceLayout | null;
+  private readonly reportTraces = new Map<number, ReportTrace>();
+
+  private trace(reportId: number, data: DataView): void {
+    let entry = this.reportTraces.get(reportId);
+    if (!entry) {
+      entry = { reportId, count: 0, byteLength: 0, lastBytesHex: '' };
+      this.reportTraces.set(reportId, entry);
+    }
+    entry.count++;
+    entry.byteLength = data.byteLength;
+    const bytes: string[] = [];
+    for (let i = 0; i < data.byteLength; i++) {
+      bytes.push(data.getUint8(i).toString(16).padStart(2, '0'));
+    }
+    entry.lastBytesHex = bytes.join(' ');
+  }
 
   private readonly handleInputReport = (event: HIDInputReportEvent): void => {
-    if (event.reportId === REPORT_ID_BUTTONS) {
+    this.trace(event.reportId, event.data);
+
+    // Buttons: the report id the descriptor names, or the classic 3 when the
+    // descriptor is silent. A report that carries axes is never buttons.
+    const axisFields = this.layout?.reports.get(event.reportId);
+    const buttonsId = this.layout?.buttonsReportId ?? REPORT_ID_BUTTONS;
+    if (!axisFields && event.reportId === buttonsId) {
       const pressed = parseButtonsReport(event.data);
       const now = new Set(pressed);
       for (const index of pressed) {
@@ -93,7 +161,12 @@ export class SpaceMouseSession {
       this.buttonsDown = now;
       return;
     }
-    this.state = parseSpaceMouseReport(event.reportId, event.data, this.state);
+
+    // 6DoF: descriptor-derived fields when the descriptor covers this report,
+    // legacy fixed offsets otherwise (also the fake-device path in e2e tests).
+    this.state = axisFields
+      ? parseReportWithLayout(axisFields, event.data, this.state)
+      : parseSpaceMouseReport(event.reportId, event.data, this.state);
     this.lastSampleAt = performance.now();
     this.options.onSample?.(this.state);
   };
@@ -108,6 +181,7 @@ export class SpaceMouseSession {
     readonly device: HIDDevice,
     private readonly options: SpaceMouseSessionOptions,
   ) {
+    this.layout = buildDeviceLayout(device.collections);
     device.addEventListener('inputreport', this.handleInputReport);
     navigator.hid?.addEventListener('disconnect', this.handleGlobalDisconnect);
   }
@@ -128,6 +202,78 @@ export class SpaceMouseSession {
 
   get productName(): string {
     return this.device.productName || 'SpaceMouse';
+  }
+
+  /** Snapshot for the panel diagnostics section (cheap; poll at UI rate). */
+  getDiagnostics(): SpaceMouseDiagnostics {
+    return {
+      productName: this.productName,
+      vendorId: this.device.vendorId,
+      productId: this.device.productId,
+      layoutSource: this.layout ? 'descriptor' : 'legacy',
+      layoutAxes: this.layout ? layoutAxisCount(this.layout) : 0,
+      axes: { ...this.state },
+      lastSampleAt: this.lastSampleAt,
+      buttonsDown: [...this.buttonsDown].sort((a, b) => a - b),
+      reports: [...this.reportTraces.values()].sort((a, b) => a.reportId - b.reportId),
+      buildDump: () => this.buildDump(),
+    };
+  }
+
+  /**
+   * Human-postable JSON describing the device: ids, the HID report descriptor
+   * as the browser sees it, the derived layout and the recent report traffic.
+   * This is what we ask users to paste into an issue when motion is wrong on
+   * hardware we cannot test against.
+   */
+  private buildDump(): string {
+    const describeCollection = (c: HIDCollectionInfo): unknown => ({
+      usagePage: hex(c.usagePage),
+      usage: hex(c.usage),
+      inputReports: (c.inputReports ?? []).map((r) => ({
+        reportId: r.reportId ?? 0,
+        items: (r.items ?? []).map((item) => ({
+          usages: item.isRange
+            ? `range ${hex(item.usageMinimum ?? 0, 8)}..${hex(item.usageMaximum ?? 0, 8)}`
+            : (item.usages ?? []).map((u) => hex(u, 8)),
+          reportSize: item.reportSize,
+          reportCount: item.reportCount,
+          logicalMin: item.logicalMinimum,
+          logicalMax: item.logicalMaximum,
+          ...(item.isConstant ? { isConstant: true } : {}),
+        })),
+      })),
+      ...(c.children && c.children.length > 0
+        ? { children: c.children.map(describeCollection) }
+        : {}),
+    });
+
+    return JSON.stringify(
+      {
+        product: this.productName,
+        vendorId: hex(this.device.vendorId),
+        productId: hex(this.device.productId),
+        layoutSource: this.layout ? 'descriptor' : 'legacy',
+        derivedLayout: this.layout
+          ? [...this.layout.reports.entries()].map(([reportId, fields]) => ({
+              reportId,
+              axes: fields.map((f) => ({
+                axis: f.axis,
+                bitOffset: f.bitOffset,
+                bitSize: f.bitSize,
+                logicalMin: f.logicalMinimum,
+                logicalMax: f.logicalMaximum,
+              })),
+            }))
+          : null,
+        buttonsReportId: this.layout?.buttonsReportId ?? null,
+        reportsSeen: [...this.reportTraces.values()].sort((a, b) => a.reportId - b.reportId),
+        lastAxes: this.state,
+        collections: (this.device.collections ?? []).map(describeCollection),
+      },
+      null,
+      2,
+    );
   }
 
   /**

--- a/apps/viewer/src/store/slices/spaceMouseSlice.ts
+++ b/apps/viewer/src/store/slices/spaceMouseSlice.ts
@@ -16,6 +16,7 @@
 
 import type { StateCreator } from 'zustand';
 import { SENSITIVITY } from '@/lib/spacemouse/constants';
+import type { SpaceMouseDiagnostics } from '@/lib/spacemouse/device';
 
 export interface SpaceMouseSlice {
   /** True when navigator.hid exists (Chromium-based browsers). */
@@ -38,6 +39,12 @@ export interface SpaceMouseSlice {
   spaceMouseConnect: (() => void) | null;
   /** Disconnect action registered by `useSpaceMouseControls` while connected. */
   spaceMouseDisconnect: (() => void) | null;
+  /**
+   * Diagnostics snapshot getter registered while connected. The panel polls it
+   * at UI rate (device reports stream at ~125Hz; routing every sample through
+   * the store would be waste).
+   */
+  spaceMouseGetDiagnostics: (() => SpaceMouseDiagnostics) | null;
 
   setSpaceMouseSupported: (supported: boolean) => void;
   setSpaceMouseConnected: (connected: boolean, deviceName?: string | null) => void;
@@ -47,6 +54,7 @@ export interface SpaceMouseSlice {
   toggleSpaceMousePanel: () => void;
   setSpaceMouseConnect: (connect: (() => void) | null) => void;
   setSpaceMouseDisconnect: (disconnect: (() => void) | null) => void;
+  setSpaceMouseGetDiagnostics: (getDiagnostics: (() => SpaceMouseDiagnostics) | null) => void;
 }
 
 const STORAGE_KEY = 'ifc-lite:spacemouse';
@@ -85,6 +93,7 @@ export const createSpaceMouseSlice: StateCreator<SpaceMouseSlice, [], [], SpaceM
   spaceMousePanelOpen: false,
   spaceMouseConnect: null,
   spaceMouseDisconnect: null,
+  spaceMouseGetDiagnostics: null,
 
   setSpaceMouseSupported: (spaceMouseSupported) => set({ spaceMouseSupported }),
   setSpaceMouseConnected: (spaceMouseConnected, deviceName = null) =>
@@ -104,4 +113,5 @@ export const createSpaceMouseSlice: StateCreator<SpaceMouseSlice, [], [], SpaceM
   toggleSpaceMousePanel: () => set((s) => ({ spaceMousePanelOpen: !s.spaceMousePanelOpen })),
   setSpaceMouseConnect: (spaceMouseConnect) => set({ spaceMouseConnect }),
   setSpaceMouseDisconnect: (spaceMouseDisconnect) => set({ spaceMouseDisconnect }),
+  setSpaceMouseGetDiagnostics: (spaceMouseGetDiagnostics) => set({ spaceMouseGetDiagnostics }),
 });

--- a/apps/viewer/src/webhid-types.d.ts
+++ b/apps/viewer/src/webhid-types.d.ts
@@ -22,9 +22,31 @@ interface HIDDeviceRequestOptions {
   filters: HIDDeviceFilter[];
 }
 
+interface HIDReportItem {
+  readonly isAbsolute?: boolean;
+  readonly isArray?: boolean;
+  readonly isConstant?: boolean;
+  readonly isRange?: boolean;
+  /** Extended usages: (usagePage << 16) | usageId, one per report element. */
+  readonly usages?: readonly number[];
+  readonly usageMinimum?: number;
+  readonly usageMaximum?: number;
+  readonly reportSize?: number;
+  readonly reportCount?: number;
+  readonly logicalMinimum?: number;
+  readonly logicalMaximum?: number;
+}
+
+interface HIDReportInfo {
+  readonly reportId?: number;
+  readonly items?: readonly HIDReportItem[];
+}
+
 interface HIDCollectionInfo {
   readonly usagePage: number;
   readonly usage: number;
+  readonly children?: readonly HIDCollectionInfo[];
+  readonly inputReports?: readonly HIDReportInfo[];
 }
 
 interface HIDInputReportEvent extends Event {


### PR DESCRIPTION
## Problem

Hardware feedback on #1677 from @FliesEyes: after updating drivers and trying Chrome and Edge, only a tilt-to-zoom motion works; pan and orbit are dead. The shipped parser assumes one fixed byte layout (report 1 = three int16 translations, report 2 = rotations, >= 12 bytes = combined) and hard-codes a +/-350 full scale. Real 3Dconnexion devices vary in report split, axis order, field width and logical range, and we had no way to see what a remote device actually sends.

## Fix

**Descriptor-driven parsing** (`descriptor.ts`): WebHID exposes the device's HID report descriptor via `HIDDevice.collections`. We now derive the axis layout from it: per-report X/Y/Z/RX/RY/RZ fields with exact bit offsets, widths and logical ranges, plus the buttons report id. This handles:
- any report split (classic split, combined, rotation-first)
- 8-bit, 16-bit and unaligned bit fields (an 8-bit combined report read as int16 pairs smears one physical axis into another, which reproduces exactly the reported "only tilt zooms" symptom)
- per-device full scale (350 / 511 / whatever the descriptor declares), rescaled to the legacy window so dead zone, sensitivity and rates are untouched
- constant padding, usage ranges, nested collections, malformed descriptors (never throws)

Devices without a usable descriptor (< 3 named axes) keep the legacy fixed layout, so existing behaviour and the fake-device e2e idiom are unchanged. Device-interface ranking now prefers the interface whose descriptor names the 6DoF axes.

**Diagnostics** (SpaceMouse panel): a collapsible section with live axis bars, per-report traffic (count, size, last raw bytes), the layout source, and a "Copy device report" button that puts a JSON dump (ids, full descriptor, derived layout, recent reports) on the clipboard. When motion is wrong on hardware we do not own, users can paste that dump into an issue and the fix becomes a data problem instead of a guessing game.

## Verification

- 14 new unit tests for the descriptor path (split/combined/rotation-first layouts, 8-bit and 10-bit unaligned fields, rescaling, padding, usage ranges, nested collections, truncation, malformed input); full viewer suite green (1707 tests).
- Verified in the running viewer with a stubbed `navigator.hid`:
  - 8-bit combined-report device (broken class before this PR): tilt lands on RX only, twist orbits the ViewCube yaw, pull zooms the scale bar 13.8m -> 17.1m.
  - descriptor-less device: falls back to `layout: legacy` and still orbits/zooms.
  - diagnostics bars match injected bytes exactly; copy button flips to "Copied" and the dump JSON contains descriptor + derived layout; clipboard failure now shows "Copy failed" instead of silence.

Closes nothing on its own until @FliesEyes confirms on hardware; the diagnostics dump is the ask in the issue thread.

Ref #1677

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an expandable SpaceMouse Diagnostics panel with live axis readings, report metadata, and clipboard export.
  * Improved compatibility with devices using varied HID report layouts and axis formats.
  * Added automatic fallback handling for unsupported or incomplete device descriptors.

* **Bug Fixes**
  * Improved report decoding for signed, unsigned, packed, truncated, and differently scaled axis data.
  * Preserved existing axis values when reports omit or truncate fields.

* **Tests**
  * Added comprehensive coverage for HID descriptor parsing and report decoding scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->