### PR TITLE
fix(parser): preserve STEP token kind (Enum vs String) through columnar parser

### DIFF
--- a/.changeset/step-token-kind-channel.md
+++ b/.changeset/step-token-kind-channel.md
@@ -1,0 +1,6 @@
+---
+"@ifc-lite/data": minor
+"@ifc-lite/parser": patch
+---
+
+Preserve the STEP token kind (Enum vs quoted String) through the columnar parser (#1799). `EntityExtractor` now records which top-level attributes were bare enumeration tokens (`.USERDEFINED.`) in a new optional `IfcEntity.enumAttrIndices` side channel — the value representation is unchanged (enums are still stored as dotted strings), so existing consumers are unaffected. `extractRootAttributesFromEntity` rejects enum tokens on the unknown-type fixed-index fallback by token KIND instead of the #1779 dotted-string shape heuristic: a quoted string that merely looks like an enum (`'.USERDEFINED.'`) now survives, exactly matching the Rust server path's `AttributeValue::String` / `AttributeValue::Enum` split, while a bare `PredefinedType` enum landing on a fallback slot (e.g. IFC4X3 `IfcAlignment` attr 7) is still blanked.

--- a/packages/data/src/types.ts
+++ b/packages/data/src/types.ts
@@ -583,4 +583,20 @@ export interface IfcEntity {
   expressId: number;
   type: string;
   attributes: IfcAttributeValue[];
+  /**
+   * STEP token-kind side channel (#1799): indices into `attributes` whose
+   * TOP-LEVEL source token was a bare enumeration (`.USERDEFINED.` — dotted in
+   * the source, unquoted). The value representation is unchanged (an enum is
+   * still stored as its dotted string), so existing consumers are unaffected;
+   * this channel only records the token KIND, letting consumers distinguish a
+   * bare enum from a quoted string that happens to look like one
+   * (`'.USERDEFINED.'`) — mirroring the Rust parser's separate
+   * `AttributeValue::String` / `AttributeValue::Enum` variants.
+   *
+   * Optional: absent when the entity has no bare-enum attributes, or when the
+   * producer predates / does not track token kinds (hand-built entities,
+   * mutation authoring). Nested tokens (inside lists or typed values) are not
+   * tracked. Indices are in ascending order.
+   */
+  enumAttrIndices?: readonly number[];
 }

--- a/packages/parser/src/columnar-parser.ts
+++ b/packages/parser/src/columnar-parser.ts
@@ -1064,11 +1064,6 @@ interface RootAttrIndices {
 // entities, keeping the on-demand path cheap even when called per entity.
 const rootAttrIndexCache = new Map<string, RootAttrIndices>();
 
-/** A STEP bare-enumeration token as the extractor stores it — dotted, uppercase
- *  (`.USERDEFINED.`, `.FLAT_ROOF.`). Quoted strings arrive with quotes stripped,
- *  so a genuine text value never has the surrounding dots. */
-const STEP_ENUM_TOKEN = /^\.[A-Z][A-Z0-9_]*\.$/;
-
 function getRootAttrIndices(type: string): RootAttrIndices {
     let idx = rootAttrIndexCache.get(type);
     if (!idx) {
@@ -1106,18 +1101,21 @@ export function extractRootAttributesFromEntity(
     entity: IfcEntity
 ): { globalId: string; name: string; description: string; objectType: string; tag: string } {
     const attrs = entity.attributes || [];
+    const enumIdx = entity.enumAttrIndices;
     const idx = getRootAttrIndices(entity.type);
     const pick = (schemaIndex: number, fallbackIndex: number): string => {
         const i = idx.known ? schemaIndex : fallbackIndex;
         const raw = i >= 0 ? attrs[i] : undefined;
         if (typeof raw !== 'string') return '';
         // Unknown-type fallback only: a fixed index can land on a STEP bare-enum
-        // token — the extractor stores it as a dotted string (`.USERDEFINED.`),
-        // e.g. a PredefinedType at attr 7 for a non-IfcElement layout — which
-        // must not leak into a Tag/Description cell. Mirror the Rust server path
-        // (string_at rejects enums), which renders these blank (#1779). Skipped
-        // for known types, whose schema indices point at genuine string slots.
-        if (!idx.known && STEP_ENUM_TOKEN.test(raw)) return '';
+        // token — e.g. a PredefinedType at attr 7 for a non-IfcElement layout —
+        // which must not leak into a Tag/Description cell. Reject by token KIND
+        // via the extractor's side channel (#1799), not by dotted-string shape:
+        // a quoted string that merely looks like an enum ('.USERDEFINED.')
+        // survives, exactly matching the Rust server path (string_at accepts
+        // AttributeValue::String and rejects ::Enum, #1779). Skipped for known
+        // types, whose schema indices point at genuine string slots.
+        if (!idx.known && enumIdx !== undefined && enumIdx.includes(i)) return '';
         return raw;
     };
     return {

--- a/packages/parser/src/entity-extractor.ts
+++ b/packages/parser/src/entity-extractor.ts
@@ -18,6 +18,31 @@ const log = createLogger('EntityExtractor');
 /** Maximum recursion depth for parsing nested structures (prevents DoS via deeply nested data) */
 const MAX_PARSE_DEPTH = 100;
 
+/**
+ * Is this raw source token a bare STEP enumeration token (`.USERDEFINED.`,
+ * `.T.`, `.FLAT_ROOF.`)? Mirrors the Rust tokenizer's `enum_value` rule —
+ * `'.' [A-Za-z0-9_]+ '.'` — so client and server classify the token KIND
+ * identically (#1799). Must be called on the token as it appears in the
+ * source (before quote-stripping): a quoted string `'.USERDEFINED.'` starts
+ * with a quote and is never flagged. Char-code loop, no per-call allocation.
+ */
+function isBareEnumToken(token: string): boolean {
+  const n = token.length;
+  if (n < 3 || token.charCodeAt(0) !== 0x2e /* . */ || token.charCodeAt(n - 1) !== 0x2e) {
+    return false;
+  }
+  for (let i = 1; i < n - 1; i++) {
+    const c = token.charCodeAt(i);
+    const alnum =
+      (c >= 0x30 && c <= 0x39) || // 0-9
+      (c >= 0x41 && c <= 0x5a) || // A-Z
+      (c >= 0x61 && c <= 0x7a) || // a-z
+      c === 0x5f; // _
+    if (!alnum) return false;
+  }
+  return true;
+}
+
 export class EntityExtractor {
   private buffer: Uint8Array;
 
@@ -49,13 +74,18 @@ export class EntityExtractor {
       const paramsText = match[3];
 
       // Parse attributes (simplified - handles basic types)
-      const attributes = this.parseAttributes(paramsText);
+      const { attributes, enumAttrIndices } = this.parseAttributes(paramsText);
 
-      return {
+      const entity: IfcEntity = {
         expressId,
         type,
         attributes,
       };
+      // Token-kind side channel (#1799): only attached when at least one
+      // top-level attribute was a bare enum, so the common case allocates
+      // nothing extra and the object shape stays stable for most entities.
+      if (enumAttrIndices) entity.enumAttrIndices = enumAttrIndices;
+      return entity;
     } catch (error) {
       log.error('Failed to extract entity', error, {
         operation: 'extractEntity',
@@ -66,10 +96,18 @@ export class EntityExtractor {
     }
   }
 
-  private parseAttributes(paramsText: string): any[] {
-    if (!paramsText.trim()) return [];
+  private parseAttributes(paramsText: string): {
+    attributes: any[];
+    enumAttrIndices?: number[];
+  } {
+    if (!paramsText.trim()) return { attributes: [] };
 
     const attributes: any[] = [];
+    // Indices of top-level attributes whose source token was a bare enum
+    // (`.USERDEFINED.`). Lazily allocated — undefined when the entity has none.
+    // Kind is decided on the RAW token, before parseAttributeValue strips
+    // quotes, so `'.USERDEFINED.'` (a genuine string) is never flagged (#1799).
+    let enumAttrIndices: number[] | undefined;
     let depth = 0;
     let current = '';
     let inString = false;
@@ -100,7 +138,9 @@ export class EntityExtractor {
         current += char;
       } else if (char === ',' && depth === 0) {
         // End of attribute
-        attributes.push(this.parseAttributeValue(current.trim()));
+        const token = current.trim();
+        if (isBareEnumToken(token)) (enumAttrIndices ??= []).push(attributes.length);
+        attributes.push(this.parseAttributeValue(token));
         current = '';
       } else {
         current += char;
@@ -108,11 +148,13 @@ export class EntityExtractor {
     }
 
     // Add last attribute
-    if (current.trim()) {
-      attributes.push(this.parseAttributeValue(current.trim()));
+    const lastToken = current.trim();
+    if (lastToken) {
+      if (isBareEnumToken(lastToken)) (enumAttrIndices ??= []).push(attributes.length);
+      attributes.push(this.parseAttributeValue(lastToken));
     }
 
-    return attributes;
+    return { attributes, enumAttrIndices };
   }
 
   private parseAttributeValue(value: string, depth: number = 0): any {

--- a/packages/parser/test/root-attr-enum-fallback.test.ts
+++ b/packages/parser/test/root-attr-enum-fallback.test.ts
@@ -9,28 +9,51 @@
  * PredefinedType enum at attr 7; the extractor stores it as a dotted string
  * (`.USERDEFINED.`), which used to surface as `Tag`. The Rust server path
  * rejects enums, so the client must render blank too.
+ *
+ * Since #1799 rejection is by token KIND (the extractor's `enumAttrIndices`
+ * side channel), not by dotted-string shape: a QUOTED string that merely looks
+ * like an enum (`'.USERDEFINED.'`) survives, exactly matching the Rust path's
+ * `AttributeValue::String` / `AttributeValue::Enum` split.
  */
 
 import { describe, it, expect } from 'vitest';
 import { extractRootAttributesFromEntity } from '../src/columnar-parser.js';
 import { getAttributeNames } from '../src/ifc-schema.js';
+import { EntityExtractor } from '../src/entity-extractor.js';
 import type { IfcEntity } from '@ifc-lite/data';
 
-describe('extractRootAttributesFromEntity — enum fallback (#1779)', () => {
+/** Run a single STEP record through the real extractor (the kind-channel producer). */
+function extract(record: string, expressId: number, type: string): IfcEntity {
+  const buffer = new TextEncoder().encode(record);
+  const entity = new EntityExtractor(buffer).extractEntity({
+    expressId,
+    type,
+    byteOffset: 0,
+    byteLength: buffer.length,
+    lineNumber: 1,
+  });
+  if (!entity) throw new Error(`extractEntity failed for: ${record}`);
+  return entity;
+}
+
+describe('extractRootAttributesFromEntity — enum fallback (#1779, #1799)', () => {
   it('IfcAlignment is unknown to the pinned registry (premise of the fallback tests)', () => {
     // If a future registry pin adds IfcAlignment, the fallback tests below would
     // silently stop exercising the unknown-type path — pin the premise here.
     expect(getAttributeNames('IfcAlignment')).toHaveLength(0);
   });
 
-  it('drops a dotted enum token at a fallback index instead of leaking it as Tag', () => {
+  it('drops a bare enum token at a fallback index instead of leaking it as Tag', () => {
     // IfcAlignment is unknown to the IFC4 registry → fixed-index fallback.
     // attrs: [GlobalId, OwnerHistory, Name, Description, ObjectType, ..., PredefinedType@7]
-    const entity: IfcEntity = {
-      expressId: 1,
-      type: 'IfcAlignment',
-      attributes: ['0GUID', null, 'Main Alignment', 'centre line', 'objtype', null, null, '.USERDEFINED.'],
-    };
+    const entity = extract(
+      "#1=IFCALIGNMENT('0GUID',$,'Main Alignment','centre line','objtype',$,$,.USERDEFINED.)",
+      1,
+      'IFCALIGNMENT'
+    );
+    // The extractor flagged the bare token's KIND without changing its value.
+    expect(entity.attributes[7]).toBe('.USERDEFINED.');
+    expect(entity.enumAttrIndices).toEqual([7]);
     const attrs = extractRootAttributesFromEntity(entity);
     expect(attrs.tag).toBe(''); // was '.USERDEFINED.'
     // Genuine (non-enum) string attributes still resolve on the fallback path.
@@ -39,27 +62,35 @@ describe('extractRootAttributesFromEntity — enum fallback (#1779)', () => {
     expect(attrs.objectType).toBe('objtype');
   });
 
+  it('keeps a QUOTED enum-shaped string at a fallback index (kind beats shape, #1799)', () => {
+    // Same record, but the source token is a quoted STRING '.USERDEFINED.' —
+    // the Rust server path keeps it (AttributeValue::String), and since #1799
+    // the client does too. Under the #1779 shape heuristic this was blanked.
+    const entity = extract(
+      "#1=IFCALIGNMENT('0GUID',$,'Main Alignment',$,$,$,$,'.USERDEFINED.')",
+      1,
+      'IFCALIGNMENT'
+    );
+    expect(entity.attributes[7]).toBe('.USERDEFINED.'); // value identical to the bare case…
+    expect(entity.enumAttrIndices).toBeUndefined(); // …but the kind channel says String
+    expect(extractRootAttributesFromEntity(entity).tag).toBe('.USERDEFINED.');
+  });
+
   it('leaves a genuine string Tag untouched on the fallback path', () => {
-    const entity: IfcEntity = {
-      expressId: 2,
-      type: 'IfcAlignment',
-      attributes: ['0GUID', null, 'A', null, null, null, null, 'TAG-123'],
-    };
+    const entity = extract("#2=IFCALIGNMENT('0GUID',$,'A',$,$,$,$,'TAG-123')", 2, 'IFCALIGNMENT');
+    expect(entity.enumAttrIndices).toBeUndefined();
     expect(extractRootAttributesFromEntity(entity).tag).toBe('TAG-123');
   });
 
   it('does not touch known types (schema index → genuine Tag slot)', () => {
     // IfcWall attr 7 is Tag by schema; a normal string tag is unaffected.
-    const entity: IfcEntity = {
-      expressId: 3,
-      type: 'IfcWall',
-      attributes: ['0GUID', null, 'W-1', null, null, null, null, 'wall-tag'],
-    };
+    const entity = extract("#3=IFCWALL('0GUID',$,'W-1',$,$,$,$,'wall-tag',.SOLIDWALL.)", 3, 'IFCWALL');
+    expect(entity.enumAttrIndices).toEqual([8]); // PredefinedType flagged, Tag not
     expect(extractRootAttributesFromEntity(entity).tag).toBe('wall-tag');
   });
 
-  it('does not blank a dotted token on a KNOWN type (filter is unknown-only)', () => {
-    // Scoping proof: even a value shaped like an enum survives on a known type,
+  it('does not blank an enum-flagged slot on a KNOWN type (filter is unknown-only)', () => {
+    // Scoping proof: even a bare enum token at attr 7 survives on a known type,
     // because the schema index resolves the real slot and the filter is gated
     // on !idx.known. (A genuine IfcWall Tag would never be an enum, but this
     // pins that the filter can't reach the known-type path.)
@@ -67,7 +98,44 @@ describe('extractRootAttributesFromEntity — enum fallback (#1779)', () => {
       expressId: 4,
       type: 'IfcWall',
       attributes: ['0GUID', null, 'W-2', null, null, null, null, '.USERDEFINED.'],
+      enumAttrIndices: [7],
     };
     expect(extractRootAttributesFromEntity(entity).tag).toBe('.USERDEFINED.');
+  });
+
+  it('tolerates entities without the kind channel (hand-built / legacy producers)', () => {
+    // No enumAttrIndices → nothing is enum-kind → the string survives, which is
+    // exactly what the server does for a genuine string value.
+    const entity: IfcEntity = {
+      expressId: 5,
+      type: 'IfcAlignment',
+      attributes: ['0GUID', null, 'A', null, null, null, null, '.USERDEFINED.'],
+    };
+    expect(extractRootAttributesFromEntity(entity).tag).toBe('.USERDEFINED.');
+  });
+});
+
+describe('EntityExtractor enumAttrIndices side channel (#1799)', () => {
+  it('flags bare enums at any top-level position, mirroring the Rust tokenizer rule', () => {
+    const entity = extract("#10=IFCTHING(.T.,'a',.FLAT_ROOF.,$,42,.b2_x.)", 10, 'IFCTHING');
+    // Values keep the historical representation (dotted strings)…
+    expect(entity.attributes).toEqual(['.T.', 'a', '.FLAT_ROOF.', null, 42, '.b2_x.']);
+    // …and the channel records the kind, including mid-list and tail positions.
+    // `.b2_x.` matches the Rust enum_value rule ('.' [A-Za-z0-9_]+ '.').
+    expect(entity.enumAttrIndices).toEqual([0, 2, 5]);
+  });
+
+  it('does not flag nested enums (inside lists or typed values) or non-enum tokens', () => {
+    const entity = extract(
+      "#11=IFCTHING((.A.,.B.),IFCBOOLEAN(.T.),'.QUOTED.',#5,*,.NOT AN ENUM.)",
+      11,
+      'IFCTHING'
+    );
+    // list + typed value keep their nested representation, unflagged
+    expect(entity.attributes[0]).toEqual(['.A.', '.B.']);
+    expect(entity.attributes[1]).toEqual(['IFCBOOLEAN', '.T.']);
+    // quoted string, reference, derived (*), and a dotted token with a space
+    // (which the Rust tokenizer would not lex as an enum) are all non-enum-kind
+    expect(entity.enumAttrIndices).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

Proper follow-up to #1779 (PR #1797). The client-side `EntityExtractor` collapsed quoted STEP strings and bare enumeration tokens into indistinguishable JS strings, forcing #1779's unknown-type root-attribute fallback to reject enums by dotted-string **shape** (`^\.[A-Z][A-Z0-9_]*\.$`) — which also blanked the (astronomically rare) genuine quoted string `'.USERDEFINED.'`, a one-directional parity divergence from the Rust server path that keeps separate `AttributeValue::String` / `AttributeValue::Enum` variants.

This PR preserves the token **kind** instead:

- **`@ifc-lite/data`**: new optional `IfcEntity.enumAttrIndices?: readonly number[]` — a parallel kind side channel listing the top-level attribute indices whose source token was a bare enum. The value representation is untouched (enums are still stored as dotted strings), so every existing consumer of `parseAttributeValue` output is unaffected; producers that don't track kinds simply omit the field.
- **`@ifc-lite/parser` `EntityExtractor.parseAttributes`**: classifies each top-level raw token with an allocation-free char-code check mirroring the Rust tokenizer's `enum_value` rule (`'.' [A-Za-z0-9_]+ '.'`), lazily allocating the index array only when an enum is present. Kind is decided on the raw token *before* quote-stripping, so `'.USERDEFINED.'` (quoted) is never flagged. Nested tokens (inside lists / typed values) are intentionally not tracked — the channel exists for top-level attribute reads.
- **`extractRootAttributesFromEntity`**: the #1779 shape heuristic (`STEP_ENUM_TOKEN` regex) is replaced by kind-based rejection via the side channel, still gated to the unknown-type fixed-index fallback only.

## Server parity

Matches `apps/server/src/services/data_model/metadata.rs` exactly: `string_at` accepts only `AttributeValue::String` (so a quoted `'.USERDEFINED.'` survives), and a bare enum landing on a fallback slot (e.g. IFC4X3 `IfcAlignment` PredefinedType at attr 7) is rejected/blank on both paths. The TS enum classifier mirrors `rust/core/src/parser/tokenizer.rs::enum_value` (lowercase and digit-leading tokens included), not the narrower uppercase-only #1779 regex.

## Tests

`root-attr-enum-fallback.test.ts` now drives the real `EntityExtractor` end-to-end:
- bare `.USERDEFINED.` at IfcAlignment attr 7 → still blanked (the #1779 regression scenario), name/description/objectType unaffected;
- quoted `'.USERDEFINED.'` at the same slot → **survives** (the parity fix; identical stored value, different kind);
- known types (IfcWall) untouched, including an enum-flagged slot (filter is unknown-only);
- entities without the channel (hand-built/legacy producers) → no blanking, matching server treatment of genuine strings;
- channel unit tests: enums flagged at head/mid/tail positions per the Rust tokenizer rule (`.T.`, `.FLAT_ROOF.`, `.b2_x.`); nested list/typed-value enums, quoted strings, refs, `*`, and non-lexable dotted tokens (`.NOT AN ENUM.`) unflagged.

`@ifc-lite/parser` 311 tests, `@ifc-lite/data` 64, `@ifc-lite/query` 112, `@ifc-lite/mutations` 73 all pass; repo-wide `pnpm typecheck` (33 tasks) green. Changeset included (`@ifc-lite/data` minor, `@ifc-lite/parser` patch); no new exports, so the api-surface snapshot is unchanged.

Closes #1799

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of STEP enumeration values during parsing.
  * Prevented bare enumeration tokens from appearing incorrectly in display fields for unrecognized entity types.
  * Preserved quoted strings that resemble enumeration values.
  * Maintained existing enum value representations while improving attribute interpretation.

* **Tests**
  * Added coverage for bare and quoted enumeration values, known and unknown entity types, nested values, and compatibility with existing parsed data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->