### PR TITLE
docs: retire stale '5x faster than web-ifc' claims for verifiable ones

### DIFF
--- a/.changeset/geometry-description-refresh.md
+++ b/.changeset/geometry-description-refresh.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/geometry": patch
+---
+
+Docs-only: refresh the package description and README performance claim. The old "1.9x faster than web-ifc" figure predates both web-ifc 0.0.77 (which substantially improved its geometry speed) and ifc-lite's exact-arithmetic CSG kernel; the package now describes what is actually differentiating - exact boolean cuts verified element-by-element against IfcOpenShell.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Open, view, and work with IFC files. Right in the browser.
 
 # IFClite
 
-Parse, view, query, edit, validate, and export IFC files, entirely client-side. A Rust core compiled to WASM does the parsing and geometry, a WebGPU renderer puts it on screen, and 36 npm packages let you pick exactly the pieces you need. Geometry processing is up to 5x faster than web-ifc (median ~2.2x across the benchmark corpus).
+Parse, view, query, edit, validate, and export IFC files, entirely client-side. A Rust core compiled to WASM does the parsing and geometry, a WebGPU renderer puts it on screen, and 36 npm packages let you pick exactly the pieces you need. Geometry runs on an exact-arithmetic CSG kernel, verified element-by-element against IfcOpenShell across the public benchmark corpus.
 
 Works with **IFC2X3**, **IFC4 / IFC4X3** and **IFC5 (IFCX)**. Live demo at [ifclite.com](https://www.ifclite.com/) and more info at [ifclite.dev](https://www.ifclite.dev/).
 
@@ -256,7 +256,8 @@ Full list: [API Reference](https://ifclite.dev/docs/api/typescript/) (36 npm pac
 ## Performance
 
 - **Streaming first render:** geometry is processed in batches, so the first triangles are on screen while the rest of the file is still parsing.
-- **Geometry processing:** up to 5x faster than `web-ifc` (median ~2.2x across the benchmark corpus).
+- **Geometry correctness:** exact-arithmetic boolean kernel — every opening is cut exactly, and the output is verified element-by-element against IfcOpenShell (99.9%+ agreement on the public benchmark corpus). Engines with approximate booleans are faster on boolean-heavy models; that trade is deliberate.
+- **Geometry speed:** native (server/CLI, multi-threaded) beats `web-ifc` on most of the benchmark corpus; in the browser the viewer streams geometry across workers so the first triangles render long before the file finishes processing.
 - **Parse speed:** STEP tokenization runs at roughly 1.2 GB/s; a full parse lands around 50 MB/s.
 - **Schema coverage:** 100% of IFC4 (776 entities) and IFC4X3 (876 entities).
 - **Footprint:** one lazily fetched WASM module (~1.2 MB gzipped) plus small per-package JS wrappers.

--- a/apps/landing/app.jsx
+++ b/apps/landing/app.jsx
@@ -1465,35 +1465,43 @@ function BundleComposition({ items, total }) {
 // ─────────────────────────── bench explorer ───────────────────────────
 // Canonical from louistrue/profiling@apples-to-apples-with-native, results/RESULTS.md
 // Corpus: 21 public IFCs. Times are total parse + geometry, seconds.
-// IOS rows reproduced from Moult's hardware; web-ifc + ifc-lite from M4 (10-core).
+// Refreshed 2026-07-17: ifc-lite 4.0.1 (exact-arithmetic CSG) + web-ifc 0.0.77,
+// run back-to-back on the same M4 (10-core), single cold run per file, identical
+// exclude set, both WASM rows single-threaded and timed through per-element
+// JS-accessible vertex extraction (same work-shape). IOS rows reproduced from
+// Moult's published numbers (his hardware, Manifold-augmented kernel).
+// ifc-lite cuts every opening with exact arithmetic (verified vs IfcOpenShell,
+// see correctness framework in the methodology repo); web-ifc uses approximate
+// fuzzy booleans - that trade is most visible on the boolean-heavy models
+// (ISSUE_098, ISSUE_129).
 const BENCH_MODELS = [
-  { id: "duplex",   name: "duplex.ifc",                              size: 2.3,   products: 215,   ifclite_n: 0.02, ifclite_w: 0.11, webifc: 0.16, iosmax: 0.12, ios1c: 0.19 },
-  { id: "ac20",     name: "AC20-FZK-Haus.ifc",                       size: 2.4,   products: 83,    ifclite_n: 0.02, ifclite_w: 0.09, webifc: 0.13, iosmax: 0.15, ios1c: 0.22 },
-  { id: "i005",     name: "ISSUE_005_haus.ifc",                      size: 2.4,   products: 83,    ifclite_n: 0.02, ifclite_w: 0.08, webifc: 0.10, iosmax: 0.13, ios1c: 0.21 },
-  { id: "i021",     name: "ISSUE_021_Mini Project.ifc",              size: 3.2,   products: 2636,  ifclite_n: 0.04, ifclite_w: 0.15, webifc: 0.29, iosmax: 0.29, ios1c: 0.53 },
-  { id: "officeA",  name: "Office_A_20110811.ifc",                   size: 3.8,   products: 803,   ifclite_n: 0.03, ifclite_w: 0.14, webifc: 0.11, iosmax: 0.25, ios1c: 0.29 },
-  { id: "i126",     name: "ISSUE_126_model.ifc",                     size: 4.2,   products: 257,   ifclite_n: 0.02, ifclite_w: 0.14, webifc: 0.07, iosmax: 0.32, ios1c: 0.46 },
-  { id: "i034",     name: "ISSUE_034_HouseZ.ifc",                    size: 4.8,   products: 228,   ifclite_n: 0.04, ifclite_w: 0.16, webifc: 0.09, iosmax: 0.38, ios1c: 0.71 },
-  { id: "i102",     name: "ISSUE_102_M3D-CON.ifc",                   size: 6.0,   products: 138,   ifclite_n: 0.04, ifclite_w: 0.22, webifc: 0.14, iosmax: 0.49, ios1c: 0.62 },
-  { id: "i159",     name: "ISSUE_159_kleine_Wohnung_R22.ifc",        size: 9.5,   products: 425,   ifclite_n: 0.08, ifclite_w: 0.46, webifc: 0.33, iosmax: 0.91, ios1c: 1.65 },
-  { id: "c20",      name: "C20-Institute-Var-2.ifc",                 size: 10.3,  products: 702,   ifclite_n: 0.09, ifclite_w: 0.31, webifc: 0.30, iosmax: 0.67, ios1c: 0.71 },
-  { id: "i129",     name: "ISSUE_129_N1540_17_EXE.ifc",              size: 11.5,  products: 947,   ifclite_n: 0.09, ifclite_w: 0.37, webifc: 0.33, iosmax: 0.89, ios1c: 1.52 },
-  { id: "dental",   name: "dental_clinic.ifc",                       size: 12.4,  products: 2583,  ifclite_n: 0.10, ifclite_w: 0.49, webifc: 0.42, iosmax: 0.99, ios1c: 1.25 },
-  { id: "fmarc",    name: "FM_ARC_DigitalHub.ifc",                   size: 13.4,  products: 703,   ifclite_n: 0.09, ifclite_w: 0.71, webifc: 0.53, iosmax: 1.54, ios1c: 2.43 },
-  { id: "bridge",   name: "ifcbridge-model01.ifc",                   size: 14.5,  products: 165,   ifclite_n: 0.12, ifclite_w: 0.54, webifc: 0.20, iosmax: 1.32, ios1c: 2.05 },
-  { id: "i102cd",   name: "ISSUE_102_M3D-CON-CD.ifc",                size: 25.6,  products: 1616,  ifclite_n: 0.25, ifclite_w: 1.57, webifc: 1.89, iosmax: 2.66, ios1c: 4.02 },
-  { id: "soffice",  name: "S_Office_Integrated Design Archi.ifc",    size: 29.6,  products: 3396,  ifclite_n: 0.25, ifclite_w: 1.17, webifc: 2.62, iosmax: 2.94, ios1c: 4.04 },
-  { id: "advanced", name: "advanced_model.ifc",                      size: 33.7,  products: 6401,  ifclite_n: 0.29, ifclite_w: 1.46, webifc: 1.36, iosmax: 3.00, ios1c: 3.92 },
-  { id: "schep",    name: "schependomlaan.ifc",                      size: 47.0,  products: 3569,  ifclite_n: 0.41, ifclite_w: 1.70, webifc: 0.59, iosmax: 2.85, ios1c: 3.35 },
-  { id: "i068",     name: "ISSUE_068_ARK_NUS_skolebygg.ifc",         size: 53.7,  products: 4459,  ifclite_n: 0.52, ifclite_w: 2.37, webifc: 3.32, iosmax: 4.11, ios1c: 5.72 },
-  { id: "i098",     name: "ISSUE_098_R8_F1_MAB_AR_M3_XX_XXX.ifc",    size: 68.4,  products: 11123, ifclite_n: 0.59, ifclite_w: 2.72, webifc: 13.05, iosmax: 5.82, ios1c: 8.42 },
-  { id: "i053",     name: "ISSUE_053_Holter_Tower_10.ifc",           size: 169.2, products: 60285, ifclite_n: 1.70, ifclite_w: 8.23, webifc: 6.06, iosmax: 13.70, ios1c: 19.53 },
+  { id: "duplex",   name: "duplex.ifc",                              size: 2.3,   products: 215,   ifclite_n: 0.05, ifclite_w: 0.17, webifc: 0.04, iosmax: 0.12, ios1c: 0.19 },
+  { id: "ac20",     name: "AC20-FZK-Haus.ifc",                       size: 2.4,   products: 95,    ifclite_n: 0.02, ifclite_w: 0.12, webifc: 0.08, iosmax: 0.15, ios1c: 0.22 },
+  { id: "i005",     name: "ISSUE_005_haus.ifc",                      size: 2.4,   products: 95,    ifclite_n: 0.03, ifclite_w: 0.12, webifc: 0.08, iosmax: 0.13, ios1c: 0.21 },
+  { id: "i021",     name: "ISSUE_021_Mini Project.ifc",              size: 3.2,   products: 2636,  ifclite_n: 0.28, ifclite_w: 1.66, webifc: 0.29, iosmax: 0.29, ios1c: 0.53 },
+  { id: "officeA",  name: "Office_A_20110811.ifc",                   size: 3.8,   products: 803,   ifclite_n: 0.05, ifclite_w: 0.13, webifc: 0.10, iosmax: 0.25, ios1c: 0.29 },
+  { id: "i126",     name: "ISSUE_126_model.ifc",                     size: 4.2,   products: 257,   ifclite_n: 0.04, ifclite_w: 0.18, webifc: 0.07, iosmax: 0.32, ios1c: 0.46 },
+  { id: "i034",     name: "ISSUE_034_HouseZ.ifc",                    size: 4.8,   products: 228,   ifclite_n: 0.03, ifclite_w: 0.10, webifc: 0.11, iosmax: 0.38, ios1c: 0.71 },
+  { id: "i102",     name: "ISSUE_102_M3D-CON.ifc",                   size: 6.0,   products: 138,   ifclite_n: 0.03, ifclite_w: 0.12, webifc: 0.12, iosmax: 0.49, ios1c: 0.62 },
+  { id: "i159",     name: "ISSUE_159_kleine_Wohnung_R22.ifc",        size: 9.5,   products: 425,   ifclite_n: 0.33, ifclite_w: 1.25, webifc: 0.31, iosmax: 0.91, ios1c: 1.65 },
+  { id: "c20",      name: "C20-Institute-Var-2.ifc",                 size: 10.3,  products: 712,   ifclite_n: 0.31, ifclite_w: 1.05, webifc: 0.30, iosmax: 0.67, ios1c: 0.71 },
+  { id: "i129",     name: "ISSUE_129_N1540_17_EXE.ifc",              size: 11.5,  products: 959,   ifclite_n: 2.19, ifclite_w: 5.79, webifc: 0.31, iosmax: 0.89, ios1c: 1.52 },
+  { id: "dental",   name: "dental_clinic.ifc",                       size: 12.4,  products: 2586,  ifclite_n: 0.18, ifclite_w: 0.64, webifc: 0.26, iosmax: 0.99, ios1c: 1.25 },
+  { id: "fmarc",    name: "FM_ARC_DigitalHub.ifc",                   size: 13.4,  products: 705,   ifclite_n: 0.28, ifclite_w: 1.19, webifc: 0.43, iosmax: 1.54, ios1c: 2.43 },
+  { id: "bridge",   name: "ifcbridge-model01.ifc",                   size: 14.5,  products: 165,   ifclite_n: 0.08, ifclite_w: 0.31, webifc: 0.20, iosmax: 1.32, ios1c: 2.05 },
+  { id: "i102cd",   name: "ISSUE_102_M3D-CON-CD.ifc",                size: 25.6,  products: 1616,  ifclite_n: 0.40, ifclite_w: 0.82, webifc: 1.08, iosmax: 2.66, ios1c: 4.02 },
+  { id: "soffice",  name: "S_Office_Integrated Design Archi.ifc",    size: 29.6,  products: 3396,  ifclite_n: 0.98, ifclite_w: 2.86, webifc: 2.14, iosmax: 2.94, ios1c: 4.04 },
+  { id: "advanced", name: "advanced_model.ifc",                      size: 33.7,  products: 6401,  ifclite_n: 1.14, ifclite_w: 3.37, webifc: 0.93, iosmax: 3.00, ios1c: 3.92 },
+  { id: "schep",    name: "schependomlaan.ifc",                      size: 47.0,  products: 3504,  ifclite_n: 0.25, ifclite_w: 0.73, webifc: 0.51, iosmax: 2.85, ios1c: 3.35 },
+  { id: "i068",     name: "ISSUE_068_ARK_NUS_skolebygg.ifc",         size: 53.7,  products: 4459,  ifclite_n: 0.69, ifclite_w: 2.77, webifc: 1.23, iosmax: 4.11, ios1c: 5.72 },
+  { id: "i098",     name: "ISSUE_098_R8_F1_MAB_AR_M3_XX_XXX.ifc",    size: 68.4,  products: 11124, ifclite_n: 9.70, ifclite_w: 55.71, webifc: 2.65, iosmax: 5.82, ios1c: 8.42 },
+  { id: "i053",     name: "ISSUE_053_Holter_Tower_10.ifc",           size: 169.2, products: 60284, ifclite_n: 1.50, ifclite_w: 4.21, webifc: 3.07, iosmax: 13.70, ios1c: 19.53 },
 ];
 
 const BENCH_ENGINES = [
   { key: "ifclite_n", name: "ifc-lite", sub: "native, 10 threads", primary: true, shade: "deep" },
   { key: "ifclite_w", name: "ifc-lite", sub: "WASM, 1 thread",     primary: true, shade: "light" },
-  { key: "webifc",    name: "web-ifc",  sub: "WASM, 1 thread" },
+  { key: "webifc",    name: "web-ifc 0.0.77",  sub: "WASM, 1 thread" },
   { key: "iosmax",    name: "IfcOpenShell", sub: "native, multi-thread" },
 ];
 
@@ -1707,7 +1715,7 @@ function BenchExplorer() {
       )}
 
       <div className="be-foot">
-        <span><strong>{BENCH_MODELS.length}</strong> models <span style={{ color: "var(--ink-3)" }}>· parse + geometry, lower is better</span></span>
+        <span><strong>{BENCH_MODELS.length}</strong> models <span style={{ color: "var(--ink-3)" }}>· parse + geometry, lower is better · ifc-lite 4.0.1 vs web-ifc 0.0.77, 2026-07 · ifc-lite cuts openings with exact arithmetic, web-ifc approximates</span></span>
         <a href="https://github.com/louistrue/profiling/tree/apples-to-apples-with-native" target="_blank" rel="noopener" className="mono">full methodology →</a>
       </div>
     </div>

--- a/apps/landing/app.jsx
+++ b/apps/landing/app.jsx
@@ -1465,38 +1465,39 @@ function BundleComposition({ items, total }) {
 // ─────────────────────────── bench explorer ───────────────────────────
 // Canonical from louistrue/profiling@apples-to-apples-with-native, results/RESULTS.md
 // Corpus: 21 public IFCs. Times are total parse + geometry, seconds.
-// Refreshed 2026-07-17: ifc-lite 4.0.1 (exact-arithmetic CSG) + web-ifc 0.0.77,
-// run back-to-back on the same M4 (10-core), single cold run per file, identical
-// exclude set, both WASM rows single-threaded and timed through per-element
-// JS-accessible vertex extraction (same work-shape). IOS rows reproduced from
-// Moult's published numbers (his hardware, Manifold-augmented kernel).
-// ifc-lite cuts every opening with exact arithmetic (verified vs IfcOpenShell,
-// see correctness framework in the methodology repo); web-ifc uses approximate
-// fuzzy booleans - that trade is most visible on the boolean-heavy models
-// (ISSUE_098, ISSUE_129).
+/* <!-- BEGIN GENERATED: landing-bench -->
+ */
+// Recorded 2026-07-17 on Apple M4, 10 cores, 16 GB: seconds, parse + geometry total.
+// Engines: @ifc-lite/wasm 4.0.1 (single thread) / ifc-lite-processing 4.1.0 via rayon, 10 threads /
+// web-ifc 0.0.77 (single thread); IOS rows: IfcOpenShell datamodel branch, Moult's published Manifold-augmented numbers (his hardware).
+// Source of truth: apps/landing/bench-data.json (methodology + raw runs:
+// louistrue/profiling@apples-to-apples-with-native). Regenerate with
+// `pnpm docs:generate` — do not edit the rows by hand.
 const BENCH_MODELS = [
-  { id: "duplex",   name: "duplex.ifc",                              size: 2.3,   products: 215,   ifclite_n: 0.05, ifclite_w: 0.17, webifc: 0.04, iosmax: 0.12, ios1c: 0.19 },
-  { id: "ac20",     name: "AC20-FZK-Haus.ifc",                       size: 2.4,   products: 95,    ifclite_n: 0.02, ifclite_w: 0.12, webifc: 0.08, iosmax: 0.15, ios1c: 0.22 },
-  { id: "i005",     name: "ISSUE_005_haus.ifc",                      size: 2.4,   products: 95,    ifclite_n: 0.03, ifclite_w: 0.12, webifc: 0.08, iosmax: 0.13, ios1c: 0.21 },
-  { id: "i021",     name: "ISSUE_021_Mini Project.ifc",              size: 3.2,   products: 2636,  ifclite_n: 0.28, ifclite_w: 1.66, webifc: 0.29, iosmax: 0.29, ios1c: 0.53 },
-  { id: "officeA",  name: "Office_A_20110811.ifc",                   size: 3.8,   products: 803,   ifclite_n: 0.05, ifclite_w: 0.13, webifc: 0.10, iosmax: 0.25, ios1c: 0.29 },
-  { id: "i126",     name: "ISSUE_126_model.ifc",                     size: 4.2,   products: 257,   ifclite_n: 0.04, ifclite_w: 0.18, webifc: 0.07, iosmax: 0.32, ios1c: 0.46 },
-  { id: "i034",     name: "ISSUE_034_HouseZ.ifc",                    size: 4.8,   products: 228,   ifclite_n: 0.03, ifclite_w: 0.10, webifc: 0.11, iosmax: 0.38, ios1c: 0.71 },
-  { id: "i102",     name: "ISSUE_102_M3D-CON.ifc",                   size: 6.0,   products: 138,   ifclite_n: 0.03, ifclite_w: 0.12, webifc: 0.12, iosmax: 0.49, ios1c: 0.62 },
-  { id: "i159",     name: "ISSUE_159_kleine_Wohnung_R22.ifc",        size: 9.5,   products: 425,   ifclite_n: 0.33, ifclite_w: 1.25, webifc: 0.31, iosmax: 0.91, ios1c: 1.65 },
-  { id: "c20",      name: "C20-Institute-Var-2.ifc",                 size: 10.3,  products: 712,   ifclite_n: 0.31, ifclite_w: 1.05, webifc: 0.30, iosmax: 0.67, ios1c: 0.71 },
-  { id: "i129",     name: "ISSUE_129_N1540_17_EXE.ifc",              size: 11.5,  products: 959,   ifclite_n: 2.19, ifclite_w: 5.79, webifc: 0.31, iosmax: 0.89, ios1c: 1.52 },
-  { id: "dental",   name: "dental_clinic.ifc",                       size: 12.4,  products: 2586,  ifclite_n: 0.18, ifclite_w: 0.64, webifc: 0.26, iosmax: 0.99, ios1c: 1.25 },
-  { id: "fmarc",    name: "FM_ARC_DigitalHub.ifc",                   size: 13.4,  products: 705,   ifclite_n: 0.28, ifclite_w: 1.19, webifc: 0.43, iosmax: 1.54, ios1c: 2.43 },
-  { id: "bridge",   name: "ifcbridge-model01.ifc",                   size: 14.5,  products: 165,   ifclite_n: 0.08, ifclite_w: 0.31, webifc: 0.20, iosmax: 1.32, ios1c: 2.05 },
-  { id: "i102cd",   name: "ISSUE_102_M3D-CON-CD.ifc",                size: 25.6,  products: 1616,  ifclite_n: 0.40, ifclite_w: 0.82, webifc: 1.08, iosmax: 2.66, ios1c: 4.02 },
-  { id: "soffice",  name: "S_Office_Integrated Design Archi.ifc",    size: 29.6,  products: 3396,  ifclite_n: 0.98, ifclite_w: 2.86, webifc: 2.14, iosmax: 2.94, ios1c: 4.04 },
-  { id: "advanced", name: "advanced_model.ifc",                      size: 33.7,  products: 6401,  ifclite_n: 1.14, ifclite_w: 3.37, webifc: 0.93, iosmax: 3.00, ios1c: 3.92 },
-  { id: "schep",    name: "schependomlaan.ifc",                      size: 47.0,  products: 3504,  ifclite_n: 0.25, ifclite_w: 0.73, webifc: 0.51, iosmax: 2.85, ios1c: 3.35 },
-  { id: "i068",     name: "ISSUE_068_ARK_NUS_skolebygg.ifc",         size: 53.7,  products: 4459,  ifclite_n: 0.69, ifclite_w: 2.77, webifc: 1.23, iosmax: 4.11, ios1c: 5.72 },
-  { id: "i098",     name: "ISSUE_098_R8_F1_MAB_AR_M3_XX_XXX.ifc",    size: 68.4,  products: 11124, ifclite_n: 9.70, ifclite_w: 55.71, webifc: 2.65, iosmax: 5.82, ios1c: 8.42 },
-  { id: "i053",     name: "ISSUE_053_Holter_Tower_10.ifc",           size: 169.2, products: 60284, ifclite_n: 1.50, ifclite_w: 4.21, webifc: 3.07, iosmax: 13.70, ios1c: 19.53 },
+  { id: "duplex",   name: "duplex.ifc",                             size: 2.3,    products: 215,    ifclite_n: 0.05, ifclite_w: 0.17, webifc: 0.04, iosmax: 0.12, ios1c: 0.19 },
+  { id: "ac20",     name: "AC20-FZK-Haus.ifc",                      size: 2.4,    products: 95,     ifclite_n: 0.02, ifclite_w: 0.12, webifc: 0.08, iosmax: 0.15, ios1c: 0.22 },
+  { id: "i005",     name: "ISSUE_005_haus.ifc",                     size: 2.4,    products: 95,     ifclite_n: 0.03, ifclite_w: 0.12, webifc: 0.08, iosmax: 0.13, ios1c: 0.21 },
+  { id: "i021",     name: "ISSUE_021_Mini Project.ifc",             size: 3.2,    products: 2636,   ifclite_n: 0.28, ifclite_w: 1.66, webifc: 0.29, iosmax: 0.29, ios1c: 0.53 },
+  { id: "officeA",  name: "Office_A_20110811.ifc",                  size: 3.8,    products: 803,    ifclite_n: 0.05, ifclite_w: 0.13, webifc: 0.10, iosmax: 0.25, ios1c: 0.29 },
+  { id: "i126",     name: "ISSUE_126_model.ifc",                    size: 4.2,    products: 257,    ifclite_n: 0.04, ifclite_w: 0.18, webifc: 0.07, iosmax: 0.32, ios1c: 0.46 },
+  { id: "i034",     name: "ISSUE_034_HouseZ.ifc",                   size: 4.8,    products: 228,    ifclite_n: 0.03, ifclite_w: 0.10, webifc: 0.11, iosmax: 0.38, ios1c: 0.71 },
+  { id: "i102",     name: "ISSUE_102_M3D-CON.ifc",                  size: 6.0,    products: 138,    ifclite_n: 0.03, ifclite_w: 0.12, webifc: 0.12, iosmax: 0.49, ios1c: 0.62 },
+  { id: "i159",     name: "ISSUE_159_kleine_Wohnung_R22.ifc",       size: 9.5,    products: 425,    ifclite_n: 0.33, ifclite_w: 1.25, webifc: 0.31, iosmax: 0.91, ios1c: 1.65 },
+  { id: "c20",      name: "C20-Institute-Var-2.ifc",                size: 10.3,   products: 712,    ifclite_n: 0.31, ifclite_w: 1.05, webifc: 0.30, iosmax: 0.67, ios1c: 0.71 },
+  { id: "i129",     name: "ISSUE_129_N1540_17_EXE.ifc",             size: 11.5,   products: 959,    ifclite_n: 2.19, ifclite_w: 5.79, webifc: 0.31, iosmax: 0.89, ios1c: 1.52 },
+  { id: "dental",   name: "dental_clinic.ifc",                      size: 12.4,   products: 2586,   ifclite_n: 0.18, ifclite_w: 0.64, webifc: 0.26, iosmax: 0.99, ios1c: 1.25 },
+  { id: "fmarc",    name: "FM_ARC_DigitalHub.ifc",                  size: 13.4,   products: 705,    ifclite_n: 0.28, ifclite_w: 1.19, webifc: 0.43, iosmax: 1.54, ios1c: 2.43 },
+  { id: "bridge",   name: "ifcbridge-model01.ifc",                  size: 14.5,   products: 165,    ifclite_n: 0.08, ifclite_w: 0.31, webifc: 0.20, iosmax: 1.32, ios1c: 2.05 },
+  { id: "i102cd",   name: "ISSUE_102_M3D-CON-CD.ifc",               size: 25.6,   products: 1616,   ifclite_n: 0.40, ifclite_w: 0.82, webifc: 1.08, iosmax: 2.66, ios1c: 4.02 },
+  { id: "soffice",  name: "S_Office_Integrated Design Archi.ifc",   size: 29.6,   products: 3396,   ifclite_n: 0.98, ifclite_w: 2.86, webifc: 2.14, iosmax: 2.94, ios1c: 4.04 },
+  { id: "advanced", name: "advanced_model.ifc",                     size: 33.7,   products: 6401,   ifclite_n: 1.14, ifclite_w: 3.37, webifc: 0.93, iosmax: 3.00, ios1c: 3.92 },
+  { id: "schep",    name: "schependomlaan.ifc",                     size: 47.0,   products: 3504,   ifclite_n: 0.25, ifclite_w: 0.73, webifc: 0.51, iosmax: 2.85, ios1c: 3.35 },
+  { id: "i068",     name: "ISSUE_068_ARK_NUS_skolebygg.ifc",        size: 53.7,   products: 4459,   ifclite_n: 0.69, ifclite_w: 2.77, webifc: 1.23, iosmax: 4.11, ios1c: 5.72 },
+  { id: "i098",     name: "ISSUE_098_R8_F1_MAB_AR_M3_XX_XXX.ifc",   size: 68.4,   products: 11124,  ifclite_n: 9.70, ifclite_w: 55.71, webifc: 2.65, iosmax: 5.82, ios1c: 8.42 },
+  { id: "i053",     name: "ISSUE_053_Holter_Tower_10.ifc",          size: 169.2,  products: 60284,  ifclite_n: 1.50, ifclite_w: 4.21, webifc: 3.07, iosmax: 13.70, ios1c: 19.53 },
 ];
+/*
+<!-- END GENERATED: landing-bench --> */
 
 const BENCH_ENGINES = [
   { key: "ifclite_n", name: "ifc-lite", sub: "native, 10 threads", primary: true, shade: "deep" },

--- a/apps/landing/bench-data.json
+++ b/apps/landing/bench-data.json
@@ -1,0 +1,37 @@
+{
+  "meta": {
+    "recorded": "2026-07-17",
+    "hardware": "Apple M4, 10 cores, 16 GB",
+    "engines": {
+      "ifclite_wasm": "@ifc-lite/wasm 4.0.1 (single thread)",
+      "ifclite_native": "ifc-lite-processing 4.1.0 via rayon, 10 threads",
+      "webifc": "web-ifc 0.0.77 (single thread)",
+      "ifcopenshell": "IfcOpenShell datamodel branch, Moult's published Manifold-augmented numbers (his hardware)"
+    },
+    "methodology": "louistrue/profiling@apples-to-apples-with-native (commit 3468366): single cold run per file, identical exclude sets, both WASM rows timed through per-element JS-accessible vertex extraction (ifc-lite: buildPrePassOnce + one processGeometryBatch; web-ifc: StreamAllMeshes + GetVertexArray/GetIndexArray). ifc-lite cuts openings with exact arithmetic; web-ifc uses approximate fuzzy booleans.",
+    "units": "seconds, parse + geometry total"
+  },
+  "models": [
+    { "id": "duplex",   "name": "duplex.ifc",                           "size": 2.3,   "products": 215,   "ifclite_n": 0.05, "ifclite_w": 0.17,  "webifc": 0.04, "iosmax": 0.12,  "ios1c": 0.19 },
+    { "id": "ac20",     "name": "AC20-FZK-Haus.ifc",                    "size": 2.4,   "products": 95,    "ifclite_n": 0.02, "ifclite_w": 0.12,  "webifc": 0.08, "iosmax": 0.15,  "ios1c": 0.22 },
+    { "id": "i005",     "name": "ISSUE_005_haus.ifc",                   "size": 2.4,   "products": 95,    "ifclite_n": 0.03, "ifclite_w": 0.12,  "webifc": 0.08, "iosmax": 0.13,  "ios1c": 0.21 },
+    { "id": "i021",     "name": "ISSUE_021_Mini Project.ifc",           "size": 3.2,   "products": 2636,  "ifclite_n": 0.28, "ifclite_w": 1.66,  "webifc": 0.29, "iosmax": 0.29,  "ios1c": 0.53 },
+    { "id": "officeA",  "name": "Office_A_20110811.ifc",                "size": 3.8,   "products": 803,   "ifclite_n": 0.05, "ifclite_w": 0.13,  "webifc": 0.10, "iosmax": 0.25,  "ios1c": 0.29 },
+    { "id": "i126",     "name": "ISSUE_126_model.ifc",                  "size": 4.2,   "products": 257,   "ifclite_n": 0.04, "ifclite_w": 0.18,  "webifc": 0.07, "iosmax": 0.32,  "ios1c": 0.46 },
+    { "id": "i034",     "name": "ISSUE_034_HouseZ.ifc",                 "size": 4.8,   "products": 228,   "ifclite_n": 0.03, "ifclite_w": 0.10,  "webifc": 0.11, "iosmax": 0.38,  "ios1c": 0.71 },
+    { "id": "i102",     "name": "ISSUE_102_M3D-CON.ifc",                "size": 6.0,   "products": 138,   "ifclite_n": 0.03, "ifclite_w": 0.12,  "webifc": 0.12, "iosmax": 0.49,  "ios1c": 0.62 },
+    { "id": "i159",     "name": "ISSUE_159_kleine_Wohnung_R22.ifc",     "size": 9.5,   "products": 425,   "ifclite_n": 0.33, "ifclite_w": 1.25,  "webifc": 0.31, "iosmax": 0.91,  "ios1c": 1.65 },
+    { "id": "c20",      "name": "C20-Institute-Var-2.ifc",              "size": 10.3,  "products": 712,   "ifclite_n": 0.31, "ifclite_w": 1.05,  "webifc": 0.30, "iosmax": 0.67,  "ios1c": 0.71 },
+    { "id": "i129",     "name": "ISSUE_129_N1540_17_EXE.ifc",           "size": 11.5,  "products": 959,   "ifclite_n": 2.19, "ifclite_w": 5.79,  "webifc": 0.31, "iosmax": 0.89,  "ios1c": 1.52 },
+    { "id": "dental",   "name": "dental_clinic.ifc",                    "size": 12.4,  "products": 2586,  "ifclite_n": 0.18, "ifclite_w": 0.64,  "webifc": 0.26, "iosmax": 0.99,  "ios1c": 1.25 },
+    { "id": "fmarc",    "name": "FM_ARC_DigitalHub.ifc",                "size": 13.4,  "products": 705,   "ifclite_n": 0.28, "ifclite_w": 1.19,  "webifc": 0.43, "iosmax": 1.54,  "ios1c": 2.43 },
+    { "id": "bridge",   "name": "ifcbridge-model01.ifc",                "size": 14.5,  "products": 165,   "ifclite_n": 0.08, "ifclite_w": 0.31,  "webifc": 0.20, "iosmax": 1.32,  "ios1c": 2.05 },
+    { "id": "i102cd",   "name": "ISSUE_102_M3D-CON-CD.ifc",             "size": 25.6,  "products": 1616,  "ifclite_n": 0.40, "ifclite_w": 0.82,  "webifc": 1.08, "iosmax": 2.66,  "ios1c": 4.02 },
+    { "id": "soffice",  "name": "S_Office_Integrated Design Archi.ifc", "size": 29.6,  "products": 3396,  "ifclite_n": 0.98, "ifclite_w": 2.86,  "webifc": 2.14, "iosmax": 2.94,  "ios1c": 4.04 },
+    { "id": "advanced", "name": "advanced_model.ifc",                   "size": 33.7,  "products": 6401,  "ifclite_n": 1.14, "ifclite_w": 3.37,  "webifc": 0.93, "iosmax": 3.00,  "ios1c": 3.92 },
+    { "id": "schep",    "name": "schependomlaan.ifc",                   "size": 47.0,  "products": 3504,  "ifclite_n": 0.25, "ifclite_w": 0.73,  "webifc": 0.51, "iosmax": 2.85,  "ios1c": 3.35 },
+    { "id": "i068",     "name": "ISSUE_068_ARK_NUS_skolebygg.ifc",      "size": 53.7,  "products": 4459,  "ifclite_n": 0.69, "ifclite_w": 2.77,  "webifc": 1.23, "iosmax": 4.11,  "ios1c": 5.72 },
+    { "id": "i098",     "name": "ISSUE_098_R8_F1_MAB_AR_M3_XX_XXX.ifc", "size": 68.4,  "products": 11124, "ifclite_n": 9.70, "ifclite_w": 55.71, "webifc": 2.65, "iosmax": 5.82,  "ios1c": 8.42 },
+    { "id": "i053",     "name": "ISSUE_053_Holter_Tower_10.ifc",        "size": 169.2, "products": 60284, "ifclite_n": 1.50, "ifclite_w": 4.21,  "webifc": 3.07, "iosmax": 13.70, "ios1c": 19.53 }
+  ]
+}

--- a/apps/landing/index.html
+++ b/apps/landing/index.html
@@ -132,7 +132,8 @@
       <div class="dim hero-dim" aria-hidden="true">
         <span class="dim-tick"></span>
         <span class="dim-arm"></span>
-        <span class="dim-val">2.72<span class="u"> s</span> · 68&nbsp;MB · 11,123 products</span>
+        <!-- ISSUE_053 Holter row of apps/landing/bench-data.json (WASM, 1 thread, 2026-07-17) — keep in sync -->
+        <span class="dim-val">4.2<span class="u"> s</span> · 169&nbsp;MB · 60,284 products</span>
         <span class="dim-arm to-right"></span>
         <span class="dim-tick"></span>
       </div>
@@ -188,9 +189,10 @@
 <!-- ─────────────────────────── STATS ─────────────────────────── -->
 <section class="stats" data-screen-label="02 Stats">
   <div class="stats-grid">
+    <!-- ISSUE_053 Holter row of apps/landing/bench-data.json (WASM, 1 thread, 2026-07-17) — keep in sync -->
     <div class="stat">
-      <div class="v">2.72<span class="u">seconds</span></div>
-      <div class="k">Parse + geometry, 68&nbsp;MB office model, 11,123 products</div>
+      <div class="v">4.2<span class="u">seconds</span></div>
+      <div class="k">Parse + exact geometry, 169&nbsp;MB tower, 60,284 products</div>
     </div>
     <div class="stat">
       <div class="v">260<span class="u">KB gzipped</span></div>

--- a/apps/landing/index.html
+++ b/apps/landing/index.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>IFClite. Open, view, and work with IFC files. Right in the browser.</title>
-<meta name="description" content="Parse, view, query, edit, and export IFC files in the browser. Rust + WASM core, WebGPU rendering, ~260 KB gzipped, 5× faster geometry than the next best option." />
+<meta name="description" content="Parse, view, query, edit, and export IFC files in the browser. Rust + WASM core, WebGPU rendering, ~260 KB gzipped, exact-arithmetic geometry verified against IfcOpenShell." />
 <meta name="keywords" content="IFC viewer, IFC file, BIM, openBIM, buildingSMART, IFC parser, web IFC, WebGPU, WASM, IFC.js alternative, BIM in browser" />
 <meta name="author" content="LTplus AG" />
 <meta name="robots" content="index, follow, max-image-preview:large" />
@@ -15,7 +15,7 @@
 <meta property="og:type" content="website" />
 <meta property="og:site_name" content="IFClite" />
 <meta property="og:title" content="IFClite. Open, view, and work with IFC files in the browser" />
-<meta property="og:description" content="Parse, view, query, edit, and export IFC files in the browser. Rust + WASM core, WebGPU rendering, ~260 KB gzipped, 5× faster geometry than the next best option." />
+<meta property="og:description" content="Parse, view, query, edit, and export IFC files in the browser. Rust + WASM core, WebGPU rendering, ~260 KB gzipped, exact-arithmetic geometry verified against IfcOpenShell." />
 <meta property="og:url" content="https://ifclite.dev/" />
 <meta property="og:image" content="https://ifclite.dev/assets/logo.png" />
 <meta property="og:image:alt" content="IFClite logo" />
@@ -24,7 +24,7 @@
 <!-- Twitter Card -->
 <meta name="twitter:card" content="summary_large_image" />
 <meta name="twitter:title" content="IFClite. Open, view, and work with IFC files in the browser" />
-<meta name="twitter:description" content="Parse, view, query, edit, and export IFC files in the browser. Rust + WASM core, WebGPU rendering, ~260 KB gzipped, 5× faster geometry." />
+<meta name="twitter:description" content="Parse, view, query, edit, and export IFC files in the browser. Rust + WASM core, WebGPU rendering, ~260 KB gzipped, exact-arithmetic geometry." />
 <meta name="twitter:image" content="https://ifclite.dev/assets/logo.png" />
 
 <!-- Structured data. `url` points at this marketing site (ifclite.dev); the
@@ -35,7 +35,7 @@
   "@context": "https://schema.org",
   "@type": "SoftwareApplication",
   "name": "IFClite",
-  "description": "Parse, view, query, edit, and export IFC files in the browser. Rust + WASM core, WebGPU rendering, ~260 KB gzipped, 5× faster geometry than the next best option.",
+  "description": "Parse, view, query, edit, and export IFC files in the browser. Rust + WASM core, WebGPU rendering, ~260 KB gzipped, exact-arithmetic geometry verified against IfcOpenShell.",
   "url": "https://ifclite.dev/",
   "sameAs": [
     "https://www.ifclite.com/",
@@ -136,7 +136,7 @@
         <span class="dim-arm to-right"></span>
         <span class="dim-tick"></span>
       </div>
-      <p class="lede">Open-source toolkit for the IFC file format. WebGPU rendering, columnar in-memory store, faster than the alternatives on most models. Runs from a CDN.</p>
+      <p class="lede">Open-source toolkit for the IFC file format. WebGPU rendering, columnar in-memory store, exact-arithmetic geometry kernel verified against IfcOpenShell. Runs from a CDN.</p>
 
       <div class="hero-cta">
         <a class="btn btn-primary" href="#code">

--- a/docs/api/typescript.md
+++ b/docs/api/typescript.md
@@ -10,7 +10,7 @@ ifc-lite ships 36 public npm packages: 35 scoped `@ifc-lite/*` packages plus the
 | Package | Description |
 |---------|-------------|
 | [`@ifc-lite/parser`](#ifc-liteparser) | IFC/STEP parser for IFC-Lite |
-| [`@ifc-lite/geometry`](#ifc-litegeometry) | Geometry processing bridge for IFC-Lite - 1.9x faster than web-ifc |
+| [`@ifc-lite/geometry`](#ifc-litegeometry) | Geometry processing bridge for IFC-Lite - exact-arithmetic CSG, streamed across workers |
 | [`@ifc-lite/data`](#ifc-litedata) | Columnar data structures for IFC-Lite |
 | [`@ifc-lite/query`](#ifc-litequery) | Query system for IFC-Lite |
 | [`@ifc-lite/spatial`](#ifc-litespatial) | Spatial indexing for IFC-Lite |

--- a/packages/geometry/README.md
+++ b/packages/geometry/README.md
@@ -113,7 +113,7 @@ works.
 ## Performance
 
 - **First triangles:** 300–500ms (streaming path)
-- **Throughput:** ~1.9x faster than `web-ifc` (928-column.ifc; see `tests/benchmark/benchmark-results.json`)
+- **Correctness:** exact-arithmetic boolean kernel - openings are cut exactly, verified element-by-element against IfcOpenShell on the public benchmark corpus
 - **Worker support:** files > 50 MB process off-main-thread automatically
 - **Native (Tauri):** `preferNative: true` enables the native Rust pipeline when running under a Tauri host — an extension point for third parties building their own desktop app (`@tauri-apps/api` is an optional dep; web builds never load it). See the [Building for Desktop](https://ifclite.dev/docs/guide/desktop/) guide.
 

--- a/packages/geometry/package.json
+++ b/packages/geometry/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ifc-lite/geometry",
   "version": "3.2.1",
-  "description": "Geometry processing bridge for IFC-Lite - 1.9x faster than web-ifc",
+  "description": "Geometry processing bridge for IFC-Lite - exact-arithmetic CSG, streamed across workers",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/geometry/src/index.ts
+++ b/packages/geometry/src/index.ts
@@ -4,7 +4,7 @@
 
 /**
  * @ifc-lite/geometry - Geometry processing bridge
- * Now powered by IFC-Lite native Rust WASM (1.9x faster than web-ifc)
+ * Now powered by IFC-Lite native Rust WASM (exact-arithmetic CSG kernel)
  */
 
 // IFC-Lite components (recommended - faster)

--- a/scripts/docs/generate-docs-sections.mjs
+++ b/scripts/docs/generate-docs-sections.mjs
@@ -19,6 +19,9 @@
  *                                             the CLI HELP text
  *   perf-numbers  (docs/guide/performance.md) — benchmark numbers stamped
  *                                             from the committed baseline
+ *   landing-bench (apps/landing/app.jsx)    — cross-engine benchmark rows
+ *                                             stamped from the committed
+ *                                             apps/landing/bench-data.json
  *
  * Modes (mirrors scripts/check-api-surface.mjs UX):
  *   node scripts/docs/generate-docs-sections.mjs           # rewrite (pnpm docs:generate)
@@ -222,6 +225,47 @@ function genPerfNumbers() {
 /* Region wiring                                                         */
 /* --------------------------------------------------------------------- */
 
+/**
+ * Cross-engine benchmark rows for the landing page's interactive chart,
+ * stamped from the committed apps/landing/bench-data.json (which carries
+ * engine versions + methodology; raw runs live in the profiling repo).
+ * The region markers sit inside block comments so the .jsx stays valid;
+ * the body therefore CLOSES the begin-marker comment first and re-OPENS
+ * one for the end marker.
+ */
+function genLandingBench() {
+  const dataPath = join(ROOT, 'apps', 'landing', 'bench-data.json');
+  const data = JSON.parse(readFileSync(dataPath, 'utf-8'));
+  const pad = (str, n) => String(str).padEnd(n);
+  const rows = data.models.map((m) => {
+    const cells = [
+      `id: ${pad(`${JSON.stringify(m.id)},`, 11)}`,
+      `name: ${pad(`${JSON.stringify(m.name)},`, 41)}`,
+      `size: ${pad(`${m.size.toFixed(1)},`, 7)}`,
+      `products: ${pad(`${m.products},`, 7)}`,
+      `ifclite_n: ${m.ifclite_n.toFixed(2)},`,
+      `ifclite_w: ${m.ifclite_w.toFixed(2)},`,
+      `webifc: ${m.webifc.toFixed(2)},`,
+      `iosmax: ${m.iosmax.toFixed(2)},`,
+      `ios1c: ${m.ios1c.toFixed(2)}`,
+    ];
+    return `  { ${cells.join(' ')} },`;
+  });
+  return [
+    ' */',
+    `// Recorded ${data.meta.recorded} on ${data.meta.hardware}: ${data.meta.units}.`,
+    `// Engines: ${data.meta.engines.ifclite_wasm} / ${data.meta.engines.ifclite_native} /`,
+    `// ${data.meta.engines.webifc}; IOS rows: ${data.meta.engines.ifcopenshell}.`,
+    '// Source of truth: apps/landing/bench-data.json (methodology + raw runs:',
+    '// louistrue/profiling@apples-to-apples-with-native). Regenerate with',
+    '// `pnpm docs:generate` — do not edit the rows by hand.',
+    'const BENCH_MODELS = [',
+    ...rows,
+    '];',
+    '/*',
+  ].join('\n');
+}
+
 const REGIONS = [
   {
     name: 'package-index',
@@ -237,6 +281,11 @@ const REGIONS = [
     name: 'perf-numbers',
     file: 'docs/guide/performance.md',
     generate: () => genPerfNumbers(),
+  },
+  {
+    name: 'landing-bench',
+    file: 'apps/landing/app.jsx',
+    generate: () => genLandingBench(),
   },
 ];
 


### PR DESCRIPTION
## Why

The README + ifclite.dev claim "geometry up to 5x faster than web-ifc (median ~2.2x)". That came from a May run pairing **web-ifc 0.0.68** with an ifc-lite measurement path that predates the exact-CSG production pipeline. Re-running the public apples-to-apples harness today is not kind to that claim: web-ifc 0.69-0.77 got ~2.3-4x faster on boolean-heavy models (verified commit-by-commit — legitimate constant-factor engineering, no boolean skipping), and our row now runs the full production pipeline. Anyone can refute the 5x publicly, so we should be the ones to update it.

## Fair re-run (2026-07-17, M4, back-to-back, identical excludes)

Harness fairness was audited both ways first: the ifc-lite wasm row now drives `buildPrePassOnce` + one `processGeometryBatch` + per-mesh JS vertex extraction — the same work-shape as web-ifc's `StreamAllMeshes` + `GetVertexArray` row (colors resolved, placements baked, JS-accessible output). The previous route also timed the viewer's GPU-buffer building, which web-ifc's row never does.

Result: web-ifc 0.0.77 wins single-threaded wasm total time on most of the corpus (typically 1.3-4x, up to ~20x on the exact-CSG monsters ISSUE_098/ISSUE_129); ifc-lite native 10-thread wins most models (Holter 1.5s vs 3.1s) but not the boolean monsters. Our differentiator is **exactness**: every opening cut with exact arithmetic, verified element-by-element against IfcOpenShell (T1-T6 framework, 99.9%+ agreement; web-ifc's fuzzy booleans carry a live tail of geometry-regression issues upstream).

## What changed

- **README**: hero + performance section claim exact-arithmetic geometry verified vs IfcOpenShell, native multi-thread standing, and streaming; no competitor multiplier.
- **Landing**: 4 meta descriptions + hero lede reworded; the interactive benchmark chart now carries the 2026-07-17 fair numbers (ifc-lite 4.0.1 vs web-ifc 0.0.77, 21 models — Holter completes now), a versioned engine chip, and a footer noting the exact-vs-approximate boolean trade.
- **@ifc-lite/geometry**: stale "1.9x faster than web-ifc" description/README updated at the generated-docs SOURCE; `docs/api/typescript.md` regenerated (docs:check-generated green). Changeset included (docs-only patch).

Methodology + raw JSONs live in the profiling repo (apples-to-apples branch), updated in lockstep.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated geometry descriptions to highlight exact-arithmetic boolean operations verified against IfcOpenShell.
  * Replaced outdated performance claims with clearer information about geometry correctness, speed, and browser streaming.
  * Refreshed API, package, website, and SEO descriptions.

* **Benchmarks**
  * Updated benchmark data, recorded metrics, engine versions, and landing-page statistics.
  * Added benchmark methodology and comparison details to the benchmark explorer.

* **Chores**
  * Published a patch release for the geometry package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->