### PR TITLE
fix(geometry): sync process() stack overflow on >65k-mesh models

### DIFF
--- a/.changeset/sync-process-mesh-spread.md
+++ b/.changeset/sync-process-mesh-spread.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/geometry": patch
+---
+
+Fix `GeometryProcessor.process()` throwing `RangeError: Maximum call stack size exceeded` on models with more than ~65k meshes (e.g. 169MB Holter tower, ~110k meshes). The synchronous collect path spread the whole mesh batch into a single `Array.push(...)` call, which passes one argument per mesh and blows V8's argument ceiling; it now appends in a loop. The streaming path was never affected.

--- a/packages/geometry/src/index.ts
+++ b/packages/geometry/src/index.ts
@@ -437,7 +437,12 @@ export class GeometryProcessor {
           prePass.materialColorCounts,
           prePass.materialColors,
         );
-        meshes.push(...convertMeshCollectionToBatch(collection));
+        // Loop, not `push(...batch)`: spreading passes one ARGUMENT per mesh,
+        // and past V8's ~65k argument ceiling that throws RangeError "Maximum
+        // call stack size exceeded" — real models (Holter: ~110k meshes) hit
+        // it, killing the whole sync process() call.
+        const batch = convertMeshCollectionToBatch(collection);
+        for (let i = 0; i < batch.length; i++) meshes.push(batch[i]);
       }
 
       return { meshes, buildingRotation: prePass.buildingRotation ?? undefined };


### PR DESCRIPTION
## What

`GeometryProcessor.process()` (the synchronous path used by SDK/Node callers and the profiling bench — the viewer streams and is unaffected) throws `RangeError: Maximum call stack size exceeded` on any model with more than ~65k meshes. `collectMeshesViaPrePass` spread the entire batch into a single `meshes.push(...)` call: one JS **argument** per mesh, which exceeds V8's argument ceiling. Appends in a loop instead — the same pattern the viewer already uses ("use loop to avoid stack overflow with large batches").

## Repro

Found running the apples-to-apples bench against the freshly published `@ifc-lite/geometry@3.2.1`: ISSUE_053 Holter (169MB, ~110k meshes) fails with the RangeError at the collect step; every smaller model passes. This replaces the historical "WASM unreachable" failure cause recorded for Holter in the profiling findings — the wasm pipeline itself completes now; only this JS collect step dies.

## Notes

- One-line behavioural change + comment; changeset `@ifc-lite/geometry` patch.
- Audited the hot packages for the same pattern: the only other `push(...x)` (classification-extractor) spreads per-relation object lists, which are bounded small.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed synchronous geometry processing for models containing more than approximately 65,000 meshes.
  * Prevented processing failures caused by call stack limits when collecting large mesh batches.

* **Chores**
  * Documented the fix in the upcoming patch release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->