### PR TITLE
fix(ids): resolve type-inherited property sets on server-parsed stores (#1787)

### DIFF
--- a/.changeset/ids-server-type-psets.md
+++ b/.changeset/ids-server-type-psets.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/ids": patch
+---
+
+IDS validation on server-parsed models now sees type-inherited property sets (#1787). The bridge's `appendInheritedPropertySets` resolved type psets only via `extractTypePropertiesOnDemand`, which bails on the empty `source` buffer of a server-parsed store — so a facet checking a property that lives on the element's `IfcTypeProduct` (rather than the instance) passed on the in-browser path but was invisible on the server path. It now falls back to the prebuilt property table keyed by the type id (resolved through `IfcRelDefinesByType`), mirroring the Lists server-path type fallback. No wire or cache change; the WASM path is unaffected (guarded on empty `source`).

--- a/packages/ids/src/bridge/properties.ts
+++ b/packages/ids/src/bridge/properties.ts
@@ -165,12 +165,17 @@ function appendInheritedPropertySets(
   scale: number | undefined,
   out: PropertySetInfo[]
 ): void {
-  const inherited = extractTypePropertiesOnDemand(store, expressId);
-  if (!inherited || !inherited.properties || inherited.properties.length === 0)
-    return;
+  // Source-backed extraction (WASM/columnar parse) first; it bails on stores
+  // with no `source` buffer — i.e. server-parsed stores — so fall back to the
+  // prebuilt property table keyed by the element's IfcTypeProduct id (issue
+  // #1787), mirroring the Lists adapter's server-path type fallback.
+  const inheritedPsets =
+    extractTypePropertiesOnDemand(store, expressId)?.properties ??
+    typePropertySetsFromTable(store, expressId);
+  if (inheritedPsets.length === 0) return;
 
   const seen = new Set(out.map((p) => p.name));
-  for (const pset of inherited.properties) {
+  for (const pset of inheritedPsets) {
     if (seen.has(pset.name)) continue;
     out.push({
       name: pset.name,
@@ -179,6 +184,30 @@ function appendInheritedPropertySets(
       ),
     });
   }
+}
+
+/** Type-inherited property sets for server-parsed stores: resolve the element's
+ *  IfcTypeProduct via IfcRelDefinesByType, then read the prebuilt table for
+ *  that type id (server materialises type sets under the type's own id — see
+ *  serverDataModel's TYPEHASPROPERTYSETS merge). [] for WASM stores, which the
+ *  source-backed extractor already handled. */
+function typePropertySetsFromTable(
+  store: IfcDataStore,
+  expressId: number
+): Array<{ name: string; properties: RawProp[] }> {
+  // Server-parsed stores only — a WASM store has a `source` buffer and its type
+  // sets were already resolved by extractTypePropertiesOnDemand above, so this
+  // never runs there (no behaviour change on the WASM path).
+  if (store.source && store.source.length > 0) return [];
+  const typeIds =
+    store.relationships?.getRelated?.(
+      expressId,
+      RelationshipType.DefinesByType,
+      'inverse'
+    ) || [];
+  if (typeIds.length === 0) return [];
+  const psets = store.properties?.getForEntity?.(typeIds[0]);
+  return (psets ?? []) as unknown as Array<{ name: string; properties: RawProp[] }>;
 }
 
 function appendTypeEntityOwnProperties(

--- a/packages/ids/src/bridge/type-inherited-server.test.ts
+++ b/packages/ids/src/bridge/type-inherited-server.test.ts
@@ -1,0 +1,98 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * IDS on server-parsed stores must see TYPE-inherited property sets — the
+ * source-backed `extractTypePropertiesOnDemand` bails on the empty `source`
+ * buffer, so the bridge falls back to the prebuilt property table keyed by the
+ * element's IfcTypeProduct id (issue #1787), mirroring the Lists server-path
+ * type fallback. A facet checking a type-only property (incl. one reachable
+ * only via a candidate `values[]`) now passes on the server path.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { RelationshipType } from '@ifc-lite/data';
+import type { IfcDataStore, PropertySet } from '@ifc-lite/parser';
+import { createDataAccessor } from './data-accessor.js';
+import { checkPropertyFacet } from '../facets/property-facet.js';
+import type { IDSPropertyFacet, IDSSimpleValue } from '../types.js';
+
+const sv = (value: string): IDSSimpleValue => ({ type: 'simpleValue', value });
+
+// Server-shaped store: empty `source`; wall #10 --DefinesByType--> type #20;
+// the type's Pset_WallCommon lives under the TYPE id in the property table.
+function serverStore(): IfcDataStore {
+  const typePsets: PropertySet[] = [
+    {
+      name: 'Pset_WallCommon',
+      globalId: '',
+      properties: [
+        { name: 'FireRating', type: 0, value: 'REI 90' },
+        { name: 'AcousticRating', type: 0, value: 'R1, R2', values: ['R1', 'R2'] },
+      ],
+    } as unknown as PropertySet,
+  ];
+  return {
+    schemaVersion: 'IFC4',
+    source: new Uint8Array(), // server path
+    entities: {
+      getTypeName: (id: number) => (id === 10 ? 'IfcWall' : id === 20 ? 'IfcWallType' : undefined),
+      getByType: () => [10],
+      getName: () => undefined,
+      getGlobalId: () => undefined,
+      getDescription: () => undefined,
+      getObjectType: () => undefined,
+    },
+    entityIndex: { byId: new Map(), byType: new Map() },
+    relationships: {
+      getRelated: (id: number, relType: RelationshipType, dir: 'forward' | 'inverse') =>
+        dir === 'inverse' && id === 10 && relType === RelationshipType.DefinesByType ? [20] : [],
+    },
+    // Instance #10 has no own psets; the type #20 carries them.
+    properties: { getForEntity: (id: number) => (id === 20 ? typePsets : []) },
+    quantities: { getForEntity: () => [] },
+  } as unknown as IfcDataStore;
+}
+
+const facet = (val: string): IDSPropertyFacet => ({
+  type: 'property',
+  propertySet: sv('Pset_WallCommon'),
+  baseName: sv('FireRating'),
+  value: sv(val),
+});
+
+describe('IDS type-inherited psets on server-parsed stores (#1787)', () => {
+  it('resolves a type-only property (FireRating from IfcWallType)', () => {
+    const accessor = createDataAccessor(serverStore());
+    expect(checkPropertyFacet(facet('REI 90'), 10, accessor).passed).toBe(true);
+  });
+
+  it('matches a type-only candidate reachable only via values[] (AcousticRating R2)', () => {
+    const accessor = createDataAccessor(serverStore());
+    const f: IDSPropertyFacet = {
+      type: 'property',
+      propertySet: sv('Pset_WallCommon'),
+      baseName: sv('AcousticRating'),
+      value: sv('R2'),
+    };
+    expect(checkPropertyFacet(f, 10, accessor).passed).toBe(true);
+  });
+
+  it('fails value-mismatch on a resolved type property (no false positive)', () => {
+    const accessor = createDataAccessor(serverStore());
+    // FireRating resolves from the type, but "REI 999" is not its value.
+    expect(checkPropertyFacet(facet('REI 999'), 10, accessor).passed).toBe(false);
+  });
+
+  it('does not fabricate a property the type lacks (PROPERTY_MISSING)', () => {
+    const accessor = createDataAccessor(serverStore());
+    const result = checkPropertyFacet(
+      { type: 'property', propertySet: sv('Pset_WallCommon'), baseName: sv('LoadBearing') },
+      10,
+      accessor,
+    );
+    expect(result.passed).toBe(false);
+    expect(result.failure?.type).toBe('PROPERTY_MISSING');
+  });
+});


### PR DESCRIPTION
Closes #1787. Final IDS/server parity gap after #1766.

## Problem
`packages/ids/src/bridge/properties.ts` `appendInheritedPropertySets` resolved type-inherited psets only via `extractTypePropertiesOnDemand`, which returns null when `store.source` is empty — i.e. on **server-parsed** stores. So an IDS facet targeting a property that lives on the element's `IfcTypeProduct` (not the instance) passed on the in-browser path but was invisible on the server path.

## Fix
Fall back to `store.properties.getForEntity(typeId)` — resolving the type through `IfcRelDefinesByType` — exactly like the Lists adapter's server-path type fallback (#1759). The server materialises type sets under the type's own id (the `TYPEHASPROPERTYSETS` merge), so the table lookup surfaces them with their candidate `values[]` (#1766) intact. **Guarded on empty `source`**, so the WASM path never enters this branch and is provably unchanged. No wire/cache/Rust change — pure TS bridge fix.

## Verification
New bridge test over a server-shaped store where the wall's `Pset_WallCommon` lives on its `IfcWallType`:
- a facet on a type-only property (`FireRating = REI 90`) **passes**
- a type-only candidate reachable **only via `values[]`** (`AcousticRating` requiring `R2`) **passes**
- a non-existent value still **fails**

`@ifc-lite/ids` 295/295, build + api-surface + viewer typecheck clean. Changeset: `@ifc-lite/ids` (patch).

## Deploy
No server change — but the property extraction it consumes ships with #1766 (already live). This is client-only, so it goes out with the next Vercel deploy of the viewer; no `railway up` needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)