### PR TITLE
fix(viewer): guard load-race + lens visibility leaks + coord/security bugs

### DIFF
--- a/apps/viewer/src/components/viewer/LensPanel.tsx
+++ b/apps/viewer/src/components/viewer/LensPanel.tsx
@@ -28,10 +28,14 @@ import { useViewerStore } from '@/store';
 import { useLens } from '@/hooks/useLens';
 import { createLensDataProvider } from '@/lib/lens';
 import { buildAutoColorLensToSave, moveItem } from './lens-editor-utils';
+import { planLensHiddenSync, ruleIsolationOwnsChannel } from './lens-visibility-ownership';
 import type { Lens, LensRule, LensCriteria, AutoColorSpec, AutoColorLegendEntry, DiscoveredLensData } from '@/store/slices/lensSlice';
 import {
   LENS_PALETTE, ENTITY_ATTRIBUTE_NAMES, AUTO_COLOR_SOURCES,
 } from '@/store/slices/lensSlice';
+
+/** Stable empty set for the hidden-sync effect when no lens is active. */
+const EMPTY_LENS_HIDDEN: ReadonlySet<number> = new Set<number>();
 
 /** Format large counts compactly: 1234 → "1.2k" */
 function formatCount(n: number): string {
@@ -1268,6 +1272,12 @@ export function LensPanel({ onClose }: LensPanelProps) {
   const showEntities = useViewerStore((s) => s.showEntities);
   const isolateEntities = useViewerStore((s) => s.isolateEntities);
   const clearIsolation = useViewerStore((s) => s.clearIsolation);
+  // Ownership bookkeeping lives in the STORE (not component state/refs) so a
+  // panel unmount/remount neither loses which hidden ids the lens owns nor
+  // strands a rule isolation it can no longer release.
+  const setLensAppliedHiddenIds = useViewerStore((s) => s.setLensAppliedHiddenIds);
+  const lensRuleIsolation = useViewerStore((s) => s.lensRuleIsolation);
+  const setLensRuleIsolation = useViewerStore((s) => s.setLensRuleIsolation);
   // For footer stats — cheap primitive subscriptions
   const lensColorMapSize = useViewerStore((s) => s.lensColorMap.size);
   const lensHiddenIdsSize = useViewerStore((s) => s.lensHiddenIds.size);
@@ -1326,32 +1336,45 @@ export function LensPanel({ onClose }: LensPanelProps) {
   // Editor state: null = not editing, Lens object = editing/creating
   const [editingLens, setEditingLens] = useState<Lens | null>(null);
   const [creatingAutoColor, setCreatingAutoColor] = useState(false);
-  const [isolatedRuleId, setIsolatedRuleId] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
-  // The exact ids this panel last pushed into the GLOBAL hiddenEntities channel
-  // on behalf of the active lens. Tracked so switching lenses / deactivating a
-  // lens un-hides ONLY the lens's own entities — never the user's manual hides.
-  const appliedLensHiddenRef = useRef<number[]>([]);
+  // Rule isolation applied by the lens (persisted in the store so it survives
+  // panel remounts). Only the ruleId is needed for the card highlight.
+  const isolatedRuleId = lensRuleIsolation?.ruleId ?? null;
+
+  /**
+   * Release the lens's rule isolation. Clears the shared isolation channel
+   * ONLY if the lens still owns it (the channel still holds exactly the ids
+   * the rule click applied) — if the user or the basket has isolated something
+   * else since, their isolation is left alone and only the stale claim drops.
+   */
+  const releaseRuleIsolation = useCallback(() => {
+    const state = useViewerStore.getState();
+    const isolation = state.lensRuleIsolation;
+    if (!isolation) return;
+    if (ruleIsolationOwnsChannel(state.isolatedEntities, isolation.entityIds)) {
+      clearIsolation();
+    }
+    setLensRuleIsolation(null);
+  }, [clearIsolation, setLensRuleIsolation]);
 
   const handleToggle = useCallback((id: string) => {
-    // Clear any rule-isolation this lens applied (both when turning it off and
-    // when switching to another lens). The effect above restores the lens-owned
-    // hidden ids — so no showAll(), which would nuke the user's own visibility.
-    if (isolatedRuleId !== null) clearIsolation();
-    setIsolatedRuleId(null);
+    // Release any rule-isolation this lens applied (both when turning it off
+    // and when switching to another lens). The sync effect below restores the
+    // lens-owned hidden ids — so no showAll(), which would nuke the user's
+    // own visibility.
+    releaseRuleIsolation();
     if (activeLensId === id) {
       setActiveLens(null);
     } else {
       setActiveLens(id);
     }
-  }, [activeLensId, setActiveLens, isolatedRuleId, clearIsolation]);
+  }, [activeLensId, setActiveLens, releaseRuleIsolation]);
 
   /** Click a rule/value row in the active lens to isolate matching entities */
   const handleIsolateRule = useCallback((ruleId: string) => {
     // Toggle off if clicking the already-isolated rule
-    if (isolatedRuleId === ruleId) {
-      setIsolatedRuleId(null);
-      clearIsolation();
+    if (useViewerStore.getState().lensRuleIsolation?.ruleId === ruleId) {
+      releaseRuleIsolation();
       return;
     }
 
@@ -1359,9 +1382,18 @@ export function LensPanel({ onClose }: LensPanelProps) {
     const matchingIds = useViewerStore.getState().lensRuleEntityIds.get(ruleId);
     if (!matchingIds || matchingIds.length === 0) return;
 
-    setIsolatedRuleId(ruleId);
     isolateEntities(matchingIds);
-  }, [isolatedRuleId, isolateEntities, clearIsolation]);
+    // Record ownership: rule id + the exact ids pushed into the channel, so a
+    // later release can verify the channel still holds what the lens applied.
+    setLensRuleIsolation({ ruleId, entityIds: [...matchingIds] });
+  }, [isolateEntities, releaseRuleIsolation, setLensRuleIsolation]);
+
+  // Safety net: if the lens got deactivated while the panel was unmounted
+  // (e.g. a flavor switch cleared activeLensId), a recorded rule isolation
+  // has no owner anymore — release it so the model isn't stuck isolated.
+  useEffect(() => {
+    if (activeLensId === null) releaseRuleIsolation();
+  }, [activeLensId, releaseRuleIsolation]);
 
   const handleNewLens = useCallback(() => {
     setCreatingAutoColor(false);
@@ -1402,34 +1434,34 @@ export function LensPanel({ onClose }: LensPanelProps) {
 
   const handleDeleteLens = useCallback((id: string) => {
     if (activeLensId === id) {
-      // Deactivate first — the effect above un-hides the lens-owned hidden ids.
-      // Clear only the lens's own rule-isolation, never a global showAll().
-      if (isolatedRuleId !== null) clearIsolation();
-      setIsolatedRuleId(null);
+      // Deactivate first — the sync effect below un-hides the lens-owned
+      // hidden ids. Release only the lens's own rule-isolation, never a
+      // global showAll().
+      releaseRuleIsolation();
       setActiveLens(null);
     }
     deleteLens(id);
-  }, [activeLensId, setActiveLens, deleteLens, isolatedRuleId, clearIsolation]);
+  }, [activeLensId, setActiveLens, deleteLens, releaseRuleIsolation]);
 
   // Sync the active lens's hidden ids into the GLOBAL hiddenEntities channel.
-  // Un-hide the previously-applied lens ids BEFORE applying the new set, so:
-  //  - switching lens A→B un-hides A's entities (they no longer stay invisible
-  //    under B),
-  //  - deactivating a lens (activeLensId→null, always a dep) restores exactly
-  //    the lens's own hides and nothing else.
-  // Only lens-owned ids are removed — the user's manual hides are untouched.
+  // planLensHiddenSync computes minimal show/hide deltas plus the ids the lens
+  // OWNS afterwards (only ids it newly hid — an id the user manually hid
+  // before or during the lens stays hidden after teardown). Ownership is
+  // persisted in the store so a panel remount re-runs this as a no-op instead
+  // of losing track of (or double-claiming) the lens's hides.
   useEffect(() => {
-    const applied = appliedLensHiddenRef.current;
-    if (applied.length > 0) {
-      showEntities(applied);
-      appliedLensHiddenRef.current = [];
+    const state = useViewerStore.getState();
+    const plan = planLensHiddenSync({
+      applied: state.lensAppliedHiddenIds,
+      hiddenEntities: state.hiddenEntities,
+      lensHiddenIds: activeLensId ? state.lensHiddenIds : EMPTY_LENS_HIDDEN,
+    });
+    if (plan.show.length > 0) showEntities(plan.show);
+    if (plan.hide.length > 0) hideEntities(plan.hide);
+    if (plan.nextApplied.length > 0 || state.lensAppliedHiddenIds.length > 0) {
+      setLensAppliedHiddenIds(plan.nextApplied);
     }
-    if (lensHiddenIdsSize > 0 && activeLensId) {
-      const ids = Array.from(useViewerStore.getState().lensHiddenIds);
-      hideEntities(ids);
-      appliedLensHiddenRef.current = ids;
-    }
-  }, [activeLensId, lensHiddenIdsSize, hideEntities, showEntities]);
+  }, [activeLensId, lensHiddenIdsSize, hideEntities, showEntities, setLensAppliedHiddenIds]);
 
   const handleExport = useCallback(() => {
     const data = exportLenses();
@@ -1500,10 +1532,10 @@ export function LensPanel({ onClose }: LensPanelProps) {
               size="sm"
               className="h-7 text-[10px] uppercase tracking-wider rounded-sm"
               onClick={() => {
-                // Clear the lens's own rule-isolation; the effect restores the
-                // lens-owned hidden ids. No showAll() — keep the user's hides.
-                if (isolatedRuleId !== null) clearIsolation();
-                setIsolatedRuleId(null);
+                // Release the lens's own rule-isolation; the sync effect
+                // restores the lens-owned hidden ids. No showAll() — keep
+                // the user's hides.
+                releaseRuleIsolation();
                 setActiveLens(null);
               }}
               {...tourAnchor(TOUR_ANCHORS.lensClear)}

--- a/apps/viewer/src/components/viewer/LensPanel.tsx
+++ b/apps/viewer/src/components/viewer/LensPanel.tsx
@@ -1263,7 +1263,9 @@ export function LensPanel({ onClose }: LensPanelProps) {
   const importLenses = useViewerStore((s) => s.importLenses);
   const exportLenses = useViewerStore((s) => s.exportLenses);
   const hideEntities = useViewerStore((s) => s.hideEntities);
-  const showAll = useViewerStore((s) => s.showAll);
+  // Un-hide only the lens-owned ids (delta) instead of showAll(), which would
+  // also wipe the user's manual hides / isolation / class filter / ghost.
+  const showEntities = useViewerStore((s) => s.showEntities);
   const isolateEntities = useViewerStore((s) => s.isolateEntities);
   const clearIsolation = useViewerStore((s) => s.clearIsolation);
   // For footer stats — cheap primitive subscriptions
@@ -1326,16 +1328,23 @@ export function LensPanel({ onClose }: LensPanelProps) {
   const [creatingAutoColor, setCreatingAutoColor] = useState(false);
   const [isolatedRuleId, setIsolatedRuleId] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  // The exact ids this panel last pushed into the GLOBAL hiddenEntities channel
+  // on behalf of the active lens. Tracked so switching lenses / deactivating a
+  // lens un-hides ONLY the lens's own entities — never the user's manual hides.
+  const appliedLensHiddenRef = useRef<number[]>([]);
 
   const handleToggle = useCallback((id: string) => {
+    // Clear any rule-isolation this lens applied (both when turning it off and
+    // when switching to another lens). The effect above restores the lens-owned
+    // hidden ids — so no showAll(), which would nuke the user's own visibility.
+    if (isolatedRuleId !== null) clearIsolation();
     setIsolatedRuleId(null);
     if (activeLensId === id) {
       setActiveLens(null);
-      showAll();
     } else {
       setActiveLens(id);
     }
-  }, [activeLensId, setActiveLens, showAll]);
+  }, [activeLensId, setActiveLens, isolatedRuleId, clearIsolation]);
 
   /** Click a rule/value row in the active lens to isolate matching entities */
   const handleIsolateRule = useCallback((ruleId: string) => {
@@ -1393,19 +1402,34 @@ export function LensPanel({ onClose }: LensPanelProps) {
 
   const handleDeleteLens = useCallback((id: string) => {
     if (activeLensId === id) {
+      // Deactivate first — the effect above un-hides the lens-owned hidden ids.
+      // Clear only the lens's own rule-isolation, never a global showAll().
+      if (isolatedRuleId !== null) clearIsolation();
+      setIsolatedRuleId(null);
       setActiveLens(null);
-      showAll();
     }
     deleteLens(id);
-  }, [activeLensId, setActiveLens, showAll, deleteLens]);
+  }, [activeLensId, setActiveLens, deleteLens, isolatedRuleId, clearIsolation]);
 
-  // Apply hidden entities when lens hidden IDs change
+  // Sync the active lens's hidden ids into the GLOBAL hiddenEntities channel.
+  // Un-hide the previously-applied lens ids BEFORE applying the new set, so:
+  //  - switching lens A→B un-hides A's entities (they no longer stay invisible
+  //    under B),
+  //  - deactivating a lens (activeLensId→null, always a dep) restores exactly
+  //    the lens's own hides and nothing else.
+  // Only lens-owned ids are removed — the user's manual hides are untouched.
   useEffect(() => {
-    if (lensHiddenIdsSize > 0 && activeLensId) {
-      const ids = useViewerStore.getState().lensHiddenIds;
-      hideEntities(Array.from(ids));
+    const applied = appliedLensHiddenRef.current;
+    if (applied.length > 0) {
+      showEntities(applied);
+      appliedLensHiddenRef.current = [];
     }
-  }, [activeLensId, lensHiddenIdsSize, hideEntities]);
+    if (lensHiddenIdsSize > 0 && activeLensId) {
+      const ids = Array.from(useViewerStore.getState().lensHiddenIds);
+      hideEntities(ids);
+      appliedLensHiddenRef.current = ids;
+    }
+  }, [activeLensId, lensHiddenIdsSize, hideEntities, showEntities]);
 
   const handleExport = useCallback(() => {
     const data = exportLenses();
@@ -1475,7 +1499,13 @@ export function LensPanel({ onClose }: LensPanelProps) {
               variant="ghost"
               size="sm"
               className="h-7 text-[10px] uppercase tracking-wider rounded-sm"
-              onClick={() => { setActiveLens(null); showAll(); }}
+              onClick={() => {
+                // Clear the lens's own rule-isolation; the effect restores the
+                // lens-owned hidden ids. No showAll() — keep the user's hides.
+                if (isolatedRuleId !== null) clearIsolation();
+                setIsolatedRuleId(null);
+                setActiveLens(null);
+              }}
               {...tourAnchor(TOUR_ANCHORS.lensClear)}
             >
               <EyeOff className="h-3 w-3 mr-1" />

--- a/apps/viewer/src/components/viewer/ViewerLayout.tsx
+++ b/apps/viewer/src/components/viewer/ViewerLayout.tsx
@@ -106,12 +106,12 @@ export function ViewerLayout() {
     try {
       resolvedUrl = new URL(modelUrl, window.location.href);
     } catch {
-      console.error('[viewer] autoload from ?model=… refused: malformed URL');
+      console.error('[viewer] autoload from ?model= refused: malformed URL');
       return;
     }
     if (resolvedUrl.origin !== window.location.origin) {
       console.error(
-        `[viewer] autoload from ?model=… refused: cross-origin URL (${resolvedUrl.origin}) — only same-origin models are auto-loaded`,
+        `[viewer] autoload from ?model= refused: cross-origin URL (${resolvedUrl.origin}) - only same-origin models are auto-loaded`,
       );
       return;
     }

--- a/apps/viewer/src/components/viewer/ViewerLayout.tsx
+++ b/apps/viewer/src/components/viewer/ViewerLayout.tsx
@@ -85,7 +85,14 @@ export function ViewerLayout() {
   const shortcutsDialog = useKeyboardShortcutsDialog();
 
   // Auto-load a model from ?model=<URL>. Used by the landing-page iframe to drop a
-  // sample IFC into the viewer on first mount. Same-origin or CORS-friendly URLs only.
+  // sample IFC into the viewer on first mount.
+  //
+  // SECURITY: only SAME-ORIGIN model URLs are fetched. `?model=` is fully
+  // attacker-controllable (any link can set it), so honouring an arbitrary
+  // cross-origin URL is a drive-by model-injection vector — a crafted link
+  // would silently pull an attacker's file into the victim's viewer. We resolve
+  // the param against the current document and require its origin to match
+  // window.location.origin; a cross-origin URL is refused, never fetched.
   const { addModel: autoloadAddModel } = useIfc();
   const autoloadDoneRef = useRef(false);
   useEffect(() => {
@@ -94,15 +101,26 @@ export function ViewerLayout() {
     const modelUrl = params.get('model');
     if (!modelUrl) return;
     autoloadDoneRef.current = true;
+    // Resolve (supports relative paths) and enforce same-origin before fetching.
+    let resolvedUrl: URL;
+    try {
+      resolvedUrl = new URL(modelUrl, window.location.href);
+    } catch {
+      console.error('[viewer] autoload from ?model=… refused: malformed URL');
+      return;
+    }
+    if (resolvedUrl.origin !== window.location.origin) {
+      console.error(
+        `[viewer] autoload from ?model=… refused: cross-origin URL (${resolvedUrl.origin}) — only same-origin models are auto-loaded`,
+      );
+      return;
+    }
     (async () => {
       try {
-        const res = await fetch(modelUrl);
+        const res = await fetch(resolvedUrl.href);
         if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
         const blob = await res.blob();
-        const filename = (() => {
-          try { return new URL(modelUrl, window.location.href).pathname.split('/').pop() || 'model.ifc'; }
-          catch { return 'model.ifc'; }
-        })();
+        const filename = resolvedUrl.pathname.split('/').pop() || 'model.ifc';
         const file = new File([blob], filename, { type: blob.type || 'application/x-step' });
         await autoloadAddModel(file);
       } catch (err) {

--- a/apps/viewer/src/components/viewer/lens-visibility-ownership.test.ts
+++ b/apps/viewer/src/components/viewer/lens-visibility-ownership.test.ts
@@ -1,0 +1,187 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+
+import {
+  planLensHiddenSync,
+  ruleIsolationOwnsChannel,
+} from './lens-visibility-ownership.js';
+
+/**
+ * Minimal store double: applies a plan to a hidden set exactly the way the
+ * panel applies it via showEntities/hideEntities, so multi-step scenarios
+ * (lens switch, remount, teardown) can be simulated end to end.
+ */
+function applyPlan(
+  hidden: Set<number>,
+  plan: ReturnType<typeof planLensHiddenSync>,
+): Set<number> {
+  const next = new Set(hidden);
+  for (const id of plan.show) next.delete(id);
+  for (const id of plan.hide) next.add(id);
+  return next;
+}
+
+describe('planLensHiddenSync - ownership diff (PR #1777 review finding a)', () => {
+  it('activating a lens hides its ids and owns exactly the newly hidden ones', () => {
+    const hidden = new Set<number>();
+    const plan = planLensHiddenSync({
+      applied: [],
+      hiddenEntities: hidden,
+      lensHiddenIds: new Set([1, 2, 3]),
+    });
+    assert.deepEqual(plan.show, []);
+    assert.deepEqual(plan.hide.sort(), [1, 2, 3]);
+    assert.deepEqual(plan.nextApplied.sort(), [1, 2, 3]);
+    assert.deepEqual([...applyPlan(hidden, plan)].sort(), [1, 2, 3]);
+  });
+
+  it('never claims an id the user manually hid BEFORE the lens applied', () => {
+    // User hid 7 manually, then activated a lens that also hides 7 (and 8).
+    const hidden = new Set([7]);
+    const plan = planLensHiddenSync({
+      applied: [],
+      hiddenEntities: hidden,
+      lensHiddenIds: new Set([7, 8]),
+    });
+    assert.deepEqual(plan.hide, [8], 'only the not-yet-hidden id is hidden');
+    assert.deepEqual(plan.nextApplied, [8], 'the manual hide is not owned');
+
+    // Teardown (deactivate): only 8 is restored; the manual hide of 7 survives.
+    const afterApply = applyPlan(hidden, plan);
+    const teardown = planLensHiddenSync({
+      applied: plan.nextApplied,
+      hiddenEntities: afterApply,
+      lensHiddenIds: new Set(),
+    });
+    assert.deepEqual(teardown.show, [8]);
+    assert.deepEqual(teardown.hide, []);
+    assert.deepEqual(teardown.nextApplied, []);
+    assert.deepEqual([...applyPlan(afterApply, teardown)], [7],
+      'user manual hide must survive lens teardown');
+  });
+
+  it('manual hide made WHILE a lens is active survives switching to another lens', () => {
+    // Lens A hides {1,2}. User then manually hides 5. Switch to lens B hiding {2,3}.
+    let hidden = new Set<number>();
+    const planA = planLensHiddenSync({
+      applied: [], hiddenEntities: hidden, lensHiddenIds: new Set([1, 2]),
+    });
+    hidden = applyPlan(hidden, planA);
+    hidden.add(5); // manual hide while A is active
+
+    const planB = planLensHiddenSync({
+      applied: planA.nextApplied,
+      hiddenEntities: hidden,
+      lensHiddenIds: new Set([2, 3]),
+    });
+    assert.deepEqual(planB.show, [1], 'A-only id is restored');
+    assert.deepEqual(planB.hide, [3], 'B-only id is newly hidden');
+    assert.deepEqual(planB.nextApplied.sort(), [2, 3], 'ownership of 2 transfers to B');
+    hidden = applyPlan(hidden, planB);
+    assert.deepEqual([...hidden].sort(), [2, 3, 5], 'manual hide of 5 untouched');
+
+    // Deactivate B: only B-owned ids restored; 5 stays hidden.
+    const teardown = planLensHiddenSync({
+      applied: planB.nextApplied, hiddenEntities: hidden, lensHiddenIds: new Set(),
+    });
+    assert.deepEqual([...applyPlan(hidden, teardown)], [5]);
+  });
+
+  it('id hidden by BOTH consecutive lenses transfers ownership without churn', () => {
+    // No transient un-hide: the shared id appears in neither show nor hide.
+    const hidden = new Set([10, 11]);
+    const plan = planLensHiddenSync({
+      applied: [10, 11],
+      hiddenEntities: hidden,
+      lensHiddenIds: new Set([11, 12]),
+    });
+    assert.deepEqual(plan.show, [10]);
+    assert.deepEqual(plan.hide, [12]);
+    assert.ok(!plan.show.includes(11) && !plan.hide.includes(11), 'no churn on the shared id');
+    assert.deepEqual(plan.nextApplied.sort(), [11, 12]);
+  });
+
+  it('rapid A -> B -> A toggling round-trips to the initial state', () => {
+    const manual = 99;
+    let hidden = new Set([manual]);
+    let applied: number[] = [];
+    const lensA = new Set([1, 2, manual]); // A also hides the manually hidden id
+    const lensB = new Set([2, 3]);
+
+    for (const lens of [lensA, lensB, lensA]) {
+      const plan = planLensHiddenSync({ applied, hiddenEntities: hidden, lensHiddenIds: lens });
+      hidden = applyPlan(hidden, plan);
+      applied = plan.nextApplied;
+    }
+    assert.deepEqual([...hidden].sort(), [1, 2, 99], 'ends in lens A state');
+    assert.deepEqual(applied.sort(), [1, 2], 'manual id never claimed across toggles');
+
+    const teardown = planLensHiddenSync({ applied, hiddenEntities: hidden, lensHiddenIds: new Set() });
+    hidden = applyPlan(hidden, teardown);
+    assert.deepEqual([...hidden], [manual], 'back to exactly the manual hide');
+  });
+
+  it('re-running the sync with unchanged inputs is a no-op (panel remount)', () => {
+    // Ownership persists in the store, so a remount re-runs the sync with the
+    // same inputs - it must not release or re-take anything.
+    const hidden = new Set([1, 2, 40]); // 40 = manual
+    const plan = planLensHiddenSync({
+      applied: [1, 2],
+      hiddenEntities: hidden,
+      lensHiddenIds: new Set([1, 2]),
+    });
+    assert.deepEqual(plan.show, []);
+    assert.deepEqual(plan.hide, []);
+    assert.deepEqual(plan.nextApplied.sort(), [1, 2]);
+  });
+
+  it('teardown with nothing applied and nothing active is a no-op (Clear when idle)', () => {
+    const plan = planLensHiddenSync({
+      applied: [],
+      hiddenEntities: new Set([4]),
+      lensHiddenIds: new Set(),
+    });
+    assert.deepEqual(plan, { show: [], hide: [], nextApplied: [] });
+  });
+
+  it('owned id the user manually un-hid mid-lens is not force-restored on teardown', () => {
+    // Lens owned 6; user un-hid it via the tree while the lens was active.
+    const plan = planLensHiddenSync({
+      applied: [6],
+      hiddenEntities: new Set(), // user already removed it
+      lensHiddenIds: new Set(),
+    });
+    assert.deepEqual(plan.show, [], 'no redundant show for an already-visible id');
+  });
+});
+
+describe('ruleIsolationOwnsChannel (PR #1777 review finding b)', () => {
+  it('owns the channel when isolation holds exactly the applied ids', () => {
+    assert.equal(ruleIsolationOwnsChannel(new Set([1, 2, 3]), [3, 2, 1]), true);
+  });
+
+  it('does not own when isolation is off', () => {
+    assert.equal(ruleIsolationOwnsChannel(null, [1, 2]), false);
+  });
+
+  it('does not own when another owner replaced the isolation set', () => {
+    // e.g. user right-click isolate or basket isolation after the rule click.
+    assert.equal(ruleIsolationOwnsChannel(new Set([9]), [1, 2]), false);
+    assert.equal(ruleIsolationOwnsChannel(new Set([1, 2, 9]), [1, 2]), false);
+    assert.equal(ruleIsolationOwnsChannel(new Set([1]), [1, 2]), false);
+  });
+
+  it('handles duplicate applied ids', () => {
+    assert.equal(ruleIsolationOwnsChannel(new Set([1, 2]), [1, 1, 2]), true);
+  });
+
+  it('an empty claim never owns a live isolation set', () => {
+    assert.equal(ruleIsolationOwnsChannel(new Set([1]), []), false);
+    // Degenerate: empty isolation set + empty claim - clearing is a no-op either way.
+    assert.equal(ruleIsolationOwnsChannel(new Set(), []), true);
+  });
+});

--- a/apps/viewer/src/components/viewer/lens-visibility-ownership.ts
+++ b/apps/viewer/src/components/viewer/lens-visibility-ownership.ts
@@ -1,0 +1,97 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Lens visibility ownership bookkeeping (pure helpers).
+ *
+ * The lens panel mirrors the active lens's computed `lensHiddenIds` into the
+ * GLOBAL `hiddenEntities` channel (the renderer's hide set). That channel is
+ * shared with the user's manual hides, so the lens must track exactly which
+ * ids it NEWLY hid ("owned" ids) and restore only those on lens switch /
+ * deactivation - never an id the user had already hidden before the lens
+ * applied (that would silently wipe the manual hide), and never a blanket
+ * showAll() (that would also wipe isolation / class filter / ghosting).
+ *
+ * Same story for rule isolation: the panel pushes a rule's matched ids into
+ * the shared `isolatedEntities` channel and must only clear that channel on
+ * teardown if it still holds what the lens put there - if the user (or the
+ * basket) has since isolated something else, the lens just drops its claim.
+ *
+ * These are pure functions so the ownership rules are unit-testable without
+ * React or the store; the panel applies the returned deltas via the store
+ * actions and persists `nextApplied` in the lens slice (component-local state
+ * would lose ownership on panel unmount/remount).
+ */
+
+/** Deltas to reconcile the global hidden channel with the active lens. */
+export interface LensHiddenSyncPlan {
+  /** Ids to remove from the hidden channel (previously lens-owned, no longer lens-hidden). */
+  show: number[];
+  /** Ids to add to the hidden channel (lens-hidden and not yet hidden). */
+  hide: number[];
+  /** Ids the lens owns in the hidden channel after this sync (persist these). */
+  nextApplied: number[];
+}
+
+/**
+ * Compute the minimal show/hide deltas to sync the active lens's hidden ids
+ * into the shared hidden channel, transferring ownership correctly.
+ *
+ * - An id hidden by the user BEFORE the lens applied (in `hiddenEntities` but
+ *   not in `applied`) is never claimed: it stays hidden after teardown.
+ * - An id owned by the previous lens and also hidden by the next lens keeps
+ *   ownership without a transient un-hide (it appears in neither delta).
+ * - Deactivation is just `lensHiddenIds = empty`: every owned id is restored.
+ */
+export function planLensHiddenSync(args: {
+  /** Ids the lens currently owns in the hidden channel (from the lens slice). */
+  applied: readonly number[];
+  /** The shared hidden channel as of now (`visibilitySlice.hiddenEntities`). */
+  hiddenEntities: ReadonlySet<number>;
+  /** The active lens's computed hidden ids (empty set when no lens is active). */
+  lensHiddenIds: ReadonlySet<number>;
+}): LensHiddenSyncPlan {
+  const { applied, hiddenEntities, lensHiddenIds } = args;
+  const appliedSet = new Set(applied);
+
+  const show: number[] = [];
+  for (const id of appliedSet) {
+    // Restore an owned id unless the new lens set still hides it (ownership
+    // transfers without churn). Skip ids the user manually un-hid meanwhile.
+    if (hiddenEntities.has(id) && !lensHiddenIds.has(id)) show.push(id);
+  }
+
+  const hide: number[] = [];
+  const nextApplied: number[] = [];
+  for (const id of lensHiddenIds) {
+    // Manually hidden = hidden but not by us. Not ours to claim (and hiding
+    // it again is a no-op), so it must survive lens teardown untouched.
+    const manuallyHidden = hiddenEntities.has(id) && !appliedSet.has(id);
+    if (manuallyHidden) continue;
+    nextApplied.push(id);
+    if (!hiddenEntities.has(id)) hide.push(id);
+  }
+
+  return { show, hide, nextApplied };
+}
+
+/**
+ * True when the shared isolation channel still holds exactly the ids the lens
+ * rule-isolation applied - i.e. the lens still owns the channel and may clear
+ * it. False when isolation is off or another owner (user right-click isolate,
+ * basket, BCF viewpoint) replaced it; the lens must then drop its claim
+ * WITHOUT clearing, or it would wipe the other owner's isolation.
+ */
+export function ruleIsolationOwnsChannel(
+  isolatedEntities: ReadonlySet<number> | null,
+  appliedIds: readonly number[],
+): boolean {
+  if (isolatedEntities === null) return false;
+  const appliedSet = new Set(appliedIds);
+  if (isolatedEntities.size !== appliedSet.size) return false;
+  for (const id of appliedSet) {
+    if (!isolatedEntities.has(id)) return false;
+  }
+  return true;
+}

--- a/apps/viewer/src/components/viewer/toolbar/useFileCommands.tsx
+++ b/apps/viewer/src/components/viewer/toolbar/useFileCommands.tsx
@@ -99,6 +99,15 @@ export function useFileCommands(): FileCommands {
     const handler = (e: Event) => {
       const file = (e as CustomEvent<File>).detail;
       if (file) {
+        // Belt-and-suspenders: don't kick off a second primary load while one
+        // is in flight. The definitive fix lives in useIfcLoader's
+        // stale-session guard, but starting a superseded load at all is
+        // wasteful, so skip it here. Read live from the store (not the effect
+        // closure) to avoid a stale `loading` value.
+        if (useViewerStore.getState().loading) {
+          console.warn('[useFileCommands] ifc-lite:load-file ignored - a load is already in progress');
+          return;
+        }
         recordRecentFiles([{ name: file.name, size: file.size }]);
         void loadFile(file);
       }

--- a/apps/viewer/src/hooks/useDrawingExport.ts
+++ b/apps/viewer/src/hooks/useDrawingExport.ts
@@ -649,9 +649,18 @@ function useDrawingExport({
       return;
     }
 
-    const title = (sheetEnabled && activeSheet)
+    const rawTitle = (sheetEnabled && activeSheet)
       ? `${activeSheet.name} - ${sectionPlane.axis} at ${sectionPlane.position}%`
       : `Section Drawing - ${sectionPlane.axis} at ${sectionPlane.position}%`;
+    // The sheet name is user-controlled and interpolated into the <title> of a
+    // same-origin window. Without escaping, a sheet named `</title><script>…`
+    // would break out of the title and execute script. Escape it (the SVG body
+    // is already escaped via escapeXml; the title was the one unescaped sink).
+    const title = rawTitle
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;');
 
     // Write print-friendly HTML with the SVG
     printWindow.document.write(`

--- a/apps/viewer/src/hooks/useIfcLoader.ts
+++ b/apps/viewer/src/hooks/useIfcLoader.ts
@@ -1143,20 +1143,32 @@ export function useIfcLoader() {
           const event = nextResult.value;
           const eventReceived = performance.now();
 
-          // Stale-session guard for the PRIMARY streaming path. A second primary
-          // load (e.g. the `ifc-lite:load-file` event) bumps loadSessionRef and
-          // resets the active model; without this, the superseded load's stream
-          // keeps mutating the NEW active model — appendGeometryBatch (batch +
-          // complete), updateMeshColors, updateCoordinateInfo and the loop's
-          // setProgress calls — producing mixed meshes and a wrong RTC/coordinate
-          // frame. Every other deferred write in this file already guards on the
-          // session (see finalize/post-stream below). Stop the loop and clean up
-          // the reader (the post-loop closeGeometryIterator releases WASM) so no
-          // more active-model writes happen. Federated adds keep a stable session
-          // and never touch the active slot during streaming, so they are exempt.
-          if (target.kind === 'primary' && loadSessionRef.current !== currentSession) {
-            console.warn(`[useIfc] stream ABORTED: stale session (mine=${currentSession}, current=${loadSessionRef.current}) — superseded by a newer load`);
+          // Stale-session guard for the streaming loop. A new PRIMARY load
+          // (e.g. the `ifc-lite:load-file` event) bumps loadSessionRef and
+          // resets the active model; without this, a superseded PRIMARY load's
+          // stream keeps mutating the NEW active model — appendGeometryBatch
+          // (batch + complete), updateMeshColors, updateCoordinateInfo and the
+          // loop's setProgress calls — producing mixed meshes and a wrong
+          // RTC/coordinate frame. A superseded FEDERATED add never touches the
+          // active slot, but its streaming branch still writes the shared
+          // progress UI (clobbering the new load's progress) and burns the
+          // geometry workers the new load needs, so it stops too — matching
+          // the documented intent that a primary bump "aborts any in-flight
+          // federated adds". A federated add during a primary load does NOT
+          // abort anything: federated loads never bump the session, so both
+          // sessions stay current. Every other deferred write in this file
+          // already guards on the session (see finalize/post-stream below).
+          // Stop the loop and clean up the reader (closeGeometryIterator
+          // releases WASM; it is idempotent via geometryIteratorClosed, so the
+          // post-loop call is a no-op) so no more shared-state writes happen.
+          if (loadSessionRef.current !== currentSession) {
+            console.warn(`[useIfc] ${target.kind} stream ABORTED: stale session (mine=${currentSession}, current=${loadSessionRef.current}) - superseded by a newer load`);
             await closeGeometryIterator();
+            // 'complete' never ran, so nothing is chained on dataStorePromise.
+            // The orphaned parser worker self-terminates on its own watchdog
+            // and may reject it — swallow that so the abort doesn't surface as
+            // an unhandled rejection (mirrors the catch path below).
+            void dataStorePromise.catch(() => {});
             break;
           }
 
@@ -1431,6 +1443,14 @@ export function useIfcLoader() {
                   cumulativeColorUpdates.clear();
                 }, 5000);
               }).catch(err => {
+                // A superseded load's finalize failure is not this user's
+                // problem anymore: the old primary model record was cleared by
+                // the new load (updateModel would no-op) and a stale federated
+                // toast would misattribute an error to the CURRENT load.
+                if (loadSessionRef.current !== currentSession) {
+                  console.warn('[useIfc] finalize error ignored - superseded load (stale session):', err);
+                  return;
+                }
                 // Data model parsing failed - spatial index and caching skipped
                 console.warn('[useIfc] Skipping spatial index/cache - data model unavailable:', err);
                 if (target.kind === 'federated') {

--- a/apps/viewer/src/hooks/useIfcLoader.ts
+++ b/apps/viewer/src/hooks/useIfcLoader.ts
@@ -1143,6 +1143,23 @@ export function useIfcLoader() {
           const event = nextResult.value;
           const eventReceived = performance.now();
 
+          // Stale-session guard for the PRIMARY streaming path. A second primary
+          // load (e.g. the `ifc-lite:load-file` event) bumps loadSessionRef and
+          // resets the active model; without this, the superseded load's stream
+          // keeps mutating the NEW active model — appendGeometryBatch (batch +
+          // complete), updateMeshColors, updateCoordinateInfo and the loop's
+          // setProgress calls — producing mixed meshes and a wrong RTC/coordinate
+          // frame. Every other deferred write in this file already guards on the
+          // session (see finalize/post-stream below). Stop the loop and clean up
+          // the reader (the post-loop closeGeometryIterator releases WASM) so no
+          // more active-model writes happen. Federated adds keep a stable session
+          // and never touch the active slot during streaming, so they are exempt.
+          if (target.kind === 'primary' && loadSessionRef.current !== currentSession) {
+            console.warn(`[useIfc] stream ABORTED: stale session (mine=${currentSession}, current=${loadSessionRef.current}) — superseded by a newer load`);
+            await closeGeometryIterator();
+            break;
+          }
+
           switch (event.type) {
             case 'start':
               estimatedTotal = event.totalEstimate;

--- a/apps/viewer/src/lib/collab/geometry-sync.ts
+++ b/apps/viewer/src/lib/collab/geometry-sync.ts
@@ -255,10 +255,29 @@ export async function hydrateGeometryFromRoom(
 
 /**
  * Wrap hydrated meshes into a `GeometryResult` the renderer accepts. Meshes
- * arrive already in the owner's shifted coordinate space, so we report a zero
- * origin shift and just compute bounds + totals for camera framing. Vertices
- * may be in a per-element local frame (`MeshData.origin`, world = origin +
- * position, #1114), so the origin is folded into the bounds.
+ * arrive already in the owner's shifted coordinate space; we compute bounds +
+ * totals for camera framing. Vertices may be in a per-element local frame
+ * (`MeshData.origin`, world = origin + position, #1114), so the origin is
+ * folded into the bounds.
+ *
+ * KNOWN FRAME MISMATCH — georeferenced collab (needs follow-up):
+ *   For a georeferenced model the owner's world coordinates are reconstructed as
+ *   `world = shifted + originShift (+ wasmRtcOffset)` (see coordinate-handler
+ *   `toWorld`). The blob meshes are in the owner's SHIFTED frame, but the owner's
+ *   `originShift` / `wasmRtcOffset` are NOT transmitted in the room:
+ *     - the mesh-codec (mesh-codec.ts) only carries the per-element local
+ *       `origin`, never the global shift/rtc;
+ *     - `seedGeometryToRoom` seeds mesh blobs only;
+ *     - the joiner's IFCX re-parse (viewerModelIngest.ts) hardcodes
+ *       `createCoordinateInfo(bounds)` with a zero shift too.
+ *   So we can only report zeros here. For a georeferenced model this leaves the
+ *   joiner's reconstructed world frame off from the owner's by shift+rtc (up to
+ *   ~1e6 m) — wrong georef overlay alignment and wrong coordinate readouts. The
+ *   model still renders self-consistently (all meshes share the shift), so 3D
+ *   editing/selection is unaffected; only absolute world positioning is wrong.
+ *   Proper fix (larger, touches the published @ifc-lite/collab room schema):
+ *   have the owner encode its coordinateInfo (originShift + wasmRtcOffset) into
+ *   the room at seed time and consume it here instead of the zeros below.
  */
 export function buildGeometryResultFromMeshes(meshes: MeshData[]): GeometryResult {
   let totalTriangles = 0;

--- a/apps/viewer/src/lib/recent-files.ts
+++ b/apps/viewer/src/lib/recent-files.ts
@@ -14,8 +14,11 @@
 
 const KEY = 'ifc-lite:recent-files';
 const DB_NAME = 'ifc-lite-file-cache';
-const DB_VERSION = 1;
+// v2 adds a `timestamp` index so eviction can order records newest-first via a
+// key cursor — without deserializing every blob ArrayBuffer (see cacheFileBlobs).
+const DB_VERSION = 2;
 const STORE_NAME = 'files';
+const TIMESTAMP_INDEX = 'timestamp';
 const MAX_CACHED_FILES = 5;
 /** Max file size to cache (150 MB) — avoids filling IndexedDB quota */
 const MAX_CACHE_SIZE = 150 * 1024 * 1024;
@@ -74,8 +77,16 @@ function openDB(): Promise<IDBDatabase> {
     const req = indexedDB.open(DB_NAME, DB_VERSION);
     req.onupgradeneeded = () => {
       const db = req.result;
-      if (!db.objectStoreNames.contains(STORE_NAME)) {
-        db.createObjectStore(STORE_NAME, { keyPath: 'name' });
+      // The versionchange transaction — needed to reach an existing store when
+      // upgrading v1 → v2 (createObjectStore only runs on a fresh create).
+      const tx = req.transaction;
+      const store = db.objectStoreNames.contains(STORE_NAME)
+        ? tx!.objectStore(STORE_NAME)
+        : db.createObjectStore(STORE_NAME, { keyPath: 'name' });
+      // Records have always carried a `timestamp`; the index just lets eviction
+      // walk them ordered without reading the blobs.
+      if (!store.indexNames.contains(TIMESTAMP_INDEX)) {
+        store.createIndex(TIMESTAMP_INDEX, 'timestamp', { unique: false });
       }
     };
     req.onsuccess = () => resolve(req.result);
@@ -118,16 +129,20 @@ export async function cacheFileBlobs(files: File[]): Promise<void> {
       store.put(record);
     }
 
-    // Evict old entries beyond MAX_CACHED_FILES
-    const allReq = store.getAll();
-    allReq.onsuccess = () => {
-      const all = allReq.result as { name: string; timestamp: number }[];
-      if (all.length > MAX_CACHED_FILES) {
-        all.sort((a, b) => b.timestamp - a.timestamp);
-        for (let i = MAX_CACHED_FILES; i < all.length; i++) {
-          store.delete(all[i].name);
-        }
+    // Evict old entries beyond MAX_CACHED_FILES. Walk the `timestamp` index
+    // newest-first with a KEY cursor — it yields only the index key + primary
+    // key, never the record value, so the ~1.5 GB of cached blob ArrayBuffers
+    // are never deserialized just to sort by timestamp (the old getAll() did).
+    const cursorReq = store.index(TIMESTAMP_INDEX).openKeyCursor(null, 'prev');
+    let kept = 0;
+    cursorReq.onsuccess = () => {
+      const cursor = cursorReq.result;
+      if (!cursor) return;
+      kept++;
+      if (kept > MAX_CACHED_FILES) {
+        store.delete(cursor.primaryKey);
       }
+      cursor.continue();
     };
 
     await new Promise<void>((resolve, reject) => {

--- a/apps/viewer/src/lib/wall-rects-from-meshes.test.ts
+++ b/apps/viewer/src/lib/wall-rects-from-meshes.test.ts
@@ -5,10 +5,27 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
 import { footprintOBB, wallRectsFromMeshes } from './wall-rects-from-meshes.js';
-import type { MeshData } from '@ifc-lite/geometry';
+import type { MeshData, CoordinateInfo } from '@ifc-lite/geometry';
 
 type Pt = [number, number];
 const near = (a: number, b: number, eps = 1e-6) => Math.abs(a - b) < eps;
+
+// Canonical render→IFC reconstruction, independent of the code under test:
+// coordinate-handler `toWorld` (mirrored in PropertiesPanel + lib/geo
+// `totalYupOffset`). worldYup = renderLocal + originShift + rtcYup, with
+// rtcYup = { x: rtc.x, y: rtc.z, z: -rtc.y }; then ifcX = worldYup.x,
+// ifcY = -worldYup.z, ifcZ = worldYup.y.
+function canonicalIfc(
+  rx: number, ry: number, rz: number,
+  shift: { x: number; y: number; z: number },
+  rtc: { x: number; y: number; z: number },
+): { ifcX: number; ifcY: number; ifcZ: number } {
+  const rtcYup = { x: rtc.x, y: rtc.z, z: -rtc.y };
+  const wx = rx + shift.x + rtcYup.x;
+  const wy = ry + shift.y + rtcYup.y;
+  const wz = rz + shift.z + rtcYup.z;
+  return { ifcX: wx, ifcY: -wz, ifcZ: wy };
+}
 
 // A render-frame box for one wall: plan footprint is XZ, height is Y. A wall
 // 4 m long (X) × `thick` (Z), `h0..h1` tall (Y).
@@ -90,6 +107,58 @@ describe('wallRectsFromMeshes', () => {
     // Wall Y[0..20] spans storey band [6,9] → included.
     const rects = wallRectsFromMeshes([wallBox(1, 0, 4, 0, 0.8, 0, 20)], undefined, 6, 3);
     assert.strictEqual(rects.length, 1);
+  });
+
+  it('reconstructs the footprint + elevation under a NON-ZERO originShift/rtc, matching the canonical handler', () => {
+    // Georeferenced model: non-zero originShift (viewer Y-up frame) AND
+    // wasmRtcOffset (IFC Z-up). Regression guard for the inverted shift signs —
+    // with a zero shift this test would pass even with the old (wrong) code.
+    const shift = { x: 100, y: 5, z: 20 };
+    const rtc = { x: 1000, y: 2000, z: 3000 };
+    const coord = {
+      originShift: shift,
+      wasmRtcOffset: rtc,
+      hasLargeCoordinates: true,
+      originalBounds: { min: { x: 0, y: 0, z: 0 }, max: { x: 0, y: 0, z: 0 } },
+      shiftedBounds: { min: { x: 0, y: 0, z: 0 }, max: { x: 0, y: 0, z: 0 } },
+    } as unknown as CoordinateInfo;
+
+    // Wall render box: renderX[0..4], renderZ[0..0.8], renderY[0..3].
+    // Its render-Y band maps to ifcZ = renderY + shift.y + rtc.z = renderY + 3005,
+    // so the wall occupies ifcZ ∈ [3005, 3008]. Storey band [3005, 3008].
+    const floorElevation = 3005;
+    const floorToFloor = 3;
+    const rects = wallRectsFromMeshes([wallBox(1, 0, 4, 0, 0.8, 0, 3)], coord, floorElevation, floorToFloor);
+    assert.strictEqual(rects.length, 1, 'wall should fall on the shifted storey band');
+    assert.ok(near(rects[0].thickness, 0.8, 1e-3), `thickness ${rects[0].thickness}`);
+
+    // The centreline runs along X at mid-thickness (renderZ = 0.4). Compare the
+    // wall-rects output to the canonical reconstruction of that render point.
+    const [a, b] = rects[0].centreline;
+    const endA = canonicalIfc(0, 1.5, 0.4, shift, rtc); // renderX 0
+    const endB = canonicalIfc(4, 1.5, 0.4, shift, rtc); // renderX 4
+    // endpoints may be in either order — match as an unordered pair
+    const matches =
+      (near(a[0], endA.ifcX, 1e-3) && near(a[1], endA.ifcY, 1e-3) && near(b[0], endB.ifcX, 1e-3) && near(b[1], endB.ifcY, 1e-3)) ||
+      (near(a[0], endB.ifcX, 1e-3) && near(a[1], endB.ifcY, 1e-3) && near(b[0], endA.ifcX, 1e-3) && near(b[1], endA.ifcY, 1e-3));
+    assert.ok(matches, `centreline ${JSON.stringify([a, b])} vs canonical A=${JSON.stringify(endA)} B=${JSON.stringify(endB)}`);
+    // Concretely: cx = rtc.x + shift.x = 1100, cy = rtc.y - shift.z = 1980,
+    // mid-thickness ifcY = 1980 - 0.4 = 1979.6.
+    assert.ok(near(a[1], 1979.6, 1e-3) && near(b[1], 1979.6, 1e-3), `centreline y ${a[1]},${b[1]}`);
+  });
+
+  it('excludes a wall whose SHIFTED elevation leaves the storey band', () => {
+    // Same shift/rtc, but a storey band that (after the shift) the wall misses.
+    const coord = {
+      originShift: { x: 100, y: 5, z: 20 },
+      wasmRtcOffset: { x: 1000, y: 2000, z: 3000 },
+      hasLargeCoordinates: true,
+      originalBounds: { min: { x: 0, y: 0, z: 0 }, max: { x: 0, y: 0, z: 0 } },
+      shiftedBounds: { min: { x: 0, y: 0, z: 0 }, max: { x: 0, y: 0, z: 0 } },
+    } as unknown as CoordinateInfo;
+    // Wall ifcZ ∈ [3005, 3008]; a band at ifcZ [0, 3] does NOT overlap it.
+    const rects = wallRectsFromMeshes([wallBox(1, 0, 4, 0, 0.8, 0, 3)], coord, 0, 3);
+    assert.strictEqual(rects.length, 0);
   });
 
   it('ignores non-wall meshes', () => {

--- a/apps/viewer/src/lib/wall-rects-from-meshes.ts
+++ b/apps/viewer/src/lib/wall-rects-from-meshes.ts
@@ -21,7 +21,8 @@
  * Frame: the rendered meshes are WebGL Y-up (`world = origin + position`). The
  * plan footprint is render XZ; we map it to the same "room frame" the underlay
  * uses (`useConstructionUnderlay`): `ifcX = renderX + cx`, `ifcY = cy − renderZ`,
- * with `cx = rtc.x − shift.x`, `cy = rtc.y + shift.z`. For models with no large
+ * with `cx = rtc.x + shift.x`, `cy = rtc.y − shift.z` — the canonical
+ * `toWorld`/`totalYupOffset` sign convention. For models with no large
  * coordinate shift (rtc = shift = 0) this is `(renderX, −renderZ)` — identity to
  * IFC X/Y. Storey scoping is a render-Y (height) band overlap, so a full-height
  * wall correctly bounds rooms on every storey it passes through.
@@ -128,11 +129,19 @@ export function wallRectsFromMeshes(
 ): WallRect[] {
   const rtc = coord?.wasmRtcOffset ?? { x: 0, y: 0, z: 0 };
   const shift = coord?.originShift ?? { x: 0, y: 0, z: 0 };
-  const cx = rtc.x - shift.x;
-  const cy = rtc.y + shift.z;
-  // Storey band in render-Y (height). renderY = ifcZ − rtc.z + shift.y.
-  const lo = floorElevation - rtc.z + shift.y;
-  const hi = floorElevation + floorToFloor - rtc.z + shift.y;
+  // Canonical reconstruction (coordinate-handler `toWorld`, mirrored in
+  // PropertiesPanel + lib/geo `totalYupOffset`): worldYup = renderLocal + shift
+  // + rtcYup, with rtcYup = { x: rtc.x, y: rtc.z, z: -rtc.y }; then
+  // ifcX = worldYup.x, ifcY = -worldYup.z, ifcZ = worldYup.y. Solving:
+  //   ifcX = renderX + (rtc.x + shift.x)   → cx = rtc.x + shift.x
+  //   ifcY = (rtc.y - shift.z) - renderZ   → cy = rtc.y - shift.z
+  // The shift terms were previously inverted (worked only because shift is
+  // usually 0 for non-georeferenced models).
+  const cx = rtc.x + shift.x;
+  const cy = rtc.y - shift.z;
+  // Storey band in render-Y (height). renderY = ifcZ − rtc.z − shift.y.
+  const lo = floorElevation - rtc.z - shift.y;
+  const hi = floorElevation + floorToFloor - rtc.z - shift.y;
 
   const walls = new Map<number, { pts: Pt[]; ymin: number; ymax: number }>();
   for (const m of meshes) {

--- a/apps/viewer/src/store/index.ts
+++ b/apps/viewer/src/store/index.ts
@@ -482,6 +482,10 @@ const createViewerStore = () => create<ViewerState>()((...args) => ({
       lensPanelVisible: false,
       lensColorMap: new Map<number, string>(),
       lensHiddenIds: new Set<number>(),
+      // Ownership bookkeeping for the shared hidden/isolation channels — those
+      // channels are wiped above, so stale claims must not survive the reset.
+      lensAppliedHiddenIds: [] as number[],
+      lensRuleIsolation: null,
       lensRuleCounts: new Map<string, number>(),
       lensRuleEntityIds: new Map<string, number[]>(),
 

--- a/apps/viewer/src/store/slices/lensSlice.ts
+++ b/apps/viewer/src/store/slices/lensSlice.ts
@@ -111,6 +111,18 @@ export interface LensSlice {
   lensAppliedColors: Map<number, [number, number, number, number]> | null;
   /** Computed: globalIds to hide via lens rules */
   lensHiddenIds: Set<number>;
+  /** The ids the lens panel pushed into the shared `hiddenEntities` channel on
+   *  behalf of the active lens — ONLY ids the lens NEWLY hid (ids the user had
+   *  already hidden manually are never claimed). Store-level rather than
+   *  component state so a panel unmount/remount keeps ownership and teardown
+   *  restores exactly these ids (see lens-visibility-ownership.ts). */
+  lensAppliedHiddenIds: number[];
+  /** Rule isolation the lens panel applied: the rule id plus the exact ids it
+   *  pushed into the shared `isolatedEntities` channel. Store-level so Clear /
+   *  toggle / delete can still release the isolation channel after the panel
+   *  unmounted and remounted (component-local state would reset to null and
+   *  leave the model stuck isolated). */
+  lensRuleIsolation: { ruleId: string; entityIds: number[] } | null;
   /** Computed: ruleId → matched entity count for the active lens */
   lensRuleCounts: Map<string, number>;
   /** Computed: ruleId → matched entity global IDs for the active lens */
@@ -136,6 +148,8 @@ export interface LensSlice {
   setLensColorMap: (map: Map<number, string>) => void;
   setLensAppliedColors: (map: Map<number, [number, number, number, number]> | null) => void;
   setLensHiddenIds: (ids: Set<number>) => void;
+  setLensAppliedHiddenIds: (ids: number[]) => void;
+  setLensRuleIsolation: (isolation: { ruleId: string; entityIds: number[] } | null) => void;
   setLensRuleCounts: (counts: Map<string, number>) => void;
   setLensRuleEntityIds: (ids: Map<string, number[]>) => void;
   setLensAutoColorLegend: (legend: AutoColorLegendEntry[]) => void;
@@ -171,6 +185,8 @@ export const createLensSlice: StateCreator<LensSlice, [], [], LensSlice> = (set,
   lensColorMap: new Map(),
   lensAppliedColors: null,
   lensHiddenIds: new Set(),
+  lensAppliedHiddenIds: [],
+  lensRuleIsolation: null,
   lensRuleCounts: new Map(),
   lensRuleEntityIds: new Map(),
   lensAutoColorLegend: [],
@@ -221,6 +237,8 @@ export const createLensSlice: StateCreator<LensSlice, [], [], LensSlice> = (set,
   setLensColorMap: (lensColorMap) => set({ lensColorMap }),
   setLensAppliedColors: (lensAppliedColors) => set({ lensAppliedColors }),
   setLensHiddenIds: (lensHiddenIds) => set({ lensHiddenIds }),
+  setLensAppliedHiddenIds: (lensAppliedHiddenIds) => set({ lensAppliedHiddenIds }),
+  setLensRuleIsolation: (lensRuleIsolation) => set({ lensRuleIsolation }),
   setLensRuleCounts: (lensRuleCounts) => set({ lensRuleCounts }),
   setLensRuleEntityIds: (lensRuleEntityIds) => set({ lensRuleEntityIds }),
   setLensAutoColorLegend: (lensAutoColorLegend) => set({ lensAutoColorLegend }),


### PR DESCRIPTION
Review-driven viewer batch on the load / visibility / coordinate paths.

- **useIfcLoader (the review's stream-loop session guard)**: the PRIMARY geometry streaming loop now checks `loadSessionRef` each iteration. A second primary load (e.g. `ifc-lite:load-file`) bumps the session and resets the active model; the superseded load's stream previously kept appending geometry / colors / coordinateInfo onto the NEW active model — mixed meshes and a wrong RTC/coordinate frame. The stale loop now breaks and closes its geometry iterator (releasing WASM). Federated adds keep a stable session and are exempt. `MainToolbar` also ignores `ifc-lite:load-file` while a load is in flight (belt-and-suspenders).
- **LensPanel**: switching lens A->B un-hides A's entities before applying B's (A's hides previously leaked into the global channel and stayed invisible under B). Lens teardown restores only lens-owned hidden ids + the lens's own rule-isolation instead of a global `showAll()` that wiped manual hides / isolation / class filter / ghost context.
- Plus the coordinate and security fixes in the same sweep (see commit for the full list).

Viewer app only — no changeset needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)