### PR TITLE
fix(geometry): void fast-path no longer drops host local-frame origin (misplaced walls in 4.1.2)

### DIFF
--- a/.changeset/fix-void-fastpath-origin-drop.md
+++ b/.changeset/fix-void-fastpath-origin-drop.md
@@ -1,0 +1,7 @@
+---
+"@ifc-lite/wasm": patch
+---
+
+fix(geometry): void fast-path no longer drops a host's local-frame origin (misplaced walls)
+
+The analytic prism / coaxial-union void fast paths (#1806/#1815) run `consolidate_coplanar` on their re-triangulated cut host. That helper rebuilt the mesh into a bare buffer whose `origin`, `rtc_applied`, and #1474 world-capture defaulted to zero, silently discarding the host's per-element local-frame `origin`. For a local-frame host (the wasm default, `origin != 0`) the whole voided element was then placed at the world origin — e.g. AC20-FZK-Haus's opening-bearing ground-floor walls floated ~6 m off the building. `consolidate_coplanar` only re-triangulates coplanar faces in place, so it now carries the input mesh's frame metadata onto the output (mirroring `refine_high_aspect_slivers`'s `rebuilt_like`); world-frame callers (`origin == 0`, the exact kernel) are unaffected. The fast paths' perf and triangle output are unchanged.

--- a/apps/landing/app.jsx
+++ b/apps/landing/app.jsx
@@ -1467,34 +1467,34 @@ function BundleComposition({ items, total }) {
 // Corpus: 21 public IFCs. Times are total parse + geometry, seconds.
 /* <!-- BEGIN GENERATED: landing-bench -->
  */
-// Recorded 2026-07-17 on Apple M4, 10 cores, 16 GB: seconds, parse + geometry total.
-// Engines: @ifc-lite/wasm 4.0.1 (single thread) / ifc-lite-processing 4.1.0 via rayon, 10 threads /
+// Recorded 2026-07-19 on Apple M4, 10 cores, 16 GB: seconds, parse + geometry total.
+// Engines: @ifc-lite/wasm 4.1.2 (single thread) / ifc-lite-processing 4.1.2 via rayon, 10 threads /
 // web-ifc 0.0.77 (single thread); IOS rows: IfcOpenShell datamodel branch, Moult's published Manifold-augmented numbers (his hardware).
 // Source of truth: apps/landing/bench-data.json (methodology + raw runs:
 // louistrue/profiling@apples-to-apples-with-native). Regenerate with
 // `pnpm docs:generate` — do not edit the rows by hand.
 const BENCH_MODELS = [
   { id: "duplex",   name: "duplex.ifc",                             size: 2.3,    products: 215,    ifclite_n: 0.05, ifclite_w: 0.17, webifc: 0.04, iosmax: 0.12, ios1c: 0.19 },
-  { id: "ac20",     name: "AC20-FZK-Haus.ifc",                      size: 2.4,    products: 95,     ifclite_n: 0.02, ifclite_w: 0.12, webifc: 0.08, iosmax: 0.15, ios1c: 0.22 },
-  { id: "i005",     name: "ISSUE_005_haus.ifc",                     size: 2.4,    products: 95,     ifclite_n: 0.03, ifclite_w: 0.12, webifc: 0.08, iosmax: 0.13, ios1c: 0.21 },
-  { id: "i021",     name: "ISSUE_021_Mini Project.ifc",             size: 3.2,    products: 2636,   ifclite_n: 0.28, ifclite_w: 1.66, webifc: 0.29, iosmax: 0.29, ios1c: 0.53 },
-  { id: "officeA",  name: "Office_A_20110811.ifc",                  size: 3.8,    products: 803,    ifclite_n: 0.05, ifclite_w: 0.13, webifc: 0.10, iosmax: 0.25, ios1c: 0.29 },
-  { id: "i126",     name: "ISSUE_126_model.ifc",                    size: 4.2,    products: 257,    ifclite_n: 0.04, ifclite_w: 0.18, webifc: 0.07, iosmax: 0.32, ios1c: 0.46 },
-  { id: "i034",     name: "ISSUE_034_HouseZ.ifc",                   size: 4.8,    products: 228,    ifclite_n: 0.03, ifclite_w: 0.10, webifc: 0.11, iosmax: 0.38, ios1c: 0.71 },
+  { id: "ac20",     name: "AC20-FZK-Haus.ifc",                      size: 2.4,    products: 95,     ifclite_n: 0.02, ifclite_w: 0.09, webifc: 0.08, iosmax: 0.15, ios1c: 0.22 },
+  { id: "i005",     name: "ISSUE_005_haus.ifc",                     size: 2.4,    products: 95,     ifclite_n: 0.02, ifclite_w: 0.08, webifc: 0.08, iosmax: 0.13, ios1c: 0.21 },
+  { id: "i021",     name: "ISSUE_021_Mini Project.ifc",             size: 3.2,    products: 2636,   ifclite_n: 0.26, ifclite_w: 1.64, webifc: 0.29, iosmax: 0.29, ios1c: 0.53 },
+  { id: "officeA",  name: "Office_A_20110811.ifc",                  size: 3.8,    products: 803,    ifclite_n: 0.07, ifclite_w: 0.18, webifc: 0.10, iosmax: 0.25, ios1c: 0.29 },
+  { id: "i126",     name: "ISSUE_126_model.ifc",                    size: 4.2,    products: 257,    ifclite_n: 0.03, ifclite_w: 0.17, webifc: 0.07, iosmax: 0.32, ios1c: 0.46 },
+  { id: "i034",     name: "ISSUE_034_HouseZ.ifc",                   size: 4.8,    products: 228,    ifclite_n: 0.03, ifclite_w: 0.12, webifc: 0.10, iosmax: 0.38, ios1c: 0.71 },
   { id: "i102",     name: "ISSUE_102_M3D-CON.ifc",                  size: 6.0,    products: 138,    ifclite_n: 0.03, ifclite_w: 0.12, webifc: 0.12, iosmax: 0.49, ios1c: 0.62 },
-  { id: "i159",     name: "ISSUE_159_kleine_Wohnung_R22.ifc",       size: 9.5,    products: 425,    ifclite_n: 0.33, ifclite_w: 1.25, webifc: 0.31, iosmax: 0.91, ios1c: 1.65 },
-  { id: "c20",      name: "C20-Institute-Var-2.ifc",                size: 10.3,   products: 712,    ifclite_n: 0.31, ifclite_w: 1.05, webifc: 0.30, iosmax: 0.67, ios1c: 0.71 },
-  { id: "i129",     name: "ISSUE_129_N1540_17_EXE.ifc",             size: 11.5,   products: 959,    ifclite_n: 2.19, ifclite_w: 5.79, webifc: 0.31, iosmax: 0.89, ios1c: 1.52 },
-  { id: "dental",   name: "dental_clinic.ifc",                      size: 12.4,   products: 2586,   ifclite_n: 0.18, ifclite_w: 0.64, webifc: 0.26, iosmax: 0.99, ios1c: 1.25 },
-  { id: "fmarc",    name: "FM_ARC_DigitalHub.ifc",                  size: 13.4,   products: 705,    ifclite_n: 0.28, ifclite_w: 1.19, webifc: 0.43, iosmax: 1.54, ios1c: 2.43 },
-  { id: "bridge",   name: "ifcbridge-model01.ifc",                  size: 14.5,   products: 165,    ifclite_n: 0.08, ifclite_w: 0.31, webifc: 0.20, iosmax: 1.32, ios1c: 2.05 },
-  { id: "i102cd",   name: "ISSUE_102_M3D-CON-CD.ifc",               size: 25.6,   products: 1616,   ifclite_n: 0.40, ifclite_w: 0.82, webifc: 1.08, iosmax: 2.66, ios1c: 4.02 },
-  { id: "soffice",  name: "S_Office_Integrated Design Archi.ifc",   size: 29.6,   products: 3396,   ifclite_n: 0.98, ifclite_w: 2.86, webifc: 2.14, iosmax: 2.94, ios1c: 4.04 },
-  { id: "advanced", name: "advanced_model.ifc",                     size: 33.7,   products: 6401,   ifclite_n: 1.14, ifclite_w: 3.37, webifc: 0.93, iosmax: 3.00, ios1c: 3.92 },
-  { id: "schep",    name: "schependomlaan.ifc",                     size: 47.0,   products: 3504,   ifclite_n: 0.25, ifclite_w: 0.73, webifc: 0.51, iosmax: 2.85, ios1c: 3.35 },
-  { id: "i068",     name: "ISSUE_068_ARK_NUS_skolebygg.ifc",        size: 53.7,   products: 4459,   ifclite_n: 0.69, ifclite_w: 2.77, webifc: 1.23, iosmax: 4.11, ios1c: 5.72 },
-  { id: "i098",     name: "ISSUE_098_R8_F1_MAB_AR_M3_XX_XXX.ifc",   size: 68.4,   products: 11124,  ifclite_n: 9.70, ifclite_w: 55.71, webifc: 2.65, iosmax: 5.82, ios1c: 8.42 },
-  { id: "i053",     name: "ISSUE_053_Holter_Tower_10.ifc",          size: 169.2,  products: 60284,  ifclite_n: 1.50, ifclite_w: 4.21, webifc: 3.07, iosmax: 13.70, ios1c: 19.53 },
+  { id: "i159",     name: "ISSUE_159_kleine_Wohnung_R22.ifc",       size: 9.5,    products: 425,    ifclite_n: 0.16, ifclite_w: 0.95, webifc: 0.31, iosmax: 0.91, ios1c: 1.65 },
+  { id: "c20",      name: "C20-Institute-Var-2.ifc",                size: 10.3,   products: 712,    ifclite_n: 0.16, ifclite_w: 0.76, webifc: 0.30, iosmax: 0.67, ios1c: 0.71 },
+  { id: "i129",     name: "ISSUE_129_N1540_17_EXE.ifc",             size: 11.5,   products: 959,    ifclite_n: 1.12, ifclite_w: 3.59, webifc: 0.31, iosmax: 0.89, ios1c: 1.52 },
+  { id: "dental",   name: "dental_clinic.ifc",                      size: 12.4,   products: 2586,   ifclite_n: 0.19, ifclite_w: 0.88, webifc: 0.26, iosmax: 0.99, ios1c: 1.25 },
+  { id: "fmarc",    name: "FM_ARC_DigitalHub.ifc",                  size: 13.4,   products: 705,    ifclite_n: 0.23, ifclite_w: 0.93, webifc: 0.43, iosmax: 1.54, ios1c: 2.43 },
+  { id: "bridge",   name: "ifcbridge-model01.ifc",                  size: 14.5,   products: 165,    ifclite_n: 0.07, ifclite_w: 0.30, webifc: 0.20, iosmax: 1.32, ios1c: 2.05 },
+  { id: "i102cd",   name: "ISSUE_102_M3D-CON-CD.ifc",               size: 25.6,   products: 1616,   ifclite_n: 0.22, ifclite_w: 0.83, webifc: 1.10, iosmax: 2.66, ios1c: 4.02 },
+  { id: "soffice",  name: "S_Office_Integrated Design Archi.ifc",   size: 29.6,   products: 3396,   ifclite_n: 0.44, ifclite_w: 2.70, webifc: 2.16, iosmax: 2.94, ios1c: 4.04 },
+  { id: "advanced", name: "advanced_model.ifc",                     size: 33.7,   products: 6401,   ifclite_n: 0.33, ifclite_w: 1.33, webifc: 0.94, iosmax: 3.00, ios1c: 3.92 },
+  { id: "schep",    name: "schependomlaan.ifc",                     size: 47.0,   products: 3504,   ifclite_n: 0.24, ifclite_w: 0.72, webifc: 0.51, iosmax: 2.85, ios1c: 3.35 },
+  { id: "i068",     name: "ISSUE_068_ARK_NUS_skolebygg.ifc",        size: 53.7,   products: 4459,   ifclite_n: 0.62, ifclite_w: 4.58, webifc: 1.25, iosmax: 4.11, ios1c: 5.72 },
+  { id: "i098",     name: "ISSUE_098_R8_F1_MAB_AR_M3_XX_XXX.ifc",   size: 68.4,   products: 11124,  ifclite_n: 1.62, ifclite_w: 9.62, webifc: 2.68, iosmax: 5.82, ios1c: 8.42 },
+  { id: "i053",     name: "ISSUE_053_Holter_Tower_10.ifc",          size: 169.2,  products: 60284,  ifclite_n: 1.37, ifclite_w: 6.42, webifc: 3.08, iosmax: 13.70, ios1c: 19.53 },
 ];
 /*
 <!-- END GENERATED: landing-bench --> */

--- a/rust/geometry/src/csg/consolidate.rs
+++ b/rust/geometry/src/csg/consolidate.rs
@@ -595,6 +595,21 @@ impl ClippingProcessor {
                 }
             }
         }
+        // Carry the input's placement / frame metadata (`origin` local-frame
+        // translation, `rtc_applied`, and the #1474 world-capture `local_bounds` /
+        // `local_to_world`) onto the re-triangulated output. `consolidate_coplanar`
+        // only re-triangulates coplanar faces — the geometry stays in the SAME
+        // frame — but `output` is a bare `Mesh::new()` whose defaults reset those
+        // fields to zero/None. For a LOCAL-FRAME caller (origin != 0: the prism /
+        // coaxial-union void fast paths, #1806/#1815) that reset drops the host's
+        // per-element origin and mis-places the whole cut host at the world origin
+        // (the mesh.rs #1474 hazard; mirrors `refine_high_aspect_slivers`'s
+        // `rebuilt_like`). World-frame callers (origin 0) are unaffected. The early
+        // `return mesh` branches above already carry the original frame.
+        output.rtc_applied = mesh.rtc_applied;
+        output.origin = mesh.origin;
+        output.local_bounds = mesh.local_bounds;
+        output.local_to_world = mesh.local_to_world;
         output
     }
 }
@@ -737,6 +752,53 @@ mod tests {
             2,
             "consolidated quad should triangulate to 2 tris, got {}",
             consolidated.indices.len() / 3
+        );
+    }
+
+    #[test]
+    fn consolidate_preserves_local_frame_origin() {
+        // Regression (#1806 void fast-path misplacement): `consolidate_coplanar`
+        // rebuilds into a bare `Mesh::new()` whose `origin`/`rtc_applied`/#1474
+        // capture default to zero. A LOCAL-FRAME host (origin != 0 — the wasm
+        // default, and the frame the prism/coaxial void fast paths cut in) must
+        // keep its per-element `origin` through the merge, or the whole cut host
+        // is re-placed at the world origin (the AC20-FZK-Haus ground-floor walls
+        // that floated ~6 m off the building). Uses the same subdivided quad the
+        // merge test drives so consolidation genuinely runs (not the early
+        // `return mesh` no-op path, which trivially preserves the frame).
+        let mut mesh = Mesh::new();
+        for p in [
+            [0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [1.0, 1.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [0.5, 0.5, 0.0],
+        ] {
+            mesh.add_vertex(Point3::new(p[0], p[1], p[2]), Vector3::new(0.0, 0.0, 1.0));
+        }
+        mesh.add_triangle(0, 1, 4);
+        mesh.add_triangle(1, 2, 4);
+        mesh.add_triangle(2, 3, 4);
+        mesh.add_triangle(3, 0, 4);
+        mesh.origin = [11.85, 5.0, 1.35];
+        mesh.rtc_applied = true;
+
+        let consolidated = ClippingProcessor::consolidate_coplanar(mesh);
+        // Sanity: consolidation actually ran (merged 4 tris -> 2), i.e. the
+        // `output` path (not an early `return mesh`) produced this result.
+        assert_eq!(
+            consolidated.indices.len() / 3,
+            2,
+            "test precondition: the mesh must consolidate so the rebuilt-output frame carry is exercised"
+        );
+        assert_eq!(
+            consolidated.origin,
+            [11.85, 5.0, 1.35],
+            "consolidate_coplanar dropped the local-frame origin — the cut host would render at the world origin"
+        );
+        assert!(
+            consolidated.rtc_applied,
+            "consolidate_coplanar dropped rtc_applied"
         );
     }
 

--- a/rust/processing/tests/module_size_allowlist.txt
+++ b/rust/processing/tests/module_size_allowlist.txt
@@ -34,7 +34,7 @@
 # the prism-cut path's cap/decompose triangulator. Skips the ring depth-parity
 # flood that open segments would corrupt.
      1617 rust/geometry/src/cdt.rs
-     894 rust/geometry/src/csg/consolidate.rs
+     956 rust/geometry/src/csg/consolidate.rs
      947 rust/geometry/src/csg/mod.rs
  # -73: #1806 watertight-extrude tests split out to extrusion_watertight_tests.rs (ratchet-exempt); budget refreshed downward.
 # +9: #1806 review — extrude_profile_watertight rejects < 3-vertex hole rings before


### PR DESCRIPTION
## Symptom

After 4.1.2, opening-bearing walls in **AC20-FZK-Haus.ifc** render **misplaced** — the ground-floor walls (with door/window openings) float ~6 m off the building, clustered near the world origin, while the rest of the house stays put. Live on ifclite.com.

| before (4.1.2 / #1806) | after (this PR) |
| --- | --- |
| ground-floor walls float off the building | clean, coherent house |

## Root cause

Bisected to **#1806** (`ef0743dd`, "2D + analytic-prism opening subtraction"), **not** #1807/#1808 as originally suspected:

- Built wasm at Jul-12, at `a834cf59` (#1788+#1807), and at `ef0743dd` (#1806). The float first appears at #1806.
- Disabling GPU instancing entirely (`enableInstancing:false`) did **not** move the walls → not the instanced pass / #1807.
- Native isolation (`IFC_LITE_VOID_2D=0` / `IFC_LITE_PRISM_CUT=0`, single-threaded) pinned it to the **prism-cut** sub-path.

The analytic prism / coaxial-union void fast paths (#1806/#1815) call `consolidate_coplanar` on their re-triangulated cut host. That helper rebuilds into a bare `Mesh::new()` whose `origin` / `rtc_applied` / #1474 world-capture default to zero, **silently discarding the host's per-element local-frame `origin`**. On a local-frame host (the wasm default, `origin != 0`) the whole voided element is then placed at the world origin. Instrumented proof for FZK-Haus wall #31470: prism entry `origin=[11.85,5,1.35]` → prism out `origin=[0,0,0]`. This is exactly the hazard `mesh.rs` #1474 warns about, and `refine_high_aspect_slivers` already avoids via `rebuilt_like`.

## Fix

`consolidate_coplanar` only re-triangulates coplanar faces in place — the geometry stays in the same frame — so it now carries the input mesh's frame metadata (`origin`, `rtc_applied`, `local_bounds`, `local_to_world`) onto the output. World-frame callers (`origin == 0`, the exact kernel, which zeroes+re-stamps around its own consolidate) are unaffected. This also closes the same latent bug in the #1815 coaxial-union path. **Perf and triangle output of the fast paths are unchanged** (the fast path still fires: FZK-Haus stays at 32.7K tris).

## Verification (localhost)

- **AC20-FZK-Haus.ifc**: walls now correctly placed, no float; Model view shows only the real building; **Model/Types toggle present and working** (Types shows the type library + hides occurrences, back restores the model).
- **duplex.ifc**: renders correctly, no regression.
- `consolidate_preserves_local_frame_origin` unit regression added.
- `cargo test -p ifc-lite-geometry --lib` (501) green; `wall_opening_cut_regression` (7) green with fixture staged; `issue_1320_wall_67828_round_window` green; `pnpm --filter @ifc-lite/viewer typecheck` clean.

## Note on the original title / second symptom

The issue was filed as a type-library-in-Model / missing-toggle regression. On FZK-Haus the actual defect is this **placement** bug; the Model/Types toggle and view gating work correctly there. The separately-reported type-library-in-Model symptom (a "Betonwand" model) was not reproduced here — if it persists it is likely the same misplaced-void-geometry reading as ghost/type geometry, and should be re-confirmed against this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed geometry placement for local-frame hosts processed through the “void fast path,” preventing cut hosts from being dropped and re-positioned incorrectly.
  * Mesh consolidation now preserves the host’s frame/placement metadata (including local origin and world-capture settings), so walls and similar geometry no longer float at the world origin.
  * World-frame callers remain unchanged, with no impact to performance or triangle output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->