### PR TITLE
release: bump anchor to 4.1.1 — republish crates without the stale 5x README claim

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1468,11 +1468,11 @@ checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "ifc-lite-clash"
-version = "4.1.0"
+version = "4.1.1"
 
 [[package]]
 name = "ifc-lite-core"
-version = "4.1.0"
+version = "4.1.1"
 dependencies = [
  "fast-float2",
  "futures-core",
@@ -1490,7 +1490,7 @@ dependencies = [
 
 [[package]]
 name = "ifc-lite-export"
-version = "4.1.0"
+version = "4.1.1"
 dependencies = [
  "arrow",
  "ifc-lite-core",
@@ -1505,7 +1505,7 @@ dependencies = [
 
 [[package]]
 name = "ifc-lite-ffi"
-version = "4.1.0"
+version = "4.1.1"
 dependencies = [
  "ifc-lite-processing",
  "mimalloc",
@@ -1515,7 +1515,7 @@ dependencies = [
 
 [[package]]
 name = "ifc-lite-geometry"
-version = "4.1.0"
+version = "4.1.1"
 dependencies = [
  "approx",
  "bnum",
@@ -1543,7 +1543,7 @@ dependencies = [
 
 [[package]]
 name = "ifc-lite-processing"
-version = "4.1.0"
+version = "4.1.1"
 dependencies = [
  "ifc-lite-core",
  "ifc-lite-geometry",
@@ -1557,7 +1557,7 @@ dependencies = [
 
 [[package]]
 name = "ifc-lite-server"
-version = "4.1.0"
+version = "4.1.1"
 dependencies = [
  "anyhow",
  "arrow",
@@ -1593,7 +1593,7 @@ dependencies = [
 
 [[package]]
 name = "ifc-lite-wasm"
-version = "4.1.0"
+version = "4.1.1"
 dependencies = [
  "console_error_panic_hook",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ ifc-lite-core = { version = "4.1.1", path = "rust/core" }
 ifc-lite-geometry = { version = "4.1.1", path = "rust/geometry" }
 ifc-lite-processing = { version = "4.1.1", path = "rust/processing" }
 ifc-lite-clash = { version = "4.1.1", path = "rust/clash" }
-ifc-lite-export = { version = "4.1.0", path = "rust/export" }
+ifc-lite-export = { version = "4.1.1", path = "rust/export" }
 ifc-lite-wasm = { version = "4.1.1", path = "rust/wasm-bindings" }
 
 # Numeric-safety policy, inherited by every member via `[lints] workspace = true`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,19 +4,19 @@ members = ["rust/core", "rust/geometry", "rust/processing", "rust/clash", "rust/
 resolver = "2"
 
 [workspace.package]
-version = "4.1.0"
+version = "4.1.1"
 edition = "2021"
 authors = ["IFC-Lite Contributors"]
 license = "MPL-2.0"
 repository = "https://github.com/LTplus-AG/ifc-lite"
 
 [workspace.dependencies]
-ifc-lite-core = { version = "4.1.0", path = "rust/core" }
-ifc-lite-geometry = { version = "4.1.0", path = "rust/geometry" }
-ifc-lite-processing = { version = "4.1.0", path = "rust/processing" }
-ifc-lite-clash = { version = "4.1.0", path = "rust/clash" }
+ifc-lite-core = { version = "4.1.1", path = "rust/core" }
+ifc-lite-geometry = { version = "4.1.1", path = "rust/geometry" }
+ifc-lite-processing = { version = "4.1.1", path = "rust/processing" }
+ifc-lite-clash = { version = "4.1.1", path = "rust/clash" }
 ifc-lite-export = { version = "4.1.0", path = "rust/export" }
-ifc-lite-wasm = { version = "4.1.0", path = "rust/wasm-bindings" }
+ifc-lite-wasm = { version = "4.1.1", path = "rust/wasm-bindings" }
 
 # Numeric-safety policy, inherited by every member via `[lints] workspace = true`.
 # clippy must not auto-rewrite numeric literals or float comparisons: `.clamp()`,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ifc-lite",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "High-performance browser IFC parser & renderer",
   "private": true,
   "type": "module",

--- a/rust/ffi/Cargo.toml
+++ b/rust/ffi/Cargo.toml
@@ -33,7 +33,7 @@ mimalloc = { version = "0.1", optional = true }
 # A path-only dep fails publish ("dependency does not specify a version").
 # `scripts/sync-versions.js` keeps this literal aligned with the workspace
 # version on every `changeset version` bump.
-ifc-lite-processing = { version = "4.1.0", path = "../processing" }
+ifc-lite-processing = { version = "4.1.1", path = "../processing" }
 rayon = "1.10"
 serde_json = "1.0"
 

--- a/rust/processing/Cargo.toml
+++ b/rust/processing/Cargo.toml
@@ -31,11 +31,11 @@ name = "csg_scaling_bench"
 required-features = ["csg-capture"]
 
 [dependencies]
-ifc-lite-core = { version = "4.1.0", path = "../core" }
+ifc-lite-core = { version = "4.1.1", path = "../core" }
 # CSG runs on the pure-Rust exact kernel inside ifc-lite-geometry on every
 # target (the Manifold C++ kernel was removed in the kernel consolidation —
 # see docs/architecture/geometry-pipeline.md).
-ifc-lite-geometry = { version = "4.1.0", path = "../geometry", default-features = false }
+ifc-lite-geometry = { version = "4.1.1", path = "../geometry", default-features = false }
 rayon = "1.10"
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"

--- a/rust/wasm-bindings/Cargo.toml
+++ b/rust/wasm-bindings/Cargo.toml
@@ -49,7 +49,7 @@ ifc-lite-processing = { version = "4.1.1", path = "../processing" }
 # Pure-geometry clash kernel (BVH broad phase + exact triangle narrow phase).
 ifc-lite-clash = { version = "4.1.1", path = "../clash" }
 # Domain-format exporters (HBJSON, OBJ, glTF/GLB, CSV, JSON, JSON-LD, STEP, IFC5, Merged).
-ifc-lite-export = { version = "4.1.0", path = "../export" }
+ifc-lite-export = { version = "4.1.1", path = "../export" }
 js-sys = "=0.3.83"
 rayon = "1.10"
 # `ifc-lite-geometry` uses rayon `par_iter` (e.g. FacetedBrep

--- a/rust/wasm-bindings/Cargo.toml
+++ b/rust/wasm-bindings/Cargo.toml
@@ -42,12 +42,12 @@ ifc-lite-core.workspace = true
 # same kernel on wasm32 and native. The Manifold C++ kernel and its
 # LLVM/emsdk build prerequisites were removed in the kernel
 # consolidation (docs/architecture/geometry-pipeline.md).
-ifc-lite-geometry = { version = "4.1.0", path = "../geometry", default-features = false, features = [] }
+ifc-lite-geometry = { version = "4.1.1", path = "../geometry", default-features = false, features = [] }
 # Canonical 2D-symbol extractor lives here; the wasm bindings just
 # delegate (issue #843 follow-up — full parity, one implementation).
-ifc-lite-processing = { version = "4.1.0", path = "../processing" }
+ifc-lite-processing = { version = "4.1.1", path = "../processing" }
 # Pure-geometry clash kernel (BVH broad phase + exact triangle narrow phase).
-ifc-lite-clash = { version = "4.1.0", path = "../clash" }
+ifc-lite-clash = { version = "4.1.1", path = "../clash" }
 # Domain-format exporters (HBJSON, OBJ, glTF/GLB, CSV, JSON, JSON-LD, STEP, IFC5, Merged).
 ifc-lite-export = { version = "4.1.0", path = "../export" }
 js-sys = "=0.3.83"

--- a/scripts/release-crates.mjs
+++ b/scripts/release-crates.mjs
@@ -33,6 +33,13 @@ const CRATES = [
   'ifc-lite-geometry',
   'ifc-lite-clash',
   'ifc-lite-processing',
+  // ifc-lite-export must precede ffi/wasm: wasm-bindings pins it by version
+  // (HBJSON/KMZ exporters, #1235) and cargo resolves that against crates.io
+  // at publish time. NOTE: the crate's FIRST publish cannot go through
+  // trusted publishing (new crates need a personal token) - bootstrap it
+  // manually once, then configure its trusted publisher, like every other
+  // crate in this list was bootstrapped.
+  'ifc-lite-export',
   'ifc-lite-ffi',
   'ifc-lite-wasm',
 ];

--- a/scripts/sync-versions.js
+++ b/scripts/sync-versions.js
@@ -82,7 +82,7 @@ function syncVersions() {
   );
 
   cargoToml = cargoToml.replace(
-    /(ifc-lite-(?:core|geometry|processing|clash|wasm)\s*=\s*\{\s*version\s*=\s*")[^"]+(")/g,
+    /(ifc-lite-(?:core|geometry|processing|clash|export|wasm)\s*=\s*\{\s*version\s*=\s*")[^"]+(")/g,
     `$1${version}$2`
   );
 
@@ -94,7 +94,7 @@ function syncVersions() {
   // path and keeps the version requirement on publish). Those literals
   // must track the workspace version or every workspace build breaks with
   // a version/path mismatch after a bump.
-  for (const member of ['core', 'geometry', 'processing', 'clash', 'ffi', 'wasm-bindings']) {
+  for (const member of ['core', 'geometry', 'processing', 'clash', 'export', 'ffi', 'wasm-bindings']) {
     const memberTomlPath = join(rootDir, 'rust', member, 'Cargo.toml');
     let memberToml;
     try {
@@ -103,7 +103,7 @@ function syncVersions() {
       continue;
     }
     const updated = memberToml.replace(
-      /(ifc-lite-(?:core|geometry|processing|clash|wasm)\s*=\s*\{\s*version\s*=\s*")[^"]+(")/g,
+      /(ifc-lite-(?:core|geometry|processing|clash|export|wasm)\s*=\s*\{\s*version\s*=\s*")[^"]+(")/g,
       `$1${version}$2`
     );
     if (updated !== memberToml) {


### PR DESCRIPTION
## Why

The five published crates ship the repo root README (`readme = "../../README.md"`), and the **4.1.0 snapshots live on crates.io still say "Geometry processing: up to 5× faster than web-ifc on the same hardware"** — the claim #1792 just retired everywhere else. Published crate pages can't be edited; only a new version replaces them. Per the release mechanics, Cargo only advances when the version anchor does.

## What

- root `package.json` 4.1.0 → 4.1.1 (the anchor)
- `node scripts/sync-versions.js`: `[workspace.package]` + internal dep pins → 4.1.1
- `cargo update --workspace`: lockfile member versions refreshed

Docs-only republish — zero Rust code changes.

## Flow after merge

1. Changesets bot regenerates the open version PR #1786 with Cargo 4.1.1.
2. Merging #1786 publishes the five crates at 4.1.1 (corrected README) **and** npm `@ifc-lite/geometry` with its corrected description/README (#1784/#1792 changesets).

Checked the other registry surfaces: npm descriptions clean except geometry (heals via #1786); PyPI `ifclite-geom` clean; the `-cat` variant crates clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the package and related components to version 4.1.1.
  * Synchronized internal component version references across native and WebAssembly packages.
  * No functional or user-facing behavior changes are included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->