### PR TITLE
feat(viewer): tabbed ribbon toolbar as selectable alternative to the classic strip (#1686)

### DIFF
--- a/apps/viewer/src/components/viewer/MainToolbar.tsx
+++ b/apps/viewer/src/components/viewer/MainToolbar.tsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import React, { useRef, useCallback, useEffect, useMemo, useSyncExternalStore } from 'react';
+import React, { useCallback, useEffect, useMemo } from 'react';
 import {
   FolderOpen,
   Download,
@@ -28,11 +28,6 @@ import {
   Loader2,
   Camera,
   Info,
-  Layers2,
-  Zap,
-  SquareX,
-  BoxSelect,
-  Building2,
   Plus,
   PackagePlus,
   MessageSquare,
@@ -50,16 +45,14 @@ import {
   Move,
   Move3d,
   PenLine,
+  PanelTop,
   Undo2,
   Redo2,
-  Boxes,
-  Shapes,
   RefreshCw,
   Share2,
   Users,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
-import { Switch } from '@/components/ui/switch';
 import { Separator } from '@/components/ui/separator';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import {
@@ -75,13 +68,11 @@ import {
   DropdownMenuSubContent,
 } from '@/components/ui/dropdown-menu';
 import { Progress } from '@/components/ui/progress';
-import { useViewerStore, isIfcxDataStore, type FederatedModel } from '@/store';
+import { useViewerStore } from '@/store';
 import { goHomeFromStore, resetVisibilityForHomeFromStore } from '@/store/homeView';
 import { executeBasketIsolate } from '@/store/basket/basketCommands';
 import { useIfc } from '@/hooks/useIfc';
 import { cn } from '@/lib/utils';
-import { exportCsvFromBytes } from '@/lib/export/csv';
-import { downloadFile, downloadDataUrl } from '@/lib/export/download';
 import { FileSpreadsheet, FileJson, FileText, Filter, Upload, Pencil, DraftingCompass } from 'lucide-react';
 import { ExportDialog } from './ExportDialog';
 import { GLBExportDialog } from './GLBExportDialog';
@@ -93,26 +84,15 @@ import { ExportChangesButton } from './ExportChangesButton';
 import { ShareDialog } from './ShareDialog';
 import { isCollabEnabled } from '@/lib/collab/config';
 import { SearchInline } from './SearchInline';
-import { recordRecentFiles, cacheFileBlobs } from '@/lib/recent-files';
-import {
-  supportsFileSystemAccess,
-  openIfcFilesWithHandles,
-  readFreshFile,
-} from '@/services/file-system-access';
 import { ThemeSwitch } from './ThemeSwitch';
 import { ExtensionToolbarSlot } from '@/components/extensions/ExtensionToolbarSlot';
-import { toast } from '@/components/ui/toast';
-import {
-  closeActiveAnalysisExtension,
-  getAnalysisExtensionsSnapshot,
-  openAnalysisExtension,
-  subscribeAnalysisExtensions,
-} from '@/services/analysis-extensions';
-import { closePanelWindow } from '@/services/panel-windows';
 import { tourAnchor, toolAnchor } from '@/lib/tours/anchors';
+import { useFileCommands } from './toolbar/useFileCommands';
+import { useExportCommands } from './toolbar/useExportCommands';
+import { useWorkspacePanelControls } from './toolbar/useWorkspacePanelControls';
+import { ClassVisibilityMenuContent } from './toolbar/ClassVisibilityMenu';
 
 type Tool = 'select' | 'walk' | 'measure' | 'section' | 'annotate' | 'addElement' | 'split' | 'spaceSketch';
-type WorkspacePanel = 'script' | 'list' | 'bcf' | 'ids' | 'lens' | 'addElement' | string;
 
 // #region FIX: Move ToolButton OUTSIDE MainToolbar to prevent recreation on every render
 // This fixes Radix UI Tooltip's asChild prop becoming stale during re-renders
@@ -167,39 +147,6 @@ function ToolButton({
         {label} {shortcut && <span className="ml-2 text-xs opacity-60">({shortcut})</span>}
       </TooltipContent>
     </Tooltip>
-  );
-}
-
-interface ClassVisibilityRowProps {
-  /** Colored class glyph (caller sets the tint). */
-  icon: React.ReactNode;
-  label: string;
-  /** One-line plain-language hint about what the IFC class covers. */
-  description: string;
-  checked: boolean;
-  onChange: (next: boolean) => void;
-}
-
-/**
- * One row of the Visibility panel: colored class icon + label/description
- * on the left, a Switch on the right. The whole row is a <label>, so a
- * click anywhere toggles the switch and — because it isn't a menu item —
- * the dropdown stays open for flipping several classes in a row. The left
- * cluster dims when off so on/off reads from saturation as well as the
- * switch position.
- */
-function ClassVisibilityRow({ icon, label, description, checked, onChange }: ClassVisibilityRowProps) {
-  return (
-    <label className="group flex items-center justify-between gap-3 rounded-md px-2 py-1.5 cursor-pointer hover:bg-muted/50 transition-colors">
-      <span className={cn('flex items-center gap-2.5 min-w-0 transition-opacity', !checked && 'opacity-50')}>
-        {icon}
-        <span className="grid gap-0.5 min-w-0">
-          <span className="text-sm leading-tight truncate">{label}</span>
-          <span className="text-[10px] leading-tight text-muted-foreground truncate">{description}</span>
-        </span>
-      </span>
-      <Switch checked={checked} onCheckedChange={onChange} />
-    </label>
   );
 }
 
@@ -301,35 +248,18 @@ function ActionButton({ icon: Icon, label, onClick, shortcut, disabled }: Action
 }
 // #endregion
 
-/** Extensions the viewer can ingest (IFC / IFCX / GLB / point clouds). */
-function isSupportedModelFile(f: File): boolean {
-  const n = f.name.toLowerCase();
-  return n.endsWith('.ifc') || n.endsWith('.ifcx') || n.endsWith('.ifczip') || n.endsWith('.glb')
-    || n.endsWith('.las') || n.endsWith('.laz') || n.endsWith('.ply') || n.endsWith('.pcd')
-    || n.endsWith('.e57') || n.endsWith('.pts') || n.endsWith('.xyz');
-}
-
-/** Case-insensitive IFCX check (filenames are accepted case-insensitively). */
-function isIfcxModelFile(f: File): boolean {
-  return f.name.toLowerCase().endsWith('.ifcx');
-}
-
 interface MainToolbarProps {
   onShowShortcuts?: () => void;
 }
 
 export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainToolbarProps) {
-  const fileInputRef = useRef<HTMLInputElement>(null);
-  const addModelInputRef = useRef<HTMLInputElement>(null);
   // Collaboration: the Share button is gated behind the collab feature flag.
   const collabEnabled = useMemo(() => isCollabEnabled(), []);
   const [shareDialogOpen, setShareDialogOpen] = React.useState(false);
   const collabPeerCount = useViewerStore((s) => s.collabPeers.length);
   const collabRoomId = useViewerStore((s) => s.collabRoomId);
   const collabPanelVisible = useViewerStore((s) => s.collabPanelVisible);
-  const layersPanelVisible = useViewerStore((s) => s.layersPanelVisible);
   const {
-    loadFile,
     loading,
     progress,
     geometryProgress,
@@ -337,53 +267,38 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
     geometryResult,
     ifcDataStore,
     models,
-    clearAllModels,
-    loadFilesSequentially,
-    loadFederatedIfcx,
-    addIfcxOverlays,
-    addModel,
   } = useIfc();
 
-  // Listen for programmatic file-load requests (from command palette recent files)
-  useEffect(() => {
-    const handler = (e: Event) => {
-      const file = (e as CustomEvent<File>).detail;
-      if (file) {
-        recordRecentFiles([{ name: file.name, size: file.size }]);
-        void loadFile(file);
-      }
-    };
-    // Federation variant: ADD the file to the current set instead of
-    // replacing it (the compare tour loads demo revision B this way).
-    const addHandler = (e: Event) => {
-      const file = (e as CustomEvent<unknown>).detail;
-      if (file instanceof File) void addModel(file);
-    };
-    // Layer-stack variant: load a File[] as a composed .ifcx federation
-    // (the Layers panel demo + tour dispatch this, see lib/layers/demo-stack).
-    const stackHandler = (e: Event) => {
-      const files = (e as CustomEvent<unknown>).detail;
-      if (Array.isArray(files) && files.every((f) => f instanceof File) && files.length > 0) {
-        void loadFederatedIfcx(files as File[]);
-      }
-    };
-    // Panels (RoomPanel empty state) request the Share dialog this way —
-    // its open state is toolbar-local.
-    const shareHandler = () => setShareDialogOpen(true);
-    window.addEventListener('ifc-lite:load-file', handler);
-    window.addEventListener('ifc-lite:add-model', addHandler);
-    window.addEventListener('ifc-lite:load-layer-stack', stackHandler);
-    window.addEventListener('ifc-lite:open-share-dialog', shareHandler);
-    return () => {
-      window.removeEventListener('ifc-lite:load-file', handler);
-      window.removeEventListener('ifc-lite:add-model', addHandler);
-      window.removeEventListener('ifc-lite:load-layer-stack', stackHandler);
-      window.removeEventListener('ifc-lite:open-share-dialog', shareHandler);
-    };
-  }, [loadFile, addModel, loadFederatedIfcx]);
+  // Shared command surfaces (also drive the ribbon toolbar): file
+  // open/add/refresh incl. the global `ifc-lite:*` load listeners and
+  // hidden inputs, data exports, and the workspace-panel dock rules.
+  const {
+    fileInputs,
+    handleOpenClick,
+    handleAddModelClick,
+    handleRefresh,
+    canRefresh,
+    hasModelsLoaded,
+  } = useFileCommands();
+  const { handleExportCSV, handleExportJSON, handleScreenshot } = useExportCommands();
+  const {
+    activeWorkspacePanels,
+    workspacePanelLabel,
+    handleToggleBottomPanel,
+    handleToggleRightPanel,
+    handleToggleAnalysisExtension,
+    rightAnalysisExtensions,
+    bottomAnalysisExtensions,
+  } = useWorkspacePanelControls();
 
-  // Check if we have models loaded (for showing add model button)
-  const hasModelsLoaded = models.size > 0 || (geometryResult?.meshes && geometryResult.meshes.length > 0);
+  // Panels (RoomPanel empty state) request the Share dialog this way —
+  // its open state is toolbar-local.
+  useEffect(() => {
+    const shareHandler = () => setShareDialogOpen(true);
+    window.addEventListener('ifc-lite:open-share-dialog', shareHandler);
+    return () => window.removeEventListener('ifc-lite:open-share-dialog', shareHandler);
+  }, []);
+
   const activeTool = useViewerStore((state) => state.activeTool);
   const setActiveTool = useViewerStore((state) => state.setActiveTool);
   const editEnabled = useViewerStore((state) => state.editEnabled);
@@ -402,48 +317,13 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
   const cameraCallbacks = useViewerStore((state) => state.cameraCallbacks);
   const hoverTooltipsEnabled = useViewerStore((state) => state.hoverTooltipsEnabled);
   const toggleHoverTooltips = useViewerStore((state) => state.toggleHoverTooltips);
-  const typeVisibility = useViewerStore((state) => state.typeVisibility);
-  const toggleTypeVisibility = useViewerStore((state) => state.toggleTypeVisibility);
-  const resetTypeVisibility = useViewerStore((state) => state.resetTypeVisibility);
-  // #957 follow-up: Model/Types 3D view switch — 'model' shows placed
-  // occurrences (default), 'types' shows the type-library shapes.
-  const typeViewMode = useViewerStore((state) => state.typeViewMode);
-  const setTypeViewMode = useViewerStore((state) => state.setTypeViewMode);
-  // Only models with type-library geometry (RepresentationMap shapes) can show
-  // anything in "Types" mode, so the switch is hidden for the common
-  // occurrence-only model. Derived in ViewportContainer from the merged meshes.
-  const hasTypeGeometry = useViewerStore((state) => state.hasTypeGeometry);
-  // How many of the class toggles are on — surfaced in the menu
-  // header so the user sees scene state at a glance.
-  const visibleClassCount = [
-    typeVisibility.spaces,
-    typeVisibility.spatialZones,
-    typeVisibility.openings,
-    typeVisibility.virtualElements,
-    typeVisibility.site,
-    typeVisibility.ifcAnnotations,
-    typeVisibility.ifcGrid,
-  ].filter(Boolean).length;
-  // Issue #540: load-time toggle that asks the WASM bridge to merge
-  // Revit-style multilayer walls. We surface this in the Class
-  // Visibility dropdown so users discover it next to the other
-  // "what shows in the scene" controls.
+  // Issue #540: the merge-multilayer-walls load-time toggle lives in the
+  // shared Class Visibility menu; the trigger only needs the flag for
+  // its non-default-setting accent dot.
   const mergeLayers = useViewerStore((state) => state.mergeLayers);
-  const setMergeLayers = useViewerStore((state) => state.setMergeLayers);
-  const geometryMode = useViewerStore((state) => state.geometryMode);
-  const setGeometryMode = useViewerStore((state) => state.setGeometryMode);
-  const resetViewerState = useViewerStore((state) => state.resetViewerState);
-  const bcfPanelVisible = useViewerStore((state) => state.bcfPanelVisible);
-  const setBcfPanelVisible = useViewerStore((state) => state.setBcfPanelVisible);
-  const idsPanelVisible = useViewerStore((state) => state.idsPanelVisible);
-  const setIdsPanelVisible = useViewerStore((state) => state.setIdsPanelVisible);
-  const clashPanelVisible = useViewerStore((state) => state.clashPanelVisible);
-  const setClashPanelVisible = useViewerStore((state) => state.setClashPanelVisible);
-  const comparePanelVisible = useViewerStore((state) => state.comparePanelVisible);
-  const setComparePanelVisible = useViewerStore((state) => state.setComparePanelVisible);
-  const listPanelVisible = useViewerStore((state) => state.listPanelVisible);
-  const setListPanelVisible = useViewerStore((state) => state.setListPanelVisible);
-  const setRightPanelCollapsed = useViewerStore((state) => state.setRightPanelCollapsed);
+  // Toolbar style switch (issue #1686): the View options menu offers the
+  // jump to the tabbed ribbon; the ribbon's View tab offers the way back.
+  const setToolbarStyle = useViewerStore((state) => state.setToolbarStyle);
   const projectionMode = useViewerStore((state) => state.projectionMode);
   const toggleProjectionMode = useViewerStore((state) => state.toggleProjectionMode);
   // Basket presentation state
@@ -451,15 +331,6 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
   const basketViewCount = useViewerStore((state) => state.basketViews.length);
   const basketPresentationVisible = useViewerStore((state) => state.basketPresentationVisible);
   const toggleBasketPresentationVisible = useViewerStore((state) => state.toggleBasketPresentationVisible);
-  // Lens state
-  const lensPanelVisible = useViewerStore((state) => state.lensPanelVisible);
-  const setLensPanelVisible = useViewerStore((state) => state.setLensPanelVisible);
-  const extensionsPanelVisible = useViewerStore((state) => state.extensionsPanelVisible);
-  const setExtensionsPanelVisible = useViewerStore((state) => state.setExtensionsPanelVisible);
-  const scriptPanelVisible = useViewerStore((state) => state.scriptPanelVisible);
-  const setScriptPanelVisible = useViewerStore((state) => state.setScriptPanelVisible);
-  const ganttPanelVisible = useViewerStore((state) => state.ganttPanelVisible);
-  const setGanttPanelVisible = useViewerStore((state) => state.setGanttPanelVisible);
   // Cesium 3D overlay state
   const cesiumAvailable = useViewerStore((state) => state.cesiumAvailable);
   const cesiumEnabled = useViewerStore((state) => state.cesiumEnabled);
@@ -476,226 +347,7 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
   const spaceMousePanelOpen = useViewerStore((state) => state.spaceMousePanelOpen);
   const toggleSpaceMousePanel = useViewerStore((state) => state.toggleSpaceMousePanel);
   const spaceMouseConnected = useViewerStore((state) => state.spaceMouseConnected);
-  const storeModels = useViewerStore((state) => state.models);
-  const analysisExtensionState = useSyncExternalStore(
-    subscribeAnalysisExtensions,
-    getAnalysisExtensionsSnapshot,
-    getAnalysisExtensionsSnapshot,
-  );
-  const activeAnalysisExtension = useMemo(
-    () => analysisExtensionState.extensions.find((extension) => extension.id === analysisExtensionState.activeId) ?? null,
-    [analysisExtensionState.activeId, analysisExtensionState.extensions],
-  );
-  const rightAnalysisExtensions = useMemo(
-    () => analysisExtensionState.extensions.filter((extension) => (extension.placement ?? 'right') === 'right'),
-    [analysisExtensionState.extensions],
-  );
-  const bottomAnalysisExtensions = useMemo(
-    () => analysisExtensionState.extensions.filter((extension) => (extension.placement ?? 'right') === 'bottom'),
-    [analysisExtensionState.extensions],
-  );
 
-  // NOTE: The Class Visibility dropdown used to gate each toggle on whether
-  // the loaded model actually contained that class (scanning meshes for
-  // Spaces/Openings/Site and probing the entity table for Annotations/Grids).
-  // That gating was removed: the toggles are persisted user preferences, so
-  // they now render unconditionally and stay sticky across models and reloads.
-
-  const handleFileSelect = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
-    const files = e.target.files;
-    if (!files || files.length === 0) return;
-
-    // Filter to supported files (IFC, IFCX, GLB, point clouds)
-    const supportedFiles = Array.from(files).filter(isSupportedModelFile);
-
-    if (supportedFiles.length === 0) return;
-
-    // Track recently opened files (metadata + blob cache for instant reload)
-    recordRecentFiles(supportedFiles.map(f => ({ name: f.name, size: f.size })));
-    cacheFileBlobs(supportedFiles);
-
-    if (supportedFiles.length === 1) {
-      // Single file - use loadFile (simpler single-model path)
-      loadFile(supportedFiles[0]);
-    } else {
-      // Multiple files - check if ALL are IFCX (use federated loading for layer composition)
-      const allIfcx = supportedFiles.every(f => f.name.endsWith('.ifcx'));
-
-      resetViewerState();
-      clearAllModels();
-
-      if (allIfcx) {
-        // IFCX files use federated loading (layer composition - later files override earlier ones)
-        // This handles overlay files that add properties without geometry
-        console.log(`[MainToolbar] Loading ${supportedFiles.length} IFCX files with federated composition`);
-        loadFederatedIfcx(supportedFiles);
-      } else {
-        // Mixed or all IFC4/GLB files - load sequentially as independent models
-        loadFilesSequentially(supportedFiles);
-      }
-    }
-
-    // Reset input so same files can be selected again
-    e.target.value = '';
-  }, [loadFile, loadFilesSequentially, loadFederatedIfcx, resetViewerState, clearAllModels]);
-
-  // Shared Add-Model routing. `handles` is positionally aligned with
-  // `supportedFiles`, carrying a live FS Access handle per file (Chromium) so
-  // each added model stays part of a refreshable federation.
-  const addSupportedFiles = useCallback((
-    supportedFiles: File[],
-    handles?: (FileSystemFileHandle | undefined)[],
-  ) => {
-    if (supportedFiles.length === 0) return;
-    const newFilesAreIfcx = supportedFiles.every(isIfcxModelFile);
-    const existingIsIfcx = isIfcxDataStore(ifcDataStore);
-
-    if (newFilesAreIfcx && existingIsIfcx) {
-      // Adding IFCX overlay(s) to existing IFCX model - re-compose with new layers
-      console.log(`[MainToolbar] Adding ${supportedFiles.length} IFCX overlay(s) to existing IFCX model - re-composing`);
-      void addIfcxOverlays(supportedFiles);
-    } else if (newFilesAreIfcx && !existingIsIfcx && ifcDataStore) {
-      // User trying to add IFCX to IFC4 model - won't work
-      console.warn('[MainToolbar] Cannot add IFCX files to non-IFCX model');
-      alert(`IFCX overlay files cannot be added to IFC4 models.\n\nPlease load IFCX files separately.`);
-    } else {
-      // Standard case - add as independent models (IFC4, GLB, or mixed)
-      void loadFilesSequentially(supportedFiles, handles);
-    }
-  }, [loadFilesSequentially, addIfcxOverlays, ifcDataStore]);
-
-  const handleAddModelSelect = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
-    const files = e.target.files;
-    if (!files || files.length === 0) return;
-    // <input> yields no live handle, so models added this way aren't refreshable.
-    const supportedFiles = Array.from(files).filter(isSupportedModelFile);
-    addSupportedFiles(supportedFiles);
-    // Reset input so same files can be selected again
-    e.target.value = '';
-  }, [addSupportedFiles]);
-
-  // Preferred Add-Model path: the picker captures a handle per file so the
-  // resulting federation can be refreshed. Falls back to the hidden <input>.
-  const handleAddModelClick = useCallback(async () => {
-    if (!supportsFileSystemAccess()) {
-      addModelInputRef.current?.click();
-      return;
-    }
-    const opened = await openIfcFilesWithHandles();
-    if (!opened) return;
-    const supported = opened.filter(o => isSupportedModelFile(o.file));
-    addSupportedFiles(supported.map(o => o.file), supported.map(o => o.handle));
-  }, [addSupportedFiles]);
-
-  // Open via the File System Access API when available (Chromium) so we capture
-  // a live FileSystemFileHandle for each file — that handle is what lets the
-  // Refresh button re-read the same file from disk later (issue #1345). Browsers
-  // without the API fall back to the hidden <input type="file">.
-  const handleOpenClick = useCallback(async () => {
-    if (!supportsFileSystemAccess()) {
-      fileInputRef.current?.click();
-      return;
-    }
-    const picked = await openIfcFilesWithHandles();
-    if (!picked) return; // cancelled, unavailable, or picker failed
-    // The picker keeps an "all files" option, so drop anything unsupported
-    // before it reaches the load pipeline (matches the <input> + Add Model paths).
-    const opened = picked.filter(o => isSupportedModelFile(o.file));
-    if (opened.length === 0) return;
-
-    const files = opened.map(o => o.file);
-    recordRecentFiles(files.map(f => ({ name: f.name, size: f.size })));
-    void cacheFileBlobs(files);
-
-    if (opened.length === 1) {
-      // Single model: keep the handle so Refresh can re-read it from disk.
-      void loadFile(opened[0].file, { kind: 'primary' }, { sourceHandle: opened[0].handle });
-    } else {
-      // Multiple files mirror handleFileSelect's branching.
-      const allIfcx = files.every(isIfcxModelFile);
-      resetViewerState();
-      clearAllModels();
-      if (allIfcx) {
-        // IFCX layers compose into one shared store — no per-file handle.
-        void loadFederatedIfcx(files);
-      } else {
-        // Carry each file's handle so the whole federation stays refreshable.
-        void loadFilesSequentially(files, opened.map(o => o.handle));
-      }
-    }
-  }, [loadFile, loadFilesSequentially, loadFederatedIfcx, resetViewerState, clearAllModels]);
-
-  // Refresh re-reads files from disk and re-parses them. Offered when EVERY
-  // loaded model has a live FS Access handle (a single model, or a federation
-  // fully opened via the picker/drag this session). Drag-drop on non-Chromium,
-  // <input type="file">, cache-restored, and IFCX-composed models have no
-  // handle, so a mixed session hides the button rather than risk dropping the
-  // handle-less models during the rebuild.
-  const canRefresh = useMemo(() => {
-    if (loading || models.size === 0) return false;
-    return Array.from(models.values()).every(m => m.sourceHandle);
-  }, [models, loading]);
-
-  const handleRefresh = useCallback(async () => {
-    const targets = (Array.from(useViewerStore.getState().models.values()) as FederatedModel[])
-      .filter((m): m is FederatedModel & { sourceHandle: FileSystemFileHandle } => Boolean(m.sourceHandle))
-      .sort((a, b) => (a.loadedAt ?? 0) - (b.loadedAt ?? 0));
-    if (targets.length === 0) return;
-
-    // Re-read every handle BEFORE clearing anything, so a failed read never
-    // leaves the viewer empty.
-    const reads = await Promise.all(
-      targets.map(async (m) => ({ model: m, fresh: await readFreshFile(m.sourceHandle) })),
-    );
-    const ok = reads.filter((r) => r.fresh) as { model: typeof targets[number]; fresh: File }[];
-    const failedNames = reads.filter((r) => !r.fresh).map((r) => `"${r.model.name}"`);
-
-    if (ok.length === 0) {
-      toast.error(`Couldn't re-read ${failedNames.join(', ')}. Files may have moved, been deleted, or access was denied.`);
-      return;
-    }
-
-    recordRecentFiles(ok.map((r) => ({ name: r.fresh.name, size: r.fresh.size })));
-    void cacheFileBlobs(ok.map((r) => r.fresh));
-
-    if (targets.length === 1) {
-      // Await so the success toast only fires once the reload has completed.
-      await loadFile(ok[0].fresh, { kind: 'primary' }, { sourceHandle: ok[0].model.sourceHandle });
-    } else {
-      // Rebuild the federation from fresh bytes, preserving id + order + state.
-      clearAllModels();
-      for (const r of ok) {
-        const reloadedId = await addModel(r.fresh, {
-          name: r.model.name,
-          modelId: r.model.id,
-          loadedAt: r.model.loadedAt,
-          visible: r.model.visible,
-          collapsed: r.model.collapsed,
-          sourceHandle: r.model.sourceHandle,
-        });
-        if (reloadedId && r.model.visible === false) {
-          useViewerStore.getState().setModelVisibility(r.model.id, false);
-        }
-      }
-    }
-
-    if (failedNames.length > 0) {
-      toast.error(`Refreshed ${ok.length}; couldn't re-read ${failedNames.join(', ')}.`);
-    } else {
-      toast.success(ok.length === 1 ? `Refreshed "${ok[0].fresh.name}"` : `Refreshed ${ok.length} models`);
-    }
-  }, [loadFile, addModel, clearAllModels]);
-
-  // The command palette dispatches this (synchronously, inside the click) so the
-  // toolbar's handle-capturing open path runs while user activation is still
-  // live — required for the file dialog to actually open on Chrome.
-  useEffect(() => {
-    const handler = () => { void handleOpenClick(); };
-    window.addEventListener('ifc-lite:open-files', handler);
-    return () => window.removeEventListener('ifc-lite:open-files', handler);
-  }, [handleOpenClick]);
-
-  const hasSelection = selectedEntityId !== null;
   // Selection chip uses the multi-select size when present; falls back
   // to the single legacy `selectedEntityId` so the chip still says
   // "1 selected" for the click-to-pick flow that hasn't migrated.
@@ -729,259 +381,10 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
     goHomeFromStore();
   }, []);
 
-  const handleToggleBottomPanel = useCallback((panel: 'script' | 'list' | 'gantt') => {
-    if (activeAnalysisExtension?.placement === 'bottom') {
-      closeActiveAnalysisExtension();
-    }
-    const nextScriptVisible = panel === 'script' ? !scriptPanelVisible : false;
-    const nextListVisible = panel === 'list' ? !listPanelVisible : false;
-    const nextGanttVisible = panel === 'gantt' ? !ganttPanelVisible : false;
-
-    setScriptPanelVisible(nextScriptVisible);
-    setListPanelVisible(nextListVisible);
-    setGanttPanelVisible(nextGanttVisible);
-
-    if (nextScriptVisible || nextListVisible || nextGanttVisible) {
-      setRightPanelCollapsed(false);
-    }
-  }, [
-    activeAnalysisExtension?.placement,
-    ganttPanelVisible,
-    listPanelVisible,
-    scriptPanelVisible,
-    setGanttPanelVisible,
-    setListPanelVisible,
-    setRightPanelCollapsed,
-    setScriptPanelVisible,
-  ]);
-
-  const handleToggleRightPanel = useCallback((panel: 'bcf' | 'ids' | 'lens' | 'clash' | 'compare' | 'addElement' | 'extensions') => {
-    if (activeAnalysisExtension?.placement !== 'bottom') {
-      closeActiveAnalysisExtension();
-    }
-
-    const nextBcfVisible = panel === 'bcf' ? !bcfPanelVisible : false;
-    const nextIdsVisible = panel === 'ids' ? !idsPanelVisible : false;
-    const nextLensVisible = panel === 'lens' ? !lensPanelVisible : false;
-    const nextClashVisible = panel === 'clash' ? !clashPanelVisible : false;
-    const nextCompareVisible = panel === 'compare' ? !comparePanelVisible : false;
-    const nextExtensionsVisible = panel === 'extensions' ? !extensionsPanelVisible : false;
-    const isAddElementActive = activeTool === 'addElement';
-    const nextAddElementActive = panel === 'addElement' ? !isAddElementActive : false;
-
-    setBcfPanelVisible(nextBcfVisible);
-    setIdsPanelVisible(nextIdsVisible);
-    setLensPanelVisible(nextLensVisible);
-    setClashPanelVisible(nextClashVisible);
-    setComparePanelVisible(nextCompareVisible);
-    setExtensionsPanelVisible(nextExtensionsVisible);
-    // Keep the float + window channels in sync (#1200/#1201/#1208): toggling a
-    // workspace panel from the toolbar re-docks it if it was floating or popped
-    // out, instead of leaving an orphaned floating panel or OS window.
-    if (panel !== 'addElement') {
-      useViewerStore.getState().closeFloatingPanel(panel);
-      closePanelWindow(panel);
-    }
-
-    if (panel === 'addElement') {
-      setActiveTool(nextAddElementActive ? 'addElement' : 'select');
-    } else if (isAddElementActive) {
-      setActiveTool('select');
-    }
-
-    if (nextBcfVisible || nextIdsVisible || nextLensVisible || nextClashVisible || nextCompareVisible || nextExtensionsVisible || nextAddElementActive) {
-      setRightPanelCollapsed(false);
-    }
-  }, [
-    activeAnalysisExtension?.placement,
-    activeTool,
-    bcfPanelVisible,
-    clashPanelVisible,
-    comparePanelVisible,
-    extensionsPanelVisible,
-    idsPanelVisible,
-    lensPanelVisible,
-    setActiveTool,
-    setBcfPanelVisible,
-    setClashPanelVisible,
-    setComparePanelVisible,
-    setExtensionsPanelVisible,
-    setIdsPanelVisible,
-    setLensPanelVisible,
-    setRightPanelCollapsed,
-  ]);
-
-  const handleToggleAnalysisExtension = useCallback((id: string) => {
-    const extension = analysisExtensionState.extensions.find((candidate) => candidate.id === id);
-    if (!extension) {
-      return;
-    }
-
-    if (analysisExtensionState.activeId === id) {
-      closeActiveAnalysisExtension();
-      return;
-    }
-
-    const opened = openAnalysisExtension(id);
-    if (!opened) {
-      return;
-    }
-
-    if ((extension.placement ?? 'right') === 'bottom') {
-      setScriptPanelVisible(false);
-      setListPanelVisible(false);
-      setGanttPanelVisible(false);
-      setRightPanelCollapsed(false);
-      return;
-    }
-
-    setBcfPanelVisible(false);
-    setIdsPanelVisible(false);
-    setLensPanelVisible(false);
-    setClashPanelVisible(false);
-    setExtensionsPanelVisible(false);
-    // The right slot is single-tenant: when an analysis extension takes
-    // it over, the AddElement tool must release it too, otherwise its 3D
-    // click handler keeps placing elements behind the extension panel.
-    if (activeTool === 'addElement') {
-      setActiveTool('select');
-    }
-    setRightPanelCollapsed(false);
-  }, [
-    activeTool,
-    analysisExtensionState.activeId,
-    analysisExtensionState.extensions,
-    setActiveTool,
-    setBcfPanelVisible,
-    setClashPanelVisible,
-    setExtensionsPanelVisible,
-    setGanttPanelVisible,
-    setIdsPanelVisible,
-    setLensPanelVisible,
-    setListPanelVisible,
-    setRightPanelCollapsed,
-    setScriptPanelVisible,
-  ]);
-
-  const activeWorkspacePanels = useMemo(() => {
-    const panels = new Set<WorkspacePanel>();
-    if (scriptPanelVisible) panels.add('script');
-    if (listPanelVisible) panels.add('list');
-    if (ganttPanelVisible) panels.add('gantt');
-    if (bcfPanelVisible) panels.add('bcf');
-    if (idsPanelVisible) panels.add('ids');
-    if (lensPanelVisible) panels.add('lens');
-    if (clashPanelVisible) panels.add('clash');
-    if (comparePanelVisible) panels.add('compare');
-    if (extensionsPanelVisible) panels.add('extensions');
-    if (activeTool === 'addElement') panels.add('addElement');
-    if (layersPanelVisible) panels.add('layers');
-    if (collabPanelVisible) panels.add('collab');
-    if (analysisExtensionState.activeId) panels.add(analysisExtensionState.activeId);
-    return panels;
-  }, [
-    activeTool,
-    analysisExtensionState.activeId,
-    bcfPanelVisible,
-    collabPanelVisible,
-    layersPanelVisible,
-    clashPanelVisible,
-    comparePanelVisible,
-    extensionsPanelVisible,
-    ganttPanelVisible,
-    idsPanelVisible,
-    lensPanelVisible,
-    listPanelVisible,
-    scriptPanelVisible,
-  ]);
-
-  const workspacePanelLabel = useMemo(() => {
-    if (activeWorkspacePanels.size === 0) return null;
-    if (activeWorkspacePanels.size > 1) return 'Multiple Panels';
-    if (activeWorkspacePanels.has('script')) return 'Script Editor';
-    if (activeWorkspacePanels.has('list')) return 'Lists';
-    if (activeWorkspacePanels.has('gantt')) return 'Schedule';
-    if (activeWorkspacePanels.has('bcf')) return 'BCF Issues';
-    if (activeWorkspacePanels.has('ids')) return 'IDS Validation';
-    if (activeWorkspacePanels.has('lens')) return 'Lens Rules';
-    if (activeWorkspacePanels.has('clash')) return 'Clash Detection';
-    if (activeWorkspacePanels.has('compare')) return 'Compare Models';
-    if (activeWorkspacePanels.has('extensions')) return 'Extensions';
-    if (activeWorkspacePanels.has('addElement')) return 'Add Element';
-    if (activeWorkspacePanels.has('layers')) return 'Layer Stack';
-    if (activeWorkspacePanels.has('collab')) return 'Collaboration Room';
-    return activeAnalysisExtension?.label ?? 'Analysis';
-  }, [activeAnalysisExtension?.label, activeWorkspacePanels]);
-
-  const handleScreenshot = useCallback(() => {
-    const canvas = document.querySelector('canvas');
-    if (!canvas) return;
-    try {
-      downloadDataUrl(canvas.toDataURL('image/png'), 'screenshot.png');
-      toast.success('Screenshot saved');
-    } catch (err) {
-      console.error('Screenshot failed:', err);
-      toast.error('Screenshot failed');
-    }
-  }, []);
-
-  const handleExportCSV = useCallback(async (type: 'entities' | 'properties' | 'quantities' | 'spatial') => {
-    if (!ifcDataStore?.source) return;
-    try {
-      const csv = await exportCsvFromBytes(ifcDataStore.source, type, { includeProperties: type === 'entities' });
-      const filename = type === 'spatial' ? 'spatial-hierarchy.csv' : `${type}.csv`;
-      downloadFile(csv, filename, 'text/csv');
-      toast.success(`Exported ${type} CSV`);
-    } catch (err) {
-      console.error('CSV export failed:', err);
-      toast.error(`CSV export failed: ${err instanceof Error ? err.message : 'Unknown error'}`);
-    }
-  }, [ifcDataStore]);
-
-  const handleExportJSON = useCallback(() => {
-    if (!ifcDataStore) return;
-    try {
-      const entities: Record<string, unknown>[] = [];
-      for (let i = 0; i < ifcDataStore.entities.count; i++) {
-        const id = ifcDataStore.entities.expressId[i];
-        entities.push({
-          expressId: id,
-          globalId: ifcDataStore.entities.getGlobalId(id),
-          name: ifcDataStore.entities.getName(id),
-          type: ifcDataStore.entities.getTypeName(id),
-          properties: ifcDataStore.properties.getForEntity(id),
-        });
-      }
-
-      const json = JSON.stringify({ entities }, null, 2);
-      downloadFile(json, 'model-data.json', 'application/json');
-      toast.success(`Exported ${entities.length} entities as JSON`);
-    } catch (err) {
-      console.error('JSON export failed:', err);
-      toast.error(`JSON export failed: ${err instanceof Error ? err.message : 'Unknown error'}`);
-    }
-  }, [ifcDataStore]);
-
   return (
     <div className="flex items-center gap-1 px-2 h-12 border-b bg-white dark:bg-black border-zinc-200 dark:border-zinc-800 relative z-50">
-      {/* ── File Operations ── */}
-      <input
-        id="file-input-open"
-        ref={fileInputRef}
-        type="file"
-        accept=".ifc,.ifcx,.ifczip,.glb,.las,.laz,.ply,.pcd,.e57,.pts,.xyz"
-        multiple
-        onChange={handleFileSelect}
-        className="hidden"
-      />
-      <input
-        ref={addModelInputRef}
-        type="file"
-        accept=".ifc,.ifcx,.ifczip,.glb,.las,.laz,.ply,.pcd,.e57,.pts,.xyz"
-        multiple
-        onChange={handleAddModelSelect}
-        className="hidden"
-      />
+      {/* ── File Operations (hidden <input> fallbacks live in the shared hook) ── */}
+      {fileInputs}
 
       <Tooltip>
         <TooltipTrigger asChild>
@@ -1568,179 +971,9 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
             {mergeLayers ? 'Visibility · Merge Multilayer Walls is on' : 'Visibility'}
           </TooltipContent>
         </Tooltip>
-        {/*
-          Settings-style panel (not a list of menu-items): each row is a
-          plain <label> wrapping a right-aligned Switch, so toggling does
-          NOT close the menu — users routinely flip several classes in one
-          pass. State reads two ways: the switch position and the row
-          dimming when off. All five render unconditionally (persisted
-          preferences, sticky across models/reloads); toggling a class the
-          model lacks is a no-op.
-        */}
-        <DropdownMenuContent align="start" className="w-[300px] p-1.5">
-          {/* Model / Types 3D view switch (#957 follow-up). A type carries a
-              RepresentationMap whose shape is drawn at its MappingOrigin; "Types"
-              shows that type library, "Model" shows the placed occurrences. The
-              two are mutually exclusive — toggling re-filters the cached mesh set
-              instantly (no reload). Only rendered when the model actually has
-              type-library geometry — most carry only occurrence geometry, where
-              "Types" would be empty, so the switch would just be a dead control. */}
-          {hasTypeGeometry && (
-            <>
-              <div className="px-1.5 pb-1 pt-0.5">
-                <span className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
-                  3D View
-                </span>
-              </div>
-              <div className="flex gap-1 px-1.5 pb-1.5" role="radiogroup" aria-label="3D view mode">
-                <button
-                  type="button"
-                  role="radio"
-                  aria-checked={typeViewMode === 'model'}
-                  onClick={() => setTypeViewMode('model')}
-                  className={cn(
-                    'flex flex-1 items-center justify-center gap-1.5 rounded-md border px-2 py-1.5 text-xs font-medium transition-colors',
-                    typeViewMode === 'model'
-                      ? 'border-primary/40 bg-primary/10 text-foreground'
-                      : 'border-transparent text-muted-foreground hover:bg-muted/50',
-                  )}
-                >
-                  <Boxes className="h-3.5 w-3.5 shrink-0" />
-                  Model
-                </button>
-                <button
-                  type="button"
-                  role="radio"
-                  aria-checked={typeViewMode === 'types'}
-                  onClick={() => setTypeViewMode('types')}
-                  className={cn(
-                    'flex flex-1 items-center justify-center gap-1.5 rounded-md border px-2 py-1.5 text-xs font-medium transition-colors',
-                    typeViewMode === 'types'
-                      ? 'border-primary/40 bg-primary/10 text-foreground'
-                      : 'border-transparent text-muted-foreground hover:bg-muted/50',
-                  )}
-                >
-                  <Shapes className="h-3.5 w-3.5 shrink-0" />
-                  Types
-                </button>
-              </div>
-
-              <DropdownMenuSeparator className="my-1" />
-            </>
-          )}
-
-          <div className="flex items-center justify-between gap-2 px-1.5 pb-1 pt-0.5">
-            <span className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
-              Visibility
-            </span>
-            <div className="flex items-center gap-1">
-              <span className="text-[11px] tabular-nums text-muted-foreground/80">
-                {visibleClassCount}/5
-              </span>
-              <Button
-                variant="ghost"
-                size="sm"
-                className="h-6 px-1.5 text-[11px] font-medium text-muted-foreground hover:text-foreground"
-                onClick={resetTypeVisibility}
-              >
-                Reset
-              </Button>
-            </div>
-          </div>
-
-          <ClassVisibilityRow
-            icon={<Box className="h-4 w-4 shrink-0" style={{ color: '#33d9ff' }} />}
-            label="Spaces"
-            description="Room volumes (IfcSpace)"
-            checked={typeVisibility.spaces}
-            onChange={() => toggleTypeVisibility('spaces')}
-          />
-          <ClassVisibilityRow
-            icon={<Box className="h-4 w-4 shrink-0" style={{ color: '#b85af2' }} />}
-            label="Spatial Zones"
-            description="Gross-area volumes (IfcSpatialZone)"
-            checked={typeVisibility.spatialZones}
-            onChange={() => toggleTypeVisibility('spatialZones')}
-          />
-          <ClassVisibilityRow
-            icon={<SquareX className="h-4 w-4 shrink-0" style={{ color: '#ff6b4a' }} />}
-            label="Openings"
-            description="Door & window voids"
-            checked={typeVisibility.openings}
-            onChange={() => toggleTypeVisibility('openings')}
-          />
-          <ClassVisibilityRow
-            icon={<BoxSelect className="h-4 w-4 shrink-0" style={{ color: '#9aa0a6' }} />}
-            label="Virtual Elements"
-            description="Non-physical boundaries & clearance volumes"
-            checked={typeVisibility.virtualElements}
-            onChange={() => toggleTypeVisibility('virtualElements')}
-          />
-          <ClassVisibilityRow
-            icon={<Building2 className="h-4 w-4 shrink-0" style={{ color: '#66cc4d' }} />}
-            label="Site"
-            description="Terrain & context"
-            checked={typeVisibility.site}
-            onChange={() => toggleTypeVisibility('site')}
-          />
-          <ClassVisibilityRow
-            icon={<Pencil className="h-4 w-4 shrink-0" style={{ color: '#e4b400' }} />}
-            label="Annotations"
-            description="Text, dimensions, leaders"
-            checked={typeVisibility.ifcAnnotations}
-            onChange={() => toggleTypeVisibility('ifcAnnotations')}
-          />
-          <ClassVisibilityRow
-            icon={<Grid3x3 className="h-4 w-4 shrink-0" style={{ color: '#e4b400' }} />}
-            label="Grids"
-            description="Structural axes"
-            checked={typeVisibility.ifcGrid}
-            onChange={() => toggleTypeVisibility('ifcGrid')}
-          />
-
-          <DropdownMenuSeparator className="my-1" />
-
-          {/* Merge multilayer walls rebuilds geometry, so unlike the live
-              toggles above it only takes effect on the next model load.
-              The "· on reload" suffix carries that nuance inline — keeps
-              the row identical in shape to the others (no header, no chip
-              crowding the long label). */}
-          <label className="group flex items-center justify-between gap-3 rounded-md px-2 py-1.5 cursor-pointer hover:bg-muted/50 transition-colors">
-            <span className={cn('flex items-center gap-2.5 min-w-0 transition-opacity', !mergeLayers && 'opacity-50')}>
-              <Layers2 className="h-4 w-4 shrink-0 text-primary" />
-              <span className="grid gap-0.5 min-w-0">
-                <span className="text-sm leading-tight truncate">Merge multilayer walls</span>
-                <span className="text-[10px] leading-tight text-muted-foreground truncate">
-                  Render walls as one solid · on reload
-                </span>
-              </span>
-            </span>
-            <Switch checked={mergeLayers} onCheckedChange={(next) => setMergeLayers(next === true)} />
-          </label>
-
-          {/* Fast vs Exact geometry — like merge-layers, a load-time geometry
-              input that only takes effect on the next model load ("· on reload").
-              Fast skips sub-10% detail cuts + auto-lowers density on heavy models
-              for quick first paint; Exact keeps every cut at full density for
-              display/measure/export fidelity. */}
-          <label className="group flex items-center justify-between gap-3 rounded-md px-2 py-1.5 cursor-pointer hover:bg-muted/50 transition-colors">
-            <span className={cn('flex items-center gap-2.5 min-w-0 transition-opacity', geometryMode !== 'fast' && 'opacity-50')}>
-              <Zap className="h-4 w-4 shrink-0 text-primary" />
-              <span className="grid gap-0.5 min-w-0">
-                <span className="text-sm leading-tight truncate">Fast geometry</span>
-                <span className="text-[10px] leading-tight text-muted-foreground truncate">
-                  {geometryMode === 'fast'
-                    ? 'Skip tiny cuts, auto-detail · on reload'
-                    : 'Exact: full cuts + density · on reload'}
-                </span>
-              </span>
-            </span>
-            <Switch
-              checked={geometryMode === 'fast'}
-              onCheckedChange={(next) => setGeometryMode(next === true ? 'fast' : 'exact')}
-            />
-          </label>
-        </DropdownMenuContent>
+        {/* Body shared with the ribbon's View tab — class toggles,
+            Model/Types switch, and load-time geometry settings. */}
+        <ClassVisibilityMenuContent align="start" />
       </DropdownMenu>
 
       <Separator orientation="vertical" className="h-6 mx-1" />
@@ -1926,6 +1159,20 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
           >
             <Info className="h-4 w-4 mr-2" />
             Hover tooltips
+          </DropdownMenuCheckboxItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuLabel className="text-[10px] uppercase tracking-wide text-muted-foreground">
+            Toolbar
+          </DropdownMenuLabel>
+          {/* Issue #1686: jump to the tabbed, IFCFlux-style ribbon. This
+              menu only renders in the classic style, so the box is never
+              checked here — the ribbon's View tab has the way back. */}
+          <DropdownMenuCheckboxItem
+            checked={false}
+            onCheckedChange={() => setToolbarStyle('ribbon')}
+          >
+            <PanelTop className="h-4 w-4 mr-2" />
+            Ribbon toolbar
           </DropdownMenuCheckboxItem>
         </DropdownMenuContent>
       </DropdownMenu>

--- a/apps/viewer/src/components/viewer/MainToolbar.tsx
+++ b/apps/viewer/src/components/viewer/MainToolbar.tsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import React, { useCallback, useEffect, useMemo } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import {
   FolderOpen,
   Download,
@@ -81,7 +81,6 @@ import { HbjsonExportDialog } from './HbjsonExportDialog';
 import { BulkPropertyEditor } from './BulkPropertyEditor';
 import { DataConnector } from './DataConnector';
 import { ExportChangesButton } from './ExportChangesButton';
-import { ShareDialog } from './ShareDialog';
 import { isCollabEnabled } from '@/lib/collab/config';
 import { SearchInline } from './SearchInline';
 import { ThemeSwitch } from './ThemeSwitch';
@@ -165,9 +164,13 @@ function UndoRedoButtons() {
   const redoStacks = useViewerStore((s) => s.redoStacks);
   const undo = useViewerStore((s) => s.undo);
   const redo = useViewerStore((s) => s.redo);
+  // Undo/redo replay authoring mutations, so they honour the same collab
+  // role gate as edit mode (null role = single-user, always editable).
+  const collabRole = useViewerStore((s) => s.collabRole);
+  const canEditInSession = collabRole === null || collabRole === 'editor' || collabRole === 'admin';
 
-  const canUndo = activeModelId !== null && (undoStacks.get(activeModelId)?.length ?? 0) > 0;
-  const canRedo = activeModelId !== null && (redoStacks.get(activeModelId)?.length ?? 0) > 0;
+  const canUndo = canEditInSession && activeModelId !== null && (undoStacks.get(activeModelId)?.length ?? 0) > 0;
+  const canRedo = canEditInSession && activeModelId !== null && (redoStacks.get(activeModelId)?.length ?? 0) > 0;
 
   return (
     <>
@@ -254,8 +257,9 @@ interface MainToolbarProps {
 
 export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainToolbarProps) {
   // Collaboration: the Share button is gated behind the collab feature flag.
+  // The ShareDialog + its `ifc-lite:open-share-dialog` listener live in
+  // useFileCommands (always mounted for the active toolbar style).
   const collabEnabled = useMemo(() => isCollabEnabled(), []);
-  const [shareDialogOpen, setShareDialogOpen] = React.useState(false);
   const collabPeerCount = useViewerStore((s) => s.collabPeers.length);
   const collabRoomId = useViewerStore((s) => s.collabRoomId);
   const collabPanelVisible = useViewerStore((s) => s.collabPanelVisible);
@@ -274,6 +278,7 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
   // hidden inputs, data exports, and the workspace-panel dock rules.
   const {
     fileInputs,
+    openShareDialog,
     handleOpenClick,
     handleAddModelClick,
     handleRefresh,
@@ -290,14 +295,6 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
     rightAnalysisExtensions,
     bottomAnalysisExtensions,
   } = useWorkspacePanelControls();
-
-  // Panels (RoomPanel empty state) request the Share dialog this way —
-  // its open state is toolbar-local.
-  useEffect(() => {
-    const shareHandler = () => setShareDialogOpen(true);
-    window.addEventListener('ifc-lite:open-share-dialog', shareHandler);
-    return () => window.removeEventListener('ifc-lite:open-share-dialog', shareHandler);
-  }, []);
 
   const activeTool = useViewerStore((state) => state.activeTool);
   const setActiveTool = useViewerStore((state) => state.setActiveTool);
@@ -576,8 +573,8 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
               <Button
                 variant="ghost"
                 size="icon-sm"
-                disabled={!geometryResult}
-                onClick={() => setShareDialogOpen(true)}
+                disabled={!hasModelsLoaded}
+                onClick={openShareDialog}
                 className="relative"
                 aria-label="Share"
               >
@@ -591,7 +588,6 @@ export function MainToolbar({ onShowShortcuts }: MainToolbarProps = {} as MainTo
             </TooltipTrigger>
             <TooltipContent>Share</TooltipContent>
           </Tooltip>
-          <ShareDialog open={shareDialogOpen} onOpenChange={setShareDialogOpen} />
           {/* Room panel toggle — live presence + management, only while in a room. */}
           {collabRoomId && (
             <Tooltip>

--- a/apps/viewer/src/components/viewer/ViewerLayout.tsx
+++ b/apps/viewer/src/components/viewer/ViewerLayout.tsx
@@ -8,6 +8,7 @@ import type { PanelImperativeHandle } from 'react-resizable-panels';
 import { TooltipProvider } from '@/components/ui/tooltip';
 import { MainToolbar } from './MainToolbar';
 import { MobileToolbar } from './MobileToolbar';
+import { RibbonToolbar } from './ribbon/RibbonToolbar';
 import { HierarchyPanel } from './HierarchyPanel';
 import { PropertiesPanel } from './PropertiesPanel';
 import { AddElementPanel } from './AddElementPanel';
@@ -168,6 +169,8 @@ export function ViewerLayout() {
 
   // Initialize theme on mount
   const theme = useViewerStore((s) => s.theme);
+  // Desktop toolbar style (issue #1686): classic strip or tabbed ribbon.
+  const toolbarStyle = useViewerStore((s) => s.toolbarStyle);
   const isMobile = useViewerStore((s) => s.isMobile);
   const setIsMobile = useViewerStore((s) => s.setIsMobile);
   const leftPanelCollapsed = useViewerStore((s) => s.leftPanelCollapsed);
@@ -344,8 +347,13 @@ export function ViewerLayout() {
         <SearchModal />
         <TourHost />
 
-        {/* Main Toolbar — use compact MobileToolbar on mobile */}
-        {isMobile ? <MobileToolbar /> : <MainToolbar onShowShortcuts={shortcutsDialog.toggle} />}
+        {/* Main Toolbar — compact MobileToolbar on mobile; on desktop the
+            user picks classic strip vs tabbed ribbon (issue #1686). */}
+        {isMobile
+          ? <MobileToolbar />
+          : toolbarStyle === 'ribbon'
+            ? <RibbonToolbar onShowShortcuts={shortcutsDialog.toggle} />
+            : <MainToolbar onShowShortcuts={shortcutsDialog.toggle} />}
 
         {/* Main Content Area - Desktop Layout */}
         {!isMobile && (

--- a/apps/viewer/src/components/viewer/ViewportContainer.tsx
+++ b/apps/viewer/src/components/viewer/ViewportContainer.tsx
@@ -44,7 +44,7 @@ import { toast } from '@/components/ui/toast';
 import { TourInvite } from '@/components/tours/TourInvite';
 import { TOUR_ANCHORS, tourAnchor } from '@/lib/tours/anchors';
 import { describeUnsupportedFormat } from '@/hooks/ingest/pointCloudIngest';
-import { Upload, MousePointer, Layers, Info, Command, AlertTriangle, ChevronDown, ExternalLink, Plus, Clock3, Sparkles, ArrowUpRight, PackagePlus , GitMerge } from 'lucide-react';
+import { Upload, Command, AlertTriangle, ChevronDown, ExternalLink, Plus, Clock3, Sparkles, ArrowUpRight, PackagePlus, GitMerge } from 'lucide-react';
 import { createBlankIfcFile } from '@/utils/createBlankIfc';
 import type { MeshData, CoordinateInfo, GeometryResult, PointCloudAsset } from '@ifc-lite/geometry';
 import { type IfcDataStore, type MapConversion } from '@ifc-lite/parser';
@@ -1102,8 +1102,14 @@ export function ViewportContainer() {
           </div>
         )}
 
-        {/* Empty state content — mobile-optimized padding and scrollable */}
-        <div className="absolute inset-0 flex flex-col items-center justify-center p-4 md:p-8 z-10 overflow-auto">
+        {/* Empty state content — mobile-optimized padding and scrollable.
+            The scroll container must NOT center via justify-center: a flex
+            child taller than an overflow-auto parent gets its top clipped
+            beyond scroll reach (the logo used to vanish under the toolbar
+            on short viewports). Instead an inner min-h-full column centers
+            when there is room and grows scrollably from the top when not. */}
+        <div className="absolute inset-0 z-10 overflow-auto p-4 md:p-8">
+          <div className="min-h-full w-full flex flex-col items-center justify-center">
 
           {/* Main Card */}
           <div {...tourAnchor(TOUR_ANCHORS.emptyStateCard)} className="max-w-md w-full bg-white dark:bg-[#16161e] border border-zinc-300 dark:border-[#3b4261] p-8 flex flex-col items-center transition-transform hover:-translate-y-1 duration-200 shadow-lg">
@@ -1245,27 +1251,9 @@ export function ViewportContainer() {
             )}
           </div>
 
-          {/* Feature Grid — hidden on mobile to save viewport space */}
-          <div className="mt-16 hidden md:grid grid-cols-1 md:grid-cols-3 gap-6 max-w-3xl w-full">
-            {[
-              { icon: MousePointer, label: "Select", desc: "Inspect elements", accentClass: 'text-blue-500 dark:text-[#7aa2f7]' },
-              { icon: Layers, label: "Filter", desc: "Isolate storeys", accentClass: 'text-purple-500 dark:text-[#bb9af7]' },
-              { icon: Info, label: "Analyze", desc: "View properties", accentClass: 'text-cyan-500 dark:text-[#7dcfff]' }
-            ].map((feature, i) => (
-              <div 
-                key={i} 
-                className="p-4 flex items-center gap-4 bg-zinc-100 dark:bg-[#1f2335] border border-zinc-300 dark:border-[#3b4261]"
-              >
-                <div className={`p-2 bg-white dark:bg-[#16161e] border border-zinc-300 dark:border-[#3b4261] ${feature.accentClass}`}>
-                  <feature.icon className="h-5 w-5" />
-                </div>
-                <div>
-                  <h3 className="font-bold uppercase text-sm tracking-wide text-zinc-900 dark:text-[#a9b1d6]">{feature.label}</h3>
-                  <p className="text-xs font-mono text-zinc-500 dark:text-[#565f89]">{feature.desc}</p>
-                </div>
-              </div>
-            ))}
-          </div>
+          {/* The old Select / Filter / Analyze feature-card grid was
+              dropped: it repeated toolbar affordances without offering an
+              action, and its height pushed the welcome card off-screen. */}
 
           {/* Moonshot callout (#1717): Layer PRs are brand new - nobody knows
               to multi-drop .ifcx files, so the welcome screen sells the demo. */}
@@ -1317,6 +1305,7 @@ export function ViewportContainer() {
             </div>
           </div>
 
+          </div>
         </div>
       </div>
     );

--- a/apps/viewer/src/components/viewer/ribbon/RibbonToolbar.tsx
+++ b/apps/viewer/src/components/viewer/ribbon/RibbonToolbar.tsx
@@ -1,0 +1,210 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Ribbon toolbar (issue #1686) — the tabbed, IFCFlux/Office-style
+ * alternative to the classic single-strip `MainToolbar`. A slim tab
+ * strip selects a command context; the band beneath lays the commands
+ * out in labeled groups with visible names, trading one strip of
+ * vertical space for zero-recall discovery. Selected per user via
+ * `uiSlice.toolbarStyle`; both styles drive the same shared command
+ * hooks so behaviour can never fork.
+ *
+ * Office conventions kept: double-click the active tab (or the chevron)
+ * to collapse the band to the tab strip; the collapsed state persists.
+ */
+
+import React, { useState } from 'react';
+import { ChevronDown, ChevronUp, HelpCircle, Loader2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Progress } from '@/components/ui/progress';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { useViewerStore } from '@/store';
+import { useIfc } from '@/hooks/useIfc';
+import { cn } from '@/lib/utils';
+import { SearchInline } from '../SearchInline';
+import { ThemeSwitch } from '../ThemeSwitch';
+import { ExportChangesButton } from '../ExportChangesButton';
+import { ExtensionToolbarSlot } from '@/components/extensions/ExtensionToolbarSlot';
+import { useFileCommands } from '../toolbar/useFileCommands';
+import { FileTab } from './tabs/FileTab';
+import { HomeTab } from './tabs/HomeTab';
+import { ViewTab } from './tabs/ViewTab';
+import { AnalyzeTab } from './tabs/AnalyzeTab';
+import { AuthorTab } from './tabs/AuthorTab';
+
+type RibbonTabId = 'file' | 'home' | 'view' | 'analyze' | 'author';
+
+const RIBBON_TABS: { id: RibbonTabId; label: string }[] = [
+  { id: 'file', label: 'File' },
+  { id: 'home', label: 'Home' },
+  { id: 'view', label: 'View' },
+  { id: 'analyze', label: 'Analyze' },
+  { id: 'author', label: 'Author' },
+];
+
+interface RibbonToolbarProps {
+  onShowShortcuts?: () => void;
+}
+
+export function RibbonToolbar({ onShowShortcuts }: RibbonToolbarProps = {} as RibbonToolbarProps) {
+  // Home first: it holds the everyday loop (tools, selection, camera).
+  const [activeTab, setActiveTab] = useState<RibbonTabId>('home');
+  const ribbonCollapsed = useViewerStore((s) => s.ribbonCollapsed);
+  const setRibbonCollapsed = useViewerStore((s) => s.setRibbonCollapsed);
+
+  // Shared command surface — registers the global load listeners and the
+  // hidden file inputs exactly once for this toolbar style.
+  const fileCommands = useFileCommands();
+
+  const { loading, progress, geometryProgress, metadataProgress } = useIfc();
+  const error = useViewerStore((state) => state.error);
+  const activeProgress = geometryProgress ?? metadataProgress ?? progress;
+
+  const handleTabClick = (id: RibbonTabId) => {
+    if (id === activeTab && !ribbonCollapsed) return;
+    setActiveTab(id);
+    // Clicking any tab while collapsed re-opens the band (Office pins on click).
+    if (ribbonCollapsed) setRibbonCollapsed(false);
+  };
+
+  return (
+    <div className="relative z-50 border-b border-zinc-200 bg-white dark:border-zinc-800 dark:bg-black">
+      {fileCommands.fileInputs}
+
+      {/* ── Tab strip ── */}
+      <div className="flex h-10 items-center gap-0.5 border-b border-zinc-200/70 px-2 dark:border-zinc-800/70">
+        <div role="tablist" aria-label="Ribbon tabs" className="flex h-full items-end gap-0.5">
+          {RIBBON_TABS.map((tab) => {
+            const isActive = tab.id === activeTab;
+            return (
+              <button
+                key={tab.id}
+                type="button"
+                role="tab"
+                aria-selected={isActive}
+                onClick={() => handleTabClick(tab.id)}
+                onDoubleClick={() => {
+                  if (isActive) setRibbonCollapsed(!ribbonCollapsed);
+                }}
+                className={cn(
+                  'relative flex h-8 select-none items-center rounded-t-md px-3 text-xs font-medium tracking-wide transition-colors',
+                  'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
+                  isActive
+                    ? 'text-foreground'
+                    : 'text-muted-foreground hover:bg-muted/60 hover:text-foreground',
+                )}
+              >
+                {tab.label}
+                {/* Drafting-pen underline for the active tab — reads in
+                    every theme without a filled pill. */}
+                {isActive && (
+                  <span aria-hidden="true" className="absolute inset-x-2 bottom-0 h-0.5 rounded-full bg-primary" />
+                )}
+              </button>
+            );
+          })}
+        </div>
+
+        <div className="flex-1" />
+
+        {/* Loading progress — lives in the strip so it survives collapse. */}
+        {loading && activeProgress && (
+          <div className="mr-2 flex items-center gap-2">
+            <span className="max-w-56 truncate text-xs text-muted-foreground">
+              {activeProgress.phase}
+              {geometryProgress && metadataProgress ? ` | ${metadataProgress.phase}` : ''}
+            </span>
+            {activeProgress.indeterminate ? (
+              <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />
+            ) : (
+              <>
+                <Progress value={activeProgress.percent ?? 0} className="h-2 w-28" />
+                <span className="text-xs tabular-nums text-muted-foreground">
+                  {Math.round(activeProgress.percent ?? 0)}%
+                </span>
+              </>
+            )}
+          </div>
+        )}
+
+        {/* Error Display */}
+        {error && (
+          <span className="mr-2 max-w-72 truncate text-xs text-destructive">{error}</span>
+        )}
+
+        {/* Search lives in the strip (Office puts it in the title row):
+            always visible, collapse-proof, and anchored to real chrome
+            instead of floating in the band. max-h trims the h-9 input to
+            the strip's rhythm without forking SearchInline. */}
+        <div className="mr-1 hidden md:block [&_input]:max-h-8">
+          <SearchInline />
+        </div>
+
+        {/* Extension toolbar contributions (right-aligned, same slot as
+            the classic toolbar). */}
+        <ExtensionToolbarSlot slot="toolbar.right" />
+
+        {/* Export Changes — pending-mutation affordance must stay visible
+            regardless of the active tab or collapse state. */}
+        <ExportChangesButton />
+
+        <div className="ml-1 flex items-center gap-1 border-l border-zinc-200 pl-2 dark:border-zinc-700/60">
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <div>
+                <ThemeSwitch />
+              </div>
+            </TooltipTrigger>
+            <TooltipContent>Toggle theme (Shift+click for secret mode)</TooltipContent>
+          </Tooltip>
+
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                aria-label="Info and keyboard shortcuts"
+                onClick={() => onShowShortcuts?.()}
+              >
+                <HelpCircle className="h-4 w-4" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Info (?)</TooltipContent>
+          </Tooltip>
+
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                aria-label={ribbonCollapsed ? 'Expand the ribbon' : 'Collapse the ribbon'}
+                aria-expanded={!ribbonCollapsed}
+                onClick={() => setRibbonCollapsed(!ribbonCollapsed)}
+              >
+                {ribbonCollapsed ? <ChevronDown className="h-4 w-4" /> : <ChevronUp className="h-4 w-4" />}
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>{ribbonCollapsed ? 'Expand the ribbon' : 'Collapse the ribbon'}</TooltipContent>
+          </Tooltip>
+        </div>
+      </div>
+
+      {/* ── Band ── */}
+      {!ribbonCollapsed && (
+        <div
+          role="tabpanel"
+          aria-label={`${activeTab} commands`}
+          className="flex h-[88px] items-stretch overflow-x-auto overflow-y-hidden px-1"
+        >
+          {activeTab === 'file' && <FileTab fileCommands={fileCommands} />}
+          {activeTab === 'home' && <HomeTab />}
+          {activeTab === 'view' && <ViewTab />}
+          {activeTab === 'analyze' && <AnalyzeTab />}
+          {activeTab === 'author' && <AuthorTab />}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/viewer/src/components/viewer/ribbon/primitives.tsx
+++ b/apps/viewer/src/components/viewer/ribbon/primitives.tsx
@@ -78,7 +78,7 @@ export const RibbonLargeButton = forwardRef<HTMLButtonElement, RibbonButtonProps
           ref={ref}
           type="button"
           aria-label={tooltip ?? label}
-          aria-pressed={active || undefined}
+          aria-pressed={active === undefined ? undefined : active}
           onClick={(e) => {
             // Blur to close the tooltip after click (house pattern).
             (e.currentTarget as HTMLButtonElement).blur();
@@ -121,7 +121,7 @@ export const RibbonSmallButton = forwardRef<HTMLButtonElement, RibbonButtonProps
           ref={ref}
           type="button"
           aria-label={tooltip ?? label}
-          aria-pressed={active || undefined}
+          aria-pressed={active === undefined ? undefined : active}
           onClick={(e) => {
             (e.currentTarget as HTMLButtonElement).blur();
             onClick?.(e);

--- a/apps/viewer/src/components/viewer/ribbon/primitives.tsx
+++ b/apps/viewer/src/components/viewer/ribbon/primitives.tsx
@@ -1,0 +1,186 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Ribbon building blocks (issue #1686). Office/IFCFlux-style grammar:
+ * a labeled RibbonGroup holds either large one-command buttons (icon
+ * over a two-line label) or a stack of small icon+label rows, and the
+ * group name sits beneath in drafting-annotation caps. All colors ride
+ * the existing shadcn tokens so light/dark/colorful themes just work.
+ */
+
+import React, { forwardRef } from 'react';
+import { ChevronDown } from 'lucide-react';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { cn } from '@/lib/utils';
+
+/** Subtle pressed-state tint shared by ribbon toggles (loud solid fills
+ *  read as alarm at ribbon scale; Office-style tint + inset ring reads
+ *  as "latched"). Per-tool accents (amber annotate, purple edit) pass
+ *  their own class instead. */
+export const RIBBON_ACTIVE_CLASS =
+  'bg-primary/15 text-foreground ring-1 ring-inset ring-primary/40';
+
+interface RibbonTooltipProps {
+  label: string;
+  /** Extra tooltip line (keyboard shortcut or state hint). */
+  shortcut?: string;
+  tooltip?: string;
+  children: React.ReactElement;
+}
+
+/** Tooltip wrapper — only mounts Radix when there is something beyond
+ *  the visible label to say (shortcut or a longer description). */
+function RibbonTooltip({ label, shortcut, tooltip, children }: RibbonTooltipProps) {
+  if (!shortcut && !tooltip) return children;
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{children}</TooltipTrigger>
+      <TooltipContent>
+        {tooltip ?? label}
+        {shortcut && <span className="ml-2 text-xs opacity-60">({shortcut})</span>}
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
+export interface RibbonButtonProps extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'children'> {
+  icon: React.ElementType;
+  label: string;
+  /** Latched/toggled state (aria-pressed). */
+  active?: boolean;
+  /** Tailwind classes for the latched state; defaults to the shared tint. */
+  activeClassName?: string;
+  /** Tooltip body when the visible label isn't the whole story. */
+  tooltip?: string;
+  /** Keyboard shortcut shown in the tooltip. */
+  shortcut?: string;
+  /** Renders a small chevron: the button opens a menu. */
+  hasMenu?: boolean;
+  /** Corner count badge (e.g. peers in room, basket size). */
+  badge?: React.ReactNode;
+}
+
+/**
+ * Large ribbon button: icon over a (wrappable) two-line label. The
+ * headline commands of each group. Forwards ref so it can serve as a
+ * DropdownMenu / Dialog trigger via `asChild`.
+ */
+export const RibbonLargeButton = forwardRef<HTMLButtonElement, RibbonButtonProps>(
+  function RibbonLargeButton(
+    { icon: Icon, label, active, activeClassName, tooltip, shortcut, hasMenu, badge, className, onClick, ...rest },
+    ref,
+  ) {
+    return (
+      <RibbonTooltip label={label} shortcut={shortcut} tooltip={tooltip}>
+        <button
+          ref={ref}
+          type="button"
+          aria-label={tooltip ?? label}
+          aria-pressed={active || undefined}
+          onClick={(e) => {
+            // Blur to close the tooltip after click (house pattern).
+            (e.currentTarget as HTMLButtonElement).blur();
+            onClick?.(e);
+          }}
+          className={cn(
+            'relative flex h-full w-14 shrink-0 select-none flex-col items-center justify-center gap-1 rounded-md px-1 py-1',
+            'text-[10px] font-medium leading-[1.15] text-foreground/90 transition-colors',
+            'hover:bg-muted/70 disabled:pointer-events-none disabled:opacity-40',
+            'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
+            active && (activeClassName ?? RIBBON_ACTIVE_CLASS),
+            className,
+          )}
+          {...rest}
+        >
+          <Icon className="h-[18px] w-[18px] shrink-0" aria-hidden="true" />
+          <span className="flex max-w-full items-center gap-0.5">
+            <span className="line-clamp-2 text-center">{label}</span>
+            {hasMenu && <ChevronDown className="h-2.5 w-2.5 shrink-0 opacity-60" aria-hidden="true" />}
+          </span>
+          {badge}
+        </button>
+      </RibbonTooltip>
+    );
+  },
+);
+
+/**
+ * Small ribbon button: one icon+label row, stacked up to three per
+ * column inside a group (wrap in `RibbonSmallStack`).
+ */
+export const RibbonSmallButton = forwardRef<HTMLButtonElement, RibbonButtonProps>(
+  function RibbonSmallButton(
+    { icon: Icon, label, active, activeClassName, tooltip, shortcut, hasMenu, badge, className, onClick, ...rest },
+    ref,
+  ) {
+    return (
+      <RibbonTooltip label={label} shortcut={shortcut} tooltip={tooltip}>
+        <button
+          ref={ref}
+          type="button"
+          aria-label={tooltip ?? label}
+          aria-pressed={active || undefined}
+          onClick={(e) => {
+            (e.currentTarget as HTMLButtonElement).blur();
+            onClick?.(e);
+          }}
+          className={cn(
+            'relative flex h-[20px] w-full min-w-0 select-none items-center gap-1.5 rounded px-1.5',
+            'text-[11px] leading-none text-foreground/90 transition-colors',
+            'hover:bg-muted/70 disabled:pointer-events-none disabled:opacity-40',
+            'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
+            active && (activeClassName ?? RIBBON_ACTIVE_CLASS),
+            className,
+          )}
+          {...rest}
+        >
+          <Icon className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+          <span className="truncate">{label}</span>
+          {hasMenu && <ChevronDown className="ml-auto h-2.5 w-2.5 shrink-0 opacity-60" aria-hidden="true" />}
+          {badge}
+        </button>
+      </RibbonTooltip>
+    );
+  },
+);
+
+/** Column of up to three small buttons, vertically centered in the band.
+ *  Width is natural (widest row wins) so group labels center on the
+ *  actual content instead of padded air. */
+export function RibbonSmallStack({ children, className }: { children: React.ReactNode; className?: string }) {
+  return (
+    <div className={cn('flex h-full w-max flex-col justify-center gap-px', className)}>
+      {children}
+    </div>
+  );
+}
+
+/**
+ * One labeled command cluster. Content row on top, the group name in
+ * tiny drafting caps beneath — the plan-sheet annotation register.
+ * Content is centered over the label (and vice versa) so a one-button
+ * group whose label is wider than the button still reads as one axis.
+ */
+export function RibbonGroup({ label, children, className }: {
+  label: string;
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <div role="group" aria-label={label} className={cn('flex h-full shrink-0 flex-col px-1.5', className)}>
+      <div className="flex min-h-0 flex-1 items-stretch justify-center gap-0.5 pt-1">
+        {children}
+      </div>
+      <div className="pb-1 pt-0.5 text-center text-[9px] font-medium uppercase tracking-[0.12em] text-muted-foreground/70">
+        {label}
+      </div>
+    </div>
+  );
+}
+
+/** Hairline divider between ribbon groups. */
+export function RibbonGroupDivider() {
+  return <div aria-hidden="true" className="my-2 w-px shrink-0 self-stretch bg-border/70" />;
+}

--- a/apps/viewer/src/components/viewer/ribbon/tabs/AnalyzeTab.tsx
+++ b/apps/viewer/src/components/viewer/ribbon/tabs/AnalyzeTab.tsx
@@ -1,0 +1,159 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Ribbon · Analyze tab — the workspace panels: validation, comparison,
+ * data tables, styling rules, and analysis extensions. Buttons latch to
+ * mirror each panel's open state; the single-tenant dock rules live in
+ * `useWorkspacePanelControls`, shared with the classic toolbar.
+ */
+
+import {
+  CalendarClock,
+  ClipboardCheck,
+  Crosshair,
+  FileCode2,
+  FileSpreadsheet,
+  GitCompareArrows,
+  Layers,
+  MessageSquare,
+  Palette,
+} from 'lucide-react';
+import { useViewerStore } from '@/store';
+import { useWorkspacePanelControls } from '../../toolbar/useWorkspacePanelControls';
+import {
+  RibbonGroup,
+  RibbonGroupDivider,
+  RibbonLargeButton,
+  RibbonSmallButton,
+  RibbonSmallStack,
+} from '../primitives';
+
+/** Chunk dynamic extension entries into ribbon-height stacks of three. */
+function chunk<T>(items: T[], size: number): T[][] {
+  const out: T[][] = [];
+  for (let i = 0; i < items.length; i += size) out.push(items.slice(i, i + size));
+  return out;
+}
+
+export function AnalyzeTab() {
+  const {
+    activeWorkspacePanels,
+    handleToggleBottomPanel,
+    handleToggleRightPanel,
+    handleToggleAnalysisExtension,
+    rightAnalysisExtensions,
+    bottomAnalysisExtensions,
+  } = useWorkspacePanelControls();
+
+  const analysisExtensions = [...rightAnalysisExtensions, ...bottomAnalysisExtensions];
+
+  return (
+    <>
+      <RibbonGroup label="Validate">
+        <RibbonLargeButton
+          icon={MessageSquare}
+          label="BCF Issues"
+          active={activeWorkspacePanels.has('bcf')}
+          onClick={() => handleToggleRightPanel('bcf')}
+        />
+        <RibbonLargeButton
+          icon={ClipboardCheck}
+          label="IDS Check"
+          tooltip="IDS validation"
+          active={activeWorkspacePanels.has('ids')}
+          onClick={() => handleToggleRightPanel('ids')}
+        />
+        <RibbonLargeButton
+          icon={Crosshair}
+          label="Clash"
+          tooltip="Clash detection"
+          active={activeWorkspacePanels.has('clash')}
+          onClick={() => handleToggleRightPanel('clash')}
+        />
+      </RibbonGroup>
+
+      <RibbonGroupDivider />
+
+      <RibbonGroup label="Compare">
+        <RibbonLargeButton
+          icon={GitCompareArrows}
+          label="Compare"
+          tooltip="Compare models"
+          active={activeWorkspacePanels.has('compare')}
+          onClick={() => handleToggleRightPanel('compare')}
+        />
+        <RibbonLargeButton
+          icon={Layers}
+          label="Layers"
+          tooltip="Layer stack"
+          active={activeWorkspacePanels.has('layers')}
+          onClick={() => useViewerStore.getState().toggleWorkspacePanel('layers')}
+        />
+      </RibbonGroup>
+
+      <RibbonGroupDivider />
+
+      <RibbonGroup label="Data">
+        <RibbonLargeButton
+          icon={FileSpreadsheet}
+          label="Lists"
+          tooltip="Lists & schedules"
+          active={activeWorkspacePanels.has('list')}
+          onClick={() => handleToggleBottomPanel('list')}
+        />
+        <RibbonLargeButton
+          icon={CalendarClock}
+          label="Schedule"
+          tooltip="Schedule (Gantt)"
+          active={activeWorkspacePanels.has('gantt')}
+          onClick={() => handleToggleBottomPanel('gantt')}
+        />
+        <RibbonLargeButton
+          icon={FileCode2}
+          label="Script"
+          tooltip="Script editor"
+          active={activeWorkspacePanels.has('script')}
+          onClick={() => handleToggleBottomPanel('script')}
+        />
+      </RibbonGroup>
+
+      <RibbonGroupDivider />
+
+      <RibbonGroup label="Style">
+        <RibbonLargeButton
+          icon={Palette}
+          label="Lens"
+          tooltip="Lens rules"
+          active={activeWorkspacePanels.has('lens')}
+          onClick={() => handleToggleRightPanel('lens')}
+        />
+      </RibbonGroup>
+
+      {/* Analysis panels contributed by installed extensions. Only the
+          contributed ANALYSIS panels live here — managing extensions and
+          flavors themselves is workspace customization (Author tab). */}
+      {analysisExtensions.length > 0 && (
+        <>
+          <RibbonGroupDivider />
+          <RibbonGroup label="Apps">
+            {chunk(analysisExtensions, 3).map((column, i) => (
+              <RibbonSmallStack key={i}>
+                {column.map((extension) => (
+                  <RibbonSmallButton
+                    key={extension.id}
+                    icon={extension.icon}
+                    label={extension.label}
+                    active={activeWorkspacePanels.has(extension.id)}
+                    onClick={() => handleToggleAnalysisExtension(extension.id)}
+                  />
+                ))}
+              </RibbonSmallStack>
+            ))}
+          </RibbonGroup>
+        </>
+      )}
+    </>
+  );
+}

--- a/apps/viewer/src/components/viewer/ribbon/tabs/AuthorTab.tsx
+++ b/apps/viewer/src/components/viewer/ribbon/tabs/AuthorTab.tsx
@@ -1,0 +1,165 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Ribbon · Author tab — the authoring surface: the global edit-mode
+ * switch, undo/redo, element creation tools, and bulk property flows.
+ * Everything here honors the same collab role gate as the classic
+ * toolbar (viewer/commenter roles cannot unlock authoring).
+ */
+
+import {
+  DraftingCompass,
+  Filter,
+  PackagePlus,
+  PenLine,
+  Puzzle,
+  Redo2,
+  Undo2,
+  Upload,
+} from 'lucide-react';
+import { useViewerStore } from '@/store';
+import { useIfc } from '@/hooks/useIfc';
+import { tourAnchor, toolAnchor } from '@/lib/tours/anchors';
+import { BulkPropertyEditor } from '../../BulkPropertyEditor';
+import { DataConnector } from '../../DataConnector';
+import { useWorkspacePanelControls } from '../../toolbar/useWorkspacePanelControls';
+import {
+  RibbonGroup,
+  RibbonGroupDivider,
+  RibbonLargeButton,
+  RibbonSmallButton,
+  RibbonSmallStack,
+} from '../primitives';
+
+/** Purple latched accent shared by the authoring toggles (matches the
+ *  classic toolbar's Edit pill so the mode reads identically). */
+const EDIT_ACTIVE_CLASS = 'bg-purple-600/20 text-foreground ring-1 ring-inset ring-purple-600/50';
+
+export function AuthorTab() {
+  const { ifcDataStore } = useIfc();
+  const activeTool = useViewerStore((state) => state.activeTool);
+  const setActiveTool = useViewerStore((state) => state.setActiveTool);
+  const editEnabled = useViewerStore((state) => state.editEnabled);
+  const toggleEditEnabled = useViewerStore((state) => state.toggleEditEnabled);
+  // Collab role: editing is reserved for editor/admin. Derive from the
+  // reactive role so the Edit switch enables/disables live when the role
+  // changes. null role = single-user, always editable.
+  const collabEditRole = useViewerStore((state) => state.collabRole);
+  const canEditInSession =
+    collabEditRole === null || collabEditRole === 'editor' || collabEditRole === 'admin';
+
+  const activeModelId = useViewerStore((s) => s.activeModelId);
+  const undoStacks = useViewerStore((s) => s.undoStacks);
+  const redoStacks = useViewerStore((s) => s.redoStacks);
+  const undo = useViewerStore((s) => s.undo);
+  const redo = useViewerStore((s) => s.redo);
+  const canUndo = activeModelId !== null && (undoStacks.get(activeModelId)?.length ?? 0) > 0;
+  const canRedo = activeModelId !== null && (redoStacks.get(activeModelId)?.length ?? 0) > 0;
+
+  const { activeWorkspacePanels, handleToggleRightPanel } = useWorkspacePanelControls();
+
+  return (
+    <>
+      <RibbonGroup label="Edit">
+        <RibbonLargeButton
+          icon={PenLine}
+          label="Edit Mode"
+          tooltip={canEditInSession
+            ? (editEnabled ? 'Exit edit mode' : 'Enter edit mode')
+            : 'Editing requires editor access in this shared session'}
+          shortcut="E"
+          active={editEnabled}
+          activeClassName={EDIT_ACTIVE_CLASS}
+          disabled={!canEditInSession}
+          onClick={toggleEditEnabled}
+        />
+        <RibbonSmallStack>
+          <RibbonSmallButton
+            icon={Undo2}
+            label="Undo"
+            shortcut="⌘Z"
+            disabled={!canUndo}
+            onClick={() => { if (activeModelId) undo(activeModelId); }}
+          />
+          <RibbonSmallButton
+            icon={Redo2}
+            label="Redo"
+            shortcut="⌘⇧Z"
+            disabled={!canRedo}
+            onClick={() => { if (activeModelId) redo(activeModelId); }}
+          />
+        </RibbonSmallStack>
+      </RibbonGroup>
+
+      <RibbonGroupDivider />
+
+      <RibbonGroup label="Create">
+        <RibbonLargeButton
+          icon={PackagePlus}
+          label="Add Element"
+          tooltip="Add element (opens the drawing panel)"
+          active={activeWorkspacePanels.has('addElement')}
+          activeClassName={EDIT_ACTIVE_CLASS}
+          disabled={!canEditInSession}
+          onClick={() => handleToggleRightPanel('addElement')}
+        />
+        {/* Space Sketch bakes IfcSpace entities; picking it flips edit
+            mode on via the AUTHORING_TOOLS rule in uiSlice, so it can
+            stay visible (not hidden behind edit mode like the classic
+            toolbar) — the ribbon has room for stable geography. */}
+        <RibbonLargeButton
+          icon={DraftingCompass}
+          label="Space Sketch"
+          active={activeTool === 'spaceSketch'}
+          activeClassName={EDIT_ACTIVE_CLASS}
+          disabled={!canEditInSession}
+          onClick={() => setActiveTool('spaceSketch')}
+          {...tourAnchor(toolAnchor('spaceSketch'))}
+        />
+      </RibbonGroup>
+
+      <RibbonGroupDivider />
+
+      <RibbonGroup label="Properties">
+        <RibbonSmallStack>
+          <BulkPropertyEditor
+            trigger={
+              <RibbonSmallButton
+                icon={Filter}
+                label="Bulk property editor"
+                disabled={!ifcDataStore}
+              />
+            }
+          />
+          <DataConnector
+            trigger={
+              <RibbonSmallButton
+                icon={Upload}
+                label="Import data (CSV)"
+                disabled={!ifcDataStore}
+              />
+            }
+          />
+        </RibbonSmallStack>
+      </RibbonGroup>
+
+      <RibbonGroupDivider />
+
+      {/* Extensions & flavors manage the workspace itself — installed
+          extensions, personal flavors, permissions. Customization, not
+          analysis, so it lives here (mirrors the classic Panels menu,
+          which files Extensions under its "Author" section). */}
+      <RibbonGroup label="Customize">
+        <RibbonLargeButton
+          icon={Puzzle}
+          label="Extensions"
+          tooltip="Extensions & flavors"
+          active={activeWorkspacePanels.has('extensions')}
+          onClick={() => handleToggleRightPanel('extensions')}
+        />
+      </RibbonGroup>
+    </>
+  );
+}

--- a/apps/viewer/src/components/viewer/ribbon/tabs/AuthorTab.tsx
+++ b/apps/viewer/src/components/viewer/ribbon/tabs/AuthorTab.tsx
@@ -55,8 +55,10 @@ export function AuthorTab() {
   const redoStacks = useViewerStore((s) => s.redoStacks);
   const undo = useViewerStore((s) => s.undo);
   const redo = useViewerStore((s) => s.redo);
-  const canUndo = activeModelId !== null && (undoStacks.get(activeModelId)?.length ?? 0) > 0;
-  const canRedo = activeModelId !== null && (redoStacks.get(activeModelId)?.length ?? 0) > 0;
+  // Undo/redo replay authoring mutations, so they honour the same collab
+  // role gate as edit mode.
+  const canUndo = canEditInSession && activeModelId !== null && (undoStacks.get(activeModelId)?.length ?? 0) > 0;
+  const canRedo = canEditInSession && activeModelId !== null && (redoStacks.get(activeModelId)?.length ?? 0) > 0;
 
   const { activeWorkspacePanels, handleToggleRightPanel } = useWorkspacePanelControls();
 

--- a/apps/viewer/src/components/viewer/ribbon/tabs/FileTab.tsx
+++ b/apps/viewer/src/components/viewer/ribbon/tabs/FileTab.tsx
@@ -1,0 +1,196 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Ribbon · File tab — everything that moves model bytes in or out:
+ * open / add / refresh, the exporter fleet, and link-based sharing.
+ */
+
+import React, { useEffect, useState } from 'react';
+import {
+  Camera,
+  Download,
+  FileJson,
+  FileSpreadsheet,
+  FileText,
+  FolderOpen,
+  Globe2,
+  Loader2,
+  Plus,
+  RefreshCw,
+  Share2,
+  Users,
+} from 'lucide-react';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { useViewerStore } from '@/store';
+import { useIfc } from '@/hooks/useIfc';
+import { isCollabEnabled } from '@/lib/collab/config';
+import { ExportDialog } from '../../ExportDialog';
+import { GLBExportDialog } from '../../GLBExportDialog';
+import { KmzExportDialog } from '../../KmzExportDialog';
+import { HbjsonExportDialog } from '../../HbjsonExportDialog';
+import { ShareDialog } from '../../ShareDialog';
+import type { FileCommands } from '../../toolbar/useFileCommands';
+import { useExportCommands } from '../../toolbar/useExportCommands';
+import {
+  RibbonGroup,
+  RibbonGroupDivider,
+  RibbonLargeButton,
+  RibbonSmallButton,
+  RibbonSmallStack,
+} from '../primitives';
+
+export function FileTab({ fileCommands }: { fileCommands: FileCommands }) {
+  const { handleOpenClick, handleAddModelClick, handleRefresh, canRefresh, hasModelsLoaded } = fileCommands;
+  const { loading, geometryResult, models, ifcDataStore } = useIfc();
+  const { handleExportCSV, handleExportJSON, handleScreenshot } = useExportCommands();
+
+  // Collaboration: the Share cluster is gated behind the collab feature flag.
+  const collabEnabled = React.useMemo(() => isCollabEnabled(), []);
+  const [shareDialogOpen, setShareDialogOpen] = useState(false);
+  const collabPeerCount = useViewerStore((s) => s.collabPeers.length);
+  const collabRoomId = useViewerStore((s) => s.collabRoomId);
+  const collabPanelVisible = useViewerStore((s) => s.collabPanelVisible);
+
+  // Panels (RoomPanel empty state) request the Share dialog this way —
+  // its open state is toolbar-local.
+  useEffect(() => {
+    const shareHandler = () => setShareDialogOpen(true);
+    window.addEventListener('ifc-lite:open-share-dialog', shareHandler);
+    return () => window.removeEventListener('ifc-lite:open-share-dialog', shareHandler);
+  }, []);
+
+  const canExport = hasModelsLoaded || Boolean(ifcDataStore);
+
+  return (
+    <>
+      <RibbonGroup label="Model">
+        <RibbonLargeButton
+          icon={loading ? Loader2 : FolderOpen}
+          label="Open"
+          tooltip="Open IFC file"
+          disabled={loading}
+          className={loading ? '[&_svg]:animate-spin' : undefined}
+          onClick={() => { void handleOpenClick(); }}
+        />
+        <RibbonSmallStack>
+          <RibbonSmallButton
+            icon={Plus}
+            label="Add model"
+            tooltip="Add model to scene (multi-select supported)"
+            disabled={loading || !hasModelsLoaded}
+            onClick={() => { void handleAddModelClick(); }}
+          />
+          <RibbonSmallButton
+            icon={RefreshCw}
+            label="Refresh"
+            tooltip={models.size > 1 ? 'Refresh models from disk' : 'Refresh model from disk'}
+            disabled={loading || !canRefresh}
+            onClick={() => { void handleRefresh(); }}
+          />
+        </RibbonSmallStack>
+      </RibbonGroup>
+
+      <RibbonGroupDivider />
+
+      <RibbonGroup label="Export">
+        {/* Gate on any loaded model, not the legacy single-model geometryResult:
+            federated / multi-model sessions populate `models` but leave
+            geometryResult null, which would hide the whole export group. */}
+        <ExportDialog
+          trigger={
+            <RibbonLargeButton icon={FileText} label="IFC" tooltip="Export IFC (with changes)" disabled={!canExport} />
+          }
+        />
+        <RibbonSmallStack>
+          <GLBExportDialog
+            trigger={<RibbonSmallButton icon={Download} label="GLB" tooltip="Export GLB (3D model)" disabled={!canExport} />}
+          />
+          <KmzExportDialog
+            trigger={<RibbonSmallButton icon={Globe2} label="KMZ" tooltip="Export KMZ (Google Earth Pro)" disabled={!canExport} />}
+          />
+          <HbjsonExportDialog
+            trigger={<RibbonSmallButton icon={Download} label="HBJSON" tooltip="Export HBJSON (energy model)" disabled={!canExport} />}
+          />
+        </RibbonSmallStack>
+        <RibbonSmallStack>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <RibbonSmallButton icon={FileSpreadsheet} label="CSV" hasMenu tooltip="Export CSV tables" disabled={!ifcDataStore} />
+            </DropdownMenuTrigger>
+            <DropdownMenuContent>
+              <DropdownMenuItem onClick={() => handleExportCSV('entities')}>
+                <FileSpreadsheet className="h-4 w-4 mr-2" />
+                Entities
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={() => handleExportCSV('properties')}>
+                <FileSpreadsheet className="h-4 w-4 mr-2" />
+                Properties
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={() => handleExportCSV('quantities')}>
+                <FileSpreadsheet className="h-4 w-4 mr-2" />
+                Quantities
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem onClick={() => handleExportCSV('spatial')}>
+                <FileSpreadsheet className="h-4 w-4 mr-2" />
+                Spatial Hierarchy
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+          <RibbonSmallButton
+            icon={FileJson}
+            label="JSON"
+            tooltip="Export JSON (all data)"
+            disabled={!ifcDataStore}
+            onClick={handleExportJSON}
+          />
+          <RibbonSmallButton icon={Camera} label="Screenshot" tooltip="Save viewport as PNG" onClick={handleScreenshot} />
+        </RibbonSmallStack>
+      </RibbonGroup>
+
+      {collabEnabled && (
+        <>
+          <RibbonGroupDivider />
+          <RibbonGroup label="Share">
+            <RibbonLargeButton
+              icon={Share2}
+              label="Share"
+              tooltip="Share: link-based multiuser collaboration"
+              disabled={!geometryResult}
+              onClick={() => setShareDialogOpen(true)}
+              badge={collabPeerCount > 0 ? (
+                <span className="absolute right-1 top-0.5 flex h-3.5 min-w-3.5 items-center justify-center rounded-full bg-primary px-1 text-[9px] font-medium text-primary-foreground">
+                  {collabPeerCount + 1}
+                </span>
+              ) : undefined}
+            />
+            {/* Room panel toggle — live presence + management, only while in a room. */}
+            {collabRoomId && (
+              <RibbonLargeButton
+                icon={Users}
+                label="Room"
+                tooltip="Collaboration room"
+                active={collabPanelVisible}
+                onClick={() => useViewerStore.getState().toggleWorkspacePanel('collab')}
+                badge={collabPeerCount > 0 ? (
+                  <span className="absolute right-1 top-0.5 flex h-3.5 min-w-3.5 items-center justify-center rounded-full bg-emerald-500 px-1 text-[9px] font-medium text-white">
+                    {collabPeerCount + 1}
+                  </span>
+                ) : undefined}
+              />
+            )}
+          </RibbonGroup>
+          <ShareDialog open={shareDialogOpen} onOpenChange={setShareDialogOpen} />
+        </>
+      )}
+    </>
+  );
+}

--- a/apps/viewer/src/components/viewer/ribbon/tabs/FileTab.tsx
+++ b/apps/viewer/src/components/viewer/ribbon/tabs/FileTab.tsx
@@ -7,7 +7,7 @@
  * open / add / refresh, the exporter fleet, and link-based sharing.
  */
 
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import {
   Camera,
   Download,
@@ -36,7 +36,6 @@ import { ExportDialog } from '../../ExportDialog';
 import { GLBExportDialog } from '../../GLBExportDialog';
 import { KmzExportDialog } from '../../KmzExportDialog';
 import { HbjsonExportDialog } from '../../HbjsonExportDialog';
-import { ShareDialog } from '../../ShareDialog';
 import type { FileCommands } from '../../toolbar/useFileCommands';
 import { useExportCommands } from '../../toolbar/useExportCommands';
 import {
@@ -48,24 +47,18 @@ import {
 } from '../primitives';
 
 export function FileTab({ fileCommands }: { fileCommands: FileCommands }) {
-  const { handleOpenClick, handleAddModelClick, handleRefresh, canRefresh, hasModelsLoaded } = fileCommands;
-  const { loading, geometryResult, models, ifcDataStore } = useIfc();
+  const { handleOpenClick, handleAddModelClick, handleRefresh, canRefresh, hasModelsLoaded, openShareDialog } = fileCommands;
+  const { loading, models, ifcDataStore } = useIfc();
   const { handleExportCSV, handleExportJSON, handleScreenshot } = useExportCommands();
 
   // Collaboration: the Share cluster is gated behind the collab feature flag.
+  // The ShareDialog itself (and its `ifc-lite:open-share-dialog` listener)
+  // lives in useFileCommands so it stays mounted on every tab and while the
+  // ribbon is collapsed — this panel only holds the buttons.
   const collabEnabled = React.useMemo(() => isCollabEnabled(), []);
-  const [shareDialogOpen, setShareDialogOpen] = useState(false);
   const collabPeerCount = useViewerStore((s) => s.collabPeers.length);
   const collabRoomId = useViewerStore((s) => s.collabRoomId);
   const collabPanelVisible = useViewerStore((s) => s.collabPanelVisible);
-
-  // Panels (RoomPanel empty state) request the Share dialog this way —
-  // its open state is toolbar-local.
-  useEffect(() => {
-    const shareHandler = () => setShareDialogOpen(true);
-    window.addEventListener('ifc-lite:open-share-dialog', shareHandler);
-    return () => window.removeEventListener('ifc-lite:open-share-dialog', shareHandler);
-  }, []);
 
   const canExport = hasModelsLoaded || Boolean(ifcDataStore);
 
@@ -164,8 +157,8 @@ export function FileTab({ fileCommands }: { fileCommands: FileCommands }) {
               icon={Share2}
               label="Share"
               tooltip="Share: link-based multiuser collaboration"
-              disabled={!geometryResult}
-              onClick={() => setShareDialogOpen(true)}
+              disabled={!hasModelsLoaded}
+              onClick={openShareDialog}
               badge={collabPeerCount > 0 ? (
                 <span className="absolute right-1 top-0.5 flex h-3.5 min-w-3.5 items-center justify-center rounded-full bg-primary px-1 text-[9px] font-medium text-primary-foreground">
                   {collabPeerCount + 1}
@@ -188,7 +181,6 @@ export function FileTab({ fileCommands }: { fileCommands: FileCommands }) {
               />
             )}
           </RibbonGroup>
-          <ShareDialog open={shareDialogOpen} onOpenChange={setShareDialogOpen} />
         </>
       )}
     </>

--- a/apps/viewer/src/components/viewer/ribbon/tabs/HomeTab.tsx
+++ b/apps/viewer/src/components/viewer/ribbon/tabs/HomeTab.tsx
@@ -1,0 +1,180 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Ribbon · Home tab — the everyday loop: pick a tool, measure or cut,
+ * act on the selection, and get the camera back home.
+ */
+
+import { useCallback } from 'react';
+import {
+  Crosshair,
+  Equal,
+  Eye,
+  EyeOff,
+  Home,
+  Maximize2,
+  MousePointer2,
+  PersonStanding,
+  Ruler,
+  Scissors,
+  StickyNote,
+} from 'lucide-react';
+import { useViewerStore } from '@/store';
+import { goHomeFromStore, resetVisibilityForHomeFromStore } from '@/store/homeView';
+import { executeBasketIsolate } from '@/store/basket/basketCommands';
+import { tourAnchor, toolAnchor } from '@/lib/tours/anchors';
+import {
+  RibbonGroup,
+  RibbonGroupDivider,
+  RibbonLargeButton,
+  RibbonSmallButton,
+  RibbonSmallStack,
+} from '../primitives';
+
+export function HomeTab() {
+  const activeTool = useViewerStore((state) => state.activeTool);
+  const setActiveTool = useViewerStore((state) => state.setActiveTool);
+  const selectedEntityId = useViewerStore((state) => state.selectedEntityId);
+  const selectedEntityIds = useViewerStore((state) => state.selectedEntityIds);
+  const hideEntities = useViewerStore((state) => state.hideEntities);
+  const clearSelection = useViewerStore((state) => state.clearSelection);
+  const cameraCallbacks = useViewerStore((state) => state.cameraCallbacks);
+
+  // Selection size uses the multi-select set when present; falls back to
+  // the single legacy `selectedEntityId` so the count still reads "1"
+  // for the click-to-pick flow that hasn't migrated.
+  const selectionCount = selectedEntityIds.size > 0
+    ? selectedEntityIds.size
+    : (selectedEntityId !== null ? 1 : 0);
+  const hasSelection = selectionCount > 0;
+
+  const handleHide = useCallback(() => {
+    // Hide ALL selected entities (multi-select or single)
+    const state = useViewerStore.getState();
+    const ids: number[] = state.selectedEntityIds.size > 0
+      ? Array.from(state.selectedEntityIds)
+      : selectedEntityId !== null ? [selectedEntityId] : [];
+    if (ids.length > 0) {
+      hideEntities(ids);
+      clearSelection();
+    }
+  }, [selectedEntityId, hideEntities, clearSelection]);
+
+  return (
+    <>
+      <RibbonGroup label="Tools">
+        <RibbonLargeButton
+          icon={MousePointer2}
+          label="Select"
+          shortcut="V"
+          active={activeTool === 'select'}
+          onClick={() => setActiveTool('select')}
+          {...tourAnchor(toolAnchor('select'))}
+        />
+        <RibbonLargeButton
+          icon={PersonStanding}
+          label="Walk"
+          shortcut="C"
+          active={activeTool === 'walk'}
+          onClick={() => setActiveTool('walk')}
+          {...tourAnchor(toolAnchor('walk'))}
+        />
+      </RibbonGroup>
+
+      <RibbonGroupDivider />
+
+      <RibbonGroup label="Measure & Mark">
+        <RibbonLargeButton
+          icon={Ruler}
+          label="Measure"
+          shortcut="M"
+          active={activeTool === 'measure'}
+          onClick={() => setActiveTool('measure')}
+          {...tourAnchor(toolAnchor('measure'))}
+        />
+        <RibbonLargeButton
+          icon={Scissors}
+          label="Section"
+          shortcut="X"
+          active={activeTool === 'section'}
+          onClick={() => setActiveTool('section')}
+          {...tourAnchor(toolAnchor('section'))}
+        />
+        <RibbonLargeButton
+          icon={StickyNote}
+          label="Annotate"
+          shortcut="P"
+          active={activeTool === 'annotate'}
+          activeClassName="bg-amber-500/20 text-foreground ring-1 ring-inset ring-amber-500/50"
+          onClick={() => setActiveTool('annotate')}
+          {...tourAnchor(toolAnchor('annotate'))}
+        />
+      </RibbonGroup>
+
+      <RibbonGroupDivider />
+
+      {/* Selection actions stay put (no appearing/disappearing chrome —
+          the ribbon's fixed geography is the point) and read their
+          availability from the disabled state. The group label carries
+          the live count so scene state is visible at a glance. */}
+      <RibbonGroup label={hasSelection ? `Selection · ${selectionCount}` : 'Selection'}>
+        <RibbonSmallStack>
+          <RibbonSmallButton
+            icon={Equal}
+            label="Isolate"
+            tooltip="Isolate selection (set basket)"
+            shortcut="I / ="
+            disabled={!hasSelection}
+            onClick={() => executeBasketIsolate()}
+          />
+          <RibbonSmallButton
+            icon={EyeOff}
+            label="Hide"
+            tooltip="Hide selection"
+            shortcut="Del / Space"
+            disabled={!hasSelection}
+            onClick={handleHide}
+          />
+          <RibbonSmallButton
+            icon={Crosshair}
+            label="Frame"
+            tooltip="Frame selection"
+            shortcut="F"
+            disabled={!hasSelection}
+            onClick={() => cameraCallbacks.frameSelection?.()}
+          />
+        </RibbonSmallStack>
+      </RibbonGroup>
+
+      <RibbonGroupDivider />
+
+      <RibbonGroup label="Scene">
+        <RibbonLargeButton
+          icon={Home}
+          label="Home"
+          tooltip="Home (isometric + reset visibility)"
+          shortcut="H"
+          onClick={goHomeFromStore}
+        />
+        <RibbonSmallStack>
+          <RibbonSmallButton
+            icon={Eye}
+            label="Show all"
+            tooltip="Show all (reset filters)"
+            shortcut="A"
+            onClick={resetVisibilityForHomeFromStore}
+          />
+          <RibbonSmallButton
+            icon={Maximize2}
+            label="Fit all"
+            tooltip="Fit all in view"
+            shortcut="Z"
+            onClick={() => cameraCallbacks.fitAll?.()}
+          />
+        </RibbonSmallStack>
+      </RibbonGroup>
+    </>
+  );
+}

--- a/apps/viewer/src/components/viewer/ribbon/tabs/ViewTab.tsx
+++ b/apps/viewer/src/components/viewer/ribbon/tabs/ViewTab.tsx
@@ -1,0 +1,222 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Ribbon · View tab — camera presets and projection, class visibility,
+ * world context (Cesium / sun / SpaceMouse), and interface options.
+ */
+
+import {
+  ArrowDown,
+  ArrowLeft,
+  ArrowRight,
+  ArrowUp,
+  Box,
+  Filter,
+  Globe2,
+  Info,
+  LayoutTemplate,
+  Move,
+  Move3d,
+  Orbit,
+  PanelTop,
+  Sun,
+} from 'lucide-react';
+import { DropdownMenu, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
+import { useViewerStore } from '@/store';
+import { goHomeFromStore } from '@/store/homeView';
+import { ClassVisibilityMenuContent, useVisibleClassCount } from '../../toolbar/ClassVisibilityMenu';
+import {
+  RibbonGroup,
+  RibbonGroupDivider,
+  RibbonLargeButton,
+  RibbonSmallButton,
+  RibbonSmallStack,
+} from '../primitives';
+
+export function ViewTab() {
+  const cameraCallbacks = useViewerStore((state) => state.cameraCallbacks);
+  const projectionMode = useViewerStore((state) => state.projectionMode);
+  const toggleProjectionMode = useViewerStore((state) => state.toggleProjectionMode);
+  const hoverTooltipsEnabled = useViewerStore((state) => state.hoverTooltipsEnabled);
+  const toggleHoverTooltips = useViewerStore((state) => state.toggleHoverTooltips);
+  const mergeLayers = useViewerStore((state) => state.mergeLayers);
+  const visibleClassCount = useVisibleClassCount();
+  const setToolbarStyle = useViewerStore((state) => state.setToolbarStyle);
+
+  // Cesium 3D overlay state
+  const cesiumAvailable = useViewerStore((state) => state.cesiumAvailable);
+  const cesiumEnabled = useViewerStore((state) => state.cesiumEnabled);
+  const toggleCesium = useViewerStore((state) => state.toggleCesium);
+  const cesiumPlacementEditMode = useViewerStore((state) => state.cesiumPlacementEditMode);
+  const setCesiumPlacementEditMode = useViewerStore((state) => state.setCesiumPlacementEditMode);
+  const activeTool = useViewerStore((state) => state.activeTool);
+  const setActiveTool = useViewerStore((state) => state.setActiveTool);
+
+  // Sun & Sky panel state (sky, lighting presets, sun-path study)
+  const solarEnabled = useViewerStore((state) => state.solarEnabled);
+  const envPanelOpen = useViewerStore((state) => state.envPanelOpen);
+  const toggleEnvPanel = useViewerStore((state) => state.toggleEnvPanel);
+  const envSkyEnabled = useViewerStore((state) => state.envSkyEnabled);
+  const envPreset = useViewerStore((state) => state.envPreset);
+
+  // SpaceMouse panel state (3D mouse navigation, #1677)
+  const spaceMousePanelOpen = useViewerStore((state) => state.spaceMousePanelOpen);
+  const toggleSpaceMousePanel = useViewerStore((state) => state.toggleSpaceMousePanel);
+  const spaceMouseConnected = useViewerStore((state) => state.spaceMouseConnected);
+
+  // Basket presentation state
+  const pinboardEntities = useViewerStore((state) => state.pinboardEntities);
+  const basketViewCount = useViewerStore((state) => state.basketViews.length);
+  const basketPresentationVisible = useViewerStore((state) => state.basketPresentationVisible);
+  const toggleBasketPresentationVisible = useViewerStore((state) => state.toggleBasketPresentationVisible);
+  const hasModels = useViewerStore((state) => state.models.size > 0 || (state.geometryResult?.meshes.length ?? 0) > 0);
+
+  return (
+    <>
+      <RibbonGroup label="Camera">
+        <RibbonLargeButton
+          icon={Box}
+          label="Isometric"
+          tooltip="Home (isometric + reset visibility)"
+          shortcut="H"
+          onClick={goHomeFromStore}
+        />
+        <RibbonSmallStack>
+          <RibbonSmallButton icon={ArrowUp} label="Top" shortcut="1" onClick={() => cameraCallbacks.setPresetView?.('top')} />
+          <RibbonSmallButton icon={ArrowRight} label="Front" shortcut="3" onClick={() => cameraCallbacks.setPresetView?.('front')} />
+          <RibbonSmallButton icon={ArrowLeft} label="Left" shortcut="5" onClick={() => cameraCallbacks.setPresetView?.('left')} />
+        </RibbonSmallStack>
+        <RibbonSmallStack>
+          <RibbonSmallButton icon={ArrowDown} label="Bottom" shortcut="2" onClick={() => cameraCallbacks.setPresetView?.('bottom')} />
+          <RibbonSmallButton icon={ArrowLeft} label="Back" shortcut="4" onClick={() => cameraCallbacks.setPresetView?.('back')} />
+          <RibbonSmallButton icon={ArrowRight} label="Right" shortcut="6" onClick={() => cameraCallbacks.setPresetView?.('right')} />
+        </RibbonSmallStack>
+        <RibbonSmallStack>
+          <RibbonSmallButton
+            icon={Orbit}
+            label="Orthographic"
+            tooltip="Toggle orthographic projection"
+            active={projectionMode === 'orthographic'}
+            onClick={() => toggleProjectionMode()}
+          />
+        </RibbonSmallStack>
+      </RibbonGroup>
+
+      <RibbonGroupDivider />
+
+      <RibbonGroup label="Visibility">
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <RibbonLargeButton
+              icon={Filter}
+              label="Classes"
+              hasMenu
+              tooltip={mergeLayers
+                ? `Class visibility (${visibleClassCount} on) · Merge Multilayer Walls is on`
+                : `Class visibility (${visibleClassCount} on)`}
+              badge={mergeLayers ? (
+                // Tiny accent dot announcing that a non-default load
+                // setting is active. Decorative — semantics live on the
+                // button's tooltip.
+                <span aria-hidden="true" className="absolute right-1.5 top-1.5 h-1.5 w-1.5 rounded-full bg-primary ring-1 ring-background" />
+              ) : undefined}
+            />
+          </DropdownMenuTrigger>
+          <ClassVisibilityMenuContent align="start" />
+        </DropdownMenu>
+      </RibbonGroup>
+
+      <RibbonGroupDivider />
+
+      <RibbonGroup label="Context">
+        {/* Cesium 3D World Context — the world-context affordance is one
+            click away when a model has georeferencing. When active, the
+            "Move georeference" sub-toggle appears beside it (its amber
+            tint signals a modal pose whose exit affordance stays visible). */}
+        {cesiumAvailable && (
+          <RibbonLargeButton
+            icon={Globe2}
+            label="World"
+            tooltip={cesiumEnabled ? 'Hide 3D world context (Cesium)' : 'Show 3D world context (Cesium)'}
+            active={cesiumEnabled}
+            activeClassName="bg-teal-600/20 text-foreground ring-1 ring-inset ring-teal-600/50"
+            onClick={() => {
+              toggleCesium();
+              if (cesiumEnabled) {
+                setCesiumPlacementEditMode(false);
+                if (activeTool === 'cesium-placement') setActiveTool('select');
+              }
+            }}
+          />
+        )}
+        <RibbonLargeButton
+          icon={Sun}
+          label="Sun & Sky"
+          tooltip="Sun, sky and lighting presets"
+          active={envPanelOpen || solarEnabled || envSkyEnabled || envPreset !== 'default'}
+          activeClassName="bg-amber-500/20 text-foreground ring-1 ring-inset ring-amber-500/50"
+          onClick={toggleEnvPanel}
+        />
+        <RibbonSmallStack>
+          {cesiumAvailable && cesiumEnabled && (
+            <RibbonSmallButton
+              icon={Move}
+              label="Move georef"
+              tooltip={cesiumPlacementEditMode ? 'Stop moving georeference' : 'Move georeference in Cesium'}
+              active={cesiumPlacementEditMode}
+              activeClassName="bg-amber-500/20 text-foreground ring-1 ring-inset ring-amber-500/50"
+              onClick={() => {
+                const next = !cesiumPlacementEditMode;
+                setCesiumPlacementEditMode(next);
+                setActiveTool(next ? 'cesium-placement' : 'select');
+              }}
+            />
+          )}
+          <RibbonSmallButton
+            icon={Move3d}
+            label="SpaceMouse"
+            tooltip="Connect a 3Dconnexion SpaceMouse (WebHID)"
+            active={spaceMousePanelOpen || spaceMouseConnected}
+            activeClassName="bg-teal-600/20 text-foreground ring-1 ring-inset ring-teal-600/50"
+            onClick={toggleSpaceMousePanel}
+          />
+        </RibbonSmallStack>
+      </RibbonGroup>
+
+      <RibbonGroupDivider />
+
+      <RibbonGroup label="Interface">
+        <RibbonLargeButton
+          icon={LayoutTemplate}
+          label="Present"
+          tooltip={`Basket presentation dock (views: ${basketViewCount}, entities: ${pinboardEntities.size})`}
+          active={basketPresentationVisible}
+          disabled={!hasModels}
+          onClick={toggleBasketPresentationVisible}
+          badge={(basketViewCount > 0 || pinboardEntities.size > 0) ? (
+            <span className="absolute -top-0.5 right-0.5 flex h-[14px] min-w-[14px] items-center justify-center rounded-full border border-background bg-primary px-0.5 text-[9px] font-bold text-primary-foreground">
+              {basketViewCount > 0 ? `${basketViewCount}/${pinboardEntities.size}` : pinboardEntities.size}
+            </span>
+          ) : undefined}
+        />
+        <RibbonSmallStack>
+          <RibbonSmallButton
+            icon={Info}
+            label="Hover tips"
+            tooltip="Show entity tooltips on hover"
+            active={hoverTooltipsEnabled}
+            onClick={() => toggleHoverTooltips()}
+          />
+          <RibbonSmallButton
+            icon={PanelTop}
+            label="Classic bar"
+            tooltip="Switch back to the classic single-strip toolbar"
+            onClick={() => setToolbarStyle('classic')}
+          />
+        </RibbonSmallStack>
+      </RibbonGroup>
+    </>
+  );
+}

--- a/apps/viewer/src/components/viewer/ribbon/tabs/ViewTab.tsx
+++ b/apps/viewer/src/components/viewer/ribbon/tabs/ViewTab.tsx
@@ -42,7 +42,7 @@ export function ViewTab() {
   const hoverTooltipsEnabled = useViewerStore((state) => state.hoverTooltipsEnabled);
   const toggleHoverTooltips = useViewerStore((state) => state.toggleHoverTooltips);
   const mergeLayers = useViewerStore((state) => state.mergeLayers);
-  const visibleClassCount = useVisibleClassCount();
+  const { visible: visibleClassCount } = useVisibleClassCount();
   const setToolbarStyle = useViewerStore((state) => state.setToolbarStyle);
 
   // Cesium 3D overlay state

--- a/apps/viewer/src/components/viewer/toolbar/ClassVisibilityMenu.tsx
+++ b/apps/viewer/src/components/viewer/toolbar/ClassVisibilityMenu.tsx
@@ -1,0 +1,272 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The Visibility dropdown body — class toggles, the Model/Types 3D view
+ * switch, and the load-time geometry settings — shared by the classic
+ * toolbar and the ribbon so the two styles can never drift.
+ *
+ * Settings-style panel (not a list of menu-items): each row is a plain
+ * <label> wrapping a right-aligned Switch, so toggling does NOT close
+ * the menu — users routinely flip several classes in one pass. State
+ * reads two ways: the switch position and the row dimming when off.
+ * All rows render unconditionally (persisted preferences, sticky across
+ * models/reloads); toggling a class the model lacks is a no-op.
+ */
+
+import React from 'react';
+import {
+  Box,
+  BoxSelect,
+  Boxes,
+  Building2,
+  Grid3x3,
+  Layers2,
+  Pencil,
+  Shapes,
+  SquareX,
+  Zap,
+} from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Switch } from '@/components/ui/switch';
+import { DropdownMenuContent, DropdownMenuSeparator } from '@/components/ui/dropdown-menu';
+import { useViewerStore } from '@/store';
+import { cn } from '@/lib/utils';
+
+interface ClassVisibilityRowProps {
+  /** Colored class glyph (caller sets the tint). */
+  icon: React.ReactNode;
+  label: string;
+  /** One-line plain-language hint about what the IFC class covers. */
+  description: string;
+  checked: boolean;
+  onChange: (next: boolean) => void;
+}
+
+/**
+ * One row of the Visibility panel: colored class icon + label/description
+ * on the left, a Switch on the right. The whole row is a <label>, so a
+ * click anywhere toggles the switch and — because it isn't a menu item —
+ * the dropdown stays open for flipping several classes in a row. The left
+ * cluster dims when off so on/off reads from saturation as well as the
+ * switch position.
+ */
+function ClassVisibilityRow({ icon, label, description, checked, onChange }: ClassVisibilityRowProps) {
+  return (
+    <label className="group flex items-center justify-between gap-3 rounded-md px-2 py-1.5 cursor-pointer hover:bg-muted/50 transition-colors">
+      <span className={cn('flex items-center gap-2.5 min-w-0 transition-opacity', !checked && 'opacity-50')}>
+        {icon}
+        <span className="grid gap-0.5 min-w-0">
+          <span className="text-sm leading-tight truncate">{label}</span>
+          <span className="text-[10px] leading-tight text-muted-foreground truncate">{description}</span>
+        </span>
+      </span>
+      <Switch checked={checked} onCheckedChange={onChange} />
+    </label>
+  );
+}
+
+/**
+ * How many of the class toggles are on — surfaced in the menu header
+ * (and on ribbon trigger tooltips) so the user sees scene state at a
+ * glance.
+ */
+export function useVisibleClassCount(): number {
+  const typeVisibility = useViewerStore((state) => state.typeVisibility);
+  return [
+    typeVisibility.spaces,
+    typeVisibility.spatialZones,
+    typeVisibility.openings,
+    typeVisibility.virtualElements,
+    typeVisibility.site,
+    typeVisibility.ifcAnnotations,
+    typeVisibility.ifcGrid,
+  ].filter(Boolean).length;
+}
+
+export function ClassVisibilityMenuContent({ align = 'start' }: { align?: 'start' | 'end' }) {
+  const typeVisibility = useViewerStore((state) => state.typeVisibility);
+  const toggleTypeVisibility = useViewerStore((state) => state.toggleTypeVisibility);
+  const resetTypeVisibility = useViewerStore((state) => state.resetTypeVisibility);
+  // #957 follow-up: Model/Types 3D view switch — 'model' shows placed
+  // occurrences (default), 'types' shows the type-library shapes.
+  const typeViewMode = useViewerStore((state) => state.typeViewMode);
+  const setTypeViewMode = useViewerStore((state) => state.setTypeViewMode);
+  // Only models with type-library geometry (RepresentationMap shapes) can show
+  // anything in "Types" mode, so the switch is hidden for the common
+  // occurrence-only model. Derived in ViewportContainer from the merged meshes.
+  const hasTypeGeometry = useViewerStore((state) => state.hasTypeGeometry);
+  const mergeLayers = useViewerStore((state) => state.mergeLayers);
+  const setMergeLayers = useViewerStore((state) => state.setMergeLayers);
+  const geometryMode = useViewerStore((state) => state.geometryMode);
+  const setGeometryMode = useViewerStore((state) => state.setGeometryMode);
+  const visibleClassCount = useVisibleClassCount();
+
+  return (
+    <DropdownMenuContent align={align} className="w-[300px] p-1.5">
+      {/* Model / Types 3D view switch (#957 follow-up). A type carries a
+          RepresentationMap whose shape is drawn at its MappingOrigin; "Types"
+          shows that type library, "Model" shows the placed occurrences. The
+          two are mutually exclusive — toggling re-filters the cached mesh set
+          instantly (no reload). Only rendered when the model actually has
+          type-library geometry — most carry only occurrence geometry, where
+          "Types" would be empty, so the switch would just be a dead control. */}
+      {hasTypeGeometry && (
+        <>
+          <div className="px-1.5 pb-1 pt-0.5">
+            <span className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+              3D View
+            </span>
+          </div>
+          <div className="flex gap-1 px-1.5 pb-1.5" role="radiogroup" aria-label="3D view mode">
+            <button
+              type="button"
+              role="radio"
+              aria-checked={typeViewMode === 'model'}
+              onClick={() => setTypeViewMode('model')}
+              className={cn(
+                'flex flex-1 items-center justify-center gap-1.5 rounded-md border px-2 py-1.5 text-xs font-medium transition-colors',
+                typeViewMode === 'model'
+                  ? 'border-primary/40 bg-primary/10 text-foreground'
+                  : 'border-transparent text-muted-foreground hover:bg-muted/50',
+              )}
+            >
+              <Boxes className="h-3.5 w-3.5 shrink-0" />
+              Model
+            </button>
+            <button
+              type="button"
+              role="radio"
+              aria-checked={typeViewMode === 'types'}
+              onClick={() => setTypeViewMode('types')}
+              className={cn(
+                'flex flex-1 items-center justify-center gap-1.5 rounded-md border px-2 py-1.5 text-xs font-medium transition-colors',
+                typeViewMode === 'types'
+                  ? 'border-primary/40 bg-primary/10 text-foreground'
+                  : 'border-transparent text-muted-foreground hover:bg-muted/50',
+              )}
+            >
+              <Shapes className="h-3.5 w-3.5 shrink-0" />
+              Types
+            </button>
+          </div>
+
+          <DropdownMenuSeparator className="my-1" />
+        </>
+      )}
+
+      <div className="flex items-center justify-between gap-2 px-1.5 pb-1 pt-0.5">
+        <span className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+          Visibility
+        </span>
+        <div className="flex items-center gap-1">
+          <span className="text-[11px] tabular-nums text-muted-foreground/80">
+            {visibleClassCount}/5
+          </span>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-6 px-1.5 text-[11px] font-medium text-muted-foreground hover:text-foreground"
+            onClick={resetTypeVisibility}
+          >
+            Reset
+          </Button>
+        </div>
+      </div>
+
+      <ClassVisibilityRow
+        icon={<Box className="h-4 w-4 shrink-0" style={{ color: '#33d9ff' }} />}
+        label="Spaces"
+        description="Room volumes (IfcSpace)"
+        checked={typeVisibility.spaces}
+        onChange={() => toggleTypeVisibility('spaces')}
+      />
+      <ClassVisibilityRow
+        icon={<Box className="h-4 w-4 shrink-0" style={{ color: '#b85af2' }} />}
+        label="Spatial Zones"
+        description="Gross-area volumes (IfcSpatialZone)"
+        checked={typeVisibility.spatialZones}
+        onChange={() => toggleTypeVisibility('spatialZones')}
+      />
+      <ClassVisibilityRow
+        icon={<SquareX className="h-4 w-4 shrink-0" style={{ color: '#ff6b4a' }} />}
+        label="Openings"
+        description="Door & window voids"
+        checked={typeVisibility.openings}
+        onChange={() => toggleTypeVisibility('openings')}
+      />
+      <ClassVisibilityRow
+        icon={<BoxSelect className="h-4 w-4 shrink-0" style={{ color: '#9aa0a6' }} />}
+        label="Virtual Elements"
+        description="Non-physical boundaries & clearance volumes"
+        checked={typeVisibility.virtualElements}
+        onChange={() => toggleTypeVisibility('virtualElements')}
+      />
+      <ClassVisibilityRow
+        icon={<Building2 className="h-4 w-4 shrink-0" style={{ color: '#66cc4d' }} />}
+        label="Site"
+        description="Terrain & context"
+        checked={typeVisibility.site}
+        onChange={() => toggleTypeVisibility('site')}
+      />
+      <ClassVisibilityRow
+        icon={<Pencil className="h-4 w-4 shrink-0" style={{ color: '#e4b400' }} />}
+        label="Annotations"
+        description="Text, dimensions, leaders"
+        checked={typeVisibility.ifcAnnotations}
+        onChange={() => toggleTypeVisibility('ifcAnnotations')}
+      />
+      <ClassVisibilityRow
+        icon={<Grid3x3 className="h-4 w-4 shrink-0" style={{ color: '#e4b400' }} />}
+        label="Grids"
+        description="Structural axes"
+        checked={typeVisibility.ifcGrid}
+        onChange={() => toggleTypeVisibility('ifcGrid')}
+      />
+
+      <DropdownMenuSeparator className="my-1" />
+
+      {/* Merge multilayer walls rebuilds geometry, so unlike the live
+          toggles above it only takes effect on the next model load.
+          The "· on reload" suffix carries that nuance inline — keeps
+          the row identical in shape to the others (no header, no chip
+          crowding the long label). */}
+      <label className="group flex items-center justify-between gap-3 rounded-md px-2 py-1.5 cursor-pointer hover:bg-muted/50 transition-colors">
+        <span className={cn('flex items-center gap-2.5 min-w-0 transition-opacity', !mergeLayers && 'opacity-50')}>
+          <Layers2 className="h-4 w-4 shrink-0 text-primary" />
+          <span className="grid gap-0.5 min-w-0">
+            <span className="text-sm leading-tight truncate">Merge multilayer walls</span>
+            <span className="text-[10px] leading-tight text-muted-foreground truncate">
+              Render walls as one solid · on reload
+            </span>
+          </span>
+        </span>
+        <Switch checked={mergeLayers} onCheckedChange={(next) => setMergeLayers(next === true)} />
+      </label>
+
+      {/* Fast vs Exact geometry — like merge-layers, a load-time geometry
+          input that only takes effect on the next model load ("· on reload").
+          Fast skips sub-10% detail cuts + auto-lowers density on heavy models
+          for quick first paint; Exact keeps every cut at full density for
+          display/measure/export fidelity. */}
+      <label className="group flex items-center justify-between gap-3 rounded-md px-2 py-1.5 cursor-pointer hover:bg-muted/50 transition-colors">
+        <span className={cn('flex items-center gap-2.5 min-w-0 transition-opacity', geometryMode !== 'fast' && 'opacity-50')}>
+          <Zap className="h-4 w-4 shrink-0 text-primary" />
+          <span className="grid gap-0.5 min-w-0">
+            <span className="text-sm leading-tight truncate">Fast geometry</span>
+            <span className="text-[10px] leading-tight text-muted-foreground truncate">
+              {geometryMode === 'fast'
+                ? 'Skip tiny cuts, auto-detail · on reload'
+                : 'Exact: full cuts + density · on reload'}
+            </span>
+          </span>
+        </span>
+        <Switch
+          checked={geometryMode === 'fast'}
+          onCheckedChange={(next) => setGeometryMode(next === true ? 'fast' : 'exact')}
+        />
+      </label>
+    </DropdownMenuContent>
+  );
+}

--- a/apps/viewer/src/components/viewer/toolbar/ClassVisibilityMenu.tsx
+++ b/apps/viewer/src/components/viewer/toolbar/ClassVisibilityMenu.tsx
@@ -72,9 +72,9 @@ function ClassVisibilityRow({ icon, label, description, checked, onChange }: Cla
  * (and on ribbon trigger tooltips) so the user sees scene state at a
  * glance.
  */
-export function useVisibleClassCount(): number {
+export function useVisibleClassCount(): { visible: number; total: number } {
   const typeVisibility = useViewerStore((state) => state.typeVisibility);
-  return [
+  const toggles = [
     typeVisibility.spaces,
     typeVisibility.spatialZones,
     typeVisibility.openings,
@@ -82,7 +82,8 @@ export function useVisibleClassCount(): number {
     typeVisibility.site,
     typeVisibility.ifcAnnotations,
     typeVisibility.ifcGrid,
-  ].filter(Boolean).length;
+  ];
+  return { visible: toggles.filter(Boolean).length, total: toggles.length };
 }
 
 export function ClassVisibilityMenuContent({ align = 'start' }: { align?: 'start' | 'end' }) {
@@ -101,7 +102,7 @@ export function ClassVisibilityMenuContent({ align = 'start' }: { align?: 'start
   const setMergeLayers = useViewerStore((state) => state.setMergeLayers);
   const geometryMode = useViewerStore((state) => state.geometryMode);
   const setGeometryMode = useViewerStore((state) => state.setGeometryMode);
-  const visibleClassCount = useVisibleClassCount();
+  const { visible: visibleClassCount, total: classToggleCount } = useVisibleClassCount();
 
   return (
     <DropdownMenuContent align={align} className="w-[300px] p-1.5">
@@ -162,7 +163,7 @@ export function ClassVisibilityMenuContent({ align = 'start' }: { align?: 'start
         </span>
         <div className="flex items-center gap-1">
           <span className="text-[11px] tabular-nums text-muted-foreground/80">
-            {visibleClassCount}/5
+            {visibleClassCount}/{classToggleCount}
           </span>
           <Button
             variant="ghost"

--- a/apps/viewer/src/components/viewer/toolbar/useExportCommands.ts
+++ b/apps/viewer/src/components/viewer/toolbar/useExportCommands.ts
@@ -1,0 +1,73 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Data-export commands (CSV / JSON / screenshot) shared by the classic
+ * toolbar and the ribbon. The dialog-based exporters (IFC, GLB, KMZ,
+ * HBJSON) stay as dialog components with a `trigger` prop — each
+ * toolbar style supplies its own trigger element.
+ */
+
+import { useCallback } from 'react';
+import { useIfc } from '@/hooks/useIfc';
+import { exportCsvFromBytes } from '@/lib/export/csv';
+import { downloadFile, downloadDataUrl } from '@/lib/export/download';
+import { toast } from '@/components/ui/toast';
+
+export type CsvExportType = 'entities' | 'properties' | 'quantities' | 'spatial';
+
+export function useExportCommands() {
+  const { ifcDataStore } = useIfc();
+
+  const handleExportCSV = useCallback(async (type: CsvExportType) => {
+    if (!ifcDataStore?.source) return;
+    try {
+      const csv = await exportCsvFromBytes(ifcDataStore.source, type, { includeProperties: type === 'entities' });
+      const filename = type === 'spatial' ? 'spatial-hierarchy.csv' : `${type}.csv`;
+      downloadFile(csv, filename, 'text/csv');
+      toast.success(`Exported ${type} CSV`);
+    } catch (err) {
+      console.error('CSV export failed:', err);
+      toast.error(`CSV export failed: ${err instanceof Error ? err.message : 'Unknown error'}`);
+    }
+  }, [ifcDataStore]);
+
+  const handleExportJSON = useCallback(() => {
+    if (!ifcDataStore) return;
+    try {
+      const entities: Record<string, unknown>[] = [];
+      for (let i = 0; i < ifcDataStore.entities.count; i++) {
+        const id = ifcDataStore.entities.expressId[i];
+        entities.push({
+          expressId: id,
+          globalId: ifcDataStore.entities.getGlobalId(id),
+          name: ifcDataStore.entities.getName(id),
+          type: ifcDataStore.entities.getTypeName(id),
+          properties: ifcDataStore.properties.getForEntity(id),
+        });
+      }
+
+      const json = JSON.stringify({ entities }, null, 2);
+      downloadFile(json, 'model-data.json', 'application/json');
+      toast.success(`Exported ${entities.length} entities as JSON`);
+    } catch (err) {
+      console.error('JSON export failed:', err);
+      toast.error(`JSON export failed: ${err instanceof Error ? err.message : 'Unknown error'}`);
+    }
+  }, [ifcDataStore]);
+
+  const handleScreenshot = useCallback(() => {
+    const canvas = document.querySelector('canvas');
+    if (!canvas) return;
+    try {
+      downloadDataUrl(canvas.toDataURL('image/png'), 'screenshot.png');
+      toast.success('Screenshot saved');
+    } catch (err) {
+      console.error('Screenshot failed:', err);
+      toast.error('Screenshot failed');
+    }
+  }, []);
+
+  return { ifcDataStore, handleExportCSV, handleExportJSON, handleScreenshot };
+}

--- a/apps/viewer/src/components/viewer/toolbar/useFileCommands.tsx
+++ b/apps/viewer/src/components/viewer/toolbar/useFileCommands.tsx
@@ -1,0 +1,331 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * File-command surface shared by every desktop toolbar style (classic
+ * `MainToolbar` and the ribbon). Owns the Open / Add Model / Refresh
+ * flows, the hidden file inputs, and the global `ifc-lite:*` load
+ * events, so both toolbars drive the exact same load pipeline and the
+ * logic lives once. Exactly one toolbar mounts at a time, so the
+ * window listeners registered here never double-fire.
+ */
+
+import React, { useRef, useCallback, useEffect, useMemo } from 'react';
+import { useViewerStore, isIfcxDataStore, type FederatedModel } from '@/store';
+import { useIfc } from '@/hooks/useIfc';
+import { recordRecentFiles, cacheFileBlobs } from '@/lib/recent-files';
+import {
+  supportsFileSystemAccess,
+  openIfcFilesWithHandles,
+  readFreshFile,
+} from '@/services/file-system-access';
+import { toast } from '@/components/ui/toast';
+
+/** Extensions the viewer can ingest (IFC / IFCX / GLB / point clouds). */
+export function isSupportedModelFile(f: File): boolean {
+  const n = f.name.toLowerCase();
+  return n.endsWith('.ifc') || n.endsWith('.ifcx') || n.endsWith('.ifczip') || n.endsWith('.glb')
+    || n.endsWith('.las') || n.endsWith('.laz') || n.endsWith('.ply') || n.endsWith('.pcd')
+    || n.endsWith('.e57') || n.endsWith('.pts') || n.endsWith('.xyz');
+}
+
+/** Case-insensitive IFCX check (filenames are accepted case-insensitively). */
+function isIfcxModelFile(f: File): boolean {
+  return f.name.toLowerCase().endsWith('.ifcx');
+}
+
+const FILE_ACCEPT = '.ifc,.ifcx,.ifczip,.glb,.las,.laz,.ply,.pcd,.e57,.pts,.xyz';
+
+export interface FileCommands {
+  /** Render once inside the toolbar: the two hidden `<input type="file">` fallbacks. */
+  fileInputs: React.ReactNode;
+  /** Open file(s), replacing the current session (FS Access picker when available). */
+  handleOpenClick: () => Promise<void>;
+  /** Add model(s) to the current federation (FS Access picker when available). */
+  handleAddModelClick: () => Promise<void>;
+  /** Re-read every loaded model from disk. Only meaningful when `canRefresh`. */
+  handleRefresh: () => Promise<void>;
+  /** True when every loaded model has a live FS Access handle. */
+  canRefresh: boolean;
+  /** True when any model (federated map or legacy single result) is loaded. */
+  hasModelsLoaded: boolean;
+}
+
+export function useFileCommands(): FileCommands {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const addModelInputRef = useRef<HTMLInputElement>(null);
+  const {
+    loadFile,
+    loading,
+    geometryResult,
+    ifcDataStore,
+    models,
+    clearAllModels,
+    loadFilesSequentially,
+    loadFederatedIfcx,
+    addIfcxOverlays,
+    addModel,
+  } = useIfc();
+  const resetViewerState = useViewerStore((state) => state.resetViewerState);
+
+  // Listen for programmatic file-load requests (from command palette recent files)
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const file = (e as CustomEvent<File>).detail;
+      if (file) {
+        recordRecentFiles([{ name: file.name, size: file.size }]);
+        void loadFile(file);
+      }
+    };
+    // Federation variant: ADD the file to the current set instead of
+    // replacing it (the compare tour loads demo revision B this way).
+    const addHandler = (e: Event) => {
+      const file = (e as CustomEvent<unknown>).detail;
+      if (file instanceof File) void addModel(file);
+    };
+    // Layer-stack variant: load a File[] as a composed .ifcx federation
+    // (the Layers panel demo + tour dispatch this, see lib/layers/demo-stack).
+    const stackHandler = (e: Event) => {
+      const files = (e as CustomEvent<unknown>).detail;
+      if (Array.isArray(files) && files.every((f) => f instanceof File) && files.length > 0) {
+        void loadFederatedIfcx(files as File[]);
+      }
+    };
+    window.addEventListener('ifc-lite:load-file', handler);
+    window.addEventListener('ifc-lite:add-model', addHandler);
+    window.addEventListener('ifc-lite:load-layer-stack', stackHandler);
+    return () => {
+      window.removeEventListener('ifc-lite:load-file', handler);
+      window.removeEventListener('ifc-lite:add-model', addHandler);
+      window.removeEventListener('ifc-lite:load-layer-stack', stackHandler);
+    };
+  }, [loadFile, addModel, loadFederatedIfcx]);
+
+  const hasModelsLoaded = models.size > 0 || Boolean(geometryResult?.meshes && geometryResult.meshes.length > 0);
+
+  const handleFileSelect = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = e.target.files;
+    if (!files || files.length === 0) return;
+
+    // Filter to supported files (IFC, IFCX, GLB, point clouds)
+    const supportedFiles = Array.from(files).filter(isSupportedModelFile);
+
+    if (supportedFiles.length === 0) return;
+
+    // Track recently opened files (metadata + blob cache for instant reload)
+    recordRecentFiles(supportedFiles.map(f => ({ name: f.name, size: f.size })));
+    cacheFileBlobs(supportedFiles);
+
+    if (supportedFiles.length === 1) {
+      // Single file - use loadFile (simpler single-model path)
+      loadFile(supportedFiles[0]);
+    } else {
+      // Multiple files - check if ALL are IFCX (use federated loading for layer composition)
+      const allIfcx = supportedFiles.every(f => f.name.endsWith('.ifcx'));
+
+      resetViewerState();
+      clearAllModels();
+
+      if (allIfcx) {
+        // IFCX files use federated loading (layer composition - later files override earlier ones)
+        // This handles overlay files that add properties without geometry
+        console.log(`[toolbar] Loading ${supportedFiles.length} IFCX files with federated composition`);
+        loadFederatedIfcx(supportedFiles);
+      } else {
+        // Mixed or all IFC4/GLB files - load sequentially as independent models
+        loadFilesSequentially(supportedFiles);
+      }
+    }
+
+    // Reset input so same files can be selected again
+    e.target.value = '';
+  }, [loadFile, loadFilesSequentially, loadFederatedIfcx, resetViewerState, clearAllModels]);
+
+  // Shared Add-Model routing. `handles` is positionally aligned with
+  // `supportedFiles`, carrying a live FS Access handle per file (Chromium) so
+  // each added model stays part of a refreshable federation.
+  const addSupportedFiles = useCallback((
+    supportedFiles: File[],
+    handles?: (FileSystemFileHandle | undefined)[],
+  ) => {
+    if (supportedFiles.length === 0) return;
+    const newFilesAreIfcx = supportedFiles.every(isIfcxModelFile);
+    const existingIsIfcx = isIfcxDataStore(ifcDataStore);
+
+    if (newFilesAreIfcx && existingIsIfcx) {
+      // Adding IFCX overlay(s) to existing IFCX model - re-compose with new layers
+      console.log(`[toolbar] Adding ${supportedFiles.length} IFCX overlay(s) to existing IFCX model - re-composing`);
+      void addIfcxOverlays(supportedFiles);
+    } else if (newFilesAreIfcx && !existingIsIfcx && ifcDataStore) {
+      // User trying to add IFCX to IFC4 model - won't work
+      console.warn('[toolbar] Cannot add IFCX files to non-IFCX model');
+      alert(`IFCX overlay files cannot be added to IFC4 models.\n\nPlease load IFCX files separately.`);
+    } else {
+      // Standard case - add as independent models (IFC4, GLB, or mixed)
+      void loadFilesSequentially(supportedFiles, handles);
+    }
+  }, [loadFilesSequentially, addIfcxOverlays, ifcDataStore]);
+
+  const handleAddModelSelect = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = e.target.files;
+    if (!files || files.length === 0) return;
+    // <input> yields no live handle, so models added this way aren't refreshable.
+    const supportedFiles = Array.from(files).filter(isSupportedModelFile);
+    addSupportedFiles(supportedFiles);
+    // Reset input so same files can be selected again
+    e.target.value = '';
+  }, [addSupportedFiles]);
+
+  // Preferred Add-Model path: the picker captures a handle per file so the
+  // resulting federation can be refreshed. Falls back to the hidden <input>.
+  const handleAddModelClick = useCallback(async () => {
+    if (!supportsFileSystemAccess()) {
+      addModelInputRef.current?.click();
+      return;
+    }
+    const opened = await openIfcFilesWithHandles();
+    if (!opened) return;
+    const supported = opened.filter(o => isSupportedModelFile(o.file));
+    addSupportedFiles(supported.map(o => o.file), supported.map(o => o.handle));
+  }, [addSupportedFiles]);
+
+  // Open via the File System Access API when available (Chromium) so we capture
+  // a live FileSystemFileHandle for each file — that handle is what lets the
+  // Refresh button re-read the same file from disk later (issue #1345). Browsers
+  // without the API fall back to the hidden <input type="file">.
+  const handleOpenClick = useCallback(async () => {
+    if (!supportsFileSystemAccess()) {
+      fileInputRef.current?.click();
+      return;
+    }
+    const picked = await openIfcFilesWithHandles();
+    if (!picked) return; // cancelled, unavailable, or picker failed
+    // The picker keeps an "all files" option, so drop anything unsupported
+    // before it reaches the load pipeline (matches the <input> + Add Model paths).
+    const opened = picked.filter(o => isSupportedModelFile(o.file));
+    if (opened.length === 0) return;
+
+    const files = opened.map(o => o.file);
+    recordRecentFiles(files.map(f => ({ name: f.name, size: f.size })));
+    void cacheFileBlobs(files);
+
+    if (opened.length === 1) {
+      // Single model: keep the handle so Refresh can re-read it from disk.
+      void loadFile(opened[0].file, { kind: 'primary' }, { sourceHandle: opened[0].handle });
+    } else {
+      // Multiple files mirror handleFileSelect's branching.
+      const allIfcx = files.every(isIfcxModelFile);
+      resetViewerState();
+      clearAllModels();
+      if (allIfcx) {
+        // IFCX layers compose into one shared store — no per-file handle.
+        void loadFederatedIfcx(files);
+      } else {
+        // Carry each file's handle so the whole federation stays refreshable.
+        void loadFilesSequentially(files, opened.map(o => o.handle));
+      }
+    }
+  }, [loadFile, loadFilesSequentially, loadFederatedIfcx, resetViewerState, clearAllModels]);
+
+  // Refresh re-reads files from disk and re-parses them. Offered when EVERY
+  // loaded model has a live FS Access handle (a single model, or a federation
+  // fully opened via the picker/drag this session). Drag-drop on non-Chromium,
+  // <input type="file">, cache-restored, and IFCX-composed models have no
+  // handle, so a mixed session hides the button rather than risk dropping the
+  // handle-less models during the rebuild.
+  const canRefresh = useMemo(() => {
+    if (loading || models.size === 0) return false;
+    return Array.from(models.values()).every(m => m.sourceHandle);
+  }, [models, loading]);
+
+  const handleRefresh = useCallback(async () => {
+    const targets = (Array.from(useViewerStore.getState().models.values()) as FederatedModel[])
+      .filter((m): m is FederatedModel & { sourceHandle: FileSystemFileHandle } => Boolean(m.sourceHandle))
+      .sort((a, b) => (a.loadedAt ?? 0) - (b.loadedAt ?? 0));
+    if (targets.length === 0) return;
+
+    // Re-read every handle BEFORE clearing anything, so a failed read never
+    // leaves the viewer empty.
+    const reads = await Promise.all(
+      targets.map(async (m) => ({ model: m, fresh: await readFreshFile(m.sourceHandle) })),
+    );
+    const ok = reads.filter((r) => r.fresh) as { model: typeof targets[number]; fresh: File }[];
+    const failedNames = reads.filter((r) => !r.fresh).map((r) => `"${r.model.name}"`);
+
+    if (ok.length === 0) {
+      toast.error(`Couldn't re-read ${failedNames.join(', ')}. Files may have moved, been deleted, or access was denied.`);
+      return;
+    }
+
+    recordRecentFiles(ok.map((r) => ({ name: r.fresh.name, size: r.fresh.size })));
+    void cacheFileBlobs(ok.map((r) => r.fresh));
+
+    if (targets.length === 1) {
+      // Await so the success toast only fires once the reload has completed.
+      await loadFile(ok[0].fresh, { kind: 'primary' }, { sourceHandle: ok[0].model.sourceHandle });
+    } else {
+      // Rebuild the federation from fresh bytes, preserving id + order + state.
+      clearAllModels();
+      for (const r of ok) {
+        const reloadedId = await addModel(r.fresh, {
+          name: r.model.name,
+          modelId: r.model.id,
+          loadedAt: r.model.loadedAt,
+          visible: r.model.visible,
+          collapsed: r.model.collapsed,
+          sourceHandle: r.model.sourceHandle,
+        });
+        if (reloadedId && r.model.visible === false) {
+          useViewerStore.getState().setModelVisibility(r.model.id, false);
+        }
+      }
+    }
+
+    if (failedNames.length > 0) {
+      toast.error(`Refreshed ${ok.length}; couldn't re-read ${failedNames.join(', ')}.`);
+    } else {
+      toast.success(ok.length === 1 ? `Refreshed "${ok[0].fresh.name}"` : `Refreshed ${ok.length} models`);
+    }
+  }, [loadFile, addModel, clearAllModels]);
+
+  // The command palette dispatches this (synchronously, inside the click) so the
+  // toolbar's handle-capturing open path runs while user activation is still
+  // live — required for the file dialog to actually open on Chrome.
+  useEffect(() => {
+    const handler = () => { void handleOpenClick(); };
+    window.addEventListener('ifc-lite:open-files', handler);
+    return () => window.removeEventListener('ifc-lite:open-files', handler);
+  }, [handleOpenClick]);
+
+  const fileInputs = (
+    <>
+      <input
+        id="file-input-open"
+        ref={fileInputRef}
+        type="file"
+        accept={FILE_ACCEPT}
+        multiple
+        onChange={handleFileSelect}
+        className="hidden"
+      />
+      <input
+        ref={addModelInputRef}
+        type="file"
+        accept={FILE_ACCEPT}
+        multiple
+        onChange={handleAddModelSelect}
+        className="hidden"
+      />
+    </>
+  );
+
+  return {
+    fileInputs,
+    handleOpenClick,
+    handleAddModelClick,
+    handleRefresh,
+    canRefresh,
+    hasModelsLoaded,
+  };
+}

--- a/apps/viewer/src/components/viewer/toolbar/useFileCommands.tsx
+++ b/apps/viewer/src/components/viewer/toolbar/useFileCommands.tsx
@@ -11,7 +11,7 @@
  * window listeners registered here never double-fire.
  */
 
-import React, { useRef, useCallback, useEffect, useMemo } from 'react';
+import React, { useRef, useState, useCallback, useEffect, useMemo } from 'react';
 import { useViewerStore, isIfcxDataStore, type FederatedModel } from '@/store';
 import { useIfc } from '@/hooks/useIfc';
 import { recordRecentFiles, cacheFileBlobs } from '@/lib/recent-files';
@@ -21,6 +21,8 @@ import {
   readFreshFile,
 } from '@/services/file-system-access';
 import { toast } from '@/components/ui/toast';
+import { isCollabEnabled } from '@/lib/collab/config';
+import { ShareDialog } from '../ShareDialog';
 
 /** Extensions the viewer can ingest (IFC / IFCX / GLB / point clouds). */
 export function isSupportedModelFile(f: File): boolean {
@@ -38,8 +40,16 @@ function isIfcxModelFile(f: File): boolean {
 const FILE_ACCEPT = '.ifc,.ifcx,.ifczip,.glb,.las,.laz,.ply,.pcd,.e57,.pts,.xyz';
 
 export interface FileCommands {
-  /** Render once inside the toolbar: the two hidden `<input type="file">` fallbacks. */
+  /**
+   * Render once inside the toolbar: the two hidden `<input type="file">`
+   * fallbacks plus the Share dialog (when collab is enabled). The dialog
+   * lives here — not in a tab panel — so `ifc-lite:open-share-dialog`
+   * always has a mounted receiver regardless of the active ribbon tab or
+   * collapse state.
+   */
   fileInputs: React.ReactNode;
+  /** Open the Share dialog (same path the `ifc-lite:open-share-dialog` event takes). */
+  openShareDialog: () => void;
   /** Open file(s), replacing the current session (FS Access picker when available). */
   handleOpenClick: () => Promise<void>;
   /** Add model(s) to the current federation (FS Access picker when available). */
@@ -68,6 +78,21 @@ export function useFileCommands(): FileCommands {
     addModel,
   } = useIfc();
   const resetViewerState = useViewerStore((state) => state.resetViewerState);
+
+  // Share dialog host. Owned here (not by a toolbar or tab panel) because
+  // this hook is mounted by whichever toolbar style is active for the whole
+  // session, while ribbon tab panels unmount on tab switch/collapse — the
+  // `ifc-lite:open-share-dialog` event (RoomPanel's "Create a room") must
+  // always find a live listener.
+  const collabEnabled = useMemo(() => isCollabEnabled(), []);
+  const [shareDialogOpen, setShareDialogOpen] = useState(false);
+  const openShareDialog = useCallback(() => setShareDialogOpen(true), []);
+  useEffect(() => {
+    if (!collabEnabled) return;
+    const shareHandler = () => setShareDialogOpen(true);
+    window.addEventListener('ifc-lite:open-share-dialog', shareHandler);
+    return () => window.removeEventListener('ifc-lite:open-share-dialog', shareHandler);
+  }, [collabEnabled]);
 
   // Listen for programmatic file-load requests (from command palette recent files)
   useEffect(() => {
@@ -122,7 +147,7 @@ export function useFileCommands(): FileCommands {
       loadFile(supportedFiles[0]);
     } else {
       // Multiple files - check if ALL are IFCX (use federated loading for layer composition)
-      const allIfcx = supportedFiles.every(f => f.name.endsWith('.ifcx'));
+      const allIfcx = supportedFiles.every(isIfcxModelFile);
 
       resetViewerState();
       clearAllModels();
@@ -258,6 +283,14 @@ export function useFileCommands(): FileCommands {
       return;
     }
 
+    // A federation rebuild starts with clearAllModels(), so a partial read
+    // would silently drop every failed model from the scene. Refuse instead:
+    // the user keeps the loaded (stale) federation and gets told why.
+    if (targets.length > 1 && failedNames.length > 0) {
+      toast.error(`Refresh cancelled: couldn't re-read ${failedNames.join(', ')}. Keeping the loaded models.`);
+      return;
+    }
+
     recordRecentFiles(ok.map((r) => ({ name: r.fresh.name, size: r.fresh.size })));
     void cacheFileBlobs(ok.map((r) => r.fresh));
 
@@ -282,11 +315,9 @@ export function useFileCommands(): FileCommands {
       }
     }
 
-    if (failedNames.length > 0) {
-      toast.error(`Refreshed ${ok.length}; couldn't re-read ${failedNames.join(', ')}.`);
-    } else {
-      toast.success(ok.length === 1 ? `Refreshed "${ok[0].fresh.name}"` : `Refreshed ${ok.length} models`);
-    }
+    // Any failed read returned early above, so reaching here means every
+    // targeted model was re-read and reloaded.
+    toast.success(ok.length === 1 ? `Refreshed "${ok[0].fresh.name}"` : `Refreshed ${ok.length} models`);
   }, [loadFile, addModel, clearAllModels]);
 
   // The command palette dispatches this (synchronously, inside the click) so the
@@ -317,11 +348,13 @@ export function useFileCommands(): FileCommands {
         onChange={handleAddModelSelect}
         className="hidden"
       />
+      {collabEnabled && <ShareDialog open={shareDialogOpen} onOpenChange={setShareDialogOpen} />}
     </>
   );
 
   return {
     fileInputs,
+    openShareDialog,
     handleOpenClick,
     handleAddModelClick,
     handleRefresh,

--- a/apps/viewer/src/components/viewer/toolbar/useWorkspacePanelControls.ts
+++ b/apps/viewer/src/components/viewer/toolbar/useWorkspacePanelControls.ts
@@ -176,6 +176,7 @@ export function useWorkspacePanelControls() {
     setIdsPanelVisible(false);
     setLensPanelVisible(false);
     setClashPanelVisible(false);
+    setComparePanelVisible(false);
     setExtensionsPanelVisible(false);
     // The right slot is single-tenant: when an analysis extension takes
     // it over, the AddElement tool must release it too, otherwise its 3D
@@ -191,6 +192,7 @@ export function useWorkspacePanelControls() {
     setActiveTool,
     setBcfPanelVisible,
     setClashPanelVisible,
+    setComparePanelVisible,
     setExtensionsPanelVisible,
     setGanttPanelVisible,
     setIdsPanelVisible,

--- a/apps/viewer/src/components/viewer/toolbar/useWorkspacePanelControls.ts
+++ b/apps/viewer/src/components/viewer/toolbar/useWorkspacePanelControls.ts
@@ -1,0 +1,262 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Workspace-panel toggling shared by the classic toolbar's Panels menu
+ * and the ribbon's Analyze / Author tabs. Encodes the single-tenant
+ * right-slot and bottom-slot rules (one docked panel per region) plus
+ * the analysis-extension handoff, exactly as the toolbar always did.
+ */
+
+import { useCallback, useMemo, useSyncExternalStore } from 'react';
+import { useViewerStore } from '@/store';
+import {
+  closeActiveAnalysisExtension,
+  getAnalysisExtensionsSnapshot,
+  openAnalysisExtension,
+  subscribeAnalysisExtensions,
+} from '@/services/analysis-extensions';
+import { closePanelWindow } from '@/services/panel-windows';
+
+export type BottomPanel = 'script' | 'list' | 'gantt';
+export type RightPanel = 'bcf' | 'ids' | 'lens' | 'clash' | 'compare' | 'addElement' | 'extensions';
+export type WorkspacePanel = BottomPanel | RightPanel | string;
+
+export function useWorkspacePanelControls() {
+  const activeTool = useViewerStore((state) => state.activeTool);
+  const setActiveTool = useViewerStore((state) => state.setActiveTool);
+  const bcfPanelVisible = useViewerStore((state) => state.bcfPanelVisible);
+  const setBcfPanelVisible = useViewerStore((state) => state.setBcfPanelVisible);
+  const idsPanelVisible = useViewerStore((state) => state.idsPanelVisible);
+  const setIdsPanelVisible = useViewerStore((state) => state.setIdsPanelVisible);
+  const clashPanelVisible = useViewerStore((state) => state.clashPanelVisible);
+  const setClashPanelVisible = useViewerStore((state) => state.setClashPanelVisible);
+  const comparePanelVisible = useViewerStore((state) => state.comparePanelVisible);
+  const setComparePanelVisible = useViewerStore((state) => state.setComparePanelVisible);
+  const listPanelVisible = useViewerStore((state) => state.listPanelVisible);
+  const setListPanelVisible = useViewerStore((state) => state.setListPanelVisible);
+  const lensPanelVisible = useViewerStore((state) => state.lensPanelVisible);
+  const setLensPanelVisible = useViewerStore((state) => state.setLensPanelVisible);
+  const extensionsPanelVisible = useViewerStore((state) => state.extensionsPanelVisible);
+  const setExtensionsPanelVisible = useViewerStore((state) => state.setExtensionsPanelVisible);
+  const scriptPanelVisible = useViewerStore((state) => state.scriptPanelVisible);
+  const setScriptPanelVisible = useViewerStore((state) => state.setScriptPanelVisible);
+  const ganttPanelVisible = useViewerStore((state) => state.ganttPanelVisible);
+  const setGanttPanelVisible = useViewerStore((state) => state.setGanttPanelVisible);
+  const layersPanelVisible = useViewerStore((state) => state.layersPanelVisible);
+  const collabPanelVisible = useViewerStore((state) => state.collabPanelVisible);
+  const setRightPanelCollapsed = useViewerStore((state) => state.setRightPanelCollapsed);
+
+  const analysisExtensionState = useSyncExternalStore(
+    subscribeAnalysisExtensions,
+    getAnalysisExtensionsSnapshot,
+    getAnalysisExtensionsSnapshot,
+  );
+  const activeAnalysisExtension = useMemo(
+    () => analysisExtensionState.extensions.find((extension) => extension.id === analysisExtensionState.activeId) ?? null,
+    [analysisExtensionState.activeId, analysisExtensionState.extensions],
+  );
+  const rightAnalysisExtensions = useMemo(
+    () => analysisExtensionState.extensions.filter((extension) => (extension.placement ?? 'right') === 'right'),
+    [analysisExtensionState.extensions],
+  );
+  const bottomAnalysisExtensions = useMemo(
+    () => analysisExtensionState.extensions.filter((extension) => (extension.placement ?? 'right') === 'bottom'),
+    [analysisExtensionState.extensions],
+  );
+
+  const handleToggleBottomPanel = useCallback((panel: BottomPanel) => {
+    if (activeAnalysisExtension?.placement === 'bottom') {
+      closeActiveAnalysisExtension();
+    }
+    const nextScriptVisible = panel === 'script' ? !scriptPanelVisible : false;
+    const nextListVisible = panel === 'list' ? !listPanelVisible : false;
+    const nextGanttVisible = panel === 'gantt' ? !ganttPanelVisible : false;
+
+    setScriptPanelVisible(nextScriptVisible);
+    setListPanelVisible(nextListVisible);
+    setGanttPanelVisible(nextGanttVisible);
+
+    if (nextScriptVisible || nextListVisible || nextGanttVisible) {
+      setRightPanelCollapsed(false);
+    }
+  }, [
+    activeAnalysisExtension?.placement,
+    ganttPanelVisible,
+    listPanelVisible,
+    scriptPanelVisible,
+    setGanttPanelVisible,
+    setListPanelVisible,
+    setRightPanelCollapsed,
+    setScriptPanelVisible,
+  ]);
+
+  const handleToggleRightPanel = useCallback((panel: RightPanel) => {
+    if (activeAnalysisExtension?.placement !== 'bottom') {
+      closeActiveAnalysisExtension();
+    }
+
+    const nextBcfVisible = panel === 'bcf' ? !bcfPanelVisible : false;
+    const nextIdsVisible = panel === 'ids' ? !idsPanelVisible : false;
+    const nextLensVisible = panel === 'lens' ? !lensPanelVisible : false;
+    const nextClashVisible = panel === 'clash' ? !clashPanelVisible : false;
+    const nextCompareVisible = panel === 'compare' ? !comparePanelVisible : false;
+    const nextExtensionsVisible = panel === 'extensions' ? !extensionsPanelVisible : false;
+    const isAddElementActive = activeTool === 'addElement';
+    const nextAddElementActive = panel === 'addElement' ? !isAddElementActive : false;
+
+    setBcfPanelVisible(nextBcfVisible);
+    setIdsPanelVisible(nextIdsVisible);
+    setLensPanelVisible(nextLensVisible);
+    setClashPanelVisible(nextClashVisible);
+    setComparePanelVisible(nextCompareVisible);
+    setExtensionsPanelVisible(nextExtensionsVisible);
+    // Keep the float + window channels in sync (#1200/#1201/#1208): toggling a
+    // workspace panel from the toolbar re-docks it if it was floating or popped
+    // out, instead of leaving an orphaned floating panel or OS window.
+    if (panel !== 'addElement') {
+      useViewerStore.getState().closeFloatingPanel(panel);
+      closePanelWindow(panel);
+    }
+
+    if (panel === 'addElement') {
+      setActiveTool(nextAddElementActive ? 'addElement' : 'select');
+    } else if (isAddElementActive) {
+      setActiveTool('select');
+    }
+
+    if (nextBcfVisible || nextIdsVisible || nextLensVisible || nextClashVisible || nextCompareVisible || nextExtensionsVisible || nextAddElementActive) {
+      setRightPanelCollapsed(false);
+    }
+  }, [
+    activeAnalysisExtension?.placement,
+    activeTool,
+    bcfPanelVisible,
+    clashPanelVisible,
+    comparePanelVisible,
+    extensionsPanelVisible,
+    idsPanelVisible,
+    lensPanelVisible,
+    setActiveTool,
+    setBcfPanelVisible,
+    setClashPanelVisible,
+    setComparePanelVisible,
+    setExtensionsPanelVisible,
+    setIdsPanelVisible,
+    setLensPanelVisible,
+    setRightPanelCollapsed,
+  ]);
+
+  const handleToggleAnalysisExtension = useCallback((id: string) => {
+    const extension = analysisExtensionState.extensions.find((candidate) => candidate.id === id);
+    if (!extension) {
+      return;
+    }
+
+    if (analysisExtensionState.activeId === id) {
+      closeActiveAnalysisExtension();
+      return;
+    }
+
+    const opened = openAnalysisExtension(id);
+    if (!opened) {
+      return;
+    }
+
+    if ((extension.placement ?? 'right') === 'bottom') {
+      setScriptPanelVisible(false);
+      setListPanelVisible(false);
+      setGanttPanelVisible(false);
+      setRightPanelCollapsed(false);
+      return;
+    }
+
+    setBcfPanelVisible(false);
+    setIdsPanelVisible(false);
+    setLensPanelVisible(false);
+    setClashPanelVisible(false);
+    setExtensionsPanelVisible(false);
+    // The right slot is single-tenant: when an analysis extension takes
+    // it over, the AddElement tool must release it too, otherwise its 3D
+    // click handler keeps placing elements behind the extension panel.
+    if (activeTool === 'addElement') {
+      setActiveTool('select');
+    }
+    setRightPanelCollapsed(false);
+  }, [
+    activeTool,
+    analysisExtensionState.activeId,
+    analysisExtensionState.extensions,
+    setActiveTool,
+    setBcfPanelVisible,
+    setClashPanelVisible,
+    setExtensionsPanelVisible,
+    setGanttPanelVisible,
+    setIdsPanelVisible,
+    setLensPanelVisible,
+    setListPanelVisible,
+    setRightPanelCollapsed,
+    setScriptPanelVisible,
+  ]);
+
+  const activeWorkspacePanels = useMemo(() => {
+    const panels = new Set<WorkspacePanel>();
+    if (scriptPanelVisible) panels.add('script');
+    if (listPanelVisible) panels.add('list');
+    if (ganttPanelVisible) panels.add('gantt');
+    if (bcfPanelVisible) panels.add('bcf');
+    if (idsPanelVisible) panels.add('ids');
+    if (lensPanelVisible) panels.add('lens');
+    if (clashPanelVisible) panels.add('clash');
+    if (comparePanelVisible) panels.add('compare');
+    if (extensionsPanelVisible) panels.add('extensions');
+    if (activeTool === 'addElement') panels.add('addElement');
+    if (layersPanelVisible) panels.add('layers');
+    if (collabPanelVisible) panels.add('collab');
+    if (analysisExtensionState.activeId) panels.add(analysisExtensionState.activeId);
+    return panels;
+  }, [
+    activeTool,
+    analysisExtensionState.activeId,
+    bcfPanelVisible,
+    collabPanelVisible,
+    layersPanelVisible,
+    clashPanelVisible,
+    comparePanelVisible,
+    extensionsPanelVisible,
+    ganttPanelVisible,
+    idsPanelVisible,
+    lensPanelVisible,
+    listPanelVisible,
+    scriptPanelVisible,
+  ]);
+
+  const workspacePanelLabel = useMemo(() => {
+    if (activeWorkspacePanels.size === 0) return null;
+    if (activeWorkspacePanels.size > 1) return 'Multiple Panels';
+    if (activeWorkspacePanels.has('script')) return 'Script Editor';
+    if (activeWorkspacePanels.has('list')) return 'Lists';
+    if (activeWorkspacePanels.has('gantt')) return 'Schedule';
+    if (activeWorkspacePanels.has('bcf')) return 'BCF Issues';
+    if (activeWorkspacePanels.has('ids')) return 'IDS Validation';
+    if (activeWorkspacePanels.has('lens')) return 'Lens Rules';
+    if (activeWorkspacePanels.has('clash')) return 'Clash Detection';
+    if (activeWorkspacePanels.has('compare')) return 'Compare Models';
+    if (activeWorkspacePanels.has('extensions')) return 'Extensions';
+    if (activeWorkspacePanels.has('addElement')) return 'Add Element';
+    if (activeWorkspacePanels.has('layers')) return 'Layer Stack';
+    if (activeWorkspacePanels.has('collab')) return 'Collaboration Room';
+    return activeAnalysisExtension?.label ?? 'Analysis';
+  }, [activeAnalysisExtension?.label, activeWorkspacePanels]);
+
+  return {
+    activeWorkspacePanels,
+    workspacePanelLabel,
+    handleToggleBottomPanel,
+    handleToggleRightPanel,
+    handleToggleAnalysisExtension,
+    rightAnalysisExtensions,
+    bottomAnalysisExtensions,
+  };
+}

--- a/apps/viewer/src/store/constants.ts
+++ b/apps/viewer/src/store/constants.ts
@@ -334,7 +334,10 @@ function getInitialToolbarStyle(): ToolbarStyle {
   if (typeof window === 'undefined') return 'classic';
   try {
     return localStorage.getItem(TOOLBAR_STYLE_STORAGE_KEY) === 'ribbon' ? 'ribbon' : 'classic';
-  } catch {
+  } catch (err) {
+    // Blocked storage (Safari private mode): fall back to the default so the
+    // toolbar still renders, but say why the preference didn't stick.
+    console.warn('[toolbar-style] storage unavailable; using classic', err);
     return 'classic';
   }
 }
@@ -347,7 +350,8 @@ function getInitialRibbonCollapsed(): boolean {
   if (typeof window === 'undefined') return false;
   try {
     return localStorage.getItem(RIBBON_COLLAPSED_STORAGE_KEY) === 'true';
-  } catch {
+  } catch (err) {
+    console.warn('[ribbon-collapsed] storage unavailable; using expanded', err);
     return false;
   }
 }

--- a/apps/viewer/src/store/constants.ts
+++ b/apps/viewer/src/store/constants.ts
@@ -320,6 +320,38 @@ export function resolveLoadTessellationTier(
   return undefined;
 }
 
+/**
+ * localStorage key for the desktop toolbar style (issue #1686). `classic`
+ * is the original single-strip toolbar; `ribbon` is the tabbed,
+ * IFCFlux-style ribbon. Same sticky-preference pattern as the theme.
+ */
+export const TOOLBAR_STYLE_STORAGE_KEY = 'ifc-lite-toolbar-style';
+
+export type ToolbarStyle = 'classic' | 'ribbon';
+
+/** Resolve the initial toolbar style from localStorage; default `classic`. */
+function getInitialToolbarStyle(): ToolbarStyle {
+  if (typeof window === 'undefined') return 'classic';
+  try {
+    return localStorage.getItem(TOOLBAR_STYLE_STORAGE_KEY) === 'ribbon' ? 'ribbon' : 'classic';
+  } catch {
+    return 'classic';
+  }
+}
+
+/** localStorage key for the ribbon's collapsed state (tab strip only). */
+export const RIBBON_COLLAPSED_STORAGE_KEY = 'ifc-lite-ribbon-collapsed';
+
+/** Resolve the initial ribbon collapsed state from localStorage; default expanded. */
+function getInitialRibbonCollapsed(): boolean {
+  if (typeof window === 'undefined') return false;
+  try {
+    return localStorage.getItem(RIBBON_COLLAPSED_STORAGE_KEY) === 'true';
+  } catch {
+    return false;
+  }
+}
+
 export const UI_DEFAULTS = {
   /** Default active tool */
   ACTIVE_TOOL: 'select',
@@ -361,6 +393,14 @@ export const UI_DEFAULTS = {
    * `exact` for full display/measure/export fidelity.
    */
   GEOMETRY_MODE: getInitialGeometryMode(),
+  /**
+   * Desktop toolbar style (issue #1686): `classic` single strip or the
+   * tabbed `ribbon`. Read from localStorage on boot so the choice
+   * survives reloads.
+   */
+  TOOLBAR_STYLE: getInitialToolbarStyle(),
+  /** Ribbon band collapsed to the tab strip only. */
+  RIBBON_COLLAPSED: getInitialRibbonCollapsed(),
 } as const;
 
 // ============================================================================

--- a/apps/viewer/src/store/slices/uiSlice.toolbar-style.test.ts
+++ b/apps/viewer/src/store/slices/uiSlice.toolbar-style.test.ts
@@ -1,0 +1,167 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert';
+
+// Same in-memory localStorage shim strategy as uiSlice.merge-layers.test.ts:
+// `constants.ts` reads localStorage at import-time to seed UI_DEFAULTS, and
+// the slice's setters write back to it, so the shim must exist before the
+// first slice import.
+interface MutableStorage {
+  store: Record<string, string>;
+}
+
+const STYLE_KEY = 'ifc-lite-toolbar-style';
+const COLLAPSED_KEY = 'ifc-lite-ribbon-collapsed';
+
+function installLocalStorage(initial: Record<string, string> = {}): MutableStorage {
+  const handle: MutableStorage = { store: { ...initial } };
+  const storage = {
+    getItem: (key: string) => (key in handle.store ? handle.store[key] : null),
+    setItem: (key: string, value: string) => {
+      handle.store[key] = String(value);
+    },
+    removeItem: (key: string) => {
+      delete handle.store[key];
+    },
+    clear: () => {
+      handle.store = {};
+    },
+    key: (i: number) => Object.keys(handle.store)[i] ?? null,
+    get length() {
+      return Object.keys(handle.store).length;
+    },
+  };
+  Object.defineProperty(globalThis, 'localStorage', {
+    value: storage,
+    configurable: true,
+    writable: true,
+  });
+  Object.defineProperty(globalThis, 'window', {
+    value: globalThis,
+    configurable: true,
+    writable: true,
+  });
+  Object.defineProperty(globalThis, 'matchMedia', {
+    value: () => ({
+      matches: false,
+      media: '',
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    }),
+    configurable: true,
+    writable: true,
+  });
+  Object.defineProperty(globalThis, 'document', {
+    value: {
+      documentElement: {
+        classList: {
+          toggle: () => {},
+          add: () => {},
+          remove: () => {},
+          contains: () => false,
+        },
+      },
+    },
+    configurable: true,
+    writable: true,
+  });
+  return handle;
+}
+
+function uninstallLocalStorage(): void {
+  Reflect.deleteProperty(globalThis as Record<string, unknown>, 'localStorage');
+  Reflect.deleteProperty(globalThis as Record<string, unknown>, 'window');
+  Reflect.deleteProperty(globalThis as Record<string, unknown>, 'matchMedia');
+  Reflect.deleteProperty(globalThis as Record<string, unknown>, 'document');
+}
+
+async function buildSlice() {
+  const mod = await import('./uiSlice.js');
+  const createUISlice = (mod as { createUISlice: (...args: unknown[]) => unknown }).createUISlice;
+  let state: Record<string, unknown> = {
+    models: new Map(),
+    geometryResult: null,
+  };
+  const setState = (partial: unknown) => {
+    if (typeof partial === 'function') {
+      const updates = (partial as (s: Record<string, unknown>) => Record<string, unknown>)(state);
+      state = { ...state, ...updates };
+    } else {
+      state = { ...state, ...(partial as Record<string, unknown>) };
+    }
+  };
+  const get = () => state;
+  state = {
+    ...state,
+    ...(createUISlice as (set: unknown, get: unknown, api: unknown) => Record<string, unknown>)(setState, get, {}),
+  };
+  return {
+    get state() {
+      return state;
+    },
+  };
+}
+
+describe('UISlice — toolbar style (issue #1686)', () => {
+  let storage: MutableStorage | null = null;
+
+  beforeEach(() => {
+    storage = installLocalStorage();
+  });
+
+  afterEach(() => {
+    storage = null;
+    uninstallLocalStorage();
+  });
+
+  it('seeds toolbarStyle and ribbonCollapsed from UI_DEFAULTS', async () => {
+    // ESM modules load once per process, so the initial state mirrors
+    // whatever `UI_DEFAULTS` carried at first import — asserting the
+    // slice against the defaults table proves it never drifts from it.
+    const constantsMod = await import('../constants.js');
+    const slice = await buildSlice();
+    assert.strictEqual(slice.state.toolbarStyle, constantsMod.UI_DEFAULTS.TOOLBAR_STYLE);
+    assert.strictEqual(slice.state.ribbonCollapsed, constantsMod.UI_DEFAULTS.RIBBON_COLLAPSED);
+  });
+
+  it('setToolbarStyle switches the style and persists it', async () => {
+    const slice = await buildSlice();
+    (slice.state.setToolbarStyle as (v: string) => void)('ribbon');
+    assert.strictEqual(slice.state.toolbarStyle, 'ribbon');
+    assert.strictEqual(storage!.store[STYLE_KEY], 'ribbon');
+
+    (slice.state.setToolbarStyle as (v: string) => void)('classic');
+    assert.strictEqual(slice.state.toolbarStyle, 'classic');
+    assert.strictEqual(storage!.store[STYLE_KEY], 'classic');
+  });
+
+  it('setRibbonCollapsed flips and persists the collapsed flag', async () => {
+    const slice = await buildSlice();
+    (slice.state.setRibbonCollapsed as (v: boolean) => void)(true);
+    assert.strictEqual(slice.state.ribbonCollapsed, true);
+    assert.strictEqual(storage!.store[COLLAPSED_KEY], 'true');
+
+    (slice.state.setRibbonCollapsed as (v: boolean) => void)(false);
+    assert.strictEqual(slice.state.ribbonCollapsed, false);
+    assert.strictEqual(storage!.store[COLLAPSED_KEY], 'false');
+  });
+
+  it('survives a locked localStorage (Safari private mode)', async () => {
+    const slice = await buildSlice();
+    // Simulate storage.setItem throwing after construction.
+    (globalThis.localStorage as unknown as { setItem: () => void }).setItem = () => {
+      throw new Error('QuotaExceededError');
+    };
+    (slice.state.setToolbarStyle as (v: string) => void)('ribbon');
+    assert.strictEqual(slice.state.toolbarStyle, 'ribbon');
+    (slice.state.setRibbonCollapsed as (v: boolean) => void)(true);
+    assert.strictEqual(slice.state.ribbonCollapsed, true);
+  });
+});

--- a/apps/viewer/src/store/slices/uiSlice.ts
+++ b/apps/viewer/src/store/slices/uiSlice.ts
@@ -7,7 +7,15 @@
  */
 
 import type { StateCreator } from 'zustand';
-import { MERGE_LAYERS_STORAGE_KEY, GEOMETRY_MODE_STORAGE_KEY, UI_DEFAULTS, type GeometryMode } from '../constants.js';
+import {
+  MERGE_LAYERS_STORAGE_KEY,
+  GEOMETRY_MODE_STORAGE_KEY,
+  TOOLBAR_STYLE_STORAGE_KEY,
+  RIBBON_COLLAPSED_STORAGE_KEY,
+  UI_DEFAULTS,
+  type GeometryMode,
+  type ToolbarStyle,
+} from '../constants.js';
 import type { ContactShadingQuality, SeparationLinesQuality } from '@ifc-lite/renderer';
 import type { FederatedModel } from '../types.js';
 import type { GeometryResult } from '@ifc-lite/geometry';
@@ -116,6 +124,14 @@ export interface UISlice {
   geometryMode: GeometryMode;
   /** True after the user flipped `geometryMode` while a model was loaded. */
   geometryModePendingReload: boolean;
+  /**
+   * Desktop toolbar style (issue #1686): the original `classic` strip
+   * or the tabbed, IFCFlux-style `ribbon`. Persisted preference — the
+   * mobile toolbar is orthogonal (`isMobile` wins on small screens).
+   */
+  toolbarStyle: ToolbarStyle;
+  /** Ribbon collapsed to its tab strip (Office-style double-click). */
+  ribbonCollapsed: boolean;
 
   // Actions
   setLeftPanelCollapsed: (collapsed: boolean) => void;
@@ -150,6 +166,10 @@ export interface UISlice {
   setGeometryMode: (v: GeometryMode) => void;
   /** Acknowledge the geometry-mode reload banner without performing a reload. */
   clearGeometryModePendingReload: () => void;
+  /** Switch the desktop toolbar style and persist the choice. */
+  setToolbarStyle: (style: ToolbarStyle) => void;
+  /** Collapse/expand the ribbon band and persist the choice. */
+  setRibbonCollapsed: (collapsed: boolean) => void;
 }
 
 /** Apply the correct CSS classes on <html> for the given theme */
@@ -195,6 +215,8 @@ export const createUISlice: StateCreator<UISlice & UICrossSliceState, [], [], UI
   mergeLayersPendingReload: false,
   geometryMode: UI_DEFAULTS.GEOMETRY_MODE,
   geometryModePendingReload: false,
+  toolbarStyle: UI_DEFAULTS.TOOLBAR_STYLE,
+  ribbonCollapsed: UI_DEFAULTS.RIBBON_COLLAPSED,
 
   // Actions
   setLeftPanelCollapsed: (leftPanelCollapsed) => set({ leftPanelCollapsed }),
@@ -340,4 +362,25 @@ export const createUISlice: StateCreator<UISlice & UICrossSliceState, [], [], UI
   },
 
   clearGeometryModePendingReload: () => set({ geometryModePendingReload: false }),
+
+  setToolbarStyle: (toolbarStyle) => {
+    // Persist eagerly so the next page-load boots straight into the chosen
+    // style (constants.ts `getInitialToolbarStyle`). Wrap in try/catch —
+    // Safari private mode / locked storage throws.
+    try {
+      localStorage.setItem(TOOLBAR_STYLE_STORAGE_KEY, toolbarStyle);
+    } catch (err) {
+      console.warn('[toolbar-style] persist failed; in-memory only', err);
+    }
+    set({ toolbarStyle });
+  },
+
+  setRibbonCollapsed: (ribbonCollapsed) => {
+    try {
+      localStorage.setItem(RIBBON_COLLAPSED_STORAGE_KEY, String(ribbonCollapsed));
+    } catch (err) {
+      console.warn('[ribbon-collapsed] persist failed; in-memory only', err);
+    }
+    set({ ribbonCollapsed });
+  },
 });


### PR DESCRIPTION
## Summary

Adds an Office/IFCFlux-style **ribbon toolbar** to the viewer as a user-selectable alternative to the classic single-strip toolbar (part of #1686, item 5: editable toolbar zone).

- **Five tabs** - File / Home / View / Analyze / Author - with labeled command groups (Model, Export, Tools, Measure & Mark, Selection, Scene, Camera, Visibility, Context, Interface, Edit, Create, Properties, Customize).
- **Shared command hooks** (`useFileCommands`, `useExportCommands`, `useWorkspacePanelControls`, `ClassVisibilityMenu`) extracted from `MainToolbar` (-838 lines) so classic and ribbon drive the exact same handlers and can never fork behaviour.
- **Persisted preference**: `uiSlice.toolbarStyle` (`classic` | `ribbon`), sticky via localStorage, same pattern as the theme. Toggle lives in the classic toolbar's View options menu ('Ribbon toolbar' checkbox) and in the ribbon's View tab ('Classic bar' button).
- **Office conventions**: double-click the active tab (or the chevron) collapses the band to the tab strip; collapsed state persists; clicking a tab while collapsed reopens the band. Loading progress, errors, search, extension slot, and Export Changes live in the tab strip so they survive collapse.
- Mobile is unaffected (`MobileToolbar` still wins on small screens).

Also fixes the empty-state welcome card getting clipped on short viewports (flex `justify-center` inside `overflow-auto` clips the top beyond scroll reach) and drops the decorative Select/Filter/Analyze feature grid that pushed the card off-screen.

## Verification

- `tsc --noEmit` clean; full viewer suite **1696 pass / 0 fail** (incl. new `uiSlice.toolbar-style.test.ts`: persistence, default, locked-localStorage fallback).
- Exercised live on localhost with a model loaded: all five tabs render and execute (Measure activates the tool, Clash detection opens the panel, exports enumerate); collapse/expand + persistence verified; classic <-> ribbon round-trip via both real UI paths; console clean.

Part of #1686.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable desktop ribbon toolbar with tabbed sections (File, View, Analyze, Author) for common workflows.
  * Added persistent toolbar style (classic vs ribbon) and ribbon collapsed/expanded preference.
  * Enhanced toolbar controls for model loading/refresh, export, class visibility, and workspace panel toggling.
  * Improved empty-state layout and removed the welcome feature-card grid.

* **Bug Fixes**
  * Toolbar preferences continue working when browser storage is unavailable.
  * Ribbon/tab and collapsed behavior stays consistent when switching tools and panels.
  * Undo/Redo now respects edit permissions more reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->