### PR TITLE
ci(server): freshness guard for generated attr_indices.rs (#1780)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -337,6 +337,14 @@ jobs:
       # can't ship silently.
       - name: Check API surface
         run: node scripts/check-api-surface.mjs
+      # The server-parse root-attribute table (attr_indices.rs) is generated
+      # from @ifc-lite/parser's SCHEMA_REGISTRY — the SAME table the in-browser
+      # parse resolves names against. Guard that the committed file is in sync
+      # so a registry change can't silently break server↔client parity. Uses
+      # the parser dist from the build artifact above; format-agnostic, no Rust
+      # toolchain needed (issue #1780).
+      - name: Check server attr-indices freshness
+        run: node scripts/generate-server-attr-indices.mjs --check
       # Docs upkeep guards (cheap, no build/fixtures needed — the doc-sample
       # typecheck resolves @ifc-lite/* to each package's src via tsconfig
       # paths). Keep the docs in lockstep with the code they describe.

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "check:api-surface": "node scripts/check-api-surface.mjs",
     "api-surface:update": "node scripts/check-api-surface.mjs --update",
     "generate:server-attr-indices": "pnpm turbo build --filter=@ifc-lite/parser && node scripts/generate-server-attr-indices.mjs",
-    "check:server-attr-indices": "node scripts/generate-server-attr-indices.mjs --check",
+    "check:server-attr-indices": "pnpm turbo build --filter=@ifc-lite/parser && node scripts/generate-server-attr-indices.mjs --check",
     "test:regression": "node scripts/test-geometry-regression.mjs",
     "test:esm": "node scripts/verify-esm-entrypoints.mjs",
     "test:ids-corpus": "node scripts/test-ids-corpus.mjs",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
     "check:test-wiring": "node scripts/check-test-wiring.mjs",
     "check:api-surface": "node scripts/check-api-surface.mjs",
     "api-surface:update": "node scripts/check-api-surface.mjs --update",
+    "generate:server-attr-indices": "pnpm turbo build --filter=@ifc-lite/parser && node scripts/generate-server-attr-indices.mjs",
+    "check:server-attr-indices": "node scripts/generate-server-attr-indices.mjs --check",
     "test:regression": "node scripts/test-geometry-regression.mjs",
     "test:esm": "node scripts/verify-esm-entrypoints.mjs",
     "test:ids-corpus": "node scripts/test-ids-corpus.mjs",

--- a/scripts/generate-server-attr-indices.mjs
+++ b/scripts/generate-server-attr-indices.mjs
@@ -17,13 +17,22 @@
  *
  * Regenerate after a schema-registry change:
  *   pnpm turbo build --filter=@ifc-lite/parser && node scripts/generate-server-attr-indices.mjs
+ *   (then `cargo fmt -p ifc-lite-server` — the emitted arms are single-line)
+ *
+ * `--check` compares the committed file's per-type indices against a fresh
+ * derivation from the registry and exits 1 on drift. The comparison is
+ * SEMANTIC (parses the indices out of the committed arms), so it's immune to
+ * rustfmt reflowing the single-line arms into multiple lines — no Rust
+ * toolchain required in CI (issue #1780).
  *
  * Output: apps/server/src/services/data_model/generated/attr_indices.rs
  */
 
-import { writeFileSync, mkdirSync } from 'node:fs';
+import { writeFileSync, mkdirSync, readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+
+const CHECK = process.argv.includes('--check');
 
 const root = join(dirname(fileURLToPath(import.meta.url)), '..');
 const { SCHEMA_REGISTRY, getAttributeNames } = await import(
@@ -80,6 +89,47 @@ ${arms}
 `;
 
 const outPath = join(root, 'apps/server/src/services/data_model/generated/attr_indices.rs');
+
+if (CHECK) {
+  // Parse the committed arms semantically (format-agnostic): each type maps to
+  // its [description, object_type, tag, predefined_type] tuple.
+  let committed;
+  try {
+    committed = readFileSync(outPath, 'utf8');
+  } catch {
+    console.error(`✗ ${outPath} is missing — run: node scripts/generate-server-attr-indices.mjs`);
+    process.exit(1);
+  }
+  const parseArms = (text) => {
+    const map = new Map();
+    const re = /"([A-Z0-9_]+)"\s*=>\s*Some\(RootAttrIndices\s*\{\s*description:\s*(-?\d+)\s*,\s*object_type:\s*(-?\d+)\s*,\s*tag:\s*(-?\d+)\s*,\s*predefined_type:\s*(-?\d+)\s*,?\s*\}\)/g;
+    for (const m of text.matchAll(re)) {
+      map.set(m[1], [Number(m[2]), Number(m[3]), Number(m[4]), Number(m[5])].join(','));
+    }
+    return map;
+  };
+  const expected = new Map(rows.map((r) => [r.upper, r.idx.join(',')]));
+  const actual = parseArms(committed);
+
+  const drift = [];
+  for (const [k, v] of expected) {
+    if (!actual.has(k)) drift.push(`  missing row: ${k}`);
+    else if (actual.get(k) !== v) drift.push(`  ${k}: committed [${actual.get(k)}] != registry [${v}]`);
+  }
+  for (const k of actual.keys()) if (!expected.has(k)) drift.push(`  stale row (not in registry): ${k}`);
+
+  if (drift.length > 0) {
+    console.error(
+      `✗ apps/server/.../generated/attr_indices.rs is out of sync with @ifc-lite/parser's SCHEMA_REGISTRY (${SCHEMA_REGISTRY.name}).\n` +
+      `  Regenerate: pnpm turbo build --filter=@ifc-lite/parser && node scripts/generate-server-attr-indices.mjs && cargo fmt -p ifc-lite-server\n` +
+      `${drift.slice(0, 20).join('\n')}${drift.length > 20 ? `\n  …and ${drift.length - 20} more` : ''}`,
+    );
+    process.exit(1);
+  }
+  console.log(`✓ attr_indices.rs in sync (${expected.size} types, registry ${SCHEMA_REGISTRY.name})`);
+  process.exit(0);
+}
+
 mkdirSync(dirname(outPath), { recursive: true });
 writeFileSync(outPath, out);
 console.log(`wrote ${outPath} (${rows.length} types, registry ${SCHEMA_REGISTRY.name})`);

--- a/scripts/generate-server-attr-indices.mjs
+++ b/scripts/generate-server-attr-indices.mjs
@@ -100,18 +100,25 @@ if (CHECK) {
     console.error(`✗ ${outPath} is missing — run: node scripts/generate-server-attr-indices.mjs`);
     process.exit(1);
   }
+  // Rust `match` is FIRST-arm-wins; a Map is last-wins. Track duplicates so a
+  // hand-added second arm can't slip a wrong value past this guard by matching
+  // the registry on its (dead) last copy while Rust dispatches the first.
   const parseArms = (text) => {
     const map = new Map();
+    const dups = new Set();
     const re = /"([A-Z0-9_]+)"\s*=>\s*Some\(RootAttrIndices\s*\{\s*description:\s*(-?\d+)\s*,\s*object_type:\s*(-?\d+)\s*,\s*tag:\s*(-?\d+)\s*,\s*predefined_type:\s*(-?\d+)\s*,?\s*\}\)/g;
     for (const m of text.matchAll(re)) {
-      map.set(m[1], [Number(m[2]), Number(m[3]), Number(m[4]), Number(m[5])].join(','));
+      // Keep the FIRST arm's value (mirrors Rust dispatch); flag the rest.
+      if (map.has(m[1])) dups.add(m[1]);
+      else map.set(m[1], [Number(m[2]), Number(m[3]), Number(m[4]), Number(m[5])].join(','));
     }
-    return map;
+    return { map, dups };
   };
   const expected = new Map(rows.map((r) => [r.upper, r.idx.join(',')]));
-  const actual = parseArms(committed);
+  const { map: actual, dups } = parseArms(committed);
 
   const drift = [];
+  for (const k of dups) drift.push(`  duplicate arm (Rust uses the first, unreachable rest): ${k}`);
   for (const [k, v] of expected) {
     if (!actual.has(k)) drift.push(`  missing row: ${k}`);
     else if (actual.get(k) !== v) drift.push(`  ${k}: committed [${actual.get(k)}] != registry [${v}]`);

--- a/scripts/generate-server-attr-indices.mjs
+++ b/scripts/generate-server-attr-indices.mjs
@@ -100,10 +100,18 @@ if (CHECK) {
     console.error(`✗ ${outPath} is missing — run: node scripts/generate-server-attr-indices.mjs`);
     process.exit(1);
   }
+  // A commented-out arm is dead to Rust (it falls back to the unknown-type
+  // indices), but the arm regex would still match it and report "in sync" —
+  // recreating the very drift this guards against. Strip Rust block and line
+  // comments first. (attr_indices.rs holds no string literals containing `//`
+  // or `/*` — type-name keys are `[A-Z0-9_]+` — so this can't eat a real arm.)
+  const stripRustComments = (text) =>
+    text.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/[^\n]*/g, '');
   // Rust `match` is FIRST-arm-wins; a Map is last-wins. Track duplicates so a
   // hand-added second arm can't slip a wrong value past this guard by matching
   // the registry on its (dead) last copy while Rust dispatches the first.
-  const parseArms = (text) => {
+  const parseArms = (rawText) => {
+    const text = stripRustComments(rawText);
     const map = new Map();
     const dups = new Set();
     const re = /"([A-Z0-9_]+)"\s*=>\s*Some\(RootAttrIndices\s*\{\s*description:\s*(-?\d+)\s*,\s*object_type:\s*(-?\d+)\s*,\s*tag:\s*(-?\d+)\s*,\s*predefined_type:\s*(-?\d+)\s*,?\s*\}\)/g;


### PR DESCRIPTION
Closes #1780.

## What

The server-parse root-attribute table `apps/server/src/services/data_model/generated/attr_indices.rs` (per-IFC-type positions of Description / ObjectType / Tag / PredefinedType) is code-generated from `@ifc-lite/parser`'s `SCHEMA_REGISTRY` — the **same** registry the in-browser (WASM/columnar) parse resolves attribute names against. That shared source is what makes the two parse paths extract identical values (the parity arc #1748 → #1759 → #1765 → #1766).

Nothing guarded that the committed `.rs` file stayed in sync with the registry. A future schema-registry change that wasn't regenerated would silently reintroduce server↔client divergence.

## How

- Add a `--check` mode to `scripts/generate-server-attr-indices.mjs`. It semantically parses the committed file's per-type `[description, object_type, tag, predefined_type]` tuples (regex over the match arms) and diffs them against a fresh derivation from the registry. On drift it exits 1 with a precise per-type diff (`IFCWALL: committed [3,4,7,99] != registry [3,4,7,8]`), plus missing/stale-row detection and regen instructions. On match: `✓ attr_indices.rs in sync (776 types, registry IFC4_ADD2_TC1)`, exit 0.
- The comparison is **format-agnostic** — immune to `rustfmt` reflowing the single-line arms into multiple lines — so CI needs **no Rust toolchain**, just the parser `dist` that's already in the build artifact.
- Wire it into the `node-tests` CI job next to the api-surface check (same precedent as the Plato `--check` freshness gate).
- Add `package.json` scripts: `check:server-attr-indices` and `generate:server-attr-indices`.

## Verification

- In-sync file → `✓ … 776 types`, exit 0.
- Injected drift (mutated IFCWALL `predefined_type` 8→99) → exit 1 with `IFCWALL: committed [3,4,7,99] != registry [3,4,7,8]`, then restored.
- Missing-file and stale-row paths covered by the diff logic.

No behavior change to the server or client — this is a CI/tooling guard only. No published-package change, so no changeset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added commands to generate and verify server attribute indices.
  * Added validation to detect when generated server attribute data is out of sync.

* **Bug Fixes**
  * Automated checks now flag stale or missing generated attribute indices during testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->