### PR TITLE
perf(geometry): drop parametric-profile fillets to sharp corners at Low/Lowest (#1809)

### DIFF
--- a/rust/geometry/src/profiles/shapes.rs
+++ b/rust/geometry/src/profiles/shapes.rs
@@ -118,12 +118,16 @@ impl ProfileProcessor {
         // FilletRadius (attr 7) rounds the four web↔flange junctions (concave,
         // adds the root-fillet material). FlangeEdgeRadius (8) and FlangeSlope
         // (9) are not yet modelled (rare; absent in the ara3d set).
-        let fillet = profile
-            .get_float(7)
-            .unwrap_or(0.0)
-            .clamp(0.0, ((overall_depth - 2.0 * flange_thickness) * 0.5)
-                .min((overall_width - web_thickness) * 0.5)
-                .max(0.0));
+        // Below Medium the radius collapses to 0 and the section stays at its
+        // 12 sharp corners (issue #1809).
+        let fillet = self.quality().profile_fillet_radius(
+            profile
+                .get_float(7)
+                .unwrap_or(0.0)
+                .clamp(0.0, ((overall_depth - 2.0 * flange_thickness) * 0.5)
+                    .min((overall_width - web_thickness) * 0.5)
+                    .max(0.0)),
+        );
 
         let half_width = overall_width / 2.0;
         let half_depth = overall_depth / 2.0;

--- a/rust/geometry/src/profiles/steel_shapes.rs
+++ b/rust/geometry/src/profiles/steel_shapes.rs
@@ -51,13 +51,19 @@ impl ProfileProcessor {
         // FilletRadius rounds the inner re-entrant corner (concave, adds
         // material); EdgeRadius rounds the two leg toes (convex, removes the
         // sharp tips). Both optional; clamp so the arcs stay inside the legs.
-        let rf = profile
-            .get_float(6)
-            .unwrap_or(0.0)
-            .clamp(0.0, (width - t).min(depth - t).max(0.0));
-        let re = profile.get_float(7).unwrap_or(0.0).clamp(0.0, (t * 0.999).max(0.0));
+        // Below Medium both collapse to 0 — sharp corners only (issue #1809).
+        let q = self.quality();
+        let rf = q.profile_fillet_radius(
+            profile
+                .get_float(6)
+                .unwrap_or(0.0)
+                .clamp(0.0, (width - t).min(depth - t).max(0.0)),
+        );
+        let re = q.profile_fillet_radius(
+            profile.get_float(7).unwrap_or(0.0).clamp(0.0, (t * 0.999).max(0.0)),
+        );
         // Root-fillet segments per corner: 6 at Medium+, coarser below.
-        let seg = self.quality().profile_arc_segments(6, 2);
+        let seg = q.profile_arc_segments(6, 2);
         let half_pi = std::f64::consts::FRAC_PI_2;
         let pi = std::f64::consts::PI;
 
@@ -111,13 +117,19 @@ impl ProfileProcessor {
         // FilletRadius (attr 7) rounds the two inner web↔flange junctions
         // (concave); EdgeRadius (attr 8) rounds the two flange toes (convex).
         // FlangeSlope (9) not modelled.
+        // Below Medium both collapse to 0 — sharp corners only (issue #1809).
         let half_depth = depth / 2.0;
         let ft = flange_thickness;
-        let rf = profile
-            .get_float(7)
-            .unwrap_or(0.0)
-            .clamp(0.0, (flange_width - web_thickness).min(half_depth - ft).max(0.0));
-        let re = profile.get_float(8).unwrap_or(0.0).clamp(0.0, (ft * 0.999).max(0.0));
+        let q = self.quality();
+        let rf = q.profile_fillet_radius(
+            profile
+                .get_float(7)
+                .unwrap_or(0.0)
+                .clamp(0.0, (flange_width - web_thickness).min(half_depth - ft).max(0.0)),
+        );
+        let re = q.profile_fillet_radius(
+            profile.get_float(8).unwrap_or(0.0).clamp(0.0, (ft * 0.999).max(0.0)),
+        );
 
         // Sharp outline (counter-clockwise). 2,5 = flange toes; 3,4 = junctions.
         let sharp = [
@@ -131,7 +143,7 @@ impl ProfileProcessor {
             Point2::new(0.0, half_depth),                 // 7 back-top outer
         ];
         // Root-fillet segments per corner: 6 at Medium+, coarser below.
-        let seg = self.quality().profile_arc_segments(6, 2);
+        let seg = q.profile_arc_segments(6, 2);
         let radii = [(2, re), (3, rf), (4, rf), (5, re)];
         Ok(Profile2D::new(fillet_outline(&sharp, &radii, seg)))
     }
@@ -163,12 +175,20 @@ impl ProfileProcessor {
         let half_web = web_thickness / 2.0;
         let ft = flange_thickness;
         let ftf = depth - ft; // flange inner face Y
-        let rf = profile
-            .get_float(7)
-            .unwrap_or(0.0)
-            .clamp(0.0, (half_flange - half_web).min(ftf).max(0.0));
-        let r_fl = profile.get_float(8).unwrap_or(0.0).clamp(0.0, (ft * 0.999).max(0.0));
-        let r_web = profile.get_float(9).unwrap_or(0.0).clamp(0.0, (half_web * 0.999).max(0.0));
+        // Below Medium all three collapse to 0 — sharp corners only (issue #1809).
+        let q = self.quality();
+        let rf = q.profile_fillet_radius(
+            profile
+                .get_float(7)
+                .unwrap_or(0.0)
+                .clamp(0.0, (half_flange - half_web).min(ftf).max(0.0)),
+        );
+        let r_fl = q.profile_fillet_radius(
+            profile.get_float(8).unwrap_or(0.0).clamp(0.0, (ft * 0.999).max(0.0)),
+        );
+        let r_web = q.profile_fillet_radius(
+            profile.get_float(9).unwrap_or(0.0).clamp(0.0, (half_web * 0.999).max(0.0)),
+        );
 
         // Sharp outline (counter-clockwise). 1,6 = junctions; 2,5 = flange toes;
         // 0,7 = web free-end corners.
@@ -183,7 +203,7 @@ impl ProfileProcessor {
             Point2::new(half_web, 0.0),        // 7 web bottom-right (web edge)
         ];
         // Root-fillet segments per corner: 6 at Medium+, coarser below.
-        let seg = self.quality().profile_arc_segments(6, 2);
+        let seg = q.profile_arc_segments(6, 2);
         let radii = [
             (0, r_web),
             (1, rf),

--- a/rust/geometry/src/profiles/tests.rs
+++ b/rust/geometry/src/profiles/tests.rs
@@ -182,12 +182,14 @@ use super::*;
     }
 
     fn process_content(content: &str, id: u32) -> Profile2D {
+        process_content_at(content, id, TessellationQuality::Medium)
+    }
+
+    fn process_content_at(content: &str, id: u32, quality: TessellationQuality) -> Profile2D {
         let mut decoder = EntityDecoder::new(content);
         let processor = ProfileProcessor::new(IfcSchema::new());
         let entity = decoder.decode_by_id(id).unwrap();
-        processor
-            .process(&entity, &mut decoder, TessellationQuality::Medium)
-            .unwrap()
+        processor.process(&entity, &mut decoder, quality).unwrap()
     }
 
     // A U-shape (channel) is centred on its bounding box: X spans
@@ -730,4 +732,84 @@ use super::*;
         assert!(processor
             .process(&entity, &mut decoder, TessellationQuality::Medium)
             .is_ok());
+    }
+
+    // Issue #1809: at Low/Lowest the parametric steel-section fillet and edge
+    // radii collapse to sharp corners — a filleted I-section costs the same 12
+    // outline vertices as an unfilleted one, cutting the cross-section triangle
+    // count on slender members where the root fillet is sub-pixel anyway.
+    #[test]
+    fn steel_fillets_drop_to_sharp_corners_below_medium() {
+        // ISSUE_021 W180 I-beam with FilletRadius 15 (same fixture as
+        // `test_i_shape_honours_fillet_radius`).
+        const I_BEAM: &str = "#1=IFCISHAPEPROFILEDEF(.AREA.,$,$,180.,171.,6.,9.5,15.,$,$);\n";
+        for q in [TessellationQuality::Low, TessellationQuality::Lowest] {
+            let profile = process_content_at(I_BEAM, 1, q);
+            assert_eq!(
+                profile.outer.len(),
+                12,
+                "{q:?} I-shape should be the 12-point sharp section"
+            );
+            // Sharp section area (closed form): 180·171 − (180−6)·(171−2·9.5).
+            let expected = 180.0 * 171.0 - 174.0 * 152.0;
+            let area = outer_area(&profile);
+            assert!(
+                (area - expected).abs() < 1e-6,
+                "{q:?} sharp I area {area:.3} vs {expected:.3}"
+            );
+            // Fillets are interior, so the bbox is the nominal section either way.
+            let (mnx, mny, mxx, mxy) = outer_bbox(&profile);
+            assert!((mxx - mnx - 180.0).abs() < 1e-6 && (mxy - mny - 171.0).abs() < 1e-6);
+        }
+    }
+
+    // Medium and above are untouched by #1809 — the arcs must stay byte-identical
+    // to the pre-change output, which is the `TessellationQuality` identity
+    // invariant the whole enum rests on.
+    #[test]
+    fn steel_fillets_unchanged_at_medium_and_above() {
+        const I_BEAM: &str = "#1=IFCISHAPEPROFILEDEF(.AREA.,$,$,180.,171.,6.,9.5,15.,$,$);\n";
+        let medium = process_content_at(I_BEAM, 1, TessellationQuality::Medium);
+        assert!(
+            medium.outer.len() > 12,
+            "Medium must keep the fillet arcs, got {} points",
+            medium.outer.len()
+        );
+        for q in [TessellationQuality::High, TessellationQuality::Highest] {
+            let profile = process_content_at(I_BEAM, 1, q);
+            assert_eq!(profile.outer.len(), medium.outer.len(), "{q:?} vertex count");
+            for (a, b) in profile.outer.iter().zip(medium.outer.iter()) {
+                assert_eq!((a.x, a.y), (b.x, b.y), "{q:?} must be byte-identical to Medium");
+            }
+        }
+    }
+
+    // Asymmetric radii (L-shape FilletRadius 12 / EdgeRadius 8, C-shape via the
+    // U-channel's toe edges) all collapse together, leaving the plain sharp
+    // corner counts: L = 6, U = 8, T = 8.
+    #[test]
+    fn asymmetric_steel_radii_drop_together_below_medium() {
+        let cases = [
+            // Depth 100, Width 80, Thickness 10, FilletRadius 12, EdgeRadius 8.
+            ("#1=IFCLSHAPEPROFILEDEF(.AREA.,$,$,100.,80.,10.,12.,8.,$,$,$);\n", 6),
+            // Depth 200, FlangeWidth 80, Web 10, Flange 12, Fillet 12, Edge 6.
+            ("#1=IFCUSHAPEPROFILEDEF(.AREA.,$,$,200.,80.,10.,12.,12.,6.,$,$);\n", 8),
+            // Depth 200, FlangeWidth 100, Web 10, Flange 15, Fillet 12,
+            // FlangeEdgeRadius 6, WebEdgeRadius 4.
+            ("#1=IFCTSHAPEPROFILEDEF(.AREA.,$,$,200.,100.,10.,15.,12.,6.,4.,$,$);\n", 8),
+        ];
+        for (content, sharp_points) in cases {
+            for q in [TessellationQuality::Low, TessellationQuality::Lowest] {
+                let profile = process_content_at(content, 1, q);
+                assert_eq!(
+                    profile.outer.len(),
+                    sharp_points,
+                    "{q:?} expected {sharp_points} sharp points for {content}"
+                );
+            }
+            assert!(
+                process_content(content, 1).outer.len() > sharp_points,
+                "Medium must still round {content}"
+            );
+        }
     }

--- a/rust/geometry/src/profiles/tests.rs
+++ b/rust/geometry/src/profiles/tests.rs
@@ -784,9 +784,11 @@ use super::*;
         }
     }
 
-    // Asymmetric radii (L-shape FilletRadius 12 / EdgeRadius 8, C-shape via the
-    // U-channel's toe edges) all collapse together, leaving the plain sharp
-    // corner counts: L = 6, U = 8, T = 8.
+    // Profiles carrying several independent radii collapse all of them together,
+    // leaving the plain sharp corner counts: L = 6, U = 8, T = 8. The L-shape
+    // separates FilletRadius (concave root) from EdgeRadius (convex toes), and
+    // the T-shape splits its edge radius into flange and web variants, so this
+    // covers the mixed concave/convex cases the I-shape alone does not.
     #[test]
     fn asymmetric_steel_radii_drop_together_below_medium() {
         let cases = [

--- a/rust/geometry/src/tessellation.rs
+++ b/rust/geometry/src/tessellation.rs
@@ -121,8 +121,13 @@ impl TessellationQuality {
         n.max(min)
     }
 
-    /// Fillet / edge radius for a **parametric steel-section corner**
-    /// (`IfcI/L/U/T/C/ZShapeProfileDef`), given the model's declared `radius`.
+    /// Fillet / edge radius for a **parametric steel-section corner**, given the
+    /// model's declared `radius`.
+    ///
+    /// Callers today are `IfcI/L/U/TShapeProfileDef` — the profiles whose builders
+    /// actually read a radius attribute. `IfcC/ZShapeProfileDef` build plain sharp
+    /// point lists and ignore their radius attributes entirely, so they never reach
+    /// here; route them through this helper if that ever changes.
     ///
     /// Below `Medium` the radius collapses to `0.0`, so the corner is emitted
     /// sharp instead of as an arc: an I-section drops from ~28 outline vertices

--- a/rust/geometry/src/tessellation.rs
+++ b/rust/geometry/src/tessellation.rs
@@ -121,6 +121,27 @@ impl TessellationQuality {
         n.max(min)
     }
 
+    /// Fillet / edge radius for a **parametric steel-section corner**
+    /// (`IfcI/L/U/T/C/ZShapeProfileDef`), given the model's declared `radius`.
+    ///
+    /// Below `Medium` the radius collapses to `0.0`, so the corner is emitted
+    /// sharp instead of as an arc: an I-section drops from ~28 outline vertices
+    /// to its 12 sharp ones, halving the cross-section triangles on slender
+    /// members where the fillet is a sub-pixel detail anyway (issue #1809).
+    /// `Medium` and above return the radius untouched, keeping default output
+    /// byte-identical — the same identity invariant as
+    /// [`profile_arc_segments`](Self::profile_arc_segments).
+    ///
+    /// This only applies to parametric profiles swept by `IfcExtrudedAreaSolid`;
+    /// faceted / tessellated exports have their fillets baked into the mesh.
+    #[inline]
+    pub fn profile_fillet_radius(self, radius: f64) -> f64 {
+        match self {
+            Self::Lowest | Self::Low => 0.0,
+            Self::Medium | Self::High | Self::Highest => radius,
+        }
+    }
+
     /// Segment count for a **circular profile** outline (opening cutter / cap),
     /// where `base` is the historical fixed count (e.g. 36 for
     /// `IfcCircleProfileDef`).
@@ -255,6 +276,19 @@ mod tests {
         }
         // Floor respected.
         assert_eq!(Lowest.profile_arc_segments(6, 2), 2);
+    }
+
+    #[test]
+    fn profile_fillet_radius_drops_below_medium_identity_above() {
+        use TessellationQuality::*;
+        for q in [Lowest, Low] {
+            assert_eq!(q.profile_fillet_radius(15.0), 0.0, "{q:?} must go sharp");
+        }
+        for q in [Medium, High, Highest] {
+            assert_eq!(q.profile_fillet_radius(15.0), 15.0, "{q:?} keeps the radius");
+        }
+        // An already-sharp corner stays sharp everywhere.
+        assert_eq!(Medium.profile_fillet_radius(0.0), 0.0);
     }
 
     #[test]


### PR DESCRIPTION
Closes #1809.

## What

Steel sections authored as parametric profiles carry their root fillets and toe edge radii as attributes, and the outline builders tessellate each one into an arc. At preview tessellation levels that fillet is a sub-pixel detail which still costs a full arc's worth of cross-section triangles on every extruded member.

`TessellationQuality::profile_fillet_radius` returns `0.0` at `Low`/`Lowest` and the declared radius unchanged at `Medium` and above. `round_corner` / `push_arc` already emit a sharp corner when the radius falls below 1 µm, so zeroing the radius at the source needs no new branching in the builders — it sits alongside the existing `profile_arc_segments` / `circle_profile_segments` helpers and keeps the same "Medium is the identity" invariant.

Applied to the four profiles that model radii today:

| builder | radii collapsed |
|---|---|
| `process_i_shape` | FilletRadius |
| `process_l_shape` | FilletRadius + EdgeRadius |
| `process_u_shape` | FilletRadius + EdgeRadius |
| `process_t_shape` | FilletRadius + Flange/WebEdgeRadius |

The issue also lists C and Z. Those need no change: `process_c_shape` and `process_z_shape` already build plain sharp point lists and never read their radius attributes, so they are at the target output at every level already. Left alone rather than expanding scope into modelling fillets that do not exist yet.

## Measurements

A/B of the same build with and without the change, on a real Tekla steel model (`130_KM.ifc` — 682 `IfcExtrudedAreaSolid`, 25 parametric profiles carrying radii, IFC2X3):

| | triangles |
|---|---|
| medium (reference) | 2 933 223 |
| low **without** the change | 1 301 370 |
| low **with** the change | 1 092 875 |

−208 495 triangles, a further −16% on top of what `low` already did. `medium` matched to the triangle across both builds — the no-regression-above-Medium guarantee, confirmed on real data rather than only in unit tests.

On a synthetic file of pure parametric members (HEA300 / L150 / U200 / T200, all with fillets): 528 → 120 triangles, −77%. That is the 40–60% cross-section figure from the issue, seen without the surrounding plate/cut geometry diluting it.

## Tests

- Filleted W180 I-beam → exactly 12 outline vertices at `Low` and `Lowest`, area matching the closed-form sharp section (`180·171 − 174·152`), bbox unchanged (fillets are interior).
- `Medium` keeps its arcs; `High`/`Highest` asserted **coordinate-identical** to `Medium`.
- Asymmetric radii (L 12/8, U 12/6, T 12/6/4) collapse together to 6/8/8 sharp points, each paired with an assertion that `Medium` still rounds it.
- Unit test on the helper itself.

`cargo test -p ifc-lite-geometry` green (469 lib + all integration suites). Clippy clean on the touched files.

## Scope

Only parametric profiles swept by `IfcExtrudedAreaSolid` benefit. Faceted / tessellated exports have their fillets baked into the mesh and are unaffected — verified on a second Tekla model exported as `SurfaceGeometry` (2036 `IfcFacetedBrep`, zero profile definitions), where this change is correctly a no-op.

Worth flagging for review: dropping a concave root fillet removes material, so the cross-section area moves (~4.5% on a W180 with r=15). That is fine for the on-screen preview levels this targets, but it is a reason not to route `Low`/`Lowest` into anything that derives geometry-based numbers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added quality-aware profile geometry processing.
  * Low and Lowest quality now use sharp corners by removing profile fillets.
  * Medium, High, and Highest quality preserve rounded profile geometry.

* **Bug Fixes**
  * Improved consistency across I-, L-, U-, and T-shaped steel profiles.
  * Preserved profile dimensions while simplifying low-quality tessellation.

* **Tests**
  * Added coverage confirming geometry, vertex counts, and areas across tessellation quality levels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->