### PR TITLE
perf(geometry): fuzzy-boolean f64 subtract fast-tier with exact fallback

### DIFF
--- a/.changeset/perf-fuzzy-boolean-tier.md
+++ b/.changeset/perf-fuzzy-boolean-tier.md
@@ -1,0 +1,7 @@
+---
+"@ifc-lite/wasm": patch
+---
+
+perf(geometry): fuzzy-boolean f64 subtract fast-tier with exact fallback
+
+Add a tolerance-based f64 boolean SUBTRACT (ported from web-ifc's `fuzzybools`) as an opt-in FAST TIER in front of the exact mesh-arrangement kernel, for the batched disjoint-cutter path (`mesh_bridge::subtract_many`). It shared-position snaps both operands onto the kernel grid, intersects BVH-culled host×cutter triangle pairs into per-face constraint segments, re-triangulates only the intersected faces with the in-tree deterministic CDT (untouched faces pass through verbatim — the speedup vs re-arranging everything), and classifies each sub-triangle inside/outside by a ray-cast from a non-barycentric centroid voted across three fixed directions. All f64, FMA-free, IEEE-sqrt only, so native==wasm bit-identical. Every fuzzy result is STRICT self-checked — watertight AND removed-volume == the disjoint oracle Σ|host∩cutterᵢ| within 1% — and discarded (exact kernel runs unchanged) on any failure, so correctness can never regress. Gated OFF by default via `IFC_LITE_FUZZY_BOOL`; a default build is byte-identical to the exact kernel (mesh-determinism manifest unperturbed). First increment: on ISSUE_129 the tier is performance-neutral (the strict exact-volume oracle costs about as much as the exact difference it replaces, and only the few batched many-opening hosts are hooked), with zero verdict regression on the IfcOpenShell correctness harness (ISSUE_129 361/361, duplex 86/86, ISSUE_098 unchanged). Refs #1788.

--- a/rust/geometry/src/kernel/fuzzy/classify.rs
+++ b/rust/geometry/src/kernel/fuzzy/classify.rs
@@ -1,0 +1,103 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Point-in-mesh classification by f64 ray-cast crossing parity, BVH-culled and
+//! voted across three fixed directions for robustness.
+//!
+//! A closed oriented mesh contains `p` iff a ray from `p` crosses its surface an
+//! odd number of times. We use Möller–Trumbore ray–triangle tests (no back-face
+//! cull — a solid's far side must count), prune candidates with the shared BVH,
+//! and take the MAJORITY verdict over three fixed generic directions so a single
+//! grazing/edge-hit degeneracy on one ray cannot flip the result. Any residual
+//! misclassification only makes the fuzzy mesh fail the caller's watertight /
+//! volume self-check → exact fallback, never a silent wrong answer.
+//!
+//! DETERMINISM: FMA-free f64, fixed directions, IEEE ops only; the crossing
+//! COUNT (hence parity) is independent of BVH candidate order ⇒ byte-identical
+//! native==wasm.
+
+use super::super::arrangement::Tri;
+use super::super::broadphase::Bvh;
+use super::{cross, dot, sub};
+
+/// Three fixed generic ray directions: none axis-aligned, no two components
+/// equal, and no pairwise ratio near a simple architectural slope — so a ray is
+/// unlikely to lie in any operand face plane. (The first mirrors the exact
+/// kernel's parity direction.)
+const DIRS: [[f64; 3]; 3] = [
+    [0.301_511_3, 0.557_328_1, 0.773_890_1],
+    [-0.673_1, 0.211_7, 0.708_9],
+    [0.418_3, -0.802_5, 0.425_7],
+];
+
+/// Möller–Trumbore: does the ray `orig + s·dir` (`s ∈ (ε, 1]` along `orig→far`,
+/// parametrised so `dir = far − orig`) cross triangle `t`? Two-sided; a grazing
+/// (near-parallel or barycentric-boundary) hit is rejected — the non-barycentric
+/// centroid and 3-direction vote make those vanishingly rare and self-cancelling.
+fn ray_hits(orig: [f64; 3], dir: [f64; 3], t: &Tri) -> bool {
+    let e1 = sub(t[1], t[0]);
+    let e2 = sub(t[2], t[0]);
+    let pvec = cross(dir, e2);
+    let det = dot(e1, pvec);
+    // Parallel / edge-on: reject (grazing).
+    if det.abs() <= 1.0e-12 {
+        return false;
+    }
+    let inv = 1.0 / det;
+    let tvec = sub(orig, t[0]);
+    let u = dot(tvec, pvec) * inv;
+    if u <= 0.0 || u >= 1.0 {
+        return false;
+    }
+    let qvec = cross(tvec, e1);
+    let v = dot(dir, qvec) * inv;
+    if v <= 0.0 || u + v >= 1.0 {
+        return false;
+    }
+    let s = dot(e2, qvec) * inv;
+    // s ∈ (ε, 1]: strictly in front of the origin and within the segment.
+    s > 1.0e-9 && s <= 1.0
+}
+
+/// Crossing parity of the segment `p → p + dir·(far/|dir|)` against `tris`
+/// (BVH-culled). `far_len` is the ray length (past the operand extent). Returns
+/// `true` for an odd count (inside).
+fn crossings_odd(
+    p: [f64; 3],
+    unit_dir: [f64; 3],
+    tris: &[Tri],
+    bvh: &Bvh,
+    far_len: f64,
+    scratch: &mut Vec<u32>,
+) -> bool {
+    let dir = [unit_dir[0] * far_len, unit_dir[1] * far_len, unit_dir[2] * far_len];
+    let far = [p[0] + dir[0], p[1] + dir[1], p[2] + dir[2]];
+    scratch.clear();
+    bvh.ray_candidates(p, far, scratch);
+    let mut count = 0usize;
+    for &i in scratch.iter() {
+        if ray_hits(p, dir, &tris[i as usize]) {
+            count += 1;
+        }
+    }
+    count % 2 == 1
+}
+
+/// Is `p` inside the closed mesh `tris`? Majority vote of the three fixed-
+/// direction ray parities (`far_len` past the operand extent).
+pub(super) fn inside_vote(
+    p: [f64; 3],
+    tris: &[Tri],
+    bvh: &Bvh,
+    far_len: f64,
+    scratch: &mut Vec<u32>,
+) -> bool {
+    let mut yes = 0u8;
+    for d in DIRS {
+        if crossings_odd(p, d, tris, bvh, far_len, scratch) {
+            yes += 1;
+        }
+    }
+    yes >= 2
+}

--- a/rust/geometry/src/kernel/fuzzy/intersect.rs
+++ b/rust/geometry/src/kernel/fuzzy/intersect.rs
@@ -1,0 +1,129 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Plain-f64 triangle–triangle intersection SEGMENT (the fuzzy tier's
+//! constraint generator), FMA-free and deterministic.
+//!
+//! Method (Möller interval form): the two triangle planes meet in a line
+//! `L = n_a × n_b`. Each triangle, if it straddles the OTHER's plane, crosses it
+//! in a segment lying on `L`; the triangles overlap iff those two collinear
+//! segments overlap, and their common part is the intersection segment.
+//!
+//! Only TRANSVERSAL crossings are emitted. Parallel/coplanar pairs (`|L| ≈ 0`)
+//! and vertex-on-plane degeneracies (a triangle that does not cross in exactly
+//! two edges) return `None` — the fuzzy result is then either legitimately
+//! seam-free there or, if not, rejected by the caller's watertight/volume
+//! self-check and handled by the exact kernel. All FMA-free f64 over the input
+//! (already snap-grid) coordinates ⇒ byte-identical native==wasm.
+
+use super::super::arrangement::Tri;
+use super::{cross, dot, sub, tri_normal};
+
+/// An intersection segment: two f64 endpoints on the shared intersection line.
+pub(super) type Seg = ([f64; 3], [f64; 3]);
+
+/// Unit normal of a triangle, or `None` for a degenerate (zero-area) one.
+fn unit_normal(t: &Tri) -> Option<[f64; 3]> {
+    let n = tri_normal(t);
+    let len2 = dot(n, n);
+    if len2 <= 0.0 || !len2.is_finite() {
+        return None;
+    }
+    let len = len2.sqrt();
+    Some([n[0] / len, n[1] / len, n[2] / len])
+}
+
+/// Signed distances of `t`'s three vertices to the plane `(n·(x−p0)=0)`.
+fn plane_dists(t: &Tri, n: [f64; 3], p0: [f64; 3]) -> [f64; 3] {
+    [dot(sub(t[0], p0), n), dot(sub(t[1], p0), n), dot(sub(t[2], p0), n)]
+}
+
+/// The two points where triangle `t` crosses a plane, given its per-vertex
+/// signed distances `d`. Only STRICT sign changes count as crossings; a
+/// well-formed transversal straddle produces exactly two, else `None`.
+fn crossing_points(t: &Tri, d: [f64; 3]) -> Option<[[f64; 3]; 2]> {
+    let mut pts: [[f64; 3]; 2] = [[0.0; 3]; 2];
+    let mut n = 0usize;
+    for (i, j) in [(0usize, 1usize), (1, 2), (2, 0)] {
+        let (di, dj) = (d[i], d[j]);
+        let crosses = (di < 0.0 && dj > 0.0) || (di > 0.0 && dj < 0.0);
+        if crosses {
+            if n >= 2 {
+                return None; // >2 crossings ⇒ numerically ill-formed; defer
+            }
+            let s = di / (di - dj);
+            pts[n] = [
+                t[i][0] + s * (t[j][0] - t[i][0]),
+                t[i][1] + s * (t[j][1] - t[i][1]),
+                t[i][2] + s * (t[j][2] - t[i][2]),
+            ];
+            n += 1;
+        }
+    }
+    if n == 2 {
+        Some(pts)
+    } else {
+        None
+    }
+}
+
+/// Intersection segment of triangles `ta` and `tb`, or `None` when they don't
+/// cross transversally. `ext` is the operand coordinate magnitude (sizes the
+/// parallel-plane and interval-overlap epsilons).
+pub(super) fn tri_tri_segment(ta: &Tri, tb: &Tri, ext: f64) -> Option<Seg> {
+    let na = unit_normal(ta)?;
+    let nb = unit_normal(tb)?;
+    // Line direction; if the planes are (near-)parallel there is no transversal
+    // segment (coplanar overlap is deliberately deferred to the exact kernel).
+    let dir = cross(na, nb);
+    let dir_len2 = dot(dir, dir);
+    if dir_len2 <= 1.0e-14 {
+        return None;
+    }
+    // Each triangle must straddle the other's plane in exactly two edges.
+    let db = plane_dists(tb, na, ta[0]); // tb vs plane A
+    let da = plane_dists(ta, nb, tb[0]); // ta vs plane B
+    // A perpendicular-gap floor scaled to the operand: distances below it are
+    // treated as "on plane" (not a strict crossing) so a flush face doesn't
+    // fabricate a spurious hairline segment.
+    let eps = (1.0e-9 * ext).max(1.0e-12);
+    let snap = |v: [f64; 3]| [zero_if(v[0], eps), zero_if(v[1], eps), zero_if(v[2], eps)];
+    let seg_b = crossing_points(tb, snap(db))?; // segment of tb on line L
+    let seg_a = crossing_points(ta, snap(da))?; // segment of ta on line L
+
+    // Parametrise all four endpoints along `dir`; intersect the two intervals.
+    let param = |p: [f64; 3]| dot(p, dir);
+    let (a0, a1) = order(seg_a[0], seg_a[1], param);
+    let (b0, b1) = order(seg_b[0], seg_b[1], param);
+    // overlap [lo, hi]: start = the later of the two lows, end = the earlier high
+    let (lo_pt, lo_t) = if param(a0) >= param(b0) { (a0, param(a0)) } else { (b0, param(b0)) };
+    let (hi_pt, hi_t) = if param(a1) <= param(b1) { (a1, param(a1)) } else { (b1, param(b1)) };
+    // Reject an empty or degenerate (point) overlap. The tolerance is an
+    // in-line length scaled by |dir| (== 1 for unit normals unless the planes
+    // are near-parallel, already screened above).
+    let len_eps = (1.0e-9 * ext).max(1.0e-12) * dir_len2.sqrt();
+    if hi_t - lo_t <= len_eps {
+        return None;
+    }
+    Some((lo_pt, hi_pt))
+}
+
+#[inline]
+fn zero_if(x: f64, eps: f64) -> f64 {
+    if x.abs() <= eps {
+        0.0
+    } else {
+        x
+    }
+}
+
+/// Order two points by their `param`, returning `(low, high)`.
+#[inline]
+fn order(p: [f64; 3], q: [f64; 3], param: impl Fn([f64; 3]) -> f64) -> ([f64; 3], [f64; 3]) {
+    if param(p) <= param(q) {
+        (p, q)
+    } else {
+        (q, p)
+    }
+}

--- a/rust/geometry/src/kernel/fuzzy/mod.rs
+++ b/rust/geometry/src/kernel/fuzzy/mod.rs
@@ -21,11 +21,11 @@
 //!    SUBTRACT keeps host tris OUTSIDE the cutters + cutter tris INSIDE the host
 //!    (flipped) as reveal caps.
 //!
-//! This is NOT a replacement: the caller ([`super::mesh_bridge::subtract_many`])
-//! STRICT-SELF-CHECKS every fuzzy result (watertight AND removed-volume == the
-//! disjoint oracle Σ|host∩cutterᵢ|) and DISCARDS it — running the exact kernel
-//! unchanged — on any failure. A bad fuzzy result can therefore never regress
-//! correctness; the tier only ever makes a provably-good result faster.
+//! This is NOT a replacement: the callers (`mesh_bridge::subtract` binary AND
+//! `subtract_many` batched) STRICT-SELF-CHECK every fuzzy result (watertight AND
+//! removed-volume == the cheap/exact oracle Σ|host∩cutterᵢ|) and DISCARD it —
+//! running the exact kernel unchanged — on any failure. A volume/topology-bad
+//! fuzzy result can therefore never regress; the tier only accepts a good one.
 //!
 //! DETERMINISM: all f64, FMA-free (no `mul_add`), fixed ray directions,
 //! deterministic vertex/face ordering, IEEE `sqrt` only, and the shared CDT is
@@ -169,8 +169,7 @@ pub(super) fn subtract(host: &[Tri], comps: &[Vec<Tri>]) -> Option<Vec<Tri>> {
     if host.is_empty() {
         return Some(Vec::new());
     }
-    // Reject non-finite / malformed operands up front (defensive: `mesh_to_tris`
-    // already drops non-finite, but a caller could pass raw tris).
+    // Reject non-finite / malformed operands up front (defensive).
     if !all_finite(host) || !comps.iter().all(|c| all_finite(c)) {
         return None;
     }
@@ -278,7 +277,13 @@ pub(super) fn subtract_checked(host: &[Tri], comps: &[Vec<Tri>]) -> Option<crate
         trace_fallback("not-watertight");
         return None;
     }
-    let inter_sum = match oracle_removed_volume(host, comps) {
+    // CHEAP INDEPENDENT ORACLE FIRST (#1806 Σ-box): Σ|vol6(contained cutter)|
+    // when every cutter is provably inside/outside the host (no boolean); only a
+    // cutter straddling ∂A pays the exact per-cutter intersection oracle. Both
+    // are independent of the fuzzy retri/classify, so either self-checks it.
+    let inter_sum = match cheap_oracle_removed_volume(host, comps)
+        .or_else(|| oracle_removed_volume(host, comps))
+    {
         Some(s) => s,
         None => {
             trace_fallback("oracle-tripped");
@@ -326,6 +331,52 @@ pub(super) fn oracle_removed_volume(host: &[Tri], comps: &[Vec<Tri>]) -> Option<
     } else {
         Some(inter_sum)
     }
+}
+
+/// CHEAP, INDEPENDENT removed-volume oracle (the O(cutters) analytic alternative
+/// to [`oracle_removed_volume`]'s per-cutter exact boolean; #1806 Σ-box idea).
+///
+/// For `A − ∪Bᵢ` with disjoint cutters removed = `Σ vol(A∩Bᵢ)`. A cutter that
+/// never crosses `∂A` is entirely inside (`vol(A∩Bᵢ)=|vol6(Bᵢ)|`) or outside
+/// (`0`) — read from the cutter alone, no boolean. If ANY cutter STRADDLES `∂A`
+/// (a transversal tri-tri crossing) the identity fails, so return `None` and let
+/// the caller fall to the exact oracle. Independent of the fuzzy retri/classify
+/// (only cutter signed volumes + host containment), so it validly self-checks a
+/// fuzzy result. Units: ×6 volume, matching `oracle_removed_volume`.
+pub(super) fn cheap_oracle_removed_volume(host: &[Tri], comps: &[Vec<Tri>]) -> Option<f64> {
+    if host.is_empty() {
+        return Some(0.0);
+    }
+    let host_bvh = Bvh::build(host);
+    let mut ext = coord_extent(host);
+    for c in comps {
+        ext = ext.max(coord_extent(c));
+    }
+    let ray_far = 4.0 * ext + 1.0;
+    let mut scratch: Vec<u32> = Vec::new();
+    let mut cand: Vec<u32> = Vec::new();
+    let mut sum = 0.0f64;
+    for c in comps {
+        if c.is_empty() {
+            continue;
+        }
+        // Any transversal crossing ⇒ cutter straddles ∂A ⇒ defer the whole group.
+        for ct in c {
+            cand.clear();
+            host_bvh.query(&super::broadphase::tri_aabb(ct), &mut cand);
+            for &j in &cand {
+                if intersect::tri_tri_segment(ct, &host[j as usize], ext).is_some() {
+                    return None;
+                }
+            }
+        }
+        // No crossing: fully inside or fully outside. Vote a non-barycentric
+        // centroid (off any shared edge/vertex) against the host.
+        if classify::inside_vote(centroid_nb(&c[0]), host, &host_bvh, ray_far, &mut scratch) {
+            sum += super::signed_volume::signed_volume6(c).abs();
+        }
+    }
+    Some(sum)
 }
 
 /// Is the f64 triangle list a CLOSED oriented surface — every directed edge

--- a/rust/geometry/src/kernel/fuzzy/mod.rs
+++ b/rust/geometry/src/kernel/fuzzy/mod.rs
@@ -1,0 +1,349 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Fuzzy (tolerance-based f64) boolean SUBTRACT — a FAST TIER in front of the
+//! exact mesh-arrangement kernel, ported from web-ifc's `fuzzybools` approach.
+//!
+//! The exact kernel ([`super::arrangement`]) is correct-by-construction but pays
+//! symbolic/BigRational escalation and re-arranges every intersected face over a
+//! shared interner. On many-opening hosts (ISSUE_129) that N-ary arrangement is
+//! the dominant cost. web-ifc is ~4× faster on the same corpus because it runs a
+//! plain f64 tolerance boolean instead. This module adopts that as a fast path:
+//!
+//! 1. Intersect (BVH-culled) host×cutter triangle pairs → per-face constraint
+//!    segments in plain f64 ([`intersect`]).
+//! 2. Re-triangulate each INTERSECTED face with those constraints via the
+//!    in-tree deterministic CDT ([`retri`]); untouched faces pass through
+//!    verbatim (the big win — no global re-arrangement).
+//! 3. Classify every resulting sub-triangle inside/outside by a ray-cast from a
+//!    NON-barycentric centroid, voting across 3 fixed directions ([`classify`]).
+//!    SUBTRACT keeps host tris OUTSIDE the cutters + cutter tris INSIDE the host
+//!    (flipped) as reveal caps.
+//!
+//! This is NOT a replacement: the caller ([`super::mesh_bridge::subtract_many`])
+//! STRICT-SELF-CHECKS every fuzzy result (watertight AND removed-volume == the
+//! disjoint oracle Σ|host∩cutterᵢ|) and DISCARDS it — running the exact kernel
+//! unchanged — on any failure. A bad fuzzy result can therefore never regress
+//! correctness; the tier only ever makes a provably-good result faster.
+//!
+//! DETERMINISM: all f64, FMA-free (no `mul_add`), fixed ray directions,
+//! deterministic vertex/face ordering, IEEE `sqrt` only, and the shared CDT is
+//! already native==wasm bit-identical (it is used in production by the prism-cut
+//! path under the `mesh_determinism` manifest). So the fuzzy output is
+//! byte-identical native==wasm too. The tier is env-gated OFF by default
+//! (`IFC_LITE_FUZZY_BOOL`), so a default build is byte-identical to the exact
+//! kernel and the determinism manifest is unperturbed.
+
+use super::arrangement::Tri;
+use super::broadphase::{candidate_pairs, Bvh};
+
+mod classify;
+mod intersect;
+mod retri;
+#[cfg(test)]
+mod tests;
+
+// --- small FMA-free f64 vec3 helpers, shared across the submodules ----------
+
+#[inline]
+pub(super) fn sub(a: [f64; 3], b: [f64; 3]) -> [f64; 3] {
+    [a[0] - b[0], a[1] - b[1], a[2] - b[2]]
+}
+
+#[inline]
+pub(super) fn cross(a: [f64; 3], b: [f64; 3]) -> [f64; 3] {
+    [a[1] * b[2] - a[2] * b[1], a[2] * b[0] - a[0] * b[2], a[0] * b[1] - a[1] * b[0]]
+}
+
+#[inline]
+pub(super) fn dot(a: [f64; 3], b: [f64; 3]) -> f64 {
+    a[0] * b[0] + a[1] * b[1] + a[2] * b[2]
+}
+
+/// Raw (un-normalised) face normal of a triangle.
+#[inline]
+pub(super) fn tri_normal(t: &Tri) -> [f64; 3] {
+    cross(sub(t[1], t[0]), sub(t[2], t[0]))
+}
+
+/// NON-barycentric centroid `(a + 1.02·b + 1.03·c)/3.05`. The asymmetric weights
+/// push the sample off any vertex/edge/median so a classification ray is
+/// vanishingly unlikely to graze a shared edge or hit a vertex of the operand it
+/// probes (web-ifc's degenerate-ray avoidance). FMA-free.
+#[inline]
+pub(super) fn centroid_nb(t: &Tri) -> [f64; 3] {
+    [
+        (t[0][0] + 1.02 * t[1][0] + 1.03 * t[2][0]) / 3.05,
+        (t[0][1] + 1.02 * t[1][1] + 1.03 * t[2][1]) / 3.05,
+        (t[0][2] + 1.02 * t[1][2] + 1.03 * t[2][2]) / 3.05,
+    ]
+}
+
+/// SHARED-POSITION snap (design step 1). Quantise a coordinate to the kernel's
+/// `SNAP_GRID` (a power of two ⇒ the divide/round/multiply is EXACT and
+/// bit-deterministic). Applied to BOTH operands' vertices AND every computed
+/// intersection endpoint so a point that two different triangle pairs compute
+/// independently (e.g. an opening corner shared by two host faces) lands on the
+/// SAME grid cell — the coincidence that makes the re-triangulated seams close
+/// watertight without a shared symbolic interner. Coarse enough (~15 µm) to
+/// merge ULP-scattered duplicates; three orders below the smallest real feature.
+#[inline]
+pub(super) fn snap_coord(c: f64) -> f64 {
+    (c / super::mesh_bridge::SNAP_GRID).round() * super::mesh_bridge::SNAP_GRID
+}
+
+#[inline]
+pub(super) fn snap_pt(p: [f64; 3]) -> [f64; 3] {
+    [snap_coord(p[0]), snap_coord(p[1]), snap_coord(p[2])]
+}
+
+fn snap_tris(tris: &[Tri]) -> Vec<Tri> {
+    tris.iter().map(|t| [snap_pt(t[0]), snap_pt(t[1]), snap_pt(t[2])]).collect()
+}
+
+/// Coordinate magnitude (max |component|) over a triangle list — sizes the
+/// intersection epsilon and the ray far-length to the operand.
+pub(super) fn coord_extent(tris: &[Tri]) -> f64 {
+    let mut hi = 1.0f64;
+    for t in tris {
+        for v in t {
+            for &c in v {
+                hi = hi.max(c.abs());
+            }
+        }
+    }
+    hi
+}
+
+/// Is the fuzzy tier enabled? Env gate `IFC_LITE_FUZZY_BOOL` (read ONCE):
+/// `1`/`true`/`on` ⇒ ON, anything else (incl. absent — the default, and the wasm
+/// case where env is unavailable) ⇒ OFF. Default OFF keeps a default build
+/// byte-identical to the exact kernel (`mesh_determinism` manifest unperturbed);
+/// the tier is opted into explicitly for the A/B and, once proven, a follow-up
+/// flip of this default.
+pub fn enabled() -> bool {
+    use std::sync::OnceLock;
+    static ON: OnceLock<bool> = OnceLock::new();
+    *ON.get_or_init(|| {
+        matches!(std::env::var("IFC_LITE_FUZZY_BOOL").as_deref(), Ok("1") | Ok("true") | Ok("on"))
+    })
+}
+
+/// Measurement-only stderr trace of fuzzy claim/fallback decisions, gated by
+/// `IFC_LITE_FUZZY_STATS=1` (read once). OFF by default ⇒ zero cost on the hot
+/// path (no atomics, no I/O); it exists solely so a bench run can count the
+/// fuzzy HIT-RATE (claims vs fallbacks) without instrumenting the caller. Not
+/// consulted by any test, so it cannot race a correctness assertion.
+fn stats_on() -> bool {
+    use std::sync::OnceLock;
+    static ON: OnceLock<bool> = OnceLock::new();
+    *ON.get_or_init(|| std::env::var("IFC_LITE_FUZZY_STATS").as_deref() == Ok("1"))
+}
+
+pub(super) fn trace_claim() {
+    if stats_on() {
+        eprintln!("FUZZY_BOOL claim");
+    }
+}
+
+pub(super) fn trace_fallback(reason: &str) {
+    if stats_on() {
+        eprintln!("FUZZY_BOOL fallback:{reason}");
+    }
+}
+
+/// `host − (∪ comps)` as an f64 triangle list, computed by the fuzzy tolerance
+/// boolean. `comps` are the PAIRWISE-DISJOINT, per-component-closed, outward-
+/// wound cutter components (exactly what [`super::mesh_bridge::subtract_many`]
+/// prepares for the exact path). Returns `None` on any structural failure (a
+/// face whose constrained CDT could not be built, a degenerate operand) so the
+/// caller falls straight to the exact kernel; a `Some` result is NOT yet trusted
+/// — the caller still watertight/volume self-checks it.
+///
+/// SUBTRACT rule (web-ifc): keep host sub-triangles whose centroid is OUTSIDE
+/// the cutter union, plus cutter sub-triangles whose centroid is INSIDE the host
+/// — the latter WINDING-FLIPPED so their normals face out of the removed cavity
+/// (the reveal/jamb caps), matching `A−B = (A outside B) ∪ flip(B inside A)`.
+pub(super) fn subtract(host: &[Tri], comps: &[Vec<Tri>]) -> Option<Vec<Tri>> {
+    if host.is_empty() {
+        return Some(Vec::new());
+    }
+    // Reject non-finite / malformed operands up front (defensive: `mesh_to_tris`
+    // already drops non-finite, but a caller could pass raw tris).
+    if !all_finite(host) || !comps.iter().all(|c| all_finite(c)) {
+        return None;
+    }
+    // Shared-position snap of BOTH operands onto the kernel grid (design step 1),
+    // so coincident vertices across operands are bit-identical.
+    let host: Vec<Tri> = snap_tris(host);
+    // Flatten the disjoint cutter components into one union soup for the
+    // host-vs-cutters ray parity. Disjoint closed solids ⇒ parity-of-total-
+    // crossings == inside-exactly-one, so a single union mesh + BVH is correct.
+    let cutters: Vec<Tri> = comps.iter().flat_map(|c| c.iter().map(|t| [snap_pt(t[0]), snap_pt(t[1]), snap_pt(t[2])])).collect();
+    if cutters.is_empty() {
+        return Some(host);
+    }
+
+    let host_bvh = Bvh::build(&host);
+    let cut_bvh = Bvh::build(&cutters);
+    let host_ext = coord_extent(&host).max(coord_extent(&cutters));
+
+    // 1+2. Per-face intersection constraint segments (host and cutter sides).
+    let mut host_segs: Vec<Vec<intersect::Seg>> = vec![Vec::new(); host.len()];
+    let mut cut_segs: Vec<Vec<intersect::Seg>> = vec![Vec::new(); cutters.len()];
+    for (i, j) in candidate_pairs(&host, &cutters) {
+        if let Some((a, b)) = intersect::tri_tri_segment(&host[i], &cutters[j], host_ext) {
+            // Snap the endpoints onto the shared grid so a corner two different
+            // triangle pairs compute independently is bit-identical, and feed the
+            // SAME f64 endpoints to BOTH faces ⇒ watertight seam (the shared-
+            // interner role, done here by shared snapped f64 coordinates).
+            let seg = (snap_pt(a), snap_pt(b));
+            host_segs[i].push(seg);
+            cut_segs[j].push(seg);
+        }
+    }
+
+    // Global de-duplicated intersection-endpoint sets, one per operand, for the
+    // cross-face T-junction resolution: a point that is a seam vertex on ONE
+    // face must also split any OTHER face's edge it lies on, or the shared edge
+    // tears. `retriangulate` injects the on-edge subset per face.
+    let host_pts = dedup_pts(&host_segs);
+    let cut_pts = dedup_pts(&cut_segs);
+
+    let ray_far = 4.0 * host_ext + 1.0;
+    let mut out: Vec<Tri> = Vec::new();
+    let mut scratch: Vec<u32> = Vec::new();
+
+    // 3a. Host faces: re-triangulate, keep sub-triangles OUTSIDE the cutters.
+    for (i, ht) in host.iter().enumerate() {
+        let pieces = retri::retriangulate(ht, &host_segs[i], &host_pts)?;
+        for tri in pieces {
+            let c = centroid_nb(&tri);
+            if !classify::inside_vote(c, &cutters, &cut_bvh, ray_far, &mut scratch) {
+                out.push(tri);
+            }
+        }
+    }
+    // 3b. Cutter faces: re-triangulate, keep sub-triangles INSIDE the host,
+    // winding-flipped to face out of the removed cavity (reveal caps).
+    for (j, ct) in cutters.iter().enumerate() {
+        let pieces = retri::retriangulate(ct, &cut_segs[j], &cut_pts)?;
+        for tri in pieces {
+            let c = centroid_nb(&tri);
+            if classify::inside_vote(c, &host, &host_bvh, ray_far, &mut scratch) {
+                out.push([tri[0], tri[2], tri[1]]);
+            }
+        }
+    }
+    if out.is_empty() {
+        return None;
+    }
+    Some(out)
+}
+
+fn all_finite(tris: &[Tri]) -> bool {
+    tris.iter().all(|t| t.iter().all(|v| v.iter().all(|c| c.is_finite())))
+}
+
+/// Flatten a per-face segment list into a de-duplicated point set (exact f64
+/// bits), the global endpoint pool for cross-face T-junction resolution.
+/// Deterministic order (first-seen) via an insertion-ordered dedup.
+fn dedup_pts(per_face: &[Vec<intersect::Seg>]) -> Vec<[f64; 3]> {
+    use rustc_hash::FxHashSet;
+    let mut seen: FxHashSet<(u64, u64, u64)> = FxHashSet::default();
+    let mut out: Vec<[f64; 3]> = Vec::new();
+    for segs in per_face {
+        for &(a, b) in segs {
+            for p in [a, b] {
+                let k = (p[0].to_bits(), p[1].to_bits(), p[2].to_bits());
+                if seen.insert(k) {
+                    out.push(p);
+                }
+            }
+        }
+    }
+    out
+}
+
+/// Run the fuzzy f64 subtract and its STRICT self-check, returning the finished
+/// `Mesh` ONLY when the fuzzy result is (a) watertight AND (b) removes exactly
+/// the disjoint oracle volume Σ|host∩cutterᵢ| within a tight relative tolerance;
+/// `None` otherwise so `subtract_many` uses the exact kernel. This is what makes
+/// the tier safe: a torn or over/under-cutting fuzzy result is caught here and
+/// never returned.
+pub(super) fn subtract_checked(host: &[Tri], comps: &[Vec<Tri>]) -> Option<crate::mesh::Mesh> {
+    let f = subtract(host, comps)?;
+    if !is_watertight(&f) {
+        trace_fallback("not-watertight");
+        return None;
+    }
+    let inter_sum = match oracle_removed_volume(host, comps) {
+        Some(s) => s,
+        None => {
+            trace_fallback("oracle-tripped");
+            return None;
+        }
+    };
+    let removed = super::signed_volume::signed_volume6(host).abs()
+        - super::signed_volume::signed_volume6(&f).abs();
+    let tol = inter_sum.abs().max(1.0e-9) * 0.01;
+    if (removed - inter_sum).abs() <= tol {
+        trace_claim();
+        Some(super::mesh_bridge::tris_to_mesh(&f))
+    } else {
+        trace_fallback("volume-mismatch");
+        None
+    }
+}
+
+/// The disjoint-cutter volume oracle Σ|host ∩ cutterᵢ| (#1788): batched cutters
+/// are pairwise disjoint (the `subtract_many` contract), so the TRUE removed
+/// volume is the sum of each cutter's exact intersection with the PRISTINE host
+/// — each a small single boolean in the well-conditioned regime. `None` when an
+/// oracle intersection trips the escalation budget (its volume is then
+/// untrustworthy). Budget snapshot/restore keeps the oracle work OFF the
+/// caller's batch budget (codex P2 on #1660). Shared by the fuzzy self-check
+/// here AND `mesh_bridge`'s exact lenient-batch acceptance check, so both weigh
+/// removed volume against the SAME trusted reference.
+pub(super) fn oracle_removed_volume(host: &[Tri], comps: &[Vec<Tri>]) -> Option<f64> {
+    use super::arrangement::{boolean, BoolOp};
+    let budget_snap = super::budget::snapshot_counters();
+    let mut inter_sum = 0.0f64;
+    let mut tripped = false;
+    for c in comps {
+        super::budget::begin();
+        let i = boolean(host, c, BoolOp::Intersection);
+        if super::budget::tripped() {
+            tripped = true;
+            break;
+        }
+        inter_sum += super::signed_volume::signed_volume6(&i).abs();
+    }
+    super::budget::restore_counters(budget_snap);
+    if tripped {
+        None
+    } else {
+        Some(inter_sum)
+    }
+}
+
+/// Is the f64 triangle list a CLOSED oriented surface — every directed edge
+/// matched by its exact reverse? Keyed on the raw f64 bits (no rounding): two
+/// seam vertices that differ by even one ULP read as a crack, which is exactly
+/// the watertightness bar the self-check needs. Empty ⇒ not watertight.
+pub(super) fn is_watertight(tris: &[Tri]) -> bool {
+    use rustc_hash::FxHashMap;
+    if tris.is_empty() {
+        return false;
+    }
+    let key = |p: [f64; 3]| (p[0].to_bits(), p[1].to_bits(), p[2].to_bits());
+    let mut edges: FxHashMap<((u64, u64, u64), (u64, u64, u64)), i32> = FxHashMap::default();
+    for t in tris {
+        for (a, b) in [(t[0], t[1]), (t[1], t[2]), (t[2], t[0])] {
+            *edges.entry((key(a), key(b))).or_insert(0) += 1;
+            *edges.entry((key(b), key(a))).or_insert(0) -= 1;
+        }
+    }
+    edges.values().all(|&c| c == 0)
+}

--- a/rust/geometry/src/kernel/fuzzy/retri.rs
+++ b/rust/geometry/src/kernel/fuzzy/retri.rs
@@ -1,0 +1,268 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Re-triangulate one face constrained by its intersection segments, via the
+//! in-tree deterministic CDT ([`crate::cdt::triangulate_pslg`]).
+//!
+//! The CDT is fed the face's three corners plus every intersection segment
+//! endpoint (deduplicated by exact f64 bits so a segment endpoint shared with a
+//! neighbouring face — or another segment — is ONE vertex), and constrained by
+//! the three triangle edges plus each intersection segment. `triangulate_pslg`
+//! inserts NO Steiner points, so its output vertices are exactly the input
+//! points in input order: each output triangle index maps DIRECTLY back to the
+//! original f64 3-D coordinate, with no plane-lift rounding — so the seam
+//! vertices shared with the cutter faces stay bit-identical (watertight).
+//!
+//! COLLINEAR CLEANUP: a box side face splits into two triangles, so one hole
+//! edge on the host plane arrives as two overlapping/abutting collinear
+//! segments. `triangulate_pslg`'s constrained CDT rejects overlapping
+//! constraints, so per supporting line we merge the segments into a clean chain
+//! (split at every internal endpoint, covered spans only) before triangulating.
+//!
+//! Winding: `triangulate_pslg` emits CCW in the projected plane; each lifted
+//! sub-triangle is oriented to AGREE with the parent face normal (an exact index
+//! swap), so the fuzzy output inherits the operand's outward winding.
+
+use super::super::arrangement::Tri;
+use super::intersect::Seg;
+use super::{dot, sub, tri_normal};
+use crate::cdt::triangulate_pslg;
+use crate::Point2;
+use rustc_hash::FxHashMap;
+
+/// Re-triangulate `face` under its intersection-segment constraints. Returns the
+/// resulting sub-triangles (the face itself, verbatim, when there are no
+/// constraints — the common fast case), or `None` when the constrained CDT
+/// cannot be built (crossing/degenerate constraints) so the caller falls to the
+/// exact kernel.
+pub(super) fn retriangulate(face: &Tri, segs: &[Seg], edge_pts: &[[f64; 3]]) -> Option<Vec<Tri>> {
+    if segs.is_empty() && edge_pts.is_empty() {
+        return Some(vec![*face]);
+    }
+    let n = tri_normal(face);
+    let axis = drop_axis(n);
+    let face_ext = face.iter().flat_map(|v| v.iter()).fold(1.0f64, |m, &x| m.max(x.abs()));
+    let band = super::super::mesh_bridge::near_band_from_extent(face_ext);
+
+    // Deduplicated point set: 3 corners first (indices 0,1,2), then segment
+    // endpoints. A `to_bits` key makes a shared endpoint exactly one vertex.
+    let mut pts3d: Vec<[f64; 3]> = Vec::with_capacity(3 + segs.len() * 2);
+    let mut index: FxHashMap<(u64, u64, u64), usize> = FxHashMap::default();
+    let mut intern = |p: [f64; 3], pts3d: &mut Vec<[f64; 3]>| -> usize {
+        let k = (p[0].to_bits(), p[1].to_bits(), p[2].to_bits());
+        if let Some(&i) = index.get(&k) {
+            return i;
+        }
+        let i = pts3d.len();
+        pts3d.push(p);
+        index.insert(k, i);
+        i
+    };
+    let c0 = intern(face[0], &mut pts3d);
+    let c1 = intern(face[1], &mut pts3d);
+    let c2 = intern(face[2], &mut pts3d);
+
+    // Raw constraint index pairs: the three triangle edges + each intersection
+    // segment. Collinear cleanup below turns overlapping ones into a clean chain.
+    let mut raw: Vec<(usize, usize)> = vec![(c0, c1), (c1, c2), (c2, c0)];
+    for &(a, b) in segs {
+        let ia = intern(a, &mut pts3d);
+        let ib = intern(b, &mut pts3d);
+        if ia != ib {
+            raw.push((ia, ib));
+        }
+    }
+
+    // CROSS-FACE T-JUNCTION RESOLUTION: intern any GLOBAL intersection endpoint
+    // that lies ON one of this face's three edges (within the snap band) but is
+    // not already a vertex. Without this, an opening corner that touches a host-
+    // face internal diagonal on ONLY one of the two adjacent triangles splits
+    // that diagonal on one side and not the other → an open seam. Injecting the
+    // shared (bit-identical) point makes BOTH faces split the shared edge at it.
+    let edges3 = [(face[0], face[1]), (face[1], face[2]), (face[2], face[0])];
+    for &p in edge_pts {
+        if on_any_edge(p, &edges3, band) {
+            intern(p, &mut pts3d);
+        }
+    }
+
+    // Project to 2-D by dropping the dominant-normal axis (non-degenerate since
+    // `n` is the face normal and we drop its largest component).
+    let pts2d: Vec<Point2<f64>> = pts3d.iter().map(|p| project(*p, axis)).collect();
+    let ext = pts2d.iter().fold(1.0f64, |m, p| m.max(p.x.abs()).max(p.y.abs()));
+    let segments = clean_collinear(&pts2d, &raw, ext);
+    if segments.is_empty() {
+        return None;
+    }
+
+    let (out_pts, idx) = triangulate_pslg(&pts2d, &segments)?;
+    // No Steiner insertion ⇒ output points are the input points in input order.
+    // If that invariant is ever violated, indices could reference a point we
+    // have no 3-D coordinate for: reject rather than fabricate one.
+    if out_pts.len() != pts2d.len() {
+        return None;
+    }
+
+    let mut tris: Vec<Tri> = Vec::with_capacity(idx.len() / 3);
+    for w in idx.chunks_exact(3) {
+        let (a, b, c) = (w[0], w[1], w[2]);
+        if a >= pts3d.len() || b >= pts3d.len() || c >= pts3d.len() {
+            return None;
+        }
+        let mut t: Tri = [pts3d[a], pts3d[b], pts3d[c]];
+        // Orient to agree with the parent face normal (drop zero-area slivers).
+        let tn = tri_normal(&t);
+        let d = dot(tn, n);
+        if d == 0.0 {
+            continue; // collinear sub-triangle: no area, no contribution
+        }
+        if d < 0.0 {
+            t.swap(1, 2);
+        }
+        tris.push(t);
+    }
+    if tris.is_empty() {
+        return None;
+    }
+    Some(tris)
+}
+
+/// Merge constraint segments that share a supporting line into a clean,
+/// non-overlapping chain: group by (canonical direction, signed offset), then on
+/// each line keep only COVERED spans between consecutive distinct endpoints. The
+/// result has no overlapping constraints (which the constrained CDT rejects) yet
+/// preserves every vertex, so the seam stays conforming.
+fn clean_collinear(pts: &[Point2<f64>], segs: &[(usize, usize)], ext: f64) -> Vec<(usize, usize)> {
+    // Snap-scale tolerance: the shared-position snap scatters a point up to
+    // ~SNAP_GRID off the line it geometrically lies on, so the collinearity /
+    // on-line / overlap tests must admit that band (the kernel's near-coplanar
+    // band, widened far from origin) — a 1e-9 tolerance would miss every snapped
+    // T-junction vertex (e.g. a hole corner on the triangle diagonal).
+    let eps = super::super::mesh_bridge::near_band_from_extent(ext);
+    let q = |x: f64| (x / eps).round() as i64;
+    // group key → member segment indices
+    let mut groups: FxHashMap<(i64, i64, i64), Vec<usize>> = FxHashMap::default();
+    for (si, &(a, b)) in segs.iter().enumerate() {
+        let (pa, pb) = (pts[a], pts[b]);
+        let mut dx = pb.x - pa.x;
+        let mut dy = pb.y - pa.y;
+        let len = (dx * dx + dy * dy).sqrt();
+        if len <= eps {
+            continue;
+        }
+        dx /= len;
+        dy /= len;
+        // canonical direction sign (so a↔b order doesn't split a line)
+        if dx < 0.0 || (dx.abs() <= eps && dy < 0.0) {
+            dx = -dx;
+            dy = -dy;
+        }
+        // signed perpendicular offset of the line from the origin
+        let off = dx * pa.y - dy * pa.x;
+        groups.entry((q(dx), q(dy), q(off))).or_default().push(si);
+    }
+
+    let mut out: Vec<(usize, usize)> = Vec::new();
+    for members in groups.values() {
+        // direction of this line (from its first member, canonicalised)
+        let &(fa, fb) = &segs[members[0]];
+        let (pa, pb) = (pts[fa], pts[fb]);
+        let (mut dx, mut dy) = (pb.x - pa.x, pb.y - pa.y);
+        let len = (dx * dx + dy * dy).sqrt();
+        dx /= len;
+        dy /= len;
+        if dx < 0.0 || (dx.abs() <= eps && dy < 0.0) {
+            dx = -dx;
+            dy = -dy;
+        }
+        let param = |i: usize| dx * pts[i].x + dy * pts[i].y;
+        let off = dx * pa.y - dy * pa.x;
+        // covered spans: [min,max] param of each member segment
+        let spans: Vec<(f64, f64)> = members
+            .iter()
+            .map(|&si| {
+                let (u, v) = (param(segs[si].0), param(segs[si].1));
+                if u <= v {
+                    (u, v)
+                } else {
+                    (v, u)
+                }
+            })
+            .collect();
+        let (span_lo, span_hi) = spans.iter().fold((f64::MAX, f64::MIN), |(lo, hi), &(a, b)| {
+            (lo.min(a), hi.max(b))
+        });
+        // Every VERTEX lying on this line within the covered span is a split
+        // point — not only the member segments' own endpoints. A constraint that
+        // passes through a third vertex (e.g. the triangle diagonal crossing a
+        // hole corner) is illegal in the constrained CDT, so it must be split
+        // there for the seam to stay conforming (T-junction resolution).
+        let mut ends: Vec<usize> = Vec::new();
+        for i in 0..pts.len() {
+            let on_line = (dx * pts[i].y - dy * pts[i].x - off).abs() <= eps;
+            if !on_line {
+                continue;
+            }
+            let p = param(i);
+            if p >= span_lo - eps && p <= span_hi + eps && !ends.contains(&i) {
+                ends.push(i);
+            }
+        }
+        ends.sort_by(|&x, &y| param(x).partial_cmp(&param(y)).unwrap_or(std::cmp::Ordering::Equal));
+        // emit consecutive covered pairs
+        for w in ends.windows(2) {
+            let (i, j) = (w[0], w[1]);
+            if i == j {
+                continue;
+            }
+            let mid = 0.5 * (param(i) + param(j));
+            if spans.iter().any(|&(lo, hi)| mid >= lo - eps && mid <= hi + eps) {
+                out.push((i, j));
+            }
+        }
+    }
+    out
+}
+
+/// Does `p` lie strictly interior to any of the three edges, within `band`
+/// perpendicular distance? (Endpoints are excluded — they are already vertices.)
+fn on_any_edge(p: [f64; 3], edges: &[([f64; 3], [f64; 3]); 3], band: f64) -> bool {
+    let band2 = band * band;
+    edges.iter().any(|&(a, b)| {
+        let ab = sub(b, a);
+        let len2 = dot(ab, ab);
+        if len2 <= 0.0 {
+            return false;
+        }
+        let t = dot(sub(p, a), ab) / len2;
+        if t <= 1.0e-6 || t >= 1.0 - 1.0e-6 {
+            return false; // at/near an endpoint, or off the segment span
+        }
+        let proj = [a[0] + t * ab[0], a[1] + t * ab[1], a[2] + t * ab[2]];
+        let d = sub(p, proj);
+        dot(d, d) <= band2
+    })
+}
+
+/// Which axis carries the largest |normal| component (the one to drop for a
+/// non-degenerate 2-D projection).
+fn drop_axis(n: [f64; 3]) -> u8 {
+    let a = [n[0].abs(), n[1].abs(), n[2].abs()];
+    if a[0] >= a[1] && a[0] >= a[2] {
+        0
+    } else if a[1] >= a[2] {
+        1
+    } else {
+        2
+    }
+}
+
+#[inline]
+fn project(p: [f64; 3], axis: u8) -> Point2<f64> {
+    match axis {
+        0 => Point2::new(p[1], p[2]),
+        1 => Point2::new(p[0], p[2]),
+        _ => Point2::new(p[0], p[1]),
+    }
+}

--- a/rust/geometry/src/kernel/fuzzy/tests.rs
+++ b/rust/geometry/src/kernel/fuzzy/tests.rs
@@ -8,7 +8,9 @@
 
 use super::super::arrangement::{box_mesh, cube_mesh};
 use super::super::arrangement::Tri;
-use super::{is_watertight, subtract};
+use super::{
+    cheap_oracle_removed_volume, is_watertight, oracle_removed_volume, subtract, subtract_checked,
+};
 
 fn vol6(tris: &[Tri]) -> f64 {
     // ×6 signed volume about origin — inputs here are near-origin boxes.
@@ -131,6 +133,103 @@ fn fuzzy_flush_bottom_notch_fails_self_check() {
     assert!(
         rejected,
         "flush-bottom fuzzy result must fail the watertight self-check so the exact kernel takes over"
+    );
+}
+
+/// ×6 volume of an ifc-lite `Mesh` (for the `subtract_checked` binary-path test).
+fn mesh_vol6(m: &crate::mesh::Mesh) -> f64 {
+    let vertex = |i: u32| {
+        let b = (i as usize) * 3;
+        [m.positions[b] as f64, m.positions[b + 1] as f64, m.positions[b + 2] as f64]
+    };
+    m.indices
+        .chunks_exact(3)
+        .map(|c| {
+            let (a, bb, cc) = (vertex(c[0]), vertex(c[1]), vertex(c[2]));
+            let cr = [
+                bb[1] * cc[2] - bb[2] * cc[1],
+                bb[2] * cc[0] - bb[0] * cc[2],
+                bb[0] * cc[1] - bb[1] * cc[0],
+            ];
+            a[0] * cr[0] + a[1] * cr[1] + a[2] * cr[2]
+        })
+        .sum()
+}
+
+/// Fix A — the cheap oracle DEFERS (returns `None`) when a cutter protrudes
+/// outside the host: a through-opening box crossing both faces of a slab
+/// straddles `∂A`, so `vol(A∩B)≠vol(B)` and the cheap identity is refused. The
+/// caller then falls to the exact oracle rather than trusting a wrong reference.
+#[test]
+fn cheap_oracle_defers_on_protruding_cutter() {
+    let host = box_mesh([0., 0., 0.], [4., 4., 1.]); // slab, thickness 1
+    let through = box_mesh([1., 1., -0.5], [2., 2., 1.5]); // pokes out top AND bottom
+    assert!(
+        cheap_oracle_removed_volume(&host, &[through]).is_none(),
+        "a cutter protruding through the host must DEFER the cheap oracle (return None)"
+    );
+}
+
+/// Fix A — a cutter FULLY INSIDE the host: the cheap oracle's `Σ|vol6(cutter)|`
+/// equals the exact per-cutter intersection oracle (both = the cutter volume,
+/// since `B⊂A ⇒ A∩B=B`). This is the containment case the cheap path claims.
+#[test]
+fn cheap_oracle_matches_exact_for_contained_cutter() {
+    let host = cube_mesh(0.0, 10.0); // vol 1000
+    let inner = box_mesh([3., 3., 3.], [5., 6., 7.]); // 2×3×4 = 24, strictly inside
+    let comps = std::slice::from_ref(&inner);
+    let cheap = cheap_oracle_removed_volume(&host, comps)
+        .expect("contained cutter must give a cheap oracle value");
+    let exact = oracle_removed_volume(&host, comps)
+        .expect("exact oracle must resolve a contained intersection");
+    // both are ×6 volume; the contained cutter's ×6 volume is 24×6 = 144
+    assert!((cheap - 144.0).abs() < 1e-6, "cheap oracle ×6 vol = {cheap}, expected 144");
+    assert!(
+        (cheap - exact).abs() <= exact.abs().max(1.0) * 1e-9,
+        "cheap oracle {cheap} != exact oracle {exact} for a fully-contained cutter"
+    );
+}
+
+/// A disjoint (non-overlapping) cutter contributes 0 to the cheap oracle — it is
+/// fully OUTSIDE the host, removes nothing, and does not straddle (no crossing),
+/// so the oracle resolves to 0 rather than deferring.
+#[test]
+fn cheap_oracle_zero_for_disjoint_cutter() {
+    let host = cube_mesh(0.0, 1.0);
+    let far = cube_mesh(5.0, 6.0);
+    let v = cheap_oracle_removed_volume(&host, &[far]).expect("disjoint cutter must not defer");
+    assert!(v.abs() < 1e-12, "a fully-outside cutter must contribute 0, got {v}");
+}
+
+/// Fix B — the binary single-cutter fuzzy path is watertight AND volume-checked
+/// end to end: `subtract_checked` on ONE fully-contained cutter returns a
+/// watertight `Mesh` whose removed volume matches the cutter (the cheap oracle
+/// validates it). This is the self-check the binary hook in
+/// `mesh_bridge::subtract` relies on.
+#[test]
+fn binary_fuzzy_path_is_watertight_and_volume_checked() {
+    let host = cube_mesh(0.0, 10.0); // vol 1000
+    let inner = box_mesh([3., 3., 3.], [5., 6., 7.]); // vol 24, strictly inside
+    let m = subtract_checked(&host, &[inner]).expect("contained binary cut must self-check");
+    // watertight (host shell + internal cavity, both closed) — reconstruct the
+    // f64 tris from the result mesh and reuse the exact-bit edge-pairing check.
+    let tris: Vec<Tri> = m
+        .indices
+        .chunks_exact(3)
+        .map(|c| {
+            let v = |i: u32| {
+                let b = (i as usize) * 3;
+                [m.positions[b] as f64, m.positions[b + 1] as f64, m.positions[b + 2] as f64]
+            };
+            [v(c[0]), v(c[1]), v(c[2])]
+        })
+        .collect();
+    assert!(is_watertight(&tris), "binary fuzzy cut is not watertight");
+    // removed volume == contained cutter volume: |vol6(host)| − |vol6(result)| = 24×6
+    let removed6 = 6.0 * 1000.0 - mesh_vol6(&m).abs();
+    assert!(
+        (removed6 - 144.0).abs() < 1e-3,
+        "binary fuzzy removed ×6 vol = {removed6}, expected 144 (cutter 24)"
     );
 }
 

--- a/rust/geometry/src/kernel/fuzzy/tests.rs
+++ b/rust/geometry/src/kernel/fuzzy/tests.rs
@@ -1,0 +1,149 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Unit tests for the fuzzy f64 subtract tier. These exercise the fuzzy path
+//! DIRECTLY (not through the env gate), so they run regardless of
+//! `IFC_LITE_FUZZY_BOOL`.
+
+use super::super::arrangement::{box_mesh, cube_mesh};
+use super::super::arrangement::Tri;
+use super::{is_watertight, subtract};
+
+fn vol6(tris: &[Tri]) -> f64 {
+    // ×6 signed volume about origin — inputs here are near-origin boxes.
+    tris.iter()
+        .map(|t| {
+            let cr = [
+                t[1][1] * t[2][2] - t[1][2] * t[2][1],
+                t[1][2] * t[2][0] - t[1][0] * t[2][2],
+                t[1][0] * t[2][1] - t[1][1] * t[2][0],
+            ];
+            t[0][0] * cr[0] + t[0][1] * cr[1] + t[0][2] * cr[2]
+        })
+        .sum()
+}
+
+fn vol(tris: &[Tri]) -> f64 {
+    vol6(tris) / 6.0
+}
+
+/// A single box subtracted from a slab: the fuzzy result must be watertight and
+/// match the exact box−box volume, with the opening actually removed.
+#[test]
+fn fuzzy_box_from_slab_is_watertight_and_exact_volume() {
+    // slab [0,4]×[0,3]×[0,0.2] (vol 2.4) minus a through-opening box
+    // [1,2]×[1,2]×[-0.5,0.7] (removed 0.2) ⇒ 2.2.
+    let host = box_mesh([0., 0., 0.], [4., 3., 0.2]);
+    let opening = box_mesh([1., 1., -0.5], [2., 2., 0.7]);
+    let result = subtract(&host, &[opening]).expect("fuzzy subtract produced no mesh");
+    assert!(is_watertight(&result), "fuzzy result is not watertight");
+    let v = vol(&result);
+    assert!((v - 2.2).abs() < 2e-3, "fuzzy volume = {v}, expected ~2.2 (snap-scale tol)");
+}
+
+/// Two pairwise-disjoint through-openings: fuzzy result watertight + analytic
+/// volume, the same 3-D contract the exact `subtract_many` verifies.
+#[test]
+fn fuzzy_two_disjoint_openings_match_analytic() {
+    let host = box_mesh([0., 0., 0.], [6., 3., 0.2]); // vol 3.6
+    let op1 = box_mesh([1., 1., -0.5], [2., 2., 0.7]); // 0.2
+    let op2 = box_mesh([4., 1., -0.5], [5., 2., 0.7]); // 0.2
+    let result = subtract(&host, &[op1, op2]).expect("fuzzy subtract produced no mesh");
+    assert!(is_watertight(&result), "fuzzy result is not watertight");
+    let v = vol(&result);
+    assert!((v - 3.2).abs() < 2e-3, "fuzzy volume = {v}, expected ~3.2 (snap-scale tol)");
+}
+
+/// Corner-overlap cube−cube (the classic 7-of-8 case): watertight + volume 7.
+#[test]
+fn fuzzy_corner_overlap_cube_is_exact() {
+    let host = cube_mesh(0.0, 2.0); // vol 8
+    let cutter = cube_mesh(1.0, 3.0); // overlap [1,2]³ = 1
+    let result = subtract(&host, &[cutter]).expect("fuzzy subtract produced no mesh");
+    assert!(is_watertight(&result), "fuzzy corner-overlap result not watertight");
+    let v = vol(&result);
+    assert!((v - 7.0).abs() < 1e-6, "fuzzy volume = {v}, expected 7");
+}
+
+/// Determinism: the same input yields byte-identical output triangles (the
+/// fuzzy path must be reproducible, the manifest precondition).
+#[test]
+fn fuzzy_subtract_is_deterministic() {
+    let host = box_mesh([0., 0., 0.], [6., 3., 0.2]);
+    let op1 = box_mesh([1., 1., -0.5], [2., 2., 0.7]);
+    let op2 = box_mesh([4., 1., -0.5], [5., 2., 0.7]);
+    let a = subtract(&host, &[op1.clone(), op2.clone()]).unwrap();
+    let b = subtract(&host, &[op1, op2]).unwrap();
+    assert_eq!(a.len(), b.len(), "fuzzy output triangle count varied");
+    for (ta, tb) in a.iter().zip(b.iter()) {
+        for k in 0..3 {
+            for c in 0..3 {
+                assert_eq!(
+                    ta[k][c].to_bits(),
+                    tb[k][c].to_bits(),
+                    "fuzzy output not bit-identical across runs"
+                );
+            }
+        }
+    }
+}
+
+/// A disjoint (non-overlapping) cutter removes nothing: every host face is kept,
+/// no cutter face is inside the host — the result equals the host (watertight,
+/// same volume). Guards the classification "outside stays" branch.
+#[test]
+fn fuzzy_disjoint_cutter_keeps_host() {
+    let host = cube_mesh(0.0, 1.0); // vol 1
+    let far = cube_mesh(5.0, 6.0); // no overlap
+    // No candidate pairs ⇒ every face passes through; result is the host itself.
+    let result = subtract(&host, &[far]).expect("fuzzy subtract produced no mesh");
+    assert!(is_watertight(&result), "disjoint result not watertight");
+    let v = vol(&result);
+    assert!((v - 1.0).abs() < 1e-9, "disjoint fuzzy volume = {v}, expected 1");
+}
+
+/// `is_watertight` rejects an open surface (a single triangle) — the guard the
+/// self-check relies on to force exact fallback on a torn fuzzy result.
+#[test]
+fn watertight_rejects_open_surface() {
+    let open: Vec<Tri> = vec![[[0., 0., 0.], [1., 0., 0.], [0., 1., 0.]]];
+    assert!(!is_watertight(&open), "a lone triangle must read as not watertight");
+    assert!(!is_watertight(&[]), "empty must read as not watertight");
+    // A closed box reads watertight.
+    assert!(is_watertight(&cube_mesh(0.0, 1.0)), "a closed box must read watertight");
+}
+
+/// A FLUSH-BOTTOM notch (cutter bottom coplanar with the host bottom, top and
+/// sides transversal) is a partial coplanar interface the transversal fuzzy
+/// intersection does not resolve, so it produces a NON-watertight result — which
+/// the self-check catches, forcing `subtract_many` to discard it and run the
+/// exact kernel. This pins the fallback trigger: a torn fuzzy result is never
+/// accepted (correctness cannot regress). The exact kernel handles this case.
+#[test]
+fn fuzzy_flush_bottom_notch_fails_self_check() {
+    let host = box_mesh([0., 0., 0.], [4., 4., 2.]);
+    let cutter = box_mesh([1., 1., 0.], [3., 3., 1.]); // bottom z=0 flush with host
+    let rejected = match subtract(&host, &[cutter]) {
+        None => true,                  // structurally gave up ⇒ fall back
+        Some(m) => !is_watertight(&m), // torn ⇒ self-check rejects ⇒ fall back
+    };
+    assert!(
+        rejected,
+        "flush-bottom fuzzy result must fail the watertight self-check so the exact kernel takes over"
+    );
+}
+
+/// Default-OFF guard: with no `IFC_LITE_FUZZY_BOOL` in the environment the tier
+/// is disabled, so a default build routes every subtract through the exact
+/// kernel and is byte-identical to `main` (and the `mesh_determinism` manifest
+/// is unperturbed). The A/B and any future default flip are explicit opt-ins.
+#[test]
+fn fuzzy_tier_is_off_by_default() {
+    // Only meaningful when the env does NOT force the tier on (the CI `=0` leg
+    // and a bare run); a deliberate `IFC_LITE_FUZZY_BOOL=1` A/B leg is exempt so
+    // this test never contradicts the "with it ON, green" requirement.
+    if std::env::var_os("IFC_LITE_FUZZY_BOOL").is_none() {
+        assert!(!super::enabled(), "fuzzy tier must be OFF unless IFC_LITE_FUZZY_BOOL opts in");
+    }
+}

--- a/rust/geometry/src/kernel/mesh_bridge.rs
+++ b/rust/geometry/src/kernel/mesh_bridge.rs
@@ -314,6 +314,17 @@ pub fn subtract(host: &Mesh, cutter: &Mesh) -> Mesh {
     let mut c = mesh_to_tris(cutter);
     promote_cutter_verts_onto_host_faces(&mut c, &h);
     let c = orient_outward(c);
+    // FUZZY FAST TIER (env-gated OFF by default): the binary single-cutter path
+    // is where the BULK of subtract cost lives (most opening cuts route here, not
+    // through the batched `subtract_many`). Try the f64 tolerance boolean first,
+    // accepted only if it self-checks watertight AND removes the cheap oracle
+    // volume; on any failure fall straight through to the exact kernel — a bad
+    // fuzzy result can never regress correctness.
+    if super::fuzzy::enabled() {
+        if let Some(m) = super::fuzzy::subtract_checked(&h, std::slice::from_ref(&c)) {
+            return m;
+        }
+    }
     tris_to_mesh(&boolean(&h, &c, BoolOp::Difference))
 }
 

--- a/rust/geometry/src/kernel/mesh_bridge.rs
+++ b/rust/geometry/src/kernel/mesh_bridge.rs
@@ -341,6 +341,18 @@ pub fn subtract_many(host: &Mesh, cutters: &[&Mesh]) -> Option<Mesh> {
             orient_outward(c)
         })
         .collect();
+
+    // FUZZY FAST TIER (env-gated OFF by default via `IFC_LITE_FUZZY_BOOL`): try
+    // the f64 tolerance boolean first, but ACCEPT it only if it self-checks
+    // watertight AND removes exactly the disjoint oracle volume. On any failure
+    // fall straight through to the exact kernel below — a bad fuzzy result can
+    // never regress correctness, it can only be discarded here.
+    if super::fuzzy::enabled() {
+        if let Some(m) = super::fuzzy::subtract_checked(&h, &comp_tris) {
+            return Some(m);
+        }
+    }
+
     let refs: Vec<&[Tri]> = comp_tris.iter().map(|c| c.as_slice()).collect();
     // Conforming batch: the fast, exact, byte-identical common path.
     if let Some(r) = difference_all(&h, &refs) {
@@ -353,34 +365,8 @@ pub fn subtract_many(host: &Mesh, cutters: &[&Mesh]) -> Option<Mesh> {
     // Trust the lenient batch ONLY when its removed volume matches the true removed
     // volume; else None, so the caller runs its full sequential path.
     let batch = difference_all_lenient(&h, &refs);
-    // ORACLE for the volume comparison (#1788): batched cutters are pairwise
-    // disjoint (this fn's contract), so the TRUE removed volume is
-    // Σ |host ∩ cutterᵢ| — each a small single boolean against the PRISTINE
-    // host, the well-conditioned regime. The previous oracle re-ran the
-    // sequential subtract chain, but that chain re-jitters its own seams
-    // cut-over-cut and UNDER-cuts on multi-void walls — on the ISSUE_098
-    // Poroton wall its "reference" removed 2% less volume than the (correct)
-    // batch, so a perfect batch was rejected in favour of the broken
-    // sequential fallback, leaving an opening uncut (T6 fail:opening-not-cut).
-    // Budget snapshot/restore: oracle work isn't charged to the caller's
-    // batch budget (codex P2 on #1660); a trip DURING an oracle intersection
-    // makes its volume untrustworthy ⇒ reject the group (as before).
-    let budget_snap = super::budget::snapshot_counters();
-    let mut inter_sum = 0.0f64;
-    let mut oracle_tripped = false;
-    for c in &comp_tris {
-        super::budget::begin();
-        let i = boolean(&h, c, BoolOp::Intersection);
-        if super::budget::tripped() {
-            oracle_tripped = true;
-            break;
-        }
-        inter_sum += signed_volume6(&i).abs();
-    }
-    super::budget::restore_counters(budget_snap);
-    if oracle_tripped {
-        return None;
-    }
+    // `?`: an oracle intersection tripping the budget ⇒ reject the group (None).
+    let inter_sum = super::fuzzy::oracle_removed_volume(&h, &comp_tris)?;
     let host_v = signed_volume6(&h).abs();
     let batch_removed = host_v - signed_volume6(&batch).abs();
     // 1% agreement — above f64/FMA noise (parity-stable branch), tight enough to

--- a/rust/geometry/src/kernel/mod.rs
+++ b/rust/geometry/src/kernel/mod.rs
@@ -19,6 +19,7 @@ pub mod broadphase;
 pub mod budget;
 pub mod coplanar;
 pub mod fixed;
+pub mod fuzzy;
 // Public because `fixed::Lam` (a `pub type`) and the `pub` cached-lambda
 // predicates expose `FixedInt` exactly as they previously exposed the external
 // `bnum::types::I512`; a narrower visibility would trip `private_interfaces`.

--- a/rust/geometry/tests/issue_1109_budget.rs
+++ b/rust/geometry/tests/issue_1109_budget.rs
@@ -125,6 +125,19 @@ fn element_escalations(host: &Mesh, cutters: &[Mesh]) -> (u64, Mesh) {
 
 #[test]
 fn issue_1109_per_element_budget_bounds_pathological_csg() {
+    // This measures the EXACT mesh-arrangement kernel's per-element escalation
+    // budget. With the fuzzy fast-tier ON (IFC_LITE_FUZZY_BOOL) the tolerance
+    // boolean resolves these transversal planar cuts watertight+volume-checked
+    // and the exact path is never entered (0 escalations), so the >60k-premise
+    // below does not apply — skip on the fuzzy-ON leg. The default (OFF) CI leg
+    // exercises the budget; the fuzzy result stays correctness-safe via its own
+    // self-check regardless.
+    if matches!(
+        std::env::var("IFC_LITE_FUZZY_BOOL").as_deref(),
+        Ok("1") | Ok("true") | Ok("on")
+    ) {
+        return;
+    }
     // A host slab cut by several coplanar-fragment slabs at staggered internal
     // heights — the dense-coplanar-cut pattern that hung the exact kernel.
     let host = box_mesh([0.0, 0.0, 0.0], [10.0, 10.0, 10.0]);


### PR DESCRIPTION
## Design

A tolerance-based **f64 boolean SUBTRACT** (ported from web-ifc's `fuzzybools`), added as an opt-in **fast tier** in front of the exact mesh-arrangement kernel, hooked into the batched disjoint-cutter path `mesh_bridge::subtract_many`. New module `rust/geometry/src/kernel/fuzzy/`:

1. **Shared-position snap** — both operands are quantised onto the kernel's `SNAP_GRID` (a power of two → exact, deterministic), so a point two triangle pairs compute independently (an opening corner shared by two faces) lands on the same cell. This is the coincidence that lets re-triangulated seams close watertight without a shared symbolic interner.
2. **Intersect** — BVH-cull (reusing `kernel/broadphase`) host×cutter triangle pairs, compute the intersection segment in plain f64 (Möller interval form), and push the **same** snapped endpoints to both faces.
3. **Re-triangulate** only the intersected faces via the in-tree deterministic CDT (`crate::cdt::triangulate_pslg`); **untouched faces pass through verbatim** — the speedup vs re-arranging everything. Per-face **collinear-merge** (a box side-face splits into two triangles → overlapping collinear segments the CDT rejects) and **cross-face T-junction resolution** (inject global endpoints that lie on a face's edges) keep the seams conforming.
4. **Classify** each sub-triangle inside/outside by a ray-cast from a **non-barycentric centroid** `(a+1.02b+1.03c)/3.05`, voted across 3 fixed directions. SUBTRACT keeps host tris OUTSIDE the cutters + cutter tris INSIDE the host (winding-flipped) as reveal caps.

All f64, FMA-free (no `mul_add`), fixed ray directions, deterministic ordering + hashers, IEEE `sqrt` only → **native==wasm bit-identical** (the shared CDT is already manifest-pinned via the prism-cut path).

## Safety: strict self-check + exact fallback

This is **not a replacement**. Every fuzzy result is strict self-checked in `subtract_many`:
- **(a) watertight** — every directed edge matched by its exact reverse (f64-bit keyed), and
- **(b) removed-volume == the disjoint oracle Σ\|host∩cutterᵢ\|** (the exact-kernel intersection oracle already used by `subtract_many`) within a tight 1% relative tolerance.

If **both** pass → use the fuzzy result. If **either** fails → discard it and run the existing exact path unchanged. A bad fuzzy result can therefore never regress correctness — the self-check catches it and the exact kernel takes over.

## Default: OFF

Env gate `IFC_LITE_FUZZY_BOOL` (default **OFF**). A default build is byte-identical to the exact kernel, so `cargo test -p ifc-lite-processing` `mesh_determinism` manifest and every pinned boolean manifest are unperturbed. **Rationale for shipping OFF:** (1) the A/B below is performance-neutral, so there is no user-visible upside to flipping it yet; (2) turning it ON would change tessellation on the determinism battery's void hosts, forcing a manifest re-pin (a real geometry change) — not warranted for a neutral first increment.

## i129 / i098 before→after (10 threads, best-of / warm interleaved, isolated `t_geom`)

| model | OFF | ON | Δ |
|---|---|---|---|
| **ISSUE_129** | min 1.153 / median 1.215 s | min 1.139 / median 1.232 s | **neutral (±~1%, in noise)** |
| **ISSUE_098** | ~1.45 s | ~1.45–1.49 s | neutral (no regression) |
| duplex | 0.035 s | 0.035 s | unchanged (no batched voids) |

Does **not** beat or meaningfully approach web-ifc's 0.31 s on i129 — see honesty note.

## Fuzzy hit-rate (per `subtract_many` call, `IFC_LITE_FUZZY_STATS=1`)

- **ISSUE_129**: 2 claimed / 1 fell back (3 batched groups total).
- **ISSUE_098**: 4 claimed / 6 fell back (10 batched groups total; all fallbacks = `not-watertight`, caught by the self-check).

## Honest magnitude

This is a **first increment of a large lever**, and the numbers say so plainly:
- The tier only hooks the **batched** `subtract_many` path. i129 invokes that only **~3 times** — the bulk of i129's opening cost is in the **binary** `subtract_mesh` path and the #1806 analytic/2D paths, none of which this tier touches.
- On the calls it *does* claim, the **strict exact-volume oracle** (Σ\|host∩cutterᵢ\|, computed via the exact kernel on every accepted call) costs about as much as the exact difference it's trying to avoid, so the fast f64 boolean's savings are cancelled by the correctness insurance. Net: performance-neutral.

The value delivered here is the **correct, deterministic, self-checking infrastructure** (guaranteed zero-regression), not a speedup yet. Clear follow-ups: (1) hook the binary `subtract_mesh` path, (2) a **cheaper independent volume oracle** so the self-check doesn't re-pay exact-kernel cost.

## Correctness harness — zero verdict regression (fuzzy ON)

IfcOpenShell (pip 0.8.2) harness, `correctness/run.sh`, ON vs OFF:

| model | semantic (T6 opening-cut) | T1–T5 vs IOS |
|---|---|---|
| **duplex** | 86 pass / 2 skip (both) | 215/215 matched, 0 fail (both) |
| **ISSUE_129** | 361/361 pass (both) | 959/959 matched, 1 pre-existing fail (both) |
| **ISSUE_098** | 5855 pass / 1 warn (both) | — |

Every verdict identical ON vs OFF. The self-check + fallback guarantee this by construction.

## Validation

- `cargo test -p ifc-lite-geometry` green (fuzzy OFF **and** `IFC_LITE_FUZZY_BOOL=1`); `cargo test -p ifc-lite-processing` green incl. `module_size_ratchet` + `mesh_determinism`.
- `cargo clippy --workspace --exclude ifc-lite-wasm --all-targets -- -D warnings` clean.
- 8 new fuzzy unit tests: box-from-slab (watertight + volume), two disjoint openings, corner-overlap cube, determinism (byte-identical), disjoint-cutter keeps host, watertight-rejects-open-surface, flush-bottom notch **fails self-check → fallback**, default-off guard.
- Module-size ratchet respected (mesh_bridge kept under its 904 budget by homing the integration helpers in `fuzzy/`; each new file <400 lines; tests in `*_tests`-style `tests.rs`).

Refs #1788.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional fuzzy fast path for mesh subtraction (single and batched).
  * Improved performance for suitable geometry boolean operations using tolerance-based processing.
  * Added automatic validation to ensure subtraction results are watertight and preserve expected removed volumes.

* **Bug Fixes**
  * Invalid or uncertain fast-path results now safely fall back to the existing exact processing.

* **Configuration**
  * The performance optimization is disabled by default and can be enabled with `IFC_LITE_FUZZY_BOOL`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->