### PR TITLE
perf(kernel): u32-digit FixedInt multiply on wasm32 (-20-31% wasm geometry, byte-identical)

### DIFF
--- a/.changeset/wasm-u32-digit-mul.md
+++ b/.changeset/wasm-u32-digit-mul.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/wasm": patch
+---
+
+Cut wasm exact-CSG geometry time 20-31% (measured on five CSG-heavy models, byte-identical output). wasm32 has no native 128-bit multiply, so the FixedInt exact-predicate tier's u64-limb schoolbook multiplies lowered every partial product to a `__multi3` libcall; the kernel now dispatches to a u32-digit schoolbook on wasm32 (`u32*u32->u64` = one `i64.mul`). Native builds keep the u64/u128 path verbatim. Both digit widths are pinned bit-identical by a new differential fuzz across all supported widths.

--- a/rust/geometry/src/kernel/fixed_int/mod.rs
+++ b/rust/geometry/src/kernel/fixed_int/mod.rs
@@ -43,6 +43,9 @@ use num_traits::{
     CheckedAdd, CheckedMul, CheckedSub, FromPrimitive, Num, One, Signed, ToPrimitive, Zero,
 };
 
+mod mul;
+use mul::{mul_full, mul_low};
+
 /// Little-endian, two's-complement fixed-width signed integer with `K` u64
 /// limbs (`self.0[0]` is the least-significant limb; the sign bit is bit 63 of
 /// `self.0[K-1]`). Instantiated at K ∈ {4, 8, 16, 32} = I256/I512/I1024/I2048.
@@ -129,26 +132,6 @@ fn magnitude<const K: usize>(a: &FixedInt<K>) -> ([u64; K], bool) {
     }
 }
 
-/// Low `K` limbs of the unsigned product `a * b` (mod 2^(K*64)). Exact for the
-/// low limbs because a partial product `a[i]*b[j]` with `i+j >= K` is a multiple
-/// of `2^(K*64)` and any carry off limb `K-1` lands at bit `>= K*64`, so both
-/// are `0 mod 2^(K*64)` and may be dropped.
-#[inline]
-fn mul_low<const K: usize>(a: &[u64; K], b: &[u64; K]) -> [u64; K] {
-    let mut out = [0u64; K];
-    for i in 0..K {
-        let mut carry: u128 = 0;
-        let mut j = 0;
-        while i + j < K {
-            let idx = i + j;
-            let t = (a[i] as u128) * (b[j] as u128) + (out[idx] as u128) + carry;
-            out[idx] = t as u64;
-            carry = t >> 64;
-            j += 1;
-        }
-    }
-    out
-}
 
 /// Wrapping two's-complement limb addition (drops the final carry). Kept a free
 /// function so the carry-combine `|` stays out of the `Add` trait impl, where
@@ -250,16 +233,7 @@ fn checked_mul_limbs<const K: usize>(a: &FixedInt<K>, b: &FixedInt<K>) -> Option
     debug_assert!(K <= 32, "FixedInt checked_mul scratch supports only K <= 32");
     let n2 = 2 * K;
     let mut full = [0u64; 64];
-    for i in 0..K {
-        let mut carry: u128 = 0;
-        for j in 0..K {
-            let idx = i + j;
-            let t = (ma[i] as u128) * (mb[j] as u128) + (full[idx] as u128) + carry;
-            full[idx] = t as u64;
-            carry = t >> 64;
-        }
-        full[i + K] = carry as u64;
-    }
+    mul_full(&ma, &mb, &mut full);
     if neg {
         // Two's-complement negate over the low n2 limbs in place.
         let mut c = 1u64;

--- a/rust/geometry/src/kernel/fixed_int/mul.rs
+++ b/rust/geometry/src/kernel/fixed_int/mul.rs
@@ -1,0 +1,152 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Schoolbook limb multiplication for [`super::FixedInt`], with digit-width
+//! dispatch: native uses u64 limbs (u64*u64→u128 is one `mulx`-class op);
+//! wasm32 uses u32 digits, because wasm32 has no native 128-bit multiply and
+//! every `(u64 as u128) * (u64 as u128)` partial product lowers to a
+//! `__multi3` libcall there. The u32-digit schoolbook does up to 4x the
+//! partial products, but each is a single `i64.mul` — the same trade upstream
+//! bnum#74 makes. The product mod 2^(K*64) is digit-width independent, so
+//! both paths are bit-identical; `super::tests::digit_width_*` pins that per
+//! width, and the bnum differential fuzz pins the dispatching callers.
+
+/// Low `K` limbs of the unsigned product `a * b` (mod 2^(K*64)). Exact for the
+/// low limbs because a partial product `a[i]*b[j]` with `i+j >= K` is a multiple
+/// of `2^(K*64)` and any carry off limb `K-1` lands at bit `>= K*64`, so both
+/// are `0 mod 2^(K*64)` and may be dropped.
+#[inline]
+pub(super) fn mul_low<const K: usize>(a: &[u64; K], b: &[u64; K]) -> [u64; K] {
+    #[cfg(target_arch = "wasm32")]
+    {
+        mul_low_u32(a, b)
+    }
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        mul_low_u64(a, b)
+    }
+}
+
+/// u64-limb schoolbook low product.
+#[inline]
+#[cfg_attr(target_arch = "wasm32", allow(dead_code))]
+pub(super) fn mul_low_u64<const K: usize>(a: &[u64; K], b: &[u64; K]) -> [u64; K] {
+    let mut out = [0u64; K];
+    for i in 0..K {
+        let mut carry: u128 = 0;
+        let mut j = 0;
+        while i + j < K {
+            let idx = i + j;
+            let t = (a[i] as u128) * (b[j] as u128) + (out[idx] as u128) + carry;
+            out[idx] = t as u64;
+            carry = t >> 64;
+            j += 1;
+        }
+    }
+    out
+}
+
+/// u32-digit schoolbook low product (wasm32: u32*u32→u64 is one `i64.mul`).
+/// All-zero digits are skipped — a zero partial-product row adds nothing, so
+/// the result is unchanged; on narrow magnitudes (the common case in the
+/// predicate cascade) it also erases most of the 4x digit-count overhead.
+#[inline]
+#[cfg_attr(not(target_arch = "wasm32"), allow(dead_code))]
+pub(super) fn mul_low_u32<const K: usize>(a: &[u64; K], b: &[u64; K]) -> [u64; K] {
+    debug_assert!(K <= 32, "FixedInt u32-digit scratch supports only K <= 32");
+    let n = 2 * K;
+    let mut ad = [0u32; 64];
+    let mut bd = [0u32; 64];
+    for i in 0..K {
+        ad[2 * i] = a[i] as u32;
+        ad[2 * i + 1] = (a[i] >> 32) as u32;
+        bd[2 * i] = b[i] as u32;
+        bd[2 * i + 1] = (b[i] >> 32) as u32;
+    }
+    let mut out = [0u32; 64];
+    for i in 0..n {
+        let d = ad[i] as u64;
+        if d == 0 {
+            continue;
+        }
+        let mut carry: u64 = 0;
+        let mut j = 0;
+        while i + j < n {
+            let idx = i + j;
+            let t = d * (bd[j] as u64) + (out[idx] as u64) + carry;
+            out[idx] = t as u32;
+            carry = t >> 32;
+            j += 1;
+        }
+    }
+    let mut res = [0u64; K];
+    for i in 0..K {
+        res[i] = (out[2 * i] as u64) | ((out[2 * i + 1] as u64) << 32);
+    }
+    res
+}
+
+/// Full 2K-limb unsigned magnitude product into `full[..2K]` (same digit-width
+/// dispatch rationale as [`mul_low`]).
+#[inline]
+pub(super) fn mul_full<const K: usize>(ma: &[u64; K], mb: &[u64; K], full: &mut [u64; 64]) {
+    #[cfg(target_arch = "wasm32")]
+    {
+        mul_full_u32(ma, mb, full)
+    }
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        mul_full_u64(ma, mb, full)
+    }
+}
+
+/// u64-limb schoolbook full product.
+#[inline]
+#[cfg_attr(target_arch = "wasm32", allow(dead_code))]
+pub(super) fn mul_full_u64<const K: usize>(ma: &[u64; K], mb: &[u64; K], full: &mut [u64; 64]) {
+    for i in 0..K {
+        let mut carry: u128 = 0;
+        for j in 0..K {
+            let idx = i + j;
+            let t = (ma[i] as u128) * (mb[j] as u128) + (full[idx] as u128) + carry;
+            full[idx] = t as u64;
+            carry = t >> 64;
+        }
+        full[i + K] = carry as u64;
+    }
+}
+
+/// u32-digit schoolbook full product (wasm32; see [`mul_low_u32`]).
+#[inline]
+#[cfg_attr(not(target_arch = "wasm32"), allow(dead_code))]
+pub(super) fn mul_full_u32<const K: usize>(ma: &[u64; K], mb: &[u64; K], full: &mut [u64; 64]) {
+    debug_assert!(K <= 32, "FixedInt u32-digit scratch supports only K <= 32");
+    let n = 2 * K;
+    let mut ad = [0u32; 64];
+    let mut bd = [0u32; 64];
+    for i in 0..K {
+        ad[2 * i] = ma[i] as u32;
+        ad[2 * i + 1] = (ma[i] >> 32) as u32;
+        bd[2 * i] = mb[i] as u32;
+        bd[2 * i + 1] = (mb[i] >> 32) as u32;
+    }
+    let mut out = [0u32; 128];
+    for i in 0..n {
+        let d = ad[i] as u64;
+        if d == 0 {
+            continue;
+        }
+        let mut carry: u64 = 0;
+        for j in 0..n {
+            let idx = i + j;
+            let t = d * (bd[j] as u64) + (out[idx] as u64) + carry;
+            out[idx] = t as u32;
+            carry = t >> 32;
+        }
+        out[i + n] = carry as u32;
+    }
+    for (i, slot) in full.iter_mut().enumerate().take(n) {
+        *slot = (out[2 * i] as u64) | ((out[2 * i + 1] as u64) << 32);
+    }
+}

--- a/rust/geometry/src/kernel/fixed_int/mul.rs
+++ b/rust/geometry/src/kernel/fixed_int/mul.rs
@@ -89,8 +89,18 @@ pub(super) fn mul_low_u32<const K: usize>(a: &[u64; K], b: &[u64; K]) -> [u64; K
 
 /// Full 2K-limb unsigned magnitude product into `full[..2K]` (same digit-width
 /// dispatch rationale as [`mul_low`]).
+///
+/// PRECONDITION: `full[..2K]` must be zero on entry (debug-asserted). The u64
+/// path folds `full[idx]` into its partial products (schoolbook accumulate)
+/// while the u32 path computes into local scratch and writes back, so on a
+/// dirty buffer the two digit widths would silently diverge — exactly the
+/// bit-identity this module promises. The sole caller passes a fresh array.
 #[inline]
 pub(super) fn mul_full<const K: usize>(ma: &[u64; K], mb: &[u64; K], full: &mut [u64; 64]) {
+    debug_assert!(
+        full[..2 * K].iter().all(|&limb| limb == 0),
+        "mul_full requires a zeroed output buffer (digit paths diverge on dirty input)"
+    );
     #[cfg(target_arch = "wasm32")]
     {
         mul_full_u32(ma, mb, full)
@@ -117,7 +127,8 @@ pub(super) fn mul_full_u64<const K: usize>(ma: &[u64; K], mb: &[u64; K], full: &
     }
 }
 
-/// u32-digit schoolbook full product (wasm32; see [`mul_low_u32`]).
+/// u32-digit schoolbook full product (wasm32; see [`mul_low_u32`]). Requires
+/// the zeroed buffer [`mul_full`] asserts.
 #[inline]
 #[cfg_attr(not(target_arch = "wasm32"), allow(dead_code))]
 pub(super) fn mul_full_u32<const K: usize>(ma: &[u64; K], mb: &[u64; K], full: &mut [u64; 64]) {

--- a/rust/geometry/src/kernel/fixed_int/tests.rs
+++ b/rust/geometry/src/kernel/fixed_int/tests.rs
@@ -7,6 +7,7 @@
 //! `Some`/`None` overflow verdict across all four widths, boundary values, and
 //! a deterministic LCG stream. See the module doc in `mod.rs` for why.
 
+use super::mul::{mul_full_u32, mul_full_u64, mul_low_u32, mul_low_u64};
 use super::*;
 use num_traits::{CheckedAdd, CheckedMul, CheckedSub, FromPrimitive, One, ToPrimitive};
 
@@ -278,3 +279,81 @@ fn checked_mul_min_boundary() {
     // Positive 2^255 must overflow.
     assert_eq!(CheckedMul::checked_mul(&two128, &two127), None);
 }
+
+/// The wasm32 build multiplies with u32 digits (`mul_low_u32` / `mul_full_u32`,
+/// avoiding `__multi3` libcalls); native uses u64 limbs. Cargo tests run on the
+/// host, so the wasm digit path would otherwise be unexercised — pin both digit
+/// widths to bit-identical outputs on boundary and random limb patterns for
+/// every supported width. Raw (not magnitude) patterns are included because the
+/// wrapping `Mul` impl feeds two's-complement limbs to `mul_low` directly.
+macro_rules! digit_width_fuzz {
+    ($name:ident, $K:literal) => {
+        #[test]
+        fn $name() {
+            let mut patterns: Vec<[u64; $K]> = vec![[0u64; $K], [u64::MAX; $K]];
+            // Single-bit walk (stride 7 hits every limb + misaligned bits).
+            for bit in (0..$K * 64).step_by(7) {
+                let mut l = [0u64; $K];
+                l[bit / 64] = 1u64 << (bit % 64);
+                patterns.push(l);
+            }
+            // Dense all-ones prefixes/suffixes (worst-case carry chains).
+            for k in 0..$K {
+                let mut lo = [0u64; $K];
+                for slot in lo.iter_mut().take(k + 1) {
+                    *slot = u64::MAX;
+                }
+                patterns.push(lo);
+                let mut hi = [0u64; $K];
+                for slot in hi.iter_mut().skip($K - 1 - k) {
+                    *slot = u64::MAX;
+                }
+                patterns.push(hi);
+            }
+            // Random limbs at random bit-lengths (varied zero-digit skips).
+            let mut rng = Lcg(0xabcd_ef01_2345_6789 ^ ($K as u64));
+            for _ in 0..1_500 {
+                let mut l = [0u64; $K];
+                for slot in l.iter_mut() {
+                    *slot = rng.u();
+                }
+                let cut = (rng.u() as usize) % ($K * 64 + 1);
+                for i in 0..$K {
+                    let lo = i * 64;
+                    if lo >= cut {
+                        l[i] = 0;
+                    } else if lo + 64 > cut {
+                        l[i] &= (1u64 << (cut - lo)) - 1;
+                    }
+                }
+                patterns.push(l);
+            }
+
+            for a in &patterns {
+                for b in patterns.iter().take(48) {
+                    assert_eq!(
+                        mul_low_u32(a, b),
+                        mul_low_u64(a, b),
+                        "mul_low digit-width mismatch a={:?} b={:?}",
+                        a,
+                        b
+                    );
+                    let mut full32 = [0u64; 64];
+                    let mut full64 = [0u64; 64];
+                    mul_full_u32(a, b, &mut full32);
+                    mul_full_u64(a, b, &mut full64);
+                    assert_eq!(
+                        full32, full64,
+                        "mul_full digit-width mismatch a={:?} b={:?}",
+                        a, b
+                    );
+                }
+            }
+        }
+    };
+}
+
+digit_width_fuzz!(digit_width_i256, 4);
+digit_width_fuzz!(digit_width_i512, 8);
+digit_width_fuzz!(digit_width_i1024, 16);
+digit_width_fuzz!(digit_width_i2048, 32);


### PR DESCRIPTION
## What

wasm32 has no native 128-bit multiply, so every `(u64 as u128) * (u64 as u128)` partial product in `FixedInt`'s schoolbook loops lowers to a `__multi3` libcall. Since #1655 moved the exact-predicate tier off bnum onto `FixedInt`, those two loops (`mul_low` fast-accept + the ambiguous-band full product) are the wasm CSG hot path: `checked_mul_limbs` is 25.6% self-time in the native flame, multiplied by the libcall tax under wasm.

This adds digit-width dispatch in a new `kernel/fixed_int/mul.rs` (module-size ratchet stays green):
- **native**: the u64/u128 loops, verbatim — zero change to native codegen paths.
- **wasm32**: u32-digit schoolbook (`u32*u32->u64` = one `i64.mul`) with zero-digit row skipping — the same trade as upstream [bnum#74](https://github.com/isaacholt100/bnum/pull/74).

The product mod 2^(K*64) is digit-width independent, so both paths are bit-identical.

## Measured

Node V8, single-threaded `buildPrePassOnce` + one `processGeometryBatch` over all jobs, interleaved best-of-3, fresh process per run. FNV-1a over all mesh positions+indices **identical baseline vs patched on every model**:

| model | baseline | patched | delta |
|---|---:|---:|---:|
| ISSUE_159 (9.5MB) | 1795 ms | 1232 ms | **-31.4%** |
| dental_clinic (13MB) | 756 ms | 594 ms | **-21.4%** |
| FM_ARC_DigitalHub (14MB) | 1465 ms | 1164 ms | **-20.5%** |
| ISSUE_129 (12MB) | 7490 ms | 5727 ms | **-23.5%** |
| 170_KM_tekla (20MB) | 26138 ms | 18769 ms | **-28.2%** |

This lands directly in the browser geometry stream (browser total ≈ stream complete on CSG-heavy loads).

## Verification

- New `digit_width_i256/512/1024/2048` differential fuzz: u32 vs u64 paths over boundary values, dense carry chains, and random bit-length corpus (both `mul_low` and `mul_full`).
- Existing FixedInt-vs-bnum differential fuzz (all widths) green.
- `mesh_determinism` pinned manifests byte-identical; full `ifc-lite-geometry` suite 598/598; clippy clean; module-size ratchet 4/4.

## Notes

- The bnum#74 `[patch.crates-io]` route was built and measured first: **flat** (0% across the same corpus) — bnum is cold post-#1655 (only Div/Rem/to_f64 delegation). Dropped in favour of this in-kernel fix.
- Changeset: `@ifc-lite/wasm` patch.