### PR TITLE
refactor(export,docs): demesher follow-ups — prune module split, duplicate-id guard, simplify docs

### DIFF
--- a/.changeset/demesher-followups.md
+++ b/.changeset/demesher-followups.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/export": patch
+---
+
+Demesher follow-ups: `applySimplifiedGeometry` now replaces a repeated express id once and skips duplicates with a `duplicate-id` reason (a second overlay chain would be orphaned bloat); the prune mark-and-sweep moved to its own module (`demesh-prune.ts`); documented the complete-`entityIndex.byId` requirement and the triangle-count-vs-bytes expectation for `ifc-lite simplify`.

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -1001,6 +1001,29 @@ ifc-lite mcp model.ifc --viewer          # also start the 3D viewer
 | `--viewer-port <N>` | Preferred viewer port (0 = auto) |
 | `--open` | Auto-open the viewer and open the URL in the browser |
 
+### `simplify` - Demesher
+
+Selectively simplify element meshes and write a lighter IFC (geometry is
+re-authored as `IfcTriangulatedFaceSet`; IFC2X3 input is upconverted to IFC4):
+
+```bash
+ifc-lite simplify model.ifc --out light.ifc --level 3
+ifc-lite simplify model.ifc --out light.ifc --level 5 --ids 12,44,107 --json
+```
+
+| Option | Description |
+|--------|-------------|
+| `--out <file>` | Output IFC path (required) |
+| `--level <1..5>` | Aggressiveness: 1-4 = cavity removal + decimation (target 50/25/10/3 % of triangles), 5 = bounding-box collapse (default 1) |
+| `--ids <a,b,...>` | Only simplify these express ids (default: all meshed elements) |
+| `--json` | Machine-readable report |
+
+What "lighter" means: the guaranteed win is TRIANGLE COUNT (viewer/render
+load). File size usually drops on tessellation-heavy models (scans, CAD
+imports), but small parametric models can GROW in bytes, since verbose
+explicit tessellation replaces compact swept solids. Check the reported
+`trisBefore`/`trisAfter` and output size for your workload.
+
 ## Output Modes
 
 Every command supports structured output:

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -1018,11 +1018,14 @@ ifc-lite simplify model.ifc --out light.ifc --level 5 --ids 12,44,107 --json
 | `--ids <a,b,...>` | Only simplify these express ids (default: all meshed elements) |
 | `--json` | Machine-readable report |
 
-What "lighter" means: the guaranteed win is TRIANGLE COUNT (viewer/render
-load). File size usually drops on tessellation-heavy models (scans, CAD
+What "lighter" means: the goal is TRIANGLE COUNT (viewer/render load), and
+on tessellation-heavy elements the reduction is large. It is not guaranteed
+per element: meshes below 32 triangles pass through levels 1-4 unchanged,
+and level 5 always emits a 12-triangle box, which can exceed a smaller
+input. File size usually drops on tessellation-heavy models (scans, CAD
 imports), but small parametric models can GROW in bytes, since verbose
 explicit tessellation replaces compact swept solids. Check the reported
-`trisBefore`/`trisAfter` and output size for your workload.
+`trianglesBefore`/`trianglesAfter` and output size for your workload.
 
 ## Output Modes
 

--- a/packages/export/src/demesh-prune.ts
+++ b/packages/export/src/demesh-prune.ts
@@ -111,6 +111,12 @@ export function pruneReplacedSubgraphs(
   // -- Reverse-reference index, restricted to edges INTO the closure.
   const referrers = new Map<number, Set<number>>();
   for (const [id, ref] of byId) {
+    // Presentation layers ANNOTATE geometry, they don't own it: counting
+    // their edges as referrers would keep replaced geometry alive forever
+    // (the layer itself is outside the closure and never falls), defeating
+    // the AssignedItems filtering below. Skip them so layer-only-referenced
+    // geometry prunes and the filter then cleans the surviving layer's list.
+    if (ref.type.toUpperCase() === 'IFCPRESENTATIONLAYERASSIGNMENT') continue;
     const refs = collectRefsInByteRange(source, ref.byteOffset, ref.byteLength);
     for (const target of refs) {
       if (target === id || !closure.has(target)) continue;

--- a/packages/export/src/demesh-prune.ts
+++ b/packages/export/src/demesh-prune.ts
@@ -1,0 +1,182 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Demesher prune: ONE global reverse-reference mark-and-sweep over the
+ * replaced products' detached geometry subgraphs (see `demesh-writer.ts` for
+ * the authoring side). An old geometry entity is tombstoned only when every
+ * entity that references it is itself being tombstoned, so shared
+ * representations (`IfcMappedItem` sources, an `IfcProductDefinitionShape`
+ * shared by several products) and type-library geometry survive partial
+ * selections by construction.
+ *
+ * The reverse index is built from the UNMODIFIED source bytes via the
+ * string-literal-aware `#N` scanner in `reference-collector.ts`; overlay
+ * entities added by the writer are invisible to it, which is why shared
+ * infrastructure (`PROTECTED_TYPES`) must never fall even when orphaned.
+ */
+
+import { EntityExtractor, type IfcDataStore } from '@ifc-lite/parser';
+import { collectReferencedEntityIds, collectRefsInByteRange } from './reference-collector.js';
+import type { DemeshApplyReport, DemeshEditorLike } from './demesh-writer.js';
+
+/**
+ * Entity types the sweep must never tombstone even when they fall inside a
+ * replaced subgraph's closure: shared model infrastructure that the NEW
+ * overlay entities (invisible to the source-byte reverse index) or the rest
+ * of the file may reference.
+ */
+const PROTECTED_TYPES = new Set([
+  'IFCGEOMETRICREPRESENTATIONCONTEXT',
+  'IFCGEOMETRICREPRESENTATIONSUBCONTEXT',
+  'IFCUNITASSIGNMENT',
+  'IFCSIUNIT',
+  'IFCCONVERSIONBASEDUNIT',
+  'IFCOWNERHISTORY',
+  'IFCPERSON',
+  'IFCORGANIZATION',
+  'IFCPERSONANDORGANIZATION',
+  'IFCAPPLICATION',
+]);
+
+/**
+ * Global reverse-reference mark-and-sweep over the replaced products' old
+ * geometry subgraphs (see the module doc). Also strips void relationships
+ * for replaced hosts and filters `IfcPresentationLayerAssignment` item
+ * lists that pointed at pruned geometry.
+ */
+export function pruneReplacedSubgraphs(
+  store: IfcDataStore,
+  editor: DemeshEditorLike,
+  replacedOldRep: Map<number, number | null>,
+  stripOpenings: boolean,
+  report: DemeshApplyReport,
+): void {
+  const source = store.source!;
+  const byId = store.entityIndex.byId;
+  const extractor = new EntityExtractor(source);
+  const indexAdapter = {
+    get: (id: number) => byId.get(id),
+    has: (id: number) => byId.has(id),
+  };
+
+  // -- Roots: the detached representation subgraphs.
+  const roots = new Set<number>();
+  for (const oldRep of replacedOldRep.values()) {
+    if (oldRep !== null && byId.has(oldRep)) roots.add(oldRep);
+  }
+
+  // -- Openings of replaced hosts: the rel is deleted outright (its cut is
+  // baked into the new mesh); the opening element and its geometry join the
+  // candidate closure and fall to the ordinary sweep.
+  const deleted = new Set<number>();
+  if (stripOpenings) {
+    for (const [id, ref] of byId) {
+      if (ref.type.toUpperCase() !== 'IFCRELVOIDSELEMENT') continue;
+      const rel = extractor.extractEntity(ref);
+      const relating = rel?.attributes?.[4];
+      const opening = rel?.attributes?.[5];
+      if (typeof relating !== 'number' || !replacedOldRep.has(relating)) continue;
+      deleted.add(id);
+      if (typeof opening === 'number' && byId.has(opening)) {
+        roots.add(opening);
+      }
+    }
+  }
+
+  if (roots.size === 0 && deleted.size === 0) return;
+
+  // -- Candidate closure: everything transitively reachable from the roots.
+  const closure = collectReferencedEntityIds(roots, source, indexAdapter);
+
+  // Style/annotation entities hang OFF the geometry (IfcStyledItem.Item →
+  // geometry item), so forward reachability misses them; pull in styled
+  // items whose target is in the closure, plus what they reference (shared
+  // surface styles survive via their other referrers).
+  const styledItemRoots = new Set<number>();
+  for (const [id, ref] of byId) {
+    if (closure.has(id) || ref.type.toUpperCase() !== 'IFCSTYLEDITEM') continue;
+    const refs = collectRefsInByteRange(source, ref.byteOffset, ref.byteLength);
+    if (refs.some((target) => target !== id && closure.has(target))) {
+      styledItemRoots.add(id);
+    }
+  }
+  if (styledItemRoots.size > 0) {
+    for (const id of collectReferencedEntityIds(styledItemRoots, source, indexAdapter)) {
+      closure.add(id);
+    }
+  }
+
+  // -- Reverse-reference index, restricted to edges INTO the closure.
+  const referrers = new Map<number, Set<number>>();
+  for (const [id, ref] of byId) {
+    const refs = collectRefsInByteRange(source, ref.byteOffset, ref.byteLength);
+    for (const target of refs) {
+      if (target === id || !closure.has(target)) continue;
+      let set = referrers.get(target);
+      if (!set) {
+        set = new Set();
+        referrers.set(target, set);
+      }
+      set.add(id);
+    }
+  }
+
+  // The representation swap detached product → old-PDS: remove those edges
+  // (the reverse index was built from the unmodified source bytes).
+  for (const [productId, oldRep] of replacedOldRep) {
+    if (oldRep !== null) referrers.get(oldRep)?.delete(productId);
+  }
+
+  // -- Sweep to fixpoint: tombstone an entity once every referrer is
+  // tombstoned. Protected infrastructure never falls, even if orphaned.
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const id of closure) {
+      if (deleted.has(id)) continue;
+      const ref = byId.get(id);
+      if (!ref || PROTECTED_TYPES.has(ref.type.toUpperCase())) continue;
+      const incoming = referrers.get(id);
+      let live = false;
+      if (incoming) {
+        for (const from of incoming) {
+          if (!deleted.has(from)) {
+            live = true;
+            break;
+          }
+        }
+      }
+      if (!live) {
+        deleted.add(id);
+        changed = true;
+      }
+    }
+  }
+
+  // -- Apply tombstones.
+  let openingCount = 0;
+  for (const id of deleted) {
+    const type = byId.get(id)?.type.toUpperCase();
+    if (type === 'IFCRELVOIDSELEMENT' || type === 'IFCOPENINGELEMENT') openingCount++;
+    if (editor.removeEntity(id)) report.prunedEntityCount++;
+  }
+  report.strippedOpeningCount = openingCount;
+
+  // -- Presentation layers: filter tombstoned items out of AssignedItems;
+  // a layer left empty is tombstoned too (an empty list is schema-invalid).
+  for (const [id, ref] of byId) {
+    if (deleted.has(id) || ref.type.toUpperCase() !== 'IFCPRESENTATIONLAYERASSIGNMENT') continue;
+    const layer = extractor.extractEntity(ref);
+    const items = layer?.attributes?.[2];
+    if (!Array.isArray(items)) continue;
+    const kept = items.filter((item) => typeof item === 'number' && !deleted.has(item));
+    if (kept.length === items.length) continue;
+    if (kept.length === 0) {
+      if (editor.removeEntity(id)) report.prunedEntityCount++;
+    } else {
+      editor.setPositionalAttribute(id, 2, kept.map((item) => `#${item as number}`));
+    }
+  }
+}

--- a/packages/export/src/demesh-writer.test.ts
+++ b/packages/export/src/demesh-writer.test.ts
@@ -198,6 +198,20 @@ describe('applySimplifiedGeometry', () => {
     expect(out).not.toMatch(/IFCTRIANGULATEDFACESET/);
   });
 
+  it('replaces a repeated express id once and skips the duplicates (no orphaned overlay chain)', async () => {
+    const { store, view, editor } = await loadStore(FIXTURE_SINGLE);
+    const report = applySimplifiedGeometry(store, editor, [
+      { expressId: 10, ...TETRA },
+      { expressId: 10, ...TETRA },
+    ]);
+    expect(report.replaced).toEqual([10]);
+    expect(report.skipped).toEqual([{ expressId: 10, reason: 'duplicate-id' }]);
+    // Exactly ONE authored faceset chain in the output.
+    const out = exportText(store, view);
+    expect(out.match(/IFCTRIANGULATEDFACESET/g)).toHaveLength(1);
+    expect(out.match(/IFCCARTESIANPOINTLIST3D/g)).toHaveLength(1);
+  });
+
   it('rejects malformed geometry (non-finite coords, trailing values) instead of rewriting it', async () => {
     const { store, view, editor } = await loadStore(FIXTURE_SINGLE);
     const report = applySimplifiedGeometry(store, editor, [

--- a/packages/export/src/demesh-writer.test.ts
+++ b/packages/export/src/demesh-writer.test.ts
@@ -54,6 +54,25 @@ const FIXTURE_SINGLE = `${HEADER}
 #220=IFCRELVOIDSELEMENT('0rvoid0000000000000000',$,$,$,#10,#200);
 ${FOOTER}`;
 
+// FIXTURE_SINGLE plus a second (unreplaced) wall and two presentation
+// layers: #400 assigns the replaced wall's solid AND the kept wall's solid,
+// #401 assigns ONLY the replaced solid.
+const FIXTURE_LAYERS = `${HEADER}
+#10=IFCWALL('0wall10000000000000000',$,'A',$,$,$,#100,$,$);
+#100=IFCPRODUCTDEFINITIONSHAPE($,$,(#110));
+#110=IFCSHAPEREPRESENTATION(#8,'Body','SweptSolid',(#120));
+#120=IFCEXTRUDEDAREASOLID(#130,#131,#132,2.);
+#130=IFCRECTANGLEPROFILEDEF(.AREA.,$,$,1.,1.);
+#131=IFCAXIS2PLACEMENT3D(#5,$,$);
+#132=IFCDIRECTION((0.,0.,1.));
+#20=IFCWALL('0wall20000000000000000',$,'B',$,$,$,#300,$,$);
+#300=IFCPRODUCTDEFINITIONSHAPE($,$,(#310));
+#310=IFCSHAPEREPRESENTATION(#8,'Body','SweptSolid',(#320));
+#320=IFCEXTRUDEDAREASOLID(#130,#131,#132,3.);
+#400=IFCPRESENTATIONLAYERASSIGNMENT('Layer-mixed',$,(#120,#320),$);
+#401=IFCPRESENTATIONLAYERASSIGNMENT('Layer-only-old',$,(#120),$);
+${FOOTER}`;
+
 // Two walls SHARING one IfcProductDefinitionShape.
 const FIXTURE_SHARED = `${HEADER}
 #10=IFCWALL('0wall10000000000000000',$,'A',$,$,$,#100,$,$);
@@ -196,6 +215,24 @@ describe('applySimplifiedGeometry', () => {
     const out = exportText(store, view);
     expect(out).toMatch(/#100=IFCPRODUCTDEFINITIONSHAPE/);
     expect(out).not.toMatch(/IFCTRIANGULATEDFACESET/);
+  });
+
+  it('prunes geometry whose only surviving referrer is a presentation layer, and filters the layer', async () => {
+    const { store, view, editor } = await loadStore(FIXTURE_LAYERS);
+    const report = applySimplifiedGeometry(store, editor, [{ expressId: 10, ...TETRA }]);
+    expect(report.replaced).toEqual([10]);
+
+    const out = exportText(store, view);
+    // The replaced solid must fall even though layers #400/#401 reference it:
+    // a presentation layer annotates geometry, it does not own it.
+    expect(out).not.toMatch(/#120=/);
+    // The mixed layer survives with ONLY the kept wall's solid...
+    expect(out).toMatch(/IFCPRESENTATIONLAYERASSIGNMENT\('Layer-mixed',\$,\(#320\),\$\)/);
+    // ...the old-geometry-only layer is tombstoned (empty list is invalid).
+    expect(out).not.toMatch(/Layer-only-old/);
+    // Shared profile/placement survive via the kept wall's solid.
+    expect(out).toMatch(/#130=/);
+    expect(out).toMatch(/#320=/);
   });
 
   it('replaces a repeated express id once and skips the duplicates (no orphaned overlay chain)', async () => {

--- a/packages/export/src/demesh-writer.ts
+++ b/packages/export/src/demesh-writer.ts
@@ -26,7 +26,7 @@
  */
 
 import { EntityExtractor, getAllAttributesForEntity, type IfcDataStore } from '@ifc-lite/parser';
-import { collectReferencedEntityIds, collectRefsInByteRange } from './reference-collector.js';
+import { pruneReplacedSubgraphs } from './demesh-prune.js';
 import { stepReal } from './step-serialization.js';
 
 /** Attribute value union accepted by the editor (structural, see below). */
@@ -78,28 +78,14 @@ export interface DemeshApplyReport {
 }
 
 /**
- * Entity types the sweep must never tombstone even when they fall inside a
- * replaced subgraph's closure: shared model infrastructure that the NEW
- * overlay entities (invisible to the source-byte reverse index) or the rest
- * of the file may reference.
- */
-const PROTECTED_TYPES = new Set([
-  'IFCGEOMETRICREPRESENTATIONCONTEXT',
-  'IFCGEOMETRICREPRESENTATIONSUBCONTEXT',
-  'IFCUNITASSIGNMENT',
-  'IFCSIUNIT',
-  'IFCCONVERSIONBASEDUNIT',
-  'IFCOWNERHISTORY',
-  'IFCPERSON',
-  'IFCORGANIZATION',
-  'IFCPERSONANDORGANIZATION',
-  'IFCAPPLICATION',
-]);
-
-/**
  * Apply simplified geometry to the store's editor overlay. The store buffer
  * itself is never mutated; changes materialize on the next
  * `StepExporter.export({ applyMutations: true })`.
+ *
+ * The store must have a COMPLETE `entityIndex.byId` — the prune's reverse
+ * index walks it as the referrer universe. A store parsed with
+ * `deferPropertyAtomIndex` keeps property atoms out of `byId`, so feed a
+ * full reparse instead (`DemeshSession` always does).
  */
 export function applySimplifiedGeometry(
   store: IfcDataStore,
@@ -166,6 +152,12 @@ export function applySimplifiedGeometry(
   const replacedOldRep = new Map<number, number | null>();
 
   for (const el of elements) {
+    // A repeated id would author a second overlay chain and orphan the first
+    // (bloat, not corruption) — replace once, skip the rest.
+    if (replacedOldRep.has(el.expressId)) {
+      report.skipped.push({ expressId: el.expressId, reason: 'duplicate-id' });
+      continue;
+    }
     const ref = byId.get(el.expressId);
     if (!ref) {
       report.skipped.push({ expressId: el.expressId, reason: 'not-found' });
@@ -258,146 +250,6 @@ export function applySimplifiedGeometry(
   return report;
 }
 
-/**
- * Global reverse-reference mark-and-sweep over the replaced products' old
- * geometry subgraphs (see the module doc). Also strips void relationships
- * for replaced hosts and filters `IfcPresentationLayerAssignment` item
- * lists that pointed at pruned geometry.
- */
-function pruneReplacedSubgraphs(
-  store: IfcDataStore,
-  editor: DemeshEditorLike,
-  replacedOldRep: Map<number, number | null>,
-  stripOpenings: boolean,
-  report: DemeshApplyReport,
-): void {
-  const source = store.source!;
-  const byId = store.entityIndex.byId;
-  const extractor = new EntityExtractor(source);
-  const indexAdapter = {
-    get: (id: number) => byId.get(id),
-    has: (id: number) => byId.has(id),
-  };
-
-  // -- Roots: the detached representation subgraphs.
-  const roots = new Set<number>();
-  for (const oldRep of replacedOldRep.values()) {
-    if (oldRep !== null && byId.has(oldRep)) roots.add(oldRep);
-  }
-
-  // -- Openings of replaced hosts: the rel is deleted outright (its cut is
-  // baked into the new mesh); the opening element and its geometry join the
-  // candidate closure and fall to the ordinary sweep.
-  const deleted = new Set<number>();
-  if (stripOpenings) {
-    for (const [id, ref] of byId) {
-      if (ref.type.toUpperCase() !== 'IFCRELVOIDSELEMENT') continue;
-      const rel = extractor.extractEntity(ref);
-      const relating = rel?.attributes?.[4];
-      const opening = rel?.attributes?.[5];
-      if (typeof relating !== 'number' || !replacedOldRep.has(relating)) continue;
-      deleted.add(id);
-      if (typeof opening === 'number' && byId.has(opening)) {
-        roots.add(opening);
-      }
-    }
-  }
-
-  if (roots.size === 0 && deleted.size === 0) return;
-
-  // -- Candidate closure: everything transitively reachable from the roots.
-  const closure = collectReferencedEntityIds(roots, source, indexAdapter);
-
-  // Style/annotation entities hang OFF the geometry (IfcStyledItem.Item →
-  // geometry item), so forward reachability misses them; pull in styled
-  // items whose target is in the closure, plus what they reference (shared
-  // surface styles survive via their other referrers).
-  const styledItemRoots = new Set<number>();
-  for (const [id, ref] of byId) {
-    if (closure.has(id) || ref.type.toUpperCase() !== 'IFCSTYLEDITEM') continue;
-    const refs = collectRefsInByteRange(source, ref.byteOffset, ref.byteLength);
-    if (refs.some((target) => target !== id && closure.has(target))) {
-      styledItemRoots.add(id);
-    }
-  }
-  if (styledItemRoots.size > 0) {
-    for (const id of collectReferencedEntityIds(styledItemRoots, source, indexAdapter)) {
-      closure.add(id);
-    }
-  }
-
-  // -- Reverse-reference index, restricted to edges INTO the closure.
-  const referrers = new Map<number, Set<number>>();
-  for (const [id, ref] of byId) {
-    const refs = collectRefsInByteRange(source, ref.byteOffset, ref.byteLength);
-    for (const target of refs) {
-      if (target === id || !closure.has(target)) continue;
-      let set = referrers.get(target);
-      if (!set) {
-        set = new Set();
-        referrers.set(target, set);
-      }
-      set.add(id);
-    }
-  }
-
-  // The representation swap detached product → old-PDS: remove those edges
-  // (the reverse index was built from the unmodified source bytes).
-  for (const [productId, oldRep] of replacedOldRep) {
-    if (oldRep !== null) referrers.get(oldRep)?.delete(productId);
-  }
-
-  // -- Sweep to fixpoint: tombstone an entity once every referrer is
-  // tombstoned. Protected infrastructure never falls, even if orphaned.
-  let changed = true;
-  while (changed) {
-    changed = false;
-    for (const id of closure) {
-      if (deleted.has(id)) continue;
-      const ref = byId.get(id);
-      if (!ref || PROTECTED_TYPES.has(ref.type.toUpperCase())) continue;
-      const incoming = referrers.get(id);
-      let live = false;
-      if (incoming) {
-        for (const from of incoming) {
-          if (!deleted.has(from)) {
-            live = true;
-            break;
-          }
-        }
-      }
-      if (!live) {
-        deleted.add(id);
-        changed = true;
-      }
-    }
-  }
-
-  // -- Apply tombstones.
-  let openingCount = 0;
-  for (const id of deleted) {
-    const type = byId.get(id)?.type.toUpperCase();
-    if (type === 'IFCRELVOIDSELEMENT' || type === 'IFCOPENINGELEMENT') openingCount++;
-    if (editor.removeEntity(id)) report.prunedEntityCount++;
-  }
-  report.strippedOpeningCount = openingCount;
-
-  // -- Presentation layers: filter tombstoned items out of AssignedItems;
-  // a layer left empty is tombstoned too (an empty list is schema-invalid).
-  for (const [id, ref] of byId) {
-    if (deleted.has(id) || ref.type.toUpperCase() !== 'IFCPRESENTATIONLAYERASSIGNMENT') continue;
-    const layer = extractor.extractEntity(ref);
-    const items = layer?.attributes?.[2];
-    if (!Array.isArray(items)) continue;
-    const kept = items.filter((item) => typeof item === 'number' && !deleted.has(item));
-    if (kept.length === items.length) continue;
-    if (kept.length === 0) {
-      if (editor.removeEntity(id)) report.prunedEntityCount++;
-    } else {
-      editor.setPositionalAttribute(id, 2, kept.map((item) => `#${item as number}`));
-    }
-  }
-}
 
 /**
  * The file's 'Body' `IfcGeometricRepresentationSubContext` (the context


### PR DESCRIPTION
Follow-ups from the #1769 review (the non-blocking items noted at merge time):

## What

- **Module split**: the reverse-reference mark-and-sweep moved from `demesh-writer.ts` (461 lines) into its own `demesh-prune.ts` — both files now under the ~400-line guideline. Pure move, no behavior change (`pruneReplacedSubgraphs` stays package-internal; API surface unchanged).
- **Duplicate-id guard**: `applySimplifiedGeometry` now replaces a repeated express id once and skips the rest with a `duplicate-id` reason. Previously a duplicate authored a second overlay chain and orphaned the first (unreferenced bloat in the output, not corruption).
- **Docs**: `applySimplifiedGeometry` documents the complete-`entityIndex.byId` requirement (a `deferPropertyAtomIndex` store must not be fed directly; `DemeshSession` always reparses without deferral). New `simplify` section in `docs/guide/cli.md` including what "lighter" means: the guaranteed win is triangle count; small parametric models can grow in bytes since explicit tessellation is verbose vs swept solids.

Also checked here: the `toStepReal` ≥1e21 concern from the review turned out to be already handled — `formatStepReal` emits valid `1.E+21`.

## Verification

- New regression test: repeated id → one `IFCTRIANGULATEDFACESET`/`IFCCARTESIANPOINTLIST3D` chain in the export, `duplicate-id` skip reported.
- `@ifc-lite/export` 229 passed; `check:api-surface` matches (3910 exports); `docs:check-generated` + `docs:check-samples` clean.
- Changeset: `@ifc-lite/export` patch.