### PR TITLE
chore: add .railwayignore to keep .claude out of railway up uploads

### DIFF
--- a/.railwayignore
+++ b/.railwayignore
@@ -1,0 +1,8 @@
+# Files excluded from `railway up` uploads (gitignore syntax). Everything the
+# server build needs comes from the git tree via apps/server/Dockerfile, so we
+# drop local-only state that would otherwise bloat the upload.
+
+# Local agent / editor state. The .claude memory dir can be multiple GB, which
+# makes `railway up` uploads slow or drop the connection mid-upload. Not needed
+# for any Railway build.
+.claude/


### PR DESCRIPTION
`railway up` tars the working directory (respecting `.gitignore`/`.railwayignore`) and uploads it. A local `.claude/` agent-memory dir can grow to multiple GB, which makes the upload slow and can drop the connection mid-transfer. Nothing under `.claude/` is needed for the server build (it builds from `apps/server/Dockerfile` via the git tree), so exclude it.

Surfaced while deploying #1759 (`datamodel-v3`) — a `railway up` from a checkout carrying a ~3.2 GB `.claude/` failed at the upload stage.

No runtime/CI impact: `.railwayignore` only affects manual `railway up` uploads; the Docker/CI image build is unchanged.