### PR TITLE
fix(viewer): share compiled wasm module across workers to kill cold-start wait

### DIFF
--- a/.changeset/fix-shared-wasm-module-cold-start.md
+++ b/.changeset/fix-shared-wasm-module-cold-start.md
@@ -1,0 +1,7 @@
+---
+"@ifc-lite/geometry": patch
+---
+
+fix(viewer): share compiled wasm module across workers to kill cold-start wait
+
+Compile the geometry engine's `WebAssembly.Module` ONCE on the main thread and structured-clone that single compiled module to every geometry + pre-pass worker, which then `initSync` it (cheap) instead of each independently fetching and compiling the ~3.9 MB binary. Previously all N geometry workers plus the pre-pass worker called wasm-bindgen `init()`, so 4-5 parallel cold compiles of a multi-MB module contended on the CPU on a user's first load — producing a multi-second "WASM ready" stagger before any geometry appeared, and on large files enough startup latency to trip the geometry-stream stall watchdog. The worker already accepted a shared module but the path was dead code: it called `initSync({ module_or_path })` while wasm-bindgen's glue destructures `.module`, so it would have thrown `new WebAssembly.Module(undefined)` — and the host never sent a module. Uses `compileStreaming` (compile-while-download), caches the module for the session (federation/reload reuse it), and falls back to per-worker `init()` when the URL can't be resolved or compilation fails, so non-Vite consumers are unaffected. Geometry output is unchanged.

--- a/packages/geometry/src/geometry-parallel.ts
+++ b/packages/geometry/src/geometry-parallel.ts
@@ -33,6 +33,77 @@ import type { BatchSizingConfig } from './batch-sizing.js';
 import { notifyIfWasmAssetUnavailable, notifyIfWorkerScriptUnavailable } from './wasm-asset-error.js';
 
 /**
+ * Compile the geometry engine's `WebAssembly.Module` ONCE per session and share
+ * that single compiled module to every geometry + pre-pass worker.
+ *
+ * Before this, each of the N geometry workers PLUS the pre-pass worker called
+ * wasm-bindgen `init()`, which fetches and COMPILES the ~3.9 MB binary
+ * independently. Four-to-five parallel compiles of a multi-MB module contend on
+ * the CPU, producing a multi-second "WASM ready" stagger (one worker finishes
+ * ~3 s, the rest ~8-22 s) before any geometry is meshed — and on large files
+ * the extra startup latency tips the geometry stream past the stall watchdog.
+ *
+ * A `WebAssembly.Module` is structured-cloneable and cheap to instantiate per
+ * worker (`initSync`, ~tens of ms), so compiling once on the main thread and
+ * broadcasting the module removes the N× compile entirely.
+ *
+ * Cached module-level so repeated loads in one session (federation, reload,
+ * export) reuse the already-compiled module. Resolves to `null` — the caller
+ * then leaves each worker on its own `init()` — when the URL can't be resolved
+ * or compilation fails, so non-Vite consumers and offline/edge failures degrade
+ * to the previous behaviour rather than breaking.
+ */
+let sharedWasmModulePromise: Promise<WebAssembly.Module | null> | null = null;
+
+function resolveWasmUrl(explicitUrl?: string): string | URL | null {
+  if (explicitUrl) return explicitUrl;
+  try {
+    // Source-aliased (Vite) build: the sibling `@ifc-lite/wasm` package's
+    // binary, resolved relative to THIS module. Vite statically rewrites this
+    // `new URL(..., import.meta.url)` to the emitted, content-hashed asset URL
+    // — the same asset the worker's wasm-bindgen glue resolves. In a plain
+    // tsc/npm build it resolves against dist/ and may 404, which the caller
+    // treats as "no shared module" and falls back to per-worker init.
+    return new URL('../../wasm/pkg/ifc-lite_bg.wasm', import.meta.url);
+  } catch {
+    return null;
+  }
+}
+
+async function compileSharedWasmModule(explicitUrl?: string): Promise<WebAssembly.Module | null> {
+  if (sharedWasmModulePromise) return sharedWasmModulePromise;
+  const p = (async (): Promise<WebAssembly.Module | null> => {
+    if (typeof WebAssembly === 'undefined') return null;
+    const url = resolveWasmUrl(explicitUrl);
+    if (!url) return null;
+    try {
+      if (typeof WebAssembly.compileStreaming === 'function') {
+        try {
+          // Compile WHILE the binary downloads (one streaming fetch + compile
+          // for the whole pool).
+          return await WebAssembly.compileStreaming(fetch(url));
+        } catch {
+          // Some static hosts serve `.wasm` with the wrong MIME type, which
+          // rejects compileStreaming — fall through to the buffer path.
+        }
+      }
+      const resp = await fetch(url);
+      if (!resp.ok) return null;
+      return await WebAssembly.compile(await resp.arrayBuffer());
+    } catch (err) {
+      console.warn('[stream] shared wasm compile failed; workers will self-init:', err);
+      return null;
+    }
+  })();
+  sharedWasmModulePromise = p;
+  const result = await p;
+  // Don't cache a failure — let the next load retry (a transient fetch error
+  // shouldn't permanently disable the shared-module fast path for the session).
+  if (result === null) sharedWasmModulePromise = null;
+  return result;
+}
+
+/**
  * Plan content-affinity routing for one chunk: assign each job (by index) to a
  * worker bucket so that every job sharing an affinity key lands on the SAME
  * worker — across the whole stream, since `keyToWorker` is the caller's sticky
@@ -306,6 +377,11 @@ export async function* processParallel(
 
   yield { type: 'start', totalEstimate: buffer.length / 1000 };
   yield { type: 'model-open', modelID: 0 };
+
+  // Kick off the ONE shared wasm compile immediately so it overlaps the SAB
+  // setup + worker-count planning below; awaited just before the workers init
+  // (see `compileSharedWasmModule`). Null ⇒ each worker self-inits (unchanged).
+  const wasmModulePromise = compileSharedWasmModule(options?.wasmUrls?.wasm);
 
   // SAB sharing — see Tier-1 / fix-RAM history. Three paths:
   //   1. Caller-supplied SAB.
@@ -632,24 +708,38 @@ export async function* processParallel(
   });
   const workerCount = workerCountResult.count;
 
+  // Await the ONE shared compile (started up-front) so every worker instantiates
+  // the SAME module via `initSync` instead of recompiling the binary N+1 times.
+  // `null` (URL unresolved / compile failed) keeps the legacy per-worker `init`.
+  const sharedWasmModule = await wasmModulePromise;
+  if (sharedWasmModule) {
+    console.log('[stream] shared wasm module compiled once — workers initSync (no per-worker recompile)');
+  }
+
   const workers: Worker[] = [];
   for (let i = 0; i < workerCount; i++) {
     const worker = makeGeometryWorker();
     workers.push(worker);
     installWorkerHandlers(worker, i);
-    // Kick off WASM compile concurrently with the pre-pass scan. The
-    // worker's tail-promise serialiser guarantees this `init` completes
-    // before any subsequent `stream-start`/`stream-chunk` runs.
+    // Instantiate WASM. When the host compiled the module once (above), each
+    // worker `initSync`s it (cheap); otherwise it falls back to compiling from
+    // bytes. The worker's tail-promise serialiser guarantees this `init`
+    // completes before any subsequent `stream-start`/`stream-chunk` runs.
     //
-    // `wasmUrl` is forwarded only when the consumer explicitly provided
-    // one — undefined leaves the worker on wasm-bindgen's default
-    // `import.meta.url`-based resolution, which is what Vite + webpack
-    // already handle.
+    // `wasmUrl` is forwarded only when the consumer explicitly provided one AND
+    // no shared module is available — undefined leaves the worker on
+    // wasm-bindgen's default `import.meta.url`-based resolution (Vite + webpack).
     const wasmUrlForWorker = options?.wasmUrls?.wasm;
-    worker.postMessage({
-      type: 'init',
-      ...(wasmUrlForWorker ? { wasmUrl: wasmUrlForWorker } : {}),
-    });
+    worker.postMessage(
+      {
+        type: 'init',
+        ...(sharedWasmModule
+          ? { wasmModule: sharedWasmModule }
+          : wasmUrlForWorker
+            ? { wasmUrl: wasmUrlForWorker }
+            : {}),
+      },
+    );
     // Issue #540: forward the user's "Merge Multilayer Walls" toggle
     // BEFORE any stream-start so the worker's IfcAPI has the flag set
     // before its first parse call. The tail-promise serialiser inside
@@ -1143,7 +1233,13 @@ export async function* processParallel(
   // legacy (non-threaded) wasm, so `wasmUrls.wasm` is the right key.
   // Skipped entirely when no URL was provided — keeps Vite/webpack
   // consumers on the bundler-native resolution path.
-  if (options?.wasmUrls?.wasm) {
+  // The pre-pass worker runs the same bundle + legacy wasm, so give it the ONE
+  // shared compiled module too (else it independently compiles the binary, the
+  // 4th/5th parallel compile that fed the cold-start stagger). Falls back to the
+  // explicit URL, then to wasm-bindgen's `import.meta.url` default.
+  if (sharedWasmModule) {
+    prepassWorker.postMessage({ type: 'init', wasmModule: sharedWasmModule });
+  } else if (options?.wasmUrls?.wasm) {
     prepassWorker.postMessage({ type: 'init', wasmUrl: options.wasmUrls.wasm });
   }
   let chunkArrivals = 0;

--- a/packages/geometry/src/geometry-parallel.ts
+++ b/packages/geometry/src/geometry-parallel.ts
@@ -53,7 +53,11 @@ import { notifyIfWasmAssetUnavailable, notifyIfWorkerScriptUnavailable } from '.
  * or compilation fails, so non-Vite consumers and offline/edge failures degrade
  * to the previous behaviour rather than breaking.
  */
-let sharedWasmModulePromise: Promise<WebAssembly.Module | null> | null = null;
+// Keyed by the RESOLVED wasm URL, not a single global slot: federation / version
+// skew can load a DIFFERENT binary in the same session, and returning the first
+// compiled module for a later, incompatible URL would initialize the worker's
+// wasm-bindgen glue against the wrong module. One promise per distinct binary.
+const sharedWasmModulePromises = new Map<string, Promise<WebAssembly.Module | null>>();
 
 function resolveWasmUrl(explicitUrl?: string): string | URL | null {
   if (explicitUrl) return explicitUrl;
@@ -71,11 +75,13 @@ function resolveWasmUrl(explicitUrl?: string): string | URL | null {
 }
 
 async function compileSharedWasmModule(explicitUrl?: string): Promise<WebAssembly.Module | null> {
-  if (sharedWasmModulePromise) return sharedWasmModulePromise;
+  if (typeof WebAssembly === 'undefined') return null;
+  const url = resolveWasmUrl(explicitUrl);
+  if (!url) return null;
+  const cacheKey = url instanceof URL ? url.href : url;
+  const cached = sharedWasmModulePromises.get(cacheKey);
+  if (cached) return cached;
   const p = (async (): Promise<WebAssembly.Module | null> => {
-    if (typeof WebAssembly === 'undefined') return null;
-    const url = resolveWasmUrl(explicitUrl);
-    if (!url) return null;
     try {
       if (typeof WebAssembly.compileStreaming === 'function') {
         try {
@@ -95,11 +101,12 @@ async function compileSharedWasmModule(explicitUrl?: string): Promise<WebAssembl
       return null;
     }
   })();
-  sharedWasmModulePromise = p;
+  sharedWasmModulePromises.set(cacheKey, p);
   const result = await p;
-  // Don't cache a failure — let the next load retry (a transient fetch error
-  // shouldn't permanently disable the shared-module fast path for the session).
-  if (result === null) sharedWasmModulePromise = null;
+  // Don't cache a failure — evict ONLY this URL's entry so the next load retries
+  // (a transient fetch error shouldn't permanently disable the shared-module fast
+  // path for the session), while other URLs' successful modules stay cached.
+  if (result === null) sharedWasmModulePromises.delete(cacheKey);
   return result;
 }
 

--- a/packages/geometry/src/geometry.worker.ts
+++ b/packages/geometry/src/geometry.worker.ts
@@ -1464,7 +1464,14 @@ async function handleMessage(e: MessageEvent<GeometryWorkerRequest>): Promise<vo
     if (e.data.type === 'init') {
       if (e.data.wasmUrl) cachedWasmUrl = e.data.wasmUrl;
       if (e.data.wasmModule) {
-        initSync({ module_or_path: e.data.wasmModule });
+        // Instantiate from the pre-compiled module the host compiled ONCE and
+        // structured-cloned to every worker — no per-worker recompile of the
+        // multi-MB binary. NB: wasm-bindgen's `initSync` destructures the
+        // `.module` key (see `initSync(module)` in the generated glue); the
+        // older `{ module_or_path }` shape here silently destructured to
+        // `undefined` and threw `new WebAssembly.Module(undefined)`, which is
+        // why the shared-module path was never actually taken.
+        initSync({ module: e.data.wasmModule });
         api = new IfcAPI();
         mergeLayersApplied = false;
         applyMergeLayersToApi();


### PR DESCRIPTION
## Symptom

On a user's first (cold) load, a large file showed a multi-second wait before any geometry appeared, and a very large file (62 MB) stalled hard:

- 45 MB cold: `worker[3] WASM ready @ 3142ms`, but `worker[0/1/2] @ 8044-8168ms` — a ~5 s stagger; first visible geometry @ 11336 ms.
- 62 MB cold: `worker[3] @ 9233ms`, `worker[0/1/2] @ 21923-22492ms`, then `Geometry stream stalled after 33733ms. Last rendered meshes: 0` — hard failure.
- Cached files load fast (~556 ms) — the cost is COLD wasm instantiation, per file/session.

## Root cause

Each of the N geometry workers **plus** the pre-pass worker called wasm-bindgen `init()`, which fetches and **compiles the ~3.9 MB binary independently**. Four-to-five parallel cold compiles of a multi-MB module contend on the CPU, producing the multi-second "WASM ready" stagger — and on large files the extra startup latency trips the geometry-stream stall watchdog (fires at 0 meshes).

The worker already had a shared-module code path, but it was **dead and broken**:
- It called `initSync({ module_or_path })`, while wasm-bindgen's generated glue destructures the `.module` key — so it would have thrown `new WebAssembly.Module(undefined)`.
- And the host (`geometry-parallel.ts`) **never sent a compiled module** — it only ever sent `{ type: 'init', wasmUrl? }`, leaving every worker to self-compile.

Contributing factor: the 4.1.2 perf work (#1806 `prism_cut.rs` +3106 lines, #1815 `coaxial_union.rs` +704 lines) grew the binary **+207.7 KB (+5.7%)**, 3,717,277 → 3,930,035 bytes, worsening each per-worker compile.

## Fix

Compile the module **once** on the main thread (`WebAssembly.compileStreaming`, compile-while-download) and structured-clone that single `WebAssembly.Module` to every geometry + pre-pass worker, which `initSync` it (~tens of ms) — eliminating the N× compile and the redundant N fetches. The module is cached per session (federation / reload reuse it). If the URL can't be resolved or compilation fails, it falls back to the previous per-worker `init()` path, so non-Vite consumers and offline/edge failures degrade gracefully. Also fixes the broken `initSync({ module_or_path })` → `initSync({ module })`.

Geometry perf behaviour (#1806/#1815) is untouched — this is startup only.

## Verification (localhost, 68 MB ISSUE_098 model, Vite dev)

**With fix** — all workers ready near-simultaneously and identical output:
```
[stream] shared wasm module compiled once — workers initSync (no per-worker recompile)
[stream] worker[0] WASM ready @ 50ms
[stream] worker[3] WASM ready @ 60ms
[stream] worker[2] WASM ready @ 61ms
[stream] worker[1] WASM ready @ 61ms
First visible geometry @ 1278ms · Stream complete @ 10090ms · 30456 meshes · no stall
```

**Without fix** (same machine): `worker[0/1] @ 53ms, worker[2] @ 67ms, worker[3] @ 71ms`; 30456 meshes; no stall.

**Honest caveat on the numbers:** this dev machine (10 fast cores, localhost-served wasm, and V8's wasm code cache which is shared across workers via the HTTP cache) **cannot reproduce the production cold-CDN / cold-code-cache / genuinely-parallel-compile contention** — even a fresh isolated browser context under 4× CPU throttle showed only a ~20-40 ms spread in both before and after. The production stagger (`3142ms` vs `8044-8168ms`) is exactly that first-visit cold path. The fix is a structural guarantee that removes the N× compile and N× fetch that only manifest as multi-second contention on cold clients; both local before/after runs remain healthy with byte-identical geometry (30456 meshes), confirming no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P8GV9upEMy3G3tEEMyyUAo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved viewer startup by compiling the geometry engine once and sharing it across workers.
  * Reduced repeated WebAssembly downloads and compilation during parallel processing.
* **Bug Fixes**
  * Fixed worker initialization when using a shared precompiled WebAssembly module.
  * Preserved a fallback initialization path when shared compilation is unavailable or fails.
  * Geometry output remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->