### PR TITLE
feat(lists): Count aggregation with multi-criteria grouping

### DIFF
--- a/.changeset/lists-count-multi-grouping.md
+++ b/.changeset/lists-count-multi-grouping.md
@@ -2,4 +2,4 @@
 "@ifc-lite/lists": minor
 ---
 
-Count aggregation with multi-criteria grouping in lists (issue #1790): `ListGrouping.columnIds` groups rows by several columns in order (e.g. Building, then Storey); `summariseListRows` emits a flat pre-order group list with `level`/`path` and a per-group `count` (the Count aggregate) plus per-column sums at every nesting level. New `groupingColumnIds` helper resolves the effective group columns with full backward compatibility for the legacy single `columnId`.
+Count aggregation with multi-criteria grouping in lists (issue #1790): `ListGrouping.columnIds` groups rows by several columns in order (e.g. Building, then Storey); `summariseListRows` emits a flat pre-order group list with `level`/`path` and a per-group `count` (the Count aggregate) plus per-column sums at every nesting level. New helpers: `groupingColumnIds` resolves the effective group columns with full backward compatibility for the legacy single `columnId`, and `groupPathKey` encodes a group path into its collision-free unique key (`ListGroup.key` is now this JSON path encoding).

--- a/.changeset/lists-count-multi-grouping.md
+++ b/.changeset/lists-count-multi-grouping.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/lists": minor
+---
+
+Count aggregation with multi-criteria grouping in lists (issue #1790): `ListGrouping.columnIds` groups rows by several columns in order (e.g. Building, then Storey); `summariseListRows` emits a flat pre-order group list with `level`/`path` and a per-group `count` (the Count aggregate) plus per-column sums at every nesting level. New `groupingColumnIds` helper resolves the effective group columns with full backward compatibility for the legacy single `columnId`.

--- a/apps/viewer/src/components/viewer/lists/ColumnHeaderMenu.tsx
+++ b/apps/viewer/src/components/viewer/lists/ColumnHeaderMenu.tsx
@@ -22,6 +22,9 @@ import { cn } from '@/lib/utils';
 interface ColumnHeaderMenuProps {
   isNumeric: boolean;
   isGroupedBy: boolean;
+  /** Grouping is active on OTHER columns — grouping this one adds a nesting
+   *  level (multi-criteria grouping, issue #1790). */
+  groupedElsewhere: boolean;
   isSummed: boolean;
   active: boolean;
   onSort: (dir: 'asc' | 'desc') => void;
@@ -31,7 +34,7 @@ interface ColumnHeaderMenuProps {
 }
 
 export function ColumnHeaderMenu({
-  isNumeric, isGroupedBy, isSummed, active,
+  isNumeric, isGroupedBy, groupedElsewhere, isSummed, active,
   onSort, onToggleGroup, onToggleSum, onColorBy,
 }: ColumnHeaderMenuProps) {
   return (
@@ -60,8 +63,10 @@ export function ColumnHeaderMenu({
         <DropdownMenuSeparator />
         <DropdownMenuItem className="gap-2 text-xs" onClick={onToggleGroup}>
           {isGroupedBy
-            ? (<><Ungroup className="h-3.5 w-3.5" /> Remove grouping</>)
-            : (<><Group className="h-3.5 w-3.5" /> Group by this column</>)}
+            ? (<><Ungroup className="h-3.5 w-3.5" /> Remove from grouping</>)
+            : groupedElsewhere
+              ? (<><Group className="h-3.5 w-3.5" /> Add grouping level</>)
+              : (<><Group className="h-3.5 w-3.5" /> Group by this column</>)}
         </DropdownMenuItem>
         <DropdownMenuCheckboxItem
           className="text-xs"

--- a/apps/viewer/src/components/viewer/lists/ListBuilder.tsx
+++ b/apps/viewer/src/components/viewer/lists/ListBuilder.tsx
@@ -36,7 +36,7 @@ import type {
   PropertyCondition,
   ConditionOperator,
 } from '@ifc-lite/lists';
-import { discoverColumns, ENTITY_ATTRIBUTES } from '@ifc-lite/lists';
+import { discoverColumns, ENTITY_ATTRIBUTES, groupingColumnIds } from '@ifc-lite/lists';
 import { collectScopeTypes } from '@/lib/lists/scope-types';
 import {
   isEditableColumn,
@@ -222,7 +222,10 @@ export function ListBuilder({ providers, stores, initial, onSave, onCancel, onEx
     for (const p of providers) { const n = p.getModelName?.(); if (n) set.add(n); }
     return Array.from(set).sort();
   }, [providers]);
-  const [groupByColumnId, setGroupByColumnId] = useState<string>(initial?.grouping?.columnId ?? '');
+  // Ordered group-by columns, outermost first (multi-criteria grouping #1790).
+  const [groupByColumnIds, setGroupByColumnIds] = useState<string[]>(
+    () => groupingColumnIds(initial?.grouping)
+  );
   const [sumColumnIds, setSumColumnIds] = useState<Set<string>>(
     new Set(initial?.grouping?.sumColumnIds ?? [])
   );
@@ -266,7 +269,7 @@ export function ListBuilder({ providers, stores, initial, onSave, onCancel, onEx
   const removeColumn = useCallback((id: string) => {
     setColumns(prev => prev.filter(c => c.id !== id));
     // Keep grouping consistent when its column is removed.
-    setGroupByColumnId(prev => (prev === id ? '' : prev));
+    setGroupByColumnIds(prev => (prev.includes(id) ? prev.filter(g => g !== id) : prev));
     setSumColumnIds(prev => {
       if (!prev.has(id)) return prev;
       const next = new Set(prev);
@@ -328,13 +331,31 @@ export function ListBuilder({ providers, stores, initial, onSave, onCancel, onEx
     });
   }, []);
 
+  // Set / clear one grouping level. An empty id removes the level; setting the
+  // slot one past the end appends a new level (multi-criteria grouping #1790).
+  const setGroupLevel = useCallback((level: number, id: string) => {
+    setGroupByColumnIds(prev => {
+      const next = [...prev];
+      if (id === '') {
+        if (level < next.length) next.splice(level, 1);
+      } else if (level < next.length) {
+        next[level] = id;
+      } else {
+        next.push(id);
+      }
+      // Safety de-dup (the selects already hide ids used at other levels).
+      return next.filter((v, i) => next.indexOf(v) === i);
+    });
+  }, []);
+
   const buildDefinition = useCallback((): ListDefinition => {
-    const groupValid = groupByColumnId && columns.some(c => c.id === groupByColumnId);
+    const validGroupIds = groupByColumnIds.filter(id => columns.some(c => c.id === id));
     const sumCols = columns.filter(c => sumColumnIds.has(c.id)).map(c => c.id);
     // Keep grouping when there's a valid group column OR any sum column — sums
     // alone still produce grand totals, and may have been set from the table.
-    const grouping = (groupValid || sumCols.length > 0)
-      ? { columnId: groupValid ? groupByColumnId : '', sumColumnIds: sumCols }
+    // `columnId` mirrors the first level for pre-multi-level consumers.
+    const grouping = (validGroupIds.length > 0 || sumCols.length > 0)
+      ? { columnId: validGroupIds[0] ?? '', columnIds: validGroupIds, sumColumnIds: sumCols }
       : undefined;
     return {
       id: initial?.id ?? crypto.randomUUID(),
@@ -349,7 +370,7 @@ export function ListBuilder({ providers, stores, initial, onSave, onCancel, onEx
       columns,
       grouping,
     };
-  }, [initial, name, description, selectedTypes, conditions, columns, groupByColumnId, sumColumnIds]);
+  }, [initial, name, description, selectedTypes, conditions, columns, groupByColumnIds, sumColumnIds]);
 
   const handleSave = useCallback(() => onSave(buildDefinition()), [buildDefinition, onSave]);
   const handleRun = useCallback(() => onExecute(buildDefinition()), [buildDefinition, onExecute]);
@@ -469,9 +490,9 @@ export function ListBuilder({ providers, stores, initial, onSave, onCancel, onEx
             <Section label="Grouping & Totals">
               <GroupingBody
                 columns={columns}
-                groupByColumnId={groupByColumnId}
+                groupByColumnIds={groupByColumnIds}
                 sumColumnIds={sumColumnIds}
-                onGroupByChange={setGroupByColumnId}
+                onGroupLevelChange={setGroupLevel}
                 onToggleSum={toggleSumColumn}
               />
             </Section>
@@ -1014,32 +1035,49 @@ function PickerItem({
 
 function GroupingBody({
   columns,
-  groupByColumnId,
+  groupByColumnIds,
   sumColumnIds,
-  onGroupByChange,
+  onGroupLevelChange,
   onToggleSum,
 }: {
   columns: ColumnDefinition[];
-  groupByColumnId: string;
+  /** Ordered group-by columns, outermost first (multi-criteria grouping #1790). */
+  groupByColumnIds: string[];
   sumColumnIds: Set<string>;
-  onGroupByChange: (id: string) => void;
+  onGroupLevelChange: (level: number, id: string) => void;
   onToggleSum: (id: string) => void;
 }) {
+  // One select per active level, plus a trailing empty slot to add the next
+  // level (as long as ungrouped columns remain).
+  const levelSlots = groupByColumnIds.length < columns.length
+    ? [...groupByColumnIds, '']
+    : groupByColumnIds;
   return (
     <div className="space-y-3 rounded-md border border-border/60 bg-card p-2.5">
-      <label className="flex items-center gap-2 text-xs">
-        <span className="w-16 shrink-0 text-muted-foreground">Group by</span>
-        <select
-          value={groupByColumnId}
-          onChange={(e) => onGroupByChange(e.target.value)}
-          className="h-7 flex-1 rounded-md border border-border bg-background px-2 text-xs focus:outline-none focus:ring-1 focus:ring-ring"
-        >
-          <option value="">— None (flat list) —</option>
-          {columns.map((c) => (
-            <option key={c.id} value={c.id}>{c.label ?? c.propertyName}</option>
-          ))}
-        </select>
-      </label>
+      <div className="space-y-1.5">
+        {levelSlots.map((id, level) => (
+          <label key={level} className="flex items-center gap-2 text-xs">
+            <span className="w-16 shrink-0 text-muted-foreground">{level === 0 ? 'Group by' : 'then by'}</span>
+            <select
+              value={id}
+              onChange={(e) => onGroupLevelChange(level, e.target.value)}
+              className="h-7 flex-1 rounded-md border border-border bg-background px-2 text-xs focus:outline-none focus:ring-1 focus:ring-ring"
+            >
+              <option value="">{level === 0 ? '— None (flat list) —' : 'None'}</option>
+              {columns
+                .filter((c) => c.id === id || !groupByColumnIds.includes(c.id))
+                .map((c) => (
+                  <option key={c.id} value={c.id}>{c.label ?? c.propertyName}</option>
+                ))}
+            </select>
+          </label>
+        ))}
+        {groupByColumnIds.length > 0 && (
+          <div className="text-[11px] text-muted-foreground">
+            Each group shows its element count.
+          </div>
+        )}
+      </div>
       <div>
         <div className="mb-1 text-[11px] text-muted-foreground">
           Σ Totals — sum these columns per group and overall

--- a/apps/viewer/src/components/viewer/lists/ListBuilder.tsx
+++ b/apps/viewer/src/components/viewer/lists/ListBuilder.tsx
@@ -286,8 +286,12 @@ export function ListBuilder({ providers, stores, initial, onSave, onCancel, onEx
   }, []);
 
   const toggleColumn = useCallback((col: ColumnDefinition) => {
-    setColumns(prev => (prev.some(c => c.id === col.id) ? prev.filter(c => c.id !== col.id) : [...prev, col]));
-  }, []);
+    // Delegate to add/removeColumn so the removal path shares removeColumn's
+    // grouping + sum cleanup — otherwise toggling off a grouped/summed column
+    // would strand a stale level in the config until buildDefinition prunes it.
+    if (columns.some(c => c.id === col.id)) removeColumn(col.id);
+    else addColumn(col);
+  }, [columns, addColumn, removeColumn]);
 
   // Would `draft` duplicate an EXISTING column's definition? Keyed by content
   // (source + set + property), not by column id, so the guard still fires after

--- a/apps/viewer/src/components/viewer/lists/ListGroupingBar.tsx
+++ b/apps/viewer/src/components/viewer/lists/ListGroupingBar.tsx
@@ -23,7 +23,7 @@ interface ListGroupingBarProps {
   onToggleExpandAll: () => void;
 }
 
-function Chip({ icon, children, onRemove }: { icon: React.ReactNode; children: React.ReactNode; onRemove: () => void }) {
+function Chip({ icon, children, onRemove, removeLabel = 'Remove' }: { icon: React.ReactNode; children: React.ReactNode; onRemove: () => void; removeLabel?: string }) {
   return (
     <span className="inline-flex items-center gap-1 rounded-full border border-primary/30 bg-primary/10 py-0.5 pl-2 pr-1 text-[11px] font-medium text-foreground">
       {icon}
@@ -31,7 +31,7 @@ function Chip({ icon, children, onRemove }: { icon: React.ReactNode; children: R
       <button
         onClick={onRemove}
         className="ml-0.5 rounded-full p-0.5 text-muted-foreground hover:bg-primary/20 hover:text-foreground"
-        aria-label="Remove"
+        aria-label={removeLabel}
       >
         <X className="h-3 w-3" />
       </button>
@@ -58,14 +58,14 @@ export function ListGroupingBar({
 
       {grouped
         ? groups.map((g, i) => (
-            <Chip key={g.id} icon={<Group className="h-3 w-3 text-primary" />} onRemove={() => onRemoveGroup(g.id)}>
+            <Chip key={g.id} icon={<Group className="h-3 w-3 text-primary" />} onRemove={() => onRemoveGroup(g.id)} removeLabel={`Remove grouping by ${g.label}`}>
               {i === 0 ? `Grouped by ${g.label}` : `then ${g.label}`}
             </Chip>
           ))
         : <span className="text-muted-foreground">No grouping — use a column&apos;s <span className="font-medium text-foreground">⋮</span> menu to group or sum</span>}
 
       {sums.map((s) => (
-        <Chip key={s.id} icon={<Sigma className="h-3 w-3 text-primary" />} onRemove={() => onRemoveSum(s.id)}>{s.label}</Chip>
+        <Chip key={s.id} icon={<Sigma className="h-3 w-3 text-primary" />} onRemove={() => onRemoveSum(s.id)} removeLabel={`Remove sum of ${s.label}`}>{s.label}</Chip>
       ))}
 
       <span className={cn('ml-auto whitespace-nowrap font-medium text-muted-foreground')}>

--- a/apps/viewer/src/components/viewer/lists/ListGroupingBar.tsx
+++ b/apps/viewer/src/components/viewer/lists/ListGroupingBar.tsx
@@ -12,12 +12,13 @@ import { Group, Sigma, X, ChevronsDownUp, ChevronsUpDown } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 interface ListGroupingBarProps {
-  groupLabel: string | null;
+  /** Active grouping columns, outermost first (multi-criteria, issue #1790). */
+  groups: { id: string; label: string }[];
   sums: { id: string; label: string }[];
   groupCount: number;
   count: number;
   allExpanded: boolean;
-  onClearGroup: () => void;
+  onRemoveGroup: (id: string) => void;
   onRemoveSum: (id: string) => void;
   onToggleExpandAll: () => void;
 }
@@ -39,10 +40,10 @@ function Chip({ icon, children, onRemove }: { icon: React.ReactNode; children: R
 }
 
 export function ListGroupingBar({
-  groupLabel, sums, groupCount, count, allExpanded,
-  onClearGroup, onRemoveSum, onToggleExpandAll,
+  groups, sums, groupCount, count, allExpanded,
+  onRemoveGroup, onRemoveSum, onToggleExpandAll,
 }: ListGroupingBarProps) {
-  const grouped = groupLabel !== null;
+  const grouped = groups.length > 0;
   return (
     <div className="flex flex-wrap items-center gap-1.5 border-b bg-muted/30 px-3 py-1.5 text-xs">
       {grouped && (
@@ -56,7 +57,11 @@ export function ListGroupingBar({
       )}
 
       {grouped
-        ? <Chip icon={<Group className="h-3 w-3 text-primary" />} onRemove={onClearGroup}>Grouped by {groupLabel}</Chip>
+        ? groups.map((g, i) => (
+            <Chip key={g.id} icon={<Group className="h-3 w-3 text-primary" />} onRemove={() => onRemoveGroup(g.id)}>
+              {i === 0 ? `Grouped by ${g.label}` : `then ${g.label}`}
+            </Chip>
+          ))
         : <span className="text-muted-foreground">No grouping — use a column&apos;s <span className="font-medium text-foreground">⋮</span> menu to group or sum</span>}
 
       {sums.map((s) => (

--- a/apps/viewer/src/components/viewer/lists/ListResultsTable.tsx
+++ b/apps/viewer/src/components/viewer/lists/ListResultsTable.tsx
@@ -23,7 +23,7 @@ import { useViewerStore } from '@/store';
 import { getVisibleBasketEntityRefsFromStore } from '@/store/basketVisibleSet';
 import { toGlobalIdFromModels } from '@/store/globalId';
 import { useEntityListMultiSelect, type MultiSelectItem } from '@/hooks/useEntityListMultiSelect';
-import type { ListResult, ListRow, ColumnDefinition, ListGrouping } from '@ifc-lite/lists';
+import { groupingColumnIds, type ListResult, type ListRow, type ColumnDefinition, type ListGrouping } from '@ifc-lite/lists';
 import type { ProjectUnits } from '@ifc-lite/parser';
 import { exportList, buildExportModel, EXPORT_LABELS, type ExportFormat } from '@/lib/lists/export';
 import { resolveListColumnUnits } from '@/lib/units/list-column-units';
@@ -132,24 +132,31 @@ export function ListResultsTable({ result, listName, grouping, onGroupingChange,
   );
 
   // ── Grouping / aggregation derived from the definition ──
-  const groupByColumnId = grouping?.columnId ?? '';
+  // Multi-criteria grouping (issue #1790): ordered group-by columns,
+  // outermost first, restricted to columns that actually exist in the result.
+  const groupColumnIds = useMemo(
+    () => groupingColumnIds(grouping).filter((id) => columns.some((c) => c.id === id)),
+    [grouping, columns]);
   const sumColumnIds = useMemo(() => grouping?.sumColumnIds ?? [], [grouping]);
-  const isGrouped = groupByColumnId !== '' && columns.some((c) => c.id === groupByColumnId);
-  const groupColLabel = useMemo(() => {
-    const c = columns.find((c) => c.id === groupByColumnId);
-    return c ? (c.label ?? c.propertyName) : null;
-  }, [columns, groupByColumnId]);
+  const isGrouped = groupColumnIds.length > 0;
+  const groupChips = useMemo(
+    () => groupColumnIds.map((id) => {
+      const c = columns.find((c) => c.id === id);
+      return { id, label: c ? (c.label ?? c.propertyName) : id };
+    }),
+    [groupColumnIds, columns]);
 
   const { items, groupCount, totals, groupKeys } = useMemo<{
     items: DisplayItem[]; groupCount: number; totals: Totals; groupKeys: string[];
   }>(() => {
     if (isGrouped) {
       const sort = sortCol === null ? null : { colIdx: sortCol, dir: sortDir };
-      const view = buildGroupedView(displayRows, columns, { columnId: groupByColumnId, sumColumnIds }, expandedGroups, sort);
-      return {
-        items: view.items, groupCount: view.groupCount, totals: view.totals,
-        groupKeys: view.items.filter((i) => i.kind === 'group').map((i) => (i as { key: string }).key),
-      };
+      const view = buildGroupedView(
+        displayRows, columns,
+        { columnId: groupColumnIds[0], columnIds: groupColumnIds, sumColumnIds },
+        expandedGroups, sort,
+      );
+      return { items: view.items, groupCount: view.groupCount, totals: view.totals, groupKeys: view.groupKeys };
     }
     return {
       items: displayRows.map((row): DisplayItem => ({ kind: 'row', row })),
@@ -157,7 +164,7 @@ export function ListResultsTable({ result, listName, grouping, onGroupingChange,
       totals: flatTotals(displayRows, columns, sumColumnIds),
       groupKeys: [],
     };
-  }, [isGrouped, displayRows, columns, groupByColumnId, sumColumnIds, expandedGroups, sortCol, sortDir]);
+  }, [isGrouped, displayRows, columns, groupColumnIds, sumColumnIds, expandedGroups, sortCol, sortDir]);
 
   const columnWidths = useMemo(
     () => columns.map((c, i) => widthOverrides[c.id] ?? autoColumnWidth(c.label ?? c.propertyName, result.rows, i)),
@@ -190,17 +197,26 @@ export function ListResultsTable({ result, listName, grouping, onGroupingChange,
     setColorByColIdx(colIdx);
   }, [activateAutoColorFromColumn]);
 
+  // Toggling a column in/out of the grouping: a second (third, …) column adds
+  // a nesting level (multi-criteria grouping, issue #1790). `columnId` is kept
+  // in sync with the first level for pre-multi-level consumers.
   const toggleGroupBy = useCallback((colId: string) => {
     if (!onGroupingChange) return;
-    if (groupByColumnId === colId) onGroupingChange(sumColumnIds.length ? { columnId: '', sumColumnIds } : undefined);
-    else onGroupingChange({ columnId: colId, sumColumnIds });
-  }, [onGroupingChange, groupByColumnId, sumColumnIds]);
+    const next = groupColumnIds.includes(colId)
+      ? groupColumnIds.filter((x) => x !== colId)
+      : [...groupColumnIds, colId];
+    onGroupingChange((next.length || sumColumnIds.length)
+      ? { columnId: next[0] ?? '', columnIds: next, sumColumnIds }
+      : undefined);
+  }, [onGroupingChange, groupColumnIds, sumColumnIds]);
 
   const toggleSum = useCallback((colId: string) => {
     if (!onGroupingChange) return;
     const next = sumColumnIds.includes(colId) ? sumColumnIds.filter((x) => x !== colId) : [...sumColumnIds, colId];
-    onGroupingChange((groupByColumnId || next.length) ? { columnId: groupByColumnId, sumColumnIds: next } : undefined);
-  }, [onGroupingChange, groupByColumnId, sumColumnIds]);
+    onGroupingChange((groupColumnIds.length || next.length)
+      ? { columnId: groupColumnIds[0] ?? '', columnIds: groupColumnIds, sumColumnIds: next }
+      : undefined);
+  }, [onGroupingChange, groupColumnIds, sumColumnIds]);
 
   const toggleGroupExpand = useCallback((key: string) => {
     setExpandedGroups((prev) => { const n = new Set(prev); if (n.has(key)) n.delete(key); else n.add(key); return n; });
@@ -334,12 +350,12 @@ export function ListResultsTable({ result, listName, grouping, onGroupingChange,
       {/* Grouping / totals control strip */}
       {(isGrouped || showSumRow) && onGroupingChange && (
         <ListGroupingBar
-          groupLabel={isGrouped ? groupColLabel : null}
+          groups={groupChips}
           sums={sumChips}
           groupCount={groupCount}
           count={totals.count}
           allExpanded={allExpanded}
-          onClearGroup={() => onGroupingChange(sumColumnIds.length ? { columnId: '', sumColumnIds } : undefined)}
+          onRemoveGroup={(id) => toggleGroupBy(id)}
           onRemoveSum={(id) => toggleSum(id)}
           onToggleExpandAll={toggleExpandAll}
         />
@@ -352,7 +368,8 @@ export function ListResultsTable({ result, listName, grouping, onGroupingChange,
           <div className="flex sticky top-0 z-10 bg-muted/80 backdrop-blur-sm border-b">
             {columns.map((col, colIdx) => {
               const colored = activeLensId === AUTO_COLOR_FROM_LIST_ID && colorByColIdx === colIdx;
-              const groupedBy = groupByColumnId === col.id;
+              const groupLevel = groupColumnIds.indexOf(col.id);
+              const groupedBy = groupLevel >= 0;
               const summed = sumColumnIds.includes(col.id);
               const unit = unitResolver.unitSymbol(colIdx);
               return (
@@ -367,6 +384,11 @@ export function ListResultsTable({ result, listName, grouping, onGroupingChange,
                 >
                   <button className="flex min-w-0 flex-1 items-center gap-1 hover:text-foreground" onClick={() => handleHeaderClick(colIdx)}>
                     {groupedBy && <ChevronDown className="h-3 w-3 shrink-0 text-primary" aria-label="grouped" />}
+                    {groupedBy && groupColumnIds.length > 1 && (
+                      <span className="shrink-0 text-[9px] font-semibold tabular-nums text-primary" aria-label={`grouping level ${groupLevel + 1}`}>
+                        {groupLevel + 1}
+                      </span>
+                    )}
                     <span className="truncate">{col.label ?? col.propertyName}{unit ? ` (${unit})` : ''}</span>
                     {summed && <span className="text-primary">Σ</span>}
                     {sortCol === colIdx && (sortDir === 'asc' ? <ArrowUp className="h-3 w-3 shrink-0" /> : <ArrowDown className="h-3 w-3 shrink-0" />)}
@@ -375,6 +397,7 @@ export function ListResultsTable({ result, listName, grouping, onGroupingChange,
                     <ColumnHeaderMenu
                       isNumeric={numericCols[colIdx]}
                       isGroupedBy={groupedBy}
+                      groupedElsewhere={isGrouped && !groupedBy}
                       isSummed={summed}
                       active={groupedBy || summed || colored}
                       onSort={(dir) => { setSortCol(colIdx); setSortDir(dir); }}
@@ -412,7 +435,12 @@ export function ListResultsTable({ result, listName, grouping, onGroupingChange,
                     onClick={() => toggleGroupExpand(item.key)}
                   >
                     {columns.map((col, colIdx) => (
-                      <div key={col.id} className="flex items-center gap-1 border-r border-border/20 px-2 py-1 text-xs font-medium shrink-0" style={{ width: columnWidths[colIdx] }}>
+                      <div
+                        key={col.id}
+                        className="flex items-center gap-1 border-r border-border/20 px-2 py-1 text-xs font-medium shrink-0"
+                        // Sub-groups indent one step per nesting level (#1790).
+                        style={{ width: columnWidths[colIdx], ...(colIdx === 0 && item.level > 0 ? { paddingLeft: 8 + item.level * 14 } : undefined) }}
+                      >
                         {colIdx === 0 && (
                           <>
                             {expanded ? <ChevronDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground" /> : <ChevronRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />}
@@ -442,8 +470,9 @@ export function ListResultsTable({ result, listName, grouping, onGroupingChange,
                   {row.values.map((value, colIdx) => (
                     <div
                       key={colIdx}
-                      className={cn('border-r border-border/20 px-2 py-1 text-xs truncate shrink-0', numericCols[colIdx] && 'text-right font-mono tabular-nums', isGrouped && colIdx === 0 && 'pl-6')}
-                      style={{ width: columnWidths[colIdx] }}
+                      className={cn('border-r border-border/20 px-2 py-1 text-xs truncate shrink-0', numericCols[colIdx] && 'text-right font-mono tabular-nums')}
+                      // Member rows sit one indent step past the deepest group header.
+                      style={{ width: columnWidths[colIdx], ...(isGrouped && colIdx === 0 ? { paddingLeft: 8 + groupColumnIds.length * 16 } : undefined) }}
                       title={value !== null ? String(value) : ''}
                     >
                       {formatCellValue(value)}

--- a/apps/viewer/src/components/viewer/lists/list-table-utils.test.ts
+++ b/apps/viewer/src/components/viewer/lists/list-table-utils.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
-import type { ColumnDefinition, ListRow } from '@ifc-lite/lists';
+import { GROUP_KEY_SEPARATOR, type ColumnDefinition, type ListRow } from '@ifc-lite/lists';
 import { buildGroupedView, compareCells, type GroupSort } from './list-table-utils';
 
 const columns: ColumnDefinition[] = [
@@ -97,6 +97,90 @@ describe('buildGroupedView group ordering (#1498)', () => {
     const noSum = { columnId: 'cat', sumColumnIds: [] };
     const view = buildGroupedView(sample, columns, noSum, NO_EXPAND, { colIdx: 1, dir: 'asc' });
     assert.deepStrictEqual(groupOrder(view), ['C', 'A', 'B']);
+  });
+});
+
+// Multi-criteria grouping (issue #1790): e.g. group by Building, then Storey.
+describe('buildGroupedView multi-criteria grouping (#1790)', () => {
+  const cols: ColumnDefinition[] = [
+    { id: 'building', source: 'spatial', propertyName: 'Building' },
+    { id: 'storey', source: 'spatial', propertyName: 'Storey' },
+    { id: 'qty', source: 'quantity', propertyName: 'Qty' },
+  ];
+  const mkRows = (...tuples: [string, string, number][]): ListRow[] =>
+    tuples.map(([b, s, q], i) => ({ entityId: i + 1, modelId: 'm', values: [b, s, q] }));
+  // Building A: 3 rows over 2 storeys; Building B: 1 row.
+  const sample = mkRows(['A', 'L0', 1], ['A', 'L0', 2], ['A', 'L1', 3], ['B', 'L0', 4]);
+  const grouping = { columnId: 'building', columnIds: ['building', 'storey'], sumColumnIds: ['qty'] };
+  const keyAL0 = `A${GROUP_KEY_SEPARATOR}L0`;
+
+  it('collapsed: shows only top-level headers, but groupKeys covers every level', () => {
+    const view = buildGroupedView(sample, cols, grouping, new Set(), null);
+    assert.deepStrictEqual(
+      view.items.map((i) => (i.kind === 'group' ? [i.level, i.label, i.count] : 'row')),
+      [[0, 'A', 3], [0, 'B', 1]],
+    );
+    assert.strictEqual(view.groupCount, 2);
+    assert.deepStrictEqual(view.groupKeys, ['A', keyAL0, `A${GROUP_KEY_SEPARATOR}L1`, 'B', `B${GROUP_KEY_SEPARATOR}L0`]);
+  });
+
+  it('expanding a parent reveals its sub-groups with per-group counts, not rows', () => {
+    const view = buildGroupedView(sample, cols, grouping, new Set(['A']), null);
+    assert.deepStrictEqual(
+      view.items.map((i) => (i.kind === 'group' ? [i.level, i.label, i.count] : 'row')),
+      [[0, 'A', 3], [1, 'L0', 2], [1, 'L1', 1], [0, 'B', 1]],
+    );
+  });
+
+  it('expanding a leaf sub-group reveals its member rows in place', () => {
+    const view = buildGroupedView(sample, cols, grouping, new Set(['A', keyAL0]), null);
+    assert.deepStrictEqual(
+      view.items.map((i) => (i.kind === 'group' ? `${i.level}:${i.label}` : `row:${(i as { row: ListRow }).row.entityId}`)),
+      ['0:A', '1:L0', 'row:1', 'row:2', '1:L1', '0:B'],
+    );
+  });
+
+  it('a collapsed parent hides expanded children (no orphaned sub-headers)', () => {
+    const view = buildGroupedView(sample, cols, grouping, new Set([keyAL0]), null);
+    assert.deepStrictEqual(
+      view.items.map((i) => (i.kind === 'group' ? i.label : 'row')),
+      ['A', 'B'],
+    );
+  });
+
+  it('sums subtotal at every level and grand totals are not double-counted', () => {
+    const view = buildGroupedView(sample, cols, grouping, new Set(['A']), null);
+    const byLabel = new Map(view.items.filter((i) => i.kind === 'group').map((g) => [`${(g as { level: number }).level}:${(g as { label: string }).label}`, (g as { sums: Record<string, number> }).sums.qty]));
+    assert.strictEqual(byLabel.get('0:A'), 6);
+    assert.strictEqual(byLabel.get('1:L0'), 3);
+    assert.strictEqual(byLabel.get('1:L1'), 3);
+    assert.strictEqual(view.totals.sums.qty, 10);
+    assert.strictEqual(view.totals.count, 4);
+  });
+
+  it('the same sub-label under two parents stays two distinct groups', () => {
+    const view = buildGroupedView(sample, cols, grouping, new Set(['A', 'B']), null);
+    const l0Groups = view.items.filter((i) => i.kind === 'group' && (i as { label: string }).label === 'L0');
+    assert.strictEqual(l0Groups.length, 2);
+    const keys = l0Groups.map((g) => (g as { key: string }).key);
+    assert.deepStrictEqual(keys, [keyAL0, `B${GROUP_KEY_SEPARATOR}L0`]);
+  });
+
+  it('an empty row set yields no groups and zero totals', () => {
+    const view = buildGroupedView([], cols, grouping, new Set(), null);
+    assert.deepStrictEqual(view.items, []);
+    assert.strictEqual(view.groupCount, 0);
+    assert.deepStrictEqual(view.groupKeys, []);
+    assert.strictEqual(view.totals.count, 0);
+    assert.strictEqual(view.totals.sums.qty, 0);
+  });
+
+  it('legacy single-columnId grouping is unchanged (level 0 only)', () => {
+    const view = buildGroupedView(sample, cols, { columnId: 'building', sumColumnIds: [] }, new Set(['A']), null);
+    assert.deepStrictEqual(
+      view.items.map((i) => (i.kind === 'group' ? [i.level, i.label, i.count] : 'row')),
+      [[0, 'A', 3], 'row', 'row', 'row', [0, 'B', 1]],
+    );
   });
 });
 

--- a/apps/viewer/src/components/viewer/lists/list-table-utils.test.ts
+++ b/apps/viewer/src/components/viewer/lists/list-table-utils.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
-import { GROUP_KEY_SEPARATOR, type ColumnDefinition, type ListRow } from '@ifc-lite/lists';
+import { groupPathKey, type ColumnDefinition, type ListRow } from '@ifc-lite/lists';
 import { buildGroupedView, compareCells, type GroupSort } from './list-table-utils';
 
 const columns: ColumnDefinition[] = [
@@ -112,7 +112,9 @@ describe('buildGroupedView multi-criteria grouping (#1790)', () => {
   // Building A: 3 rows over 2 storeys; Building B: 1 row.
   const sample = mkRows(['A', 'L0', 1], ['A', 'L0', 2], ['A', 'L1', 3], ['B', 'L0', 4]);
   const grouping = { columnId: 'building', columnIds: ['building', 'storey'], sumColumnIds: ['qty'] };
-  const keyAL0 = `A${GROUP_KEY_SEPARATOR}L0`;
+  const keyA = groupPathKey(['A']);
+  const keyB = groupPathKey(['B']);
+  const keyAL0 = groupPathKey(['A', 'L0']);
 
   it('collapsed: shows only top-level headers, but groupKeys covers every level', () => {
     const view = buildGroupedView(sample, cols, grouping, new Set(), null);
@@ -121,11 +123,11 @@ describe('buildGroupedView multi-criteria grouping (#1790)', () => {
       [[0, 'A', 3], [0, 'B', 1]],
     );
     assert.strictEqual(view.groupCount, 2);
-    assert.deepStrictEqual(view.groupKeys, ['A', keyAL0, `A${GROUP_KEY_SEPARATOR}L1`, 'B', `B${GROUP_KEY_SEPARATOR}L0`]);
+    assert.deepStrictEqual(view.groupKeys, [keyA, keyAL0, groupPathKey(['A', 'L1']), keyB, groupPathKey(['B', 'L0'])]);
   });
 
   it('expanding a parent reveals its sub-groups with per-group counts, not rows', () => {
-    const view = buildGroupedView(sample, cols, grouping, new Set(['A']), null);
+    const view = buildGroupedView(sample, cols, grouping, new Set([keyA]), null);
     assert.deepStrictEqual(
       view.items.map((i) => (i.kind === 'group' ? [i.level, i.label, i.count] : 'row')),
       [[0, 'A', 3], [1, 'L0', 2], [1, 'L1', 1], [0, 'B', 1]],
@@ -133,7 +135,7 @@ describe('buildGroupedView multi-criteria grouping (#1790)', () => {
   });
 
   it('expanding a leaf sub-group reveals its member rows in place', () => {
-    const view = buildGroupedView(sample, cols, grouping, new Set(['A', keyAL0]), null);
+    const view = buildGroupedView(sample, cols, grouping, new Set([keyA, keyAL0]), null);
     assert.deepStrictEqual(
       view.items.map((i) => (i.kind === 'group' ? `${i.level}:${i.label}` : `row:${(i as { row: ListRow }).row.entityId}`)),
       ['0:A', '1:L0', 'row:1', 'row:2', '1:L1', '0:B'],
@@ -149,7 +151,7 @@ describe('buildGroupedView multi-criteria grouping (#1790)', () => {
   });
 
   it('sums subtotal at every level and grand totals are not double-counted', () => {
-    const view = buildGroupedView(sample, cols, grouping, new Set(['A']), null);
+    const view = buildGroupedView(sample, cols, grouping, new Set([keyA]), null);
     const byLabel = new Map(view.items.filter((i) => i.kind === 'group').map((g) => [`${(g as { level: number }).level}:${(g as { label: string }).label}`, (g as { sums: Record<string, number> }).sums.qty]));
     assert.strictEqual(byLabel.get('0:A'), 6);
     assert.strictEqual(byLabel.get('1:L0'), 3);
@@ -159,11 +161,18 @@ describe('buildGroupedView multi-criteria grouping (#1790)', () => {
   });
 
   it('the same sub-label under two parents stays two distinct groups', () => {
-    const view = buildGroupedView(sample, cols, grouping, new Set(['A', 'B']), null);
+    const view = buildGroupedView(sample, cols, grouping, new Set([keyA, keyB]), null);
     const l0Groups = view.items.filter((i) => i.kind === 'group' && (i as { label: string }).label === 'L0');
     assert.strictEqual(l0Groups.length, 2);
     const keys = l0Groups.map((g) => (g as { key: string }).key);
-    assert.deepStrictEqual(keys, [keyAL0, `B${GROUP_KEY_SEPARATOR}L0`]);
+    assert.deepStrictEqual(keys, [keyAL0, groupPathKey(['B', 'L0'])]);
+  });
+
+  it('labels containing separator-like characters cannot collide (JSON path keys)', () => {
+    // Crafted so a naive join would collide: "X/Y"+"Z" vs "X"+"Y/Z".
+    const tricky = mkRows(['X/Y', 'Z', 1], ['X', 'Y/Z', 2]);
+    const view = buildGroupedView(tricky, cols, grouping, new Set(), null);
+    assert.strictEqual(new Set(view.groupKeys).size, view.groupKeys.length);
   });
 
   it('an empty row set yields no groups and zero totals', () => {
@@ -176,7 +185,7 @@ describe('buildGroupedView multi-criteria grouping (#1790)', () => {
   });
 
   it('legacy single-columnId grouping is unchanged (level 0 only)', () => {
-    const view = buildGroupedView(sample, cols, { columnId: 'building', sumColumnIds: [] }, new Set(['A']), null);
+    const view = buildGroupedView(sample, cols, { columnId: 'building', sumColumnIds: [] }, new Set([keyA]), null);
     assert.deepStrictEqual(
       view.items.map((i) => (i.kind === 'group' ? [i.level, i.label, i.count] : 'row')),
       [[0, 'A', 3], 'row', 'row', 'row', [0, 'B', 1]],

--- a/apps/viewer/src/components/viewer/lists/list-table-utils.ts
+++ b/apps/viewer/src/components/viewer/lists/list-table-utils.ts
@@ -8,8 +8,8 @@
  * aggregation that powers the in-table (settings-free) grouped view.
  */
 
-import type { CellValue, ColumnDefinition, ListRow, ListGrouping } from '@ifc-lite/lists';
-import { buildGroupBuckets, compareCells, orderGroups, type GroupSort, type OrderableGroup } from '@/lib/lists/group-sort';
+import { groupingColumnIds, type CellValue, type ColumnDefinition, type ListRow, type ListGrouping } from '@ifc-lite/lists';
+import { buildNestedGroupBuckets, compareCells, orderGroups, type GroupSort, type OrderableGroup } from '@/lib/lists/group-sort';
 
 // Re-exported so existing consumers keep importing the list-table barrel.
 export { compareCells, orderGroups };
@@ -56,11 +56,19 @@ export function autoColumnWidth(label: string, rows: ListRow[], colIdx: number):
 }
 
 export type DisplayItem =
-  | { kind: 'group'; key: string; label: string; count: number; sums: Record<string, number> }
+  | { kind: 'group'; key: string; label: string; count: number; sums: Record<string, number>; level: number }
   | { kind: 'row'; row: ListRow };
 
 export interface Totals { count: number; sums: Record<string, number> }
-export interface GroupedView { items: DisplayItem[]; groupCount: number; totals: Totals }
+export interface GroupedView {
+  items: DisplayItem[];
+  /** Number of top-level groups. */
+  groupCount: number;
+  totals: Totals;
+  /** EVERY group key at every nesting level (including ones hidden inside a
+   *  collapsed parent), so expand-all can open the whole tree at once. */
+  groupKeys: string[];
+}
 
 function sumIndices(columns: ColumnDefinition[], sumColumnIds: string[]) {
   return sumColumnIds
@@ -68,9 +76,11 @@ function sumIndices(columns: ColumnDefinition[], sumColumnIds: string[]) {
     .filter((s) => s.idx >= 0);
 }
 
-/** Bucket already-filtered/sorted rows by the group-by column, accumulate
+/** Bucket already-filtered/sorted rows by the group-by column(s), accumulate
  *  per-group + grand count/sums, and flatten into a virtualizable list
- *  (group header followed by its rows when the group is expanded). */
+ *  (group header followed by its subgroups/rows when the group is expanded).
+ *  Multi-criteria grouping (issue #1790) nests one header level per group
+ *  column; every header carries its member count. */
 export function buildGroupedView(
   rows: ListRow[],
   columns: ColumnDefinition[],
@@ -78,28 +88,52 @@ export function buildGroupedView(
   expanded: Set<string>,
   sort: GroupSort = null,
 ): GroupedView {
-  const groupIdx = columns.findIndex((c) => c.id === grouping.columnId);
+  const groupIds = groupingColumnIds(grouping).filter((id) => columns.some((c) => c.id === id));
+  // No resolvable group column keeps the legacy single-"(none)"-bucket shape.
+  const levelIndices = groupIds.length > 0
+    ? groupIds.map((id) => columns.findIndex((c) => c.id === id))
+    : [-1];
   const sums = sumIndices(columns, grouping.sumColumnIds);
 
-  const byKey = buildGroupBuckets(
+  const nested = buildNestedGroupBuckets(
     rows,
-    (r) => (groupIdx >= 0 ? r.values[groupIdx] : null),
+    levelIndices,
     sums,
     (r, idx) => r.values[idx],
     formatCellValue,
+    sort,
   );
 
-  // Grand totals are the sum of the per-group subtotals.
+  // Grand totals from the TOP-LEVEL subtotals only (deeper levels re-split the
+  // same rows — adding them too would double-count).
   const totals: Totals = { count: rows.length, sums: Object.fromEntries(sums.map((s) => [s.id, 0])) };
-  for (const g of byKey.values()) for (const s of sums) totals.sums[s.id] += g.sums[s.id];
-
-  const groups = orderGroups(Array.from(byKey.values()), sort, groupIdx, sums);
-  const items: DisplayItem[] = [];
-  for (const g of groups) {
-    items.push({ kind: 'group', key: g.key, label: g.label, count: g.count, sums: g.sums });
-    if (expanded.has(g.key)) for (const r of g.rows) items.push({ kind: 'row', row: r });
+  let groupCount = 0;
+  for (const g of nested) {
+    if (g.level !== 0) continue;
+    groupCount++;
+    for (const s of sums) totals.sums[s.id] += g.sums[s.id];
   }
-  return { items, groupCount: groups.length, totals };
+
+  const items: DisplayItem[] = [];
+  const groupKeys: string[] = [];
+  const leafLevel = levelIndices.length - 1;
+  // Visibility of the currently open branch, per level. Pre-order guarantees a
+  // parent is visited before its children, so index level-1 is this group's
+  // direct parent.
+  const branchOpen: boolean[] = [];
+  for (const g of nested) {
+    groupKeys.push(g.key);
+    const parentVisible = g.level === 0 || branchOpen[g.level - 1] === true;
+    if (parentVisible) {
+      items.push({ kind: 'group', key: g.key, label: g.label, count: g.count, sums: g.sums, level: g.level });
+    }
+    const open = parentVisible && expanded.has(g.key);
+    branchOpen[g.level] = open;
+    if (open && g.level === leafLevel) {
+      for (const r of g.rows) items.push({ kind: 'row', row: r });
+    }
+  }
+  return { items, groupCount, totals, groupKeys };
 }
 
 /** Grand totals for the flat (ungrouped) view when sum columns are active. */

--- a/apps/viewer/src/lib/lists/export/csv.ts
+++ b/apps/viewer/src/lib/lists/export/csv.ts
@@ -18,7 +18,9 @@ function esc(s: string, delim: string): string {
 /**
  * CSV faithful to the configured columns. When grouped, a leading "Group"
  * column preserves the grouping as data (so it stays re-importable), rows are
- * ordered by group, and a TOTAL row carries the grand count + sums.
+ * ordered by group, and a TOTAL row carries the grand count + sums. With
+ * multi-criteria grouping the Group cell carries the full path ("Building /
+ * Storey") so nested grouping survives as flat data.
  */
 export function toCsv(model: ExportModel, delimiter = ','): string {
   const grouped = model.groups !== null;
@@ -32,7 +34,8 @@ export function toCsv(model: ExportModel, delimiter = ','): string {
   };
 
   if (grouped && model.groups) {
-    for (const g of model.groups) for (const r of g.rows) lines.push(line(g.label, r));
+    // Only leaf groups carry rows; parents are represented via the path.
+    for (const g of model.groups) for (const r of g.rows) lines.push(line(g.path.join(' / '), r));
   } else {
     for (const r of model.rows) lines.push(line(null, r));
   }

--- a/apps/viewer/src/lib/lists/export/csv.ts
+++ b/apps/viewer/src/lib/lists/export/csv.ts
@@ -10,8 +10,10 @@ function esc(s: string, delim: string): string {
   // TAB or CR makes a cell execute as a formula in Excel/LibreOffice/Sheets.
   // List cells derive from attacker-controllable IFC values, so prefix such
   // cells with an apostrophe. A leading UTF-8 BOM is treated as file metadata
-  // by spreadsheet importers, so a marker hidden behind one still executes.
-  if (/^\uFEFF?[=+\-@\t\r]/.test(s)) s = `'${s}`;
+  // by spreadsheet importers, so a marker hidden behind one still executes;
+  // strip the BOM first so the apostrophe guard actually lands in front.
+  s = s.replace(/^\uFEFF/, '');
+  if (/^[=+\-@\t\r]/.test(s)) s = `'${s}`;
   return /["\r\n]/.test(s) || s.includes(delim) ? `"${s.replace(/"/g, '""')}"` : s;
 }
 

--- a/apps/viewer/src/lib/lists/export/csv.ts
+++ b/apps/viewer/src/lib/lists/export/csv.ts
@@ -3,17 +3,12 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import type { CellValue } from '@ifc-lite/lists';
-import { displayCell, type ExportModel } from './model';
+import { displayCell, neutralizeSpreadsheetFormula, type ExportModel } from './model';
 
 function esc(s: string, delim: string): string {
-  // Neutralize spreadsheet formula injection (CWE-1236): a leading =, +, -, @,
-  // TAB or CR makes a cell execute as a formula in Excel/LibreOffice/Sheets.
-  // List cells derive from attacker-controllable IFC values, so prefix such
-  // cells with an apostrophe. A leading UTF-8 BOM is treated as file metadata
-  // by spreadsheet importers, so a marker hidden behind one still executes;
-  // strip the BOM first so the apostrophe guard actually lands in front.
-  s = s.replace(/^\uFEFF/, '');
-  if (/^[=+\-@\t\r]/.test(s)) s = `'${s}`;
+  // Neutralize spreadsheet formula injection (CWE-1236) via the shared guard,
+  // then apply CSV quoting for the delimiter/quote/newline cases.
+  s = neutralizeSpreadsheetFormula(s);
   return /["\r\n]/.test(s) || s.includes(delim) ? `"${s.replace(/"/g, '""')}"` : s;
 }
 

--- a/apps/viewer/src/lib/lists/export/injection.test.ts
+++ b/apps/viewer/src/lib/lists/export/injection.test.ts
@@ -1,0 +1,83 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Spreadsheet formula injection (CWE-1236) guard for list exports (#1790
+ * review): group labels, cell values and custom column headers all derive from
+ * attacker-controllable IFC values and must be neutralized before Excel /
+ * LibreOffice / Sheets treats a leading =/+/-/@/TAB/CR as a live formula. CSV
+ * and XLSX share `neutralizeSpreadsheetFormula`.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import type { ColumnDefinition, ListRow } from '@ifc-lite/lists';
+import { buildExportModel, neutralizeSpreadsheetFormula } from './model';
+import { toCsv } from './csv';
+import { toXlsx } from './xlsx';
+
+describe('neutralizeSpreadsheetFormula (#1790 review, CWE-1236)', () => {
+  it('prefixes an apostrophe to every formula-trigger lead char', () => {
+    for (const s of ['=1+1', '+1', '-1', '@SUM(A1)', '\tx', '\rx']) {
+      assert.strictEqual(neutralizeSpreadsheetFormula(s), `'${s}`);
+    }
+  });
+  it('leaves benign strings untouched', () => {
+    for (const s of ['Building A', 'A Level 0', 'IfcWall', '3.14', '']) {
+      assert.strictEqual(neutralizeSpreadsheetFormula(s), s);
+    }
+  });
+  it('strips a leading BOM so a BOM-hidden marker still gets guarded', () => {
+    assert.strictEqual(neutralizeSpreadsheetFormula('\uFEFF=evil'), `'=evil`);
+  });
+});
+
+// A model whose group label AND a cell value are formula markers.
+const columns: ColumnDefinition[] = [
+  { id: 'grp', source: 'attribute', propertyName: 'Group' },
+  { id: 'name', source: 'attribute', propertyName: 'Name' },
+];
+const rows: ListRow[] = [
+  { entityId: 1, modelId: 'm', values: ['=cmd|calc', '=HYPERLINK("http://evil")'] },
+];
+const input = {
+  title: 'List',
+  columns,
+  rows,
+  numericCols: [false, false],
+  columnWidths: [120, 120],
+  generatedAt: 'now',
+  grouping: { columnId: 'grp', sumColumnIds: [] },
+};
+
+describe('list exports neutralize formula injection in group labels and cells', () => {
+  it('CSV guards the Group path cell and the value cell', () => {
+    const csv = toCsv(buildExportModel(input));
+    // The malicious group label is quoted-and-apostrophized, never bare "=cmd".
+    assert.ok(!/(^|,)=cmd/m.test(csv), 'bare =cmd formula must not appear in CSV');
+    assert.ok(csv.includes(`'=cmd|calc`), 'group label must be apostrophe-guarded');
+    assert.ok(csv.includes(`'=HYPERLINK`), 'value cell must be apostrophe-guarded');
+  });
+
+  it('XLSX writes the group header and value cells as guarded text', async () => {
+    const blob = await toXlsx(buildExportModel(input));
+    const ab = await blob.arrayBuffer();
+    const ExcelJS = (await import('exceljs')).default;
+    const wb = new ExcelJS.Workbook();
+    await wb.xlsx.load(ab);
+    const ws = wb.worksheets[0];
+    let sawGuardedGroup = false;
+    let sawGuardedValue = false;
+    ws.eachRow((row) => {
+      row.eachCell((cell) => {
+        const v = typeof cell.value === 'string' ? cell.value : '';
+        if (v.includes(`'=cmd|calc`)) sawGuardedGroup = true;
+        if (v.includes(`'=HYPERLINK`)) sawGuardedValue = true;
+        assert.ok(!/^=cmd/.test(v), `no cell may start with a live formula: ${v}`);
+      });
+    });
+    assert.ok(sawGuardedGroup, 'XLSX group header cell must be apostrophe-guarded');
+    assert.ok(sawGuardedValue, 'XLSX value cell must be apostrophe-guarded');
+  });
+});

--- a/apps/viewer/src/lib/lists/export/model.test.ts
+++ b/apps/viewer/src/lib/lists/export/model.test.ts
@@ -51,6 +51,56 @@ describe('buildExportModel grouped-section order honours the on-screen sort (#14
   });
 });
 
+// Multi-criteria grouping in exports (issue #1790): nested sections in
+// pre-order, per-group counts at every level, member rows on leaves only.
+describe('buildExportModel multi-criteria grouping (#1790)', () => {
+  const cols3: ColumnDefinition[] = [
+    { id: 'building', source: 'spatial', propertyName: 'Building' },
+    { id: 'storey', source: 'spatial', propertyName: 'Storey' },
+    { id: 'qty', source: 'quantity', propertyName: 'Qty' },
+  ];
+  const rows3: ListRow[] = ([
+    ['A', 'L0', 1], ['A', 'L0', 2], ['A', 'L1', 3], ['B', 'L0', 4],
+  ] as [string, string, number][]).map(([b, s, q], i) => ({ entityId: i + 1, modelId: 'm', values: [b, s, q] }));
+  const input = {
+    title: 'List',
+    columns: cols3,
+    rows: rows3,
+    numericCols: [false, false, true],
+    columnWidths: [120, 120, 120],
+    generatedAt: 'now',
+    grouping: { columnId: 'building', columnIds: ['building', 'storey'], sumColumnIds: ['qty'] },
+  };
+
+  it('emits pre-order nested groups with level, path and per-group count', () => {
+    const m = buildExportModel({ ...input });
+    assert.deepStrictEqual(
+      m.groups?.map((g) => [g.level, g.label, g.count, g.rows.length]),
+      [
+        [0, 'A', 3, 0],
+        [1, 'L0', 2, 2],
+        [1, 'L1', 1, 1],
+        [0, 'B', 1, 0],
+        [1, 'L0', 1, 1],
+      ],
+    );
+    assert.deepStrictEqual(m.groups?.[1].path, ['A', 'L0']);
+    assert.deepStrictEqual(m.groupColumnIds, ['building', 'storey']);
+    assert.strictEqual(m.groupColumnId, 'building');
+    // Subtotals at both levels; grand totals not double-counted.
+    assert.strictEqual(m.groups?.[0].sums.qty, 6);
+    assert.strictEqual(m.groups?.[1].sums.qty, 3);
+    assert.strictEqual(m.totals.sums.qty, 10);
+    assert.strictEqual(m.totals.count, 4);
+  });
+
+  it('single-level grouping keeps rows on every group (all groups are leaves)', () => {
+    const m = buildExportModel({ ...input, grouping: { columnId: 'building', sumColumnIds: [] } });
+    assert.deepStrictEqual(m.groups?.map((g) => [g.level, g.label, g.rows.length]), [[0, 'A', 3], [0, 'B', 1]]);
+    assert.deepStrictEqual(m.groupColumnIds, ['building']);
+  });
+});
+
 // #1573: quantity/measure columns export converted into the user's
 // display-unit override, with the resolved symbol folded into the header.
 describe('buildExportModel display-unit conversion (#1573)', () => {

--- a/apps/viewer/src/lib/lists/export/model.ts
+++ b/apps/viewer/src/lib/lists/export/model.ts
@@ -101,6 +101,21 @@ export function displayCell(value: CellValue): string {
   return String(value);
 }
 
+/**
+ * Neutralize spreadsheet formula injection (CWE-1236): a leading =, +, -, @,
+ * TAB or CR makes a cell execute as a formula in Excel/LibreOffice/Sheets.
+ * List-export cells (values, group labels, custom column headers) derive from
+ * attacker-controllable IFC values, so any such cell is prefixed with an
+ * apostrophe. A leading UTF-8 BOM is treated as file metadata by spreadsheet
+ * importers, so a marker hidden behind one still executes; strip the BOM first
+ * so the apostrophe guard actually lands in front. Shared by the CSV and XLSX
+ * writers so both honour the guideline identically.
+ */
+export function neutralizeSpreadsheetFormula(s: string): string {
+  s = s.replace(/^\uFEFF/, '');
+  return /^[=+\-@\t\r]/.test(s) ? `'${s}` : s;
+}
+
 export function buildExportModel(input: BuildModelInput): ExportModel {
   const { columns, rows, grouping, sort, numericCols, columnWidths, title, generatedAt, modelUnits, unitDisplayOverrides } = input;
   const sumColumnIds = grouping?.sumColumnIds ?? [];

--- a/apps/viewer/src/lib/lists/export/model.ts
+++ b/apps/viewer/src/lib/lists/export/model.ts
@@ -9,9 +9,9 @@
  * grouped sections with per-group count + subtotals, plus grand totals.
  */
 
-import type { CellValue, ColumnDefinition, ListRow, ListGrouping } from '@ifc-lite/lists';
+import { groupingColumnIds, type CellValue, type ColumnDefinition, type ListRow, type ListGrouping } from '@ifc-lite/lists';
 import type { ProjectUnits } from '@ifc-lite/parser';
-import { buildGroupBuckets, orderGroups, type GroupSort } from '@/lib/lists/group-sort';
+import { buildNestedGroupBuckets, type GroupSort } from '@/lib/lists/group-sort';
 import { resolveListColumnUnits } from '@/lib/units/list-column-units';
 
 export interface ExportColumn {
@@ -32,20 +32,30 @@ export interface ExportColumn {
 
 export interface ExportGroup {
   label: string;
+  /** Member-row count of this group (the Count aggregate, issue #1790). */
   count: number;
   sums: Record<string, number>;
+  /** Member rows. With multi-criteria grouping only LEAF groups carry rows
+   *  (parents would duplicate them); parent groups export with `rows: []`. */
   rows: CellValue[][];
+  /** 0-based nesting depth (0 = outermost grouping column). */
+  level: number;
+  /** Group labels from the outermost level down to this group. */
+  path: string[];
 }
 
 export interface ExportModel {
   title: string;
   generatedAt: string;
   columns: ExportColumn[];
-  /** Grouped sections (with member rows), or null when the list isn't grouped. */
+  /** Grouped sections in pre-order (parent group immediately followed by its
+   *  subgroups), or null when the list isn't grouped. */
   groups: ExportGroup[] | null;
   /** All rows in display order (flat) — used by writers that don't section. */
   rows: CellValue[][];
   groupColumnId: string | null;
+  /** Ordered group-by column ids, outermost first (multi-criteria #1790). */
+  groupColumnIds: string[];
   sumColumnIds: string[];
   totals: { count: number; sums: Record<string, number> };
 }
@@ -142,24 +152,32 @@ export function buildExportModel(input: BuildModelInput): ExportModel {
   const flatRows: CellValue[][] = [];
   for (const r of convertedRows) { flatRows.push(r.values); addSums(totals.sums, r.values); }
 
-  const groupColumnId = grouping?.columnId && columns.some((c) => c.id === grouping.columnId)
-    ? grouping.columnId : null;
+  const groupColumnIds = groupingColumnIds(grouping).filter((id) => columns.some((c) => c.id === id));
+  const groupColumnId = groupColumnIds[0] ?? null;
 
   let groups: ExportGroup[] | null = null;
-  if (groupColumnId) {
-    const groupIdx = columns.findIndex((c) => c.id === groupColumnId);
+  if (groupColumnIds.length > 0) {
+    const levelIndices = groupColumnIds.map((id) => columns.findIndex((c) => c.id === id));
+    const leafLevel = levelIndices.length - 1;
     // Bucket + subtotal via the shared helper so the sections match the table
-    // exactly, then order and project each member row to its display values.
-    const byKey = buildGroupBuckets(
+    // exactly (multi-criteria grouping nests one section level per group
+    // column), then project each LEAF group's member rows to display values.
+    groups = buildNestedGroupBuckets(
       convertedRows,
-      (r) => r.values[groupIdx],
+      levelIndices,
       sumIdx,
       (r, idx) => r.values[idx],
       displayCell,
-    );
-    groups = orderGroups(Array.from(byKey.values()), sort ?? null, groupIdx, sumIdx)
-      .map((g) => ({ label: g.label, count: g.count, sums: g.sums, rows: g.rows.map((r) => r.values) }));
+      sort ?? null,
+    ).map((g) => ({
+      label: g.label,
+      count: g.count,
+      sums: g.sums,
+      level: g.level,
+      path: g.path,
+      rows: g.level === leafLevel ? g.rows.map((r) => r.values) : [],
+    }));
   }
 
-  return { title, generatedAt, columns: exportCols, groups, rows: flatRows, groupColumnId, sumColumnIds, totals };
+  return { title, generatedAt, columns: exportCols, groups, rows: flatRows, groupColumnId, groupColumnIds, sumColumnIds, totals };
 }

--- a/apps/viewer/src/lib/lists/export/pdf.ts
+++ b/apps/viewer/src/lib/lists/export/pdf.ts
@@ -26,9 +26,11 @@ export async function toPdf(model: ExportModel): Promise<Blob> {
   const body: Array<Array<string | { content: string; styles: Record<string, unknown> }>> = [];
 
   if (model.groups) {
+    // Nested (multi-criteria) grouping: sub-group headers indent one step per
+    // level and carry their own count; member rows sit on leaf groups only.
     for (const g of model.groups) {
       body.push(model.columns.map((c, i) => ({
-        content: i === 0 ? `${g.label}  (${g.count})` : (c.summed ? displayCell(g.sums[c.id]) : ''),
+        content: i === 0 ? `${'    '.repeat(g.level)}${g.label}  (${g.count})` : (c.summed ? displayCell(g.sums[c.id]) : ''),
         styles: { fontStyle: 'bold', fillColor: [226, 232, 240] as unknown as number[] },
       })));
       for (const r of g.rows) body.push(model.columns.map((_, i) => cell(r, i)));

--- a/apps/viewer/src/lib/lists/export/xlsx.ts
+++ b/apps/viewer/src/lib/lists/export/xlsx.ts
@@ -62,14 +62,16 @@ export async function toXlsx(model: ExportModel): Promise<Blob> {
   if (model.groups) {
     // Nested (multi-criteria) grouping: sub-group headers indent one step per
     // level and carry their own count; member rows sit on leaf groups only.
+    // Outline levels are clamped to Excel's maximum of 8.
+    const MAX_OUTLINE = 8;
     for (const g of model.groups) {
       const gr = ws.addRow(cols.map((c, i) => (i === 0 ? `${'  '.repeat(g.level)}${g.label} (${g.count})` : (c.summed ? g.sums[c.id] : null))));
       gr.font = { bold: true };
       gr.eachCell((cell) => { cell.fill = { type: 'pattern', pattern: 'solid', fgColor: { argb: 'FFE2E8F0' } }; });
-      if (g.level > 0) gr.outlineLevel = g.level;
-      for (const row of g.rows) addDataRow(row, g.level + 1);
+      if (g.level > 0) gr.outlineLevel = Math.min(g.level, MAX_OUTLINE);
+      for (const row of g.rows) addDataRow(row, Math.min(g.level + 1, MAX_OUTLINE));
     }
-    ws.properties.outlineLevelRow = model.groups.reduce((m, g) => Math.max(m, g.level + 1), 1);
+    ws.properties.outlineLevelRow = Math.min(model.groups.reduce((m, g) => Math.max(m, g.level + 1), 1), MAX_OUTLINE);
   } else {
     for (const row of model.rows) addDataRow(row);
   }

--- a/apps/viewer/src/lib/lists/export/xlsx.ts
+++ b/apps/viewer/src/lib/lists/export/xlsx.ts
@@ -60,13 +60,16 @@ export async function toXlsx(model: ExportModel): Promise<Blob> {
   };
 
   if (model.groups) {
+    // Nested (multi-criteria) grouping: sub-group headers indent one step per
+    // level and carry their own count; member rows sit on leaf groups only.
     for (const g of model.groups) {
-      const gr = ws.addRow(cols.map((c, i) => (i === 0 ? `${g.label} (${g.count})` : (c.summed ? g.sums[c.id] : null))));
+      const gr = ws.addRow(cols.map((c, i) => (i === 0 ? `${'  '.repeat(g.level)}${g.label} (${g.count})` : (c.summed ? g.sums[c.id] : null))));
       gr.font = { bold: true };
       gr.eachCell((cell) => { cell.fill = { type: 'pattern', pattern: 'solid', fgColor: { argb: 'FFE2E8F0' } }; });
-      for (const row of g.rows) addDataRow(row, 1);
+      if (g.level > 0) gr.outlineLevel = g.level;
+      for (const row of g.rows) addDataRow(row, g.level + 1);
     }
-    ws.properties.outlineLevelRow = 1;
+    ws.properties.outlineLevelRow = model.groups.reduce((m, g) => Math.max(m, g.level + 1), 1);
   } else {
     for (const row of model.rows) addDataRow(row);
   }

--- a/apps/viewer/src/lib/lists/export/xlsx.ts
+++ b/apps/viewer/src/lib/lists/export/xlsx.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import type { CellValue } from '@ifc-lite/lists';
-import { displayCell, type ExportModel, type ExportColumn } from './model';
+import { displayCell, neutralizeSpreadsheetFormula, type ExportModel, type ExportColumn } from './model';
 
 const XLSX_MIME = 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
 const NUM_FMT = '#,##0.####';
@@ -16,7 +16,9 @@ const excelWidth = (px: number): number => Math.max(8, Math.min(80, Math.round(p
 function cellValue(v: CellValue, c: ExportColumn): string | number | null {
   if (v === null || v === undefined) return null;
   if (c.numeric && typeof v === 'number' && Number.isFinite(v)) return v;
-  return displayCell(v);
+  // String cells derive from attacker-controllable IFC values — neutralize
+  // spreadsheet formula injection before Excel treats a leading =/+/-/@ as one.
+  return neutralizeSpreadsheetFormula(displayCell(v));
 }
 
 export async function toXlsx(model: ExportModel): Promise<Blob> {
@@ -39,8 +41,9 @@ export async function toXlsx(model: ExportModel): Promise<Blob> {
   ws.getCell(2, 1).font = { italic: true, size: 9, color: { argb: 'FF94A3B8' } };
   ws.addRow([]);
 
-  // Header.
-  const header = ws.addRow(cols.map((c) => c.label));
+  // Header. Column labels can be user-authored (custom pset/regex columns), so
+  // they pass through the same formula-injection guard.
+  const header = ws.addRow(cols.map((c) => neutralizeSpreadsheetFormula(c.label)));
   header.font = { bold: true, color: { argb: 'FFFFFFFF' } };
   header.eachCell((cell) => {
     cell.fill = { type: 'pattern', pattern: 'solid', fgColor: { argb: 'FF334155' } };
@@ -65,7 +68,7 @@ export async function toXlsx(model: ExportModel): Promise<Blob> {
     // Outline levels are clamped to Excel's maximum of 8.
     const MAX_OUTLINE = 8;
     for (const g of model.groups) {
-      const gr = ws.addRow(cols.map((c, i) => (i === 0 ? `${'  '.repeat(g.level)}${g.label} (${g.count})` : (c.summed ? g.sums[c.id] : null))));
+      const gr = ws.addRow(cols.map((c, i) => (i === 0 ? `${'  '.repeat(g.level)}${neutralizeSpreadsheetFormula(g.label)} (${g.count})` : (c.summed ? g.sums[c.id] : null))));
       gr.font = { bold: true };
       gr.eachCell((cell) => { cell.fill = { type: 'pattern', pattern: 'solid', fgColor: { argb: 'FFE2E8F0' } }; });
       if (g.level > 0) gr.outlineLevel = Math.min(g.level, MAX_OUTLINE);

--- a/apps/viewer/src/lib/lists/group-sort.ts
+++ b/apps/viewer/src/lib/lists/group-sort.ts
@@ -9,7 +9,7 @@
  * in agreement) without a component → lib layer inversion.
  */
 
-import { GROUP_KEY_SEPARATOR, type CellValue } from '@ifc-lite/lists';
+import { groupPathKey, type CellValue } from '@ifc-lite/lists';
 
 /** Null-first, numbers-numeric, everything-else locale-compared. */
 export function compareCells(a: CellValue, b: CellValue): number {
@@ -71,7 +71,9 @@ export function buildGroupBuckets<R>(
 export type NestedGroupBucket<R> = GroupBucket<R> & {
   /** 0-based nesting depth (0 = outermost grouping column). */
   level: number;
-  /** Group labels from the outermost level down to this group. */
+  /** Group labels from the outermost level down to this group. The bucket's
+   *  `key` is `groupPathKey(path)` — a collision-free JSON encoding, matching
+   *  the engine's `ListGroup.key`. */
   path: string[];
 };
 
@@ -93,7 +95,7 @@ export function buildNestedGroupBuckets<R>(
   sort: GroupSort,
 ): NestedGroupBucket<R>[] {
   const out: NestedGroupBucket<R>[] = [];
-  const walk = (subRows: R[], level: number, parentKey: string, parentPath: string[]) => {
+  const walk = (subRows: R[], level: number, parentPath: string[]) => {
     const colIdx = levelIndices[level];
     const byKey = buildGroupBuckets(
       subRows,
@@ -104,13 +106,12 @@ export function buildNestedGroupBuckets<R>(
     );
     const ordered = orderGroups(Array.from(byKey.values()), sort, colIdx, sums);
     for (const g of ordered) {
-      const key = parentKey === '' ? g.label : `${parentKey}${GROUP_KEY_SEPARATOR}${g.label}`;
       const path = [...parentPath, g.label];
-      out.push({ ...g, key, level, path });
-      if (level + 1 < levelIndices.length) walk(g.rows, level + 1, key, path);
+      out.push({ ...g, key: groupPathKey(path), level, path });
+      if (level + 1 < levelIndices.length) walk(g.rows, level + 1, path);
     }
   };
-  if (levelIndices.length > 0) walk(rows, 0, '', []);
+  if (levelIndices.length > 0) walk(rows, 0, []);
   return out;
 }
 

--- a/apps/viewer/src/lib/lists/group-sort.ts
+++ b/apps/viewer/src/lib/lists/group-sort.ts
@@ -9,7 +9,7 @@
  * in agreement) without a component → lib layer inversion.
  */
 
-import type { CellValue } from '@ifc-lite/lists';
+import { GROUP_KEY_SEPARATOR, type CellValue } from '@ifc-lite/lists';
 
 /** Null-first, numbers-numeric, everything-else locale-compared. */
 export function compareCells(a: CellValue, b: CellValue): number {
@@ -63,6 +63,55 @@ export function buildGroupBuckets<R>(
     }
   }
   return byKey;
+}
+
+/** A group in a multi-criteria (nested) grouping — one bucket per group-by
+ *  value at one nesting `level`, keyed by the full `path` so the same label
+ *  under two different parents stays two distinct groups. */
+export type NestedGroupBucket<R> = GroupBucket<R> & {
+  /** 0-based nesting depth (0 = outermost grouping column). */
+  level: number;
+  /** Group labels from the outermost level down to this group. */
+  path: string[];
+};
+
+/**
+ * Bucket rows by SEVERAL group columns (multi-criteria grouping, issue #1790)
+ * into a FLAT pre-order list: each parent group immediately followed by its
+ * subgroups. Every group carries its own count and per-column subtotals.
+ * Groups within a level are ordered by `orderGroups` (header sort, or the
+ * count-descending default). Shared by the table view and the export model so
+ * the two can never diverge on grouping.
+ */
+export function buildNestedGroupBuckets<R>(
+  rows: R[],
+  /** Column index per grouping level, outermost first (-1 buckets under "(none)"). */
+  levelIndices: number[],
+  sums: { id: string; idx: number }[],
+  getCell: (row: R, idx: number) => CellValue,
+  formatLabel: (cell: CellValue) => string,
+  sort: GroupSort,
+): NestedGroupBucket<R>[] {
+  const out: NestedGroupBucket<R>[] = [];
+  const walk = (subRows: R[], level: number, parentKey: string, parentPath: string[]) => {
+    const colIdx = levelIndices[level];
+    const byKey = buildGroupBuckets(
+      subRows,
+      (r) => (colIdx >= 0 ? getCell(r, colIdx) : null),
+      sums,
+      getCell,
+      formatLabel,
+    );
+    const ordered = orderGroups(Array.from(byKey.values()), sort, colIdx, sums);
+    for (const g of ordered) {
+      const key = parentKey === '' ? g.label : `${parentKey}${GROUP_KEY_SEPARATOR}${g.label}`;
+      const path = [...parentPath, g.label];
+      out.push({ ...g, key, level, path });
+      if (level + 1 < levelIndices.length) walk(g.rows, level + 1, key, path);
+    }
+  };
+  if (levelIndices.length > 0) walk(rows, 0, '', []);
+  return out;
 }
 
 /** Order the group headers to match the active header sort so that toggling

--- a/apps/viewer/src/lib/lists/index.ts
+++ b/apps/viewer/src/lib/lists/index.ts
@@ -21,7 +21,7 @@ export {
   executeList,
   summariseListRows,
   groupingColumnIds,
-  GROUP_KEY_SEPARATOR,
+  groupPathKey,
   listResultToCSV,
   discoverColumns,
   LIST_PRESETS,

--- a/apps/viewer/src/lib/lists/index.ts
+++ b/apps/viewer/src/lib/lists/index.ts
@@ -20,6 +20,8 @@ export {
   ENTITY_ATTRIBUTES,
   executeList,
   summariseListRows,
+  groupingColumnIds,
+  GROUP_KEY_SEPARATOR,
   listResultToCSV,
   discoverColumns,
   LIST_PRESETS,

--- a/packages/lists/src/engine.test.ts
+++ b/packages/lists/src/engine.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, it, expect } from 'vitest';
 import { IfcTypeEnum } from '@ifc-lite/data';
-import { executeList, listResultToCSV, summariseListRows, GROUP_KEY_SEPARATOR } from './engine.js';
+import { executeList, listResultToCSV, summariseListRows, groupPathKey } from './engine.js';
 import { discoverColumns } from './discovery.js';
 import { LIST_PRESETS } from './presets.js';
 import type { ListDataProvider, ListDefinition } from './types.js';
@@ -655,7 +655,7 @@ describe('grouping & summary', () => {
       grouping: { columnId: 'fire', sumColumnIds: [] },
     };
     const result = executeList(def, provider);
-    expect(result.groups).toEqual([{ key: '(none)', label: '(none)', count: 2, sums: {}, level: 0, path: ['(none)'] }]);
+    expect(result.groups).toEqual([{ key: groupPathKey(['(none)']), label: '(none)', count: 2, sums: {}, level: 0, path: ['(none)'] }]);
   });
 
   // Multi-criteria grouping + per-group Count (issue #1790).
@@ -689,7 +689,7 @@ describe('grouping & summary', () => {
     // Composite keys are unique and carry the full path.
     const sub = result.groups?.find(g => g.level === 1 && g.label === 'Wall-01');
     expect(sub?.path).toEqual(['IfcWall', 'Wall-01']);
-    expect(sub?.key).toBe(`IfcWall${GROUP_KEY_SEPARATOR}Wall-01`);
+    expect(sub?.key).toBe(groupPathKey(['IfcWall', 'Wall-01']));
     // Sums subtotal at every level.
     expect(result.groups?.find(g => g.level === 0 && g.label === 'IfcWall')?.sums.len).toBeCloseTo(8.5);
     expect(sub?.sums.len).toBeCloseTo(5.0);
@@ -746,6 +746,58 @@ describe('grouping & summary', () => {
       [1, 'T1', 1],
     ]);
     expect(summary?.count).toBe(3);
+  });
+
+  it('keeps a repeated child label under different parents as two distinct groups', () => {
+    const def: ListDefinition = {
+      id: 'grp-shared-child',
+      name: 'Test',
+      createdAt: 0,
+      updatedAt: 0,
+      entityTypes: [],
+      conditions: [],
+      columns: [
+        { id: 'a', source: 'attribute', propertyName: 'Class' },
+        { id: 'b', source: 'attribute', propertyName: 'Name' },
+      ],
+      grouping: { columnId: 'a', columnIds: ['a', 'b'], sumColumnIds: [] },
+    };
+    const { groups } = summariseListRows(def, [
+      { entityId: 10, modelId: 'm', values: ['IfcWall', 'Shared'] },
+      { entityId: 11, modelId: 'm', values: ['IfcSlab', 'Shared'] },
+    ]);
+    const children = groups?.filter(g => g.level === 1) ?? [];
+    expect(new Set(children.map(g => g.key))).toEqual(new Set([
+      groupPathKey(['IfcWall', 'Shared']),
+      groupPathKey(['IfcSlab', 'Shared']),
+    ]));
+    expect(children.map(g => g.path)).toEqual(expect.arrayContaining([
+      ['IfcWall', 'Shared'],
+      ['IfcSlab', 'Shared'],
+    ]));
+  });
+
+  it('composite keys stay collision-free when a label contains separator-like characters', () => {
+    const def: ListDefinition = {
+      id: 'grp-key-collision',
+      name: 'Test',
+      createdAt: 0,
+      updatedAt: 0,
+      entityTypes: [],
+      conditions: [],
+      columns: [
+        { id: 'a', source: 'attribute', propertyName: 'Class' },
+        { id: 'b', source: 'attribute', propertyName: 'Name' },
+      ],
+      grouping: { columnId: 'a', columnIds: ['a', 'b'], sumColumnIds: [] },
+    };
+    // Labels crafted so a naive join would collide: "A|B"+"C" vs "A"+"B|C".
+    const { groups } = summariseListRows(def, [
+      { entityId: 1, modelId: 'm', values: ['A|B', 'C'] },
+      { entityId: 2, modelId: 'm', values: ['A', 'B|C'] },
+    ]);
+    const keys = (groups ?? []).map(g => g.key);
+    expect(new Set(keys).size).toBe(keys.length);
   });
 
   it('returns empty groups and a zero-count summary for an empty row set', () => {

--- a/packages/lists/src/engine.test.ts
+++ b/packages/lists/src/engine.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, it, expect } from 'vitest';
 import { IfcTypeEnum } from '@ifc-lite/data';
-import { executeList, listResultToCSV } from './engine.js';
+import { executeList, listResultToCSV, summariseListRows, GROUP_KEY_SEPARATOR } from './engine.js';
 import { discoverColumns } from './discovery.js';
 import { LIST_PRESETS } from './presets.js';
 import type { ListDataProvider, ListDefinition } from './types.js';
@@ -655,7 +655,134 @@ describe('grouping & summary', () => {
       grouping: { columnId: 'fire', sumColumnIds: [] },
     };
     const result = executeList(def, provider);
-    expect(result.groups).toEqual([{ key: '(none)', label: '(none)', count: 2, sums: {} }]);
+    expect(result.groups).toEqual([{ key: '(none)', label: '(none)', count: 2, sums: {}, level: 0, path: ['(none)'] }]);
+  });
+
+  // Multi-criteria grouping + per-group Count (issue #1790).
+  it('groups by several columns in order, counting instances per group at every level', () => {
+    const provider = createMockProvider();
+    const def: ListDefinition = {
+      id: 'grp-multi',
+      name: 'Test',
+      createdAt: 0,
+      updatedAt: 0,
+      entityTypes: [IfcTypeEnum.IfcWall, IfcTypeEnum.IfcSlab],
+      conditions: [],
+      columns: [
+        { id: 'class', source: 'attribute', propertyName: 'Class' },
+        { id: 'name', source: 'attribute', propertyName: 'Name' },
+        { id: 'len', source: 'quantity', psetName: 'Qto_WallBaseQuantities', propertyName: 'Length' },
+      ],
+      grouping: { columnId: 'class', columnIds: ['class', 'name'], sumColumnIds: ['len'] },
+    };
+
+    const result = executeList(def, provider);
+
+    // Pre-order flat list: parent group immediately followed by its subgroups.
+    expect(result.groups?.map(g => [g.level, g.label, g.count])).toEqual([
+      [0, 'IfcWall', 2],
+      [1, 'Wall-01', 1],
+      [1, 'Wall-02', 1],
+      [0, 'IfcSlab', 1],
+      [1, 'Slab-01', 1],
+    ]);
+    // Composite keys are unique and carry the full path.
+    const sub = result.groups?.find(g => g.level === 1 && g.label === 'Wall-01');
+    expect(sub?.path).toEqual(['IfcWall', 'Wall-01']);
+    expect(sub?.key).toBe(`IfcWall${GROUP_KEY_SEPARATOR}Wall-01`);
+    // Sums subtotal at every level.
+    expect(result.groups?.find(g => g.level === 0 && g.label === 'IfcWall')?.sums.len).toBeCloseTo(8.5);
+    expect(sub?.sums.len).toBeCloseTo(5.0);
+    // Whole-result summary is unaffected by nesting depth (no double count).
+    expect(result.summary?.count).toBe(3);
+    expect(result.summary?.sums.len).toBeCloseTo(8.5);
+  });
+
+  it('columnIds takes precedence over columnId; a lone columnId still works', () => {
+    const provider = createMockProvider();
+    const base: ListDefinition = {
+      id: 'grp-compat',
+      name: 'Test',
+      createdAt: 0,
+      updatedAt: 0,
+      entityTypes: [IfcTypeEnum.IfcWall],
+      conditions: [],
+      columns: [
+        { id: 'class', source: 'attribute', propertyName: 'Class' },
+        { id: 'name', source: 'attribute', propertyName: 'Name' },
+      ],
+      grouping: { columnId: 'class', columnIds: ['name'], sumColumnIds: [] },
+    };
+    // columnIds wins: two name groups, not one class group.
+    expect(executeList(base, provider).groups?.map(g => g.label)).toEqual(['Wall-01', 'Wall-02']);
+    // Legacy single columnId (no columnIds) unchanged.
+    const legacy = { ...base, grouping: { columnId: 'class', sumColumnIds: [] } };
+    expect(executeList(legacy, provider).groups?.map(g => [g.label, g.count, g.level])).toEqual([['IfcWall', 2, 0]]);
+  });
+
+  it('buckets rows with an empty value at a sub-level under "(none)" and counts them', () => {
+    const def: ListDefinition = {
+      id: 'grp-none-sub',
+      name: 'Test',
+      createdAt: 0,
+      updatedAt: 0,
+      entityTypes: [],
+      conditions: [],
+      columns: [
+        { id: 'a', source: 'attribute', propertyName: 'Name' },
+        { id: 'b', source: 'attribute', propertyName: 'Tag' },
+      ],
+      grouping: { columnId: 'a', columnIds: ['a', 'b'], sumColumnIds: [] },
+    };
+    const rows = [
+      { entityId: 1, modelId: 'm', values: ['X', 'T1'] },
+      { entityId: 2, modelId: 'm', values: ['X', null] },
+      { entityId: 3, modelId: 'm', values: ['X', ''] },
+    ];
+    const { groups, summary } = summariseListRows(def, rows);
+    expect(groups?.map(g => [g.level, g.label, g.count])).toEqual([
+      [0, 'X', 3],
+      [1, '(none)', 2],
+      [1, 'T1', 1],
+    ]);
+    expect(summary?.count).toBe(3);
+  });
+
+  it('returns empty groups and a zero-count summary for an empty row set', () => {
+    const def: ListDefinition = {
+      id: 'grp-empty',
+      name: 'Test',
+      createdAt: 0,
+      updatedAt: 0,
+      entityTypes: [],
+      conditions: [],
+      columns: [
+        { id: 'a', source: 'attribute', propertyName: 'Name' },
+        { id: 'n', source: 'quantity', propertyName: 'Length' },
+      ],
+      grouping: { columnId: 'a', columnIds: ['a'], sumColumnIds: ['n'] },
+    };
+    const { groups, summary } = summariseListRows(def, []);
+    expect(groups).toEqual([]);
+    expect(summary).toEqual({ count: 0, sums: { n: 0 } });
+  });
+
+  it('a group column id that matches no column still yields a single "(none)" level', () => {
+    const def: ListDefinition = {
+      id: 'grp-missing-col',
+      name: 'Test',
+      createdAt: 0,
+      updatedAt: 0,
+      entityTypes: [],
+      conditions: [],
+      columns: [{ id: 'a', source: 'attribute', propertyName: 'Name' }],
+      grouping: { columnId: 'gone', columnIds: ['gone'], sumColumnIds: [] },
+    };
+    const { groups } = summariseListRows(def, [
+      { entityId: 1, modelId: 'm', values: ['X'] },
+      { entityId: 2, modelId: 'm', values: ['Y'] },
+    ]);
+    expect(groups?.map(g => [g.label, g.count])).toEqual([['(none)', 2]]);
   });
 
   it('omits groups/summary when grouping is not configured', () => {

--- a/packages/lists/src/engine.ts
+++ b/packages/lists/src/engine.ts
@@ -94,8 +94,6 @@ interface ColumnMeta {
 // Grouping & Aggregation
 // ============================================================================
 
-/** Separator used to build unique composite group keys from group paths. */
-export const GROUP_KEY_SEPARATOR = '\u001f';
 
 /**
  * Effective ordered group-by column ids for a grouping config — `columnIds`
@@ -129,9 +127,12 @@ export function summariseListRows(
   if (!grouping) return {};
 
   const columns = definition.columns;
-  const groupIds = groupingColumnIds(grouping);
-  // No group column configured (sums only) keeps the legacy single-bucket
-  // behaviour: every row lands in one "(none)" group.
+  // Drop group ids that no longer resolve to a column (e.g. the column was
+  // removed after the grouping was persisted) so the hierarchy matches the
+  // viewer/export exactly instead of inserting synthetic "(none)" levels.
+  const groupIds = groupingColumnIds(grouping).filter(id => columns.some(c => c.id === id));
+  // No resolvable group column (sums only, or every group column gone) keeps
+  // the legacy single-bucket behaviour: every row lands in one "(none)" group.
   const levelIndices = groupIds.length > 0
     ? groupIds.map(id => columns.findIndex(c => c.id === id))
     : [-1];
@@ -157,7 +158,7 @@ export function summariseListRows(
   // Recursive per-level bucketing, preserving first-seen order within a level,
   // then ordered largest-group-first (stable default) before flattening.
   const groups: ListGroup[] = [];
-  const walk = (subRows: ListRow[], level: number, parentKey: string, parentPath: string[]) => {
+  const walk = (subRows: ListRow[], level: number, parentPath: string[]) => {
     const colIdx = levelIndices[level];
     const byKey = new Map<string, { group: ListGroup; rows: ListRow[] }>();
     for (const row of subRows) {
@@ -167,8 +168,7 @@ export function summariseListRows(
       let bucket = byKey.get(label);
       if (!bucket) {
         const path = [...parentPath, label];
-        const key = parentKey === '' ? label : `${parentKey}${GROUP_KEY_SEPARATOR}${label}`;
-        bucket = { group: { key, label, count: 0, sums: zeroSums(), level, path }, rows: [] };
+        bucket = { group: { key: groupPathKey(path), label, count: 0, sums: zeroSums(), level, path }, rows: [] };
         byKey.set(label, bucket);
       }
       bucket.group.count++;
@@ -185,13 +185,23 @@ export function summariseListRows(
     for (const bucket of ordered) {
       groups.push(bucket.group);
       if (level + 1 < levelIndices.length) {
-        walk(bucket.rows, level + 1, bucket.group.key, bucket.group.path!);
+        walk(bucket.rows, level + 1, bucket.group.path!);
       }
     }
   };
-  walk(rows, 0, '', []);
+  walk(rows, 0, []);
 
   return { groups, summary };
+}
+
+/**
+ * Collision-free unique key for a group path: the JSON encoding of the label
+ * array. A plain label join would be ambiguous whenever a model-derived label
+ * contains the join separator, silently merging distinct groups' expansion /
+ * render identity downstream.
+ */
+export function groupPathKey(path: string[]): string {
+  return JSON.stringify(path);
 }
 
 // ============================================================================

--- a/packages/lists/src/engine.ts
+++ b/packages/lists/src/engine.ts
@@ -18,6 +18,7 @@ import type {
   ListResult,
   ListRow,
   ListGroup,
+  ListGrouping,
   ListSummary,
   CellValue,
   PropertyCondition,
@@ -93,11 +94,32 @@ interface ColumnMeta {
 // Grouping & Aggregation
 // ============================================================================
 
+/** Separator used to build unique composite group keys from group paths. */
+export const GROUP_KEY_SEPARATOR = '\u001f';
+
+/**
+ * Effective ordered group-by column ids for a grouping config — `columnIds`
+ * (multi-criteria, issue #1790) when present, else the legacy single
+ * `columnId`. `[]` when the config only carries sum columns (or is absent).
+ */
+export function groupingColumnIds(grouping: ListGrouping | undefined): string[] {
+  if (!grouping) return [];
+  const ids = grouping.columnIds && grouping.columnIds.length > 0
+    ? grouping.columnIds
+    : (grouping.columnId ? [grouping.columnId] : []);
+  return ids.filter(id => id !== '');
+}
+
 /**
  * Build the grouped breakdown + whole-result summary for a definition over a
  * row set. Returns `{}` when no grouping is configured, so the result shape is
  * unchanged for plain flat lists. Exported so federated callers can re-derive
  * groups/summary after merging rows from several models.
+ *
+ * Multi-criteria grouping (issue #1790): with several group columns the
+ * returned `groups` is a FLAT pre-order list — each parent group followed by
+ * its subgroups, `level`/`path` carrying the nesting. Every group carries its
+ * own `count` (the Count aggregate) and per-column sums.
  */
 export function summariseListRows(
   definition: ListDefinition,
@@ -107,7 +129,12 @@ export function summariseListRows(
   if (!grouping) return {};
 
   const columns = definition.columns;
-  const groupIdx = columns.findIndex(c => c.id === grouping.columnId);
+  const groupIds = groupingColumnIds(grouping);
+  // No group column configured (sums only) keeps the legacy single-bucket
+  // behaviour: every row lands in one "(none)" group.
+  const levelIndices = groupIds.length > 0
+    ? groupIds.map(id => columns.findIndex(c => c.id === id))
+    : [-1];
   const sumIndices = grouping.sumColumnIds
     .map(id => ({ id, idx: columns.findIndex(c => c.id === id) }))
     .filter(s => s.idx >= 0);
@@ -118,35 +145,51 @@ export function summariseListRows(
     return out;
   };
 
-  // Whole-result summary.
+  // Whole-result summary (accumulated once, independent of nesting depth).
   const summary: ListSummary = { count: rows.length, sums: zeroSums() };
-
-  // Group accumulation, preserving first-seen order.
-  const byKey = new Map<string, ListGroup>();
   for (const row of rows) {
-    const raw = groupIdx >= 0 ? row.values[groupIdx] : null;
-    const label = raw === null || raw === undefined || raw === '' ? '(none)' : String(raw);
-    const key = label;
-
-    let group = byKey.get(key);
-    if (!group) {
-      group = { key, label, count: 0, sums: zeroSums() };
-      byKey.set(key, group);
-    }
-    group.count++;
-
     for (const s of sumIndices) {
       const v = row.values[s.idx];
-      if (typeof v === 'number' && Number.isFinite(v)) {
-        group.sums[s.id] += v;
-        summary.sums[s.id] += v;
-      }
+      if (typeof v === 'number' && Number.isFinite(v)) summary.sums[s.id] += v;
     }
   }
 
-  const groups = Array.from(byKey.values());
-  // Stable, useful default: largest groups first.
-  groups.sort((a, b) => b.count - a.count || a.label.localeCompare(b.label));
+  // Recursive per-level bucketing, preserving first-seen order within a level,
+  // then ordered largest-group-first (stable default) before flattening.
+  const groups: ListGroup[] = [];
+  const walk = (subRows: ListRow[], level: number, parentKey: string, parentPath: string[]) => {
+    const colIdx = levelIndices[level];
+    const byKey = new Map<string, { group: ListGroup; rows: ListRow[] }>();
+    for (const row of subRows) {
+      const raw = colIdx >= 0 ? row.values[colIdx] : null;
+      const label = raw === null || raw === undefined || raw === '' ? '(none)' : String(raw);
+
+      let bucket = byKey.get(label);
+      if (!bucket) {
+        const path = [...parentPath, label];
+        const key = parentKey === '' ? label : `${parentKey}${GROUP_KEY_SEPARATOR}${label}`;
+        bucket = { group: { key, label, count: 0, sums: zeroSums(), level, path }, rows: [] };
+        byKey.set(label, bucket);
+      }
+      bucket.group.count++;
+      bucket.rows.push(row);
+
+      for (const s of sumIndices) {
+        const v = row.values[s.idx];
+        if (typeof v === 'number' && Number.isFinite(v)) bucket.group.sums[s.id] += v;
+      }
+    }
+
+    const ordered = Array.from(byKey.values())
+      .sort((a, b) => b.group.count - a.group.count || a.group.label.localeCompare(b.group.label));
+    for (const bucket of ordered) {
+      groups.push(bucket.group);
+      if (level + 1 < levelIndices.length) {
+        walk(bucket.rows, level + 1, bucket.group.key, bucket.group.path!);
+      }
+    }
+  };
+  walk(rows, 0, '', []);
 
   return { groups, summary };
 }

--- a/packages/lists/src/index.ts
+++ b/packages/lists/src/index.ts
@@ -22,7 +22,7 @@ export type {
 export { ENTITY_ATTRIBUTES } from './types.js';
 
 // Engine
-export { executeList, listResultToCSV, summariseListRows } from './engine.js';
+export { executeList, listResultToCSV, summariseListRows, groupingColumnIds, GROUP_KEY_SEPARATOR } from './engine.js';
 
 // Name pattern matching (Bonsai-style `/regex/` set/property names)
 export { compileNameMatcher, isNamePattern } from './name-pattern.js';

--- a/packages/lists/src/index.ts
+++ b/packages/lists/src/index.ts
@@ -22,7 +22,7 @@ export type {
 export { ENTITY_ATTRIBUTES } from './types.js';
 
 // Engine
-export { executeList, listResultToCSV, summariseListRows, groupingColumnIds, GROUP_KEY_SEPARATOR } from './engine.js';
+export { executeList, listResultToCSV, summariseListRows, groupingColumnIds, groupPathKey } from './engine.js';
 
 // Name pattern matching (Bonsai-style `/regex/` set/property names)
 export { compileNameMatcher, isNamePattern } from './name-pattern.js';

--- a/packages/lists/src/types.ts
+++ b/packages/lists/src/types.ts
@@ -172,6 +172,13 @@ export interface ListDefinition {
 export interface ListGrouping {
   /** Column id to group rows by (e.g. a Type / Material / Storey column). */
   columnId: string;
+  /**
+   * Multi-criteria grouping (issue #1790): ordered column ids to group by,
+   * outermost first (e.g. Building, then Storey). When present and non-empty
+   * this takes precedence over `columnId`; `columnId` is kept in sync with the
+   * first entry for consumers built before multi-level grouping existed.
+   */
+  columnIds?: string[];
   /** Column ids whose numeric values are summed per group and overall. */
   sumColumnIds: string[];
 }
@@ -270,16 +277,24 @@ export interface ListResult {
   summary?: ListSummary;
 }
 
-/** One group in a grouped list result. */
+/** One group in a grouped list result. With multi-criteria grouping (issue
+ *  #1790) groups are emitted as a FLAT pre-order list: each parent group is
+ *  immediately followed by its subgroups (`level` gives the nesting depth). */
 export interface ListGroup {
-  /** Group-by value, stringified. Empty values group under `label`. */
+  /** Unique group key — the `path` labels joined with `'\u001f'` (equals the
+   *  label for a top-level group). */
   key: string;
-  /** Display label for the group header. */
+  /** Display label for the group header (this level's value only). */
   label: string;
-  /** Number of rows in the group. */
+  /** Number of rows in the group (the Count aggregate, issue #1790). */
   count: number;
   /** columnId → summed numeric value, for the configured sum columns. */
   sums: Record<string, number>;
+  /** 0-based nesting depth (0 = outermost grouping column). Always emitted by
+   *  `summariseListRows`; optional for backward type compatibility. */
+  level?: number;
+  /** Group-by labels from the outermost level down to this group. */
+  path?: string[];
 }
 
 /** Whole-result aggregates. */

--- a/packages/lists/src/types.ts
+++ b/packages/lists/src/types.ts
@@ -281,8 +281,9 @@ export interface ListResult {
  *  #1790) groups are emitted as a FLAT pre-order list: each parent group is
  *  immediately followed by its subgroups (`level` gives the nesting depth). */
 export interface ListGroup {
-  /** Unique group key — the `path` labels joined with `'\u001f'` (equals the
-   *  label for a top-level group). */
+  /** Opaque unique group key - the JSON encoding of `path` (see
+   *  `groupPathKey`), collision-free even when a model-derived label contains
+   *  separator-like characters. */
   key: string;
   /** Display label for the group header (this level's value only). */
   label: string;

--- a/scripts/api-surface.json
+++ b/scripts/api-surface.json
@@ -2032,6 +2032,8 @@
     "compileNameMatcher: function",
     "discoverColumns: function",
     "executeList: function",
+    "groupPathKey: function",
+    "groupingColumnIds: function",
     "isNamePattern: function",
     "listResultToCSV: function",
     "summariseListRows: function"


### PR DESCRIPTION
## Summary

Implements the Bonsai-style Count function in Lists (#1790): multi-criteria grouping (e.g. group by Building, then Storey) with the quantity of instances shown per group at every nesting level.

Running the engine over Building/Storey data now produces exactly the requested output shape:

```
A (3)
  L0 (2)
  L1 (1)
B (1)
  L0 (1)
```

## What already existed vs what this adds

Lists already had single-column grouping (`ListGrouping.columnId`) with a per-group `count` and sum columns. This PR extends that same mechanism instead of adding a parallel one:

**Engine (`@ifc-lite/lists`)**
- `ListGrouping.columnIds` — ordered group-by columns, outermost first. `columnId` stays and is kept in sync with the first level, so persisted/imported definitions and older consumers keep working unchanged.
- `summariseListRows` now emits a flat pre-order group list (`level` / `path` on each `ListGroup`); every group carries its own `count` (the Count aggregate) and per-column subtotal sums. Whole-result summary is accumulated once (no double counting across levels).
- New `groupingColumnIds` + `groupPathKey` helpers; group keys are the JSON encoding of the label path, so identical labels under different parents (or labels containing separator-like characters) can never collide.
- Type-property fallback logic is untouched (grouping operates on already-extracted row values).

**Viewer UI (minimal, on the existing surfaces)**
- Results table: one nested, indented, collapsible header level per group column, each with its count badge (the count badge itself already existed for single-level grouping). Column header menu shows "Add grouping level" when grouping is already active on other columns; grouped headers show their level number when more than one level is active.
- Grouping bar: one removable chip per level ("Grouped by Building", "then Storey"). Expand/collapse-all opens the whole tree (all levels).
- List builder: "Group by" select gains "then by" level selects; already-used columns are hidden from other levels.

**Exports**
- XLSX/PDF already carried per-group counts (`Label (N)`); they now indent sub-group header rows per level (XLSX also nests row outline levels) so counts appear at every level.
- CSV stays flat re-importable data: the leading `Group` column now carries the full path ("Building / Storey"); per-group counts remain an XLSX/PDF/table concern by design (a CSV subtotal row would break re-import).

## Review follow-up (second commit)

- Committed the regenerated `scripts/api-surface.json` (CI's api-surface guard flagged the new intentional exports).
- CodeRabbit CLI findings addressed: collision-free JSON path keys (engine + viewer), engine now drops unresolvable group columns to match viewer/export, CSV `esc()` strips a leading BOM before the formula-injection guard, XLSX outline levels clamped to Excel's max of 8, plus regression tests for repeated child labels and separator-containing labels.

## Tests

- `packages/lists`: 103 tests pass (new: multi-level grouping with counts/sums per level, `columnIds` precedence + legacy `columnId` compat, empty row set, empty values at a sub-level bucketing under `(none)`, missing group column).
- Viewer (`tsx --test`): 43 lists tests pass (new: nested view visibility/expansion, distinct same-label subgroups, totals not double-counted, legacy single-level unchanged; export model pre-order sections with leaf-only rows).
- `pnpm --filter @ifc-lite/viewer typecheck` clean.

Closes #1790

🤖 Generated with [Claude Code](https://claude.com/claude-code)
