### PR TITLE
perf(geometry): zero-copy sharded index delivery + drop the per-mesh re-map

### DIFF
--- a/.changeset/stream-zero-copy-index.md
+++ b/.changeset/stream-zero-copy-index.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/geometry": patch
+---
+
+Cold-load main-thread work reduction in the parallel geometry stream: the sharded pre-pass now stitches the entity-index columns directly into exact-size SharedArrayBuffer-backed storage (two-phase stitch), so index delivery to the geometry workers, the parser worker, and the sharded pre-pass is zero-copy instead of three full-column copies on the critical path that gates job dispatch. The worker batch handler also stops re-allocating a wrapper object per mesh (~110k per large load) and passes the structured-clone mesh objects straight through. Render parity is exact (verified mesh-count identical on 177MB and 883MB models).

--- a/docs/architecture/wasm-wide-arithmetic.md
+++ b/docs/architecture/wasm-wide-arithmetic.md
@@ -70,6 +70,16 @@ Shipping it to browser users is blocked on TWO upstream items, both confirmed he
    module (`WebAssembly.validate()` -> false, "invalid numeric opcode 0xfc13");
    stable Chrome/Safari are not expected to differ today.
 
+**Status re-check (2026-07-16):** blocker 1 is CLEARED upstream — `walrus`
+merged wide-arith parsing (wasm-bindgen/walrus#306, released in walrus 0.26.0,
+2026-03-25) and current `wasm-bindgen` 0.2.126 depends on walrus 0.26.1, so
+bumping our pinned `=0.2.106` would let `pkg-wide` build. Blocker 2 still
+stands: V8 has the implementation but behind
+`--experimental-wasm-wide-arithmetic` (default **off**, pre-staged tier in
+`wasm-feature-flags.h`); no stable browser ships it. Verdict unchanged:
+track-and-adopt — do NOT pay a wasm-bindgen major-pin bump for a bundle no
+browser can run; re-check when V8 stages/ships the flag on by default.
+
 Net: the lever is proven and worth tracking, but **not shippable now**. The plan
 below is the design to wire once BOTH clear. The runtime feature-detect makes it
 a safe, zero-cost no-op for every user until then — the wide `.wasm` is never

--- a/packages/geometry/src/geometry-parallel.ts
+++ b/packages/geometry/src/geometry-parallel.ts
@@ -131,31 +131,20 @@ interface ShardColumns {
  */
 function stitchShards(shards: ShardColumns[]): { ids: Uint32Array; starts: Uint32Array; lengths: Uint32Array; classes: Uint8Array } | null {
   const n = shards.length;
-  // Total upper bound = sum of shard record counts (validated slices are a subset).
-  let cap = 0;
-  for (const s of shards) cap += s.ids.length;
-  const outIds = new Uint32Array(cap);
-  const outStarts = new Uint32Array(cap);
-  const outLengths = new Uint32Array(cap);
-  const outClasses = new Uint8Array(cap);
-  let w = 0;
 
-  // Shard 0: authoritative, take every record.
-  {
-    const s = shards[0];
-    outIds.set(s.ids, w);
-    outStarts.set(s.starts, w);
-    outLengths.set(s.lengths, w);
-    outClasses.set(s.classes, w);
-    w += s.ids.length;
-  }
+  // Phase 1 — locate each shard's validated slice (binary-search the previous
+  // shard's handoff) WITHOUT copying, so the output size is exact before any
+  // allocation. Exactness matters: the id/start/length columns are allocated
+  // SAB-backed below and handed to every worker as full-buffer views, so a
+  // cap-sized buffer would let consumers read past the last real record.
+  const sliceFrom = new Array<number>(n).fill(0);
+  let used = 1;
+  let w = shards[0].ids.length; // shard 0 is authoritative, take every record
   let expectedStart = shards[0].handoff; // -1 => no more real entities
-
   for (let i = 1; i < n; i++) {
     if (expectedStart < 0) break;
-    const s = shards[i];
     // starts is strictly increasing → binary-search for expectedStart.
-    const starts = s.starts;
+    const starts = shards[i].starts;
     let lo = 0;
     let hi = starts.length - 1;
     let p = -1;
@@ -170,21 +159,38 @@ function stitchShards(shards: ShardColumns[]): { ids: Uint32Array; starts: Uint3
       // Handoff not present in this shard — fallback path (not implemented here).
       return null;
     }
-    const take = starts.length - p;
-    outIds.set(s.ids.subarray(p), w);
-    outStarts.set(s.starts.subarray(p), w);
-    outLengths.set(s.lengths.subarray(p), w);
-    outClasses.set(s.classes.subarray(p), w);
-    w += take;
-    expectedStart = s.handoff;
+    sliceFrom[i] = p;
+    w += starts.length - p;
+    expectedStart = shards[i].handoff;
+    used = i + 1;
   }
 
-  return {
-    ids: outIds.subarray(0, w),
-    starts: outStarts.subarray(0, w),
-    lengths: outLengths.subarray(0, w),
-    classes: outClasses.subarray(0, w),
-  };
+  // Phase 2 — single concatenation copy, straight into SharedArrayBuffer-backed
+  // columns. The stitched index used to be copied THREE times per column on the
+  // main thread (cap-array stitch → `.slice()` to contiguous → `.set()` into
+  // fresh SABs in deliverEntityIndex); writing the stitch output into SABs
+  // directly makes index delivery zero-copy (~450 MB of critical-path memcpy
+  // saved on a 19M-entity file). `classes` stays plain: its only consumer past
+  // the span-extraction loop is the pre-pass worker, which takes it by transfer.
+  const sabAvailable = typeof SharedArrayBuffer !== 'undefined';
+  const u32Column = (len: number) =>
+    new Uint32Array(sabAvailable ? new SharedArrayBuffer(len * 4) : new ArrayBuffer(len * 4));
+  const outIds = u32Column(w);
+  const outStarts = u32Column(w);
+  const outLengths = u32Column(w);
+  const outClasses = new Uint8Array(w);
+  let o = 0;
+  for (let i = 0; i < used; i++) {
+    const s = shards[i];
+    const p = sliceFrom[i];
+    outIds.set(p === 0 ? s.ids : s.ids.subarray(p), o);
+    outStarts.set(p === 0 ? s.starts : s.starts.subarray(p), o);
+    outLengths.set(p === 0 ? s.lengths : s.lengths.subarray(p), o);
+    outClasses.set(p === 0 ? s.classes : s.classes.subarray(p), o);
+    o += s.ids.length - p;
+  }
+
+  return { ids: outIds, starts: outStarts, lengths: outLengths, classes: outClasses };
 }
 
 interface PrepassMeta {
@@ -509,49 +515,13 @@ export async function* processParallel(
           firstBatchByWorker[workerIndex] = elapsed();
           console.log(`[stream] worker[${workerIndex}] first batch @ ${elapsed()}ms (${msg.meshes?.length ?? 0} meshes)`);
         }
-        const meshes: MeshData[] = msg.meshes.map((m: {
-          expressId: number;
-          ifcType?: string;
-          positions: Float32Array;
-          normals: Float32Array;
-          indices: Uint32Array;
-          color: [number, number, number, number];
-          shadingColor?: [number, number, number, number];
-          // #961: optional per-vertex UVs + decoded surface texture.
-          uvs?: MeshData['uvs'];
-          texture?: MeshData['texture'];
-          geometryHash?: bigint;
-          geometryClass?: number;
-          origin?: [number, number, number];
-          localBounds?: MeshData['localBounds'];
-          localToWorld?: MeshData['localToWorld'];
-        }) => ({
-          expressId: m.expressId,
-          ifcType: m.ifcType,
-          positions: m.positions instanceof Float32Array ? m.positions : new Float32Array(m.positions),
-          normals: m.normals instanceof Float32Array ? m.normals : new Float32Array(m.normals),
-          indices: m.indices instanceof Uint32Array ? m.indices : new Uint32Array(m.indices),
-          color: m.color,
-          // SurfaceColour for GLB "Shading" export (worker parity fix).
-          ...(m.shadingColor ? { shadingColor: m.shadingColor } : {}),
-          // #961: carry per-vertex UVs + decoded surface texture through to the
-          // renderer (transferables; already typed arrays from the worker).
-          ...(m.uvs ? { uvs: m.uvs } : {}),
-          ...(m.texture ? { texture: m.texture } : {}),
-          // Carry the model-diff fingerprint through the worker boundary
-          // (issue #924); undefined when hashing is off.
-          ...(m.geometryHash !== undefined ? { geometryHash: m.geometryHash } : {}),
-          // #957 follow-up: carry the Model/Types geometry class through the
-          // worker→main re-map (else the viewer's view-mode filter sees only
-          // class 0 and the Types view renders nothing).
-          ...(m.geometryClass !== undefined ? { geometryClass: m.geometryClass } : {}),
-          // Per-element local-frame origin (world = origin + position); the
-          // renderer reconstructs world via a per-batch model-matrix translate.
-          ...(m.origin ? { origin: m.origin } : {}),
-          // Local (pre-placement) AABB + placement transform (issue #1474).
-          ...(m.localBounds ? { localBounds: m.localBounds } : {}),
-          ...(m.localToWorld ? { localToWorld: m.localToWorld } : {}),
-        }));
+        // The worker already emits `MeshData`-shaped objects (see the worker's
+        // `meshData` construction: typed arrays ride the transfer list, optional
+        // fields are conditionally spread there). Structured clone preserves
+        // typed-array types, so re-mapping every mesh here only re-allocated
+        // ~one wrapper object per mesh (~110k per large load) on the main
+        // thread. Pass the transferred objects straight through.
+        const meshes: MeshData[] = msg.meshes as MeshData[];
         // GPU-instancing: per-batch IFNS shards ride alongside the flat meshes.
         // Opaque repeated occurrences render ONLY via these shards (taken off the
         // flat `meshes` array), so their count must be folded into the running
@@ -908,12 +878,29 @@ export async function* processParallel(
   ) => {
     console.log(`[stream] entity-index (${source}) @ ${elapsed()}ms (${ids.length} entries)`);
     if (typeof SharedArrayBuffer !== 'undefined') {
-      const sabIds = new SharedArrayBuffer(ids.byteLength);
-      const sabStarts = new SharedArrayBuffer(starts.byteLength);
-      const sabLengths = new SharedArrayBuffer(lengths.byteLength);
-      new Uint32Array(sabIds).set(ids);
-      new Uint32Array(sabStarts).set(starts);
-      new Uint32Array(sabLengths).set(lengths);
+      // Sharded-stitch columns arrive already SAB-backed (stitchShards writes
+      // its exact-size output into SABs) — share them as-is. The serial
+      // pre-pass path still hands over plain transferred buffers, which need
+      // the one copy into SABs to be shareable with every worker.
+      let sabIds: SharedArrayBuffer;
+      let sabStarts: SharedArrayBuffer;
+      let sabLengths: SharedArrayBuffer;
+      if (
+        ids.buffer instanceof SharedArrayBuffer &&
+        starts.buffer instanceof SharedArrayBuffer &&
+        lengths.buffer instanceof SharedArrayBuffer
+      ) {
+        sabIds = ids.buffer;
+        sabStarts = starts.buffer;
+        sabLengths = lengths.buffer;
+      } else {
+        sabIds = new SharedArrayBuffer(ids.byteLength);
+        sabStarts = new SharedArrayBuffer(starts.byteLength);
+        sabLengths = new SharedArrayBuffer(lengths.byteLength);
+        new Uint32Array(sabIds).set(ids);
+        new Uint32Array(sabStarts).set(starts);
+        new Uint32Array(sabLengths).set(lengths);
+      }
       for (const w of workers) {
         try {
           w.postMessage({
@@ -977,10 +964,11 @@ export async function* processParallel(
       return;
     }
     console.log(`[stream][shard] stitched ${stitched.ids.length} entities @ ${elapsed()}ms (shard scan started @ ${shardScanDispatchedAt}ms)`);
-    // Copy out of the subarray views so the held columns own contiguous buffers.
-    const ids = stitched.ids.slice();
-    const starts = stitched.starts.slice();
-    const lengths = stitched.lengths.slice();
+    // Exact-size SAB-backed columns straight from the stitch — no contiguity
+    // copy needed, and deliverEntityIndex shares them zero-copy.
+    const ids = stitched.ids;
+    const starts = stitched.starts;
+    const lengths = stitched.lengths;
     entityIndexDeliveredEarly = true;
     // set-entity-index reaches every worker FIRST (FIFO), so the style-shard
     // messages below always find the index installed.
@@ -1038,7 +1026,9 @@ export async function* processParallel(
     // Start the sharded pre-pass with the stitched index columns + classes
     // (stage 2: the pre-pass discovers jobs/spans from the class column and
     // never byte-scans the file).
-    startPrepass(true, { ids, starts, lengths, classes: classes.slice() });
+    // `classes` is exact-size (two-phase stitch) so it transfers as-is; the
+    // span-extraction loop above already read everything main needs from it.
+    startPrepass(true, { ids, starts, lengths, classes });
   };
 
   /**
@@ -1427,6 +1417,23 @@ export async function* processParallel(
     indexColumns?: { ids: Uint32Array; starts: Uint32Array; lengths: Uint32Array; classes: Uint8Array },
   ) => {
     if (sharded && indexColumns) {
+      // The id/start/length columns are SharedArrayBuffer-backed (two-phase
+      // stitch): they CANNOT go on the transfer list (transferring a SAB
+      // throws) and don't need to — postMessage shares the SAB for free.
+      // `classes` is a plain exact-size buffer and is the pre-pass worker's
+      // alone from here, so it still transfers (a structured clone would
+      // double its transient memory).
+      const transfers: ArrayBuffer[] = [];
+      for (const column of [
+        indexColumns.ids.buffer,
+        indexColumns.starts.buffer,
+        indexColumns.lengths.buffer,
+        indexColumns.classes.buffer,
+      ]) {
+        if (typeof SharedArrayBuffer === 'undefined' || !(column instanceof SharedArrayBuffer)) {
+          transfers.push(column as ArrayBuffer);
+        }
+      }
       prepassWorker.postMessage({
         type: 'prepass-streaming-sharded',
         sharedBuffer,
@@ -1437,15 +1444,7 @@ export async function* processParallel(
         indexStarts: indexColumns.starts,
         indexLengths: indexColumns.lengths,
         indexClasses: indexColumns.classes,
-      }, [
-        // TRANSFER the ~230MB of stitched columns (deliverEntityIndex already
-        // copied them into SABs for the other consumers) — a structured clone
-        // here would double the copy cost and the transient memory.
-        indexColumns.ids.buffer,
-        indexColumns.starts.buffer,
-        indexColumns.lengths.buffer,
-        indexColumns.classes.buffer,
-      ]);
+      }, transfers);
     } else {
       prepassWorker.postMessage({
         type: 'prepass-streaming',

--- a/packages/geometry/src/geometry.worker.ts
+++ b/packages/geometry/src/geometry.worker.ts
@@ -1301,7 +1301,10 @@ async function handleMessage(e: MessageEvent<GeometryWorkerRequest>): Promise<vo
       const onEvent = (event: unknown) => {
         (self as unknown as Worker).postMessage({ type: 'prepass-stream', event });
       };
-      const run = (bytes: Uint8Array) =>
+      const run = (
+        bytes: Uint8Array,
+        ids: Uint32Array, starts: Uint32Array, lengths: Uint32Array, classes: Uint8Array,
+      ) =>
         (ifcApi as unknown as {
           buildPrePassStreamingSharded: (
             data: Uint8Array, onEvent: (e: unknown) => void, chunkSize: number,
@@ -1310,15 +1313,21 @@ async function handleMessage(e: MessageEvent<GeometryWorkerRequest>): Promise<vo
           ) => unknown;
         }).buildPrePassStreamingSharded(
           bytes, onEvent, chunkSize, disabledTypes, skipTypeGeometry,
-          indexIds, indexStarts, indexLengths, indexClasses,
+          ids, starts, lengths, classes,
         );
       try {
-        run(viewSharedBytes(sharedBuffer));
+        run(viewSharedBytes(sharedBuffer), indexIds, indexStarts, indexLengths, indexClasses);
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         console.warn(`[Worker] Sharded streaming prepass with SAB view failed (${msg}), retrying with copy`);
         try {
-          run(materialiseSharedBytes(sharedBuffer));
+          // The id/start/length columns are SAB-backed too (zero-copy stitch
+          // delivery), so a SAB-view rejection needs them materialised along
+          // with the file bytes — `.slice()` of a SAB view yields a plain copy.
+          run(
+            materialiseSharedBytes(sharedBuffer),
+            indexIds.slice(), indexStarts.slice(), indexLengths.slice(), indexClasses.slice(),
+          );
         } catch (retryErr) {
           throw largeFilePrepassError(retryErr, sharedBuffer.byteLength) ?? retryErr;
         }


### PR DESCRIPTION
## What

Two main-thread cold-load reductions in the parallel geometry stream (sharded pre-pass path, #1720/#1722/#1724):

1. **Zero-copy entity-index delivery.** `stitchShards` is now two-phase: locate every shard's validated slice first (binary search, no copying), then write the exact-size output columns straight into SharedArrayBuffer-backed storage. `deliverEntityIndex` shares those SABs as-is instead of allocating fresh SABs and memcpy-ing the whole index again, and the pre-pass message shares the same views (the transfer list now carries only the plain `classes` column — SABs cannot be transferred and don't need to be). The stitched index used to be copied 3x per column on the critical path that gates job dispatch (stitch → `.slice()` → SAB `.set`, ~450 MB of memcpy on a 19M-entity file); now 1x (the stitch itself). Exact sizing matters and is why phase 1 exists: workers get full-buffer views, so a cap-sized buffer would expose garbage records.
2. **Per-mesh re-map dropped.** The batch handler re-allocated a `MeshData` wrapper per mesh (~110k objects on a large load) purely to re-spread fields the worker had already shaped (typed arrays ride the transfer list either way). The structured-clone objects now pass straight through.

Also: the sharded prepass SAB-view retry path materialises the index columns too (they are SAB-backed after this change), and the wasm-wide-arithmetic doc gets a 2026-07-16 status re-check (walrus/wasm-bindgen unblocked upstream, V8 still flag-gated — still track-and-adopt).

## Measured

Playwright viewer benchmark, 3 cold runs per side, **same wasm build on both sides**, min-of-3. Mesh counts identical on both sides (110,632 / 59,060):

| model | metric | before | after |
|---|---|---:|---:|
| Holter (177MB, 2.8M entities) | first visible | 611 ms | 594 ms |
| Holter | stream complete | 4501 ms | 4462 ms |
| CatiaA1 (883MB, 19.1M entities) | first visible | 7106 ms | **6842 ms (-3.7%)** |
| CatiaA1 | stream complete | 12495 ms | 12269 ms (-1.8%) |

Modest but consistent (all four minimums improved, largest on the 19M-entity model where the copy elimination is biggest); the mechanism is deterministic — strictly fewer full-index copies and ~110k fewer allocations per load. Also halves the transient memory spike at stitch time (no duplicate cap-sized arrays + SAB copies alive at once).

## Behaviour notes

- Sharded path only (already SAB-gated by `shardActive`); the serial pre-pass fallback and the flag-off path (`__IFC_LITE_SHARD_SCAN=0`) keep the copy semantics they had.
- Stitch fallback (handoff-not-found → serial pre-pass) unchanged.
- Changeset: `@ifc-lite/geometry` patch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved geometry loading by reducing data copying and memory transfers during parallel processing.
  * Preserved exact render output while streamlining worker communication and mesh handling.

* **Bug Fixes**
  * Added a fallback for environments that cannot directly use shared memory views during geometry preprocessing.

* **Documentation**
  * Updated WebAssembly arithmetic delivery status and compatibility guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->