### PR TITLE
fix(geometry): cut missed Poroton opening + slab inner-tessellation decimation + wedge-cut discard (#1788)

### DIFF
--- a/.changeset/void-cut-correctness-1788.md
+++ b/.changeset/void-cut-correctness-1788.md
@@ -1,0 +1,10 @@
+---
+"@ifc-lite/wasm": patch
+---
+
+Geometry-correctness fixes from the T1-T6 vs IfcOpenShell sweep (#1788):
+
+- Batched void subtraction now verifies the lenient (non-conforming) batch against the sum of per-cutter intersection volumes instead of re-running the sequential subtract chain. The chain re-jitters its own seams cut-over-cut and under-cuts multi-void walls, so a perfect batch was being rejected in favour of the broken sequential fallback — leaving one Poroton wall opening entirely uncut (ISSUE_098 T6 `fail:opening-not-cut`) and fragmenting/drifting the volume of five sibling walls.
+- A void cut that keeps the host's triangle count but moves its volume (a miter/end cut replacing a 12-tri box with another 12-tri box) is no longer misread as "no change" — previously the perfect cut was discarded and the #635 AABB fallback carved the cutter's world-axis box instead (ISSUE_129 `IGC_MUR` wedge wall).
+- New stray-shard sweep after void cutting: faces with no original-host material on either side (misclassified extended-cutter fragments up to ~1 m off a plan-rotated wall's plane, invisible to the world-AABB clip) are provably not part of `host − openings` and are dropped, with vertex arrays compacted so bounds/hull readers no longer see the shards.
+- Profile smooth-curve simplification (RDP) now caps its epsilon at an absolute 10 mm (converted through the file's length unit) instead of scaling unboundedly with profile size — a 2.5 m curved slab's correctly-tessellated 4-arc boundary was being decimated from ~60 to 17 points (ISSUE_098 `1AR_PAV_CS008` slabs, voxel-IoU 0.64 vs IfcOpenShell). Window-scale openings are unaffected.

--- a/rust/geometry/src/kernel/mesh_bridge.rs
+++ b/rust/geometry/src/kernel/mesh_bridge.rs
@@ -350,28 +350,43 @@ pub fn subtract_many(host: &Mesh, cutters: &[&Mesh]) -> Option<Mesh> {
     // traversal recovery). Its exact topology is CLEANER than sequential per-cutter
     // re-jitter on dense faceted-reveal walls (issue #098 V5C: 532→108 open edges),
     // but a straddling misclassification can over/under-cut VOLUME (#559171/#1167).
-    // Trust the lenient batch ONLY when its removed volume matches the sequential
-    // reference; else None, so the caller runs its full sequential path.
+    // Trust the lenient batch ONLY when its removed volume matches the true removed
+    // volume; else None, so the caller runs its full sequential path.
     let batch = difference_all_lenient(&h, &refs);
-    // The sequential reference is an ORACLE for the volume comparison, not the
-    // operation — snapshot/restore the budget so these full booleans don't charge
-    // the caller's batch budget. Otherwise a dense group could trip the shared
-    // #1109 budget merely computing the reference, and the caller would discard
-    // even a volume-matched batch, defeating recovery on exactly the hard cases
-    // this path targets (codex P2 on #1660).
+    // ORACLE for the volume comparison (#1788): batched cutters are pairwise
+    // disjoint (this fn's contract), so the TRUE removed volume is
+    // Σ |host ∩ cutterᵢ| — each a small single boolean against the PRISTINE
+    // host, the well-conditioned regime. The previous oracle re-ran the
+    // sequential subtract chain, but that chain re-jitters its own seams
+    // cut-over-cut and UNDER-cuts on multi-void walls — on the ISSUE_098
+    // Poroton wall its "reference" removed 2% less volume than the (correct)
+    // batch, so a perfect batch was rejected in favour of the broken
+    // sequential fallback, leaving an opening uncut (T6 fail:opening-not-cut).
+    // Budget snapshot/restore: oracle work isn't charged to the caller's
+    // batch budget (codex P2 on #1660); a trip DURING an oracle intersection
+    // makes its volume untrustworthy ⇒ reject the group (as before).
     let budget_snap = super::budget::snapshot_counters();
-    let mut seq = tris_to_mesh(&h);
-    for c in cutters {
-        seq = subtract(&seq, c);
+    let mut inter_sum = 0.0f64;
+    let mut oracle_tripped = false;
+    for c in &comp_tris {
+        super::budget::begin();
+        let i = boolean(&h, c, BoolOp::Intersection);
+        if super::budget::tripped() {
+            oracle_tripped = true;
+            break;
+        }
+        inter_sum += signed_volume6(&i).abs();
     }
     super::budget::restore_counters(budget_snap);
+    if oracle_tripped {
+        return None;
+    }
     let host_v = signed_volume6(&h).abs();
     let batch_removed = host_v - signed_volume6(&batch).abs();
-    let seq_removed = host_v - signed_volume6(&mesh_to_tris(&seq)).abs();
     // 1% agreement — above f64/FMA noise (parity-stable branch), tight enough to
     // reject the #1167 gross under-cut (3.7 m³ vs 13 m³).
-    let tol = seq_removed.abs().max(1.0e-9) * 0.01;
-    if (batch_removed - seq_removed).abs() <= tol {
+    let tol = inter_sum.abs().max(1.0e-9) * 0.01;
+    if (batch_removed - inter_sum).abs() <= tol {
         Some(tris_to_mesh(&batch))
     } else {
         None

--- a/rust/geometry/src/profiles/mod.rs
+++ b/rust/geometry/src/profiles/mod.rs
@@ -250,11 +250,10 @@ impl ProfileProcessor {
 
         // Process outer curve
         let raw_outer = self.process_curve(&curve, decoder)?;
-        // Issue #635 — downsample over-tessellated smooth curves so that
-        // round/curved openings produce compact extrusions (historically:
-        // to fit the deleted BSP polygon budget and avoid the AABB
-        // rectangular fallback; still a big perf win on the exact kernel).
-        let outer_points = simplify_smooth_curve_polyline(&raw_outer);
+        // Issue #635 — downsample over-tessellated smooth curves so round/
+        // curved openings produce compact extrusions (a big perf win on the
+        // exact kernel; historically also the deleted BSP polygon budget).
+        let outer_points = simplify_smooth_curve_polyline(&raw_outer, decoder.length_unit_scale());
         let mut result = Profile2D::new(outer_points);
 
         // Check if this is IfcArbitraryProfileDefWithVoids (has inner curves)
@@ -264,7 +263,8 @@ impl ProfileProcessor {
                 let inner_curves = decoder.resolve_ref_list(inner_curves_attr)?;
                 for inner_curve in inner_curves {
                     let raw_hole = self.process_curve(&inner_curve, decoder)?;
-                    let hole_points = simplify_smooth_curve_polyline(&raw_hole);
+                    let hole_points =
+                        simplify_smooth_curve_polyline(&raw_hole, decoder.length_unit_scale());
                     result.add_hole(hole_points);
                 }
             }

--- a/rust/geometry/src/profiles/simplify.rs
+++ b/rust/geometry/src/profiles/simplify.rs
@@ -422,10 +422,12 @@ pub(super) fn simplify_smooth_curve_polyline(
 
     // Diagonal-relative epsilon, floored (tiny profiles) and capped at the
     // ABSOLUTE `RDP_EPSILON_MAX_M` budget in profile units, so a large
-    // profile's chord error can't grow with its size (#1788). The cap never
-    // undercuts the floor; degenerate unit scales keep the legacy behaviour.
+    // profile's chord error can't grow with its size (#1788). The cap is NOT
+    // raised to the (unit-dependent) `RDP_EPSILON_MIN` floor — it is the
+    // physical 10 mm bound and must win even where the floor exceeds it
+    // (e.g. coarse length units); degenerate scales keep legacy behaviour.
     let eps_cap_units = if length_unit_scale.is_finite() && length_unit_scale > 0.0 {
-        (RDP_EPSILON_MAX_M / length_unit_scale).max(RDP_EPSILON_MIN)
+        RDP_EPSILON_MAX_M / length_unit_scale
     } else {
         f64::INFINITY
     };

--- a/rust/geometry/src/profiles/simplify.rs
+++ b/rust/geometry/src/profiles/simplify.rs
@@ -39,6 +39,15 @@ const RDP_EPSILON_RATIO: f64 = 1.0 / 100.0;
 /// Prevents collapsing tiny profiles where ratio-derived epsilon would be
 /// numerically negligible.
 const RDP_EPSILON_MIN: f64 = 5.0e-3;
+/// Absolute upper bound on RDP epsilon, in METRES (converted to profile units
+/// through the file's length-unit scale at the call site). The diagonal-scaled
+/// epsilon is right for a ~1 m round window (the #635 target: N≈16) but grows
+/// with profile size: a 2.5 m-diagonal curved slab got a 25 mm chord budget and
+/// its correctly-tessellated 4-arc boundary was decimated to 17 points (#1788,
+/// ISSUE_098 `1AR_PAV_CS008` slabs: −1.2% volume, voxel-IoU 0.64 vs
+/// IfcOpenShell). 10 mm keeps window-scale behaviour unchanged (their ratio
+/// epsilon is ≤ ~12 mm anyway) while bounding large-profile deviation.
+const RDP_EPSILON_MAX_M: f64 = 1.0e-2;
 /// Minimum ratio of a profile's half-thickness (`area / perimeter`, its
 /// hydraulic radius) to its bounding-box diagonal for simplification to be
 /// attempted. Below this the profile is a *thin* curved sliver — e.g. a
@@ -286,7 +295,12 @@ fn loop_doubles_back(loop_: &[Point2<f64>]) -> bool {
 /// when simplification would drop it below `SIMPLIFIED_MIN_VERTICES`.
 ///
 /// See `SMOOTH_CURVE_SPACING_RATIO` for the detection criterion.
-pub(super) fn simplify_smooth_curve_polyline(points: &[Point2<f64>]) -> Vec<Point2<f64>> {
+/// `length_unit_scale` converts profile units to metres (the decoder's
+/// `length_unit_scale()`); pass `1.0` for metre-authored / unit-less input.
+pub(super) fn simplify_smooth_curve_polyline(
+    points: &[Point2<f64>],
+    length_unit_scale: f64,
+) -> Vec<Point2<f64>> {
     let raw_len = points.len();
     if raw_len < SMOOTH_CURVE_MIN_VERTICES {
         return points.to_vec();
@@ -406,7 +420,16 @@ pub(super) fn simplify_smooth_curve_polyline(points: &[Point2<f64>]) -> Vec<Poin
         return points.to_vec();
     }
 
-    let epsilon = (diag * RDP_EPSILON_RATIO).max(RDP_EPSILON_MIN);
+    // Diagonal-relative epsilon, floored (tiny profiles) and capped at the
+    // ABSOLUTE `RDP_EPSILON_MAX_M` budget in profile units, so a large
+    // profile's chord error can't grow with its size (#1788). The cap never
+    // undercuts the floor; degenerate unit scales keep the legacy behaviour.
+    let eps_cap_units = if length_unit_scale.is_finite() && length_unit_scale > 0.0 {
+        (RDP_EPSILON_MAX_M / length_unit_scale).max(RDP_EPSILON_MIN)
+    } else {
+        f64::INFINITY
+    };
+    let epsilon = (diag * RDP_EPSILON_RATIO).max(RDP_EPSILON_MIN).min(eps_cap_units);
 
     // RDP needs distinct endpoints; rotate-then-simplify by treating the
     // closed loop as an open polyline whose first/last vertex are pinned.
@@ -456,251 +479,5 @@ pub(super) fn simplify_smooth_curve_polyline(points: &[Point2<f64>]) -> Vec<Poin
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn closed_loop_self_intersects_detects_bowtie() {
-        // Simple unit square — no crossings.
-        let square = [
-            Point2::new(0.0, 0.0),
-            Point2::new(1.0, 0.0),
-            Point2::new(1.0, 1.0),
-            Point2::new(0.0, 1.0),
-        ];
-        assert!(!closed_loop_self_intersects(&square));
-
-        // Bow-tie: swapping the last two vertices makes the closing edges
-        // cross in the middle.
-        let bowtie = [
-            Point2::new(0.0, 0.0),
-            Point2::new(1.0, 0.0),
-            Point2::new(0.0, 1.0),
-            Point2::new(1.0, 1.0),
-        ];
-        assert!(closed_loop_self_intersects(&bowtie));
-
-        // Degenerate (fewer than 4 vertices) can't self-cross.
-        assert!(!closed_loop_self_intersects(&square[..3]));
-    }
-
-    /// Build a dense closed loop for a thin annular sector centred at
-    /// (0, -radius) (the issue #820 topology): an outer arc at `radius` and an
-    /// inner arc at `radius - thickness`, swept `span` radians and joined by
-    /// short radial caps. `seg` samples per arc.
-    fn annular_sector_loop(radius: f64, thickness: f64, span: f64, seg: usize) -> Vec<Point2<f64>> {
-        let c = Point2::new(0.0, -radius);
-        let mut loop_ = Vec::with_capacity(2 * seg + 2);
-        for i in 0..=seg {
-            let a = -span / 2.0 + span * (i as f64 / seg as f64);
-            loop_.push(Point2::new(c.x + radius * a.cos(), c.y + radius * a.sin()));
-        }
-        let inner = radius - thickness;
-        for i in 0..=seg {
-            let a = span / 2.0 - span * (i as f64 / seg as f64);
-            loop_.push(Point2::new(c.x + inner * a.cos(), c.y + inner * a.sin()));
-        }
-        loop_
-    }
-
-    fn loop_area(loop_: &[Point2<f64>]) -> f64 {
-        let n = loop_.len();
-        let mut a = 0.0;
-        for i in 0..n {
-            let p = loop_[i];
-            let q = loop_[(i + 1) % n];
-            a += p.x * q.y - q.x * p.y;
-        }
-        (a * 0.5).abs()
-    }
-
-    #[test]
-    fn simplify_thin_annular_sector_stays_simple_and_area_preserving() {
-        // Regression for issue #820 *and* the silent-area-distortion class the
-        // review flagged. A thin curved wall has a feature size (its thickness)
-        // far below the bbox diagonal; the thickness-capped RDP epsilon must
-        // keep every simplification both topologically simple (no folded-flap
-        // seam) and area-faithful. The first row is the real fixture's
-        // proportions (r=12000, 100 mm, 240°); the rest are the thicker/shorter
-        // sectors the reviewer reproduced losing/gaining 5–13% area under the
-        // un-capped epsilon.
-        let cases = [
-            (12000.0, 100.0, 240.0_f64),
-            (12000.0, 300.0, 240.0),
-            (12000.0, 600.0, 90.0),
-            (12000.0, 600.0, 180.0),
-        ];
-        for (radius, thickness, span_deg) in cases {
-            let span = span_deg.to_radians();
-            let dense = annular_sector_loop(radius, thickness, span, 200);
-            assert!(
-                !closed_loop_self_intersects(&dense),
-                "input sector r={radius} t={thickness} {span_deg}° should start simple",
-            );
-            let out = simplify_smooth_curve_polyline(&dense);
-
-            // Topology: never a folded-flap seam.
-            assert!(
-                !closed_loop_self_intersects(&out),
-                "simplified sector r={radius} t={thickness} {span_deg}° self-intersects",
-            );
-
-            // Area: within 2% of the dense original (was up to ±13% pre-fix).
-            let (a_in, a_out) = (loop_area(&dense), loop_area(&out));
-            let rel = (a_out - a_in).abs() / a_in;
-            assert!(
-                rel < 0.02,
-                "sector r={radius} t={thickness} {span_deg}°: area drift {:.1}% \
-                 (in={a_in:.0} out={a_out:.0}) — thin curved wall was distorted",
-                rel * 100.0,
-            );
-        }
-    }
-
-    #[test]
-    fn simplify_still_reduces_fat_round_disk() {
-        // Guards THIN_FEATURE_RATIO from being set so high it suppresses the
-        // issue #635 case it must preserve: an over-tessellated round window
-        // (a *fat* disk, half-thickness ≈ radius/2) must still simplify to a
-        // small recognizable polygon so void cuts fit the CSG polygon budget.
-        let mut disk = Vec::new();
-        let seg = 127;
-        for i in 0..seg {
-            let a = std::f64::consts::TAU * (i as f64 / seg as f64);
-            disk.push(Point2::new(0.5 * a.cos(), 0.5 * a.sin()));
-        }
-        let out = simplify_smooth_curve_polyline(&disk);
-        assert!(
-            out.len() < disk.len() && out.len() >= SIMPLIFIED_MIN_VERTICES,
-            "round disk should simplify from {} to [{SIMPLIFIED_MIN_VERTICES}, {}) verts, got {}",
-            disk.len(),
-            disk.len(),
-            out.len(),
-        );
-        assert!(!closed_loop_self_intersects(&out));
-    }
-
-    fn ellipse_loop(ar: f64, seg: usize) -> Vec<Point2<f64>> {
-        let (a, b) = (ar * 0.5, 0.5);
-        (0..seg)
-            .map(|i| {
-                let t = std::f64::consts::TAU * (i as f64 / seg as f64);
-                Point2::new(a * t.cos(), b * t.sin())
-            })
-            .collect()
-    }
-
-    #[test]
-    fn elongated_filled_ellipse_is_not_thin_gated() {
-        // Regression for the review's P1. An elongated *filled* ellipse is thin
-        // by the half-thickness/diagonal measure (an 8:1 ellipse sits at ~0.048,
-        // below THIN_FEATURE_RATIO, rising to ~0.020 at 20:1) — but it is convex
-        // and does NOT double back, so the thin gate must not fire on it. The
-        // earlier thinness-only gate wrongly skipped these, pinning a densely
-        // sampled elliptical opening at its full vertex count, overflowing the
-        // BSP void-cut budget and forcing the AABB-rectangle fallback (#635).
-        for ar in [6.0_f64, 8.0, 12.0, 20.0] {
-            assert!(
-                !loop_doubles_back(&ellipse_loop(ar, 128)),
-                "AR={ar} filled ellipse is convex — must not read as doubling back",
-            );
-        }
-
-        // With the gate no longer blocking it, an elongated ellipse simplifies
-        // exactly as it does without any thin gate (i.e. as on main): RDP +
-        // SIMPLIFIED_MIN_VERTICES. At 8:1, RDP retains ≥ the floor, so it
-        // genuinely reduces and stays simple. (Higher ratios bottom out at the
-        // floor and keep the original — a pre-existing #635 limitation, not the
-        // thin gate, and unchanged by this fix.)
-        let ellipse = ellipse_loop(8.0, 128);
-        let out = simplify_smooth_curve_polyline(&ellipse);
-        assert!(
-            out.len() < ellipse.len() && out.len() >= SIMPLIFIED_MIN_VERTICES,
-            "8:1 ellipse must still simplify (was wrongly thin-gated): {} -> {} verts",
-            ellipse.len(),
-            out.len(),
-        );
-        assert!(!closed_loop_self_intersects(&out));
-        // Inscribed simplification of an elongated convex opening shaves a few
-        // percent — acceptable for a void approximation (and the same as main).
-        let rel = (loop_area(&out) - loop_area(&ellipse)).abs() / loop_area(&ellipse);
-        assert!(rel < 0.08, "8:1 ellipse area drift {:.1}%", rel * 100.0);
-    }
-
-    #[test]
-    fn doubles_back_ignores_localized_spikes() {
-        // The reflex-fraction metric must flag a genuine two-arc annular sector
-        // but NOT a convex thin opening carrying a single localized defect — a
-        // lone inward notch or the sub-mm out-and-back jog where a composite
-        // curve closes. A total-turning measure double-counts such a spike and
-        // would wrongly gate these convex openings back into the #635 AABB cut.
-
-        // Genuine doubling-back: the #820 thin annular sector.
-        assert!(loop_doubles_back(&annular_sector_loop(
-            12000.0,
-            100.0,
-            (240.0_f64).to_radians(),
-            128
-        )));
-
-        // Clean convex ellipse — not doubling back.
-        let mut e = ellipse_loop(8.0, 128);
-        assert!(!loop_doubles_back(&e));
-
-        // ...with one deep inward notch at the blunt (x-tip) vertex. Find the
-        // vertex of greatest |x| and pull it 25% of the minor axis toward centre.
-        let tip = (0..e.len())
-            .max_by(|&i, &j| e[i].x.abs().partial_cmp(&e[j].x.abs()).unwrap())
-            .unwrap();
-        e[tip].x *= 0.75;
-        assert!(
-            !loop_doubles_back(&e),
-            "a single notch on a convex ellipse must not read as doubling back",
-        );
-
-        // Convex disk with a tiny out-and-back seam jog (a real, non-degenerate
-        // near-coincident self-intersection of the kind the #820 seam leaves).
-        let mut disk: Vec<Point2<f64>> = (0..128)
-            .map(|i| {
-                let t = std::f64::consts::TAU * (i as f64 / 128.0);
-                Point2::new(t.cos(), t.sin())
-            })
-            .collect();
-        // Insert a 1e-4 radial jog at vertex 0's neighbourhood.
-        disk.insert(1, Point2::new(disk[0].x * 0.9999, disk[0].y * 0.9999));
-        assert!(
-            !loop_doubles_back(&disk),
-            "a sub-mm seam jog on a convex loop must not read as doubling back",
-        );
-    }
-
-    #[test]
-    fn doubles_back_independent_of_per_boundary_sampling_density() {
-        // Codex review: measuring reflex VERTICES (not arc length) let a thin
-        // sector slip when its two arcs are sampled at very different densities.
-        // Their exact example: a 90° sector, r=12000, thickness=10, with the
-        // convex outer arc finely sampled (96 segs) and the reflex inner arc
-        // coarsely (16 segs). A count fraction reads ~0.13 (< gate) and the
-        // wall is wrongly simplified to ~55% area drift; an arc-length fraction
-        // reads ~0.5 because the inner and outer arcs are nearly equal LENGTH.
-        let centre = Point2::new(0.0, -12000.0);
-        let (r_out, r_in) = (12000.0, 12000.0 - 10.0);
-        let span = (90.0_f64).to_radians();
-        let mut loop_ = Vec::new();
-        for i in 0..=96 {
-            let a = -span / 2.0 + span * (i as f64 / 96.0);
-            loop_.push(Point2::new(centre.x + r_out * a.cos(), centre.y + r_out * a.sin()));
-        }
-        for i in 0..=16 {
-            let a = span / 2.0 - span * (i as f64 / 16.0);
-            loop_.push(Point2::new(centre.x + r_in * a.cos(), centre.y + r_in * a.sin()));
-        }
-        assert!(
-            loop_doubles_back(&loop_),
-            "a non-uniformly tessellated thin sector must still read as doubling back",
-        );
-        // And it is gated end-to-end: simplify returns the faithful original.
-        let out = simplify_smooth_curve_polyline(&loop_);
-        assert_eq!(out.len(), loop_.len(), "skewed-sampling thin sector must be gated");
-    }
-}
+#[path = "simplify_tests.rs"]
+mod tests;

--- a/rust/geometry/src/profiles/simplify_tests.rs
+++ b/rust/geometry/src/profiles/simplify_tests.rs
@@ -341,6 +341,12 @@ fn ellipse_simplification_is_unit_invariant() {
         out_m.len(),
         out_mm.len()
     );
+    for (a, b) in out_m.iter().zip(out_mm.iter()) {
+        assert!(
+            (a.x * 1000.0 - b.x).abs() < 1e-6 && (a.y * 1000.0 - b.y).abs() < 1e-6,
+            "mm ellipse output must be the metre output scaled x1000, not merely equal in count"
+        );
+    }
 }
 
 /// #1802 review: the thin doubling-back gate (#820) must keep firing when the
@@ -355,4 +361,9 @@ fn thin_profile_gate_holds_under_mm_units() {
         loop_mm.len(),
         "thin mm-unit annular sector must be gated (kept verbatim)"
     );
+    // Gated profiles are returned untouched — assert point-for-point identity,
+    // not just an equal vertex count (which a re-simplified loop could match).
+    for (a, b) in out.iter().zip(loop_mm.iter()) {
+        assert_eq!((a.x, a.y), (b.x, b.y), "gated profile must be kept verbatim");
+    }
 }

--- a/rust/geometry/src/profiles/simplify_tests.rs
+++ b/rust/geometry/src/profiles/simplify_tests.rs
@@ -261,3 +261,98 @@ fn doubles_back_independent_of_per_boundary_sampling_density() {
         "skewed-sampling thin sector must be gated"
     );
 }
+
+/// #1802 review: the absolute 10 mm cap must be unit-invariant — a physically
+/// identical profile authored in millimetres (coords ×1000, scale 0.001) must
+/// simplify to the same polygon as its metre twin. Both sit in the cap-bound
+/// regime (diagonal-relative epsilon above 10 mm), where the (unit-dependent)
+/// `RDP_EPSILON_MIN` floor plays no role.
+#[test]
+fn cap_is_unit_invariant_for_round_profile() {
+    let seg = 127;
+    let m: Vec<Point2<f64>> = (0..seg)
+        .map(|i| {
+            let a = std::f64::consts::TAU * (i as f64 / seg as f64);
+            Point2::new(a.cos(), a.sin()) // radius 1 m
+        })
+        .collect();
+    let mm: Vec<Point2<f64>> = m.iter().map(|p| Point2::new(p.x * 1000.0, p.y * 1000.0)).collect();
+    let out_m = simplify_smooth_curve_polyline(&m, 1.0);
+    let out_mm = simplify_smooth_curve_polyline(&mm, 0.001);
+    assert!(
+        out_m.len() < m.len(),
+        "metre-unit 2 m disk must simplify ({} -> {})",
+        m.len(),
+        out_m.len()
+    );
+    assert_eq!(
+        out_m.len(),
+        out_mm.len(),
+        "physically identical mm profile must simplify identically (m: {}, mm: {})",
+        out_m.len(),
+        out_mm.len()
+    );
+    for (a, b) in out_m.iter().zip(out_mm.iter()) {
+        assert!(
+            (a.x * 1000.0 - b.x).abs() < 1e-6 && (a.y * 1000.0 - b.y).abs() < 1e-6,
+            "mm output must be the metre output scaled x1000"
+        );
+    }
+}
+
+/// #1802 review: a round opening profile authored in millimetre units must
+/// still simplify (the #635 target), with the cap converted through the unit
+/// scale rather than swamped by it.
+#[test]
+fn round_profile_still_simplifies_under_mm_units() {
+    let seg = 127;
+    let disk_mm: Vec<Point2<f64>> = (0..seg)
+        .map(|i| {
+            let a = std::f64::consts::TAU * (i as f64 / seg as f64);
+            Point2::new(500.0 * a.cos(), 500.0 * a.sin()) // radius 500 mm
+        })
+        .collect();
+    let out = simplify_smooth_curve_polyline(&disk_mm, 0.001);
+    assert!(
+        out.len() < disk_mm.len() && out.len() >= SIMPLIFIED_MIN_VERTICES,
+        "mm-unit round disk should simplify from {} to [{SIMPLIFIED_MIN_VERTICES}, {}), got {}",
+        disk_mm.len(),
+        disk_mm.len(),
+        out.len(),
+    );
+    assert!(!closed_loop_self_intersects(&out));
+}
+
+/// #1802 review: ellipse simplification must be unit-invariant in the
+/// cap-bound regime (8 m x 1 m ellipse; diagonal-relative epsilon far above
+/// the 10 mm cap in both unit systems).
+#[test]
+fn ellipse_simplification_is_unit_invariant() {
+    let ellipse_m = ellipse_loop(8.0, 128);
+    let ellipse_mm: Vec<Point2<f64>> =
+        ellipse_m.iter().map(|p| Point2::new(p.x * 1000.0, p.y * 1000.0)).collect();
+    let out_m = simplify_smooth_curve_polyline(&ellipse_m, 1.0);
+    let out_mm = simplify_smooth_curve_polyline(&ellipse_mm, 0.001);
+    assert!(out_m.len() < ellipse_m.len(), "metre ellipse must simplify");
+    assert_eq!(
+        out_m.len(),
+        out_mm.len(),
+        "mm-authored ellipse must simplify identically (m: {}, mm: {})",
+        out_m.len(),
+        out_mm.len()
+    );
+}
+
+/// #1802 review: the thin doubling-back gate (#820) must keep firing when the
+/// profile is authored in millimetres and the metres-per-unit scale is passed
+/// correctly — the 12.5 m-radius, 100 mm-thick curved wall stays untouched.
+#[test]
+fn thin_profile_gate_holds_under_mm_units() {
+    let loop_mm = annular_sector_loop(12_500.0, 100.0, 0.3, 64);
+    let out = simplify_smooth_curve_polyline(&loop_mm, 0.001);
+    assert_eq!(
+        out.len(),
+        loop_mm.len(),
+        "thin mm-unit annular sector must be gated (kept verbatim)"
+    );
+}

--- a/rust/geometry/src/profiles/simplify_tests.rs
+++ b/rust/geometry/src/profiles/simplify_tests.rs
@@ -1,0 +1,263 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Tests for `profiles::simplify` (split out of `simplify.rs`; `*_tests.rs`
+//! is module-size-ratchet exempt).
+
+use super::*;
+
+#[test]
+fn closed_loop_self_intersects_detects_bowtie() {
+    // Simple unit square — no crossings.
+    let square = [
+        Point2::new(0.0, 0.0),
+        Point2::new(1.0, 0.0),
+        Point2::new(1.0, 1.0),
+        Point2::new(0.0, 1.0),
+    ];
+    assert!(!closed_loop_self_intersects(&square));
+
+    // Bow-tie: swapping the last two vertices makes the closing edges
+    // cross in the middle.
+    let bowtie = [
+        Point2::new(0.0, 0.0),
+        Point2::new(1.0, 0.0),
+        Point2::new(0.0, 1.0),
+        Point2::new(1.0, 1.0),
+    ];
+    assert!(closed_loop_self_intersects(&bowtie));
+
+    // Degenerate (fewer than 4 vertices) can't self-cross.
+    assert!(!closed_loop_self_intersects(&square[..3]));
+}
+
+/// Build a dense closed loop for a thin annular sector centred at
+/// (0, -radius) (the issue #820 topology): an outer arc at `radius` and an
+/// inner arc at `radius - thickness`, swept `span` radians and joined by
+/// short radial caps. `seg` samples per arc.
+fn annular_sector_loop(radius: f64, thickness: f64, span: f64, seg: usize) -> Vec<Point2<f64>> {
+    let c = Point2::new(0.0, -radius);
+    let mut loop_ = Vec::with_capacity(2 * seg + 2);
+    for i in 0..=seg {
+        let a = -span / 2.0 + span * (i as f64 / seg as f64);
+        loop_.push(Point2::new(c.x + radius * a.cos(), c.y + radius * a.sin()));
+    }
+    let inner = radius - thickness;
+    for i in 0..=seg {
+        let a = span / 2.0 - span * (i as f64 / seg as f64);
+        loop_.push(Point2::new(c.x + inner * a.cos(), c.y + inner * a.sin()));
+    }
+    loop_
+}
+
+fn loop_area(loop_: &[Point2<f64>]) -> f64 {
+    let n = loop_.len();
+    let mut a = 0.0;
+    for i in 0..n {
+        let p = loop_[i];
+        let q = loop_[(i + 1) % n];
+        a += p.x * q.y - q.x * p.y;
+    }
+    (a * 0.5).abs()
+}
+
+#[test]
+fn simplify_thin_annular_sector_stays_simple_and_area_preserving() {
+    // Regression for issue #820 *and* the silent-area-distortion class the
+    // review flagged. A thin curved wall has a feature size (its thickness)
+    // far below the bbox diagonal; the thickness-capped RDP epsilon must
+    // keep every simplification both topologically simple (no folded-flap
+    // seam) and area-faithful. The first row is the real fixture's
+    // proportions (r=12000, 100 mm, 240°); the rest are the thicker/shorter
+    // sectors the reviewer reproduced losing/gaining 5–13% area under the
+    // un-capped epsilon.
+    let cases = [
+        (12000.0, 100.0, 240.0_f64),
+        (12000.0, 300.0, 240.0),
+        (12000.0, 600.0, 90.0),
+        (12000.0, 600.0, 180.0),
+    ];
+    for (radius, thickness, span_deg) in cases {
+        let span = span_deg.to_radians();
+        let dense = annular_sector_loop(radius, thickness, span, 200);
+        assert!(
+            !closed_loop_self_intersects(&dense),
+            "input sector r={radius} t={thickness} {span_deg}° should start simple",
+        );
+        let out = simplify_smooth_curve_polyline(&dense, 1.0);
+
+        // Topology: never a folded-flap seam.
+        assert!(
+            !closed_loop_self_intersects(&out),
+            "simplified sector r={radius} t={thickness} {span_deg}° self-intersects",
+        );
+
+        // Area: within 2% of the dense original (was up to ±13% pre-fix).
+        let (a_in, a_out) = (loop_area(&dense), loop_area(&out));
+        let rel = (a_out - a_in).abs() / a_in;
+        assert!(
+            rel < 0.02,
+            "sector r={radius} t={thickness} {span_deg}°: area drift {:.1}% \
+                 (in={a_in:.0} out={a_out:.0}) — thin curved wall was distorted",
+            rel * 100.0,
+        );
+    }
+}
+
+#[test]
+fn simplify_still_reduces_fat_round_disk() {
+    // Guards THIN_FEATURE_RATIO from being set so high it suppresses the
+    // issue #635 case it must preserve: an over-tessellated round window
+    // (a *fat* disk, half-thickness ≈ radius/2) must still simplify to a
+    // small recognizable polygon so void cuts fit the CSG polygon budget.
+    let mut disk = Vec::new();
+    let seg = 127;
+    for i in 0..seg {
+        let a = std::f64::consts::TAU * (i as f64 / seg as f64);
+        disk.push(Point2::new(0.5 * a.cos(), 0.5 * a.sin()));
+    }
+    let out = simplify_smooth_curve_polyline(&disk, 1.0);
+    assert!(
+        out.len() < disk.len() && out.len() >= SIMPLIFIED_MIN_VERTICES,
+        "round disk should simplify from {} to [{SIMPLIFIED_MIN_VERTICES}, {}) verts, got {}",
+        disk.len(),
+        disk.len(),
+        out.len(),
+    );
+    assert!(!closed_loop_self_intersects(&out));
+}
+
+fn ellipse_loop(ar: f64, seg: usize) -> Vec<Point2<f64>> {
+    let (a, b) = (ar * 0.5, 0.5);
+    (0..seg)
+        .map(|i| {
+            let t = std::f64::consts::TAU * (i as f64 / seg as f64);
+            Point2::new(a * t.cos(), b * t.sin())
+        })
+        .collect()
+}
+
+#[test]
+fn elongated_filled_ellipse_is_not_thin_gated() {
+    // Regression for the review's P1. An elongated *filled* ellipse is thin
+    // by the half-thickness/diagonal measure (an 8:1 ellipse sits at ~0.048,
+    // below THIN_FEATURE_RATIO, rising to ~0.020 at 20:1) — but it is convex
+    // and does NOT double back, so the thin gate must not fire on it. The
+    // earlier thinness-only gate wrongly skipped these, pinning a densely
+    // sampled elliptical opening at its full vertex count, overflowing the
+    // BSP void-cut budget and forcing the AABB-rectangle fallback (#635).
+    for ar in [6.0_f64, 8.0, 12.0, 20.0] {
+        assert!(
+            !loop_doubles_back(&ellipse_loop(ar, 128)),
+            "AR={ar} filled ellipse is convex — must not read as doubling back",
+        );
+    }
+
+    // With the gate no longer blocking it, an elongated ellipse simplifies
+    // exactly as it does without any thin gate (i.e. as on main): RDP +
+    // SIMPLIFIED_MIN_VERTICES. At 8:1, RDP retains ≥ the floor, so it
+    // genuinely reduces and stays simple. (Higher ratios bottom out at the
+    // floor and keep the original — a pre-existing #635 limitation, not the
+    // thin gate, and unchanged by this fix.)
+    let ellipse = ellipse_loop(8.0, 128);
+    let out = simplify_smooth_curve_polyline(&ellipse, 1.0);
+    assert!(
+        out.len() < ellipse.len() && out.len() >= SIMPLIFIED_MIN_VERTICES,
+        "8:1 ellipse must still simplify (was wrongly thin-gated): {} -> {} verts",
+        ellipse.len(),
+        out.len(),
+    );
+    assert!(!closed_loop_self_intersects(&out));
+    // Inscribed simplification of an elongated convex opening shaves a few
+    // percent — acceptable for a void approximation (and the same as main).
+    let rel = (loop_area(&out) - loop_area(&ellipse)).abs() / loop_area(&ellipse);
+    assert!(rel < 0.08, "8:1 ellipse area drift {:.1}%", rel * 100.0);
+}
+
+#[test]
+fn doubles_back_ignores_localized_spikes() {
+    // The reflex-fraction metric must flag a genuine two-arc annular sector
+    // but NOT a convex thin opening carrying a single localized defect — a
+    // lone inward notch or the sub-mm out-and-back jog where a composite
+    // curve closes. A total-turning measure double-counts such a spike and
+    // would wrongly gate these convex openings back into the #635 AABB cut.
+
+    // Genuine doubling-back: the #820 thin annular sector.
+    assert!(loop_doubles_back(&annular_sector_loop(
+        12000.0,
+        100.0,
+        (240.0_f64).to_radians(),
+        128
+    )));
+
+    // Clean convex ellipse — not doubling back.
+    let mut e = ellipse_loop(8.0, 128);
+    assert!(!loop_doubles_back(&e));
+
+    // ...with one deep inward notch at the blunt (x-tip) vertex. Find the
+    // vertex of greatest |x| and pull it 25% of the minor axis toward centre.
+    let tip = (0..e.len())
+        .max_by(|&i, &j| e[i].x.abs().partial_cmp(&e[j].x.abs()).unwrap())
+        .unwrap();
+    e[tip].x *= 0.75;
+    assert!(
+        !loop_doubles_back(&e),
+        "a single notch on a convex ellipse must not read as doubling back",
+    );
+
+    // Convex disk with a tiny out-and-back seam jog (a real, non-degenerate
+    // near-coincident self-intersection of the kind the #820 seam leaves).
+    let mut disk: Vec<Point2<f64>> = (0..128)
+        .map(|i| {
+            let t = std::f64::consts::TAU * (i as f64 / 128.0);
+            Point2::new(t.cos(), t.sin())
+        })
+        .collect();
+    // Insert a 1e-4 radial jog at vertex 0's neighbourhood.
+    disk.insert(1, Point2::new(disk[0].x * 0.9999, disk[0].y * 0.9999));
+    assert!(
+        !loop_doubles_back(&disk),
+        "a sub-mm seam jog on a convex loop must not read as doubling back",
+    );
+}
+
+#[test]
+fn doubles_back_independent_of_per_boundary_sampling_density() {
+    // Codex review: measuring reflex VERTICES (not arc length) let a thin
+    // sector slip when its two arcs are sampled at very different densities.
+    // Their exact example: a 90° sector, r=12000, thickness=10, with the
+    // convex outer arc finely sampled (96 segs) and the reflex inner arc
+    // coarsely (16 segs). A count fraction reads ~0.13 (< gate) and the
+    // wall is wrongly simplified to ~55% area drift; an arc-length fraction
+    // reads ~0.5 because the inner and outer arcs are nearly equal LENGTH.
+    let centre = Point2::new(0.0, -12000.0);
+    let (r_out, r_in) = (12000.0, 12000.0 - 10.0);
+    let span = (90.0_f64).to_radians();
+    let mut loop_ = Vec::new();
+    for i in 0..=96 {
+        let a = -span / 2.0 + span * (i as f64 / 96.0);
+        loop_.push(Point2::new(
+            centre.x + r_out * a.cos(),
+            centre.y + r_out * a.sin(),
+        ));
+    }
+    for i in 0..=16 {
+        let a = span / 2.0 - span * (i as f64 / 16.0);
+        loop_.push(Point2::new(
+            centre.x + r_in * a.cos(),
+            centre.y + r_in * a.sin(),
+        ));
+    }
+    assert!(
+        loop_doubles_back(&loop_),
+        "a non-uniformly tessellated thin sector must still read as doubling back",
+    );
+    // And it is gated end-to-end: simplify returns the faithful original.
+    let out = simplify_smooth_curve_polyline(&loop_, 1.0);
+    assert_eq!(
+        out.len(),
+        loop_.len(),
+        "skewed-sampling thin sector must be gated"
+    );
+}

--- a/rust/geometry/src/router/voids/mod.rs
+++ b/rust/geometry/src/router/voids/mod.rs
@@ -20,6 +20,8 @@ mod synthesis;
 mod reveal_tests;
 
 use geom::*;
+use sweep::{cut_changed_mesh, drop_faces_outside_host};
+mod sweep;
 
 /// Epsilon for normalizing direction vectors (guards against zero-length).
 const NORMALIZE_EPSILON: f64 = 1e-12;
@@ -39,8 +41,6 @@ const MAX_EXTRUSION_EXTRACT_DEPTH: usize = 32;
 /// apart on what counts as "engulfs the host".
 const ENGULF_TOLERANCE: f64 = 0.03;
 const ENGULF_TOLERANCE_F32: f32 = 0.03;
-
-
 
 /// Classification of an opening for void subtraction.
 #[derive(Clone)]
@@ -1107,6 +1107,7 @@ impl GeometryRouter {
         if ctx.is_noop() {
             return mesh;
         }
+        let original_host = mesh.clone(); // stray-shard sweep parity reference
 
         // LOCAL-FRAME CUT (issue #1167): a vertical wall rotated in plan is cut
         // in its own axis-aligned, origin-centred frame — where the exact
@@ -1489,10 +1490,11 @@ impl GeometryRouter {
                     if admissible {
                         let cutters: Vec<&Mesh> = extended.iter().map(|(_, m)| m).collect();
                         let tri_before = result.triangle_count();
+                        let vol_before = mesh_signed_volume(&result);
                         if let Ok(csg_result) = clipper.subtract_mesh_many(&result, &cutters) {
                             let min_tris = (tri_before / CSG_TRIANGLE_RETENTION_DIVISOR)
                                 .max(MIN_VALID_TRIANGLES);
-                            let changed = csg_result.triangle_count() != tri_before;
+                            let changed = cut_changed_mesh(&csg_result, tri_before, vol_before);
                             if !csg_result.is_empty()
                                 && csg_result.triangle_count() >= min_tris
                                 && changed
@@ -1630,18 +1632,11 @@ impl GeometryRouter {
                         depth_dir,
                     );
                     let cutter = &extended_opening;
+                    let vol_before = mesh_signed_volume(&result);
                     if let Ok(csg_result) = clipper.subtract_mesh(&result, cutter) {
                         let min_tris = (tri_before / CSG_TRIANGLE_RETENTION_DIVISOR)
                             .max(MIN_VALID_TRIANGLES);
-                        // CSG only counts as a success when the result actually
-                        // changed (either fewer triangles, indicating polygons
-                        // were removed, or more triangles, indicating the
-                        // opening was carved as new boundary tris). When the
-                        // safety thresholds in `subtract_mesh` short-circuit,
-                        // e.g. `MAX_CSG_POLYGONS_PER_MESH` rejects a high-poly
-                        // round/curved opening (issue #635), the host mesh is
-                        // returned unchanged, leaving the void uncut.
-                        let changed = csg_result.triangle_count() != tri_before;
+                        let changed = cut_changed_mesh(&csg_result, tri_before, vol_before);
                         csg_unchanged = !changed;
                         if !csg_result.is_empty()
                             && csg_result.triangle_count() >= min_tris
@@ -1855,6 +1850,11 @@ impl GeometryRouter {
             [wall_min.x as f32, wall_min.y as f32, wall_min.z as f32],
             [wall_max.x as f32, wall_max.y as f32, wall_max.z as f32],
         );
+
+        // STRAY-SHARD SWEEP: see `sweep::drop_faces_outside_host` (#1788).
+        if host_mutated {
+            result = drop_faces_outside_host(result, &original_host);
+        }
 
         // Per-host cut-effect snapshot: tris_before / tris_after lets the
         // diagnostic surface the silent-no-op case (rectangular boxes

--- a/rust/geometry/src/router/voids/sweep.rs
+++ b/rust/geometry/src/router/voids/sweep.rs
@@ -9,7 +9,7 @@ use super::geom::{mesh_is_closed_exact, mesh_point, mesh_signed_volume, point_in
 use crate::{Mesh, Point3};
 
 /// Whether a boolean produced a REAL change against the pre-cut host: the
-/// triangle count moved, or the enclosed (signed) volume moved beyond noise.
+/// triangle count moved, or the enclosed volume moved beyond noise.
 ///
 /// Triangle count alone misreads two opposite cases (#1788):
 ///  * an end/miter cut can replace a 12-tri box host with another 12-tri box —
@@ -18,6 +18,12 @@ use crate::{Mesh, Point3};
 ///    carved the cutter's axis-aligned world box instead;
 ///  * a kernel short-circuit returns the host byte-identical — count AND
 ///    volume are equal, which this test still (correctly) reads as unchanged.
+///
+/// Volumes are compared by MAGNITUDE: the kernel's `orient_outward`
+/// normalization can hand back a no-op subtraction of an inward-wound host
+/// with its winding flipped, and comparing raw signed values would read that
+/// as a ~2x volume change — accepting an UNCUT mesh and skipping the #635
+/// fallback (codex P1 on #1802).
 ///
 /// The volume tolerance is deliberately COARSE (0.1% relative): a rejected /
 /// short-circuited subtract may return the host re-snapped rather than
@@ -30,9 +36,21 @@ pub(super) fn cut_changed_mesh(result: &Mesh, tris_before: usize, vol_before: f6
     if result.triangle_count() != tris_before {
         return true;
     }
-    let vol_after = mesh_signed_volume(result);
-    (vol_after - vol_before).abs() > vol_before.abs().max(1.0e-9) * 1.0e-3
+    let vol_after = mesh_signed_volume(result).abs();
+    let vol_before = vol_before.abs();
+    (vol_after - vol_before).abs() > vol_before.max(1.0e-9) * 1.0e-3
 }
+
+/// Cap on `result_triangles x host_triangles` for the shard sweep. Every swept
+/// face costs up to five parity/distance queries, each a linear scan of the
+/// reference host, so the sweep is O(result·host); this cap bounds it to
+/// ~10M ray-triangle tests (a few ms) so a high-tessellation closed host can
+/// never stall the geometry stream on an already-expensive cut (codex P1 on
+/// #1802). Over budget the sweep is skipped — the pre-#1788 behaviour — which
+/// degrades to "shard stays", never to a wrong drop. The observed shard class
+/// lives on simple extrusion hosts (12..~200 reference triangles), far below
+/// the cap. Deterministic: a pure function of the two triangle counts.
+const SWEEP_COST_BUDGET: usize = 2_000_000;
 
 /// `true` iff `p` is farther than `tol` from EVERY triangle of `mesh`
 /// (point-to-triangle distance, plain f64). Early-outs on the first triangle
@@ -95,6 +113,84 @@ fn point_mesh_distance_exceeds(mesh: &Mesh, p: &Point3<f64>, tol: f64) -> bool {
     true
 }
 
+/// `true` when `mesh` decomposes into 2+ vertex-connected components whose
+/// AABBs overlap. `process_element` builds hosts by CONCATENATING
+/// representation items, so a multi-solid element can be several closed
+/// shells occupying shared space; odd/even parity across overlapping shells
+/// classifies overlap-interior points as OUTSIDE, which would let the sweep
+/// delete legitimate faces (codex P2 on #1802). Disjoint-AABB shells keep
+/// parity sound (a point is interior to at most one shell) and stay eligible.
+/// Components by bit-exact vertex position (the mesh is pre-welded).
+fn overlapping_components(mesh: &Mesh) -> bool {
+    use std::collections::HashMap;
+    let nverts = mesh.positions.len() / 3;
+    let mut parent: Vec<u32> = (0..nverts as u32).collect();
+    fn find(parent: &mut [u32], mut x: u32) -> u32 {
+        while parent[x as usize] != x {
+            parent[x as usize] = parent[parent[x as usize] as usize];
+            x = parent[x as usize];
+        }
+        x
+    }
+    // Merge bit-identical positions (welded mesh; belt-and-braces), then
+    // merge each triangle's vertices.
+    let mut by_pos: HashMap<(u32, u32, u32), u32> = HashMap::new();
+    for i in 0..nverts {
+        let b = i * 3;
+        let key = (
+            mesh.positions[b].to_bits(),
+            mesh.positions[b + 1].to_bits(),
+            mesh.positions[b + 2].to_bits(),
+        );
+        match by_pos.get(&key) {
+            Some(&j) => {
+                let (a, b2) = (find(&mut parent, i as u32), find(&mut parent, j));
+                parent[a as usize] = b2;
+            }
+            None => {
+                by_pos.insert(key, i as u32);
+            }
+        }
+    }
+    for tri in mesh.indices.chunks_exact(3) {
+        let a = find(&mut parent, tri[0]);
+        let b = find(&mut parent, tri[1]);
+        parent[a as usize] = b;
+        let b = find(&mut parent, tri[1]);
+        let c = find(&mut parent, tri[2]);
+        parent[b as usize] = c;
+    }
+    // Per-component AABB over triangle vertices.
+    let mut boxes: HashMap<u32, ([f32; 3], [f32; 3])> = HashMap::new();
+    for tri in mesh.indices.chunks_exact(3) {
+        let root = find(&mut parent, tri[0]);
+        let entry = boxes
+            .entry(root)
+            .or_insert(([f32::INFINITY; 3], [f32::NEG_INFINITY; 3]));
+        for &vi in tri {
+            let b = vi as usize * 3;
+            for k in 0..3 {
+                entry.0[k] = entry.0[k].min(mesh.positions[b + k]);
+                entry.1[k] = entry.1[k].max(mesh.positions[b + k]);
+            }
+        }
+    }
+    if boxes.len() < 2 {
+        return false;
+    }
+    let list: Vec<&([f32; 3], [f32; 3])> = boxes.values().collect();
+    for i in 0..list.len() {
+        for j in (i + 1)..list.len() {
+            let (amn, amx) = list[i];
+            let (bmn, bmx) = list[j];
+            if (0..3).all(|k| amn[k] <= bmx[k] && bmn[k] <= amx[k]) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
 /// Drop cut-result faces that have NO original-host material on either side.
 ///
 /// A subtract can only remove material, so every legitimate face of the cut
@@ -108,22 +204,40 @@ fn point_mesh_distance_exceeds(mesh: &Mesh, p: &Point3<f64>, tol: f64) -> bool {
 /// parity ray as [`point_inside_mesh`]; a real face's kept side is inside by
 /// ~a wall thickness, orders beyond ε.
 ///
-/// GATE: the sweep runs only when the (1 µm-welded) original host is
-/// bit-exact CLOSED — a closed reference makes the parity test sound, so every
-/// both-sides-outside face is provably an artifact and there is no drop cap.
-/// A non-closed reference (open imported brep) makes parity unreliable, so
-/// the sweep is skipped entirely rather than risk eating legitimate faces.
+/// GATES (all bail out to the un-swept result, the pre-#1788 behaviour):
+///  * the (1 µm-welded) reference host must be bit-exact CLOSED — a closed
+///    reference makes the parity test sound, so every both-sides-outside face
+///    is provably an artifact and there is no drop cap; an open reference
+///    would risk eating legitimate faces. The SAME welded mesh is then used
+///    for every parity/distance query, so sub-µm seams in the raw original
+///    can't pass the gate and still misclassify (CodeRabbit on #1802);
+///  * no overlapping vertex-connected components (see
+///    [`overlapping_components`]) — parity across overlapping closed shells
+///    reads overlap-interior points as outside;
+///  * `result x host` triangle product within [`SWEEP_COST_BUDGET`];
+///  * every result index in bounds (a malformed triangle would panic in the
+///    compaction slice below).
+///
 /// DETERMINISM: plain FMA-free f64, fixed probe direction and iteration order
 /// ⇒ byte-identical native==wasm.
 pub(super) fn drop_faces_outside_host(result: Mesh, original_host: &Mesh) -> Mesh {
     if result.indices.is_empty() || original_host.indices.is_empty() {
         return result;
     }
-    if !mesh_is_closed_exact(&original_host.welded_by_position(1.0e-6)) {
+    let tri_count = result.indices.len() / 3;
+    let vert_count = result.positions.len() / 3;
+    if result.indices.iter().any(|&i| i as usize >= vert_count) {
         return result;
     }
+    if tri_count.saturating_mul(original_host.indices.len() / 3) > SWEEP_COST_BUDGET {
+        return result;
+    }
+    let reference_host = original_host.welded_by_position(1.0e-6);
+    if !mesh_is_closed_exact(&reference_host) || overlapping_components(&reference_host) {
+        return result;
+    }
+    let reference_host = &reference_host;
     const EPS: f64 = 5.0e-5;
-    let tri_count = result.indices.len() / 3;
     let mut keep: Vec<bool> = Vec::with_capacity(tri_count);
     let mut dropped = 0usize;
     for tri in result.indices.chunks_exact(3) {
@@ -154,11 +268,11 @@ pub(super) fn drop_faces_outside_host(result: Mesh, original_host: &Mesh) -> Mes
         // misses it. The 1 mm clearance keeps host-surface vertices (distance
         // ~0) and corner-grazing parity noise safe.
         const VERTEX_CLEARANCE: f64 = 1.0e-3;
-        let centroid_out = !point_inside_mesh(original_host, centroid + off)
-            && !point_inside_mesh(original_host, centroid - off);
+        let centroid_out = !point_inside_mesh(reference_host, centroid + off)
+            && !point_inside_mesh(reference_host, centroid - off);
         let vertex_out = [a, b, c].iter().any(|&v| {
-            !point_inside_mesh(original_host, v)
-                && point_mesh_distance_exceeds(original_host, &v, VERTEX_CLEARANCE)
+            !point_inside_mesh(reference_host, v)
+                && point_mesh_distance_exceeds(reference_host, &v, VERTEX_CLEARANCE)
         });
         let kept = !(centroid_out || vertex_out);
         if !kept {
@@ -172,7 +286,6 @@ pub(super) fn drop_faces_outside_host(result: Mesh, original_host: &Mesh) -> Mes
     // Rebuild with COMPACTED vertex arrays: bounds/hull consumers read the
     // position array directly, so an orphaned shard vertex would keep
     // inflating them even with its faces gone.
-    let vert_count = result.positions.len() / 3;
     let mut remap: Vec<u32> = vec![u32::MAX; vert_count];
     let mut out = result.clone();
     out.positions.clear();

--- a/rust/geometry/src/router/voids/sweep.rs
+++ b/rust/geometry/src/router/voids/sweep.rs
@@ -1,0 +1,201 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Post-cut hygiene for void subtraction (#1788): real-change detection and
+//! the stray-shard sweep against the original (pre-cut) host.
+
+use super::geom::{mesh_is_closed_exact, mesh_point, mesh_signed_volume, point_inside_mesh};
+use crate::{Mesh, Point3};
+
+/// Whether a boolean produced a REAL change against the pre-cut host: the
+/// triangle count moved, or the enclosed (signed) volume moved beyond noise.
+///
+/// Triangle count alone misreads two opposite cases (#1788):
+///  * an end/miter cut can replace a 12-tri box host with another 12-tri box —
+///    same count, 8.5% volume moved (ISSUE_129 `IGC_MUR` wedge); count-only
+///    detection threw the perfect cut away and the #635 AABB fallback then
+///    carved the cutter's axis-aligned world box instead;
+///  * a kernel short-circuit returns the host byte-identical — count AND
+///    volume are equal, which this test still (correctly) reads as unchanged.
+///
+/// The volume tolerance is deliberately COARSE (0.1% relative): a rejected /
+/// short-circuited subtract may return the host re-snapped rather than
+/// byte-identical, and reading that noise as "changed" would silently skip
+/// the #635 fallback machinery. A same-count REAL cut moves volume by orders
+/// of magnitude more (8.5% on the ISSUE_129 wedge); a real cut smaller than
+/// 0.1% of the host that ALSO keeps the triangle count identical stays on
+/// the (pre-existing) fallback path, no worse than before.
+pub(super) fn cut_changed_mesh(result: &Mesh, tris_before: usize, vol_before: f64) -> bool {
+    if result.triangle_count() != tris_before {
+        return true;
+    }
+    let vol_after = mesh_signed_volume(result);
+    (vol_after - vol_before).abs() > vol_before.abs().max(1.0e-9) * 1.0e-3
+}
+
+/// `true` iff `p` is farther than `tol` from EVERY triangle of `mesh`
+/// (point-to-triangle distance, plain f64). Early-outs on the first triangle
+/// within `tol`.
+fn point_mesh_distance_exceeds(mesh: &Mesh, p: &Point3<f64>, tol: f64) -> bool {
+    let tol2 = tol * tol;
+    for tri in mesh.indices.chunks_exact(3) {
+        let (Some(a), Some(b), Some(c)) = (
+            mesh_point(mesh, tri[0]),
+            mesh_point(mesh, tri[1]),
+            mesh_point(mesh, tri[2]),
+        ) else {
+            continue;
+        };
+        // Closest point on triangle (Ericson, Real-Time Collision Detection).
+        let ab = b - a;
+        let ac = c - a;
+        let ap = p - a;
+        let d1 = ab.dot(&ap);
+        let d2 = ac.dot(&ap);
+        let q = if d1 <= 0.0 && d2 <= 0.0 {
+            a
+        } else {
+            let bp = p - b;
+            let d3 = ab.dot(&bp);
+            let d4 = ac.dot(&bp);
+            if d3 >= 0.0 && d4 <= d3 {
+                b
+            } else {
+                let vc = d1 * d4 - d3 * d2;
+                if vc <= 0.0 && d1 >= 0.0 && d3 <= 0.0 {
+                    a + ab * (d1 / (d1 - d3))
+                } else {
+                    let cp = p - c;
+                    let d5 = ab.dot(&cp);
+                    let d6 = ac.dot(&cp);
+                    if d6 >= 0.0 && d5 <= d6 {
+                        c
+                    } else {
+                        let vb = d5 * d2 - d1 * d6;
+                        if vb <= 0.0 && d2 >= 0.0 && d6 <= 0.0 {
+                            a + ac * (d2 / (d2 - d6))
+                        } else {
+                            let va = d3 * d6 - d5 * d4;
+                            if va <= 0.0 && (d4 - d3) >= 0.0 && (d5 - d6) >= 0.0 {
+                                b + (c - b) * ((d4 - d3) / ((d4 - d3) + (d5 - d6)))
+                            } else {
+                                let denom = 1.0 / (va + vb + vc);
+                                a + ab * (vb * denom) + ac * (vc * denom)
+                            }
+                        }
+                    }
+                }
+            }
+        };
+        if (p - q).norm_squared() <= tol2 {
+            return false;
+        }
+    }
+    true
+}
+
+/// Drop cut-result faces that have NO original-host material on either side.
+///
+/// A subtract can only remove material, so every legitimate face of the cut
+/// result — host skin or cutter reveal — bounds kept material that lies inside
+/// the ORIGINAL (pre-cut) host solid. A face whose both sides sit outside that
+/// solid is provably an artifact: the sequential exact subtract on an
+/// already-cut host can misclassify and keep a stray extended-cutter cap
+/// fragment ~1 m off the wall plane (the ISSUE_098 Poroton family, #1788 —
+/// invisible to the volume gates, but it inflates the hull/AABB and renders as
+/// a floating shard). Probes `centroid ± ε·normal` (ε = 50 µm) with the same
+/// parity ray as [`point_inside_mesh`]; a real face's kept side is inside by
+/// ~a wall thickness, orders beyond ε.
+///
+/// GATE: the sweep runs only when the (1 µm-welded) original host is
+/// bit-exact CLOSED — a closed reference makes the parity test sound, so every
+/// both-sides-outside face is provably an artifact and there is no drop cap.
+/// A non-closed reference (open imported brep) makes parity unreliable, so
+/// the sweep is skipped entirely rather than risk eating legitimate faces.
+/// DETERMINISM: plain FMA-free f64, fixed probe direction and iteration order
+/// ⇒ byte-identical native==wasm.
+pub(super) fn drop_faces_outside_host(result: Mesh, original_host: &Mesh) -> Mesh {
+    if result.indices.is_empty() || original_host.indices.is_empty() {
+        return result;
+    }
+    if !mesh_is_closed_exact(&original_host.welded_by_position(1.0e-6)) {
+        return result;
+    }
+    const EPS: f64 = 5.0e-5;
+    let tri_count = result.indices.len() / 3;
+    let mut keep: Vec<bool> = Vec::with_capacity(tri_count);
+    let mut dropped = 0usize;
+    for tri in result.indices.chunks_exact(3) {
+        let (Some(a), Some(b), Some(c)) = (
+            mesh_point(&result, tri[0]),
+            mesh_point(&result, tri[1]),
+            mesh_point(&result, tri[2]),
+        ) else {
+            keep.push(true);
+            continue;
+        };
+        let centroid = Point3::new(
+            (a.x + b.x + c.x) / 3.0,
+            (a.y + b.y + c.y) / 3.0,
+            (a.z + b.z + c.z) / 3.0,
+        );
+        let n = (b - a).cross(&(c - a));
+        let len = n.norm();
+        if len <= 0.0 {
+            keep.push(true); // degenerate; other hygiene passes own these
+            continue;
+        }
+        let off = n * (EPS / len);
+        // A face is an artifact when (a) BOTH sides of its centroid are
+        // outside the host, or (b) any of its vertices sits STRICTLY outside
+        // the host with real clearance — a needle that PIERCES the host keeps
+        // its centroid inside while a far vertex hangs ~1 m out, so (a) alone
+        // misses it. The 1 mm clearance keeps host-surface vertices (distance
+        // ~0) and corner-grazing parity noise safe.
+        const VERTEX_CLEARANCE: f64 = 1.0e-3;
+        let centroid_out = !point_inside_mesh(original_host, centroid + off)
+            && !point_inside_mesh(original_host, centroid - off);
+        let vertex_out = [a, b, c].iter().any(|&v| {
+            !point_inside_mesh(original_host, v)
+                && point_mesh_distance_exceeds(original_host, &v, VERTEX_CLEARANCE)
+        });
+        let kept = !(centroid_out || vertex_out);
+        if !kept {
+            dropped += 1;
+        }
+        keep.push(kept);
+    }
+    if dropped == 0 || dropped == tri_count {
+        return result;
+    }
+    // Rebuild with COMPACTED vertex arrays: bounds/hull consumers read the
+    // position array directly, so an orphaned shard vertex would keep
+    // inflating them even with its faces gone.
+    let vert_count = result.positions.len() / 3;
+    let mut remap: Vec<u32> = vec![u32::MAX; vert_count];
+    let mut out = result.clone();
+    out.positions.clear();
+    out.normals.clear();
+    out.indices.clear();
+    let has_normals = result.normals.len() == result.positions.len();
+    for (i, tri) in result.indices.chunks_exact(3).enumerate() {
+        if !keep[i] {
+            continue;
+        }
+        for &vi in tri {
+            let v = vi as usize;
+            if remap[v] == u32::MAX {
+                remap[v] = (out.positions.len() / 3) as u32;
+                out.positions
+                    .extend_from_slice(&result.positions[v * 3..v * 3 + 3]);
+                if has_normals {
+                    out.normals
+                        .extend_from_slice(&result.normals[v * 3..v * 3 + 3]);
+                }
+            }
+            out.indices.push(remap[v]);
+        }
+    }
+    out
+}


### PR DESCRIPTION
Fixes the highest-priority residuals from the 2026-07-17 T1-T6 correctness sweep vs IfcOpenShell 0.8.2 (#1788), and adjudicates the rest with evidence. Refs #1788.

## Per-pattern verdicts

| Pattern | Verdict | Detail |
|---|---|---|
| ISSUE_098 T6 `fail:opening-not-cut` (host `3t$lfYI2X2WPqlGTL_5URT`) | **FIXED (ours)** | `subtract_many`'s lenient-batch volume oracle re-ran the *sequential* subtract chain, which re-jitters its own seams cut-over-cut and under-cuts multi-void walls; a perfect batch (0.07% off true volume) was rejected because the broken chain removed 2% less. Oracle replaced with Σ per-cutter intersection volumes on the pristine host. All 7 openings of the wall now cut cleanly (wall-material-in-opening fraction 0.000 for every opening). |
| ISSUE_098 5x `fail:volume` + hull-inflation Poroton `1AR_MUR_CV003` walls | **FIXED (ours)** | Same oracle fix, plus a new stray-shard sweep: the sequential path's misclassified extended-cutter fragments sat ~1 m off the (plan-rotated) wall plane, inside the world AABB, inflating hull volume 1.43x. Faces with no original-host material on either side are provably not part of `host − openings` and are dropped (parity reference gated on a bit-exact-closed host). Hulls now match IfcOpenShell to 4 significant digits (42.472 vs 42.471, 54.09 vs 54.09). |
| ISSUE_098 3x `fail:shape` slabs `1AR_PAV_CS008` (392 vs 60-64 tris) | **FIXED (ours)** | NOT holes/inner boundaries — the profile is 4 trimmed circular arcs, tessellated correctly (~60 pts) and then decimated to 17 points by the smooth-curve RDP whose epsilon scales with profile diagonal (25 mm on this 2.5 m slab). Epsilon now capped at an absolute 10 mm through the file's length unit; window-scale cutters (the #635 target) are unchanged. Slab volume error 1.2% -> 0.35%, voxel IoU passes. |
| ISSUE_129 `fail:shape` wall `IGC_MUR_EGC-TUN-VOILE-300` | **FIXED (ours)** | The miter-wedge cut replaced the 12-tri box host with another 12-tri box; the count-only "changed" test discarded the perfect cut (volume moved 8.5%!) and the #635 AABB fallback then carved the cutter's world-axis box (over-cut) while the flush second opening was AABB-cut too. Change detection is now count OR volume. Both openings now behave exactly like IfcOpenShell (wedge cut applied; flush opening a no-op). |
| ISSUE_129 `fail:volume` column `IGC_POT_1.800 x 0.800` | **STILL OPEN (ours, documented kernel limitation)** | The inner polygonal-bounded-halfspace clip is now verified byte-correct (removes exactly the top 1.2 m except the notch column, vol 8.6471). The OUTER solid-solid difference (notch prism, congruent with the remaining material chunk) misclassifies on the once-cut host: result volume *increases* 8.6471 -> 8.7532 and stray shells remain above the cut plane. Minimal repro pinned during this work (box-minus-PBHS result minus congruent notch prism); a volume-monotonicity guard was tried and rejected (the open-boundary flux makes the violation unmeasurable at safe tolerances). Root cause is the sequential-boolean-on-once-cut-host classification family; needs kernel-level work. |
| 170_KM_tekla 38x `fail:position` railing posts + 12x `fail:volume` bracing | **STILL OPEN (ours — NOT IfcOpenShell dropping parts)** | Adjudicated from STEP: each post is a CSG chain (`base − cutter − tube − tube − tube`). Our mesh keeps a ~0.48 m slab of the base plate that the first solid-solid difference should trim (IOS trims it; our result also has inverted-winding damage: signed volume −0.0006 vs IOS +0.0000066). Same sequential-boolean-chain kernel family as the ISSUE_129 column. No evidence of IOS dropping sub-parts. |
| ISSUE_098 1x `fail:shape` wall `1AR_MUR_PV101+102` | **NEEDS VISUAL ADJUDICATION** | Both engines produce the byte-identical opening solid (44 tris, 4.288 m³ — verified by meshing the opening with ifcopenshell directly). They disagree only on the boolean: we remove 0.29 m³ more than IOS (our wall 0.640 m³ vs IOS 0.929 m³) on this near-engulfing rotated brep opening. Which result is right needs a side-by-side visual. |
| ISSUE_098 1x `only_a` IfcSlab `1AR_PAV_CS006` | **NOT OURS (IOS dropout)** | Valid `IfcExtrudedAreaSolid` over a mixed polyline+trimmed-arc composite profile; we mesh it (254 tris), IfcOpenShell emits nothing. Schema justifies emitting it. |

## Harness before/after (profiling repo T1-T6, per-element verdicts; NEW = this branch, OLD = native @ 33a952f7)

| Model | OLD | NEW | Regressions |
|---|---|---|---|
| ISSUE_098 (11,123 el) | 11,103 pass / **9 fail** / 11 warn; T6 **1 fail** + 5 warn | 11,115 pass / **1 fail** / 7 warn; T6 **0 fail** + 4 warn | none |
| ISSUE_129 (959 el) | 957 pass / **2 fail** | 956 pass / **1 fail** / 2 warn; T6 361/361 | none |
| duplex (215 el) | 210 pass / 5 warn | 212 pass / 3 warn | none |
| 170_KM_tekla (16,622 el) | 16,559 pass / **50 fail** / 13 warn | 16,556 pass / **50 fail** / 16 warn | none (3 pass -> warn:hausdorff, tessellation-density warns) |

## Tests

- `cargo test -p ifc-lite-geometry -p ifc-lite-processing`: 611+ passed, **1 pre-existing failure** — `production_smiley_all_host_walls_have_holes` fails identically (same 3/190 hosts) on clean origin/main `4c30f2d5` in this environment, verified before any change; not introduced or affected by this branch.
- Module-size ratchet green (new `router/voids/sweep.rs`, `profiles/simplify_tests.rs` split keeps every touched file within budget).
- Changeset added for `@ifc-lite/wasm`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for batched void subtraction to better accept correct “lenient” results and avoid seam/jitter rejections.
  * Corrected end/miter cut handling so volume changes are properly recognized.
  * Added post-void cleanup to drop stray shards outside the original solid, improving bounds/hull behavior.
* **New Features**
  * Improved profile smooth-curve simplification with unit-aware clamping to prevent over-decimation on large curves.
* **Tests**
  * Expanded regression and unit-invariance tests for curve simplification (including self-intersection and mm vs m behavior).
* **Release**
  * Patch release for `@ifc-lite/wasm`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->