### PR TITLE
perf(geometry): beat web-ifc 0.0.77 on the full corpus — 2D + analytic-prism opening subtraction

### DIFF
--- a/.changeset/perf-prism-cut-subtraction.md
+++ b/.changeset/perf-prism-cut-subtraction.md
@@ -1,0 +1,7 @@
+---
+"@ifc-lite/wasm": patch
+---
+
+perf(geometry): analytic prism (stepped-extrusion) void subtraction on the host mesh
+
+Subtract rectangular and rebated (stepped) prism openings — the dominant expensive void cut on CSG-heavy masonry models — analytically on ANY host mesh (faceted-brep, clipped, multi-item), instead of running the exact mesh-arrangement kernel. The cutter must weld to a closed manifold whose facets are all parallel or perpendicular to one depth axis; its per-slab cross-sections are sliced into a stepped-extrusion stack, then the host triangles are decomposed by a conforming per-triangle CDT constrained by the exact host∩cutter seam segments, and each cutter face's reveal cap is triangulated and classified by ray parity against the host solid. Every cut passes hard self-checks — an f64 volume identity (outside + inside == host, 0 < removed <= cutter volume) and a closed-surface audit stricter than the exact kernel's own output — or the host defers to the exact kernel with its full opening set (residual openings compose through the same recursion contract as the 2D path). On ISSUE_098-class models this takes native geometry from ~3.9 s to ~2.4-2.6 s at 10 threads, past web-ifc, with no per-element verdict regression on the IfcOpenShell correctness harness. Gate `IFC_LITE_PRISM_CUT=0` to force the exact kernel. Default ON on native and wasm.

--- a/.changeset/perf-void-2d-subtraction.md
+++ b/.changeset/perf-void-2d-subtraction.md
@@ -1,0 +1,7 @@
+---
+"@ifc-lite/wasm": patch
+---
+
+perf(geometry): 2D opening-subtraction fast path for extruded hosts
+
+Wire IfcOpenShell's `boolean-attempt-2d` technique into the void-cutting pipeline. For an extruded host whose openings penetrate straight through the extrusion depth (parallel to the host axis), the exact 3D mesh-boolean is replaced by a cheap 2D polygon difference on the host profile plus a re-extrude of the holed profile. Per-opening hybrid: eligible through-openings take the 2D path, ineligible ones (perpendicular sleeves, partial-depth recesses) fall to the exact kernel on the re-extruded host, so one ineligible opening no longer forfeits a host's cheap ones. Every host reconciles by bounds + volume against the real mesh and self-checks watertight before it is emitted; any doubt defers to the exact kernel with the full opening set, so geometry output is equivalent (validated against the IfcOpenShell correctness harness — no per-element verdict regression). Gate `IFC_LITE_VOID_2D=0` to force the exact kernel. Default ON on native and wasm.

--- a/rust/geometry/src/bool2d.rs
+++ b/rust/geometry/src/bool2d.rs
@@ -102,6 +102,36 @@ pub fn subtract_multiple_2d(
     shapes_to_profile(&result)
 }
 
+/// Like [`subtract_multiple_2d`], but also reports how many DISCONNECTED output
+/// shapes the difference produced (each with non-degenerate area). The returned
+/// `Profile2D` is the largest shape (as [`subtract_multiple_2d`]); a caller that
+/// must not silently drop geometry — the 2D opening-subtraction re-extrude —
+/// checks `shapes == 1` and otherwise defers to the exact kernel (a void that
+/// splits the profile into pieces can't be re-extruded from a single profile).
+pub fn subtract_multiple_2d_counted(
+    profile: &Profile2D,
+    void_contours: &[Vec<Point2<f64>>],
+) -> Result<(Profile2D, usize)> {
+    let valid_contours: Vec<_> = void_contours.iter().filter(|c| c.len() >= 3).collect();
+    if valid_contours.is_empty() {
+        return Ok((profile.clone(), 1));
+    }
+    let subject = profile_to_paths(profile);
+    let clip: Vec<Vec<[f64; 2]>> = valid_contours.iter().map(|c| contour_to_path(c)).collect();
+    let result = subject.overlay(&clip, OverlayRule::Difference, FillRule::EvenOdd);
+    let shapes = result
+        .iter()
+        .filter(|s| {
+            s.first().is_some_and(|outer| {
+                let ring: Vec<Point2<f64>> =
+                    outer.iter().map(|p| Point2::new(p[0], p[1])).collect();
+                compute_signed_area(&ring).abs() > MIN_AREA_THRESHOLD
+            })
+        })
+        .count();
+    Ok((shapes_to_profile(&result)?, shapes))
+}
+
 /// Check if a contour is valid (has area, not degenerate)
 pub fn is_valid_contour(contour: &[Point2<f64>]) -> bool {
     if contour.len() < 3 {
@@ -271,143 +301,5 @@ fn shapes_to_profile(shapes: &[Vec<Vec<[f64; 2]>>]) -> Result<Profile2D> {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_compute_signed_area_ccw() {
-        // Counter-clockwise square
-        let contour = vec![
-            Point2::new(0.0, 0.0),
-            Point2::new(1.0, 0.0),
-            Point2::new(1.0, 1.0),
-            Point2::new(0.0, 1.0),
-        ];
-        let area = compute_signed_area(&contour);
-        assert!((area - 1.0).abs() < EPSILON_2D);
-    }
-
-    #[test]
-    fn test_compute_signed_area_cw() {
-        // Clockwise square
-        let contour = vec![
-            Point2::new(0.0, 0.0),
-            Point2::new(0.0, 1.0),
-            Point2::new(1.0, 1.0),
-            Point2::new(1.0, 0.0),
-        ];
-        let area = compute_signed_area(&contour);
-        assert!((area + 1.0).abs() < EPSILON_2D);
-    }
-
-    #[test]
-    fn test_ensure_ccw() {
-        // Clockwise square
-        let cw = vec![
-            Point2::new(0.0, 0.0),
-            Point2::new(0.0, 1.0),
-            Point2::new(1.0, 1.0),
-            Point2::new(1.0, 0.0),
-        ];
-        let ccw = ensure_ccw(&cw);
-        assert!(compute_signed_area(&ccw) > 0.0);
-    }
-
-    #[test]
-    fn test_subtract_2d_simple() {
-        // 10x10 square profile
-        let profile = Profile2D::new(vec![
-            Point2::new(0.0, 0.0),
-            Point2::new(10.0, 0.0),
-            Point2::new(10.0, 10.0),
-            Point2::new(0.0, 10.0),
-        ]);
-
-        // 2x2 square void in the center
-        let void_contour = vec![
-            Point2::new(4.0, 4.0),
-            Point2::new(6.0, 4.0),
-            Point2::new(6.0, 6.0),
-            Point2::new(4.0, 6.0),
-        ];
-
-        let result = subtract_2d(&profile, &void_contour).unwrap();
-
-        // Should have one hole
-        assert_eq!(result.holes.len(), 1);
-
-        // Outer boundary should be preserved
-        assert_eq!(result.outer.len(), 4);
-    }
-
-    #[test]
-    fn test_subtract_multiple_2d() {
-        // 10x10 square profile
-        let profile = Profile2D::new(vec![
-            Point2::new(0.0, 0.0),
-            Point2::new(10.0, 0.0),
-            Point2::new(10.0, 10.0),
-            Point2::new(0.0, 10.0),
-        ]);
-
-        // Two 1x1 voids
-        let voids = vec![
-            vec![
-                Point2::new(2.0, 2.0),
-                Point2::new(3.0, 2.0),
-                Point2::new(3.0, 3.0),
-                Point2::new(2.0, 3.0),
-            ],
-            vec![
-                Point2::new(7.0, 7.0),
-                Point2::new(8.0, 7.0),
-                Point2::new(8.0, 8.0),
-                Point2::new(7.0, 8.0),
-            ],
-        ];
-
-        let result = subtract_multiple_2d(&profile, &voids).unwrap();
-
-        // Should have two holes
-        assert_eq!(result.holes.len(), 2);
-    }
-
-    #[test]
-    fn test_point_in_contour() {
-        let contour = vec![
-            Point2::new(0.0, 0.0),
-            Point2::new(10.0, 0.0),
-            Point2::new(10.0, 10.0),
-            Point2::new(0.0, 10.0),
-        ];
-
-        assert!(point_in_contour(&Point2::new(5.0, 5.0), &contour));
-        assert!(!point_in_contour(&Point2::new(15.0, 5.0), &contour));
-        assert!(!point_in_contour(&Point2::new(-1.0, 5.0), &contour));
-    }
-
-    #[test]
-    fn test_is_valid_contour() {
-        // Valid square
-        let valid = vec![
-            Point2::new(0.0, 0.0),
-            Point2::new(1.0, 0.0),
-            Point2::new(1.0, 1.0),
-            Point2::new(0.0, 1.0),
-        ];
-        assert!(is_valid_contour(&valid));
-
-        // Degenerate (all points collinear)
-        let degenerate = vec![
-            Point2::new(0.0, 0.0),
-            Point2::new(1.0, 0.0),
-            Point2::new(2.0, 0.0),
-        ];
-        assert!(!is_valid_contour(&degenerate));
-
-        // Too few points
-        let too_few = vec![Point2::new(0.0, 0.0), Point2::new(1.0, 0.0)];
-        assert!(!is_valid_contour(&too_few));
-    }
-
-}
+#[path = "bool2d_tests.rs"]
+mod tests;

--- a/rust/geometry/src/bool2d.rs
+++ b/rust/geometry/src/bool2d.rs
@@ -119,15 +119,16 @@ pub fn subtract_multiple_2d_counted(
     let subject = profile_to_paths(profile);
     let clip: Vec<Vec<[f64; 2]>> = valid_contours.iter().map(|c| contour_to_path(c)).collect();
     let result = subject.overlay(&clip, OverlayRule::Difference, FillRule::EvenOdd);
+    // Count EVERY non-empty output shape (any outer contour with >= 3 vertices),
+    // NOT just those above MIN_AREA_THRESHOLD. This gate decides single-vs-multi
+    // shape for the caller: only `shapes == 1` lets the re-extrude proceed with the
+    // largest shape. Filtering by area would let a valid-but-tiny disconnected
+    // sliver report `shapes == 1`, and its geometry would be silently dropped; the
+    // conservative count forces the exact-kernel fallback whenever the difference
+    // splits the profile at all, even into a sub-threshold piece.
     let shapes = result
         .iter()
-        .filter(|s| {
-            s.first().is_some_and(|outer| {
-                let ring: Vec<Point2<f64>> =
-                    outer.iter().map(|p| Point2::new(p[0], p[1])).collect();
-                compute_signed_area(&ring).abs() > MIN_AREA_THRESHOLD
-            })
-        })
+        .filter(|s| s.first().is_some_and(|outer| outer.len() >= 3))
         .count();
     Ok((shapes_to_profile(&result)?, shapes))
 }

--- a/rust/geometry/src/bool2d_tests.rs
+++ b/rust/geometry/src/bool2d_tests.rs
@@ -157,6 +157,76 @@ fn test_subtract_counted_splitting_void_multi_shape() {
 }
 
 #[test]
+fn test_subtract_counted_subthreshold_sliver_still_multi_shape() {
+    // Data-integrity regression: a void that splits the profile into a big piece
+    // plus a TINY disconnected sliver whose signed area is at/below
+    // MIN_AREA_THRESHOLD must STILL report shapes > 1, so the caller defers to the
+    // exact kernel instead of silently dropping the sliver via largest-shape keep.
+    //
+    // Small coordinate scale (0.02) so i_overlay's grid preserves the sliver as a
+    // distinct output shape while its area stays below MIN_AREA_THRESHOLD (a
+    // full-width band split at scale 10 either drops the sliver entirely or leaves
+    // one whose area is orders of magnitude above the threshold).
+    let scale = 0.02_f64;
+    let profile = Profile2D::new(vec![
+        Point2::new(0.0, 0.0),
+        Point2::new(scale, 0.0),
+        Point2::new(scale, scale),
+        Point2::new(0.0, scale),
+    ]);
+    // Full-width band that leaves a `scale * 1e-8`-thick sliver along the top edge.
+    let top_h = scale * 1e-8;
+    let b_lo = scale * 0.45;
+    let b_hi = scale - top_h;
+    let band = vec![
+        Point2::new(-scale, b_lo),
+        Point2::new(scale * 2.0, b_lo),
+        Point2::new(scale * 2.0, b_hi),
+        Point2::new(-scale, b_hi),
+    ];
+
+    let (_res, shapes) =
+        subtract_multiple_2d_counted(&profile, std::slice::from_ref(&band)).unwrap();
+    assert_eq!(
+        shapes, 2,
+        "a sub-threshold sliver must still be counted, forcing the exact-kernel defer"
+    );
+
+    // Confirm the split really produces a sub-threshold shape (i.e. this exercises
+    // the area-filter blind spot, not merely two above-threshold pieces): the
+    // smaller output shape's area is at/below MIN_AREA_THRESHOLD, so the old
+    // `area > MIN_AREA_THRESHOLD` count would have undercounted it to shapes == 1.
+    let subject = profile_to_paths(&profile);
+    let clip = vec![contour_to_path(&band)];
+    let result = subject.overlay(&clip, OverlayRule::Difference, FillRule::EvenOdd);
+    let mut areas: Vec<f64> = result
+        .iter()
+        .filter_map(|s| {
+            s.first().map(|o| {
+                let ring: Vec<Point2<f64>> = o.iter().map(|p| Point2::new(p[0], p[1])).collect();
+                compute_signed_area(&ring).abs()
+            })
+        })
+        .collect();
+    areas.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    assert_eq!(areas.len(), 2, "the split yields exactly two output shapes");
+    assert!(
+        areas[0] <= MIN_AREA_THRESHOLD,
+        "smaller shape area {} must be <= MIN_AREA_THRESHOLD {} (the blind spot the fix closes)",
+        areas[0],
+        MIN_AREA_THRESHOLD
+    );
+    let above_threshold = areas
+        .iter()
+        .filter(|a| **a > MIN_AREA_THRESHOLD)
+        .count();
+    assert_eq!(
+        above_threshold, 1,
+        "old area-filtered count would have seen only 1 shape and proceeded"
+    );
+}
+
+#[test]
 fn test_point_in_contour() {
     let contour = vec![
         Point2::new(0.0, 0.0),

--- a/rust/geometry/src/bool2d_tests.rs
+++ b/rust/geometry/src/bool2d_tests.rs
@@ -1,0 +1,195 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Unit tests for [`super`] (2D boolean profile operations). Split into a
+//! `*_tests.rs` file (module-size-ratchet exempt) and attached via `#[path]`.
+
+use super::*;
+
+#[test]
+fn test_compute_signed_area_ccw() {
+    // Counter-clockwise square
+    let contour = vec![
+        Point2::new(0.0, 0.0),
+        Point2::new(1.0, 0.0),
+        Point2::new(1.0, 1.0),
+        Point2::new(0.0, 1.0),
+    ];
+    let area = compute_signed_area(&contour);
+    assert!((area - 1.0).abs() < EPSILON_2D);
+}
+
+#[test]
+fn test_compute_signed_area_cw() {
+    // Clockwise square
+    let contour = vec![
+        Point2::new(0.0, 0.0),
+        Point2::new(0.0, 1.0),
+        Point2::new(1.0, 1.0),
+        Point2::new(1.0, 0.0),
+    ];
+    let area = compute_signed_area(&contour);
+    assert!((area + 1.0).abs() < EPSILON_2D);
+}
+
+#[test]
+fn test_ensure_ccw() {
+    // Clockwise square
+    let cw = vec![
+        Point2::new(0.0, 0.0),
+        Point2::new(0.0, 1.0),
+        Point2::new(1.0, 1.0),
+        Point2::new(1.0, 0.0),
+    ];
+    let ccw = ensure_ccw(&cw);
+    assert!(compute_signed_area(&ccw) > 0.0);
+}
+
+#[test]
+fn test_subtract_2d_simple() {
+    // 10x10 square profile
+    let profile = Profile2D::new(vec![
+        Point2::new(0.0, 0.0),
+        Point2::new(10.0, 0.0),
+        Point2::new(10.0, 10.0),
+        Point2::new(0.0, 10.0),
+    ]);
+
+    // 2x2 square void in the center
+    let void_contour = vec![
+        Point2::new(4.0, 4.0),
+        Point2::new(6.0, 4.0),
+        Point2::new(6.0, 6.0),
+        Point2::new(4.0, 6.0),
+    ];
+
+    let result = subtract_2d(&profile, &void_contour).unwrap();
+
+    // Should have one hole
+    assert_eq!(result.holes.len(), 1);
+
+    // Outer boundary should be preserved
+    assert_eq!(result.outer.len(), 4);
+}
+
+#[test]
+fn test_subtract_multiple_2d() {
+    // 10x10 square profile
+    let profile = Profile2D::new(vec![
+        Point2::new(0.0, 0.0),
+        Point2::new(10.0, 0.0),
+        Point2::new(10.0, 10.0),
+        Point2::new(0.0, 10.0),
+    ]);
+
+    // Two 1x1 voids
+    let voids = vec![
+        vec![
+            Point2::new(2.0, 2.0),
+            Point2::new(3.0, 2.0),
+            Point2::new(3.0, 3.0),
+            Point2::new(2.0, 3.0),
+        ],
+        vec![
+            Point2::new(7.0, 7.0),
+            Point2::new(8.0, 7.0),
+            Point2::new(8.0, 8.0),
+            Point2::new(7.0, 8.0),
+        ],
+    ];
+
+    let result = subtract_multiple_2d(&profile, &voids).unwrap();
+
+    // Should have two holes
+    assert_eq!(result.holes.len(), 2);
+}
+
+#[test]
+fn test_subtract_counted_interior_single_shape() {
+    // Two interior voids in a 10×10 plate → ONE connected shape, two holes.
+    let profile = Profile2D::new(vec![
+        Point2::new(0.0, 0.0),
+        Point2::new(10.0, 0.0),
+        Point2::new(10.0, 10.0),
+        Point2::new(0.0, 10.0),
+    ]);
+    let voids = vec![
+        vec![
+            Point2::new(2.0, 2.0),
+            Point2::new(3.0, 2.0),
+            Point2::new(3.0, 3.0),
+            Point2::new(2.0, 3.0),
+        ],
+        vec![
+            Point2::new(7.0, 7.0),
+            Point2::new(8.0, 7.0),
+            Point2::new(8.0, 8.0),
+            Point2::new(7.0, 8.0),
+        ],
+    ];
+    let (res, shapes) = subtract_multiple_2d_counted(&profile, &voids).unwrap();
+    assert_eq!(shapes, 1, "interior voids keep one connected shape");
+    assert_eq!(res.holes.len(), 2);
+}
+
+#[test]
+fn test_subtract_counted_splitting_void_multi_shape() {
+    // A void that spans the full width splits the plate into TWO pieces — the
+    // 2D re-extrude can't represent that, so the caller must see shapes > 1.
+    let profile = Profile2D::new(vec![
+        Point2::new(0.0, 0.0),
+        Point2::new(10.0, 0.0),
+        Point2::new(10.0, 10.0),
+        Point2::new(0.0, 10.0),
+    ]);
+    let slot = vec![
+        Point2::new(-1.0, 4.5),
+        Point2::new(11.0, 4.5),
+        Point2::new(11.0, 5.5),
+        Point2::new(-1.0, 5.5),
+    ];
+    let (_res, shapes) = subtract_multiple_2d_counted(&profile, &[slot]).unwrap();
+    assert_eq!(
+        shapes, 2,
+        "a full-width slot splits the profile into two shapes"
+    );
+}
+
+#[test]
+fn test_point_in_contour() {
+    let contour = vec![
+        Point2::new(0.0, 0.0),
+        Point2::new(10.0, 0.0),
+        Point2::new(10.0, 10.0),
+        Point2::new(0.0, 10.0),
+    ];
+
+    assert!(point_in_contour(&Point2::new(5.0, 5.0), &contour));
+    assert!(!point_in_contour(&Point2::new(15.0, 5.0), &contour));
+    assert!(!point_in_contour(&Point2::new(-1.0, 5.0), &contour));
+}
+
+#[test]
+fn test_is_valid_contour() {
+    // Valid square
+    let valid = vec![
+        Point2::new(0.0, 0.0),
+        Point2::new(1.0, 0.0),
+        Point2::new(1.0, 1.0),
+        Point2::new(0.0, 1.0),
+    ];
+    assert!(is_valid_contour(&valid));
+
+    // Degenerate (all points collinear)
+    let degenerate = vec![
+        Point2::new(0.0, 0.0),
+        Point2::new(1.0, 0.0),
+        Point2::new(2.0, 0.0),
+    ];
+    assert!(!is_valid_contour(&degenerate));
+
+    // Too few points
+    let too_few = vec![Point2::new(0.0, 0.0), Point2::new(1.0, 0.0)];
+    assert!(!is_valid_contour(&too_few));
+}

--- a/rust/geometry/src/cdt.rs
+++ b/rust/geometry/src/cdt.rs
@@ -1322,6 +1322,36 @@ pub(crate) fn triangulate_refined(
     Some((out_pts, idx))
 }
 
+/// Constrained Delaunay triangulation of a polygon-with-holes WITHOUT quality
+/// (Ruppert) refinement — the minimal boundary-conforming triangulation of the
+/// input vertices, no Steiner points. Returned vertex list is exactly the input
+/// (`outer ++ holes`) in order; indices reference it. This is the fast,
+/// slivers-free cap triangulator for the 2D opening-subtraction extrude: unlike
+/// earcut it never bridges holes (so a many-hole cap stays manifold), and unlike
+/// [`triangulate_refined`] it never pays the min-angle refinement that dominates
+/// on a large multi-hole face. `None` if the CDT can't be built (caller falls
+/// back to earcut).
+pub(crate) fn triangulate_constrained(
+    outer: &[Point2<f64>],
+    holes: &[Vec<Point2<f64>>],
+) -> Option<(Vec<Point2<f64>>, Vec<usize>)> {
+    let mut rings: Vec<Vec<P2>> = Vec::with_capacity(1 + holes.len());
+    rings.push(outer.iter().map(p2).collect());
+    for h in holes {
+        if h.len() >= 3 {
+            rings.push(h.iter().map(p2).collect());
+        }
+    }
+    let (points, segments) = rings_to_pslg(&rings);
+    let cdt = Cdt::build_from(points, &segments)?;
+    let (pts, idx) = cdt.emit();
+    if idx.is_empty() {
+        return None;
+    }
+    let out_pts: Vec<Point2<f64>> = pts.iter().map(|p| Point2::new(p[0], p[1])).collect();
+    Some((out_pts, idx))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1523,4 +1553,17 @@ mod tests {
         assert_structurally_valid(&cdt);
     }
 
+    /// The unrefined constrained triangulation EXCLUDES hole interiors (returns
+    /// only the material region) and adds no Steiner points — the properties the
+    /// 2D opening-subtraction re-extrude relies on for a manifold, minimal cap.
+    #[test]
+    fn constrained_excludes_holes_no_steiner() {
+        let outer = vec![pt(0.0, 0.0), pt(10.0, 0.0), pt(10.0, 10.0), pt(0.0, 10.0)];
+        let holes = vec![vec![pt(4.0, 4.0), pt(4.0, 6.0), pt(6.0, 6.0), pt(6.0, 4.0)]];
+        let (pts, idx) = super::triangulate_constrained(&outer, &holes).unwrap();
+        // No Steiner points: the vertex list is exactly outer ++ holes.
+        assert_eq!(pts.len(), 8);
+        // Material area = 100 − 4 (the hole is excluded).
+        assert!((area_of(&pts, &idx) - 96.0).abs() < 1e-9);
+    }
 }

--- a/rust/geometry/src/cdt.rs
+++ b/rust/geometry/src/cdt.rs
@@ -1352,6 +1352,54 @@ pub(crate) fn triangulate_constrained(
     Some((out_pts, idx))
 }
 
+/// Conforming (constrained) Delaunay triangulation of an arbitrary PSLG —
+/// points plus non-crossing constraint segments — returning EVERY triangle of
+/// the convex hull, with NO inside/outside domain filtering. The caller
+/// classifies each output triangle itself (e.g. by a centroid test).
+///
+/// Unlike [`triangulate_constrained`] the segments need not form closed rings:
+/// the prism-cut path passes OPEN seam polylines (host-surface cross-sections)
+/// as constraints, which would corrupt the ring depth-parity flood that
+/// [`Cdt::emit`] uses — so this entry point deliberately skips it. Vertices are
+/// exactly the input points in input order (no Steiner insertion); triangles
+/// referencing the internal super-triangle are dropped and each triangle is
+/// emitted CCW. `None` when the CDT cannot be built (degenerate input, crossing
+/// constraints) — callers fall back to their exact path.
+pub(crate) fn triangulate_pslg(
+    points: &[Point2<f64>],
+    segments: &[(usize, usize)],
+) -> Option<(Vec<Point2<f64>>, Vec<usize>)> {
+    let pts: Vec<P2> = points.iter().map(p2).collect();
+    let cdt = Cdt::build_from(pts, segments)?;
+    let keep_upto = cdt.super_base;
+    let mut indices: Vec<usize> = Vec::new();
+    for tri in &cdt.tris {
+        if !tri.alive {
+            continue;
+        }
+        let v = tri.v;
+        if v.iter().any(|&x| x >= keep_upto) {
+            continue;
+        }
+        let a = cdt.points[v[0]];
+        let b = cdt.points[v[1]];
+        let c = cdt.points[v[2]];
+        if orient(a, b, c) >= 0 {
+            indices.extend_from_slice(&[v[0], v[1], v[2]]);
+        } else {
+            indices.extend_from_slice(&[v[0], v[2], v[1]]);
+        }
+    }
+    if indices.is_empty() {
+        return None;
+    }
+    let out_pts: Vec<Point2<f64>> = cdt.points[..keep_upto]
+        .iter()
+        .map(|p| Point2::new(p[0], p[1]))
+        .collect();
+    Some((out_pts, indices))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/rust/geometry/src/extrusion.rs
+++ b/rust/geometry/src/extrusion.rs
@@ -781,94 +781,13 @@ pub fn apply_transform(mesh: &mut Mesh, transform: &Matrix4<f64>) {
 // processing orchestrator (see rust/AGENTS.md), not this per-mesh helper.
 
 #[cfg(test)]
+#[path = "extrusion_watertight_tests.rs"]
+mod watertight_tests;
+
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::profile::create_rectangle;
-
-    /// Count UNDIRECTED edges NOT shared by exactly two triangles — 0 on a closed
-    /// 2-manifold (the production watertightness contract, `param_cut_watertight`).
-    /// Vertices welded by exact f32 bits (coincident verts share bit patterns).
-    fn open_edges(m: &Mesh) -> usize {
-        use std::collections::HashMap;
-        let key = |i: u32| {
-            let b = i as usize * 3;
-            (
-                m.positions[b].to_bits(),
-                m.positions[b + 1].to_bits(),
-                m.positions[b + 2].to_bits(),
-            )
-        };
-        let mut edges: HashMap<_, u32> = HashMap::new();
-        for t in m.indices.chunks_exact(3) {
-            for (a, b) in [(t[0], t[1]), (t[1], t[2]), (t[2], t[0])] {
-                let (ka, kb) = (key(a), key(b));
-                let e = if ka < kb { (ka, kb) } else { (kb, ka) };
-                *edges.entry(e).or_insert(0) += 1;
-            }
-        }
-        edges.values().filter(|&&c| c != 2).count()
-    }
-
-    /// Total area of the triangles lying on the plane `z ≈ z0` (a cap), summed
-    /// with |signed area| so it is winding-independent.
-    fn cap_area(m: &Mesh, z0: f32) -> f64 {
-        let v = |i: u32| {
-            let b = i as usize * 3;
-            [m.positions[b], m.positions[b + 1], m.positions[b + 2]]
-        };
-        let mut a = 0.0;
-        for t in m.indices.chunks_exact(3) {
-            let (p, q, r) = (v(t[0]), v(t[1]), v(t[2]));
-            if (p[2] - z0).abs() < 1e-3 && (q[2] - z0).abs() < 1e-3 && (r[2] - z0).abs() < 1e-3 {
-                a += (((q[0] - p[0]) * (r[1] - p[1]) - (r[0] - p[0]) * (q[1] - p[1])) as f64).abs()
-                    * 0.5;
-            }
-        }
-        a
-    }
-
-    /// The 2D opening-subtraction re-extrude must produce a WATERTIGHT solid even
-    /// for a many-hole profile — the case earcut hole-bridge slivers break (they
-    /// leave the cap non-manifold, then `clean_degenerate` cracks it). A 10×10
-    /// plate with a 4×4 grid of 0.4×0.4 through-holes, extruded 2 m: the CDT caps
-    /// close as a 2-manifold (every edge shared by two triangles) and each cap's
-    /// area equals outer − holes (the holes are genuinely cut, not filled).
-    #[test]
-    fn watertight_extrude_many_holes() {
-        use nalgebra::Point2;
-        let outer = vec![
-            Point2::new(0.0, 0.0),
-            Point2::new(10.0, 0.0),
-            Point2::new(10.0, 10.0),
-            Point2::new(0.0, 10.0),
-        ];
-        let mut profile = Profile2D::new(outer);
-        let mut hole_area = 0.0;
-        for i in 0..4 {
-            for j in 0..4 {
-                let (x, y) = (1.0 + i as f64 * 2.2, 1.0 + j as f64 * 2.2);
-                // Clockwise hole (opposite the CCW outer).
-                profile.add_hole(vec![
-                    Point2::new(x, y),
-                    Point2::new(x, y + 0.4),
-                    Point2::new(x + 0.4, y + 0.4),
-                    Point2::new(x + 0.4, y),
-                ]);
-                hole_area += 0.4 * 0.4;
-            }
-        }
-        let depth = 2.0;
-        let mesh = extrude_profile_watertight(&profile, depth, None).unwrap();
-        assert_eq!(open_edges(&mesh), 0, "many-hole re-extrude must be a closed 2-manifold");
-        let expect = 100.0 - hole_area;
-        for (label, z) in [("bottom", 0.0f32), ("top", depth as f32)] {
-            assert!(
-                (cap_area(&mesh, z) - expect).abs() < 1e-3,
-                "{label} cap area {} != expected {expect} (holes not cut?)",
-                cap_area(&mesh, z)
-            );
-        }
-    }
 
     #[test]
     fn test_extrude_rectangle() {

--- a/rust/geometry/src/extrusion.rs
+++ b/rust/geometry/src/extrusion.rs
@@ -71,14 +71,14 @@ pub fn extrude_profile(
 }
 
 /// Watertight polygon-with-holes extrude for the 2D opening-subtraction path
-/// ([`crate::router`]'s `bool2d_path`). The caps are triangulated with the
-/// boundary-preserving constrained-Delaunay path
-/// ([`crate::triangulation::triangulate_polygon_with_holes_refined`]) instead of
-/// earcut: an earcut cap over a many-hole profile sprouts hole-bridge slivers
-/// that leave it non-manifold and that `clean_degenerate` later drops into
-/// cracks. The CDT keeps every profile-ring edge un-subdivided, so the caps
-/// close bit-for-bit against the side walls; only interior Steiner points are
-/// added (never on the rings), so the cap↔wall seam stays watertight.
+/// ([`crate::router`]'s `bool2d_path`). The caps are triangulated by the
+/// boundary-preserving constrained triangulator
+/// ([`crate::cdt::triangulate_constrained`]) instead of earcut: an earcut cap
+/// over a many-hole profile sprouts hole-bridge slivers that leave it
+/// non-manifold and that `clean_degenerate` later drops into cracks. The
+/// constrained triangulator performs NO refinement and adds NO Steiner points;
+/// it keeps every profile-ring edge un-subdivided, so the caps close bit-for-bit
+/// against the side walls and the cap↔wall seam stays watertight.
 #[inline]
 pub fn extrude_profile_watertight(
     profile: &Profile2D,
@@ -93,6 +93,15 @@ pub fn extrude_profile_watertight(
     if profile.outer.len() < 3 {
         return Err(Error::InvalidExtrusion(
             "Outer boundary needs >= 3 vertices".to_string(),
+        ));
+    }
+    // Reject degenerate hole rings BEFORE triangulation: `triangulate_constrained`
+    // silently drops a < 3-vertex ring from the cap, but `create_side_walls` below
+    // would still emit its walls (cap/wall mismatch → cracked mesh). Erroring here
+    // defers the whole cut to the exact kernel (`bool2d_path`'s `.ok()?`).
+    if profile.holes.iter().any(|h| h.len() < 3) {
+        return Err(Error::InvalidExtrusion(
+            "Hole ring needs >= 3 vertices".to_string(),
         ));
     }
     // Unrefined CDT caps: manifold (no earcut hole-bridge slivers) and fast (no

--- a/rust/geometry/src/extrusion.rs
+++ b/rust/geometry/src/extrusion.rs
@@ -70,6 +70,73 @@ pub fn extrude_profile(
     Ok(mesh)
 }
 
+/// Watertight polygon-with-holes extrude for the 2D opening-subtraction path
+/// ([`crate::router`]'s `bool2d_path`). The caps are triangulated with the
+/// boundary-preserving constrained-Delaunay path
+/// ([`crate::triangulation::triangulate_polygon_with_holes_refined`]) instead of
+/// earcut: an earcut cap over a many-hole profile sprouts hole-bridge slivers
+/// that leave it non-manifold and that `clean_degenerate` later drops into
+/// cracks. The CDT keeps every profile-ring edge un-subdivided, so the caps
+/// close bit-for-bit against the side walls; only interior Steiner points are
+/// added (never on the rings), so the cap↔wall seam stays watertight.
+#[inline]
+pub fn extrude_profile_watertight(
+    profile: &Profile2D,
+    depth: f64,
+    transform: Option<Matrix4<f64>>,
+) -> Result<Mesh> {
+    if depth <= 0.0 {
+        return Err(Error::InvalidExtrusion(
+            "Depth must be positive".to_string(),
+        ));
+    }
+    if profile.outer.len() < 3 {
+        return Err(Error::InvalidExtrusion(
+            "Outer boundary needs >= 3 vertices".to_string(),
+        ));
+    }
+    // Unrefined CDT caps: manifold (no earcut hole-bridge slivers) and fast (no
+    // Ruppert refinement, which dominates on a large multi-hole face). Fall back
+    // to the earcut polygon-with-holes triangulation if the CDT declines.
+    let (points, indices) =
+        match crate::cdt::triangulate_constrained(&profile.outer, &profile.holes) {
+            Some(t) => t,
+            None => {
+                let mut all: Vec<nalgebra::Point2<f64>> = profile.outer.clone();
+                for h in &profile.holes {
+                    all.extend_from_slice(h);
+                }
+                let idx = crate::triangulation::triangulate_polygon_with_holes(
+                    &profile.outer,
+                    &profile.holes,
+                )
+                .map_err(|e| Error::InvalidExtrusion(format!("cap triangulation failed: {e}")))?;
+                (all, idx)
+            }
+        };
+    let tri = Triangulation { points, indices };
+
+    let mut mesh = Mesh::new();
+    create_cap_mesh(&tri, 0.0, Vector3::new(0.0, 0.0, -1.0), &mut mesh);
+    create_cap_mesh(&tri, depth, Vector3::new(0.0, 0.0, 1.0), &mut mesh);
+    create_side_walls(&profile.outer, depth, &mut mesh);
+    for hole in &profile.holes {
+        create_side_walls(hole, depth, &mut mesh);
+    }
+    // The CDT emits cap triangles in arbitrary orientation, so the assembled
+    // solid closes as a 2-manifold but with INCONSISTENT winding — harmless for
+    // the (undirected) watertight check and for per-vertex-normal rendering, but
+    // it breaks the divergence volume that downstream consumers (and the #1297
+    // local-frame regression test) compute. Flood-fill a consistent OUTWARD
+    // orientation across the closed surface; this only flips triangle winding
+    // (per-face vertices are never welded, so creases / flat shading are intact).
+    crate::mesh_orient::orient_mesh_outward(&mut mesh);
+    if let Some(mat) = transform {
+        apply_transform(&mut mesh, &mat);
+    }
+    Ok(mesh)
+}
+
 /// Check if a profile has an extreme aspect ratio (very elongated shape)
 /// Returns true if the profile is so disproportionate the extrusion caps
 /// can't be emitted as a meaningful filled face.
@@ -717,6 +784,91 @@ pub fn apply_transform(mesh: &mut Mesh, transform: &Matrix4<f64>) {
 mod tests {
     use super::*;
     use crate::profile::create_rectangle;
+
+    /// Count UNDIRECTED edges NOT shared by exactly two triangles — 0 on a closed
+    /// 2-manifold (the production watertightness contract, `param_cut_watertight`).
+    /// Vertices welded by exact f32 bits (coincident verts share bit patterns).
+    fn open_edges(m: &Mesh) -> usize {
+        use std::collections::HashMap;
+        let key = |i: u32| {
+            let b = i as usize * 3;
+            (
+                m.positions[b].to_bits(),
+                m.positions[b + 1].to_bits(),
+                m.positions[b + 2].to_bits(),
+            )
+        };
+        let mut edges: HashMap<_, u32> = HashMap::new();
+        for t in m.indices.chunks_exact(3) {
+            for (a, b) in [(t[0], t[1]), (t[1], t[2]), (t[2], t[0])] {
+                let (ka, kb) = (key(a), key(b));
+                let e = if ka < kb { (ka, kb) } else { (kb, ka) };
+                *edges.entry(e).or_insert(0) += 1;
+            }
+        }
+        edges.values().filter(|&&c| c != 2).count()
+    }
+
+    /// Total area of the triangles lying on the plane `z ≈ z0` (a cap), summed
+    /// with |signed area| so it is winding-independent.
+    fn cap_area(m: &Mesh, z0: f32) -> f64 {
+        let v = |i: u32| {
+            let b = i as usize * 3;
+            [m.positions[b], m.positions[b + 1], m.positions[b + 2]]
+        };
+        let mut a = 0.0;
+        for t in m.indices.chunks_exact(3) {
+            let (p, q, r) = (v(t[0]), v(t[1]), v(t[2]));
+            if (p[2] - z0).abs() < 1e-3 && (q[2] - z0).abs() < 1e-3 && (r[2] - z0).abs() < 1e-3 {
+                a += (((q[0] - p[0]) * (r[1] - p[1]) - (r[0] - p[0]) * (q[1] - p[1])) as f64).abs()
+                    * 0.5;
+            }
+        }
+        a
+    }
+
+    /// The 2D opening-subtraction re-extrude must produce a WATERTIGHT solid even
+    /// for a many-hole profile — the case earcut hole-bridge slivers break (they
+    /// leave the cap non-manifold, then `clean_degenerate` cracks it). A 10×10
+    /// plate with a 4×4 grid of 0.4×0.4 through-holes, extruded 2 m: the CDT caps
+    /// close as a 2-manifold (every edge shared by two triangles) and each cap's
+    /// area equals outer − holes (the holes are genuinely cut, not filled).
+    #[test]
+    fn watertight_extrude_many_holes() {
+        use nalgebra::Point2;
+        let outer = vec![
+            Point2::new(0.0, 0.0),
+            Point2::new(10.0, 0.0),
+            Point2::new(10.0, 10.0),
+            Point2::new(0.0, 10.0),
+        ];
+        let mut profile = Profile2D::new(outer);
+        let mut hole_area = 0.0;
+        for i in 0..4 {
+            for j in 0..4 {
+                let (x, y) = (1.0 + i as f64 * 2.2, 1.0 + j as f64 * 2.2);
+                // Clockwise hole (opposite the CCW outer).
+                profile.add_hole(vec![
+                    Point2::new(x, y),
+                    Point2::new(x, y + 0.4),
+                    Point2::new(x + 0.4, y + 0.4),
+                    Point2::new(x + 0.4, y),
+                ]);
+                hole_area += 0.4 * 0.4;
+            }
+        }
+        let depth = 2.0;
+        let mesh = extrude_profile_watertight(&profile, depth, None).unwrap();
+        assert_eq!(open_edges(&mesh), 0, "many-hole re-extrude must be a closed 2-manifold");
+        let expect = 100.0 - hole_area;
+        for (label, z) in [("bottom", 0.0f32), ("top", depth as f32)] {
+            assert!(
+                (cap_area(&mesh, z) - expect).abs() < 1e-3,
+                "{label} cap area {} != expected {expect} (holes not cut?)",
+                cap_area(&mesh, z)
+            );
+        }
+    }
 
     #[test]
     fn test_extrude_rectangle() {

--- a/rust/geometry/src/extrusion_watertight_tests.rs
+++ b/rust/geometry/src/extrusion_watertight_tests.rs
@@ -1,0 +1,96 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Watertightness tests for [`super::extrude_profile_watertight`] (the 2D
+//! opening-subtraction re-extrude path, #1806). Split from `extrusion.rs`
+//! inline tests to keep that module inside its size budget; `*_tests.rs`
+//! files are ratchet-exempt.
+
+use super::*;
+use crate::profile::Profile2D;
+
+/// Count UNDIRECTED edges NOT shared by exactly two triangles — 0 on a closed
+/// 2-manifold (the production watertightness contract, `param_cut_watertight`).
+/// Vertices welded by exact f32 bits (coincident verts share bit patterns).
+fn open_edges(m: &Mesh) -> usize {
+    use std::collections::HashMap;
+    let key = |i: u32| {
+        let b = i as usize * 3;
+        (
+            m.positions[b].to_bits(),
+            m.positions[b + 1].to_bits(),
+            m.positions[b + 2].to_bits(),
+        )
+    };
+    let mut edges: HashMap<_, u32> = HashMap::new();
+    for t in m.indices.chunks_exact(3) {
+        for (a, b) in [(t[0], t[1]), (t[1], t[2]), (t[2], t[0])] {
+            let (ka, kb) = (key(a), key(b));
+            let e = if ka < kb { (ka, kb) } else { (kb, ka) };
+            *edges.entry(e).or_insert(0) += 1;
+        }
+    }
+    edges.values().filter(|&&c| c != 2).count()
+}
+
+/// Total area of the triangles lying on the plane `z ≈ z0` (a cap), summed
+/// with |signed area| so it is winding-independent.
+fn cap_area(m: &Mesh, z0: f32) -> f64 {
+    let v = |i: u32| {
+        let b = i as usize * 3;
+        [m.positions[b], m.positions[b + 1], m.positions[b + 2]]
+    };
+    let mut a = 0.0;
+    for t in m.indices.chunks_exact(3) {
+        let (p, q, r) = (v(t[0]), v(t[1]), v(t[2]));
+        if (p[2] - z0).abs() < 1e-3 && (q[2] - z0).abs() < 1e-3 && (r[2] - z0).abs() < 1e-3 {
+            a += (((q[0] - p[0]) * (r[1] - p[1]) - (r[0] - p[0]) * (q[1] - p[1])) as f64).abs()
+                * 0.5;
+        }
+    }
+    a
+}
+
+/// The 2D opening-subtraction re-extrude must produce a WATERTIGHT solid even
+/// for a many-hole profile — the case earcut hole-bridge slivers break (they
+/// leave the cap non-manifold, then `clean_degenerate` cracks it). A 10×10
+/// plate with a 4×4 grid of 0.4×0.4 through-holes, extruded 2 m: the CDT caps
+/// close as a 2-manifold (every edge shared by two triangles) and each cap's
+/// area equals outer − holes (the holes are genuinely cut, not filled).
+#[test]
+fn watertight_extrude_many_holes() {
+    use nalgebra::Point2;
+    let outer = vec![
+        Point2::new(0.0, 0.0),
+        Point2::new(10.0, 0.0),
+        Point2::new(10.0, 10.0),
+        Point2::new(0.0, 10.0),
+    ];
+    let mut profile = Profile2D::new(outer);
+    let mut hole_area = 0.0;
+    for i in 0..4 {
+        for j in 0..4 {
+            let (x, y) = (1.0 + i as f64 * 2.2, 1.0 + j as f64 * 2.2);
+            // Clockwise hole (opposite the CCW outer).
+            profile.add_hole(vec![
+                Point2::new(x, y),
+                Point2::new(x, y + 0.4),
+                Point2::new(x + 0.4, y + 0.4),
+                Point2::new(x + 0.4, y),
+            ]);
+            hole_area += 0.4 * 0.4;
+        }
+    }
+    let depth = 2.0;
+    let mesh = extrude_profile_watertight(&profile, depth, None).unwrap();
+    assert_eq!(open_edges(&mesh), 0, "many-hole re-extrude must be a closed 2-manifold");
+    let expect = 100.0 - hole_area;
+    for (label, z) in [("bottom", 0.0f32), ("top", depth as f32)] {
+        assert!(
+            (cap_area(&mesh, z) - expect).abs() < 1e-3,
+            "{label} cap area {} != expected {expect} (holes not cut?)",
+            cap_area(&mesh, z)
+        );
+    }
+}

--- a/rust/geometry/src/lib.rs
+++ b/rust/geometry/src/lib.rs
@@ -131,7 +131,7 @@ pub use nalgebra::{Point2, Point3, Vector2, Vector3};
 
 pub use bool2d::{
     compute_signed_area, ensure_ccw, ensure_cw, is_valid_contour, point_in_contour, subtract_2d,
-    subtract_multiple_2d,
+    subtract_multiple_2d, subtract_multiple_2d_counted,
 };
 pub use csg::{calculate_normals, ClippingProcessor, Plane, Triangle};
 pub use diagnostics::{BoolFailure, BoolFailureReason, BoolOp};
@@ -161,6 +161,7 @@ pub use alignment::{AlignmentCurve, AlignmentFrame};
 pub use profile::{Profile2D, Profile2DWithVoids, ProfileType, VoidInfo};
 pub use profile_extractor::{extract_profiles, ExtractedProfile};
 pub use profiles::ProfileProcessor;
+pub use router::take_bool2d_stats;
 pub use router::{
     aggregate_diagnostics, local_frame_set_enabled_override, ClassificationStats,
     GEOMETRY_DIAGNOSTICS_SCHEMA_VERSION,

--- a/rust/geometry/src/lib.rs
+++ b/rust/geometry/src/lib.rs
@@ -162,6 +162,7 @@ pub use profile::{Profile2D, Profile2DWithVoids, ProfileType, VoidInfo};
 pub use profile_extractor::{extract_profiles, ExtractedProfile};
 pub use profiles::ProfileProcessor;
 pub use router::take_bool2d_stats;
+pub use router::{take_prism_defers, take_prism_stats};
 pub use router::{
     aggregate_diagnostics, local_frame_set_enabled_override, ClassificationStats,
     GEOMETRY_DIAGNOSTICS_SCHEMA_VERSION,

--- a/rust/geometry/src/router/mod.rs
+++ b/rust/geometry/src/router/mod.rs
@@ -20,6 +20,7 @@ mod voids;
 
 pub use transforms::local_frame_set_enabled_override;
 pub use voids::RectParam;
+pub use voids::take_bool2d_stats;
 pub use diagnostics::{
     GEOMETRY_DIAGNOSTICS_SCHEMA_VERSION,
     aggregate_diagnostics, ClassificationStats, ClassificationSummary, GeometryDiagnostics,

--- a/rust/geometry/src/router/mod.rs
+++ b/rust/geometry/src/router/mod.rs
@@ -19,8 +19,7 @@ mod transforms;
 mod voids;
 
 pub use transforms::local_frame_set_enabled_override;
-pub use voids::RectParam;
-pub use voids::take_bool2d_stats;
+pub use voids::{take_bool2d_stats, take_prism_defers, take_prism_stats, RectParam};
 pub use diagnostics::{
     GEOMETRY_DIAGNOSTICS_SCHEMA_VERSION,
     aggregate_diagnostics, ClassificationStats, ClassificationSummary, GeometryDiagnostics,

--- a/rust/geometry/src/router/voids/bool2d_path.rs
+++ b/rust/geometry/src/router/voids/bool2d_path.rs
@@ -143,7 +143,9 @@ impl GeometryRouter {
         } else {
             (-host.depth, 0.0)
         };
-        let z_tol = 0.01 * host.depth + 1e-6;
+        // Numerical-precision coincidence (1 ppm): near-through blind openings
+        // defer to the exact kernel instead of becoming a full-depth hole.
+        let z_tol = 1.0e-6 * host.depth.abs() + 1.0e-9;
 
         let mut footprints: Vec<Vec<Point2<f64>>> = Vec::new();
         let mut residual_ids: Vec<u32> = Vec::new();
@@ -331,16 +333,21 @@ fn opening_solid_footprint(
     }
     let op_rot = op.m.fixed_view::<3, 3>(0, 0).into_owned();
     let op_axis = (op_rot * Vector3::new(0.0, 0.0, op.dir_sign)).try_normalize(1e-9)?;
-    if host_axis.dot(&op_axis).abs() < 0.9995 {
-        return None;
+    if host_axis.dot(&op_axis).abs() < 1.0 - 1.0e-6 {
+        return None; // near-exact host-parallelism only (~0.08°); a tilt skews the cut
     }
     let to_host = hm_inv * op.m;
     let mut fp: Vec<Point2<f64>> = Vec::with_capacity(op.profile.outer.len());
     let mut zmin = f64::INFINITY;
     let mut zmax = f64::NEG_INFINITY;
+    // Zero lateral sweep: base/far images must share host-XY (no oblique drift).
+    let lat_tol = 1.0e-4 * (hz_max - hz_min).abs() + 1.0e-6;
     for p in &op.profile.outer {
         let base = to_host.transform_point(&Point3::new(p.x, p.y, 0.0));
         let far = to_host.transform_point(&Point3::new(p.x, p.y, op.dir_sign * op.depth));
+        if (far.x - base.x).abs() > lat_tol || (far.y - base.y).abs() > lat_tol {
+            return None;
+        }
         fp.push(Point2::new(base.x, base.y));
         zmin = zmin.min(base.z.min(far.z));
         zmax = zmax.max(base.z.max(far.z));

--- a/rust/geometry/src/router/voids/bool2d_path.rs
+++ b/rust/geometry/src/router/voids/bool2d_path.rs
@@ -34,6 +34,7 @@
 //!      least one hole formed.
 //!   4. The no-hole re-extrude reconciles with the host mesh (bounds + volume),
 //!      and the holed re-extrude (watertight CDT caps) self-checks watertight.
+//!
 //! When ANY of these fail the host falls through to the exact kernel with its
 //! FULL opening set unchanged, so correctness can never regress.
 //!
@@ -362,7 +363,7 @@ use super::probe::ExtrudedSolidInfo as ExtrudedSolidLike;
 
 /// Reconcile the no-hole re-extruded `solid` against the real host `mesh` by
 /// world AABB (per axis) and signed volume. Validates that the recovered profile
-/// + composed transform reproduce the host — catching clipped hosts, unit / RTC
+/// and composed transform reproduce the host — catching clipped hosts, unit / RTC
 /// mistakes, and profiles the processor tessellates differently.
 fn reconcile_solid(host: &Mesh, solid: &Mesh) -> bool {
     let (hmn, hmx) = world_host_bounds(host); // folds host.origin

--- a/rust/geometry/src/router/voids/bool2d_path.rs
+++ b/rust/geometry/src/router/voids/bool2d_path.rs
@@ -1,0 +1,392 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! 2D opening-subtraction fast path (IfcOpenShell's `boolean-attempt-2d`).
+//!
+//! For the common case — an extruded host whose openings penetrate straight
+//! through the extrusion depth — the exact 3D mesh-boolean is replaced by a much
+//! cheaper operation: subtract the openings' footprints from the host's 2D
+//! profile ([`crate::bool2d::subtract_multiple_2d`], i_overlay), then re-extrude
+//! the holed profile. On CSG-heavy models the void-cut is ~80% of geometry time
+//! and the exact kernel is at its single-threaded, bandwidth-bound floor; this
+//! path collapses each qualifying host to a couple of profile triangulations.
+//!
+//! HYBRID per-opening eligibility. A host's openings are split at capture:
+//!   * ELIGIBLE — an extruded opening swept PARALLEL to the host axis that
+//!     penetrates the FULL host depth (a through-cut). These are subtracted from
+//!     the profile in 2D and re-extruded.
+//!   * RESIDUAL — everything else (perpendicular sleeves, partial-depth recesses,
+//!     non-extruded voids). These are cut by the exact kernel on the re-extruded
+//!     host, so one ineligible opening no longer forfeits its host's cheap ones.
+//!
+//! CORRECTNESS is paramount — every gate defers to the exact kernel on the
+//! faintest doubt, and the emitted mesh is reconciled by bounds + volume against
+//! the real host mesh and self-checked watertight:
+//!   1. Host body = ONE `IfcExtrudedAreaSolid` swept along local ±Z (arbitrary
+//!      profile OK; mapped items unwrapped; a clipped / multi-item body defers).
+//!   2. Each eligible footprint lands STRICTLY INTERIOR to the host profile
+//!      (gated at capture), so the 2D difference turns it into a clean hole —
+//!      adjacent footprints legitimately MERGE (still the exact cut). A footprint
+//!      that touches / breaches the boundary is routed to the residual instead.
+//!   3. The difference must yield ONE connected shape (a void that splits the
+//!      profile is rejected — the largest-shape keep would drop geometry) with at
+//!      least one hole formed.
+//!   4. The no-hole re-extrude reconciles with the host mesh (bounds + volume),
+//!      and the holed re-extrude (watertight CDT caps) self-checks watertight.
+//! When ANY of these fail the host falls through to the exact kernel with its
+//! FULL opening set unchanged, so correctness can never regress.
+//!
+//! Gate: `IFC_LITE_VOID_2D=0` forces every host back through the exact kernel
+//! (A/B measurement / bisection). Default ON. wasm has no env, so the default
+//! holds on both targets and native==wasm output stays deterministic (all-f64
+//! before the f32 store).
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::OnceLock;
+
+use super::geom::{mesh_signed_volume, param_cut_watertight};
+use super::{world_host_bounds, GeometryRouter, VoidContext};
+use crate::bool2d::{compute_signed_area, subtract_multiple_2d_counted};
+use crate::extrusion::{apply_transform, extrude_profile, extrude_profile_watertight};
+use crate::mesh::Mesh;
+use crate::profile::Profile2D;
+use ifc_lite_core::{DecodedEntity, EntityDecoder, IfcType};
+use nalgebra::{Matrix4, Point2, Point3, Vector3};
+
+/// `IFC_LITE_VOID_2D=0` disables the 2D opening-subtraction path (exact kernel
+/// for every host). Default ON; read once.
+pub(super) fn enabled() -> bool {
+    static ON: OnceLock<bool> = OnceLock::new();
+    *ON.get_or_init(|| std::env::var("IFC_LITE_VOID_2D").as_deref() != Ok("0"))
+}
+
+static FIRES: AtomicU64 = AtomicU64::new(0);
+static FOOTPRINTS: AtomicU64 = AtomicU64::new(0);
+
+/// Read + reset the 2D-path telemetry: (hosts cut via the 2D path, opening
+/// footprints subtracted in those hosts). Process-global; used by the perf
+/// harness to report the fast-path hit-rate. Relaxed atomics — a stale read
+/// under concurrency only mis-reports a diagnostic count, never geometry.
+pub fn take_bool2d_stats() -> (u64, u64) {
+    (
+        FIRES.swap(0, Ordering::Relaxed),
+        FOOTPRINTS.swap(0, Ordering::Relaxed),
+    )
+}
+
+/// Captured 2D-subtraction data for a host + its openings, sufficient to build
+/// the cut mesh WITHOUT the decoder (so [`GeometryRouter::apply_void_context`]
+/// can run it on pure geometry). Built in [`GeometryRouter::capture_bool2d`].
+pub(super) struct Bool2dCut {
+    /// Host profile (outer + any existing holes) in the solid's profile plane.
+    host_profile: Profile2D,
+    /// Host extrusion depth (> 0).
+    depth: f64,
+    /// +1 / -1 host sweep sense (drives the extrude cap placement).
+    dir_sign: f64,
+    /// Profile-local → world (metres, RTC-relative) transform: `scale · m − rtc`.
+    wt: Matrix4<f64>,
+    /// Eligible (parallel through-cut) opening footprints in the host profile
+    /// plane (host XY).
+    footprints: Vec<Vec<Point2<f64>>>,
+    /// Ineligible openings (perpendicular / partial / non-extruded) as a residual
+    /// exact-kernel context, cut on the re-extruded host after the 2D subtract.
+    /// `None` when every opening was eligible (pure 2D result).
+    residual: Option<Box<VoidContext>>,
+}
+
+/// Shoelace area magnitude of a 2D contour.
+#[inline]
+fn area_abs(poly: &[Point2<f64>]) -> f64 {
+    compute_signed_area(poly).abs()
+}
+
+/// True iff `fp` lies strictly interior to `profile`: every vertex is inside the
+/// outer boundary and outside every existing hole. A conservative interiority
+/// test — a footprint that touches or crosses a boundary edge (a boundary notch)
+/// fails and is routed to the exact kernel rather than approximated. Interior
+/// footprints subtract to clean holes (adjacent ones merge, still exact), so the
+/// re-extrude reproduces the boolean without dropping any profile piece.
+fn footprint_interior(fp: &[Point2<f64>], profile: &Profile2D) -> bool {
+    fp.iter().all(|v| {
+        crate::bool2d::point_in_contour(v, &profile.outer)
+            && profile
+                .holes
+                .iter()
+                .all(|h| !crate::bool2d::point_in_contour(v, h))
+    })
+}
+
+impl GeometryRouter {
+    /// Build the 2D-subtraction data for a host + its openings. Splits the
+    /// openings into eligible (parallel through-cut → 2D) and residual
+    /// (everything else → exact kernel). Returns `None` if the host is not a
+    /// single clean extrusion or no opening is eligible (nothing to gain).
+    pub(super) fn capture_bool2d(
+        &self,
+        element: &DecodedEntity,
+        opening_ids: &[u32],
+        decoder: &mut EntityDecoder,
+    ) -> Option<Bool2dCut> {
+        if opening_ids.is_empty() {
+            return None;
+        }
+        let host = self.host_extruded_solid(element, decoder)?;
+        let hm_inv = host.m.try_inverse()?;
+        let host_rot = host.m.fixed_view::<3, 3>(0, 0).into_owned();
+        let host_axis = (host_rot * Vector3::new(0.0, 0.0, host.dir_sign)).try_normalize(1e-9)?;
+        // Host extrusion span in the solid's profile frame.
+        let (hz_min, hz_max) = if host.dir_sign >= 0.0 {
+            (0.0, host.depth)
+        } else {
+            (-host.depth, 0.0)
+        };
+        let z_tol = 0.01 * host.depth + 1e-6;
+
+        let mut footprints: Vec<Vec<Point2<f64>>> = Vec::new();
+        let mut residual_ids: Vec<u32> = Vec::new();
+        for &oid in opening_ids {
+            let opening = match decoder.decode_by_id(oid) {
+                Ok(e) if e.ifc_type == IfcType::IfcOpeningElement => e,
+                // A non-opening (or undecodable) id: hand it to the exact kernel.
+                _ => {
+                    residual_ids.push(oid);
+                    continue;
+                }
+            };
+            // An opening is eligible only when EVERY constituent solid is a
+            // parallel through-cut whose hole-free footprint lands STRICTLY
+            // INTERIOR to the host profile. Interior footprints subtract to clean
+            // holes (touching ones legitimately MERGE — that is still the exact
+            // cut); a footprint that touches / breaches the boundary, or lands in
+            // an existing profile hole, is routed to the residual so it never
+            // silently no-ops. Collect tentatively; any ineligible solid sends the
+            // whole opening (all its solids) to the residual so nothing is
+            // double-cut.
+            let mut opening_footprints: Vec<Vec<Point2<f64>>> = Vec::new();
+            let eligible = self
+                .opening_extruded_solids(&opening, decoder)
+                .map(|solids| {
+                    solids.iter().all(|op| {
+                        match opening_solid_footprint(
+                            op, &hm_inv, &host_axis, hz_min, hz_max, z_tol,
+                        ) {
+                            Some(fp) if footprint_interior(&fp, &host.profile) => {
+                                opening_footprints.push(fp);
+                                true
+                            }
+                            _ => false,
+                        }
+                    })
+                })
+                .unwrap_or(false);
+            if eligible && !opening_footprints.is_empty() {
+                footprints.append(&mut opening_footprints);
+            } else {
+                residual_ids.push(oid);
+            }
+        }
+        if footprints.is_empty() {
+            return None;
+        }
+
+        // Profile-local → world metres, RTC-relative: world = scale·(m·p) − rtc.
+        // Scaling rows 0..3 (incl. their translation column) then subtracting the
+        // RTC offset reproduces `center_native · s − rtc` from the rect probe.
+        let s = self.unit_scale;
+        let (rx, ry, rz) = self.rtc_offset;
+        let mut wt = host.m;
+        for i in 0..3 {
+            for j in 0..4 {
+                wt[(i, j)] *= s;
+            }
+        }
+        wt[(0, 3)] -= rx;
+        wt[(1, 3)] -= ry;
+        wt[(2, 3)] -= rz;
+
+        // Residual exact-kernel context for the ineligible openings (diagnostics
+        // suppressed — the full opening set is already diagnosed by
+        // `build_void_context`'s own `classify_openings`).
+        let residual = if residual_ids.is_empty() {
+            None
+        } else {
+            let openings = self.classify_openings_quiet(element, &residual_ids, decoder);
+            if openings.is_empty() {
+                None
+            } else {
+                let merged = Self::merge_rectangular_openings(&openings);
+                Some(Box::new(VoidContext {
+                    openings,
+                    merged_openings: merged,
+                    param: None,
+                    bool2d: None,
+                }))
+            }
+        };
+
+        Some(Bool2dCut {
+            host_profile: host.profile,
+            depth: host.depth,
+            dir_sign: host.dir_sign,
+            wt,
+            footprints,
+            residual,
+        })
+    }
+
+    /// Emit the 2D-subtracted, re-extruded cut mesh for a captured host (eligible
+    /// openings subtracted in 2D; residual openings NOT yet cut — the caller runs
+    /// the exact kernel on the result), or `None` (→ full exact kernel) if
+    /// reconciliation or the watertight self-check fails. Deterministic f64 →
+    /// byte-identical native==wasm.
+    pub(super) fn try_bool2d_cut(&self, mesh: &Mesh, cut: &Bool2dCut) -> Option<Mesh> {
+        // A -Z sweep places the profile plane at the TOP; shift the [0, depth]
+        // extrude down so the solid occupies [-depth, 0] in the profile frame,
+        // matching the extruded-solid processor's downward-extrusion handling.
+        let transform = if cut.dir_sign >= 0.0 {
+            None
+        } else {
+            Some(Matrix4::new_translation(&Vector3::new(
+                0.0, 0.0, -cut.depth,
+            )))
+        };
+
+        // (1) No-hole solid: reconcile transform + profile recovery against the
+        // real (pre-cut) host mesh. A clipped / mis-recovered host mismatches here
+        // and defers, so the emitted geometry can only ever be a true extrusion.
+        let mut solid = extrude_profile(&cut.host_profile, cut.depth, transform).ok()?;
+        apply_transform(&mut solid, &cut.wt);
+        if !reconcile_solid(mesh, &solid) {
+            return None;
+        }
+
+        // (2) 2D difference. Footprints were gated INTERIOR at capture, so the
+        // subtract keeps the outer boundary and turns them into holes (adjacent
+        // footprints legitimately merge — still the exact cut). The one pathology
+        // interiority can't rule out is a void that SPLITS the profile into
+        // disconnected pieces (an interior slot bridging the outer to an existing
+        // hole): the difference then yields multiple shapes and only the largest
+        // is kept, silently dropping geometry. Reject any multi-shape result and
+        // require at least one hole to have formed (a zero-hole result would signal
+        // a projection error rather than a real cut).
+        let (holed, n_shapes) =
+            subtract_multiple_2d_counted(&cut.host_profile, &cut.footprints).ok()?;
+        if n_shapes != 1 {
+            return None;
+        }
+        if holed.holes.len() < cut.host_profile.holes.len() + 1 {
+            return None;
+        }
+
+        // (3) Re-extrude the holed profile (watertight CDT caps) into the host's
+        // OWN frame: fold the host mesh's per-element origin into the transform so
+        // the result carries the SAME `origin` (world = origin + position). On the
+        // native/world default `mesh.origin` is 0 and this is the absolute world
+        // build; under the wasm local-frame default it keeps the cut near its own
+        // origin (f32-precise for a georeferenced host — the #1297 precondition)
+        // instead of collapsing to coarse absolute-world coordinates. Hygiene +
+        // the watertight self-check run in this frame (small coords, precise).
+        let origin = mesh.origin;
+        let mut wt = cut.wt;
+        wt[(0, 3)] -= origin[0];
+        wt[(1, 3)] -= origin[1];
+        wt[(2, 3)] -= origin[2];
+        let mut out = extrude_profile_watertight(&holed, cut.depth, transform).ok()?;
+        apply_transform(&mut out, &wt);
+        out.origin = origin;
+        out.clean_degenerate();
+        if !param_cut_watertight(&out) {
+            return None;
+        }
+
+        FIRES.fetch_add(1, Ordering::Relaxed);
+        FOOTPRINTS.fetch_add(cut.footprints.len() as u64, Ordering::Relaxed);
+        Some(out)
+    }
+
+    /// The captured residual (ineligible-opening) exact-kernel context, if any.
+    pub(super) fn bool2d_residual<'a>(&self, cut: &'a Bool2dCut) -> Option<&'a VoidContext> {
+        cut.residual.as_deref()
+    }
+}
+
+/// Project one opening solid's outer profile into the host profile plane, and
+/// keep it only if the solid sweeps PARALLEL to the host axis and penetrates the
+/// full host depth [`hz_min`, `hz_max`]. `None` (ineligible → exact kernel) for a
+/// perpendicular sweep, a partial-depth (recess) opening, an annular opening
+/// (its own profile holes), or a degenerate footprint.
+fn opening_solid_footprint(
+    op: &ExtrudedSolidLike,
+    hm_inv: &Matrix4<f64>,
+    host_axis: &Vector3<f64>,
+    hz_min: f64,
+    hz_max: f64,
+    z_tol: f64,
+) -> Option<Vec<Point2<f64>>> {
+    if !op.profile.holes.is_empty() {
+        return None;
+    }
+    let op_rot = op.m.fixed_view::<3, 3>(0, 0).into_owned();
+    let op_axis = (op_rot * Vector3::new(0.0, 0.0, op.dir_sign)).try_normalize(1e-9)?;
+    if host_axis.dot(&op_axis).abs() < 0.9995 {
+        return None;
+    }
+    let to_host = hm_inv * op.m;
+    let mut fp: Vec<Point2<f64>> = Vec::with_capacity(op.profile.outer.len());
+    let mut zmin = f64::INFINITY;
+    let mut zmax = f64::NEG_INFINITY;
+    for p in &op.profile.outer {
+        let base = to_host.transform_point(&Point3::new(p.x, p.y, 0.0));
+        let far = to_host.transform_point(&Point3::new(p.x, p.y, op.dir_sign * op.depth));
+        fp.push(Point2::new(base.x, base.y));
+        zmin = zmin.min(base.z.min(far.z));
+        zmax = zmax.max(base.z.max(far.z));
+    }
+    // Through-cut: the opening must span the ENTIRE host depth. A partial-depth
+    // void (recess / blind pocket) would leave material the flat re-extrude can't
+    // represent — defer it to the exact kernel.
+    if zmin > hz_min + z_tol || zmax < hz_max - z_tol {
+        return None;
+    }
+    if area_abs(&fp) <= 0.0 {
+        return None;
+    }
+    Some(fp)
+}
+
+/// The subset of [`super::probe::ExtrudedSolidInfo`] this module reads. Aliased so
+/// the free function above stays decoupled from the probe struct's full shape.
+use super::probe::ExtrudedSolidInfo as ExtrudedSolidLike;
+
+/// Reconcile the no-hole re-extruded `solid` against the real host `mesh` by
+/// world AABB (per axis) and signed volume. Validates that the recovered profile
+/// + composed transform reproduce the host — catching clipped hosts, unit / RTC
+/// mistakes, and profiles the processor tessellates differently.
+fn reconcile_solid(host: &Mesh, solid: &Mesh) -> bool {
+    let (hmn, hmx) = world_host_bounds(host); // folds host.origin
+    let (smn, smx) = solid.bounds(); // solid is absolute (origin 0)
+    let hmn = [hmn.0, hmn.1, hmn.2];
+    let hmx = [hmx.0, hmx.1, hmx.2];
+    let smn = [smn.x, smn.y, smn.z];
+    let smx = [smx.x, smx.y, smx.z];
+    for k in 0..3 {
+        let ext = (hmx[k] - hmn[k]).abs().max(1e-3);
+        let tol = ext * 0.02 + 5e-3; // 2% of extent + 5 mm
+        if (hmn[k] - smn[k]).abs() > tol || (hmx[k] - smx[k]).abs() > tol {
+            return false;
+        }
+    }
+    let hv = mesh_signed_volume(host).abs();
+    let sv = mesh_signed_volume(solid).abs();
+    if hv < 1e-9 || sv < 1e-9 {
+        return false;
+    }
+    let r = sv / hv;
+    (0.97..1.03).contains(&r)
+}
+
+#[cfg(test)]
+#[path = "bool2d_path_tests.rs"]
+mod tests;

--- a/rust/geometry/src/router/voids/bool2d_path_tests.rs
+++ b/rust/geometry/src/router/voids/bool2d_path_tests.rs
@@ -1,0 +1,123 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Unit tests for the 2D opening-subtraction eligibility logic
+//! ([`super`]). Split into a `*_tests.rs` file (module-size-ratchet exempt) and
+//! attached to the parent via `#[path]` so it keeps access to the parent's
+//! private helpers.
+
+use super::*;
+use nalgebra::Rotation3;
+
+/// A unit-square opening solid at `center` (host-local XY), swept `depth`
+/// along `axis` (host-local), with `dir_sign`.
+fn opening(
+    center: (f64, f64, f64),
+    axis: Vector3<f64>,
+    depth: f64,
+    dir_sign: f64,
+) -> ExtrudedSolidLike {
+    // Rotate the profile's local +Z onto `axis`, then translate to `center`.
+    let z = Vector3::new(0.0, 0.0, 1.0);
+    let rot = Rotation3::rotation_between(&z, &axis)
+        .unwrap_or_else(Rotation3::identity)
+        .to_homogeneous();
+    let m = Matrix4::new_translation(&Vector3::new(center.0, center.1, center.2)) * rot;
+    let profile = Profile2D::new(vec![
+        Point2::new(-0.5, -0.5),
+        Point2::new(0.5, -0.5),
+        Point2::new(0.5, 0.5),
+        Point2::new(-0.5, 0.5),
+    ]);
+    ExtrudedSolidLike {
+        profile,
+        depth,
+        dir_sign,
+        m,
+    }
+}
+
+// Host: extruded +Z over [0, 4], identity placement → host frame == world.
+const HZ_MIN: f64 = 0.0;
+const HZ_MAX: f64 = 4.0;
+fn host_axis() -> Vector3<f64> {
+    Vector3::new(0.0, 0.0, 1.0)
+}
+fn hm_inv() -> Matrix4<f64> {
+    Matrix4::identity()
+}
+
+#[test]
+fn parallel_through_opening_is_eligible() {
+    // +Z, full host depth: a clean through-cut → footprint recovered.
+    let op = opening((1.0, 1.0, 0.0), host_axis(), HZ_MAX, 1.0);
+    let fp = opening_solid_footprint(&op, &hm_inv(), &host_axis(), HZ_MIN, HZ_MAX, 0.04);
+    assert!(
+        fp.is_some(),
+        "a parallel full-depth opening must be eligible"
+    );
+    assert_eq!(fp.unwrap().len(), 4);
+}
+
+#[test]
+fn perpendicular_opening_defers() {
+    // Swept along +X (through the host thickness): perpendicular to the host
+    // axis → ineligible (the exact kernel handles it).
+    let op = opening((1.0, 1.0, 2.0), Vector3::new(1.0, 0.0, 0.0), 1.0, 1.0);
+    assert!(
+        opening_solid_footprint(&op, &hm_inv(), &host_axis(), HZ_MIN, HZ_MAX, 0.04).is_none(),
+        "a perpendicular opening must defer"
+    );
+}
+
+#[test]
+fn partial_depth_opening_defers() {
+    // Parallel but only 1 m of the 4 m host depth (a recess/pocket) → defer.
+    let op = opening((1.0, 1.0, 0.0), host_axis(), 1.0, 1.0);
+    assert!(
+        opening_solid_footprint(&op, &hm_inv(), &host_axis(), HZ_MIN, HZ_MAX, 0.04).is_none(),
+        "a partial-depth opening must defer"
+    );
+}
+
+#[test]
+fn annular_opening_defers() {
+    // An opening whose own profile carries a hole can't reduce to one
+    // subtracted footprint → defer.
+    let mut op = opening((1.0, 1.0, 0.0), host_axis(), HZ_MAX, 1.0);
+    op.profile.add_hole(vec![
+        Point2::new(-0.2, -0.2),
+        Point2::new(-0.2, 0.2),
+        Point2::new(0.2, 0.2),
+        Point2::new(0.2, -0.2),
+    ]);
+    assert!(
+        opening_solid_footprint(&op, &hm_inv(), &host_axis(), HZ_MIN, HZ_MAX, 0.04).is_none(),
+        "an annular opening must defer"
+    );
+}
+
+#[test]
+fn footprint_interior_gates_boundary_breach() {
+    let profile = Profile2D::new(vec![
+        Point2::new(0.0, 0.0),
+        Point2::new(10.0, 0.0),
+        Point2::new(10.0, 10.0),
+        Point2::new(0.0, 10.0),
+    ]);
+    let interior = vec![
+        Point2::new(2.0, 2.0),
+        Point2::new(3.0, 2.0),
+        Point2::new(3.0, 3.0),
+        Point2::new(2.0, 3.0),
+    ];
+    let breaching = vec![
+        Point2::new(-1.0, 2.0),
+        Point2::new(3.0, 2.0),
+        Point2::new(3.0, 3.0),
+        Point2::new(-1.0, 3.0),
+    ];
+    assert!(footprint_interior(&interior, &profile));
+    assert!(!footprint_interior(&breaching, &profile));
+}

--- a/rust/geometry/src/router/voids/bool2d_path_tests.rs
+++ b/rust/geometry/src/router/voids/bool2d_path_tests.rs
@@ -82,6 +82,25 @@ fn partial_depth_opening_defers() {
 }
 
 #[test]
+fn near_parallel_oblique_opening_defers() {
+    // A ~1° tilt from the host axis: the OLD 0.9995 dot threshold (≈1.8°) marked
+    // this eligible and re-extruded the base contour STRAIGHT through the host —
+    // but the real cutter sweeps ~70 mm sideways across the 4 m depth
+    // (far corner ≠ base corner in host-XY), so the flat cut is wrong. Both the
+    // tightened parallelism gate and the zero-lateral-sweep gate now defer it to
+    // the exact kernel.
+    let theta = 1.0_f64.to_radians();
+    let axis = Vector3::new(theta.sin(), 0.0, theta.cos());
+    // Anchor so the tilted sweep still spans the full host depth [0, 4] (it would
+    // have passed the OLD through-cut + interior gates).
+    let op = opening((1.0, 1.0, 0.5 * theta.sin()), axis, 4.0, 1.0);
+    assert!(
+        opening_solid_footprint(&op, &hm_inv(), &host_axis(), HZ_MIN, HZ_MAX, 0.04).is_none(),
+        "a near-parallel oblique opening must defer to the exact kernel"
+    );
+}
+
+#[test]
 fn annular_opening_defers() {
     // An opening whose own profile carries a hole can't reduce to one
     // subtracted footprint → defer.

--- a/rust/geometry/src/router/voids/flap_clip_tests.rs
+++ b/rust/geometry/src/router/voids/flap_clip_tests.rs
@@ -166,6 +166,7 @@ fn nonzero_origin_host_records_world_space_bbox() {
         merged_openings: vec![opening.clone()],
         openings: vec![opening],
         param: None,
+        bool2d: None,
     };
 
     let element_id = 4242u32;
@@ -281,6 +282,7 @@ fn budget_tripped_engulfing_cutter_skips_aabb_fallback() {
         merged_openings: vec![engulf_open.clone()],
         openings: vec![engulf_open],
         param: None,
+        bool2d: None,
     };
 
     // Arm a per-element cap of 1 so the FIRST exact escalation trips the
@@ -340,6 +342,7 @@ fn budget_tripped_engulfing_cutter_skips_aabb_fallback() {
         merged_openings: vec![small_open.clone()],
         openings: vec![small_open],
         param: None,
+        bool2d: None,
     };
 
     let small_id = 91_635_u32;

--- a/rust/geometry/src/router/voids/mod.rs
+++ b/rust/geometry/src/router/voids/mod.rs
@@ -944,11 +944,12 @@ impl GeometryRouter {
             }
         }
 
-        // ANALYTIC CONVEX-PRISM fast path (flag-gated): each opening whose
-        // cutter is a genuine oriented rectangular box is subtracted from the
-        // host MESH analytically — host-shape-agnostic, so it fires on the
-        // faceted-BREP / clipped / multi-item hosts the parametric and 2D
-        // paths above cannot serve (the ISSUE_098 Poroton walls). Tried after
+        // ANALYTIC PRISM fast path (flag-gated): each opening whose cutter is
+        // a genuine stepped-extrusion prism (plain boxes AND the rebated
+        // masonry windows) is subtracted from the host MESH analytically —
+        // host-shape-agnostic, so it fires on the faceted-BREP / clipped /
+        // multi-item hosts the parametric and 2D paths above cannot serve
+        // (the ISSUE_098 Poroton walls). Tried after
         // them so their proven outputs stay byte-identical; ORIGIN-AWARE (the
         // cut runs in the host's own local frame, cutters relativized in f64,
         // `origin` re-stamped). Ineligible openings come back as a residual

--- a/rust/geometry/src/router/voids/mod.rs
+++ b/rust/geometry/src/router/voids/mod.rs
@@ -15,10 +15,12 @@ use rustc_hash::FxHashMap;
 mod aabb_clip;
 mod bool2d_path;
 mod geom;
+mod prism_cut;
 mod probe;
 mod synthesis;
 
 pub use bool2d_path::take_bool2d_stats;
+pub use prism_cut::{take_prism_defers, take_prism_stats};
 #[cfg(test)]
 mod reveal_tests;
 
@@ -938,6 +940,46 @@ impl GeometryRouter {
                 return match self.bool2d_residual(cut) {
                     None => holed,
                     Some(residual) => self.apply_void_context(holed, residual, element_id),
+                };
+            }
+        }
+
+        // ANALYTIC CONVEX-PRISM fast path (flag-gated): each opening whose
+        // cutter is a genuine oriented rectangular box is subtracted from the
+        // host MESH analytically — host-shape-agnostic, so it fires on the
+        // faceted-BREP / clipped / multi-item hosts the parametric and 2D
+        // paths above cannot serve (the ISSUE_098 Poroton walls). Tried after
+        // them so their proven outputs stay byte-identical; ORIGIN-AWARE (the
+        // cut runs in the host's own local frame, cutters relativized in f64,
+        // `origin` re-stamped). Ineligible openings come back as a residual
+        // context and are cut by the exact kernel on the analytic result — the
+        // same composition contract as the 2D path (which also routes ITS
+        // residual through this path on recursion, so a 2D host's perpendicular
+        // sleeves take the prism cut too). Any miss falls through to the exact
+        // kernel below with the FULL opening set unchanged.
+        if prism_cut::enabled() {
+            // World bounds + triangle count captured BEFORE the cut so the
+            // per-host diagnostic matches what the exact/rect paths record.
+            let prism_bounds = world_host_bounds(&mesh);
+            let prism_tris_before = mesh.triangle_count();
+            if let Some((cut, residual)) = self.try_prism_cut(&mesh, ctx) {
+                return match residual {
+                    None => {
+                        // Same per-host cut-effect snapshot the exact path
+                        // records, so prism-cut hosts aren't missing from the
+                        // diagnostics.
+                        self.record_host_cut_effect(
+                            element_id,
+                            prism_tris_before,
+                            cut.triangle_count(),
+                            ctx.merged_openings.len(),
+                            prism_bounds,
+                        );
+                        cut
+                    }
+                    // With a residual, the recursive exact pass below records
+                    // the (final) cut-effect snapshot itself.
+                    Some(res) => self.apply_void_context(cut, &res, element_id),
                 };
             }
         }

--- a/rust/geometry/src/router/voids/mod.rs
+++ b/rust/geometry/src/router/voids/mod.rs
@@ -945,11 +945,10 @@ impl GeometryRouter {
         }
 
         // ANALYTIC PRISM fast path (flag-gated): each opening whose cutter is
-        // a genuine stepped-extrusion prism (plain boxes AND the rebated
-        // masonry windows) is subtracted from the host MESH analytically —
-        // host-shape-agnostic, so it fires on the faceted-BREP / clipped /
-        // multi-item hosts the parametric and 2D paths above cannot serve
-        // (the ISSUE_098 Poroton walls). Tried after
+        // a genuine stepped-extrusion prism (plain boxes AND rebated masonry
+        // windows) is subtracted from the host MESH analytically — host-shape-
+        // agnostic, so it fires on the faceted-BREP / clipped / multi-item
+        // hosts the parametric and 2D paths above cannot serve. Tried after
         // them so their proven outputs stay byte-identical; ORIGIN-AWARE (the
         // cut runs in the host's own local frame, cutters relativized in f64,
         // `origin` re-stamped). Ineligible openings come back as a residual

--- a/rust/geometry/src/router/voids/mod.rs
+++ b/rust/geometry/src/router/voids/mod.rs
@@ -13,9 +13,12 @@ use nalgebra::Matrix3;
 use rustc_hash::FxHashMap;
 
 mod aabb_clip;
+mod bool2d_path;
 mod geom;
 mod probe;
 mod synthesis;
+
+pub use bool2d_path::take_bool2d_stats;
 #[cfg(test)]
 mod reveal_tests;
 
@@ -112,6 +115,11 @@ pub(super) struct VoidContext {
     /// captured only when `rect_fast::param_enabled()`. Drives the analytic fast
     /// path in `apply_void_context`; `None` defers to the exact kernel.
     param: Option<ParamRectCut>,
+    /// 2D opening-subtraction data (host profile + projected opening footprints),
+    /// captured only when `bool2d_path::enabled()`. Drives the arbitrary-profile
+    /// 2D re-extrude fast path in `apply_void_context`, tried after the rect
+    /// parametric path; `None` defers to the exact kernel.
+    bool2d: Option<bool2d_path::Bool2dCut>,
 }
 
 impl VoidContext {
@@ -149,6 +157,10 @@ impl VoidContext {
             // non-relativized world mesh (it makes its own frame), so the
             // relativized context never uses `param` — drop it.
             param: None,
+            // Likewise the 2D path builds its own world frame from the parametrics
+            // and runs in the OUTER apply_void_context; the relativized context
+            // never uses it.
+            bool2d: None,
         }
     }
 
@@ -661,10 +673,22 @@ impl GeometryRouter {
             None
         };
 
+        // 2D opening-subtraction capture (flag-gated). Cheap when it misses
+        // (profile recovery only, no meshing), tried after the rect parametric
+        // path in `apply_void_context` so rect+rect hosts keep their existing
+        // output byte-identical and only the arbitrary-profile / rect-declined
+        // hosts reach the 2D re-extrude.
+        let bool2d = if bool2d_path::enabled() {
+            self.capture_bool2d(element, opening_ids, decoder)
+        } else {
+            None
+        };
+
         VoidContext {
             openings,
             merged_openings,
             param,
+            bool2d,
         }
     }
 
@@ -897,6 +921,27 @@ impl GeometryRouter {
             }
         }
 
+        // 2D OPENING-SUBTRACTION fast path (flag-gated). Generalises the rect
+        // parametric path above to arbitrary extruded-host profiles: subtract the
+        // openings' footprints from the host's 2D profile and re-extrude. Tried
+        // after `try_param_rect_cut` so proven rect+rect outputs are unchanged;
+        // ORIGIN-AWARE (it builds its own world frame from the parametrics and
+        // reconciles against the real host mesh, whatever `mesh.origin`). Any miss
+        // falls through to the exact kernel below unchanged.
+        if let Some(cut) = ctx.bool2d.as_ref() {
+            if let Some(holed) = self.try_bool2d_cut(&mesh, cut) {
+                // Eligible openings are now subtracted. Any residual (ineligible)
+                // openings — perpendicular sleeves, partial-depth recesses — are
+                // cut by the exact kernel on the re-extruded host (origin 0, world
+                // frame; residual cutters are world-framed), so a single
+                // ineligible opening no longer forfeits its host's cheap ones.
+                return match self.bool2d_residual(cut) {
+                    None => holed,
+                    Some(residual) => self.apply_void_context(holed, residual, element_id),
+                };
+            }
+        }
+
         // WORLD-space host AABB for the per-host diagnostic (`bbox`), captured
         // HERE — before the local-frame branch below zeroes `mesh.origin` and
         // before `try_cut_wall_local_frame` rotates the mesh into its own frame.
@@ -1076,8 +1121,10 @@ impl GeometryRouter {
             openings: local_openings,
             // The local-frame recursion never re-captures the parametric cut
             // (issue #1209): it operates on already-classified openings, so the
-            // analytic `param` path is irrelevant here — defer to the exact path.
+            // analytic `param` / 2D paths are irrelevant here — defer to the exact
+            // path.
             param: None,
+            bool2d: None,
         };
 
         // Forward the WORLD host bounds captured before this rotation so the

--- a/rust/geometry/src/router/voids/prism_cut.rs
+++ b/rust/geometry/src/router/voids/prism_cut.rs
@@ -1,0 +1,2742 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Analytic prism subtraction on the host MESH.
+//!
+//! The dominant expensive void cut on CSG-heavy models (ISSUE_098 / ISSUE_129)
+//! is a PERPENDICULAR prism opening — a window / door / sleeve — on a host the
+//! other fast paths cannot serve: faceted-BREP walls, clipped extrusions,
+//! multi-item bodies. The exact mesh-arrangement kernel is at its
+//! single-threaded floor (~15 ms per cut), yet the cutter is just a polygonal
+//! profile swept through the wall (masonry openings are REBATED — stepped
+//! multi-vertex profiles, not plain boxes). This path subtracts such a cutter
+//! analytically from ANY host mesh:
+//!
+//! 1. DETECT that the cutter mesh is a genuine prism: a closed 2-manifold with
+//!    one depth axis `d` such that every facet is either parallel (the two end
+//!    caps, each on one extremal plane) or perpendicular (the sides) to `d`;
+//!    the profile polygon is stitched from the cap facet's boundary loop and
+//!    the enclosed volume must reconcile with `area × depth`. Any deviation
+//!    (curved-cap void, open shell, annular profile, self-intersecting
+//!    garbage) is left to the exact kernel.
+//! 2. EXTEND each cap past the host surface when (and only when) the swept
+//!    slab is provably empty of host material — a flush cap becomes a clean
+//!    transversal crossing (the #1112 lesson) while a genuine blind recess
+//!    keeps its authored bottom.
+//! 3. DECOMPOSE only the host triangles that actually reach the prism: each
+//!    such triangle T gets the exact `T ∩ ∂prism` seam segments (cap-plane
+//!    chords clipped to the profile in 2D; side-strip chords clipped to the
+//!    strip rectangle) as constraints of a per-triangle conforming CDT, whose
+//!    sub-triangles are classified inside/outside the prism by centroid.
+//!    Shared edges subdivide identically across neighbours (every edge×plane
+//!    crossing is computed once through a canonical-order cache and admitted
+//!    by a point-deterministic face-membership gate), so the kept surface
+//!    stays T-junction-free. Triangles away from the prism pass through
+//!    UNTOUCHED — original coordinates and normals.
+//! 4. CAP the reveal: each prism face (2 profile caps + one rectangle per
+//!    profile edge) is triangulated by a CDT of the face polygon constrained
+//!    by the seams from step 3, each sub-triangle kept iff its centroid lies
+//!    inside the (pre-cut) host solid by ray parity. Cap boundaries reuse the
+//!    exact seam coordinates, so caps weld to the kept host fragments.
+//!
+//! SELF-CHECKS (all hard gates — any failure defers to the exact kernel with
+//! the FULL opening set unchanged):
+//! * per-opening volume identity `vol(outside) + vol(inside) == vol(host)` in
+//!   f64 (the caps cancel; the fragments partition the host surface), plus
+//!   `0 < vol(inside) <= vol(prism)` so the caps provably close the removed
+//!   solid;
+//! * the host must arrive as a consistently-wound closed solid and the final
+//!   emitted mesh must pass the same DIRECTED quantized closed-surface audit
+//!   (which also catches doubled coincident faces and flipped caps).
+//!
+//! The whole computation runs in f64 (host f32 promoted once, stored f32 once
+//! at the end), with no FMA-sensitive matrix products and deterministic
+//! iteration order, so native == wasm stays byte-identical (#1297). Vertices
+//! are never welded (#846); per-element `origin` is preserved exactly.
+//!
+//! Gate: `IFC_LITE_PRISM_CUT=0` forces every host back through the exact
+//! kernel (A/B measurement). Default ON; wasm has no env, so the default holds
+//! on both targets.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::OnceLock;
+
+use super::geom::opening_mesh_thinnest_axis_dir;
+use super::{cutter_is_closed_manifold, GeometryRouter, OpeningType, VoidContext};
+use crate::cdt::triangulate_pslg;
+use crate::mesh::Mesh;
+use nalgebra::Point2;
+use rustc_hash::FxHashMap;
+
+/// `IFC_LITE_PRISM_CUT=0` disables the analytic prism-subtraction path (exact
+/// kernel for every host). Default ON; read once.
+pub(super) fn enabled() -> bool {
+    static ON: OnceLock<bool> = OnceLock::new();
+    *ON.get_or_init(|| std::env::var("IFC_LITE_PRISM_CUT").as_deref() != Ok("0"))
+}
+
+static FIRES: AtomicU64 = AtomicU64::new(0);
+static OPENINGS_ANALYTIC: AtomicU64 = AtomicU64::new(0);
+static OPENINGS_RESIDUAL: AtomicU64 = AtomicU64::new(0);
+
+/// Defer-reason counters (diagnostic only): indices into [`DEFER_NAMES`].
+const DEFER_NAMES: [&str; 10] = [
+    "host_not_closed",
+    "host_promote_fail",
+    "op_not_prism",
+    "op_tiny",
+    "op_no_overlap",
+    "op_engulf",
+    "op_veto_overlap",
+    "cut_cdt_fail",
+    "cut_vol_fail",
+    "out_not_closed",
+];
+static DEFERS: [AtomicU64; 10] = [
+    AtomicU64::new(0),
+    AtomicU64::new(0),
+    AtomicU64::new(0),
+    AtomicU64::new(0),
+    AtomicU64::new(0),
+    AtomicU64::new(0),
+    AtomicU64::new(0),
+    AtomicU64::new(0),
+    AtomicU64::new(0),
+    AtomicU64::new(0),
+];
+
+#[inline]
+fn defer(i: usize) {
+    DEFERS[i].fetch_add(1, Ordering::Relaxed);
+}
+
+/// Read + reset the per-reason defer counters as (name, count) pairs.
+pub fn take_prism_defers() -> Vec<(&'static str, u64)> {
+    DEFER_NAMES
+        .iter()
+        .enumerate()
+        .map(|(i, n)| (*n, DEFERS[i].swap(0, Ordering::Relaxed)))
+        .collect()
+}
+
+/// Read + reset the prism-path telemetry: (hosts cut via the prism path,
+/// openings subtracted analytically, openings routed to the exact residual on
+/// prism-cut hosts). Process-global; used by the perf harness to report the
+/// fast-path hit-rate. Relaxed atomics — a stale read under concurrency only
+/// mis-reports a diagnostic count, never geometry.
+pub fn take_prism_stats() -> (u64, u64, u64) {
+    (
+        FIRES.swap(0, Ordering::Relaxed),
+        OPENINGS_ANALYTIC.swap(0, Ordering::Relaxed),
+        OPENINGS_RESIDUAL.swap(0, Ordering::Relaxed),
+    )
+}
+
+// ─────────────────────────── small f64 vector kit ───────────────────────────
+// Explicit component arithmetic (no nalgebra matrix products) so no FMA can
+// sneak in and break native==wasm byte identity.
+
+type V3 = [f64; 3];
+type V2 = [f64; 2];
+
+#[inline]
+fn dot(a: V3, b: V3) -> f64 {
+    a[0] * b[0] + a[1] * b[1] + a[2] * b[2]
+}
+#[inline]
+fn sub(a: V3, b: V3) -> V3 {
+    [a[0] - b[0], a[1] - b[1], a[2] - b[2]]
+}
+#[inline]
+fn add(a: V3, b: V3) -> V3 {
+    [a[0] + b[0], a[1] + b[1], a[2] + b[2]]
+}
+#[inline]
+fn scale(a: V3, s: f64) -> V3 {
+    [a[0] * s, a[1] * s, a[2] * s]
+}
+#[inline]
+fn cross(a: V3, b: V3) -> V3 {
+    [
+        a[1] * b[2] - a[2] * b[1],
+        a[2] * b[0] - a[0] * b[2],
+        a[0] * b[1] - a[1] * b[0],
+    ]
+}
+#[inline]
+fn norm(a: V3) -> f64 {
+    dot(a, a).sqrt()
+}
+#[inline]
+fn normalize(a: V3) -> Option<V3> {
+    let n = norm(a);
+    if n < 1.0e-12 {
+        None
+    } else {
+        Some(scale(a, 1.0 / n))
+    }
+}
+#[inline]
+fn lerp(a: V3, b: V3, t: f64) -> V3 {
+    [
+        a[0] + (b[0] - a[0]) * t,
+        a[1] + (b[1] - a[1]) * t,
+        a[2] + (b[2] - a[2]) * t,
+    ]
+}
+#[inline]
+fn bits(p: V3) -> [u64; 3] {
+    [p[0].to_bits(), p[1].to_bits(), p[2].to_bits()]
+}
+
+/// Even-odd point-in-polygon (half-open crossing rule — deterministic on
+/// boundary-adjacent points, and identical for every caller testing the same
+/// point, which is what the neighbour-consistency argument needs).
+fn pip(pt: V2, poly: &[V2]) -> bool {
+    let (x, y) = (pt[0], pt[1]);
+    let n = poly.len();
+    let mut inside = false;
+    let mut j = n - 1;
+    for i in 0..n {
+        let (xi, yi) = (poly[i][0], poly[i][1]);
+        let (xj, yj) = (poly[j][0], poly[j][1]);
+        if (yi > y) != (yj > y) {
+            let xc = xi + (y - yi) / (yj - yi) * (xj - xi);
+            if x < xc {
+                inside = !inside;
+            }
+        }
+        j = i;
+    }
+    inside
+}
+
+/// Parameter `t ∈ [0, 1]` on segment `p→q` where it crosses segment `a→b`
+/// (proper or endpoint-touching crossing), or `None` when parallel / disjoint.
+fn seg_cross_param(p: V2, q: V2, a: V2, b: V2) -> Option<f64> {
+    let r = [q[0] - p[0], q[1] - p[1]];
+    let s = [b[0] - a[0], b[1] - a[1]];
+    let denom = r[0] * s[1] - r[1] * s[0];
+    if denom.abs() < 1.0e-18 {
+        return None;
+    }
+    let ap = [a[0] - p[0], a[1] - p[1]];
+    let t = (ap[0] * s[1] - ap[1] * s[0]) / denom;
+    let u = (ap[0] * r[1] - ap[1] * r[0]) / denom;
+    const E: f64 = 1.0e-12;
+    if (-E..=1.0 + E).contains(&t) && (-E..=1.0 + E).contains(&u) {
+        Some(t.clamp(0.0, 1.0))
+    } else {
+        None
+    }
+}
+
+/// DIRECTED quantized closed-surface audit (0.1 mm grid): every directed edge
+/// must be cancelled by its reverse. Strictly stronger than the undirected
+/// 2-manifold check — it catches inconsistent winding and doubled coincident
+/// surfaces (two triangles sharing an edge in the SAME direction), not just
+/// cracks. Triangles that collapse to a degenerate key on the grid are skipped
+/// (their edges net to zero).
+fn directed_closed(mesh: &Mesh) -> bool {
+    let key = |i: u32| -> (i64, i64, i64) {
+        let b = i as usize * 3;
+        let q = |v: f32| (v as f64 / 1.0e-4).round() as i64;
+        (
+            q(mesh.positions[b]),
+            q(mesh.positions[b + 1]),
+            q(mesh.positions[b + 2]),
+        )
+    };
+    let mut edges: FxHashMap<((i64, i64, i64), (i64, i64, i64)), i64> = FxHashMap::default();
+    for tri in mesh.indices.chunks_exact(3) {
+        let (ka, kb, kc) = (key(tri[0]), key(tri[1]), key(tri[2]));
+        if ka == kb || kb == kc || kc == ka {
+            continue;
+        }
+        for (x, y) in [(ka, kb), (kb, kc), (kc, ka)] {
+            *edges.entry((x, y)).or_insert(0) += 1;
+            *edges.entry((y, x)).or_insert(0) -= 1;
+        }
+    }
+    !edges.is_empty() && edges.values().all(|&c| c == 0)
+}
+
+/// Closed-surface audit with a HAIRLINE tolerance: the surface passes when
+/// every unpaired directed edge (0.1 mm grid) is collinearly COVERED by
+/// unpaired edges of the opposite net sign — the signature of two adjacent
+/// faces subdividing a shared boundary line differently (a T-junction chain,
+/// invisible sub-grid gap), NOT of a missing surface. A genuine hole leaves a
+/// boundary loop whose edges have nothing opposite along them and fails. The
+/// exact kernel's own output is routinely NOT even undirected-watertight on
+/// these hosts, so this gate is still far stricter than the status quo.
+fn closed_or_hairline(mesh: &Mesh) -> bool {
+    type K = (i64, i64, i64);
+    let key = |i: u32| -> K {
+        let b = i as usize * 3;
+        let q = |v: f32| (v as f64 / 1.0e-4).round() as i64;
+        (
+            q(mesh.positions[b]),
+            q(mesh.positions[b + 1]),
+            q(mesh.positions[b + 2]),
+        )
+    };
+    let mut edges: FxHashMap<(K, K), i64> = FxHashMap::default();
+    for tri in mesh.indices.chunks_exact(3) {
+        let (ka, kb, kc) = (key(tri[0]), key(tri[1]), key(tri[2]));
+        if ka == kb || kb == kc || kc == ka {
+            continue;
+        }
+        for (x, y) in [(ka, kb), (kb, kc), (kc, ka)] {
+            *edges.entry((x, y)).or_insert(0) += 1;
+            *edges.entry((y, x)).or_insert(0) -= 1;
+        }
+    }
+    if edges.is_empty() {
+        return false;
+    }
+    // Canonicalize to undirected segments with a net sign.
+    let mut bad: Vec<(K, K, i64)> = Vec::new();
+    for (&(a, b), &c) in edges.iter() {
+        if c > 0 {
+            bad.push((a, b, c));
+        }
+    }
+    if bad.is_empty() {
+        return true;
+    }
+    if bad.len() > 64 {
+        return false; // way past hairline territory
+    }
+    let p = |k: K| [k.0 as f64, k.1 as f64, k.2 as f64]; // grid units (0.1 mm)
+    let dist_pt_seg = |x: V3, a: V3, b: V3| -> f64 {
+        let ab = sub(b, a);
+        let l2 = dot(ab, ab);
+        if l2 <= 0.0 {
+            return norm(sub(x, a));
+        }
+        let t = (dot(sub(x, a), ab) / l2).clamp(0.0, 1.0);
+        norm(sub(x, add(a, scale(ab, t))))
+    };
+    // Every bad edge's midpoint must lie ON some other bad edge running the
+    // OPPOSITE way (net sign of the same orientation negative ⇒ its positive
+    // form goes the other direction along the shared line).
+    for (i, &(a, b, _)) in bad.iter().enumerate() {
+        let mid = scale(add(p(a), p(b)), 0.5);
+        let dir_i = sub(p(b), p(a));
+        let mut covered = false;
+        for (j, &(c, d, _)) in bad.iter().enumerate() {
+            if i == j {
+                continue;
+            }
+            // Opposite direction along ~the same line (the chain runs back).
+            if dot(dir_i, sub(p(d), p(c))) >= 0.0 {
+                continue;
+            }
+            if dist_pt_seg(mid, p(c), p(d)) <= 2.0 {
+                covered = true;
+                break;
+            }
+        }
+        if !covered {
+            return false;
+        }
+    }
+    true
+}
+
+/// One host triangle in f64 (positions + per-vertex normals), host-local frame.
+#[derive(Clone)]
+struct PTri {
+    p: [V3; 3],
+    n: [V3; 3],
+}
+
+impl PTri {
+    /// Signed volume contribution about the origin (divergence theorem, ×6).
+    #[inline]
+    fn vol6(&self) -> f64 {
+        dot(self.p[0], cross(self.p[1], self.p[2]))
+    }
+    #[inline]
+    fn aabb(&self) -> (V3, V3) {
+        let mut lo = self.p[0];
+        let mut hi = self.p[0];
+        for v in &self.p[1..] {
+            for k in 0..3 {
+                lo[k] = lo[k].min(v[k]);
+                hi[k] = hi[k].max(v[k]);
+            }
+        }
+        (lo, hi)
+    }
+}
+
+fn tri_volume6(tris: &[PTri]) -> f64 {
+    tris.iter().map(PTri::vol6).sum()
+}
+
+/// Promote a `Mesh` to the f64 triangle list, folding nothing (the mesh is
+/// taken in its own frame — `origin` semantics are preserved by the caller).
+fn ptris_from_mesh(mesh: &Mesh) -> Option<Vec<PTri>> {
+    let vc = mesh.positions.len() / 3;
+    let have_normals = mesh.normals.len() == mesh.positions.len();
+    let mut out = Vec::with_capacity(mesh.indices.len() / 3);
+    for t in mesh.indices.chunks_exact(3) {
+        if t.iter().any(|&i| i as usize >= vc) {
+            return None;
+        }
+        let read = |i: u32| -> V3 {
+            let b = i as usize * 3;
+            [
+                mesh.positions[b] as f64,
+                mesh.positions[b + 1] as f64,
+                mesh.positions[b + 2] as f64,
+            ]
+        };
+        let p = [read(t[0]), read(t[1]), read(t[2])];
+        if p.iter().any(|v| v.iter().any(|c| !c.is_finite())) {
+            return None;
+        }
+        let n = if have_normals {
+            let rn = |i: u32| -> V3 {
+                let b = i as usize * 3;
+                [
+                    mesh.normals[b] as f64,
+                    mesh.normals[b + 1] as f64,
+                    mesh.normals[b + 2] as f64,
+                ]
+            };
+            [rn(t[0]), rn(t[1]), rn(t[2])]
+        } else {
+            let fnrm =
+                normalize(cross(sub(p[1], p[0]), sub(p[2], p[0]))).unwrap_or([0.0, 0.0, 1.0]);
+            [fnrm, fnrm, fnrm]
+        };
+        out.push(PTri { p, n });
+    }
+    Some(out)
+}
+
+/// Store the f64 triangle list back to an f32 `Mesh` in the host's frame.
+/// Per-triangle vertices (no sharing, no welding — #846); normals normalized
+/// with the triangle's geometric normal as fallback.
+fn mesh_from_ptris(tris: &[PTri], template: &Mesh) -> Mesh {
+    let mut positions = Vec::with_capacity(tris.len() * 9);
+    let mut normals = Vec::with_capacity(tris.len() * 9);
+    let mut indices = Vec::with_capacity(tris.len() * 3);
+    for (i, t) in tris.iter().enumerate() {
+        let face = normalize(cross(sub(t.p[1], t.p[0]), sub(t.p[2], t.p[0])))
+            .unwrap_or([0.0, 0.0, 1.0]);
+        for v in 0..3 {
+            positions.push(t.p[v][0] as f32);
+            positions.push(t.p[v][1] as f32);
+            positions.push(t.p[v][2] as f32);
+            let n = normalize(t.n[v]).unwrap_or(face);
+            normals.push(n[0] as f32);
+            normals.push(n[1] as f32);
+            normals.push(n[2] as f32);
+        }
+        let base = (i * 3) as u32;
+        indices.extend_from_slice(&[base, base + 1, base + 2]);
+    }
+    Mesh {
+        positions,
+        normals,
+        indices,
+        rtc_applied: template.rtc_applied,
+        origin: template.origin,
+        instance_meta: None,
+        local_bounds: None,
+        local_to_world: None,
+    }
+}
+
+// ─────────────────────────────── prism cutter ───────────────────────────────
+
+/// Maximum profile vertex count admitted to the analytic path (face ids must
+/// fit `u8`, and a pathological many-gon belongs to the exact kernel anyway).
+const MAX_PROFILE_VERTS: usize = 120;
+
+/// A stepped-extrusion cutter: a stack of K depth slabs along axis `d`, slab
+/// `k` spanning `planes[k]..planes[k+1]` with constant CCW cross-section
+/// `profiles[k]`. K = 1 is a plain prism; K > 1 is the REBATED masonry opening
+/// (the ISSUE_098 window voids: outer box + inner box sharing a step plane).
+/// `(u, v, d)` is orthonormal right-handed (`u × v = d`).
+#[derive(Clone)]
+struct PrismFrame {
+    u: V3,
+    v: V3,
+    d: V3,
+    /// K+1 sorted depth planes.
+    planes: Vec<f64>,
+    /// K CCW simple polygons (no holes), one per slab.
+    profiles: Vec<Vec<V2>>,
+    /// Per-slab |area|.
+    slab_area: Vec<f64>,
+    /// Per-slab strictly interior point (max-area CDT triangle centroid —
+    /// robust for non-convex rebated profiles).
+    slab_interior: Vec<V2>,
+    /// Overall profile bounding box (lo, hi) in `(u, v)`.
+    bb: (V2, V2),
+}
+
+impl PrismFrame {
+    #[inline]
+    fn d0(&self) -> f64 {
+        self.planes[0]
+    }
+    #[inline]
+    fn d1(&self) -> f64 {
+        *self.planes.last().unwrap()
+    }
+    #[inline]
+    fn volume(&self) -> f64 {
+        (0..self.profiles.len())
+            .map(|k| self.slab_area[k] * (self.planes[k + 1] - self.planes[k]))
+            .sum()
+    }
+    /// Canonical lift `(u, v, depth) → 3D`. FIXED summation order so every
+    /// face computing the same point produces identical bits.
+    #[inline]
+    fn lift(&self, uu: f64, vv: f64, w: f64) -> V3 {
+        add(add(scale(self.u, uu), scale(self.v, vv)), scale(self.d, w))
+    }
+    #[inline]
+    fn to2(&self, p: V3) -> V2 {
+        [dot(p, self.u), dot(p, self.v)]
+    }
+    /// Strict interior test (open solid).
+    #[inline]
+    fn contains(&self, p: V3) -> bool {
+        let w = dot(p, self.d);
+        if w <= self.d0() || w >= self.d1() {
+            return false;
+        }
+        let q = self.to2(p);
+        for k in 0..self.profiles.len() {
+            if w < self.planes[k + 1] {
+                return pip(q, &self.profiles[k]);
+            }
+        }
+        false
+    }
+    /// Largest coordinate magnitude over the swept profile corners (epsilon
+    /// scaling).
+    fn corner_mag(&self) -> f64 {
+        let mut mag = 0.0f64;
+        for prof in &self.profiles {
+            for &[uu, vv] in prof {
+                for w in [self.d0(), self.d1()] {
+                    for c in self.lift(uu, vv, w) {
+                        mag = mag.max(c.abs());
+                    }
+                }
+            }
+        }
+        mag
+    }
+    /// Conservative OBB of the solid (profile bbox × depth) as (axes, lo, hi)
+    /// intervals for the SAT overlap veto.
+    fn obb(&self) -> ([V3; 3], V3, V3) {
+        (
+            [self.u, self.v, self.d],
+            [self.bb.0[0], self.bb.0[1], self.d0()],
+            [self.bb.1[0], self.bb.1[1], self.d1()],
+        )
+    }
+}
+
+/// One face of the stepped solid.
+#[derive(Clone, Copy)]
+enum Face {
+    /// The depth plane `planes[j]`; its exposed region is the XOR of the
+    /// adjacent slab profiles (`∅` beyond the ends).
+    Cap { j: usize },
+    /// Side strip of slab `k`, profile edge `i`, over
+    /// `planes[k]..planes[k+1]`.
+    Strip { k: usize, i: usize },
+}
+
+/// Enumerate the faces of a stack deterministically.
+fn stack_faces(pf: &PrismFrame) -> Vec<Face> {
+    let mut out = Vec::new();
+    for j in 0..pf.planes.len() {
+        out.push(Face::Cap { j });
+    }
+    for k in 0..pf.profiles.len() {
+        for i in 0..pf.profiles[k].len() {
+            out.push(Face::Strip { k, i });
+        }
+    }
+    out
+}
+
+/// Whether a 2D point lies in cap `j`'s exposed region: inside exactly one of
+/// the two adjacent slab profiles (XOR; the region a stepped shoulder or an
+/// end cap exposes). Point-deterministic — every caller agrees.
+fn cap_xor(pf: &PrismFrame, j: usize, q: V2) -> bool {
+    let in_prev = j > 0 && pip(q, &pf.profiles[j - 1]);
+    let in_next = j < pf.profiles.len() && pip(q, &pf.profiles[j]);
+    in_prev != in_next
+}
+
+/// Oriented-box overlap via the separating-axis theorem (15 axes), with a
+/// positive `margin` treating near-contact as overlap. Boxes given as
+/// (orthonormal axes, per-axis projection interval).
+fn obb_overlaps(a: &([V3; 3], V3, V3), b: &([V3; 3], V3, V3), margin: f64) -> bool {
+    let centre = |x: &([V3; 3], V3, V3)| -> V3 {
+        let mid = [
+            (x.1[0] + x.2[0]) * 0.5,
+            (x.1[1] + x.2[1]) * 0.5,
+            (x.1[2] + x.2[2]) * 0.5,
+        ];
+        add(
+            add(scale(x.0[0], mid[0]), scale(x.0[1], mid[1])),
+            scale(x.0[2], mid[2]),
+        )
+    };
+    let half = |x: &([V3; 3], V3, V3), k: usize| (x.2[k] - x.1[k]) * 0.5;
+    let dvec = sub(centre(b), centre(a));
+    let mut axes: Vec<V3> = Vec::with_capacity(15);
+    for k in 0..3 {
+        axes.push(a.0[k]);
+        axes.push(b.0[k]);
+    }
+    for i in 0..3 {
+        for j in 0..3 {
+            let c = cross(a.0[i], b.0[j]);
+            if norm(c) > 1.0e-9 {
+                axes.push(c);
+            }
+        }
+    }
+    for l in axes {
+        let Some(l) = normalize(l) else { continue };
+        let ra: f64 = (0..3).map(|k| half(a, k) * dot(a.0[k], l).abs()).sum();
+        let rb: f64 = (0..3).map(|k| half(b, k) * dot(b.0[k], l).abs()).sum();
+        if dot(dvec, l).abs() > ra + rb + margin {
+            return false;
+        }
+    }
+    true
+}
+
+/// Deterministic orthonormal right-handed basis `(u, v)` for a depth axis `d`
+/// (`u × v = d`), using the same seed convention as `OpeningFrame::from_depth`.
+fn basis_from_depth(d: V3) -> Option<(V3, V3)> {
+    let seed = if d[2].abs() < 0.9 {
+        [0.0, 0.0, 1.0]
+    } else {
+        [0.0, 1.0, 0.0]
+    };
+    let u = normalize(cross(seed, d))?;
+    let v = normalize(cross(d, u))?;
+    Some((u, v))
+}
+
+/// Maximum number of depth slabs admitted (a rebated opening has 2-3; more
+/// belongs to the exact kernel).
+const MAX_SLABS: usize = 6;
+
+/// CCW normalization + area of a 2D ring. `None` when degenerate.
+fn ccw_area(profile: &mut Vec<V2>) -> Option<f64> {
+    profile.dedup_by(|a, b| (a[0] - b[0]).abs() < 1.0e-9 && (a[1] - b[1]).abs() < 1.0e-9);
+    while profile.len() > 1 {
+        let first = profile[0];
+        let last = *profile.last().unwrap();
+        if (first[0] - last[0]).abs() < 1.0e-9 && (first[1] - last[1]).abs() < 1.0e-9 {
+            profile.pop();
+        } else {
+            break;
+        }
+    }
+    if profile.len() < 3 {
+        return None;
+    }
+    let mut signed2 = 0.0;
+    for i in 0..profile.len() {
+        let a = profile[i];
+        let b = profile[(i + 1) % profile.len()];
+        signed2 += a[0] * b[1] - a[1] * b[0];
+    }
+    if signed2 < 0.0 {
+        profile.reverse();
+        signed2 = -signed2;
+    }
+    let area = signed2 * 0.5;
+    if area < 1.0e-8 {
+        None
+    } else {
+        Some(area)
+    }
+}
+
+/// Strictly interior point of a CCW ring: the max-area CDT triangle centroid
+/// (a non-convex rebated profile's vertex centroid can lie outside).
+fn ring_interior(profile: &[V2]) -> Option<V2> {
+    let pts: Vec<Point2<f64>> = profile.iter().map(|p| Point2::new(p[0], p[1])).collect();
+    let (tp, ti) = crate::cdt::triangulate_constrained(&pts, &[])?;
+    let mut best = (0.0, [0.0, 0.0]);
+    for t in ti.chunks_exact(3) {
+        let (a, b, c) = (tp[t[0]], tp[t[1]], tp[t[2]]);
+        let ar = ((b.x - a.x) * (c.y - a.y) - (c.x - a.x) * (b.y - a.y)).abs();
+        if ar > best.0 {
+            best = (ar, [(a.x + b.x + c.x) / 3.0, (a.y + b.y + c.y) / 3.0]);
+        }
+    }
+    (best.0 > 0.0).then_some(best.1)
+}
+
+/// Cross-section ring of the welded cutter at depth `w_mid`: chord segments of
+/// every triangle crossing the plane, endpoints computed once per welded EDGE
+/// (bit-identical across the two incident triangles) and stitched into one
+/// loop by exact bit equality. `None` for anything but a single clean loop.
+fn cross_section_ring(
+    verts: &[V3],
+    tris: &[[usize; 3]],
+    d: V3,
+    u: V3,
+    v: V3,
+    w_mid: f64,
+) -> Option<Vec<V2>> {
+    let mut edge_cross: FxHashMap<(usize, usize), V3> = FxHashMap::default();
+    let mut crossing = |a: usize, b: usize| -> V3 {
+        let key = if a < b { (a, b) } else { (b, a) };
+        *edge_cross.entry(key).or_insert_with(|| {
+            let (pa, pb) = (verts[key.0], verts[key.1]);
+            let (da, db) = (dot(pa, d) - w_mid, dot(pb, d) - w_mid);
+            lerp(pa, pb, (da / (da - db)).clamp(0.0, 1.0))
+        })
+    };
+    let mut segs: Vec<(V3, V3)> = Vec::new();
+    for t in tris {
+        let dist = [
+            dot(verts[t[0]], d) - w_mid,
+            dot(verts[t[1]], d) - w_mid,
+            dot(verts[t[2]], d) - w_mid,
+        ];
+        let mut pts: Vec<V3> = Vec::new();
+        for e in 0..3 {
+            let (da, db) = (dist[e], dist[(e + 1) % 3]);
+            if (da > 0.0) != (db > 0.0) {
+                pts.push(crossing(t[e], t[(e + 1) % 3]));
+            }
+        }
+        if pts.len() == 2 {
+            segs.push((pts[0], pts[1]));
+        }
+    }
+    if segs.len() < 3 {
+        return None;
+    }
+    // Stitch by exact endpoint bits (undirected), walking one loop.
+    let mut adj: FxHashMap<[u64; 3], Vec<(usize, [u64; 3])>> = FxHashMap::default();
+    for (i, (a, b)) in segs.iter().enumerate() {
+        adj.entry(bits(*a)).or_default().push((i, bits(*b)));
+        adj.entry(bits(*b)).or_default().push((i, bits(*a)));
+    }
+    if adj.values().any(|v| v.len() != 2) {
+        return None; // branch / open curve — not a clean single section
+    }
+    let start = *adj.keys().min()?;
+    let mut ring_keys: Vec<[u64; 3]> = vec![start];
+    let mut used = vec![false; segs.len()];
+    let mut cur = start;
+    loop {
+        let nbrs = adj.get(&cur)?;
+        let Some(&(si, nxt)) = nbrs.iter().find(|(si, _)| !used[*si]) else {
+            break;
+        };
+        used[si] = true;
+        if nxt == start {
+            break;
+        }
+        ring_keys.push(nxt);
+        if ring_keys.len() > segs.len() {
+            return None;
+        }
+        cur = nxt;
+    }
+    if used.iter().any(|&x| !x) {
+        return None; // more than one loop (annular / multi-void section)
+    }
+    let to_v3 = |k: [u64; 3]| -> V3 {
+        [
+            f64::from_bits(k[0]),
+            f64::from_bits(k[1]),
+            f64::from_bits(k[2]),
+        ]
+    };
+    Some(
+        ring_keys
+            .iter()
+            .map(|&k| {
+                let p = to_v3(k);
+                [dot(p, u), dot(p, v)]
+            })
+            .collect(),
+    )
+}
+
+/// Detect that the (welded) cutter is a stepped extrusion and extract its
+/// stack. `verts`/`tris` are the welded cutter in host-local coordinates;
+/// `mesh_vol` is the enclosed volume of the (unwelded) cutter. Conservative:
+/// any doubt returns `None` → the exact kernel keeps the opening.
+fn detect_prism(verts: &[V3], tris: &[[usize; 3]], mesh_vol: f64) -> Option<PrismFrame> {
+    if tris.len() < 8 || tris.len() > 4096 {
+        return None;
+    }
+    // Facet normals; cluster into candidate depth directions.
+    let mut normals: Vec<Option<V3>> = Vec::with_capacity(tris.len());
+    for t in tris {
+        let (a, b, c) = (verts[t[0]], verts[t[1]], verts[t[2]]);
+        normals.push(normalize(cross(sub(b, a), sub(c, a))));
+    }
+    let mut clusters: Vec<V3> = Vec::new();
+    for n in normals.iter().flatten() {
+        if !clusters.iter().any(|c| dot(*n, *c).abs() > 0.999) {
+            if clusters.len() > 64 {
+                return None; // way past any stepped extrusion — bail early
+            }
+            clusters.push(*n);
+        }
+    }
+    let mut mag = 0.0f64;
+    for v in verts {
+        for c in v {
+            mag = mag.max(c.abs());
+        }
+    }
+    let plane_tol = 1.0e-4_f64.max(mag * 1.0e-6);
+    // Try each cluster direction as the depth axis: every facet must be
+    // parallel (a cap/step, on one of a few depth planes) or perpendicular
+    // (a side) to it.
+    'cand: for dc in &clusters {
+        let d = *dc;
+        let mut wlo = f64::INFINITY;
+        let mut whi = f64::NEG_INFINITY;
+        for v in verts {
+            let w = dot(*v, d);
+            wlo = wlo.min(w);
+            whi = whi.max(w);
+        }
+        if whi - wlo < 1.0e-4 {
+            continue;
+        }
+        // Collect the depth planes carried by parallel facets.
+        let mut plane_ws: Vec<f64> = vec![wlo, whi];
+        for (t, n) in tris.iter().zip(&normals) {
+            let Some(n) = n else { continue };
+            let a = dot(*n, d).abs();
+            if a > 0.9999 {
+                let w = dot(verts[t[0]], d);
+                // The whole facet must be planar in depth.
+                if t
+                    .iter()
+                    .any(|&i| (dot(verts[i], d) - w).abs() > plane_tol)
+                {
+                    continue 'cand;
+                }
+                if !plane_ws.iter().any(|p| (p - w).abs() <= plane_tol) {
+                    plane_ws.push(w);
+                }
+            } else if a > 0.002 {
+                // Neither exactly parallel nor exactly perpendicular ⇒ the
+                // cross-section varies along the depth ⇒ not a stepped
+                // extrusion about this axis. The tight band matters: a ~1°
+                // slanted side would make the mid-slab section drift ~0.5 mm
+                // across the slab, poisoning the analytic cut at the weld
+                // grid.
+                continue 'cand;
+            }
+        }
+        plane_ws.sort_by(f64::total_cmp);
+        if plane_ws.len() > MAX_SLABS + 1 {
+            continue;
+        }
+        let (u, v) = basis_from_depth(d)?;
+        // One cross-section ring per slab, sliced at the slab midpoint.
+        let n_slabs = plane_ws.len() - 1;
+        let mut raw_rings: Vec<Vec<V2>> = Vec::with_capacity(n_slabs);
+        for k in 0..n_slabs {
+            let (w_a, w_b) = (plane_ws[k], plane_ws[k + 1]);
+            if w_b - w_a < plane_tol * 2.0 {
+                continue 'cand; // sliver slab — numerically fragile, defer
+            }
+            let w_mid = (w_a + w_b) * 0.5;
+            let Some(ring) = cross_section_ring(verts, tris, d, u, v, w_mid) else {
+                continue 'cand;
+            };
+            if ring.len() > MAX_PROFILE_VERTS {
+                continue 'cand;
+            }
+            raw_rings.push(ring);
+        }
+        if raw_rings.is_empty() {
+            continue;
+        }
+        // SNAP profile coordinates across slabs: the per-slab cross-sections
+        // carry independent f32 storage jitter, so a jamb side SHARED by two
+        // slabs (no rebate step there) comes back as two near-coincident but
+        // unequal edges — µm-wide XOR slivers that wreck the cap CDT and the
+        // classification. Cluster all u values (and all v values) across the
+        // rings within the f32-jitter bound and remap every ring onto the
+        // canonical (first-seen) cluster value. Distinct REAL features (≥ mm)
+        // stay distinct; only jitter twins collapse.
+        let snap_tol = 3.0e-5_f64.max(mag * 6.0e-7);
+        for axis in 0..2 {
+            let mut vals: Vec<f64> = raw_rings
+                .iter()
+                .flat_map(|r| r.iter().map(|p| p[axis]))
+                .collect();
+            vals.sort_by(f64::total_cmp);
+            let mut canon: Vec<f64> = Vec::new();
+            for x in vals {
+                match canon.last() {
+                    Some(&last) if (x - last).abs() <= snap_tol => {}
+                    _ => canon.push(x),
+                }
+            }
+            for ring in raw_rings.iter_mut() {
+                for pnt in ring.iter_mut() {
+                    // Nearest canonical value (canon sorted; linear scan is
+                    // fine at these sizes, deterministic).
+                    let mut best = canon[0];
+                    for &cv in &canon {
+                        if (pnt[axis] - cv).abs() < (pnt[axis] - best).abs() {
+                            best = cv;
+                        }
+                    }
+                    pnt[axis] = best;
+                }
+            }
+        }
+        let mut profiles: Vec<Vec<V2>> = Vec::with_capacity(n_slabs);
+        let mut slab_area: Vec<f64> = Vec::with_capacity(n_slabs);
+        let mut slab_interior: Vec<V2> = Vec::with_capacity(n_slabs);
+        let mut vol = 0.0;
+        for (k, mut ring) in raw_rings.into_iter().enumerate() {
+            let (w_a, w_b) = (plane_ws[k], plane_ws[k + 1]);
+            let Some(area) = ccw_area(&mut ring) else {
+                continue 'cand;
+            };
+            // SLIVER-EDGE gate: a sub-half-millimetre profile edge sits at the
+            // 0.1 mm weld/audit grid where its cut features collapse to
+            // degenerate triangles and crack the closed-surface audit. Such
+            // micro-features belong to the exact kernel.
+            let nr = ring.len();
+            for ii in 0..nr {
+                let pa = ring[ii];
+                let pb = ring[(ii + 1) % nr];
+                let dx = pb[0] - pa[0];
+                let dy = pb[1] - pa[1];
+                if (dx * dx + dy * dy).sqrt() < 5.0e-4 {
+                    continue 'cand;
+                }
+            }
+            let Some(interior) = ring_interior(&ring) else {
+                continue 'cand;
+            };
+            vol += area * (w_b - w_a);
+            profiles.push(ring);
+            slab_area.push(area);
+            slab_interior.push(interior);
+        }
+        if profiles.is_empty() {
+            continue;
+        }
+        // Volume reconcile: enclosed mesh volume ≈ Σ area × slab depth
+        // (catches a section that missed part of the shape, hollow shells,
+        // twisted sides, etc.).
+        if !(0.98..1.02).contains(&(mesh_vol.abs() / vol)) {
+            continue;
+        }
+        let mut lo = [f64::INFINITY; 2];
+        let mut hi = [f64::NEG_INFINITY; 2];
+        for prof in &profiles {
+            for p in prof {
+                for k in 0..2 {
+                    lo[k] = lo[k].min(p[k]);
+                    hi[k] = hi[k].max(p[k]);
+                }
+            }
+        }
+        return Some(PrismFrame {
+            u,
+            v,
+            d,
+            planes: plane_ws,
+            profiles,
+            slab_area,
+            slab_interior,
+            bb: (lo, hi),
+        });
+    }
+    None
+}
+
+/// Build the analytic prism for one classified opening, expressed in the
+/// host's local frame (`origin` subtracted in f64). `None` ⇒ the opening is
+/// not a clean prism and stays with the exact kernel.
+fn prepare_prism(op: &OpeningType, origin: [f64; 3]) -> Option<PrismFrame> {
+    match op {
+        OpeningType::Rectangular(mn, mx, dir) => {
+            let lo = [mn.x - origin[0], mn.y - origin[1], mn.z - origin[2]];
+            let hi = [mx.x - origin[0], mx.y - origin[1], mx.z - origin[2]];
+            if (0..3).any(|k| hi[k] - lo[k] < 1.0e-4 || !lo[k].is_finite() || !hi[k].is_finite())
+            {
+                return None;
+            }
+            // Depth axis: the authored (axis-aligned) extrusion dir, else the
+            // thinnest extent (the classic wall-thickness cutter).
+            let k = match dir {
+                Some(d) => {
+                    let a = [d.x.abs(), d.y.abs(), d.z.abs()];
+                    let mut k = 0;
+                    for i in 1..3 {
+                        if a[i] > a[k] {
+                            k = i;
+                        }
+                    }
+                    k
+                }
+                None => {
+                    let ext = [hi[0] - lo[0], hi[1] - lo[1], hi[2] - lo[2]];
+                    let mut k = 0;
+                    for i in 1..3 {
+                        if ext[i] < ext[k] {
+                            k = i;
+                        }
+                    }
+                    k
+                }
+            };
+            let mut d = [0.0; 3];
+            d[k] = 1.0;
+            let (u, v) = basis_from_depth(d)?;
+            // Rectangle profile from the AABB corners projected to (u, v).
+            let mut plo = [f64::INFINITY; 2];
+            let mut phi = [f64::NEG_INFINITY; 2];
+            for ci in 0..8 {
+                let c = [
+                    if ci & 1 == 0 { lo[0] } else { hi[0] },
+                    if ci & 2 == 0 { lo[1] } else { hi[1] },
+                    if ci & 4 == 0 { lo[2] } else { hi[2] },
+                ];
+                let uu = dot(c, u);
+                let vv = dot(c, v);
+                plo[0] = plo[0].min(uu);
+                plo[1] = plo[1].min(vv);
+                phi[0] = phi[0].max(uu);
+                phi[1] = phi[1].max(vv);
+            }
+            let profile = vec![
+                [plo[0], plo[1]],
+                [phi[0], plo[1]],
+                [phi[0], phi[1]],
+                [plo[0], phi[1]],
+            ];
+            let area = (phi[0] - plo[0]) * (phi[1] - plo[1]);
+            Some(PrismFrame {
+                u,
+                v,
+                d,
+                planes: vec![lo[k], hi[k]],
+                profiles: vec![profile],
+                slab_area: vec![area],
+                slab_interior: vec![[(plo[0] + phi[0]) * 0.5, (plo[1] + phi[1]) * 0.5]],
+                bb: (plo, phi),
+            })
+        }
+        OpeningType::DiagonalRectangular(m, _) | OpeningType::NonRectangular(m, _, _, _) => {
+            // A genuine prism must weld to a closed 2-manifold; the
+            // self-intersecting "fin" cutters (#1007) and open shells fail
+            // here and keep their exact-kernel (+ malformed-recut) treatment.
+            // An opening authored as glued extrusions carries a back-to-back
+            // cap membrane mid-cutter that breaks manifoldness — deseam it
+            // first (the same repair every exact void path funnels through).
+            let deseamed;
+            let m = if cutter_is_closed_manifold(m) {
+                m
+            } else {
+                let dir = match op {
+                    OpeningType::DiagonalRectangular(_, frame) => frame.depth,
+                    OpeningType::NonRectangular(_, _, _, Some(d)) => *d,
+                    _ => opening_mesh_thinnest_axis_dir(m),
+                };
+                deseamed = GeometryRouter::remove_internal_membrane(m, dir);
+                if !cutter_is_closed_manifold(&deseamed) {
+                    return None;
+                }
+                &deseamed
+            };
+            // Host-local f64 verts (cutter origin folded, host origin removed).
+            let o = m.origin;
+            let vc = m.positions.len() / 3;
+            let mut raw: Vec<V3> = Vec::with_capacity(vc);
+            for c in m.positions.chunks_exact(3) {
+                let p = [
+                    c[0] as f64 + o[0] - origin[0],
+                    c[1] as f64 + o[1] - origin[1],
+                    c[2] as f64 + o[2] - origin[2],
+                ];
+                if p.iter().any(|x| !x.is_finite()) {
+                    return None;
+                }
+                raw.push(p);
+            }
+            // Enclosed volume from the raw (per-face-vertex) soup.
+            let mut vol6 = 0.0;
+            for t in m.indices.chunks_exact(3) {
+                if t.iter().any(|&i| i as usize >= vc) {
+                    return None;
+                }
+                let (a, b, c) = (
+                    raw[t[0] as usize],
+                    raw[t[1] as usize],
+                    raw[t[2] as usize],
+                );
+                vol6 += dot(a, cross(b, c));
+            }
+            // Weld by position for exact edge stitching of the cap boundary.
+            let mut wverts: Vec<V3> = Vec::new();
+            let mut wmap: FxHashMap<(i64, i64, i64), usize> = FxHashMap::default();
+            let q = |x: f64| (x / 1.0e-6).round() as i64;
+            let mut idx_of = vec![0usize; raw.len()];
+            for (i, p) in raw.iter().enumerate() {
+                let key = (q(p[0]), q(p[1]), q(p[2]));
+                let id = *wmap.entry(key).or_insert_with(|| {
+                    wverts.push(*p);
+                    wverts.len() - 1
+                });
+                idx_of[i] = id;
+            }
+            let mut wtris: Vec<[usize; 3]> = Vec::with_capacity(m.indices.len() / 3);
+            for t in m.indices.chunks_exact(3) {
+                let a = idx_of[t[0] as usize];
+                let b = idx_of[t[1] as usize];
+                let c = idx_of[t[2] as usize];
+                if a != b && b != c && c != a {
+                    wtris.push([a, b, c]);
+                }
+            }
+            detect_prism(&wverts, &wtris, vol6 / 6.0)
+        }
+    }
+}
+
+/// Cyclic CCW-ring equality within `tol`.
+fn rings_equal(a: &[V2], b: &[V2], tol: f64) -> bool {
+    let n = a.len();
+    if b.len() != n {
+        return false;
+    }
+    'off: for o in 0..n {
+        for i in 0..n {
+            let pa = a[i];
+            let pb = b[(i + o) % n];
+            if (pa[0] - pb[0]).abs() > tol || (pa[1] - pb[1]).abs() > tol {
+                continue 'off;
+            }
+        }
+        return true;
+    }
+    false
+}
+
+/// Merge two stacks whose union is exactly one stack: identical depth axis
+/// (hence identical deterministic basis) and TOUCHING depth ranges (within
+/// `tol`); the stacks concatenate at the touching plane, and equal adjacent
+/// profiles fuse into one slab. This is the wall-leaf half-void pattern (FZK /
+/// masonry leaf walls): one window void split into abutting halves along the
+/// wall thickness — cutting the union in one pass sidesteps their coplanar
+/// interface entirely.
+fn try_merge_prisms(a: &PrismFrame, b: &PrismFrame, tol: f64) -> Option<PrismFrame> {
+    if dot(a.d, b.d) < 1.0 - 1.0e-8 {
+        return None; // same authored axis ⇒ same deterministic basis
+    }
+    // Order along d; only TOUCHING (not overlapping) ranges concatenate.
+    let (lo, hi) = if a.d1() <= b.d0() + tol && a.d1() >= b.d0() - tol {
+        (a, b)
+    } else if b.d1() <= a.d0() + tol && b.d1() >= a.d0() - tol {
+        (b, a)
+    } else {
+        return None;
+    };
+    if lo.profiles.len() + hi.profiles.len() > MAX_SLABS {
+        return None;
+    }
+    let mut m = lo.clone();
+    // Stitch the interface: hi's first plane is re-anchored on lo's last.
+    m.planes.extend(hi.planes[1..].iter().copied());
+    m.profiles.extend(hi.profiles.iter().cloned());
+    m.slab_area.extend(hi.slab_area.iter().copied());
+    m.slab_interior.extend(hi.slab_interior.iter().copied());
+    // Fuse the two slabs meeting at the interface when their profiles match
+    // (the plain leaf-half case collapses back to a single slab).
+    let k = lo.profiles.len(); // index of hi's first slab in the merged stack
+    if k > 0 && k < m.profiles.len() && rings_equal(&m.profiles[k - 1], &m.profiles[k], tol) {
+        m.planes.remove(k);
+        m.profiles.remove(k);
+        m.slab_area.remove(k);
+        m.slab_interior.remove(k);
+    }
+    m.bb = {
+        let mut lo2 = [f64::INFINITY; 2];
+        let mut hi2 = [f64::NEG_INFINITY; 2];
+        for prof in &m.profiles {
+            for p in prof {
+                for k in 0..2 {
+                    lo2[k] = lo2[k].min(p[k]);
+                    hi2[k] = hi2[k].max(p[k]);
+                }
+            }
+        }
+        (lo2, hi2)
+    };
+    Some(m)
+}
+
+/// World-axis AABB of an opening that did NOT yield a prism, as an
+/// identity-frame OBB in the host's local frame — an overlap "blocker": a
+/// candidate prism abutting an exact-kernel opening must not be cut
+/// analytically (the residual exact cut would land flush on its caps).
+fn opening_aabb_obb(op: &OpeningType, origin: [f64; 3]) -> Option<([V3; 3], V3, V3)> {
+    let (mn, mx): (V3, V3) = match op {
+        OpeningType::Rectangular(mn, mx, _) | OpeningType::NonRectangular(_, mn, mx, _) => {
+            ([mn.x, mn.y, mn.z], [mx.x, mx.y, mx.z])
+        }
+        OpeningType::DiagonalRectangular(m, _) => {
+            let (a, b) = m.bounds();
+            let o = m.origin;
+            (
+                [a.x as f64 + o[0], a.y as f64 + o[1], a.z as f64 + o[2]],
+                [b.x as f64 + o[0], b.y as f64 + o[1], b.z as f64 + o[2]],
+            )
+        }
+    };
+    let lo = [mn[0] - origin[0], mn[1] - origin[1], mn[2] - origin[2]];
+    let hi = [mx[0] - origin[0], mx[1] - origin[1], mx[2] - origin[2]];
+    if (0..3).any(|k| !(hi[k] > lo[k]) || !lo[k].is_finite() || !hi[k].is_finite()) {
+        return None;
+    }
+    Some((
+        [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]],
+        lo,
+        hi,
+    ))
+}
+
+// ─────────────────────────── ray parity (point in solid) ─────────────────────
+
+/// Fixed skewed ray direction (same constants as `geom::point_inside_mesh`) —
+/// avoids exact grazes on the axis-dominated faces of IFC geometry.
+const RAY_DIR: V3 = [0.573_257_1, 0.665_412_3, 0.477_889_5];
+
+/// Möller–Trumbore crossing parity of `point` against the triangle list (with
+/// precomputed AABBs). Odd ⇒ inside the solid.
+fn point_inside(tris: &[PTri], aabbs: &[(V3, V3)], point: V3) -> bool {
+    let mut crossings = 0usize;
+    for (t, (_lo, hi)) in tris.iter().zip(aabbs) {
+        // Cheap reject: every component of `RAY_DIR` is positive, so a hit
+        // point has all coordinates strictly greater than the origin's — a
+        // triangle entirely below the origin on ANY axis cannot be crossed.
+        if hi[0] < point[0] || hi[1] < point[1] || hi[2] < point[2] {
+            continue;
+        }
+        let e1 = sub(t.p[1], t.p[0]);
+        let e2 = sub(t.p[2], t.p[0]);
+        let pvec = cross(RAY_DIR, e2);
+        let det = dot(e1, pvec);
+        if det.abs() < 1.0e-12 {
+            continue;
+        }
+        let inv = 1.0 / det;
+        let tvec = sub(point, t.p[0]);
+        let u = dot(tvec, pvec) * inv;
+        if !(-1.0e-9..=1.0 + 1.0e-9).contains(&u) {
+            continue;
+        }
+        let qvec = cross(tvec, e1);
+        let v = dot(RAY_DIR, qvec) * inv;
+        if v < -1.0e-9 || u + v > 1.0 + 1.0e-9 {
+            continue;
+        }
+        let dist = dot(e2, qvec) * inv;
+        if dist > 1.0e-9 {
+            crossings += 1;
+        }
+    }
+    crossings % 2 == 1
+}
+
+// ────────────────────────────── cap extension ───────────────────────────────
+
+/// Push each prism CAP outward past the host surface when the swept slab is
+/// PROVABLY empty of host material: no host triangle intersects (profile
+/// footprint × slab) AND a probe point inside the slab lies outside the host
+/// solid. A flush window cap then becomes a clean transversal crossing, while
+/// a genuine blind-recess bottom (host material beyond the cap) keeps its
+/// authored plane.
+fn extend_prism_caps(pf: &mut PrismFrame, tris: &[PTri], aabbs: &[(V3, V3)]) {
+    let span = pf.d1() - pf.d0();
+    let delta = (span * 0.1).clamp(0.005, 0.5);
+    let mag = pf.corner_mag();
+    // Flush-exclusion band: a host FACE lying exactly ON the cap plane (the
+    // flush window/sleeve case — including its f32 storage jitter) is not
+    // material BEYOND the plane and must not block the extension; only
+    // geometry clearly past the band does. 0.2 mm is far below any real shell.
+    let band = 2.0e-4_f64.max(mag * 4.0e-7);
+    let pad = 1.0e-6 * (1.0 + mag);
+    for hi_side in [false, true] {
+        let (slab_lo, slab_hi) = if hi_side {
+            (pf.d1() + band, pf.d1() + delta)
+        } else {
+            (pf.d0() - delta, pf.d0() - band)
+        };
+        if slab_hi <= slab_lo {
+            continue;
+        }
+        let (k, interior) = if hi_side {
+            (pf.profiles.len() - 1, pf.slab_interior[pf.profiles.len() - 1])
+        } else {
+            (0, pf.slab_interior[0])
+        };
+        let profile = &pf.profiles[k];
+        let occupied = tris
+            .iter()
+            .any(|t| tri_touches_slab_footprint(t, pf, profile, slab_lo, slab_hi, pad));
+        if occupied {
+            continue;
+        }
+        let probe = pf.lift(interior[0], interior[1], (slab_lo + slab_hi) * 0.5);
+        if point_inside(tris, aabbs, probe) {
+            continue;
+        }
+        let last = pf.planes.len() - 1;
+        if hi_side {
+            pf.planes[last] += delta;
+        } else {
+            pf.planes[0] -= delta;
+        }
+    }
+}
+
+/// Push a profile EDGE outward past the host surface when the swept band
+/// beyond it is provably empty of host material — the side-face analog of the
+/// cap extension. The canonical case: a DOOR whose bottom profile edge is
+/// flush with the wall's bottom face; without extension that strip is
+/// coplanar with host skin (parity garbage), with it the threshold band falls
+/// cleanly inside the cutter. Corners are re-derived by intersecting the
+/// translated edge line with the (unchanged) neighbour edge lines.
+fn extend_profile_edges(pf: &mut PrismFrame, tris: &[PTri], aabbs: &[(V3, V3)]) {
+    let mag = pf.corner_mag();
+    let band = 2.0e-4_f64.max(mag * 4.0e-7);
+    for k in 0..pf.profiles.len() {
+        let (w_a, w_b) = (pf.planes[k], pf.planes[k + 1]);
+        let mut i = 0usize;
+        while i < pf.profiles[k].len() {
+            let prof = pf.profiles[k].clone();
+            let n = prof.len();
+            let a = prof[i];
+            let b = prof[(i + 1) % n];
+            let e = [b[0] - a[0], b[1] - a[1]];
+            let len = (e[0] * e[0] + e[1] * e[1]).sqrt();
+            if len < 1.0e-6 {
+                i += 1;
+                continue;
+            }
+            let ed = [e[0] / len, e[1] / len];
+            let n2 = [ed[1], -ed[0]]; // outward for a CCW ring
+            let delta = (len * 0.1).clamp(0.01, 0.5);
+            // Neighbour edge lines must be genuinely transversal to move the
+            // corners; skip near-collinear neighbours.
+            let ap = prof[(i + n - 1) % n];
+            let bn = prof[(i + 2) % n];
+            let d_prev = [a[0] - ap[0], a[1] - ap[1]];
+            let d_next = [bn[0] - b[0], bn[1] - b[1]];
+            let cr_prev = ed[0] * d_prev[1] - ed[1] * d_prev[0];
+            let cr_next = ed[0] * d_next[1] - ed[1] * d_next[0];
+            let lp = (d_prev[0] * d_prev[0] + d_prev[1] * d_prev[1]).sqrt();
+            let ln = (d_next[0] * d_next[0] + d_next[1] * d_next[1]).sqrt();
+            if lp < 1.0e-9 || ln < 1.0e-9 || cr_prev.abs() / lp < 0.1 || cr_next.abs() / ln < 0.1
+            {
+                i += 1;
+                continue;
+            }
+            // Emptiness of the swept band (band..delta beyond the edge, this
+            // slab's depth interval), then an outside-host probe.
+            let quad = [
+                [a[0] + n2[0] * band, a[1] + n2[1] * band],
+                [b[0] + n2[0] * band, b[1] + n2[1] * band],
+                [b[0] + n2[0] * delta, b[1] + n2[1] * delta],
+                [a[0] + n2[0] * delta, a[1] + n2[1] * delta],
+            ];
+            let pad = 1.0e-6 * (1.0 + mag);
+            let occupied = tris
+                .iter()
+                .any(|t| tri_touches_slab_footprint(t, pf, &quad, w_a, w_b, pad));
+            if occupied {
+                i += 1;
+                continue;
+            }
+            let mid_off = (band + delta) * 0.5;
+            let probe2 = [
+                (a[0] + b[0]) * 0.5 + n2[0] * mid_off,
+                (a[1] + b[1]) * 0.5 + n2[1] * mid_off,
+            ];
+            let probe = pf.lift(probe2[0], probe2[1], (w_a + w_b) * 0.5);
+            if point_inside(tris, aabbs, probe) {
+                i += 1;
+                continue;
+            }
+            // Translate the edge line by delta and re-derive its two corners
+            // as intersections with the neighbour edge lines.
+            let line_pt = [a[0] + n2[0] * delta, a[1] + n2[1] * delta];
+            let isect = |p0: V2, dir0: V2| -> Option<V2> {
+                // line_pt + t·ed  ==  p0 + s·dir0
+                let den = ed[0] * dir0[1] - ed[1] * dir0[0];
+                if den.abs() < 1.0e-12 {
+                    return None;
+                }
+                let dx = [p0[0] - line_pt[0], p0[1] - line_pt[1]];
+                let t = (dx[0] * dir0[1] - dx[1] * dir0[0]) / den;
+                Some([line_pt[0] + ed[0] * t, line_pt[1] + ed[1] * t])
+            };
+            let (Some(na), Some(nb)) = (
+                isect(ap, [d_prev[0] / lp, d_prev[1] / lp]),
+                isect(b, [d_next[0] / ln, d_next[1] / ln]),
+            ) else {
+                i += 1;
+                continue;
+            };
+            pf.profiles[k][i] = na;
+            pf.profiles[k][(i + 1) % n] = nb;
+            i += 1;
+        }
+        // Refresh the slab area (the interior point stays valid — the profile
+        // only grew).
+        let mut ring = pf.profiles[k].clone();
+        if let Some(area) = ccw_area(&mut ring) {
+            pf.profiles[k] = ring;
+            pf.slab_area[k] = area;
+        }
+    }
+    // Refresh the overall bbox.
+    let mut lo = [f64::INFINITY; 2];
+    let mut hi = [f64::NEG_INFINITY; 2];
+    for prof in &pf.profiles {
+        for p in prof {
+            for k in 0..2 {
+                lo[k] = lo[k].min(p[k]);
+                hi[k] = hi[k].max(p[k]);
+            }
+        }
+    }
+    pf.bb = (lo, hi);
+}
+
+/// Whether triangle `t` has a non-degenerate piece inside the region
+/// `{depth ∈ [slab_lo, slab_hi]} ∩ {(u,v) within the (pad-inflated) profile}`.
+/// Conservative in the safe direction: any doubt reports "occupied" (⇒ no cap
+/// extension ⇒ at worst a later self-check fallback, never an over-cut).
+fn tri_touches_slab_footprint(
+    t: &PTri,
+    pf: &PrismFrame,
+    profile: &[V2],
+    slab_lo: f64,
+    slab_hi: f64,
+    pad: f64,
+) -> bool {
+    // Clip the triangle to the depth slab (two parallel planes) — convex S-H.
+    let mut poly: Vec<V3> = t.p.to_vec();
+    for hi_side in [false, true] {
+        if poly.len() < 3 {
+            return false;
+        }
+        let mut next: Vec<V3> = Vec::with_capacity(poly.len() + 1);
+        let dist = |p: V3| -> f64 {
+            let w = dot(p, pf.d);
+            if hi_side {
+                w - slab_hi
+            } else {
+                slab_lo - w
+            }
+        };
+        for i in 0..poly.len() {
+            let j = (i + 1) % poly.len();
+            let (da, db) = (dist(poly[i]), dist(poly[j]));
+            if da <= 0.0 {
+                next.push(poly[i]);
+            }
+            if (da <= 0.0) != (db <= 0.0) {
+                next.push(lerp(poly[i], poly[j], da / (da - db)));
+            }
+        }
+        poly = next;
+    }
+    if poly.len() < 3 {
+        return false;
+    }
+    // 2D overlap of the clipped (convex) polygon with the profile: vertex of
+    // one inside the other, or any edge pair crossing.
+    let poly2: Vec<V2> = poly.iter().map(|p| pf.to2(*p)).collect();
+    // bbox prefilter with pad.
+    let mut lo = [f64::INFINITY; 2];
+    let mut hi = [f64::NEG_INFINITY; 2];
+    for p in &poly2 {
+        for k in 0..2 {
+            lo[k] = lo[k].min(p[k]);
+            hi[k] = hi[k].max(p[k]);
+        }
+    }
+    if hi[0] < pf.bb.0[0] - pad
+        || lo[0] > pf.bb.1[0] + pad
+        || hi[1] < pf.bb.0[1] - pad
+        || lo[1] > pf.bb.1[1] + pad
+    {
+        return false;
+    }
+    if poly2.iter().any(|p| pip(*p, profile)) {
+        return true;
+    }
+    if profile.iter().any(|p| pip(*p, &poly2)) {
+        return true;
+    }
+    let np = poly2.len();
+    let nq = profile.len();
+    for i in 0..np {
+        let (a, b) = (poly2[i], poly2[(i + 1) % np]);
+        for j in 0..nq {
+            let (c, d2) = (profile[j], profile[(j + 1) % nq]);
+            if seg_cross_param(a, b, c, d2).is_some() {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+// ─────────────────────────────── the prism cut ──────────────────────────────
+
+/// Canonical-order edge×face-plane crossing cache. Both triangles sharing an
+/// edge compute the crossing from the SAME endpoint order, so the point is
+/// bit-identical on both sides — the T-junction-freedom cornerstone.
+type CrossCache = FxHashMap<([u64; 3], [u64; 3], u16), V3>;
+
+/// A seam sub-segment on a prism face: exact 3D endpoints plus their
+/// face-local 2D coordinates.
+struct Seam {
+    a3: V3,
+    b3: V3,
+    a2: V2,
+    b2: V2,
+}
+
+struct PrismCutOutcome {
+    tris: Vec<PTri>,
+    /// Volume removed (host ∩ cutter), from the closed inside assembly.
+    removed: f64,
+}
+
+/// Plane of a face: (unit normal, offset) with the plane `{x : n·x = c}`.
+fn face_plane(pf: &PrismFrame, face: Face) -> Option<(V3, f64)> {
+    match face {
+        Face::Cap { j } => Some((pf.d, pf.planes[j])),
+        Face::Strip { k, i } => {
+            let prof = &pf.profiles[k];
+            let n = prof.len();
+            let a = prof[i];
+            let b = prof[(i + 1) % n];
+            let e = [b[0] - a[0], b[1] - a[1]];
+            let len = (e[0] * e[0] + e[1] * e[1]).sqrt();
+            if len < 1.0e-9 {
+                return None;
+            }
+            // Outward 2D normal of a CCW ring edge.
+            let n2 = [e[1] / len, -e[0] / len];
+            let n3 = add(scale(pf.u, n2[0]), scale(pf.v, n2[1]));
+            let c = n2[0] * a[0] + n2[1] * a[1];
+            Some((n3, c))
+        }
+    }
+}
+
+/// Intersection of segment (a, b) with face plane `f` (`{x: m·x = c}`),
+/// computed in canonical endpoint order and cached. Endpoint-clamped crossings
+/// return the endpoint EXACTLY (bit-equal), so they intern to the same pooled
+/// vertex instead of a 1-ulp duplicate.
+fn cached_crossing(cache: &mut CrossCache, f: u16, m: V3, c: f64, a: V3, b: V3) -> V3 {
+    let (ka, kb) = (bits(a), bits(b));
+    let (first, second, key) = if ka <= kb {
+        (a, b, (ka, kb, f))
+    } else {
+        (b, a, (kb, ka, f))
+    };
+    if let Some(p) = cache.get(&key) {
+        return *p;
+    }
+    let da = dot(first, m) - c;
+    let db = dot(second, m) - c;
+    let denom = da - db;
+    let t = if denom.abs() < 1.0e-300 {
+        0.5
+    } else {
+        (da / denom).clamp(0.0, 1.0)
+    };
+    let p = if t <= 0.0 {
+        first
+    } else if t >= 1.0 {
+        second
+    } else {
+        lerp(first, second, t)
+    };
+    cache.insert(key, p);
+    p
+}
+
+/// Face-local 2D coordinates of a 3D point.
+fn face_coords(pf: &PrismFrame, face: Face, p: V3) -> V2 {
+    match face {
+        Face::Cap { .. } => pf.to2(p),
+        Face::Strip { k, i } => {
+            let prof = &pf.profiles[k];
+            let n = prof.len();
+            let a = prof[i];
+            let b = prof[(i + 1) % n];
+            let e = [b[0] - a[0], b[1] - a[1]];
+            let len = (e[0] * e[0] + e[1] * e[1]).sqrt();
+            let ed = [e[0] / len, e[1] / len];
+            let q = pf.to2(p);
+            [
+                (q[0] - a[0]) * ed[0] + (q[1] - a[1]) * ed[1],
+                dot(p, pf.d),
+            ]
+        }
+    }
+}
+
+/// Subtract the stepped solid `pf` from the host triangle list. `Err(defer
+/// index)` ⇒ a gate or self-check failed ⇒ the caller must leave the host
+/// untouched and route this opening to the exact kernel.
+fn cut_prism(tris: &[PTri], pf: &PrismFrame) -> Result<PrismCutOutcome, usize> {
+    let faces = stack_faces(pf);
+    if faces.len() > u16::MAX as usize {
+        return Err(7);
+    }
+    let mut planes: Vec<(V3, f64)> = Vec::with_capacity(faces.len());
+    for &face in &faces {
+        planes.push(face_plane(pf, face).ok_or(7usize)?);
+    }
+
+    let aabbs: Vec<(V3, V3)> = tris.iter().map(PTri::aabb).collect();
+    let mut cache: CrossCache = CrossCache::default();
+
+    let mut out: Vec<PTri> = Vec::with_capacity(tris.len() + 16);
+    let mut inside: Vec<PTri> = Vec::new();
+    let mut seams: Vec<Vec<Seam>> = (0..faces.len()).map(|_| Vec::new()).collect();
+    let mut any_cut = false;
+
+    for t in tris {
+        // Quick reject: depth interval and 2D bbox versus the overall bbox.
+        let w0 = dot(t.p[0], pf.d);
+        let w1 = dot(t.p[1], pf.d);
+        let w2 = dot(t.p[2], pf.d);
+        if w0.max(w1).max(w2) < pf.d0() || w0.min(w1).min(w2) > pf.d1() {
+            out.push(t.clone());
+            continue;
+        }
+        {
+            let q0 = pf.to2(t.p[0]);
+            let q1 = pf.to2(t.p[1]);
+            let q2 = pf.to2(t.p[2]);
+            let lo = [q0[0].min(q1[0]).min(q2[0]), q0[1].min(q1[1]).min(q2[1])];
+            let hi = [q0[0].max(q1[0]).max(q2[0]), q0[1].max(q1[1]).max(q2[1])];
+            if hi[0] < pf.bb.0[0]
+                || lo[0] > pf.bb.1[0]
+                || hi[1] < pf.bb.0[1]
+                || lo[1] > pf.bb.1[1]
+            {
+                out.push(t.clone());
+                continue;
+            }
+        }
+
+        // Gather T ∩ ∂solid seam sub-segments + T-edge subdivision points.
+        let mut segs: Vec<(usize, V3, V3)> = Vec::new(); // (face idx, a3, b3)
+        let mut edge_pts: [Vec<V3>; 3] = Default::default();
+        for (fi, (&face, &(m, c))) in faces.iter().zip(&planes).enumerate() {
+            // Chord of T with this face plane (strict >0 side test — symmetric
+            // and vertex-exact, so neighbours agree bit-for-bit).
+            let dist = [
+                dot(t.p[0], m) - c,
+                dot(t.p[1], m) - c,
+                dot(t.p[2], m) - c,
+            ];
+            let mut chord: Vec<(V3, usize)> = Vec::new(); // (point, tri edge)
+            for e in 0..3 {
+                let (da, db) = (dist[e], dist[(e + 1) % 3]);
+                if (da > 0.0) != (db > 0.0) {
+                    let p = cached_crossing(
+                        &mut cache,
+                        fi as u16,
+                        m,
+                        c,
+                        t.p[e],
+                        t.p[(e + 1) % 3],
+                    );
+                    chord.push((p, e));
+                }
+            }
+            if chord.len() != 2 {
+                continue;
+            }
+            let (q0, e0) = chord[0];
+            let (q1, e1) = chord[1];
+            // Face-local membership gate + clipping of the chord to the face's
+            // exposed region.
+            match face {
+                Face::Cap { j } => {
+                    let a2 = pf.to2(q0);
+                    let b2 = pf.to2(q1);
+                    // T-edge subdivision membership (point-deterministic —
+                    // both neighbours agree).
+                    if cap_xor(pf, j, a2) {
+                        edge_pts[e0].push(q0);
+                    }
+                    if cap_xor(pf, j, b2) {
+                        edge_pts[e1].push(q1);
+                    }
+                    // Subdivide the 2D chord at crossings with BOTH adjacent
+                    // profiles' edges; keep sub-segments inside the XOR region.
+                    let mut ts: Vec<f64> = vec![0.0, 1.0];
+                    for prof in [
+                        (j > 0).then(|| &pf.profiles[j - 1]),
+                        (j < pf.profiles.len()).then(|| &pf.profiles[j]),
+                    ]
+                    .into_iter()
+                    .flatten()
+                    {
+                        let npr = prof.len();
+                        for i in 0..npr {
+                            let (pa, pb) = (prof[i], prof[(i + 1) % npr]);
+                            if let Some(tt) = seg_cross_param(a2, b2, pa, pb) {
+                                ts.push(tt);
+                            }
+                        }
+                    }
+                    ts.sort_by(f64::total_cmp);
+                    ts.dedup_by(|x, y| (*x - *y).abs() < 1.0e-12);
+                    for wnd in ts.windows(2) {
+                        let (ta, tb) = (wnd[0], wnd[1]);
+                        if tb - ta < 1.0e-12 {
+                            continue;
+                        }
+                        let mid = [
+                            a2[0] + (b2[0] - a2[0]) * (ta + tb) * 0.5,
+                            a2[1] + (b2[1] - a2[1]) * (ta + tb) * 0.5,
+                        ];
+                        if cap_xor(pf, j, mid) {
+                            let sa = if ta == 0.0 { q0 } else { lerp(q0, q1, ta) };
+                            let sb = if tb == 1.0 { q1 } else { lerp(q0, q1, tb) };
+                            segs.push((fi, sa, sb));
+                        }
+                    }
+                }
+                Face::Strip { k, i } => {
+                    let prof = &pf.profiles[k];
+                    let npr = prof.len();
+                    let a = prof[i];
+                    let b = prof[(i + 1) % npr];
+                    let e2 = [b[0] - a[0], b[1] - a[1]];
+                    let len = (e2[0] * e2[0] + e2[1] * e2[1]).sqrt();
+                    let ed = [e2[0] / len, e2[1] / len];
+                    let (w_a, w_b) = (pf.planes[k], pf.planes[k + 1]);
+                    let sparam = |p: V3| -> f64 {
+                        let q = pf.to2(p);
+                        (q[0] - a[0]) * ed[0] + (q[1] - a[1]) * ed[1]
+                    };
+                    let wparam = |p: V3| dot(p, pf.d);
+                    let (s0, s1) = (sparam(q0), sparam(q1));
+                    let (wc0, wc1) = (wparam(q0), wparam(q1));
+                    // Membership gate for T-edge subdivision.
+                    let in_strip =
+                        |s: f64, w: f64| (0.0..=len).contains(&s) && (w_a..=w_b).contains(&w);
+                    if in_strip(s0, wc0) {
+                        edge_pts[e0].push(q0);
+                    }
+                    if in_strip(s1, wc1) {
+                        edge_pts[e1].push(q1);
+                    }
+                    // τ interval on the chord where both params are in range.
+                    let mut t_lo = 0.0f64;
+                    let mut t_hi = 1.0f64;
+                    for (p0, p1, lo, hi) in [(s0, s1, 0.0, len), (wc0, wc1, w_a, w_b)] {
+                        let dp = p1 - p0;
+                        if dp.abs() < 1.0e-15 {
+                            if p0 < lo || p0 > hi {
+                                t_lo = 1.0;
+                                t_hi = 0.0;
+                            }
+                        } else {
+                            let (mut ta, mut tb) = ((lo - p0) / dp, (hi - p0) / dp);
+                            if ta > tb {
+                                std::mem::swap(&mut ta, &mut tb);
+                            }
+                            t_lo = t_lo.max(ta);
+                            t_hi = t_hi.min(tb);
+                        }
+                    }
+                    if t_hi - t_lo > 1.0e-12 {
+                        let sa = if t_lo == 0.0 { q0 } else { lerp(q0, q1, t_lo) };
+                        let sb = if t_hi == 1.0 { q1 } else { lerp(q0, q1, t_hi) };
+                        segs.push((fi, sa, sb));
+                    }
+                }
+            }
+        }
+
+        if segs.is_empty() && edge_pts.iter().all(|v| v.is_empty()) {
+            // No boundary reaches this triangle: it is wholly inside or wholly
+            // outside the (open) solid.
+            let centroid = scale(add(add(t.p[0], t.p[1]), t.p[2]), 1.0 / 3.0);
+            if pf.contains(centroid) {
+                inside.push(t.clone());
+                any_cut = true;
+            } else {
+                out.push(t.clone());
+            }
+            continue;
+        }
+
+        // Conforming decomposition of T by the seam constraints.
+        if !decompose_tri(t, pf, &faces, &segs, &edge_pts, &mut out, &mut inside, &mut seams) {
+            return Err(7);
+        }
+        any_cut = true;
+    }
+
+    if !any_cut {
+        return Err(4); // nothing to remove — a silent no-op belongs to the exact path
+    }
+
+    // Canonical per-cap-plane breakpoints: the vertices of both adjacent
+    // profiles plus every proper crossing between their ring edges. Injected
+    // into the cap AND every strip bordering that plane, so the faces sharing
+    // a cutter-edge line subdivide it IDENTICALLY (T-junction freedom across
+    // faces — the cap knows about profile corners the strip alone does not).
+    let plane_pts: Vec<Vec<V2>> = (0..pf.planes.len())
+        .map(|j| cap_plane_breakpoints(pf, j))
+        .collect();
+
+    // Caps: one CDT per face, constrained by that face's seams, classified by
+    // ray parity against the PRE-CUT host.
+    let mut caps: Vec<PTri> = Vec::new();
+    for (fi, &face) in faces.iter().enumerate() {
+        if !build_face_cap(pf, face, &seams[fi], &plane_pts, tris, &aabbs, &mut caps) {
+            return Err(7);
+        }
+    }
+
+    // Volume self-checks (f64, exact identities up to roundoff):
+    //   vol_out + vol_in == vol_host   (caps cancel, fragments partition)
+    //   0 < vol_in <= vol(cutter)      (the caps close the removed solid)
+    let mut host_mag = pf.corner_mag();
+    for (lo, hi) in &aabbs {
+        for k in 0..3 {
+            host_mag = host_mag.max(lo[k].abs()).max(hi[k].abs());
+        }
+    }
+    let vol_host = tri_volume6(tris) / 6.0;
+    let caps_vol = tri_volume6(&caps) / 6.0; // caps oriented for the RESULT
+    let vol_out = tri_volume6(&out) / 6.0 + caps_vol;
+    let vol_in = tri_volume6(&inside) / 6.0 - caps_vol;
+    let scale3 = (1.0 + host_mag).powi(3);
+    let tol = 1.0e-12 * scale3 + 1.0e-9;
+    if (vol_out + vol_in - vol_host).abs() > tol.max(1.0e-6 * vol_host.abs()) {
+        return Err(8);
+    }
+    if vol_in < 1.0e-9 {
+        return Err(8); // removed nothing measurable — leave to the exact path
+    }
+    if vol_in > pf.volume() * (1.0 + 1.0e-6) + tol {
+        return Err(8);
+    }
+
+    let mut tris_out = out;
+    tris_out.append(&mut caps);
+    Ok(PrismCutOutcome {
+        tris: tris_out,
+        removed: vol_in,
+    })
+}
+
+/// 2D point pool with tolerance merging: canonical 3D/normal = first-seen.
+/// Merging kills the 1e-12 doublets a cutter-edge junction produces when two
+/// faces' clips compute the same geometric point through different arithmetic.
+struct PointPool {
+    pts2: Vec<Point2<f64>>,
+    pts3: Vec<V3>,
+    nrm: Vec<V3>,
+    buckets: FxHashMap<(i64, i64), Vec<usize>>,
+    eps: f64,
+}
+
+impl PointPool {
+    fn new(eps: f64) -> Self {
+        Self {
+            pts2: Vec::new(),
+            pts3: Vec::new(),
+            nrm: Vec::new(),
+            buckets: FxHashMap::default(),
+            eps: eps.max(1.0e-15),
+        }
+    }
+    fn intern(&mut self, q: V2, p3: V3, n: V3) -> usize {
+        let cell = |x: f64| (x / (self.eps * 4.0)).floor() as i64;
+        let (cx, cy) = (cell(q[0]), cell(q[1]));
+        for dx in -1..=1 {
+            for dy in -1..=1 {
+                if let Some(ids) = self.buckets.get(&(cx + dx, cy + dy)) {
+                    for &i in ids {
+                        let d0 = self.pts2[i].x - q[0];
+                        let d1 = self.pts2[i].y - q[1];
+                        if d0.abs() <= self.eps && d1.abs() <= self.eps {
+                            return i;
+                        }
+                    }
+                }
+            }
+        }
+        let idx = self.pts2.len();
+        self.pts2.push(Point2::new(q[0], q[1]));
+        self.pts3.push(p3);
+        self.nrm.push(n);
+        self.buckets.entry((cx, cy)).or_default().push(idx);
+        idx
+    }
+}
+
+/// Decompose one host triangle by the cutter-boundary seams via a conforming
+/// per-triangle CDT; classify each sub-triangle by its centroid; record the
+/// seams (with face-local 2D coords) for the cap builder. Returns false when
+/// the CDT cannot be built (→ exact kernel for the whole opening).
+#[allow(clippy::too_many_arguments)]
+fn decompose_tri(
+    t: &PTri,
+    pf: &PrismFrame,
+    faces: &[Face],
+    segs: &[(usize, V3, V3)],
+    edge_pts: &[Vec<V3>; 3],
+    out: &mut Vec<PTri>,
+    inside: &mut Vec<PTri>,
+    seams: &mut [Vec<Seam>],
+) -> bool {
+    // 2D basis in the triangle's plane (CCW = triangle winding).
+    let Some(u) = normalize(sub(t.p[1], t.p[0])) else {
+        out.push(t.clone());
+        return true;
+    };
+    let Some(w) = normalize(cross(sub(t.p[1], t.p[0]), sub(t.p[2], t.p[0]))) else {
+        out.push(t.clone());
+        return true;
+    };
+    let v = cross(w, u);
+    let to2 = |x: V3| -> V2 {
+        let d = sub(x, t.p[0]);
+        [dot(d, u), dot(d, v)]
+    };
+
+    let mut mag = 0.0f64;
+    for p in &t.p {
+        for c in p {
+            mag = mag.max(c.abs());
+        }
+    }
+    let mut pool = PointPool::new(1.0e-9 * (1.0 + mag));
+
+    let tri_idx = [
+        pool.intern(to2(t.p[0]), t.p[0], t.n[0]),
+        pool.intern(to2(t.p[1]), t.p[1], t.n[1]),
+        pool.intern(to2(t.p[2]), t.p[2], t.n[2]),
+    ];
+
+    let mut segments: Vec<(usize, usize)> = Vec::new();
+    // T-edge chains subdivided at the admitted crossing points.
+    for e in 0..3 {
+        let a3 = t.p[e];
+        let b3 = t.p[(e + 1) % 3];
+        let dir = sub(b3, a3);
+        let len2 = dot(dir, dir);
+        if len2 <= 0.0 {
+            continue;
+        }
+        let mut on_edge: Vec<(f64, usize)> = Vec::new();
+        for p in &edge_pts[e] {
+            // Normal interpolated along the edge.
+            let tt = (dot(sub(*p, a3), dir) / len2).clamp(0.0, 1.0);
+            let nn = lerp(t.n[e], t.n[(e + 1) % 3], tt);
+            let idx = pool.intern(to2(*p), *p, nn);
+            on_edge.push((tt, idx));
+        }
+        on_edge.sort_by(|x, y| x.0.total_cmp(&y.0));
+        let mut prev = tri_idx[e];
+        for &(_, idx) in &on_edge {
+            if idx != prev {
+                segments.push((prev, idx));
+                prev = idx;
+            }
+        }
+        let last = tri_idx[(e + 1) % 3];
+        if last != prev {
+            segments.push((prev, last));
+        }
+    }
+    // Seam constraints (+ record for the cap builder). Interior seam points
+    // carry the triangle's geometric normal (flat-facet hosts: exact).
+    let face_n = normalize(cross(sub(t.p[1], t.p[0]), sub(t.p[2], t.p[0]))).unwrap_or(w);
+    for &(fi, a3, b3) in segs {
+        let ia = pool.intern(to2(a3), a3, face_n);
+        let ib = pool.intern(to2(b3), b3, face_n);
+        if ia == ib {
+            continue;
+        }
+        segments.push((ia, ib));
+        seams[fi].push(Seam {
+            a3,
+            b3,
+            a2: face_coords(pf, faces[fi], a3),
+            b2: face_coords(pf, faces[fi], b3),
+        });
+    }
+    segments.sort();
+    segments.dedup();
+    let t0 = t.p[0];
+    resolve_crossings(
+        &mut pool,
+        |q| add(t0, add(scale(u, q[0]), scale(v, q[1]))),
+        &mut segments,
+    );
+
+    let Some((pts2, idx2)) = triangulate_pslg(&pool.pts2, &segments) else {
+        return false;
+    };
+    if pts2.len() != pool.pts2.len() {
+        return false; // CDT must not invent points — mapping back requires identity
+    }
+
+    for tri in idx2.chunks_exact(3) {
+        let (a, b, c) = (tri[0], tri[1], tri[2]);
+        let p = [pool.pts3[a], pool.pts3[b], pool.pts3[c]];
+        let centroid = scale(add(add(p[0], p[1]), p[2]), 1.0 / 3.0);
+        let piece = PTri {
+            p,
+            n: [pool.nrm[a], pool.nrm[b], pool.nrm[c]],
+        };
+        if pf.contains(centroid) {
+            inside.push(piece);
+        } else {
+            out.push(piece);
+        }
+    }
+    true
+}
+
+/// Canonical 2D breakpoints of cap plane `j`: all vertices of the adjacent
+/// slab profiles plus every proper pairwise crossing between the two rings.
+fn cap_plane_breakpoints(pf: &PrismFrame, j: usize) -> Vec<V2> {
+    let mut profs: Vec<&[V2]> = Vec::new();
+    if j > 0 {
+        profs.push(&pf.profiles[j - 1]);
+    }
+    if j < pf.profiles.len() {
+        profs.push(&pf.profiles[j]);
+    }
+    let mut out: Vec<V2> = Vec::new();
+    for prof in &profs {
+        out.extend_from_slice(prof);
+    }
+    if profs.len() == 2 {
+        let (a, b) = (profs[0], profs[1]);
+        let (na, nb) = (a.len(), b.len());
+        for i in 0..na {
+            let (p, q) = (a[i], a[(i + 1) % na]);
+            for k in 0..nb {
+                let (c, d) = (b[k], b[(k + 1) % nb]);
+                if let Some(t) = seg_cross_param(p, q, c, d) {
+                    if (1.0e-9..=1.0 - 1.0e-9).contains(&t) {
+                        out.push([p[0] + (q[0] - p[0]) * t, p[1] + (q[1] - p[1]) * t]);
+                    }
+                }
+            }
+        }
+    }
+    out
+}
+
+/// Build the cap (reveal face) for one cutter face: CDT of the face domain
+/// constrained by the reveal seams (and, for a stepped cap, the adjacent
+/// profiles' rings), each sub-triangle kept iff its centroid lies in the
+/// face's exposed region AND inside the (pre-cut) host solid by ray parity.
+/// Emitted oriented for the RESULT (normal pointing INTO the removed void).
+/// Returns false on CDT failure.
+fn build_face_cap(
+    pf: &PrismFrame,
+    face: Face,
+    seams: &[Seam],
+    plane_pts: &[Vec<V2>],
+    host: &[PTri],
+    aabbs: &[(V3, V3)],
+    caps: &mut Vec<PTri>,
+) -> bool {
+    match face {
+        Face::Strip { k, i } => {
+            let prof = &pf.profiles[k];
+            let npr = prof.len();
+            let a = prof[i];
+            let b = prof[(i + 1) % npr];
+            let e2 = [b[0] - a[0], b[1] - a[1]];
+            let len = (e2[0] * e2[0] + e2[1] * e2[1]).sqrt();
+            if len < 1.0e-9 {
+                return true;
+            }
+            let ed = [e2[0] / len, e2[1] / len];
+            let (w_a, w_b) = (pf.planes[k], pf.planes[k + 1]);
+            let lift_s =
+                |s: f64, wd: f64| -> V3 { pf.lift(a[0] + ed[0] * s, a[1] + ed[1] * s, wd) };
+            let ring2: Vec<V2> = vec![[0.0, w_a], [len, w_a], [len, w_b], [0.0, w_b]];
+            let ring3: Vec<V3> = vec![
+                lift_s(0.0, w_a),
+                lift_s(len, w_a),
+                lift_s(len, w_b),
+                lift_s(0.0, w_b),
+            ];
+            // Outward 2D normal of the CCW ring edge; the result-cap normal is
+            // its opposite (into the void). CCW-in-(s, w) lifts to the OUTWARD
+            // strip normal ⇒ always flip.
+            let n2 = [e2[1] / len, -e2[0] / len];
+            let outward = add(scale(pf.u, n2[0]), scale(pf.v, n2[1]));
+            let desired = scale(outward, -1.0);
+            // Inject the canonical breakpoints of BOTH bounding cap planes
+            // that lie on this strip's edge line, so the strip subdivides its
+            // shared boundary exactly like the neighbouring caps do.
+            let mut inject: Vec<(V2, V3)> = Vec::new();
+            let on_line_tol = 1.0e-6 * (1.0 + pf.corner_mag());
+            for (jj, wj) in [(k, w_a), (k + 1, w_b)] {
+                for q in &plane_pts[jj] {
+                    let ap = [q[0] - a[0], q[1] - a[1]];
+                    let ss = ap[0] * ed[0] + ap[1] * ed[1];
+                    if !(0.0..=len).contains(&ss) {
+                        continue;
+                    }
+                    let perp = (ap[0] * ed[1] - ap[1] * ed[0]).abs();
+                    if perp <= on_line_tol {
+                        inject.push(([ss, wj], lift_s(ss, wj)));
+                    }
+                }
+            }
+            if seams.is_empty() && inject.is_empty() {
+                // Entirely inside the host (whole-face reveal) or entirely
+                // outside — one parity probe decides.
+                let mid = |kk: usize| (ring3[0][kk] + ring3[2][kk]) * 0.5;
+                if !point_inside(host, aabbs, [mid(0), mid(1), mid(2)]) {
+                    return true;
+                }
+                emit_cap(caps, ring3[0], ring3[1], ring3[2], desired, true);
+                emit_cap(caps, ring3[0], ring3[2], ring3[3], desired, true);
+                return true;
+            }
+            if seams.is_empty() {
+                // Injected points but no seams: same parity probe decides
+                // whole-face vs nothing, but the emission must still be the
+                // subdivided CDT so the shared boundary matches the caps.
+                let mid = |kk: usize| (ring3[0][kk] + ring3[2][kk]) * 0.5;
+                if !point_inside(host, aabbs, [mid(0), mid(1), mid(2)]) {
+                    return true;
+                }
+            }
+            cap_cdt(
+                pf,
+                &ring2,
+                &ring3,
+                &[],
+                seams,
+                &inject,
+                desired,
+                true,
+                |q| pip(q, &ring2),
+                host,
+                aabbs,
+                caps,
+            )
+        }
+        Face::Cap { j } => {
+            let wdepth = pf.planes[j];
+            // Domain ring: the union bbox of the adjacent profiles, slightly
+            // inflated so profile rings are strictly interior constraints.
+            let mut lo = [f64::INFINITY; 2];
+            let mut hi = [f64::NEG_INFINITY; 2];
+            let mut aux: Vec<&[V2]> = Vec::new();
+            if j > 0 {
+                aux.push(&pf.profiles[j - 1]);
+            }
+            if j < pf.profiles.len() {
+                aux.push(&pf.profiles[j]);
+            }
+            for prof in &aux {
+                for p in prof.iter() {
+                    for k in 0..2 {
+                        lo[k] = lo[k].min(p[k]);
+                        hi[k] = hi[k].max(p[k]);
+                    }
+                }
+            }
+            let m = 1.0e-3 * (1.0 + (hi[0] - lo[0]).abs().max((hi[1] - lo[1]).abs()));
+            let (lo, hi) = ([lo[0] - m, lo[1] - m], [hi[0] + m, hi[1] + m]);
+            let ring2: Vec<V2> = vec![
+                [lo[0], lo[1]],
+                [hi[0], lo[1]],
+                [hi[0], hi[1]],
+                [lo[0], hi[1]],
+            ];
+            let ring3: Vec<V3> = ring2
+                .iter()
+                .map(|&[uu, vv]| pf.lift(uu, vv, wdepth))
+                .collect();
+            // Orientation per sub-region: where only the LOWER slab exists the
+            // removed void is below ⇒ normal −d; where only the UPPER slab
+            // exists ⇒ +d. Resolved per emitted triangle inside `cap_cdt` via
+            // the classifier below; the `desired`/flip passed in cover the
+            // "+d" branch and the emitter flips for the −d case.
+            let in_lower = |q: V2| j > 0 && pip(q, &pf.profiles[j - 1]);
+            let in_upper = |q: V2| j < pf.profiles.len() && pip(q, &pf.profiles[j]);
+            // Fast skip for the OUTERMOST caps with no seams (the common
+            // extended-cap case): probe the adjacent slab interior.
+            if seams.is_empty() && (j == 0 || j == pf.profiles.len()) {
+                let k = if j == 0 { 0 } else { pf.profiles.len() - 1 };
+                let interior = pf.slab_interior[k];
+                let probe = pf.lift(interior[0], interior[1], wdepth);
+                if !point_inside(host, aabbs, probe) {
+                    return true;
+                }
+            }
+            let inject: Vec<(V2, V3)> = plane_pts[j]
+                .iter()
+                .map(|&q| (q, pf.lift(q[0], q[1], wdepth)))
+                .collect();
+            cap_cdt_xor(
+                pf,
+                &ring2,
+                &ring3,
+                &aux,
+                seams,
+                &inject,
+                wdepth,
+                in_lower,
+                in_upper,
+                host,
+                aabbs,
+                caps,
+            )
+        }
+    }
+}
+
+/// Emit one cap triangle with the RESULT orientation: `flip` swaps the winding
+/// so the geometric normal matches `desired`.
+fn emit_cap(caps: &mut Vec<PTri>, a: V3, b: V3, c: V3, desired: V3, flip: bool) {
+    let (b, c) = if flip { (c, b) } else { (b, c) };
+    caps.push(PTri {
+        p: [a, b, c],
+        n: [desired, desired, desired],
+    });
+}
+
+/// Shared cap CDT for a SINGLE-region face (side strips): domain ring +
+/// seams, keep = `region(centroid)` && host parity.
+#[allow(clippy::too_many_arguments)]
+fn cap_cdt(
+    pf: &PrismFrame,
+    ring2: &[V2],
+    ring3: &[V3],
+    aux: &[&[V2]],
+    seams: &[Seam],
+    inject: &[(V2, V3)],
+    desired: V3,
+    flip: bool,
+    region: impl Fn(V2) -> bool,
+    host: &[PTri],
+    aabbs: &[(V3, V3)],
+    caps: &mut Vec<PTri>,
+) -> bool {
+    cap_cdt_impl(pf, ring2, ring3, aux, seams, inject, host, aabbs, caps, |q| {
+        region(q).then_some((desired, flip))
+    })
+}
+
+/// Cap CDT for a stepped cap plane: keep = XOR of the adjacent profiles, with
+/// per-region orientation (−d where only the lower slab exists, +d where only
+/// the upper does).
+#[allow(clippy::too_many_arguments)]
+fn cap_cdt_xor(
+    pf: &PrismFrame,
+    ring2: &[V2],
+    ring3: &[V3],
+    aux: &[&[V2]],
+    seams: &[Seam],
+    inject: &[(V2, V3)],
+    _wdepth: f64,
+    in_lower: impl Fn(V2) -> bool,
+    in_upper: impl Fn(V2) -> bool,
+    host: &[PTri],
+    aabbs: &[(V3, V3)],
+    caps: &mut Vec<PTri>,
+) -> bool {
+    let d = pf.d;
+    cap_cdt_impl(pf, ring2, ring3, aux, seams, inject, host, aabbs, caps, move |q| {
+        let lo = in_lower(q);
+        let up = in_upper(q);
+        if lo == up {
+            return None; // outside the exposed XOR region
+        }
+        if lo {
+            // Cutter below the plane ⇒ solid above ⇒ normal −d. CCW-in-(u,v)
+            // lifts to +d ⇒ flip.
+            Some((scale(d, -1.0), true))
+        } else {
+            Some((d, false))
+        }
+    })
+}
+
+
+/// Make a segment soup CDT-admissible: split every pair of properly-crossing
+/// constraints at their intersection (interned through `lift3`), and split
+/// every constraint at any pooled point lying strictly in its interior.
+/// Needed because adjacent slab profiles of a rebated opening genuinely CROSS
+/// (a sill / lintel detail poking past the other slab's outline), and seam
+/// endpoints can land in the interior of a ring edge.
+fn resolve_crossings(
+    pool: &mut PointPool,
+    lift3: impl Fn(V2) -> V3,
+    segs: &mut Vec<(usize, usize)>,
+) {
+    let orig = segs.clone();
+    let mut splits: Vec<Vec<(f64, usize)>> = vec![Vec::new(); orig.len()];
+    // Pairwise proper crossings on the ORIGINAL segments (sub-segment
+    // crossings are a subset, so one pass suffices).
+    for i in 0..orig.len() {
+        for j in (i + 1)..orig.len() {
+            let (a, b) = orig[i];
+            let (c, d) = orig[j];
+            if a == c || a == d || b == c || b == d {
+                continue;
+            }
+            let pa = [pool.pts2[a].x, pool.pts2[a].y];
+            let pb = [pool.pts2[b].x, pool.pts2[b].y];
+            let pc = [pool.pts2[c].x, pool.pts2[c].y];
+            let pd = [pool.pts2[d].x, pool.pts2[d].y];
+            let r = [pb[0] - pa[0], pb[1] - pa[1]];
+            let sv = [pd[0] - pc[0], pd[1] - pc[1]];
+            let den = r[0] * sv[1] - r[1] * sv[0];
+            if den.abs() < 1.0e-18 {
+                continue;
+            }
+            let ap = [pc[0] - pa[0], pc[1] - pa[1]];
+            let t = (ap[0] * sv[1] - ap[1] * sv[0]) / den;
+            let u = (ap[0] * r[1] - ap[1] * r[0]) / den;
+            const E: f64 = 1.0e-9;
+            if !(E..=1.0 - E).contains(&t) || !(E..=1.0 - E).contains(&u) {
+                continue;
+            }
+            let q = [pa[0] + r[0] * t, pa[1] + r[1] * t];
+            let idx = pool.intern(q, lift3(q), [0.0, 0.0, 1.0]);
+            splits[i].push((t, idx));
+            splits[j].push((u, idx));
+        }
+    }
+    // Pooled points strictly interior to a segment (T-junctions).
+    let n_pts = pool.pts2.len();
+    for k in 0..n_pts {
+        let p = [pool.pts2[k].x, pool.pts2[k].y];
+        for (i, &(a, b)) in orig.iter().enumerate() {
+            if a == k || b == k {
+                continue;
+            }
+            let pa = [pool.pts2[a].x, pool.pts2[a].y];
+            let pb = [pool.pts2[b].x, pool.pts2[b].y];
+            let e = [pb[0] - pa[0], pb[1] - pa[1]];
+            let len2 = e[0] * e[0] + e[1] * e[1];
+            if len2 < 1.0e-18 {
+                continue;
+            }
+            let t = ((p[0] - pa[0]) * e[0] + (p[1] - pa[1]) * e[1]) / len2;
+            if !(1.0e-9..=1.0 - 1.0e-9).contains(&t) {
+                continue;
+            }
+            let perp = ((p[0] - pa[0]) * e[1] - (p[1] - pa[1]) * e[0]).abs() / len2.sqrt();
+            if perp <= pool.eps * 4.0 {
+                splits[i].push((t, k));
+            }
+        }
+    }
+    let mut out: Vec<(usize, usize)> = Vec::with_capacity(orig.len() + 8);
+    for (i, &(a, b)) in orig.iter().enumerate() {
+        if splits[i].is_empty() {
+            out.push((a, b));
+            continue;
+        }
+        let mut sp = std::mem::take(&mut splits[i]);
+        sp.sort_by(|x, y| x.0.total_cmp(&y.0));
+        let mut prev = a;
+        for &(_, idx) in &sp {
+            if idx != prev {
+                out.push((prev, idx));
+                prev = idx;
+            }
+        }
+        if prev != b {
+            out.push((prev, b));
+        }
+    }
+    out.sort();
+    out.dedup();
+    *segs = out;
+}
+
+/// The cap CDT core: pool the ring, aux-profile rings and seams; chain every
+/// straight constraint through the pooled points lying on it; run the
+/// conforming CDT; classify each sub-triangle by `classify(centroid)` (which
+/// returns the emit orientation) && host parity.
+#[allow(clippy::too_many_arguments)]
+fn cap_cdt_impl(
+    pf: &PrismFrame,
+    ring2: &[V2],
+    ring3: &[V3],
+    aux: &[&[V2]],
+    seams: &[Seam],
+    inject: &[(V2, V3)],
+    host: &[PTri],
+    aabbs: &[(V3, V3)],
+    caps: &mut Vec<PTri>,
+    classify: impl Fn(V2) -> Option<(V3, bool)>,
+) -> bool {
+    let snap_eps = 1.0e-9 * (1.0 + pf.corner_mag());
+    let mut pool = PointPool::new(snap_eps);
+    let placeholder_n = [0.0, 0.0, 1.0];
+    let ring_idx: Vec<usize> = ring2
+        .iter()
+        .zip(ring3)
+        .map(|(&q, &p3)| pool.intern(q, p3, placeholder_n))
+        .collect();
+    // Aux profile rings (cap planes only): 2D verts lifted on the face plane.
+    // Their 3D lift shares the plane depth of ring3[0] along d.
+    let wdepth = dot(ring3[0], pf.d);
+    let mut aux_idx: Vec<Vec<usize>> = Vec::new();
+    for prof in aux {
+        aux_idx.push(
+            prof.iter()
+                .map(|&[uu, vv]| pool.intern([uu, vv], pf.lift(uu, vv, wdepth), placeholder_n))
+                .collect(),
+        );
+    }
+    // Canonical shared-boundary breakpoints (pooled so the chains below pick
+    // them up — the cross-face T-junction freedom).
+    for &(q, p3) in inject {
+        pool.intern(q, p3, placeholder_n);
+    }
+    let mut seam_segs: Vec<(usize, usize)> = Vec::new();
+    for s in seams {
+        let ia = pool.intern(s.a2, s.a3, placeholder_n);
+        let ib = pool.intern(s.b2, s.b3, placeholder_n);
+        if ia != ib {
+            seam_segs.push((ia, ib));
+        }
+    }
+    // Chain every straight constraint (ring edges + aux profile edges) through
+    // the pooled points lying on it, so seam endpoints subdivide them and the
+    // CDT stays conforming.
+    let n_pool = pool.pts2.len();
+    let mut seg_list: Vec<(usize, usize)> = seam_segs;
+    let chain = |ia: usize, ib: usize, seg_list: &mut Vec<(usize, usize)>| {
+        let a = [pool.pts2[ia].x, pool.pts2[ia].y];
+        let b = [pool.pts2[ib].x, pool.pts2[ib].y];
+        let eb = [b[0] - a[0], b[1] - a[1]];
+        let len2 = eb[0] * eb[0] + eb[1] * eb[1];
+        if len2 < 1.0e-18 {
+            return;
+        }
+        let edge_tol = snap_eps * 4.0;
+        let mut on_edge: Vec<(f64, usize)> = Vec::new();
+        for i in 0..n_pool {
+            if i == ia || i == ib {
+                continue;
+            }
+            let p = [pool.pts2[i].x, pool.pts2[i].y];
+            let ap = [p[0] - a[0], p[1] - a[1]];
+            let tt = (ap[0] * eb[0] + ap[1] * eb[1]) / len2;
+            if !(0.0..=1.0).contains(&tt) {
+                continue;
+            }
+            let perp = (ap[0] * eb[1] - ap[1] * eb[0]).abs() / len2.sqrt();
+            if perp <= edge_tol {
+                on_edge.push((tt, i));
+            }
+        }
+        on_edge.sort_by(|x, y| x.0.total_cmp(&y.0));
+        let mut prev = ia;
+        for &(_, i) in &on_edge {
+            if i != prev {
+                seg_list.push((prev, i));
+                prev = i;
+            }
+        }
+        if prev != ib {
+            seg_list.push((prev, ib));
+        }
+    };
+    let nr = ring_idx.len();
+    for e in 0..nr {
+        chain(ring_idx[e], ring_idx[(e + 1) % nr], &mut seg_list);
+    }
+    for ridx in &aux_idx {
+        let n = ridx.len();
+        for e in 0..n {
+            chain(ridx[e], ridx[(e + 1) % n], &mut seg_list);
+        }
+    }
+    seg_list.sort();
+    seg_list.dedup();
+    resolve_crossings(&mut pool, |q| pf.lift(q[0], q[1], wdepth), &mut seg_list);
+
+    let Some((pts2, idx2)) = triangulate_pslg(&pool.pts2, &seg_list) else {
+        return false;
+    };
+    if pts2.len() != pool.pts2.len() {
+        return false;
+    }
+    for tri in idx2.chunks_exact(3) {
+        let (a, b, c) = (tri[0], tri[1], tri[2]);
+        let cu = (pts2[a].x + pts2[b].x + pts2[c].x) / 3.0;
+        let cv = (pts2[a].y + pts2[b].y + pts2[c].y) / 3.0;
+        let Some((desired, flip)) = classify([cu, cv]) else {
+            continue;
+        };
+        // Lift the centroid to 3D for the host-parity test.
+        let c3 = scale(
+            add(add(pool.pts3[a], pool.pts3[b]), pool.pts3[c]),
+            1.0 / 3.0,
+        );
+        if point_inside(host, aabbs, c3) {
+            let (pa, pb, pc) = (pool.pts3[a], pool.pts3[b], pool.pts3[c]);
+            emit_cap(caps, pa, pb, pc, desired, flip);
+        }
+    }
+    true
+}
+
+// ─────────────────────────────── the driver ─────────────────────────────────
+
+impl GeometryRouter {
+    /// Try the analytic prism subtraction on `mesh`.
+    ///
+    /// Iterates the merged openings in order; each opening whose cutter is a
+    /// clean prism AND whose cut passes every self-check is subtracted
+    /// analytically; every other opening lands in the returned residual
+    /// context (cut by the exact kernel on the analytic result — the caller
+    /// recurses through [`GeometryRouter::apply_void_context`], mirroring the
+    /// 2D path's residual composition). `None` ⇒ no opening was cut and the
+    /// caller must run the FULL original context through the exact kernel.
+    pub(super) fn try_prism_cut(
+        &self,
+        mesh: &Mesh,
+        ctx: &VoidContext,
+    ) -> Option<(Mesh, Option<VoidContext>)> {
+        if ctx.merged_openings.is_empty() || mesh.is_empty() || mesh.indices.len() < 12 {
+            return None;
+        }
+        // The volume identity, the parity classification, and the closed
+        // self-check are only meaningful on a host that arrives as a
+        // consistently-wound closed solid (hairline subdivision mismatches
+        // tolerated — tessellated hosts routinely carry them).
+        if !directed_closed(mesh) && !closed_or_hairline(mesh) {
+            defer(0);
+            return None;
+        }
+        let origin = mesh.origin;
+        let Some(mut tris) = ptris_from_mesh(mesh) else {
+            defer(1);
+            return None;
+        };
+        let min_vol = Self::min_opening_volume(self.tessellation_quality);
+
+        // ── Candidate prisms ────────────────────────────────────────────────
+        // Extract a prism per opening, then MERGE prisms whose union is one
+        // prism (the wall-leaf half-void pattern: two abutting halves of one
+        // window — cutting the union in one pass sidesteps their coplanar
+        // interface). Openings without a prism become AABB "blockers".
+        struct Cand {
+            pf: PrismFrame,
+            ops: Vec<usize>, // indices into ctx.merged_openings
+        }
+        let mut cands: Vec<Cand> = Vec::new();
+        let mut blockers: Vec<([V3; 3], V3, V3)> = Vec::new();
+        let mut residual_idx: Vec<usize> = Vec::new();
+        for (i, op) in ctx.merged_openings.iter().enumerate() {
+            match prepare_prism(op, origin) {
+                Some(pf) => cands.push(Cand { pf, ops: vec![i] }),
+                None => {
+                    defer(2);
+                    residual_idx.push(i);
+                    if let Some(blk) = opening_aabb_obb(op, origin) {
+                        blockers.push(blk);
+                    }
+                }
+            }
+        }
+        const MERGE_TOL: f64 = 2.0e-3; // 2 mm: leaf-half interfaces are flush
+        loop {
+            let mut merged_pair: Option<(usize, usize, PrismFrame)> = None;
+            'search: for i in 0..cands.len() {
+                for j in (i + 1)..cands.len() {
+                    if let Some(m) = try_merge_prisms(&cands[i].pf, &cands[j].pf, MERGE_TOL) {
+                        merged_pair = Some((i, j, m));
+                        break 'search;
+                    }
+                }
+            }
+            let Some((i, j, m)) = merged_pair else { break };
+            let mut absorbed = cands.remove(j);
+            cands[i].pf = m;
+            cands[i].ops.append(&mut absorbed.ops);
+        }
+        // Overlap vetoes, decided BEFORE any cut so an abutting-but-unmergeable
+        // pair is never half-cut (cutting one against the other's flush caps —
+        // here or in the residual exact pass — is the coplanar minefield the
+        // exact kernel owns). 1 mm margin, matching the batch pad.
+        let mut vetoed = vec![false; cands.len()];
+        for i in 0..cands.len() {
+            let obb_i = cands[i].pf.obb();
+            for (j, cj) in cands.iter().enumerate().skip(i + 1) {
+                if obb_overlaps(&obb_i, &cj.pf.obb(), 1.0e-3) {
+                    vetoed[i] = true;
+                    vetoed[j] = true;
+                }
+            }
+            if blockers.iter().any(|b| obb_overlaps(&obb_i, b, 1.0e-3)) {
+                vetoed[i] = true;
+            }
+        }
+
+        // ── Sequential analytic cuts ────────────────────────────────────────
+        let mut committed_ops = 0usize;
+        for (cand, veto) in cands.iter().zip(&vetoed) {
+            let mut ok = false;
+            if *veto {
+                defer(6);
+            } else if cand.pf.volume() < min_vol {
+                // Tiny cutters keep the exact path's (identical) skip
+                // semantics.
+                defer(3);
+            } else {
+                let mut pf = cand.pf.clone();
+                // Host projection intervals on the prism axes: no-overlap ⇒
+                // silent no-op (the exact path owns that diagnostic); engulf ⇒
+                // the exact path owns the redundant-void machinery (#964,
+                // #635).
+                let axes = [pf.u, pf.v, pf.d];
+                let mut hlo = [f64::INFINITY; 3];
+                let mut hhi = [f64::NEG_INFINITY; 3];
+                for t in &tris {
+                    for p in &t.p {
+                        for k in 0..3 {
+                            let s = dot(*p, axes[k]);
+                            hlo[k] = hlo[k].min(s);
+                            hhi[k] = hhi[k].max(s);
+                        }
+                    }
+                }
+                let plo = [pf.bb.0[0], pf.bb.0[1], pf.d0()];
+                let phi = [pf.bb.1[0], pf.bb.1[1], pf.d1()];
+                let overlap = (0..3).all(|k| phi[k] > hlo[k] && plo[k] < hhi[k]);
+                if !overlap {
+                    defer(4);
+                } else {
+                    let aabbs: Vec<(V3, V3)> = tris.iter().map(PTri::aabb).collect();
+                    extend_prism_caps(&mut pf, &tris, &aabbs);
+                    extend_profile_edges(&mut pf, &tris, &aabbs);
+                    let plo = [pf.bb.0[0], pf.bb.0[1], pf.d0()];
+                    let phi = [pf.bb.1[0], pf.bb.1[1], pf.d1()];
+                    let engulfs = (0..3).all(|k| {
+                        let slack =
+                            (hhi[k] - hlo[k]).abs().max(1.0e-9) * super::ENGULF_TOLERANCE;
+                        plo[k] <= hlo[k] + slack && phi[k] >= hhi[k] - slack
+                    });
+                    if engulfs {
+                        defer(5);
+                    } else {
+                        match cut_prism(&tris, &pf) {
+                            Ok(outcome) => {
+                                debug_assert!(outcome.removed > 0.0);
+                                tris = outcome.tris;
+                                committed_ops += cand.ops.len();
+                                ok = true;
+                            }
+                            Err(reason) => defer(reason),
+                        }
+                    }
+                }
+            }
+            if !ok {
+                residual_idx.extend(cand.ops.iter().copied());
+            }
+        }
+        if committed_ops == 0 {
+            return None;
+        }
+
+        let mut out = mesh_from_ptris(&tris, mesh);
+        // Never emit a cut that is not a consistently-wound closed surface —
+        // the DIRECTED audit also catches doubled coincident faces and flipped
+        // caps that the undirected 2-manifold check cannot see. Audited BEFORE
+        // the standard `clean_degenerate` hygiene: cleaning drops sub-grid
+        // slivers on EVERY void path (the exact kernel included — the #1167
+        // fragmentation bar tolerates dozens of such hairlines), so the gate
+        // demands the analytic construction itself be closed, then applies the
+        // same hygiene every other path gets. On failure the WHOLE host (full
+        // opening set) goes back to the exact kernel.
+        if !directed_closed(&out) && !closed_or_hairline(&out) {
+            defer(9);
+            return None;
+        }
+        out.clean_degenerate();
+
+        // Residual openings in their original classification order.
+        residual_idx.sort_unstable();
+        let residual: Vec<OpeningType> = residual_idx
+            .iter()
+            .map(|&i| ctx.merged_openings[i].clone())
+            .collect();
+
+        FIRES.fetch_add(1, Ordering::Relaxed);
+        OPENINGS_ANALYTIC.fetch_add(committed_ops as u64, Ordering::Relaxed);
+        OPENINGS_RESIDUAL.fetch_add(residual.len() as u64, Ordering::Relaxed);
+
+        let residual_ctx = if residual.is_empty() {
+            None
+        } else {
+            Some(VoidContext {
+                openings: residual.clone(),
+                merged_openings: residual,
+                param: None,
+                bool2d: None,
+            })
+        };
+        Some((out, residual_ctx))
+    }
+}
+
+#[cfg(test)]
+#[path = "prism_cut_tests.rs"]
+mod tests;

--- a/rust/geometry/src/router/voids/prism_cut.rs
+++ b/rust/geometry/src/router/voids/prism_cut.rs
@@ -518,7 +518,7 @@ fn ptris_from_mesh(mesh: &Mesh) -> Option<Vec<PTri>> {
     // silently drops any trailing partial triple, so a positions/indices length
     // that is not a multiple of 3 would rebuild the solid missing its tail data
     // while every emitted index still passed its bounds check.
-    if mesh.positions.len() % 3 != 0 || mesh.indices.len() % 3 != 0 {
+    if !mesh.positions.len().is_multiple_of(3) || !mesh.indices.len().is_multiple_of(3) {
         return None;
     }
     let vc = mesh.positions.len() / 3;

--- a/rust/geometry/src/router/voids/prism_cut.rs
+++ b/rust/geometry/src/router/voids/prism_cut.rs
@@ -212,7 +212,7 @@ fn norm(a: V3) -> f64 {
 #[inline]
 fn normalize(a: V3) -> Option<V3> {
     let n = norm(a);
-    if n < 1.0e-12 {
+    if !n.is_finite() || n < 1.0e-12 {
         None
     } else {
         Some(scale(a, 1.0 / n))
@@ -350,37 +350,131 @@ fn closed_or_hairline(mesh: &Mesh) -> bool {
         return false; // way past hairline territory
     }
     let p = |k: K| [k.0 as f64, k.1 as f64, k.2 as f64]; // grid units (0.1 mm)
-    let dist_pt_seg = |x: V3, a: V3, b: V3| -> f64 {
-        let ab = sub(b, a);
-        let l2 = dot(ab, ab);
-        if l2 <= 0.0 {
-            return norm(sub(x, a));
-        }
-        let t = (dot(sub(x, a), ab) / l2).clamp(0.0, 1.0);
-        norm(sub(x, add(a, scale(ab, t))))
+
+    // Rigorous hairline test. A hairline (T-junction) boundary is one where the
+    // uncancelled directed edges, viewed as a 1-D SIGNED measure along each
+    // supporting line, net to ZERO everywhere: every stretch covered by an edge
+    // running one way is covered the SAME number of times by edges running the
+    // other way (two adjacent faces subdividing a shared line differently). A
+    // genuine hole — or a boundary edge only PARTIALLY covered, or covered the
+    // wrong number of times — leaves a stretch with nonzero net coverage and
+    // fails. This is strictly stronger than the old midpoint-proximity test,
+    // which a LONG unmatched edge could spoof merely by having a SHORT reverse
+    // edge sit near its midpoint (the short edge "covered" a single point, never
+    // the whole interval, and multiplicity was ignored entirely).
+    const COLLINEAR_TOL: f64 = 2.0; // grid units (~0.2 mm) perpendicular slack
+    const T_EPS: f64 = 1.0e-6; // grid units: ignore sub-interval slivers
+
+    struct Seg {
+        a: V3,
+        b: V3,
+        m: i64,
+    }
+    let segs: Vec<Seg> = bad
+        .iter()
+        .map(|&(a, b, c)| Seg {
+            a: p(a),
+            b: p(b),
+            m: c,
+        })
+        .collect();
+
+    // Perpendicular distance from point `x` to the infinite line `(o, dir)`
+    // (`dir` unit). Perp distance is convex along a segment, so if BOTH
+    // endpoints of a segment are within tol of a line, the whole segment is —
+    // that is our collinearity-coincidence test (no separate parallel check
+    // needed, and it correctly rejects a segment that merely crosses the line).
+    let perp = |x: V3, o: V3, dir: V3| -> f64 {
+        let w = sub(x, o);
+        let along = dot(w, dir);
+        norm(sub(w, scale(dir, along)))
     };
-    // Every bad edge's midpoint must lie ON some other bad edge running the
-    // OPPOSITE way (net sign of the same orientation negative ⇒ its positive
-    // form goes the other direction along the shared line).
-    for (i, &(a, b, _)) in bad.iter().enumerate() {
-        let mid = scale(add(p(a), p(b)), 0.5);
-        let dir_i = sub(p(b), p(a));
-        let mut covered = false;
-        for (j, &(c, d, _)) in bad.iter().enumerate() {
-            if i == j {
-                continue;
-            }
-            // Opposite direction along ~the same line (the chain runs back).
-            if dot(dir_i, sub(p(d), p(c))) >= 0.0 {
-                continue;
-            }
-            if dist_pt_seg(mid, p(c), p(d)) <= 2.0 {
-                covered = true;
-                break;
+
+    struct Line {
+        o: V3,
+        dir: V3,
+        members: Vec<usize>,
+    }
+    // Seed lines from the LONGEST segments first: a long edge fixes a stable
+    // direction, so its collinear short neighbours join it rather than each
+    // spawning a slightly-rotated line of its own (greedy fragmentation would
+    // split a genuinely-covered boundary across groups and report phantom gaps).
+    let mut order: Vec<usize> = (0..segs.len()).collect();
+    order.sort_by(|&i, &j| {
+        let li = dot(sub(segs[i].b, segs[i].a), sub(segs[i].b, segs[i].a));
+        let lj = dot(sub(segs[j].b, segs[j].a), sub(segs[j].b, segs[j].a));
+        lj.partial_cmp(&li).unwrap()
+    });
+    let mut lines: Vec<Line> = Vec::new();
+    'seg: for si in order {
+        let s = &segs[si];
+        let Some(sdir) = normalize(sub(s.b, s.a)) else {
+            // Degenerate (zero-length) bad edge: cannot seal anything → defer.
+            return false;
+        };
+        for line in lines.iter_mut() {
+            if perp(s.a, line.o, line.dir) <= COLLINEAR_TOL
+                && perp(s.b, line.o, line.dir) <= COLLINEAR_TOL
+            {
+                line.members.push(si);
+                continue 'seg;
             }
         }
-        if !covered {
-            return false;
+        lines.push(Line {
+            o: s.a,
+            dir: sdir,
+            members: vec![si],
+        });
+    }
+
+    // Sweep each line's signed multiplicity coverage. At every point along the
+    // line the signed count of covering edges (this line's `+dir` edges minus
+    // its `-dir` edges, weighted by multiplicity) must net to ZERO — the exact
+    // T-junction signature. We track the longest CONTIGUOUS mis-covered run and
+    // reject once it exceeds `GAP_TOL`: a hole, a partially-covered long edge,
+    // or a multiply-covered stretch leaves a macroscopic run, whereas the ≤0.2mm
+    // sub-grid jitter of a genuine hairline stays inside the same quantization
+    // slack the collinearity grouping already allows. (This deliberately still
+    // admits the hosts whose exact-kernel meshing is itself not undirected-
+    // watertight — the documented reason the hairline gate exists — while the
+    // old midpoint test's spoof, a long edge grazed only near its midpoint by a
+    // short reverse edge, leaves a run of nearly the whole edge and is rejected.)
+    const GAP_TOL: f64 = COLLINEAR_TOL; // 2 grid units (~0.2 mm)
+    for line in &lines {
+        let mut ints: Vec<(f64, f64, i64)> = Vec::with_capacity(line.members.len());
+        let mut breaks: Vec<f64> = Vec::with_capacity(line.members.len() * 2);
+        for &si in &line.members {
+            let s = &segs[si];
+            let ta = dot(sub(s.a, line.o), line.dir);
+            let tb = dot(sub(s.b, line.o), line.dir);
+            let sign = if tb >= ta { 1 } else { -1 };
+            ints.push((ta.min(tb), ta.max(tb), sign * s.m));
+            breaks.push(ta);
+            breaks.push(tb);
+        }
+        breaks.sort_by(|x, y| x.partial_cmp(y).unwrap());
+        let mut run = 0.0_f64;
+        for w in breaks.windows(2) {
+            let (lo, hi) = (w[0], w[1]);
+            let len = hi - lo;
+            if len <= T_EPS {
+                continue;
+            }
+            let mid = 0.5 * (lo + hi);
+            let mut sum = 0i64;
+            for &(ilo, ihi, sm) in &ints {
+                if ilo - T_EPS <= mid && mid <= ihi + T_EPS {
+                    sum += sm;
+                }
+            }
+            if sum != 0 {
+                run += len;
+                if run > GAP_TOL {
+                    return false;
+                }
+            } else {
+                run = 0.0;
+            }
         }
     }
     true
@@ -420,6 +514,13 @@ fn tri_volume6(tris: &[PTri]) -> f64 {
 /// Promote a `Mesh` to the f64 triangle list, folding nothing (the mesh is
 /// taken in its own frame — `origin` semantics are preserved by the caller).
 fn ptris_from_mesh(mesh: &Mesh) -> Option<Vec<PTri>> {
+    // Reject structurally malformed meshes outright: `chunks_exact(3)` below
+    // silently drops any trailing partial triple, so a positions/indices length
+    // that is not a multiple of 3 would rebuild the solid missing its tail data
+    // while every emitted index still passed its bounds check.
+    if mesh.positions.len() % 3 != 0 || mesh.indices.len() % 3 != 0 {
+        return None;
+    }
     let vc = mesh.positions.len() / 3;
     let have_normals = mesh.normals.len() == mesh.positions.len();
     let mut out = Vec::with_capacity(mesh.indices.len() / 3);
@@ -2802,12 +2903,16 @@ impl GeometryRouter {
                 }
             }
         }
-        const MERGE_TOL: f64 = 2.0e-3; // 2 mm: leaf-half interfaces are flush
+        // Profile-equality fusion must weld on NUMERICAL coincidence, not a 2 mm
+        // geometric slack: at 2 mm two genuinely distinct leaf profiles could be
+        // declared equal and fused, silently collapsing a real slab boundary. Use
+        // the same 8·SNAP_GRID weld the depth-concatenation gate already uses.
+        const PROFILE_FUSE_TOL: f64 = 8.0 * crate::kernel::mesh_bridge::SNAP_GRID;
         loop {
             let mut merged_pair: Option<(usize, usize, PrismFrame)> = None;
             'search: for i in 0..cands.len() {
                 for j in (i + 1)..cands.len() {
-                    if let Some(m) = try_merge_prisms(&cands[i].pf, &cands[j].pf, MERGE_TOL) {
+                    if let Some(m) = try_merge_prisms(&cands[i].pf, &cands[j].pf, PROFILE_FUSE_TOL) {
                         merged_pair = Some((i, j, m));
                         break 'search;
                     }

--- a/rust/geometry/src/router/voids/prism_cut.rs
+++ b/rust/geometry/src/router/voids/prism_cut.rs
@@ -2742,6 +2742,15 @@ impl GeometryRouter {
         }
 
         let mut out = mesh_from_ptris(&tris, mesh);
+        // COPLANAR CONSOLIDATION: the conforming per-triangle CDT deliberately
+        // over-fragments faces (every decomposed host triangle keeps its own
+        // sub-triangulation, and caps carry their constraint scaffolding). Run
+        // the SAME coplanar merge the exact kernel and the rect/param fast
+        // paths apply (i_overlay union per plane bucket + CDT re-triangulation,
+        // watertight-preserving), collapsing each planar face back to a few
+        // large triangles — 2-3x fewer output triangles on the advanced_model
+        // walls, matching the exact kernel's tessellation density.
+        out = crate::csg::ClippingProcessor::consolidate_coplanar(out);
         // WATERTIGHT SLIVER REFINEMENT (#1007): the per-triangle CDT can emit a
         // high-aspect corner sliver at an opening rim (a far-corner triangle
         // fanned to two rim vertices) — the visible roof-slope chamfer the

--- a/rust/geometry/src/router/voids/prism_cut.rs
+++ b/rust/geometry/src/router/voids/prism_cut.rs
@@ -639,6 +639,47 @@ fn basis_from_depth(d: V3) -> Option<(V3, V3)> {
 /// belongs to the exact kernel).
 const MAX_SLABS: usize = 6;
 
+/// Remove collinear run vertices from a ring (the cross-section stitcher emits
+/// one vertex per crossed cutter edge, subdividing straight profile sides).
+/// Beyond bloating the face set, they defeat the profile-edge extension: every
+/// edge's neighbours look collinear, so the corner re-derivation guard skips
+/// it — the #1112 flush-strip roofs never extended.
+fn simplify_collinear(profile: &mut Vec<V2>, tol: f64) {
+    loop {
+        let n = profile.len();
+        if n <= 3 {
+            return;
+        }
+        let mut removed = false;
+        let mut i = 0;
+        while profile.len() > 3 && i < profile.len() {
+            let m = profile.len();
+            let a = profile[(i + m - 1) % m];
+            let b = profile[i];
+            let c = profile[(i + 1) % m];
+            let ab = [b[0] - a[0], b[1] - a[1]];
+            let ac = [c[0] - a[0], c[1] - a[1]];
+            let lac = (ac[0] * ac[0] + ac[1] * ac[1]).sqrt();
+            if lac > 1.0e-12 {
+                let perp = (ab[0] * ac[1] - ab[1] * ac[0]).abs() / lac;
+                // Only drop a vertex whose removal keeps the ring within `tol`
+                // AND that lies BETWEEN its neighbours along the run (a true
+                // subdivision point, not a hairpin spike).
+                let t = (ab[0] * ac[0] + ab[1] * ac[1]) / (lac * lac);
+                if perp <= tol && (0.0..=1.0).contains(&t) {
+                    profile.remove(i);
+                    removed = true;
+                    continue;
+                }
+            }
+            i += 1;
+        }
+        if !removed {
+            return;
+        }
+    }
+}
+
 /// CCW normalization + area of a 2D ring. `None` when degenerate.
 fn ccw_area(profile: &mut Vec<V2>) -> Option<f64> {
     profile.dedup_by(|a, b| (a[0] - b[0]).abs() < 1.0e-9 && (a[1] - b[1]).abs() < 1.0e-9);
@@ -918,6 +959,7 @@ fn detect_prism(verts: &[V3], tris: &[[usize; 3]], mesh_vol: f64) -> Option<Pris
         let mut vol = 0.0;
         for (k, mut ring) in raw_rings.into_iter().enumerate() {
             let (w_a, w_b) = (plane_ws[k], plane_ws[k + 1]);
+            simplify_collinear(&mut ring, 1.0e-6 * (1.0 + mag));
             let Some(area) = ccw_area(&mut ring) else {
                 continue 'cand;
             };
@@ -1283,11 +1325,14 @@ fn extend_prism_caps(pf: &mut PrismFrame, tris: &[PTri], aabbs: &[(V3, V3)]) {
     let span = pf.d1() - pf.d0();
     let delta = (span * 0.1).clamp(0.005, 0.5);
     let mag = pf.corner_mag();
-    // Flush-exclusion band: a host FACE lying exactly ON the cap plane (the
-    // flush window/sleeve case — including its f32 storage jitter) is not
-    // material BEYOND the plane and must not block the extension; only
-    // geometry clearly past the band does. 0.2 mm is far below any real shell.
-    let band = 2.0e-4_f64.max(mag * 4.0e-7);
+    // Flush-exclusion band: a host FACE lying (near-)flush ON the cap plane —
+    // the flush window/sleeve case, or a cutter authored a hair SHORT of the
+    // surface (the #1112 roof skylights) — is not material BEYOND the plane
+    // and must not block the extension; only geometry clearly past the band
+    // does. Matches the exact kernel's flush-cap detection band
+    // (`extend_opening_mesh_through_host`: `open_span.max(1.0) * 1e-3`), so
+    // the analytic path pushes through exactly where the exact path would.
+    let band = (span.max(1.0) * 1.0e-3).max(mag * 4.0e-7);
     let pad = 1.0e-6 * (1.0 + mag);
     for hi_side in [false, true] {
         let (slab_lo, slab_hi) = if hi_side {
@@ -2697,6 +2742,40 @@ impl GeometryRouter {
         }
 
         let mut out = mesh_from_ptris(&tris, mesh);
+        // WATERTIGHT SLIVER REFINEMENT (#1007): the per-triangle CDT can emit a
+        // high-aspect corner sliver at an opening rim (a far-corner triangle
+        // fanned to two rim vertices) — the visible roof-slope chamfer the
+        // exact path also produces and repairs. Run the SAME lockstep-bisection
+        // pass the exact kernel output gets (targets aspect <= 8:1, watertight
+        // by construction), so the analytic cut meets the same rim-quality bar.
+        // The pass fixes one edge per internal round (64 max); the analytic
+        // cut can carry more rim fans than that, so drive it to a (bounded)
+        // fixpoint — each iteration is a no-op clone once no sliver remains.
+        // SELF-CHECKED application, and ONLY when this cut is FINAL (no
+        // residual): with a residual, the exact kernel still cuts this mesh and
+        // runs its own sliver refinement on ITS output — refining first would
+        // hand the arrangement midpoint-split geometry it re-fragments (#1167).
+        // On a hairline-tolerated output the lockstep split can also see just
+        // one side of an overlapping chain pair and amplify the sub-grid
+        // mismatch, and the split slivers can fall below the clean-degenerate
+        // grid — so accept the refined mesh only when it is STRICTLY closed
+        // and a cleaned probe stays at least hairline-closed.
+        if residual_idx.is_empty() && directed_closed(&out) {
+            let mut refined = out.clone();
+            for _ in 0..6 {
+                let next = crate::facet_weld::refine_high_aspect_slivers(&refined);
+                if next.indices.len() == refined.indices.len() {
+                    break;
+                }
+                refined = next;
+            }
+            let mut probe = refined.clone();
+            probe.clean_degenerate();
+            if directed_closed(&refined) && (directed_closed(&probe) || closed_or_hairline(&probe))
+            {
+                out = refined;
+            }
+        }
         // Never emit a cut that is not a consistently-wound closed surface —
         // the DIRECTED audit also catches doubled coincident faces and flipped
         // caps that the undirected 2-manifold check cannot see. Audited BEFORE

--- a/rust/geometry/src/router/voids/prism_cut.rs
+++ b/rust/geometry/src/router/voids/prism_cut.rs
@@ -1188,20 +1188,28 @@ fn rings_equal(a: &[V2], b: &[V2], tol: f64) -> bool {
 }
 
 /// Merge two stacks whose union is exactly one stack: identical depth axis
-/// (hence identical deterministic basis) and TOUCHING depth ranges (within
-/// `tol`); the stacks concatenate at the touching plane, and equal adjacent
-/// profiles fuse into one slab. This is the wall-leaf half-void pattern (FZK /
-/// masonry leaf walls): one window void split into abutting halves along the
-/// wall thickness — cutting the union in one pass sidesteps their coplanar
-/// interface entirely.
+/// (hence identical deterministic basis) and NUMERICALLY-COINCIDENT depth
+/// ranges (touching within `weld` plane jitter, NOT the geometric `tol`); the
+/// stacks concatenate at the touching plane, and equal adjacent profiles fuse
+/// into one slab (`tol` gates only that profile-equality fusion). This is the
+/// wall-leaf half-void pattern (FZK / masonry leaf walls): one window void
+/// split into abutting halves along the wall thickness — cutting the union in
+/// one pass sidesteps their coplanar interface entirely.
 fn try_merge_prisms(a: &PrismFrame, b: &PrismFrame, tol: f64) -> Option<PrismFrame> {
     if dot(a.d, b.d) < 1.0 - 1.0e-8 {
         return None; // same authored axis ⇒ same deterministic basis
     }
-    // Order along d; only TOUCHING (not overlapping) ranges concatenate.
-    let (lo, hi) = if a.d1() <= b.d0() + tol && a.d1() >= b.d0() - tol {
+    // Concatenate ONLY at a NUMERICALLY-COINCIDENT interface: depth ranges must
+    // touch within PLANE JITTER (f32 + snap-grid roundoff), never the geometric
+    // `tol`. A real gap back-fills cutter volume and a real overlap reassigns a
+    // differing-profile slab — both keep the synthesized prism self-consistent so
+    // the self-check misses the over/under-cut. Non-touching / overlapping pairs
+    // stay unmerged for the overlap veto / exact path. 8·SNAP_GRID (~122 µm) is
+    // the kernel's per-axis-snap scatter: ≫ f32 roundoff, ≪ any authored gap.
+    let weld = 8.0 * crate::kernel::mesh_bridge::SNAP_GRID;
+    let (lo, hi) = if (a.d1() - b.d0()).abs() <= weld {
         (a, b)
-    } else if b.d1() <= a.d0() + tol && b.d1() >= a.d0() - tol {
+    } else if (b.d1() - a.d0()).abs() <= weld {
         (b, a)
     } else {
         return None;
@@ -2601,6 +2609,16 @@ impl GeometryRouter {
         if ctx.merged_openings.is_empty() || mesh.is_empty() || mesh.indices.len() < 12 {
             return None;
         }
+        // Promote to the f64 triangle list FIRST: `ptris_from_mesh` bounds-checks
+        // every index, whereas the closure audits index `mesh.positions` straight
+        // from `mesh.indices`. Auditing first would PANIC (abort under
+        // panic=abort) on a malformed host index instead of recording
+        // `host_promote_fail` and deferring. Post-promotion all indices are valid.
+        let origin = mesh.origin;
+        let Some(mut tris) = ptris_from_mesh(mesh) else {
+            defer(1);
+            return None;
+        };
         // The volume identity, the parity classification, and the closed
         // self-check are only meaningful on a host that arrives as a
         // consistently-wound closed solid (hairline subdivision mismatches
@@ -2609,11 +2627,6 @@ impl GeometryRouter {
             defer(0);
             return None;
         }
-        let origin = mesh.origin;
-        let Some(mut tris) = ptris_from_mesh(mesh) else {
-            defer(1);
-            return None;
-        };
         let min_vol = Self::min_opening_volume(self.tessellation_quality);
 
         // ── Candidate prisms ────────────────────────────────────────────────
@@ -2785,20 +2798,31 @@ impl GeometryRouter {
                 out = refined;
             }
         }
-        // Never emit a cut that is not a consistently-wound closed surface —
-        // the DIRECTED audit also catches doubled coincident faces and flipped
-        // caps that the undirected 2-manifold check cannot see. Audited BEFORE
-        // the standard `clean_degenerate` hygiene: cleaning drops sub-grid
-        // slivers on EVERY void path (the exact kernel included — the #1167
-        // fragmentation bar tolerates dozens of such hairlines), so the gate
-        // demands the analytic construction itself be closed, then applies the
-        // same hygiene every other path gets. On failure the WHOLE host (full
-        // opening set) goes back to the exact kernel.
+        // Never emit a cut that is not a consistently-wound closed surface. The
+        // analytic CONSTRUCTION itself must be closed (the DIRECTED audit also
+        // catches doubled coincident faces and flipped caps the undirected
+        // 2-manifold check cannot see); if it is not, the prism decomposition was
+        // wrong and the WHOLE host (full opening set) goes back to the exact
+        // kernel.
         if !directed_closed(&out) && !closed_or_hairline(&out) {
             defer(9);
             return None;
         }
-        out.clean_degenerate();
+        // Apply the standard `clean_degenerate` hygiene (every void path, the
+        // exact kernel included, drops sub-grid slivers), then RE-AUDIT: the
+        // EMITTED mesh must be the audited one (#1806 review), because cleaning
+        // can drop a thin-but-counted triangle that was load-bearing for closure
+        // and crack the surface. When hygiene opens such a crack, keep the
+        // already-closed pre-clean construction rather than emitting the cracked
+        // mesh — its un-cleaned slivers are the same hairlines every other path
+        // (the exact kernel included, #1167) already carries, so this stays
+        // correct without paying the exact-kernel tax for a host the analytic
+        // path cut cleanly.
+        let mut cleaned = out.clone();
+        cleaned.clean_degenerate();
+        if directed_closed(&cleaned) || closed_or_hairline(&cleaned) {
+            out = cleaned;
+        }
 
         // Residual openings in their original classification order.
         residual_idx.sort_unstable();

--- a/rust/geometry/src/router/voids/prism_cut.rs
+++ b/rust/geometry/src/router/voids/prism_cut.rs
@@ -59,7 +59,6 @@
 //! kernel (A/B measurement). Default ON; wasm has no env, so the default holds
 //! on both targets.
 
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::OnceLock;
 
 use super::geom::opening_mesh_thinnest_axis_dir;
@@ -76,62 +75,104 @@ pub(super) fn enabled() -> bool {
     *ON.get_or_init(|| std::env::var("IFC_LITE_PRISM_CUT").as_deref() != Ok("0"))
 }
 
-static FIRES: AtomicU64 = AtomicU64::new(0);
-static OPENINGS_ANALYTIC: AtomicU64 = AtomicU64::new(0);
-static OPENINGS_RESIDUAL: AtomicU64 = AtomicU64::new(0);
+// ─────────────────────────── diagnostic counters ────────────────────────────
+// Per the geometry-crate convention, telemetry is compiled in ONLY under an
+// observability feature (`observability` / `csg_capture` / `debug_geometry`).
+// The default build carries no process-global atomics on the hot path — no
+// per-opening atomic traffic, and no shared mutable state for concurrent unit
+// tests to race on. `take_prism_stats` / `take_prism_defers` stay public in
+// both configurations (return zeros when the feature is off) so the crate's
+// exported surface is stable; unit tests assert path coverage through
+// `try_prism_cut`'s RETURN VALUE, not these counters.
 
-/// Defer-reason counters (diagnostic only): indices into [`DEFER_NAMES`].
-const DEFER_NAMES: [&str; 10] = [
-    "host_not_closed",
-    "host_promote_fail",
-    "op_not_prism",
-    "op_tiny",
-    "op_no_overlap",
-    "op_engulf",
-    "op_veto_overlap",
-    "cut_cdt_fail",
-    "cut_vol_fail",
-    "out_not_closed",
-];
-static DEFERS: [AtomicU64; 10] = [
-    AtomicU64::new(0),
-    AtomicU64::new(0),
-    AtomicU64::new(0),
-    AtomicU64::new(0),
-    AtomicU64::new(0),
-    AtomicU64::new(0),
-    AtomicU64::new(0),
-    AtomicU64::new(0),
-    AtomicU64::new(0),
-    AtomicU64::new(0),
-];
+#[cfg(any(feature = "observability", feature = "csg_capture", feature = "debug_geometry"))]
+mod diag {
+    use std::sync::atomic::{AtomicU64, Ordering};
 
-#[inline]
-fn defer(i: usize) {
-    DEFERS[i].fetch_add(1, Ordering::Relaxed);
+    static FIRES: AtomicU64 = AtomicU64::new(0);
+    static OPENINGS_ANALYTIC: AtomicU64 = AtomicU64::new(0);
+    static OPENINGS_RESIDUAL: AtomicU64 = AtomicU64::new(0);
+
+    /// Defer-reason counters (diagnostic only): indices into [`DEFER_NAMES`].
+    const DEFER_NAMES: [&str; 10] = [
+        "host_not_closed",
+        "host_promote_fail",
+        "op_not_prism",
+        "op_tiny",
+        "op_no_overlap",
+        "op_engulf",
+        "op_veto_overlap",
+        "cut_cdt_fail",
+        "cut_vol_fail",
+        "out_not_closed",
+    ];
+    static DEFERS: [AtomicU64; 10] = [
+        AtomicU64::new(0),
+        AtomicU64::new(0),
+        AtomicU64::new(0),
+        AtomicU64::new(0),
+        AtomicU64::new(0),
+        AtomicU64::new(0),
+        AtomicU64::new(0),
+        AtomicU64::new(0),
+        AtomicU64::new(0),
+        AtomicU64::new(0),
+    ];
+
+    #[inline]
+    pub(super) fn defer(i: usize) {
+        DEFERS[i].fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Record one analytic-cut host: (fires, openings cut, openings residual).
+    #[inline]
+    pub(super) fn record_cut(committed_ops: usize, residual: usize) {
+        FIRES.fetch_add(1, Ordering::Relaxed);
+        OPENINGS_ANALYTIC.fetch_add(committed_ops as u64, Ordering::Relaxed);
+        OPENINGS_RESIDUAL.fetch_add(residual as u64, Ordering::Relaxed);
+    }
+
+    /// Read + reset the per-reason defer counters as (name, count) pairs.
+    pub fn take_prism_defers() -> Vec<(&'static str, u64)> {
+        DEFER_NAMES
+            .iter()
+            .enumerate()
+            .map(|(i, n)| (*n, DEFERS[i].swap(0, Ordering::Relaxed)))
+            .collect()
+    }
+
+    /// Read + reset the prism-path telemetry: (hosts cut via the prism path,
+    /// openings subtracted analytically, openings routed to the exact residual
+    /// on prism-cut hosts). Process-global; the perf harness reports the
+    /// fast-path hit-rate from it. Relaxed atomics — a stale read under
+    /// concurrency only mis-reports a diagnostic count, never geometry.
+    pub fn take_prism_stats() -> (u64, u64, u64) {
+        (
+            FIRES.swap(0, Ordering::Relaxed),
+            OPENINGS_ANALYTIC.swap(0, Ordering::Relaxed),
+            OPENINGS_RESIDUAL.swap(0, Ordering::Relaxed),
+        )
+    }
 }
 
-/// Read + reset the per-reason defer counters as (name, count) pairs.
-pub fn take_prism_defers() -> Vec<(&'static str, u64)> {
-    DEFER_NAMES
-        .iter()
-        .enumerate()
-        .map(|(i, n)| (*n, DEFERS[i].swap(0, Ordering::Relaxed)))
-        .collect()
+#[cfg(not(any(feature = "observability", feature = "csg_capture", feature = "debug_geometry")))]
+mod diag {
+    #[inline]
+    pub(super) fn defer(_i: usize) {}
+    #[inline]
+    pub(super) fn record_cut(_committed_ops: usize, _residual: usize) {}
+    /// Telemetry disabled in the default build; the perf harness must enable an
+    /// observability feature to read real counts.
+    pub fn take_prism_defers() -> Vec<(&'static str, u64)> {
+        Vec::new()
+    }
+    pub fn take_prism_stats() -> (u64, u64, u64) {
+        (0, 0, 0)
+    }
 }
 
-/// Read + reset the prism-path telemetry: (hosts cut via the prism path,
-/// openings subtracted analytically, openings routed to the exact residual on
-/// prism-cut hosts). Process-global; used by the perf harness to report the
-/// fast-path hit-rate. Relaxed atomics — a stale read under concurrency only
-/// mis-reports a diagnostic count, never geometry.
-pub fn take_prism_stats() -> (u64, u64, u64) {
-    (
-        FIRES.swap(0, Ordering::Relaxed),
-        OPENINGS_ANALYTIC.swap(0, Ordering::Relaxed),
-        OPENINGS_RESIDUAL.swap(0, Ordering::Relaxed),
-    )
-}
+use diag::{defer, record_cut};
+pub use diag::{take_prism_defers, take_prism_stats};
 
 // ─────────────────────────── small f64 vector kit ───────────────────────────
 // Explicit component arithmetic (no nalgebra matrix products) so no FMA can
@@ -1196,8 +1237,16 @@ fn rings_equal(a: &[V2], b: &[V2], tol: f64) -> bool {
 /// split into abutting halves along the wall thickness — cutting the union in
 /// one pass sidesteps their coplanar interface entirely.
 fn try_merge_prisms(a: &PrismFrame, b: &PrismFrame, tol: f64) -> Option<PrismFrame> {
-    if dot(a.d, b.d) < 1.0 - 1.0e-8 {
-        return None; // same authored axis ⇒ same deterministic basis
+    // The merged stack concatenates `hi`'s (u, v)-expressed profiles onto `lo`'s
+    // planes/profiles verbatim, so the two frames must share the SAME basis:
+    // not just a coincident depth axis but coincident in-plane axes too. A
+    // frame rotated about `d` (or with u/v swapped) expresses identical
+    // geometry in incompatible 2D coordinates — stitching them silently
+    // mis-cuts, and the volume self-check (computed in the merged basis) cannot
+    // see it. Require all three basis vectors to align within a tight tol.
+    const BASIS_TOL: f64 = 1.0 - 1.0e-8;
+    if dot(a.d, b.d) < BASIS_TOL || dot(a.u, b.u) < BASIS_TOL || dot(a.v, b.v) < BASIS_TOL {
+        return None; // differing basis/frame ⇒ leave to the veto / exact path
     }
     // Concatenate ONLY at a NUMERICALLY-COINCIDENT interface: depth ranges must
     // touch within PLANE JITTER (f32 + snap-grid roundoff), never the geometric
@@ -1383,11 +1432,74 @@ fn extend_prism_caps(pf: &mut PrismFrame, tris: &[PTri], aabbs: &[(V3, V3)]) {
 /// coplanar with host skin (parity garbage), with it the threshold band falls
 /// cleanly inside the cutter. Corners are re-derived by intersecting the
 /// translated edge line with the (unchanged) neighbour edge lines.
+/// Point-in-or-on-polygon: inside by ray parity OR within `eps` of any edge.
+/// The boundary tolerance matters for the extension containment check: a
+/// re-derived corner is COLLINEAR with the authored corner it replaces (both
+/// lie on the shared neighbour-edge line), so the authored corner sits exactly
+/// on `cand`'s boundary — a strict interior test would wrongly reject it.
+fn point_in_or_on(p: V2, poly: &[V2], eps: f64) -> bool {
+    let n = poly.len();
+    let eps2 = eps * eps;
+    for i in 0..n {
+        let a = poly[i];
+        let b = poly[(i + 1) % n];
+        let ab = [b[0] - a[0], b[1] - a[1]];
+        let ap = [p[0] - a[0], p[1] - a[1]];
+        let len2 = ab[0] * ab[0] + ab[1] * ab[1];
+        if len2 < 1.0e-20 {
+            if ap[0] * ap[0] + ap[1] * ap[1] < eps2 {
+                return true;
+            }
+            continue;
+        }
+        let t = ((ap[0] * ab[0] + ap[1] * ab[1]) / len2).clamp(0.0, 1.0);
+        let proj = [a[0] + ab[0] * t, a[1] + ab[1] * t];
+        let dx = p[0] - proj[0];
+        let dy = p[1] - proj[1];
+        if dx * dx + dy * dy < eps2 {
+            return true;
+        }
+    }
+    pip(p, poly)
+}
+
+/// Whether `outer` contains every vertex of `inner` (boundary-inclusive).
+fn ring_contains_ring(outer: &[V2], inner: &[V2], eps: f64) -> bool {
+    inner.iter().all(|&p| point_in_or_on(p, outer, eps))
+}
+
+/// Whether a 2D ring is a SIMPLE polygon: no pair of non-adjacent edges
+/// crosses. Adjacent edges (sharing a vertex) are exempt. Used to reject a
+/// profile-edge extension that folded a non-convex ring back on itself.
+fn ring_is_simple(ring: &[V2]) -> bool {
+    let n = ring.len();
+    if n < 3 {
+        return false;
+    }
+    for i in 0..n {
+        let (a, b) = (ring[i], ring[(i + 1) % n]);
+        for j in (i + 1)..n {
+            // Skip edges adjacent to edge i (they legitimately share a vertex).
+            if j == (i + 1) % n || (j + 1) % n == i {
+                continue;
+            }
+            let (c, d) = (ring[j], ring[(j + 1) % n]);
+            if seg_cross_param(a, b, c, d).is_some() {
+                return false;
+            }
+        }
+    }
+    true
+}
+
 fn extend_profile_edges(pf: &mut PrismFrame, tris: &[PTri], aabbs: &[(V3, V3)]) {
     let mag = pf.corner_mag();
     let band = 2.0e-4_f64.max(mag * 4.0e-7);
     for k in 0..pf.profiles.len() {
         let (w_a, w_b) = (pf.planes[k], pf.planes[k + 1]);
+        // Authored ring for this slab: every extension must keep containing it
+        // (a moved edge on a non-convex ring can otherwise shrink the profile).
+        let authored = pf.profiles[k].clone();
         let mut i = 0usize;
         while i < pf.profiles[k].len() {
             let prof = pf.profiles[k].clone();
@@ -1464,8 +1576,24 @@ fn extend_profile_edges(pf: &mut PrismFrame, tris: &[PTri], aabbs: &[(V3, V3)]) 
                 i += 1;
                 continue;
             };
-            pf.profiles[k][i] = na;
-            pf.profiles[k][(i + 1) % n] = nb;
+            // Commit the extension only if the resulting ring stays SIMPLE and
+            // still contains the authored profile. `ccw_area` accepts a
+            // self-intersecting ring (positive signed area), so the downstream
+            // volume self-check cannot catch an over/under-cut from a folded
+            // non-convex ring — validate here and keep the un-extended edge
+            // otherwise.
+            let mut cand = pf.profiles[k].clone();
+            cand[i] = na;
+            cand[(i + 1) % n] = nb;
+            // Boundary-tolerant containment: the authored corners are collinear
+            // with (and on the boundary of) `cand`, so a strict interior test
+            // is unusable — `contain_eps` (≫ the collinearity float error, ≪
+            // any real shrink) accepts a genuine outward growth and rejects a
+            // reflex corner that pulled the profile inward.
+            let contain_eps = 1.0e-6 * (1.0 + mag);
+            if ring_is_simple(&cand) && ring_contains_ring(&cand, &authored, contain_eps) {
+                pf.profiles[k] = cand;
+            }
             i += 1;
         }
         // Refresh the slab area (the interior point stays valid — the profile
@@ -1535,7 +1663,11 @@ fn tri_touches_slab_footprint(
     // 2D overlap of the clipped (convex) polygon with the profile: vertex of
     // one inside the other, or any edge pair crossing.
     let poly2: Vec<V2> = poly.iter().map(|p| pf.to2(*p)).collect();
-    // bbox prefilter with pad.
+    // bbox prefilter with pad — against the SUPPLIED `profile` footprint, NOT
+    // `pf.bb`. The profile-edge extension passes an outward band that can lie
+    // entirely OUTSIDE the prism's overall bbox; prefiltering on pf.bb would
+    // wrongly report "empty" and let the extension sweep through nearby host
+    // material.
     let mut lo = [f64::INFINITY; 2];
     let mut hi = [f64::NEG_INFINITY; 2];
     for p in &poly2 {
@@ -1544,10 +1676,18 @@ fn tri_touches_slab_footprint(
             hi[k] = hi[k].max(p[k]);
         }
     }
-    if hi[0] < pf.bb.0[0] - pad
-        || lo[0] > pf.bb.1[0] + pad
-        || hi[1] < pf.bb.0[1] - pad
-        || lo[1] > pf.bb.1[1] + pad
+    let mut footprint_lo = [f64::INFINITY; 2];
+    let mut footprint_hi = [f64::NEG_INFINITY; 2];
+    for p in profile {
+        for k in 0..2 {
+            footprint_lo[k] = footprint_lo[k].min(p[k]);
+            footprint_hi[k] = footprint_hi[k].max(p[k]);
+        }
+    }
+    if hi[0] < footprint_lo[0] - pad
+        || lo[0] > footprint_hi[0] + pad
+        || hi[1] < footprint_lo[1] - pad
+        || lo[1] > footprint_hi[1] + pad
     {
         return false;
     }
@@ -2066,11 +2206,20 @@ fn decompose_tri(
     segments.sort();
     segments.dedup();
     let t0 = t.p[0];
+    // `resolve_crossings` interns any new seam×seam / T-junction points with a
+    // placeholder [0,0,1] normal. These points land on the RETAINED host
+    // surface (`out`), so a Z-up placeholder on a non-horizontal face shades
+    // wrong. Overwrite every point it created with the host triangle's own
+    // face normal.
+    let existing_points = pool.nrm.len();
     resolve_crossings(
         &mut pool,
         |q| add(t0, add(scale(u, q[0]), scale(v, q[1]))),
         &mut segments,
     );
+    for n in pool.nrm.iter_mut().skip(existing_points) {
+        *n = face_n;
+    }
 
     let Some((pts2, idx2)) = triangulate_pslg(&pool.pts2, &segments) else {
         return false;
@@ -2831,9 +2980,7 @@ impl GeometryRouter {
             .map(|&i| ctx.merged_openings[i].clone())
             .collect();
 
-        FIRES.fetch_add(1, Ordering::Relaxed);
-        OPENINGS_ANALYTIC.fetch_add(committed_ops as u64, Ordering::Relaxed);
-        OPENINGS_RESIDUAL.fetch_add(residual.len() as u64, Ordering::Relaxed);
+        record_cut(committed_ops, residual.len());
 
         let residual_ctx = if residual.is_empty() {
             None

--- a/rust/geometry/src/router/voids/prism_cut_tests.rs
+++ b/rust/geometry/src/router/voids/prism_cut_tests.rs
@@ -1,0 +1,521 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Unit tests for the analytic convex-prism (oriented-box) subtraction path.
+
+use super::*;
+use crate::router::GeometryRouter;
+use crate::{Mesh, Point3, Vector3};
+
+/// Closed box mesh with outward flat-shaded faces (per-face vertices), built
+/// from an oriented frame: `center + axes·(±half)`.
+fn framed_box_mesh(center: [f64; 3], axes: [[f64; 3]; 3], half: [f64; 3]) -> Mesh {
+    let corner = |sx: f64, sy: f64, sz: f64| -> [f64; 3] {
+        let mut p = center;
+        for k in 0..3 {
+            p[k] += axes[0][k] * (sx * half[0])
+                + axes[1][k] * (sy * half[1])
+                + axes[2][k] * (sz * half[2]);
+        }
+        p
+    };
+    let c = [
+        corner(-1.0, -1.0, -1.0),
+        corner(1.0, -1.0, -1.0),
+        corner(1.0, 1.0, -1.0),
+        corner(-1.0, 1.0, -1.0),
+        corner(-1.0, -1.0, 1.0),
+        corner(1.0, -1.0, 1.0),
+        corner(1.0, 1.0, 1.0),
+        corner(-1.0, 1.0, 1.0),
+    ];
+    let faces: [[usize; 4]; 6] = [
+        [0, 3, 2, 1],
+        [4, 5, 6, 7],
+        [0, 1, 5, 4],
+        [2, 3, 7, 6],
+        [0, 4, 7, 3],
+        [1, 2, 6, 5],
+    ];
+    let mut m = Mesh::new();
+    for f in &faces {
+        let a = c[f[0]];
+        let b = c[f[1]];
+        let d = c[f[2]];
+        let e1 = [b[0] - a[0], b[1] - a[1], b[2] - a[2]];
+        let e2 = [d[0] - a[0], d[1] - a[1], d[2] - a[2]];
+        let n = [
+            e1[1] * e2[2] - e1[2] * e2[1],
+            e1[2] * e2[0] - e1[0] * e2[2],
+            e1[0] * e2[1] - e1[1] * e2[0],
+        ];
+        let len = (n[0] * n[0] + n[1] * n[1] + n[2] * n[2]).sqrt().max(1e-30);
+        let nn = [
+            (n[0] / len) as f32,
+            (n[1] / len) as f32,
+            (n[2] / len) as f32,
+        ];
+        let base = (m.positions.len() / 3) as u32;
+        for &i in f {
+            m.positions.extend_from_slice(&[
+                c[i][0] as f32,
+                c[i][1] as f32,
+                c[i][2] as f32,
+            ]);
+            m.normals.extend_from_slice(&nn);
+        }
+        m.indices
+            .extend_from_slice(&[base, base + 1, base + 2, base, base + 2, base + 3]);
+    }
+    m
+}
+
+fn axis_frame() -> [[f64; 3]; 3] {
+    [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
+}
+
+/// Frame rotated by `angle` radians about Z.
+fn rot_z_frame(angle: f64) -> [[f64; 3]; 3] {
+    let (s, c) = angle.sin_cos();
+    [[c, s, 0.0], [-s, c, 0.0], [0.0, 0.0, 1.0]]
+}
+
+/// A 4 m × 0.3 m × 3 m wall (thin along Y), centred at `center`, in frame `axes`.
+fn wall(center: [f64; 3], axes: [[f64; 3]; 3]) -> Mesh {
+    framed_box_mesh(center, axes, [2.0, 0.15, 1.5])
+}
+
+fn ctx_of(openings: Vec<OpeningType>) -> VoidContext {
+    VoidContext {
+        merged_openings: openings.clone(),
+        openings,
+        param: None,
+        bool2d: None,
+    }
+}
+
+fn mesh_volume(m: &Mesh) -> f64 {
+    super::super::geom::mesh_signed_volume(m).abs()
+}
+
+fn watertight(m: &Mesh) -> bool {
+    super::super::geom::param_cut_watertight(m)
+}
+
+/// An L-shaped (non-convex) cutter: two glued boxes sharing a face, welded to
+/// one closed shell via the exact union of their triangles is complex; instead
+/// author it directly as an open-stepped shell that is NOT a box (extra
+/// interior planes). The detection must reject it.
+fn l_shaped_cutter() -> Mesh {
+    // Two boxes side by side with different heights — the merged mesh has two
+    // top planes on the same axis, which `detect_box` must reject even though
+    // each individual facet is axis-aligned.
+    let a = framed_box_mesh([0.0, 0.0, 0.5], axis_frame(), [0.4, 0.4, 0.5]);
+    let b = framed_box_mesh([0.6, 0.0, 0.25], axis_frame(), [0.2, 0.4, 0.25]);
+    let mut m = a;
+    let base = (m.positions.len() / 3) as u32;
+    m.positions.extend_from_slice(&b.positions);
+    m.normals.extend_from_slice(&b.normals);
+    m.indices.extend(b.indices.iter().map(|i| i + base));
+    m
+}
+
+#[test]
+fn box_cutter_through_wall_watertight_and_volume_exact() {
+    let router = GeometryRouter::new();
+    let host = wall([0.0, 0.0, 0.0], axis_frame());
+    // Window 1.0 × 1.0, penetrating the full 0.3 thickness plus slack.
+    let cutter = framed_box_mesh([0.3, 0.0, 0.2], axis_frame(), [0.5, 0.4, 0.5]);
+    let (mn, mx) = cutter.bounds();
+    let ctx = ctx_of(vec![OpeningType::NonRectangular(
+        cutter,
+        Point3::new(mn.x as f64, mn.y as f64, mn.z as f64),
+        Point3::new(mx.x as f64, mx.y as f64, mx.z as f64),
+        Some(Vector3::new(0.0, 1.0, 0.0)),
+    )]);
+    let (cut, residual) = router
+        .try_prism_cut(&host, &ctx)
+        .expect("box cutter must take the prism path");
+    assert!(residual.is_none(), "single eligible opening leaves no residual");
+    assert!(watertight(&cut), "prism cut must be watertight");
+    // Removed volume = 1.0 × 0.3 × 1.0 (the cutter clamped to the wall).
+    let removed = mesh_volume(&host) - mesh_volume(&cut);
+    assert!(
+        (removed - 0.3).abs() < 1.0e-3,
+        "removed {removed}, expected 0.3"
+    );
+    let _ = take_prism_stats();
+}
+
+#[test]
+fn rotated_prism_cutter_fires_and_reconciles() {
+    let router = GeometryRouter::new();
+    let frame = rot_z_frame(0.5); // ~28.6° in plan — far past the axis-aligned gates
+    let host = wall([10.0, 5.0, 2.0], frame);
+    // Window box in the SAME rotated frame, poking through the thickness.
+    let cutter = framed_box_mesh(
+        {
+            // center + 0.3·len_axis + 0.2·up_axis
+            let mut c = [10.0, 5.0, 2.0];
+            for k in 0..3 {
+                c[k] += frame[0][k] * 0.3 + frame[2][k] * 0.2;
+            }
+            c
+        },
+        frame,
+        [0.5, 0.4, 0.5],
+    );
+    let (mn, mx) = cutter.bounds();
+    let ctx = ctx_of(vec![OpeningType::NonRectangular(
+        cutter,
+        Point3::new(mn.x as f64, mn.y as f64, mn.z as f64),
+        Point3::new(mx.x as f64, mx.y as f64, mx.z as f64),
+        None,
+    )]);
+    let (cut, residual) = router
+        .try_prism_cut(&host, &ctx)
+        .expect("rotated box cutter must take the prism path");
+    assert!(residual.is_none());
+    assert!(watertight(&cut), "rotated prism cut must be watertight");
+    let removed = mesh_volume(&host) - mesh_volume(&cut);
+    assert!(
+        (removed - 0.3).abs() < 1.0e-3,
+        "removed {removed}, expected 0.3"
+    );
+    let _ = take_prism_stats();
+}
+
+#[test]
+fn non_convex_cutter_falls_back() {
+    let router = GeometryRouter::new();
+    let host = wall([0.0, 0.0, 0.0], axis_frame());
+    let cutter = l_shaped_cutter();
+    let (mn, mx) = cutter.bounds();
+    let ctx = ctx_of(vec![OpeningType::NonRectangular(
+        cutter,
+        Point3::new(mn.x as f64, mn.y as f64, mn.z as f64),
+        Point3::new(mx.x as f64, mx.y as f64, mx.z as f64),
+        None,
+    )]);
+    assert!(
+        router.try_prism_cut(&host, &ctx).is_none(),
+        "non-box cutter must defer to the exact kernel"
+    );
+    let _ = take_prism_stats();
+}
+
+#[test]
+fn open_shell_cutter_falls_back() {
+    let router = GeometryRouter::new();
+    let host = wall([0.0, 0.0, 0.0], axis_frame());
+    // A box with one face deleted: not a closed 2-manifold.
+    let mut cutter = framed_box_mesh([0.3, 0.0, 0.2], axis_frame(), [0.5, 0.4, 0.5]);
+    cutter.indices.truncate(cutter.indices.len() - 6);
+    let (mn, mx) = cutter.bounds();
+    let ctx = ctx_of(vec![OpeningType::NonRectangular(
+        cutter,
+        Point3::new(mn.x as f64, mn.y as f64, mn.z as f64),
+        Point3::new(mx.x as f64, mx.y as f64, mx.z as f64),
+        None,
+    )]);
+    assert!(
+        router.try_prism_cut(&host, &ctx).is_none(),
+        "open-shell cutter must defer (volume/manifold reconciliation)"
+    );
+    let _ = take_prism_stats();
+}
+
+#[test]
+fn multi_window_host_watertight_and_volume_exact() {
+    let router = GeometryRouter::new();
+    let host = wall([0.0, 0.0, 0.0], axis_frame());
+    let mut openings = Vec::new();
+    for i in 0..3 {
+        let cx = -1.3 + i as f64 * 1.2;
+        let cutter = framed_box_mesh([cx, 0.0, 0.1], axis_frame(), [0.35, 0.4, 0.45]);
+        let (mn, mx) = cutter.bounds();
+        openings.push(OpeningType::NonRectangular(
+            cutter,
+            Point3::new(mn.x as f64, mn.y as f64, mn.z as f64),
+            Point3::new(mx.x as f64, mx.y as f64, mx.z as f64),
+            Some(Vector3::new(0.0, 1.0, 0.0)),
+        ));
+    }
+    let ctx = ctx_of(openings);
+    let (cut, residual) = router
+        .try_prism_cut(&host, &ctx)
+        .expect("three windows must all take the prism path");
+    assert!(residual.is_none());
+    assert!(watertight(&cut), "multi-window cut must be watertight");
+    let removed = mesh_volume(&host) - mesh_volume(&cut);
+    let expect = 3.0 * 0.7 * 0.3 * 0.9;
+    assert!(
+        (removed - expect).abs() < 1.0e-3,
+        "removed {removed}, expected {expect}"
+    );
+    let (fires, analytic, resid) = take_prism_stats();
+    assert_eq!(fires, 1);
+    assert_eq!(analytic, 3);
+    assert_eq!(resid, 0);
+}
+
+#[test]
+fn mixed_eligible_and_ineligible_returns_residual() {
+    let router = GeometryRouter::new();
+    let host = wall([0.0, 0.0, 0.0], axis_frame());
+    let window = framed_box_mesh([-1.0, 0.0, 0.2], axis_frame(), [0.4, 0.4, 0.4]);
+    let (wmn, wmx) = window.bounds();
+    let l = l_shaped_cutter();
+    let (lmn, lmx) = l.bounds();
+    let ctx = ctx_of(vec![
+        OpeningType::NonRectangular(
+            window,
+            Point3::new(wmn.x as f64, wmn.y as f64, wmn.z as f64),
+            Point3::new(wmx.x as f64, wmx.y as f64, wmx.z as f64),
+            Some(Vector3::new(0.0, 1.0, 0.0)),
+        ),
+        OpeningType::NonRectangular(
+            l,
+            Point3::new(lmn.x as f64, lmn.y as f64, lmn.z as f64),
+            Point3::new(lmx.x as f64, lmx.y as f64, lmx.z as f64),
+            None,
+        ),
+    ]);
+    let (cut, residual) = router
+        .try_prism_cut(&host, &ctx)
+        .expect("the eligible window must be cut analytically");
+    let residual = residual.expect("the L-shaped void must come back as residual");
+    assert_eq!(residual.merged_openings.len(), 1);
+    assert!(watertight(&cut));
+    // Only the window was removed so far.
+    let removed = mesh_volume(&host) - mesh_volume(&cut);
+    let expect = 0.8 * 0.3 * 0.8;
+    assert!(
+        (removed - expect).abs() < 1.0e-3,
+        "removed {removed}, expected {expect}"
+    );
+    let _ = take_prism_stats();
+}
+
+#[test]
+fn blind_recess_keeps_authored_depth() {
+    let router = GeometryRouter::new();
+    let host = wall([0.0, 0.0, 0.0], axis_frame());
+    // Recess: half the wall thickness deep, entering from the -Y face only
+    // (front face at y = -0.15; recess bottom at y = 0.0, strictly interior).
+    let cutter = framed_box_mesh([0.0, -0.1, 0.0], axis_frame(), [0.4, 0.1, 0.4]);
+    let (mn, mx) = cutter.bounds();
+    let ctx = ctx_of(vec![OpeningType::NonRectangular(
+        cutter,
+        Point3::new(mn.x as f64, mn.y as f64, mn.z as f64),
+        Point3::new(mx.x as f64, mx.y as f64, mx.z as f64),
+        Some(Vector3::new(0.0, 1.0, 0.0)),
+    )]);
+    let (cut, residual) = router
+        .try_prism_cut(&host, &ctx)
+        .expect("blind recess must take the prism path");
+    assert!(residual.is_none());
+    assert!(watertight(&cut), "recess cut must be watertight");
+    // Removed = recess ∩ wall = 0.8 × 0.15 × 0.8 (from front face to bottom).
+    let removed = mesh_volume(&host) - mesh_volume(&cut);
+    let expect = 0.8 * 0.15 * 0.8;
+    assert!(
+        (removed - expect).abs() < 1.0e-3,
+        "removed {removed}, expected {expect}"
+    );
+    let _ = take_prism_stats();
+}
+
+#[test]
+fn deterministic_output() {
+    let router = GeometryRouter::new();
+    let host = wall([100.0, 50.0, 20.0], rot_z_frame(0.3));
+    let frame = rot_z_frame(0.3);
+    let cutter = framed_box_mesh(
+        {
+            let mut c = [100.0, 50.0, 20.0];
+            for k in 0..3 {
+                c[k] += frame[0][k] * 0.4;
+            }
+            c
+        },
+        frame,
+        [0.5, 0.4, 0.5],
+    );
+    let (mn, mx) = cutter.bounds();
+    let mk = |cutter: Mesh| {
+        ctx_of(vec![OpeningType::NonRectangular(
+            cutter,
+            Point3::new(mn.x as f64, mn.y as f64, mn.z as f64),
+            Point3::new(mx.x as f64, mx.y as f64, mx.z as f64),
+            None,
+        )])
+    };
+    let (a, _) = router.try_prism_cut(&host, &mk(cutter.clone())).unwrap();
+    let (b, _) = router.try_prism_cut(&host, &mk(cutter)).unwrap();
+    assert_eq!(a.positions, b.positions, "prism cut must be deterministic");
+    assert_eq!(a.indices, b.indices);
+    assert_eq!(a.normals, b.normals);
+    let _ = take_prism_stats();
+}
+
+#[test]
+fn engulfing_cutter_defers_to_exact_semantics() {
+    let router = GeometryRouter::new();
+    let host = wall([0.0, 0.0, 0.0], axis_frame());
+    // A box that contains the whole wall: the exact path owns the
+    // engulf/redundant-void semantics (#964), so the prism path must defer.
+    let cutter = framed_box_mesh([0.0, 0.0, 0.0], axis_frame(), [3.0, 1.0, 2.0]);
+    let (mn, mx) = cutter.bounds();
+    let ctx = ctx_of(vec![OpeningType::NonRectangular(
+        cutter,
+        Point3::new(mn.x as f64, mn.y as f64, mn.z as f64),
+        Point3::new(mx.x as f64, mx.y as f64, mx.z as f64),
+        None,
+    )]);
+    assert!(router.try_prism_cut(&host, &ctx).is_none());
+    let _ = take_prism_stats();
+}
+
+/// Closed stepped-extrusion cutter (the ISSUE_098 rebated masonry opening):
+/// outer profile rectangle over the first depth slab, smaller inner rectangle
+/// over the second, with the exposed step ring capped by four trapezoids — a
+/// watertight stepped solid. Depth axis +Y; profiles in (x, z).
+fn stepped_cutter(
+    outer: ([f64; 2], [f64; 2]),
+    inner: ([f64; 2], [f64; 2]),
+    y0: f64,
+    y_step: f64,
+    y1: f64,
+) -> Mesh {
+    let mut m = Mesh::new();
+    // Quad with the winding auto-oriented so its normal points along `want`.
+    let mut quad = |mut corners: [[f64; 3]; 4], want: [f64; 3]| {
+        let n_of = |c: &[[f64; 3]; 4]| {
+            let e1 = [c[1][0] - c[0][0], c[1][1] - c[0][1], c[1][2] - c[0][2]];
+            let e2 = [c[3][0] - c[0][0], c[3][1] - c[0][1], c[3][2] - c[0][2]];
+            [
+                e1[1] * e2[2] - e1[2] * e2[1],
+                e1[2] * e2[0] - e1[0] * e2[2],
+                e1[0] * e2[1] - e1[1] * e2[0],
+            ]
+        };
+        let n = n_of(&corners);
+        if n[0] * want[0] + n[1] * want[1] + n[2] * want[2] < 0.0 {
+            corners.swap(1, 3);
+        }
+        let n = n_of(&corners);
+        let l = (n[0] * n[0] + n[1] * n[1] + n[2] * n[2]).sqrt().max(1e-30);
+        let nf = [(n[0] / l) as f32, (n[1] / l) as f32, (n[2] / l) as f32];
+        let base = (m.positions.len() / 3) as u32;
+        for p in corners {
+            m.positions
+                .extend_from_slice(&[p[0] as f32, p[1] as f32, p[2] as f32]);
+            m.normals.extend_from_slice(&nf);
+        }
+        m.indices
+            .extend_from_slice(&[base, base + 1, base + 2, base, base + 2, base + 3]);
+    };
+    let (o_lo, o_hi) = outer;
+    let (i_lo, i_hi) = inner;
+    let o = [
+        [o_lo[0], o_lo[1]],
+        [o_hi[0], o_lo[1]],
+        [o_hi[0], o_hi[1]],
+        [o_lo[0], o_hi[1]],
+    ];
+    let iv = [
+        [i_lo[0], i_lo[1]],
+        [i_hi[0], i_lo[1]],
+        [i_hi[0], i_hi[1]],
+        [i_lo[0], i_hi[1]],
+    ];
+    let at = |p: [f64; 2], y: f64| [p[0], y, p[1]];
+    // Bottom cap at y0 (outer profile, normal -Y) and top cap at y1 (inner,
+    // +Y).
+    quad([at(o[0], y0), at(o[1], y0), at(o[2], y0), at(o[3], y0)], [0.0, -1.0, 0.0]);
+    quad([at(iv[0], y1), at(iv[1], y1), at(iv[2], y1), at(iv[3], y1)], [0.0, 1.0, 0.0]);
+    // Step ring at y_step: four trapezoids (outer edge k, inner edge k) — no
+    // T-junctions against the side walls.
+    for k in 0..4 {
+        let k1 = (k + 1) % 4;
+        quad(
+            [
+                at(o[k], y_step),
+                at(o[k1], y_step),
+                at(iv[k1], y_step),
+                at(iv[k], y_step),
+            ],
+            [0.0, 1.0, 0.0],
+        );
+    }
+    // Side walls: outer ring over [y0, y_step], inner over [y_step, y1]; the
+    // outward direction is the edge's 2D normal.
+    let mut walls = |ring: [[f64; 2]; 4], ya: f64, yb: f64| {
+        for k in 0..4 {
+            let k1 = (k + 1) % 4;
+            let e = [ring[k1][0] - ring[k][0], ring[k1][1] - ring[k][1]];
+            let want = [e[1], 0.0, -e[0]]; // outward for a CCW (x,z) ring
+            quad(
+                [
+                    at(ring[k], ya),
+                    at(ring[k1], ya),
+                    at(ring[k1], yb),
+                    at(ring[k], yb),
+                ],
+                want,
+            );
+        }
+    };
+    walls(o, y0, y_step);
+    walls(iv, y_step, y1);
+    m
+}
+
+#[test]
+fn rebated_stepped_cutter_fires_watertight_and_volume_exact() {
+    // 4 m × 0.3 m × 3 m wall centred at origin (thin along Y).
+    let router = GeometryRouter::new();
+    let host = wall([0.0, 0.0, 0.0], axis_frame());
+    // Rebated window: outer 1.2×1.2 over the front 0.15 m + slack, inner
+    // 0.9×0.9 over the back 0.15 m + slack (the masonry Anschlag).
+    let cutter = stepped_cutter(
+        ([-0.6, -0.6], [0.6, 0.6]),
+        ([-0.45, -0.45], [0.45, 0.45]),
+        -0.25,
+        0.0,
+        0.25,
+    );
+    let (mn, mx) = cutter.bounds();
+    let ctx = ctx_of(vec![OpeningType::NonRectangular(
+        cutter,
+        Point3::new(mn.x as f64, mn.y as f64, mn.z as f64),
+        Point3::new(mx.x as f64, mx.y as f64, mx.z as f64),
+        Some(Vector3::new(0.0, 1.0, 0.0)),
+    )]);
+    let _ = take_prism_defers();
+    let got = router.try_prism_cut(&host, &ctx);
+    if got.is_none() {
+        panic!(
+            "rebated stepped cutter must take the prism path; defers={:?}",
+            take_prism_defers()
+        );
+    }
+    let (cut, residual) = got.unwrap();
+    assert!(residual.is_none());
+    assert!(
+        watertight(&cut),
+        "stepped cut must be watertight (quantized 2-manifold)"
+    );
+    // Removed = outer 1.2² over the front half (0.15) + inner 0.9² over the
+    // back half (0.15).
+    let removed = mesh_volume(&host) - mesh_volume(&cut);
+    let expect = 1.2 * 1.2 * 0.15 + 0.9 * 0.9 * 0.15;
+    assert!(
+        (removed - expect).abs() < 2.0e-3,
+        "removed {removed}, expected {expect}"
+    );
+    let (fires, analytic, resid) = take_prism_stats();
+    assert_eq!((fires, analytic, resid), (1, 1, 0));
+}

--- a/rust/geometry/src/router/voids/prism_cut_tests.rs
+++ b/rust/geometry/src/router/voids/prism_cut_tests.rs
@@ -514,3 +514,151 @@ fn rebated_stepped_cutter_fires_watertight_and_volume_exact() {
         "removed {removed}, expected {expect}"
     );
 }
+
+/// Build a mesh from explicit f64 triangles (per-triangle vertices, computed
+/// flat normal). Used to author precise boundary-edge configurations for the
+/// `closed_or_hairline` self-check.
+fn mesh_from_tris(tris: &[[[f64; 3]; 3]]) -> Mesh {
+    let mut m = Mesh::new();
+    for t in tris {
+        let e1 = [
+            t[1][0] - t[0][0],
+            t[1][1] - t[0][1],
+            t[1][2] - t[0][2],
+        ];
+        let e2 = [
+            t[2][0] - t[0][0],
+            t[2][1] - t[0][1],
+            t[2][2] - t[0][2],
+        ];
+        let n = [
+            e1[1] * e2[2] - e1[2] * e2[1],
+            e1[2] * e2[0] - e1[0] * e2[2],
+            e1[0] * e2[1] - e1[1] * e2[0],
+        ];
+        let len = (n[0] * n[0] + n[1] * n[1] + n[2] * n[2]).sqrt().max(1e-30);
+        let nn = [
+            (n[0] / len) as f32,
+            (n[1] / len) as f32,
+            (n[2] / len) as f32,
+        ];
+        let base = (m.positions.len() / 3) as u32;
+        for v in t {
+            m.positions
+                .extend_from_slice(&[v[0] as f32, v[1] as f32, v[2] as f32]);
+            m.normals.extend_from_slice(&nn);
+        }
+        m.indices.extend_from_slice(&[base, base + 1, base + 2]);
+    }
+    m
+}
+
+/// The ORIGINAL midpoint-only hairline predicate (pre-fix), reproduced verbatim
+/// so the tightening can be demonstrated against the exact configuration it
+/// wrongly accepted. Do not "improve" this — it is a frozen witness.
+fn old_closed_or_hairline(mesh: &Mesh) -> bool {
+    type K = (i64, i64, i64);
+    let key = |i: u32| -> K {
+        let b = i as usize * 3;
+        let q = |v: f32| (v as f64 / 1.0e-4).round() as i64;
+        (
+            q(mesh.positions[b]),
+            q(mesh.positions[b + 1]),
+            q(mesh.positions[b + 2]),
+        )
+    };
+    let mut edges: std::collections::HashMap<(K, K), i64> = std::collections::HashMap::new();
+    for tri in mesh.indices.chunks_exact(3) {
+        let (ka, kb, kc) = (key(tri[0]), key(tri[1]), key(tri[2]));
+        if ka == kb || kb == kc || kc == ka {
+            continue;
+        }
+        for (x, y) in [(ka, kb), (kb, kc), (kc, ka)] {
+            *edges.entry((x, y)).or_insert(0) += 1;
+            *edges.entry((y, x)).or_insert(0) -= 1;
+        }
+    }
+    if edges.is_empty() {
+        return false;
+    }
+    let mut bad: Vec<(K, K, i64)> = Vec::new();
+    for (&(a, b), &c) in edges.iter() {
+        if c > 0 {
+            bad.push((a, b, c));
+        }
+    }
+    if bad.is_empty() {
+        return true;
+    }
+    if bad.len() > 64 {
+        return false;
+    }
+    let p = |k: K| [k.0 as f64, k.1 as f64, k.2 as f64];
+    let dist_pt_seg = |x: [f64; 3], a: [f64; 3], b: [f64; 3]| -> f64 {
+        let ab = sub(b, a);
+        let l2 = dot(ab, ab);
+        if l2 <= 0.0 {
+            return norm(sub(x, a));
+        }
+        let t = (dot(sub(x, a), ab) / l2).clamp(0.0, 1.0);
+        norm(sub(x, add(a, scale(ab, t))))
+    };
+    for (i, &(a, b, _)) in bad.iter().enumerate() {
+        let mid = scale(add(p(a), p(b)), 0.5);
+        let dir_i = sub(p(b), p(a));
+        let mut covered = false;
+        for (j, &(c, d, _)) in bad.iter().enumerate() {
+            if i == j {
+                continue;
+            }
+            if dot(dir_i, sub(p(d), p(c))) >= 0.0 {
+                continue;
+            }
+            if dist_pt_seg(mid, p(c), p(d)) <= 2.0 {
+                covered = true;
+                break;
+            }
+        }
+        if !covered {
+            return false;
+        }
+    }
+    true
+}
+
+/// A LONG unmatched boundary edge (`A→B`, 10 m along +x on the grid line y=0)
+/// whose midpoint is merely GRAZED by a reverse-oriented edge that runs 0.3 mm
+/// (3 grid units) off that line. The old midpoint-only test declared `A→B`
+/// "covered" — the reverse edge passes 0.15 mm from the midpoint — and admitted
+/// this open triangle as watertight, the exact hole the whole prism safety net
+/// leans on. The tightened test groups edges by their supporting LINE: the
+/// reverse edge is NOT collinear with `A→B` (its far endpoint sits 3 grid units
+/// off, beyond the 2-unit slack), so `A→B` is genuinely uncovered along its own
+/// line and the surface is correctly rejected.
+#[test]
+fn hairline_long_edge_grazed_by_offline_reverse_now_rejected() {
+    // Single open triangle: base A→B on y=0, apex 3 grid units off the line.
+    let m = mesh_from_tris(&[[[0.0, 0.0, 0.0], [10.0, 0.0, 0.0], [10.0, 0.000_3, 0.0]]]);
+    assert!(
+        old_closed_or_hairline(&m),
+        "the OLD midpoint test wrongly accepted the grazed long edge"
+    );
+    assert!(
+        !closed_or_hairline(&m),
+        "the tightened test must reject the genuinely-open long edge"
+    );
+}
+
+/// Regression guard for the tightening: a genuine near-collinear hairline —
+/// where the reverse edge DOES lie along the boundary line (0.1 mm / 1 grid
+/// unit off, inside the 2-unit slack) and fully covers it — must still be
+/// accepted, so the stricter self-check does not needlessly defer real
+/// hairline hosts to the exact path.
+#[test]
+fn hairline_true_collinear_cover_still_accepted() {
+    let m = mesh_from_tris(&[[[0.0, 0.0, 0.0], [10.0, 0.0, 0.0], [10.0, 0.000_1, 0.0]]]);
+    assert!(
+        closed_or_hairline(&m),
+        "a near-collinear fully-covered hairline must remain accepted"
+    );
+}

--- a/rust/geometry/src/router/voids/prism_cut_tests.rs
+++ b/rust/geometry/src/router/voids/prism_cut_tests.rs
@@ -145,7 +145,6 @@ fn box_cutter_through_wall_watertight_and_volume_exact() {
         (removed - 0.3).abs() < 1.0e-3,
         "removed {removed}, expected 0.3"
     );
-    let _ = take_prism_stats();
 }
 
 #[test]
@@ -183,7 +182,6 @@ fn rotated_prism_cutter_fires_and_reconciles() {
         (removed - 0.3).abs() < 1.0e-3,
         "removed {removed}, expected 0.3"
     );
-    let _ = take_prism_stats();
 }
 
 #[test]
@@ -202,7 +200,6 @@ fn non_convex_cutter_falls_back() {
         router.try_prism_cut(&host, &ctx).is_none(),
         "non-box cutter must defer to the exact kernel"
     );
-    let _ = take_prism_stats();
 }
 
 #[test]
@@ -223,7 +220,6 @@ fn open_shell_cutter_falls_back() {
         router.try_prism_cut(&host, &ctx).is_none(),
         "open-shell cutter must defer (volume/manifold reconciliation)"
     );
-    let _ = take_prism_stats();
 }
 
 #[test]
@@ -243,10 +239,16 @@ fn multi_window_host_watertight_and_volume_exact() {
         ));
     }
     let ctx = ctx_of(openings);
+    // NOTE: path coverage is asserted through the RETURN VALUE, never through
+    // `take_prism_stats()` — the stats are process-global atomics shared by
+    // every concurrently running test in this binary, so exact counts are a
+    // scheduling race (CI x86_64 runners interleave differently than a local
+    // many-core arm64). `Some(..)` proves the prism path fired; a `None`
+    // residual proves EVERY opening was cut analytically.
     let (cut, residual) = router
         .try_prism_cut(&host, &ctx)
         .expect("three windows must all take the prism path");
-    assert!(residual.is_none());
+    assert!(residual.is_none(), "all three windows must be analytic");
     assert!(watertight(&cut), "multi-window cut must be watertight");
     let removed = mesh_volume(&host) - mesh_volume(&cut);
     let expect = 3.0 * 0.7 * 0.3 * 0.9;
@@ -254,10 +256,6 @@ fn multi_window_host_watertight_and_volume_exact() {
         (removed - expect).abs() < 1.0e-3,
         "removed {removed}, expected {expect}"
     );
-    let (fires, analytic, resid) = take_prism_stats();
-    assert_eq!(fires, 1);
-    assert_eq!(analytic, 3);
-    assert_eq!(resid, 0);
 }
 
 #[test]
@@ -295,7 +293,6 @@ fn mixed_eligible_and_ineligible_returns_residual() {
         (removed - expect).abs() < 1.0e-3,
         "removed {removed}, expected {expect}"
     );
-    let _ = take_prism_stats();
 }
 
 #[test]
@@ -324,7 +321,6 @@ fn blind_recess_keeps_authored_depth() {
         (removed - expect).abs() < 1.0e-3,
         "removed {removed}, expected {expect}"
     );
-    let _ = take_prism_stats();
 }
 
 #[test]
@@ -357,7 +353,6 @@ fn deterministic_output() {
     assert_eq!(a.positions, b.positions, "prism cut must be deterministic");
     assert_eq!(a.indices, b.indices);
     assert_eq!(a.normals, b.normals);
-    let _ = take_prism_stats();
 }
 
 #[test]
@@ -375,7 +370,6 @@ fn engulfing_cutter_defers_to_exact_semantics() {
         None,
     )]);
     assert!(router.try_prism_cut(&host, &ctx).is_none());
-    let _ = take_prism_stats();
 }
 
 /// Closed stepped-extrusion cutter (the ISSUE_098 rebated masonry opening):
@@ -502,8 +496,11 @@ fn rebated_stepped_cutter_fires_watertight_and_volume_exact() {
             take_prism_defers()
         );
     }
+    // `Some(..)` + `None` residual prove the analytic path cut the (single)
+    // opening; see the multi-window test for why global stats counters must
+    // not be asserted from parallel unit tests.
     let (cut, residual) = got.unwrap();
-    assert!(residual.is_none());
+    assert!(residual.is_none(), "the rebated opening must be analytic");
     assert!(
         watertight(&cut),
         "stepped cut must be watertight (quantized 2-manifold)"
@@ -516,6 +513,4 @@ fn rebated_stepped_cutter_fires_watertight_and_volume_exact() {
         (removed - expect).abs() < 2.0e-3,
         "removed {removed}, expected {expect}"
     );
-    let (fires, analytic, resid) = take_prism_stats();
-    assert_eq!((fires, analytic, resid), (1, 1, 0));
 }

--- a/rust/geometry/src/router/voids/probe.rs
+++ b/rust/geometry/src/router/voids/probe.rs
@@ -6,11 +6,29 @@
 
 use super::geom::*;
 use super::{GeometryRouter, RectParam, MAX_EXTRUSION_EXTRACT_DEPTH};
+use crate::profile::Profile2D;
+use crate::profiles::ProfileProcessor;
 use crate::router::is_body_representation;
 use crate::{Error, Mesh, Point3, Result, Vector3};
 use ifc_lite_core::{DecodedEntity, EntityDecoder, IfcType};
 use nalgebra::{Matrix3, Matrix4};
 use rustc_hash::FxHashSet;
+
+/// A host or opening solid recovered as a single IfcExtrudedAreaSolid swept along
+/// its profile normal (local ±Z), for the 2D opening-subtraction fast path
+/// ([`super::bool2d_path`]). `m` maps profile-local coordinates (profile in the
+/// z=0 plane, swept to `dir_sign·depth`) to NATIVE world (pre unit-scale / RTC),
+/// composed as `placement · mapped-chain · solid-Position`.
+pub(super) struct ExtrudedSolidInfo {
+    /// Full 2D profile (outer + any holes) in the solid's profile plane.
+    pub profile: Profile2D,
+    /// Extrusion depth (> 0).
+    pub depth: f64,
+    /// +1 for a +Z sweep, -1 for a -Z sweep (the only two eligible cases).
+    pub dir_sign: f64,
+    /// Profile-local → native-world transform.
+    pub m: Matrix4<f64>,
+}
 
 impl GeometryRouter {
     // Get individual bounding boxes for each representation item in an opening element.
@@ -611,5 +629,127 @@ impl GeometryRouter {
         }
 
         Ok(bounds_list)
+    }
+
+    /// Unwrap `item` — through `IfcMappedItem` (accumulating the mapping
+    /// transform), but NOT through `IfcBooleanClippingResult`/`IfcBooleanResult`
+    /// (a clipped host is ineligible for the 2D re-extrude) — to a single
+    /// `IfcExtrudedAreaSolid` swept along its profile normal (local ±Z), and
+    /// recover its full 2D profile + depth + composed profile-local→native-world
+    /// transform. Returns `None` for any non-extrusion, clipped, obliquely-swept,
+    /// or degenerate solid, so callers fall back to the exact kernel.
+    pub(super) fn extruded_solid_from_item(
+        &self,
+        item: DecodedEntity,
+        placement: &Matrix4<f64>,
+        decoder: &mut EntityDecoder,
+    ) -> Option<ExtrudedSolidInfo> {
+        let mut current = item;
+        let mut chain = Matrix4::<f64>::identity();
+        let mut visited = FxHashSet::default();
+        let solid = loop {
+            if !visited.insert(current.id) || visited.len() > MAX_EXTRUSION_EXTRACT_DEPTH {
+                return None;
+            }
+            match current.ifc_type {
+                IfcType::IfcExtrudedAreaSolid => break current,
+                IfcType::IfcMappedItem => {
+                    let source = decoder.resolve_ref(current.get(0)?).ok()??;
+                    let mapped_rep = decoder.resolve_ref(source.get(1)?).ok()??;
+                    if let Some(t) = current.get(1) {
+                        if !t.is_null() {
+                            if let Ok(Some(te)) = decoder.resolve_ref(t) {
+                                if let Ok(mm) =
+                                    self.parse_cartesian_transformation_operator(&te, decoder)
+                                {
+                                    chain *= mm;
+                                }
+                            }
+                        }
+                    }
+                    current =
+                        decoder.resolve_ref_list(mapped_rep.get(3)?).ok()?.into_iter().next()?;
+                }
+                // Boolean clipping / anything else: ineligible for the 2D path.
+                _ => return None,
+            }
+        };
+
+        let profile_entity = decoder.resolve_ref(solid.get(0)?).ok()??;
+        let profile = ProfileProcessor::new(self.schema.clone())
+            .process(&profile_entity, decoder, self.tessellation_quality)
+            .ok()?;
+        if profile.outer.len() < 3 {
+            return None;
+        }
+        let depth = solid.get_float(3)?;
+        if depth <= 0.0 {
+            return None;
+        }
+        let dir_local = {
+            let e = decoder.resolve_ref(solid.get(2)?).ok()??;
+            self.parse_direction(&e).ok()?
+        }
+        .try_normalize(1e-12)?;
+        // The 2D re-extrude is only valid when the sweep is along the profile
+        // normal (local ±Z). An oblique / sheared extrusion shifts the footprint
+        // with depth, so the through-cut projection would be wrong — defer.
+        if dir_local.x.abs() > 1e-6 || dir_local.y.abs() > 1e-6 {
+            return None;
+        }
+        let dir_sign = if dir_local.z >= 0.0 { 1.0 } else { -1.0 };
+        let solid_pos = match solid.get(1) {
+            Some(a) if !a.is_null() => {
+                let e = decoder.resolve_ref(a).ok()??;
+                self.parse_axis2_placement_3d(&e, decoder).ok()?
+            }
+            _ => Matrix4::identity(),
+        };
+        Some(ExtrudedSolidInfo {
+            profile,
+            depth,
+            dir_sign,
+            m: placement * chain * solid_pos,
+        })
+    }
+
+    /// The host element's body as a SINGLE eligible extruded solid (exactly one
+    /// Body item, an `IfcExtrudedAreaSolid` after unwrapping mapped items). A
+    /// multi-item body or a clipped host returns `None`.
+    pub(super) fn host_extruded_solid(
+        &self,
+        element: &DecodedEntity,
+        decoder: &mut EntityDecoder,
+    ) -> Option<ExtrudedSolidInfo> {
+        let placement = self
+            .get_placement_transform_from_element(element, decoder)
+            .ok()?;
+        let items = self.body_representation_items(element, decoder)?;
+        if items.len() != 1 {
+            return None;
+        }
+        self.extruded_solid_from_item(items.into_iter().next()?, &placement, decoder)
+    }
+
+    /// Every Body item of an opening element as an eligible extruded solid (an
+    /// opening may be a union of extruded prisms — Tekla multi-solid). `None` if
+    /// the body is empty or ANY item is not a clean extruded solid.
+    pub(super) fn opening_extruded_solids(
+        &self,
+        element: &DecodedEntity,
+        decoder: &mut EntityDecoder,
+    ) -> Option<Vec<ExtrudedSolidInfo>> {
+        let placement = self
+            .get_placement_transform_from_element(element, decoder)
+            .ok()?;
+        let items = self.body_representation_items(element, decoder)?;
+        if items.is_empty() {
+            return None;
+        }
+        let mut out = Vec::with_capacity(items.len());
+        for it in items {
+            out.push(self.extruded_solid_from_item(it, &placement, decoder)?);
+        }
+        Some(out)
     }
 }

--- a/rust/geometry/src/router/voids/probe.rs
+++ b/rust/geometry/src/router/voids/probe.rs
@@ -397,7 +397,13 @@ impl GeometryRouter {
         let (x_dim, y_dim, off_x, off_y, cos_t, sin_t) =
             self.read_rect_profile_2d(&profile, decoder)?;
         let depth = solid.get_float(3)?;
-        if !(x_dim > 0.0 && y_dim > 0.0 && depth > 0.0) {
+        if !(x_dim.is_finite()
+            && y_dim.is_finite()
+            && depth.is_finite()
+            && x_dim > 0.0
+            && y_dim > 0.0
+            && depth > 0.0)
+        {
             return None;
         }
         let solid_pos = match solid.get(1) {
@@ -780,7 +786,7 @@ impl GeometryRouter {
             return None;
         }
         let depth = solid.get_float(3)?;
-        if depth <= 0.0 {
+        if !depth.is_finite() || depth <= 0.0 {
             return None;
         }
         let dir_local = {

--- a/rust/geometry/src/router/voids/probe.rs
+++ b/rust/geometry/src/router/voids/probe.rs
@@ -240,7 +240,21 @@ impl GeometryRouter {
         }
     }
 
-    /// Items of the element's first non-empty Body/SweptSolid shape representation.
+    /// Items of the element's body shape representation(s), selected EXACTLY as
+    /// the main mesh path (`process_element` /
+    /// `process_element_with_submeshes_impl`): the effective representation type
+    /// (`RepresentationType`, falling back to the `RepresentationIdentifier`
+    /// when blank — CATIA #1661) filtered by [`is_body_representation`], with a
+    /// `MappedRepresentation` skipped when the element also carries direct body
+    /// geometry (the mesh path's de-dup, so the fast path reads the same solids
+    /// the renderer draws). Items from EVERY qualifying representation are
+    /// collected — the mesh path merges them all — so a probe that requires a
+    /// single item correctly DEFERS when the rendered body spans more than one
+    /// representation instead of silently cutting only the first. The old raw
+    /// `RepresentationType`-only match could latch onto an earlier auxiliary
+    /// `SweptSolid`/`SolidModel` (or miss a CATIA blank-type/`Body`-identifier
+    /// rep the renderer meshes), driving the cut off a DIFFERENT solid than the
+    /// one rendered.
     fn body_representation_items(
         &self,
         element: &DecodedEntity,
@@ -251,24 +265,84 @@ impl GeometryRouter {
             return None;
         }
         let reps = decoder.resolve_ref_list(rep.get(2)?).ok()?;
+        // Mirror the mesh path's direct-vs-mapped de-dup: a MappedRepresentation
+        // is skipped only when the element ALSO carries direct body geometry.
+        let has_direct_geometry = reps.iter().any(|sr| {
+            sr.ifc_type == IfcType::IfcShapeRepresentation
+                && crate::router::effective_rep_type(sr)
+                    .map(crate::router::is_direct_body_representation)
+                    .unwrap_or(false)
+        });
+        let mut items = Vec::new();
         for sr in reps {
             if sr.ifc_type != IfcType::IfcShapeRepresentation {
                 continue;
             }
-            let rt = sr.get(2).and_then(|a| a.as_string()).unwrap_or("");
-            if matches!(
-                rt,
-                "Body" | "SweptSolid" | "SolidModel" | "Clipping" | "AdvancedSweptSolid"
-                    | "MappedRepresentation"
-            ) {
-                if let Ok(items) = decoder.resolve_ref_list(sr.get(3)?) {
-                    if !items.is_empty() {
-                        return Some(items);
-                    }
-                }
+            let Some(rt) = crate::router::effective_rep_type(&sr) else {
+                continue;
+            };
+            if rt == "MappedRepresentation" && has_direct_geometry {
+                continue;
+            }
+            if !crate::router::is_body_representation(rt) {
+                continue;
+            }
+            let Some(items_attr) = sr.get(3) else {
+                continue;
+            };
+            if let Ok(rep_items) = decoder.resolve_ref_list(items_attr) {
+                items.extend(rep_items);
             }
         }
-        None
+        if items.is_empty() {
+            None
+        } else {
+            Some(items)
+        }
+    }
+
+    /// Whether an `IfcMappedItem`'s `RepresentationMap.MappingOrigin` (attr 0) is
+    /// a geometric no-op for the fast-path solid recovery.
+    ///
+    /// The `IfcMappedItem` MESH path drops `MappingOrigin` entirely and applies
+    /// ONLY the `MappingTarget` operator (see
+    /// [`GeometryRouter::process_mapped_item_cached`] and
+    /// `profile_extractor::extract_mapped_item_profiles`, whose composed
+    /// transform is `elem_transform · mapping_target`). To stay bit-for-bit
+    /// consistent with that rendered geometry — the very geometry the exact void
+    /// kernel also cuts — this fast path must drop it too. A non-identity origin
+    /// would shift the recovered solid off the rendered mesh, so we only proceed
+    /// when the origin provably has no effect; otherwise the caller defers the
+    /// whole opening/host to the exact kernel. Returns `true` when the origin is
+    /// absent / null / an identity `IfcAxis2Placement3D`, `false` when it is
+    /// non-identity, a 2D placement, or cannot be confirmed identity.
+    fn mapping_origin_is_identity(
+        &self,
+        source: &DecodedEntity,
+        decoder: &mut EntityDecoder,
+    ) -> bool {
+        let Some(origin_attr) = source.get(0) else {
+            return true; // no MappingOrigin attribute -> no effect
+        };
+        if origin_attr.is_null() {
+            return true;
+        }
+        let origin = match decoder.resolve_ref(origin_attr) {
+            Ok(Some(e)) => e,
+            _ => return false, // present but unresolvable -> defer
+        };
+        // Only a 3D identity placement is a provable no-op for the 3D solid
+        // recovery; a 2D placement (or anything else) -> defer.
+        if origin.ifc_type != IfcType::IfcAxis2Placement3D {
+            return false;
+        }
+        match self.parse_axis2_placement_3d(&origin, decoder) {
+            Ok(m) => {
+                let id = Matrix4::<f64>::identity();
+                m.iter().zip(id.iter()).all(|(a, b)| (a - b).abs() < 1e-9)
+            }
+            Err(_) => false,
+        }
     }
 
     /// One representation item → its EXACT oriented box, unwrapping IfcBooleanClippingResult
@@ -295,6 +369,12 @@ impl GeometryRouter {
                 IfcType::IfcMappedItem => {
                     let source = decoder.resolve_ref(current.get(0)?).ok()??;
                     let mapped_rep = decoder.resolve_ref(source.get(1)?).ok()??;
+                    // The mesh path drops MappingOrigin (applies only
+                    // MappingTarget); a non-identity origin would shift the
+                    // recovered box off the rendered solid, so defer.
+                    if !self.mapping_origin_is_identity(&source, decoder) {
+                        return None;
+                    }
                     if let Some(t) = current.get(1) {
                         if !t.is_null() {
                             if let Ok(Some(te)) = decoder.resolve_ref(t) {
@@ -656,6 +736,13 @@ impl GeometryRouter {
                 IfcType::IfcMappedItem => {
                     let source = decoder.resolve_ref(current.get(0)?).ok()??;
                     let mapped_rep = decoder.resolve_ref(source.get(1)?).ok()??;
+                    // The mesh path drops MappingOrigin (applies only
+                    // MappingTarget); a non-identity origin would shift the
+                    // re-extruded footprint off the rendered solid, so defer the
+                    // whole opening to the exact kernel.
+                    if !self.mapping_origin_is_identity(&source, decoder) {
+                        return None;
+                    }
                     // A non-null MappingTarget MUST resolve + parse to a valid
                     // transform: silently dropping it would misplace the
                     // re-extruded footprint, so any failure defers the whole

--- a/rust/geometry/src/router/voids/probe.rs
+++ b/rust/geometry/src/router/voids/probe.rs
@@ -656,19 +656,29 @@ impl GeometryRouter {
                 IfcType::IfcMappedItem => {
                     let source = decoder.resolve_ref(current.get(0)?).ok()??;
                     let mapped_rep = decoder.resolve_ref(source.get(1)?).ok()??;
+                    // A non-null MappingTarget MUST resolve + parse to a valid
+                    // transform: silently dropping it would misplace the
+                    // re-extruded footprint, so any failure defers the whole
+                    // opening to the exact kernel rather than continuing with an
+                    // identity transform.
                     if let Some(t) = current.get(1) {
                         if !t.is_null() {
-                            if let Ok(Some(te)) = decoder.resolve_ref(t) {
-                                if let Ok(mm) =
-                                    self.parse_cartesian_transformation_operator(&te, decoder)
-                                {
-                                    chain *= mm;
-                                }
-                            }
+                            let te = decoder.resolve_ref(t).ok()??;
+                            let mm =
+                                self.parse_cartesian_transformation_operator(&te, decoder).ok()?;
+                            chain *= mm;
                         }
                     }
-                    current =
-                        decoder.resolve_ref_list(mapped_rep.get(3)?).ok()?.into_iter().next()?;
+                    // Require EXACTLY ONE mapped representation item. A multi-item
+                    // mapped opening would otherwise be reduced to its first
+                    // solid, dropping the rest from BOTH the 2D footprint and the
+                    // residual exact cut; defer the whole opening instead.
+                    let mut items = decoder.resolve_ref_list(mapped_rep.get(3)?).ok()?.into_iter();
+                    let first = items.next()?;
+                    if items.next().is_some() {
+                        return None;
+                    }
+                    current = first;
                 }
                 // Boolean clipping / anything else: ineligible for the 2D path.
                 _ => return None,

--- a/rust/geometry/src/router/voids/reveal_tests.rs
+++ b/rust/geometry/src/router/voids/reveal_tests.rs
@@ -506,6 +506,7 @@
                 host,
                 openings: vec![opening],
             }),
+            bool2d: None,
         };
 
         let out1 = router

--- a/rust/geometry/src/router/voids/synthesis.rs
+++ b/rust/geometry/src/router/voids/synthesis.rs
@@ -99,11 +99,16 @@ impl GeometryRouter {
 
             let vertex_count = opening_mesh.positions.len() / 3;
 
-            // Local helper: record both the aggregate counter bump and a
-            // per-host diagnostic line in one place.
+            // Local helper: bump the aggregate counter and push a per-host
+            // diagnostic line together. QUIET mode (`record_diag == false`) is a
+            // full no-op — the host's opening set was already classified once by
+            // `classify_openings`, so bumping `ClassificationStats` again (or
+            // pushing a second host diagnostic) would double-count each residual.
             let mut bump = |router: &Self, ck: ClassificationKind, kind: OpeningKindDiag| {
-                router.bump_classification(ck);
-                host_diag.push(OpeningDiagnostic { opening_id, kind, vertex_count });
+                if record_diag {
+                    router.bump_classification(ck);
+                    host_diag.push(OpeningDiagnostic { opening_id, kind, vertex_count });
+                }
             };
 
             // Probe per-item geometry up front. An opening that holds several

--- a/rust/geometry/src/router/voids/synthesis.rs
+++ b/rust/geometry/src/router/voids/synthesis.rs
@@ -661,7 +661,7 @@ impl GeometryRouter {
     /// solids into one continuous tube whose only caps are the true outer ends, so
     /// the subtract carves a clean through-hole. A no-op for ordinary single-solid
     /// openings (no interior back-to-back cap plane exists).
-    fn remove_internal_membrane(opening_mesh: &Mesh, axis_dir: Vector3<f64>) -> Mesh {
+    pub(super) fn remove_internal_membrane(opening_mesh: &Mesh, axis_dir: Vector3<f64>) -> Mesh {
         let tri_count = opening_mesh.indices.len() / 3;
         if tri_count < 4 {
             return opening_mesh.clone();

--- a/rust/geometry/src/router/voids/synthesis.rs
+++ b/rust/geometry/src/router/voids/synthesis.rs
@@ -48,6 +48,30 @@ impl GeometryRouter {
         opening_ids: &[u32],
         decoder: &mut EntityDecoder,
     ) -> Vec<OpeningType> {
+        self.classify_openings_impl(host, opening_ids, decoder, true)
+    }
+
+    /// Classify a subset of a host's openings WITHOUT recording the per-host
+    /// diagnostic. Used by the 2D fast path to build the residual (exact-kernel)
+    /// context for the ineligible openings after the host's full opening set has
+    /// already been diagnosed once — `record_host_opening_diagnostic` appends, so
+    /// a second recording for the same host would double-count.
+    pub(super) fn classify_openings_quiet(
+        &self,
+        host: &DecodedEntity,
+        opening_ids: &[u32],
+        decoder: &mut EntityDecoder,
+    ) -> Vec<OpeningType> {
+        self.classify_openings_impl(host, opening_ids, decoder, false)
+    }
+
+    fn classify_openings_impl(
+        &self,
+        host: &DecodedEntity,
+        opening_ids: &[u32],
+        decoder: &mut EntityDecoder,
+        record_diag: bool,
+    ) -> Vec<OpeningType> {
         use super::super::{ClassificationKind, OpeningDiagnostic, OpeningKindDiag};
 
         // Per-opening diagnostic accumulator for this host. Pushed to the
@@ -246,7 +270,7 @@ impl GeometryRouter {
 
         // Stash the per-host diagnostic before returning. `host.ifc_type`
         // implements `Display` to its STEP name (e.g. "IFCWALLSTANDARDCASE").
-        if !host_diag.is_empty() {
+        if record_diag && !host_diag.is_empty() {
             self.record_host_opening_diagnostic(
                 host.id,
                 &format!("{}", host.ifc_type),

--- a/rust/geometry/tests/wall_opening_cut_regression.rs
+++ b/rust/geometry/tests/wall_opening_cut_regression.rs
@@ -144,7 +144,14 @@ fn wall_552611_2_openings_matches_ios() {
     // mesh-determinism manifest): the refinement's first-seen canonical ids
     // follow mesh order, so its bisection cascade re-baselined; bbox + oracle
     // volume above are the load-bearing invariants and are unchanged.
-    assert_eq!(mesh.indices.len() / 3, 188, "triangle count (kernel-native, was IOS 60)");
+    // Re-pinned 188 -> 204 for the analytic-prism void path (perf/beat-webifc):
+    // the conforming per-triangle CDT + the same consolidate_coplanar +
+    // refine_high_aspect_slivers post-passes tessellate the cut differently
+    // from the exact arrangement but with the same density class. The count is
+    // platform-stable for the same reason the exact pin was: FMA-free f64,
+    // deterministic CDT / i_overlay, BTreeMap bucket order. Load-bearing
+    // invariants remain the bbox + oracle volume above.
+    assert_eq!(mesh.indices.len() / 3, 204, "triangle count (kernel-native, was IOS 60)");
 }
 
 #[test]
@@ -155,7 +162,9 @@ fn wall_552761_2_openings_matches_ios() {
     let vol = mesh_volume(&mesh);
     assert!((vol - 16.3967).abs() < 1e-3, "cut volume = {vol}, expected 16.3967");
     // Kernel re-baseline (was IOS 60): ~3x from `refine_high_aspect_slivers`.
-    assert_eq!(mesh.indices.len() / 3, 188);
+    // Re-pinned 188 -> 196 for the analytic-prism void path (see wall_552611's
+    // pin note); bbox + oracle volume are the load-bearing invariants.
+    assert_eq!(mesh.indices.len() / 3, 196);
     let _ = mx; // not used; presence of non-empty mesh is the assertion
 }
 
@@ -169,7 +178,9 @@ fn wall_555082_1_opening_matches_ios() {
     // Kernel re-baseline (IOS: v=20 t=36): ~3x from `refine_high_aspect_slivers`.
     // Re-pinned 114 -> 138 with the consolidate_coplanar BTreeMap bucket order
     // (see wall_552611 above); oracle volume is the load-bearing invariant.
-    assert_eq!(mesh.indices.len() / 3, 138);
+    // Re-pinned 138 -> 130 for the analytic-prism void path (see wall_552611's
+    // pin note) — the analytic cut consolidates BELOW the exact kernel here.
+    assert_eq!(mesh.indices.len() / 3, 130);
 }
 
 // ──────────────────────────── known-bad cases ──────────────────────────

--- a/rust/geometry/tests/wall_opening_cut_regression.rs
+++ b/rust/geometry/tests/wall_opening_cut_regression.rs
@@ -56,6 +56,16 @@ fn mesh_volume(mesh: &Mesh) -> f64 {
         / 6.0
 }
 
+/// Which void path these hosts take. The analytic prism cut (default) and the
+/// exact kernel (`IFC_LITE_PRISM_CUT=0`) tessellate the same cut with the same
+/// density class but different triangle counts, so the count pins below select
+/// per path — the feature-off build must still reproduce the old exact-kernel
+/// counts byte-for-byte. The bbox + oracle volume are the path-independent
+/// load-bearing invariants and are asserted unconditionally.
+fn prism_cut_enabled() -> bool {
+    std::env::var("IFC_LITE_PRISM_CUT").as_deref() != Ok("0")
+}
+
 fn bbox(positions: &[f32]) -> Option<((f32, f32, f32), (f32, f32, f32))> {
     if positions.is_empty() {
         return None;
@@ -150,8 +160,14 @@ fn wall_552611_2_openings_matches_ios() {
     // from the exact arrangement but with the same density class. The count is
     // platform-stable for the same reason the exact pin was: FMA-free f64,
     // deterministic CDT / i_overlay, BTreeMap bucket order. Load-bearing
-    // invariants remain the bbox + oracle volume above.
-    assert_eq!(mesh.indices.len() / 3, 204, "triangle count (kernel-native, was IOS 60)");
+    // invariants remain the bbox + oracle volume above. Feature-off
+    // (IFC_LITE_PRISM_CUT=0) routes back through the exact kernel: 188.
+    let expect_tris = if prism_cut_enabled() { 204 } else { 188 };
+    assert_eq!(
+        mesh.indices.len() / 3,
+        expect_tris,
+        "triangle count (kernel-native, was IOS 60)"
+    );
 }
 
 #[test]
@@ -164,7 +180,9 @@ fn wall_552761_2_openings_matches_ios() {
     // Kernel re-baseline (was IOS 60): ~3x from `refine_high_aspect_slivers`.
     // Re-pinned 188 -> 196 for the analytic-prism void path (see wall_552611's
     // pin note); bbox + oracle volume are the load-bearing invariants.
-    assert_eq!(mesh.indices.len() / 3, 196);
+    // Feature-off (IFC_LITE_PRISM_CUT=0) routes back through the exact kernel: 188.
+    let expect_tris = if prism_cut_enabled() { 196 } else { 188 };
+    assert_eq!(mesh.indices.len() / 3, expect_tris);
     let _ = mx; // not used; presence of non-empty mesh is the assertion
 }
 
@@ -180,7 +198,9 @@ fn wall_555082_1_opening_matches_ios() {
     // (see wall_552611 above); oracle volume is the load-bearing invariant.
     // Re-pinned 138 -> 130 for the analytic-prism void path (see wall_552611's
     // pin note) — the analytic cut consolidates BELOW the exact kernel here.
-    assert_eq!(mesh.indices.len() / 3, 130);
+    // Feature-off (IFC_LITE_PRISM_CUT=0) routes back through the exact kernel: 138.
+    let expect_tris = if prism_cut_enabled() { 130 } else { 138 };
+    assert_eq!(mesh.indices.len() / 3, expect_tris);
 }
 
 // ──────────────────────────── known-bad cases ──────────────────────────

--- a/rust/processing/tests/module_size_allowlist.txt
+++ b/rust/processing/tests/module_size_allowlist.txt
@@ -130,7 +130,16 @@
 # axis; carry the host face normal onto resolve_crossings' new points; and
 # feature-gate the process-global diagnostic counters (default build carries no
 # hot-path atomics — also removes the parallel-test race).
-    3001 rust/geometry/src/router/voids/prism_cut.rs
+# +105: #1806 CodeRabbit round-2 — the hairline self-check (the whole prism
+# safety net) replaced its midpoint-proximity boundary matcher with a rigorous
+# per-supporting-line SIGNED-multiplicity coverage sweep (true collinearity +
+# full-interval coverage + multiplicity, rejecting a long open edge that a short
+# reverse edge merely grazed). Lines are seeded longest-edge-first so genuine
+# collinear hairline covers are not fragmented into phantom-gap groups (keeps the
+# analytic hit-rate on the dense faceted-reveal walls). Plus a positions/indices
+# %3 malformed-mesh guard at the top of ptris_from_mesh and the PROFILE_FUSE_TOL
+# (8·SNAP_GRID) weld for profile-equality fusion.
+    3106 rust/geometry/src/router/voids/prism_cut.rs
 # probe.rs +134: the 2D bool-path host/opening extraction — `extruded_solid_from_item`
 # (unwrap IfcMappedItem chains to a single IfcExtrudedAreaSolid + composed transform),
 # `host_extruded_solid` and `opening_extruded_solids` (single-body eligibility gates).
@@ -142,7 +151,10 @@
 # a raw RepresentationType match, and mapping_origin_is_identity defers the fast path
 # when an IfcMappedItem's RepresentationMap.MappingOrigin is non-identity (the mesh
 # path drops it) — both keep the analytic cut bit-consistent with the rendered solid.
-     852 rust/geometry/src/router/voids/probe.rs
+# +6 (#1806 CodeRabbit round-2): reject non-finite rectangle dims/extrusion depth
+# (is_finite guards) so an inf depth can no longer slip past the `> 0.0` / `<= 0.0`
+# gates into the fast path.
+     858 rust/geometry/src/router/voids/probe.rs
     1002 rust/geometry/src/router/voids/synthesis.rs
     1472 rust/geometry/src/space_dcel/mod.rs
      525 rust/geometry/src/transform.rs

--- a/rust/processing/tests/module_size_allowlist.txt
+++ b/rust/processing/tests/module_size_allowlist.txt
@@ -122,7 +122,15 @@
 # re-audit AFTER clean_degenerate so the EMITTED mesh is validated — keeping the
 # already-closed pre-clean construction when hygiene would crack it (vs deferring
 # the whole host to the exact kernel), which preserves the analytic hit-rate.
-    2854 rust/geometry/src/router/voids/prism_cut.rs
+# +147: #1806 CodeRabbit review guards — validate profile-edge extensions stay
+# SIMPLE and still contain the authored profile (ring_is_simple + boundary-
+# tolerant point_in_or_on/ring_contains_ring; a folded non-convex ring passes
+# ccw_area); prefilter occupancy against the SUPPLIED footprint bbox not pf.bb;
+# merge prisms only across an identical basis (u/v/d), not just a shared depth
+# axis; carry the host face normal onto resolve_crossings' new points; and
+# feature-gate the process-global diagnostic counters (default build carries no
+# hot-path atomics — also removes the parallel-test race).
+    3001 rust/geometry/src/router/voids/prism_cut.rs
 # probe.rs +134: the 2D bool-path host/opening extraction — `extruded_solid_from_item`
 # (unwrap IfcMappedItem chains to a single IfcExtrudedAreaSolid + composed transform),
 # `host_extruded_solid` and `opening_extruded_solids` (single-body eligibility gates).

--- a/rust/processing/tests/module_size_allowlist.txt
+++ b/rust/processing/tests/module_size_allowlist.txt
@@ -37,7 +37,10 @@
      894 rust/geometry/src/csg/consolidate.rs
      947 rust/geometry/src/csg/mod.rs
  # -73: #1806 watertight-extrude tests split out to extrusion_watertight_tests.rs (ratchet-exempt); budget refreshed downward.
-    1069 rust/geometry/src/extrusion.rs
+# +9: #1806 review — extrude_profile_watertight rejects < 3-vertex hole rings before
+# triangulation (triangulate_constrained drops them from the cap while create_side_walls
+# still emits their walls → cracked mesh); erroring defers the cut to the exact kernel.
+    1078 rust/geometry/src/extrusion.rs
 # +4: refine_high_aspect_slivers routes its rebuild through Mesh::rebuilt_like so a slivered host keeps its local-frame origin + #1474 placement capture (B7 metadata-loss fix).
 # +1: SNAP_GRID/NORMAL_QUANT single-homed to kernel::mesh_bridge / crate::grid (import replaces local const; doc rewrap costs a line).
           778 rust/geometry/src/facet_weld.rs
@@ -113,8 +116,19 @@
 # +79: #1112 roof-opening fixes — collinear profile simplification (unblocks
 # the flush-strip edge extension), exact-kernel-matched flush band, and the
 # self-checked post-cut sliver refinement (final cuts only).
-    2830 rust/geometry/src/router/voids/prism_cut.rs
-     755 rust/geometry/src/router/voids/probe.rs
+# +24: #1806 review correctness guards — bounds-check the host (ptris_from_mesh)
+# BEFORE the panic-prone closure audits, merge cutters only across a
+# numerically-coincident (8·SNAP_GRID) interface not a 2 mm gap/overlap, and
+# re-audit AFTER clean_degenerate so the EMITTED mesh is validated — keeping the
+# already-closed pre-clean construction when hygiene would crack it (vs deferring
+# the whole host to the exact kernel), which preserves the analytic hit-rate.
+    2854 rust/geometry/src/router/voids/prism_cut.rs
+# probe.rs +134: the 2D bool-path host/opening extraction — `extruded_solid_from_item`
+# (unwrap IfcMappedItem chains to a single IfcExtrudedAreaSolid + composed transform),
+# `host_extruded_solid` and `opening_extruded_solids` (single-body eligibility gates).
+# +10: mapped-item completeness guard — a non-null MappingTarget must parse and the
+# mapped representation must hold exactly one item, else the opening defers to exact.
+     765 rust/geometry/src/router/voids/probe.rs
     1002 rust/geometry/src/router/voids/synthesis.rs
     1472 rust/geometry/src/space_dcel/mod.rs
      525 rust/geometry/src/transform.rs

--- a/rust/processing/tests/module_size_allowlist.txt
+++ b/rust/processing/tests/module_size_allowlist.txt
@@ -113,7 +113,7 @@
 # +79: #1112 roof-opening fixes — collinear profile simplification (unblocks
 # the flush-strip edge extension), exact-kernel-matched flush band, and the
 # self-checked post-cut sliver refinement (final cuts only).
-    2821 rust/geometry/src/router/voids/prism_cut.rs
+    2830 rust/geometry/src/router/voids/prism_cut.rs
      755 rust/geometry/src/router/voids/probe.rs
     1002 rust/geometry/src/router/voids/synthesis.rs
     1472 rust/geometry/src/space_dcel/mod.rs

--- a/rust/processing/tests/module_size_allowlist.txt
+++ b/rust/processing/tests/module_size_allowlist.txt
@@ -29,10 +29,15 @@
 # +45: reject non-positive SegmentLength/HorizontalLength (malformed-input NaN guard) + regression test.
     1170 rust/geometry/src/alignment.rs
 # +19: split_on_edge now sets a failed flag and bails to the ear-clip fallback instead of the lone .expect() panic.
-     1569 rust/geometry/src/cdt.rs
+# +48: triangulate_pslg — conforming CDT over an arbitrary PSLG (open seam
+# polylines as constraints, all hull triangles emitted, caller classifies);
+# the prism-cut path's cap/decompose triangulator. Skips the ring depth-parity
+# flood that open segments would corrupt.
+     1617 rust/geometry/src/cdt.rs
      894 rust/geometry/src/csg/consolidate.rs
      947 rust/geometry/src/csg/mod.rs
-     1142 rust/geometry/src/extrusion.rs
+ # -73: #1806 watertight-extrude tests split out to extrusion_watertight_tests.rs (ratchet-exempt); budget refreshed downward.
+    1069 rust/geometry/src/extrusion.rs
 # +4: refine_high_aspect_slivers routes its rebuild through Mesh::rebuilt_like so a slivered host keeps its local-frame origin + #1474 placement capture (B7 metadata-loss fix).
 # +1: SNAP_GRID/NORMAL_QUANT single-homed to kernel::mesh_bridge / crate::grid (import replaces local const; doc rewrap costs a line).
           778 rust/geometry/src/facet_weld.rs
@@ -94,7 +99,18 @@
 # +32: engulf-cutter #635 AABB box-cut suppression on a #1109 budget trip (drop `!capped`) + its rewritten rationale comment and a diag_warn! else-branch (correctness: an engulfing box-cut would DELETE the host).
 # +5: ENGULF_TOLERANCE / ENGULF_TOLERANCE_F32 single-homed (3 sites shared one literal 0.03 tolerance, now one named const each).
 # +2: #1623 Phase 2 — route the voided sub-mesh path through process_element_with_submeshes_impl(allow_instancing=false) so cut occurrences never instance an un-cut template.
-     1985 rust/geometry/src/router/voids/mod.rs
+# +42: analytic convex-prism fast-path wiring — module decl + apply_void_context
+# call site with residual composition and cut-effect diagnostics parity.
+     2027 rust/geometry/src/router/voids/mod.rs
+# NEW: analytic prism (stepped-extrusion) subtraction on the host mesh — the
+# CSG-heavy-corpus lever (ISSUE_098/129: exact void booleans are ~75-82% of
+# geometry time; rebated masonry openings on brep/clipped hosts had no fast
+# path). One cohesive algorithm: stack detection via normal clustering +
+# cross-section slicing, canonical-order crossing cache, conforming CDT
+# decomposition, parity-classified reveal caps with cross-face breakpoint
+# injection, flush cap/edge extension, volume-identity + closed-surface
+# self-checks. Tests live in prism_cut_tests.rs (exempt).
+    2742 rust/geometry/src/router/voids/prism_cut.rs
      755 rust/geometry/src/router/voids/probe.rs
     1002 rust/geometry/src/router/voids/synthesis.rs
     1472 rust/geometry/src/space_dcel/mod.rs

--- a/rust/processing/tests/module_size_allowlist.txt
+++ b/rust/processing/tests/module_size_allowlist.txt
@@ -110,7 +110,10 @@
 # decomposition, parity-classified reveal caps with cross-face breakpoint
 # injection, flush cap/edge extension, volume-identity + closed-surface
 # self-checks. Tests live in prism_cut_tests.rs (exempt).
-    2742 rust/geometry/src/router/voids/prism_cut.rs
+# +79: #1112 roof-opening fixes — collinear profile simplification (unblocks
+# the flush-strip edge extension), exact-kernel-matched flush band, and the
+# self-checked post-cut sliver refinement (final cuts only).
+    2821 rust/geometry/src/router/voids/prism_cut.rs
      755 rust/geometry/src/router/voids/probe.rs
     1002 rust/geometry/src/router/voids/synthesis.rs
     1472 rust/geometry/src/space_dcel/mod.rs

--- a/rust/processing/tests/module_size_allowlist.txt
+++ b/rust/processing/tests/module_size_allowlist.txt
@@ -136,7 +136,13 @@
 # `host_extruded_solid` and `opening_extruded_solids` (single-body eligibility gates).
 # +10: mapped-item completeness guard — a non-null MappingTarget must parse and the
 # mapped representation must hold exactly one item, else the opening defers to exact.
-     765 rust/geometry/src/router/voids/probe.rs
+# +87 (#1806 CodeRabbit): body_representation_items now mirrors the mesh path's
+# effective_rep_type + is_body_representation selection (incl. MappedRepresentation
+# de-dup, collecting items across ALL body reps so a multi-rep body defers) instead of
+# a raw RepresentationType match, and mapping_origin_is_identity defers the fast path
+# when an IfcMappedItem's RepresentationMap.MappingOrigin is non-identity (the mesh
+# path drops it) — both keep the analytic cut bit-consistent with the rendered solid.
+     852 rust/geometry/src/router/voids/probe.rs
     1002 rust/geometry/src/router/voids/synthesis.rs
     1472 rust/geometry/src/space_dcel/mod.rs
      525 rust/geometry/src/transform.rs

--- a/rust/processing/tests/module_size_allowlist.txt
+++ b/rust/processing/tests/module_size_allowlist.txt
@@ -28,12 +28,11 @@
      611 rust/export/src/step.rs
 # +45: reject non-positive SegmentLength/HorizontalLength (malformed-input NaN guard) + regression test.
     1170 rust/geometry/src/alignment.rs
-     413 rust/geometry/src/bool2d.rs
 # +19: split_on_edge now sets a failed flag and bails to the ear-clip fallback instead of the lone .expect() panic.
-    1526 rust/geometry/src/cdt.rs
+     1569 rust/geometry/src/cdt.rs
      894 rust/geometry/src/csg/consolidate.rs
      947 rust/geometry/src/csg/mod.rs
-     998 rust/geometry/src/extrusion.rs
+     1142 rust/geometry/src/extrusion.rs
 # +4: refine_high_aspect_slivers routes its rebuild through Mesh::rebuilt_like so a slivered host keeps its local-frame origin + #1474 placement capture (B7 metadata-loss fix).
 # +1: SNAP_GRID/NORMAL_QUANT single-homed to kernel::mesh_bridge / crate::grid (import replaces local const; doc rewrap costs a line).
           778 rust/geometry/src/facet_weld.rs
@@ -77,7 +76,7 @@
 # +42: #1623 Phase 3 batch-local template mode — instancing_batch_local flag + instanced_sources_materialized tracker fields + set_/getter/mark_source_materialized_if_first methods (browser per-batch don't-bake).
 # +1: #1293 dedup rep_identity: build_dedup_extra_enabled/set_build_dedup_extra_override gate + DEDUP_EXTRA_OVERRIDE static; net +1 after the ItemDedupCache doc consolidation.
 # +1: #1781 `mod textured;` — texture channel split OUT of processing.rs (that file drops ~90 lines below its budget; crate trends down).
-     748 rust/geometry/src/router/mod.rs
+     749 rust/geometry/src/router/mod.rs
 # +65: #1623 Phase 2 don't-bake — the top-level mapped-item intercept (template retag + instance placeholder) + the public/impl process_element_with_submeshes split; the two eligibility/ensure helpers were extracted to router/instancing.rs (new, 92 lines) to hold the net down.
 # +7: #858 palette guard — exclude an indexed-colour single-solid source from the don't-bake decision (one .filter on the resolved solid id + explanatory comment) so its per-triangle palette survives the flat split.
 # +16: #1623 Phase 3 — thread the batch-local vs global template decision through the mapped-item intercept (is_template match arm + retag guard).
@@ -95,8 +94,8 @@
 # +32: engulf-cutter #635 AABB box-cut suppression on a #1109 budget trip (drop `!capped`) + its rewritten rationale comment and a diag_warn! else-branch (correctness: an engulfing box-cut would DELETE the host).
 # +5: ENGULF_TOLERANCE / ENGULF_TOLERANCE_F32 single-homed (3 sites shared one literal 0.03 tolerance, now one named const each).
 # +2: #1623 Phase 2 — route the voided sub-mesh path through process_element_with_submeshes_impl(allow_instancing=false) so cut occurrences never instance an un-cut template.
-    1938 rust/geometry/src/router/voids/mod.rs
-     621 rust/geometry/src/router/voids/probe.rs
+     1985 rust/geometry/src/router/voids/mod.rs
+     755 rust/geometry/src/router/voids/probe.rs
     1002 rust/geometry/src/router/voids/synthesis.rs
     1472 rust/geometry/src/space_dcel/mod.rs
      525 rust/geometry/src/transform.rs


### PR DESCRIPTION
## Summary

Wires IfcOpenShell's `boolean-attempt-2d` technique into the void-cutting pipeline. For an extruded host whose openings penetrate **straight through the extrusion depth** (parallel to the host axis), the expensive exact 3D mesh-boolean is replaced by a cheap **2D polygon difference** on the host profile (`bool2d::subtract_multiple_2d`, i_overlay) followed by a **re-extrude** of the holed profile.

The pre-existing `rect_fast` parametric path only handled clean rectangular box hosts; this generalises the idea to **arbitrary extruded profiles** and runs after it (rect+rect hosts keep their proven output byte-identical).

### Per-opening hybrid
A host's openings are split at capture:
- **Eligible** — parallel through-cuts → subtracted in 2D and re-extruded.
- **Residual** — perpendicular sleeves, partial-depth recesses, non-extruded voids → cut by the exact kernel on the re-extruded host.

So a single ineligible opening no longer forfeits its host's cheap ones.

### Correctness (any miss defers to the exact kernel with the FULL opening set)
- Host = one `IfcExtrudedAreaSolid` swept along local ±Z (arbitrary profile; mapped items unwrapped; clipped / multi-item bodies defer).
- Each footprint is gated **strictly interior** to the host profile (adjacent ones may legitimately merge; boundary-breaching ones go to the residual).
- The 2D difference must yield **one connected shape** (a profile-splitting void is rejected — the largest-shape keep would drop geometry) with at least one hole.
- The no-hole re-extrude **reconciles by bounds + volume** against the real host mesh (catches clipped / mis-recovered hosts); the holed re-extrude uses **watertight CDT caps** (earcut hole-bridge slivers would crack a many-hole cap) + an outward-orientation pass, and self-checks watertight.
- Emitted in the host mesh's **own per-element frame** (origin preserved) so the wasm local-frame / georeferenced precision path (#1297) is unaffected.

New helpers: `extrude_profile_watertight`, `cdt::triangulate_constrained` (unrefined, slivers-free, no Ruppert Steiner cost), `bool2d::subtract_multiple_2d_counted` (split detection).

Gate: `IFC_LITE_VOID_2D=0` forces the exact kernel (A/B / bisection). Default **ON**, native and wasm.

## Performance (native, 10 threads)

| model | before (t_geom) | after (t_geom) | 2D fires |
|---|---|---|---|
| ISSUE_098 | ~4.3 s | **~4.0 s (~8%)** | 60 hosts / 79 footprints |
| ISSUE_129 | ~1.28 s | ~1.28 s (neutral) | 14 hosts / 143 footprints |

**Honest note on ISSUE_129:** it does **not** reach web-ifc's 0.31 s with this technique. Measurement shows 129's through-openings (the 2D-eligible subset) are **already cheap** in the exact kernel — removing 143 of them saves only ~0.06 s. Its dominant void cost is **perpendicular sleeves through thick slabs + wall windows**, which the 2D-through technique cannot address (the host is not a prism along the opening axis). The path is a correct, net-positive optimisation that helps 098-class models; the 129 breakthrough would need a different lever.

## Correctness harness (vs IfcOpenShell 0.8.x)

Ran `correctness/run.sh` with `IFC_LITE_VOID_2D=0` (baseline) vs default (on) and diffed per-element verdicts:

- **ISSUE_129**: `957 pass, 1 fail:volume, 1 warn:volume` — **0 per-element verdict changes**; T6 opening-cut **361/361**.
- **ISSUE_098**: the 60 changed-mesh (fired) hosts all keep `pass`; T6 unchanged (`5852 pass, 4 warn:opening-partial-cut`). A net +1 `warn:hausdorff` appears on **3 byte-identical (unchanged) wall meshes** the path never touches — a harness global-alignment artifact on borderline elements when the overall mesh set shifts, not a geometry change.
- **duplex**: net improvement (`+1 pass, -1 warn:hausdorff`); T6 unchanged.

## Tests

- `cargo test -p ifc-lite-geometry` green (pre-existing `wall_opening_cut_regression` failures are missing-fixture in a fresh worktree, identical on baseline).
- New focused unit tests: watertight many-hole re-extrude (cap area = outer − holes), split detection, unrefined-CDT hole exclusion, and eligibility classification (parallel-through eligible; perpendicular / partial-depth / annular defer; interior gating).
- Module-size ratchet respected (new tests split into `*_tests.rs`; `bool2d.rs` tests extracted, dropping it off the allowlist).

Refs #1788

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added performance-optimized void-cutting fast paths for eligible openings, including a 2D subtraction route and an analytic prism-opening subtraction route, with automatic fallback to exact 3D when required.
  - Introduced `extrude_profile_watertight` for watertight extrusion of polygon-with-holes profiles and added counted 2D subtraction to report disconnected outcomes.
  - Added runtime environment gates and exposed fast-path telemetry/stats.
- **Bug Fixes**
  - Improved robustness of complex, multi-hole and staged opening cuts with stricter watertightness/validation before committing fast results.
- **Tests**
  - Expanded unit and regression coverage for 2D counting, fast-path eligibility, constrained triangulation, and watertight extrusion/cutting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->