### PR TITLE
perf(geometry): scope the prism void path's sliver refinement to the cut region

### DIFF
--- a/.changeset/holter-scoped-sliver-refine.md
+++ b/.changeset/holter-scoped-sliver-refine.md
@@ -1,0 +1,7 @@
+---
+'@ifc-lite/wasm': patch
+---
+
+Scope the prism void fast path's post-cut sliver refinement to the cut region.
+
+The refinement exists to repair high-aspect corner slivers a cut emits at an opening rim (#1007), but it scanned the whole host — so on models whose walls are legitimately full of long-thin authored faces (thin steel), it also bisected geometry the cut never created, inflating triangle output and paying the full lockstep fixpoint on every analytic-cut host. Holter Tower geometry drops ~3430ms → ~3180ms in wasm with ~10k fewer output triangles; ISSUE_098 improves ~19% natively. Unscoped callers (the exact kernel) keep their byte-identical one-split-per-round behaviour.

--- a/rust/geometry/src/facet_weld.rs
+++ b/rust/geometry/src/facet_weld.rs
@@ -438,8 +438,134 @@ fn aspect(a: [f64; 3], b: [f64; 3], c: [f64; 3]) -> f64 {
 /// Returns the input unchanged when no triangle exceeds the threshold (the
 /// common case for clean cuts).
 pub fn refine_high_aspect_slivers(mesh: &Mesh) -> Mesh {
+    refine_high_aspect_slivers_impl(mesh, None)
+}
+
+/// Region-scoped [`refine_high_aspect_slivers`]: only triangles whose AABB
+/// intersects one of `boxes` are sliver candidates; everything outside is left
+/// exactly as authored.
+///
+/// Motivation (Holter-class steel models): the sliver pass exists to repair
+/// high-aspect corner slivers a CUT emits at an opening rim (#1007). Scanning
+/// the WHOLE host instead also bisects the mesh's pre-existing long-thin
+/// authored faces (a thin steel wall is legitimately full of >8:1 quads the
+/// un-cut render path never touches), inflating triangle output and paying the
+/// full lockstep-bisection fixpoint on every analytic-cut host. Scoping to the
+/// cutter volumes keeps the #1007 rim-quality bar (every rim-incident sliver
+/// touches its cutter's box) without refining geometry the cut never created.
+/// Callers pad `boxes` for their own seam tolerance; this function adds the
+/// canonicalization slack itself.
+pub(crate) fn refine_high_aspect_slivers_within(
+    mesh: &Mesh,
+    boxes: &[([f64; 3], [f64; 3])],
+) -> Mesh {
+    if boxes.is_empty() {
+        return mesh.clone();
+    }
+    refine_high_aspect_slivers_impl(mesh, Some(boxes))
+}
+
+fn refine_high_aspect_slivers_impl(
+    mesh: &Mesh,
+    region: Option<&[([f64; 3], [f64; 3])]>,
+) -> Mesh {
     let vertex_count = mesh.positions.len() / 3;
     if vertex_count < 3 || mesh.indices.len() < 6 {
+        return mesh.clone();
+    }
+
+    // RAW NO-SLIVER PRE-SCAN (perf; Holter-class hosts fire the prism void
+    // fast path on hundreds of clean cuts): the canonicalization below hashes
+    // every vertex BEFORE the existing no-sliver fast path can fire, so a
+    // clean cut still paid an O(V) hash build per call. Scan the raw f64
+    // triangles first with a CONSERVATIVE margin: a canonical (deduped)
+    // position differs from its raw one by at most one dedup cell
+    // (≤ √3·POSITION_DEDUP_GRID per endpoint, so ≤ 2·√3·POSITION_DEDUP_GRID
+    // per edge length), so any triangle whose canonical aspect could exceed
+    // SLIVER_ASPECT is caught by widening the raw test by EDGE_SLACK. A raw
+    // "maybe" just falls through to the exact canonical scan below; a raw
+    // "clean" is proof the canonical scan would find nothing, so returning
+    // the input unchanged here is byte-identical to that no-op path.
+    const EDGE_SLACK: f64 = 4.0e-4; // > 2·√3·POSITION_DEDUP_GRID
+    // TWO paddings, because the raw pre-scan and the canonical scans test
+    // DIFFERENT coordinates against the same caller boxes:
+    //   - canonical scans use `cpos` (deduped) → EDGE_SLACK.
+    //   - the raw pre-scan uses the mesh's raw f64 → 2·EDGE_SLACK.
+    // Canonicalization can move a vertex up to one dedup cell (√3·grid) INTO
+    // the region, so a triangle sitting raw-OUTSIDE the once-padded box can be
+    // canonically INSIDE it. With only one padding the pre-scan would answer
+    // "no sliver here" for a triangle the canonical scan would have refined —
+    // silently disabling the #1007 rim repair for it. The wider raw box makes
+    // the pre-scan's "clean" verdict a genuine proof again, which is what lets
+    // it early-out byte-identically.
+    let pad_region = |slack: f64| -> Option<Vec<([f64; 3], [f64; 3])>> {
+        region.map(|boxes| {
+            boxes
+                .iter()
+                .map(|(lo, hi)| {
+                    (
+                        [lo[0] - slack, lo[1] - slack, lo[2] - slack],
+                        [hi[0] + slack, hi[1] + slack, hi[2] + slack],
+                    )
+                })
+                .collect()
+        })
+    };
+    let padded_region = pad_region(EDGE_SLACK);
+    let prescan_region = pad_region(2.0 * EDGE_SLACK);
+    let tri_in_boxes = |boxes: Option<&[([f64; 3], [f64; 3])]>,
+                        a: [f64; 3],
+                        b: [f64; 3],
+                        c: [f64; 3]|
+     -> bool {
+        let Some(boxes) = boxes else {
+            return true;
+        };
+        let lo = [
+            a[0].min(b[0]).min(c[0]),
+            a[1].min(b[1]).min(c[1]),
+            a[2].min(b[2]).min(c[2]),
+        ];
+        let hi = [
+            a[0].max(b[0]).max(c[0]),
+            a[1].max(b[1]).max(c[1]),
+            a[2].max(b[2]).max(c[2]),
+        ];
+        boxes
+            .iter()
+            .any(|(blo, bhi)| (0..3).all(|k| lo[k] <= bhi[k] && hi[k] >= blo[k]))
+    };
+    let tri_in_region = |a: [f64; 3], b: [f64; 3], c: [f64; 3]| -> bool {
+        tri_in_boxes(padded_region.as_deref(), a, b, c)
+    };
+    let raw_may_have_sliver = mesh.indices.chunks_exact(3).any(|c| {
+        let (i0, i1, i2) = (c[0] as usize, c[1] as usize, c[2] as usize);
+        if i0 >= vertex_count || i1 >= vertex_count || i2 >= vertex_count {
+            return false; // the canonical tri build drops it too
+        }
+        let p = |i: usize| -> [f64; 3] {
+            [
+                mesh.positions[i * 3] as f64,
+                mesh.positions[i * 3 + 1] as f64,
+                mesh.positions[i * 3 + 2] as f64,
+            ]
+        };
+        let (a, b, c3) = (p(i0), p(i1), p(i2));
+        // Raw coordinates ⇒ the WIDER pre-scan boxes (see pad_region above).
+        if !tri_in_boxes(prescan_region.as_deref(), a, b, c3) {
+            return false;
+        }
+        let d = |x: [f64; 3], y: [f64; 3]| {
+            ((x[0] - y[0]).powi(2) + (x[1] - y[1]).powi(2) + (x[2] - y[2]).powi(2)).sqrt()
+        };
+        let (e0, e1, e2) = (d(a, b), d(b, c3), d(c3, a));
+        let mn = e0.min(e1).min(e2);
+        let mx = e0.max(e1).max(e2);
+        // A short-min-edge triangle may canonically merge (dropped) or snap to
+        // aspect INFINITY; either way it must take the exact scan.
+        mn - EDGE_SLACK <= 1.0e-9 || (mx + EDGE_SLACK) > SLIVER_ASPECT * (mn - EDGE_SLACK)
+    });
+    if !raw_may_have_sliver {
         return mesh.clone();
     }
 
@@ -496,14 +622,24 @@ pub fn refine_high_aspect_slivers(mesh: &Mesh) -> Mesh {
     // for a triangle whose aspect exceeds SLIVER_ASPECT; if none does, the round
     // loop would build its edge map, find nothing, and return the mesh unchanged.
     // One O(T) scan detects that and skips it — byte-identical to that no-op.
-    if !tris
-        .iter()
-        .any(|t| aspect(cpos[t[0]], cpos[t[1]], cpos[t[2]]) > SLIVER_ASPECT)
-    {
+    if !tris.iter().any(|t| {
+        aspect(cpos[t[0]], cpos[t[1]], cpos[t[2]]) > SLIVER_ASPECT
+            && tri_in_region(cpos[t[0]], cpos[t[1]], cpos[t[2]])
+    }) {
         return mesh.clone();
     }
 
     let mut changed_any = false;
+    // SCOPED-mode split budget. The unscoped loop is inherently bounded (ONE
+    // split per round × MAX_BISECT_ROUNDS). The scoped batched loop splits many
+    // edges per round, so a triangle that bisection cannot improve — a
+    // DEGENERATE needle (aspect INFINITY: its min edge survives every split)
+    // — would re-qualify every round and DOUBLE its fragments each time.
+    // Guard twice: scoped candidacy requires a FINITE aspect (splitting an
+    // INFINITY needle never helps; `clean_degenerate` drops it downstream),
+    // and a hard cap on total splits bounds the worst case regardless.
+    const MAX_SCOPED_SPLITS: usize = 2048;
+    let mut splits_done = 0usize;
     for _round in 0..MAX_BISECT_ROUNDS {
         // Build edge → incident triangle indices (deterministic BTreeMap).
         let mut edge_tris: BTreeMap<(usize, usize), Vec<usize>> = BTreeMap::new();
@@ -513,9 +649,24 @@ pub fn refine_high_aspect_slivers(mesh: &Mesh) -> Mesh {
             }
         }
 
-        // Find the sliver to fix this round: lowest-keyed long edge of any
-        // triangle over the aspect threshold. Deterministic (BTreeMap order).
-        let mut target: Option<(usize, usize)> = None;
+        // Collect this round's split edges — lowest-keyed long edges of
+        // triangles over the aspect threshold. Deterministic (BTreeMap order).
+        //
+        // UNSCOPED (`region == None`, the exact-kernel caller): exactly ONE
+        // edge per round — the original, byte-pinned behavior.
+        //
+        // SCOPED (the prism void fast path): every qualifying edge whose
+        // incident triangles are not already claimed this round. A rim cut on
+        // a thin host emits DOZENS of independent reveal slivers per element;
+        // fixing one edge per round re-built this whole edge map once per
+        // split (the Holter 4.1.x void fast-path regression). Batching
+        // disjoint splits keeps the lockstep-midpoint watertightness argument
+        // per edge (each triangle splits at most once per round, both
+        // incident triangles split at the same snapped midpoint) and stays
+        // deterministic (BTreeMap iteration order; midpoint ids assigned in
+        // that same order).
+        let mut round_edges: Vec<(usize, usize)> = Vec::new();
+        let mut claimed: std::collections::BTreeSet<usize> = std::collections::BTreeSet::new();
         'outer: for (ek, incident) in &edge_tris {
             // Only split a manifold (2-incident) or boundary (1-incident) edge;
             // a non-manifold (>2) edge is skipped (splitting it can't stay
@@ -524,12 +675,20 @@ pub fn refine_high_aspect_slivers(mesh: &Mesh) -> Mesh {
             if incident.len() > 2 {
                 continue;
             }
+            if incident.iter().any(|ti| claimed.contains(ti)) {
+                continue;
+            }
             for &ti in incident {
                 let t = tris[ti];
                 let a = cpos[t[0]];
                 let b = cpos[t[1]];
                 let c = cpos[t[2]];
-                if aspect(a, b, c) <= SLIVER_ASPECT {
+                let asp = aspect(a, b, c);
+                if asp <= SLIVER_ASPECT || !tri_in_region(a, b, c) {
+                    continue;
+                }
+                // Scoped mode: finite-aspect slivers only (see MAX_SCOPED_SPLITS).
+                if region.is_some() && !asp.is_finite() {
                     continue;
                 }
                 // Is THIS edge the triangle's LONGEST? Bisecting the longest
@@ -549,40 +708,47 @@ pub fn refine_high_aspect_slivers(mesh: &Mesh) -> Mesh {
                     d(px, py)
                 };
                 if (this_len - longest).abs() < 1.0e-9 {
-                    target = Some(*ek);
-                    break 'outer;
+                    round_edges.push(*ek);
+                    claimed.extend(incident.iter().copied());
+                    if region.is_none() {
+                        break 'outer; // original one-edge-per-round behavior
+                    }
+                    if splits_done + round_edges.len() >= MAX_SCOPED_SPLITS {
+                        break 'outer;
+                    }
+                    break;
                 }
             }
         }
 
-        let Some((eu, ev)) = target else {
+        if round_edges.is_empty() {
             break; // no sliver left
-        };
-        let incident = edge_tris.get(&(eu, ev)).cloned().unwrap_or_default();
-        if incident.is_empty() {
-            break;
         }
 
-        // New midpoint canonical vertex, ON the original straight edge ⇒ volume
-        // preserved. Snap to the kernel grid for downstream consistency.
-        let pm = {
+        // New midpoint canonical vertex per split edge, ON the original
+        // straight edge ⇒ volume preserved. Snap to the kernel grid for
+        // downstream consistency. Ids assigned in `round_edges` (BTreeMap key)
+        // order — deterministic.
+        let mut edge_mid: BTreeMap<(usize, usize), usize> = BTreeMap::new();
+        for &(eu, ev) in &round_edges {
             let a = cpos[eu];
             let b = cpos[ev];
-            [
+            let pm = [
                 snap_grid(0.5 * (a[0] + b[0])),
                 snap_grid(0.5 * (a[1] + b[1])),
                 snap_grid(0.5 * (a[2] + b[2])),
-            ]
-        };
-        let mid = cpos.len();
-        cpos.push(pm);
+            ];
+            let mid = cpos.len();
+            cpos.push(pm);
+            edge_mid.insert((eu, ev), mid);
+        }
 
-        // Replace each incident triangle with its two halves about the midpoint,
-        // preserving winding. Collect the survivors + new tris.
-        let inc_set: std::collections::BTreeSet<usize> = incident.iter().copied().collect();
-        let mut new_tris: Vec<[usize; 3]> = Vec::with_capacity(tris.len() + incident.len());
+        // Replace each claimed triangle with its two halves about its split
+        // edge's midpoint, preserving winding. Each triangle carries at most
+        // one split edge (the claim rule above).
+        let mut new_tris: Vec<[usize; 3]> = Vec::with_capacity(tris.len() + round_edges.len() * 2);
         for (ti, t) in tris.iter().enumerate() {
-            if !inc_set.contains(&ti) {
+            if !claimed.contains(&ti) {
                 new_tris.push(*t);
                 continue;
             }
@@ -592,7 +758,7 @@ pub fn refine_high_aspect_slivers(mesh: &Mesh) -> Mesh {
                 let u = t[k];
                 let v = t[(k + 1) % 3];
                 let w = t[(k + 2) % 3];
-                if edge_key(u, v) == (eu, ev) {
+                if let Some(&mid) = edge_mid.get(&edge_key(u, v)) {
                     // u → mid → w  and  mid → v → w  preserves [u,v,w] winding.
                     new_tris.push([u, mid, w]);
                     new_tris.push([mid, v, w]);
@@ -606,6 +772,10 @@ pub fn refine_high_aspect_slivers(mesh: &Mesh) -> Mesh {
         }
         tris = new_tris;
         changed_any = true;
+        splits_done += round_edges.len();
+        if region.is_some() && splits_done >= MAX_SCOPED_SPLITS {
+            break;
+        }
     }
 
     if !changed_any {
@@ -776,3 +946,7 @@ mod tests {
         assert_eq!(a.indices, b.indices);
     }
 }
+
+#[cfg(test)]
+#[path = "facet_weld_scoped_tests.rs"]
+mod facet_weld_scoped_tests;

--- a/rust/geometry/src/facet_weld_scoped_tests.rs
+++ b/rust/geometry/src/facet_weld_scoped_tests.rs
@@ -1,0 +1,228 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+//! Properties of the REGION-SCOPED sliver refinement used by the prism void
+//! fast path (`refine_high_aspect_slivers_within`).
+//!
+//! The scoped path differs from the unscoped one in ways that are easy to get
+//! silently wrong and that fixture tests would not localise: it splits MANY
+//! edges per round instead of one, it skips triangles outside the cut region,
+//! and it has two independent guards against a degenerate needle that
+//! bisection cannot improve. Each test below pins one of those behaviours as a
+//! stated invariant rather than an output snapshot.
+
+use super::*;
+
+/// Directed-edge closure, canonicalised BY POSITION — every directed edge
+/// appears exactly once and its reverse exists exactly once. This is the same
+/// watertightness notion the void path audits with `directed_closed`, and it is
+/// what the batched (many-edges-per-round) split has to preserve.
+///
+/// Position-canonical, NOT index-canonical: this refinement rebuilds its output
+/// with per-triangle (unshared) vertices — the repo keeps meshes unwelded so
+/// flat shading survives (#846) — so pairing raw index ids would report every
+/// edge as unpaired for both the scoped and the unscoped pass alike.
+fn directed_closed_mesh(mesh: &Mesh) -> bool {
+    let key = |i: u32| -> (i64, i64, i64) {
+        let i = i as usize;
+        let q = |c: f32| (c as f64 / 1.0e-6).round() as i64;
+        (
+            q(mesh.positions[i * 3]),
+            q(mesh.positions[i * 3 + 1]),
+            q(mesh.positions[i * 3 + 2]),
+        )
+    };
+    type K = (i64, i64, i64);
+    let mut seen: std::collections::BTreeMap<(K, K), i32> = std::collections::BTreeMap::new();
+    for t in mesh.indices.chunks_exact(3) {
+        for k in 0..3 {
+            let a = key(t[k]);
+            let b = key(t[(k + 1) % 3]);
+            if a == b {
+                continue; // zero-length edge of a degenerate tri — not a seam
+            }
+            *seen.entry((a, b)).or_insert(0) += 1;
+        }
+    }
+    seen.iter()
+        .all(|(&(a, b), &n)| n == 1 && seen.get(&(b, a)).copied().unwrap_or(0) == 1)
+}
+
+fn signed_volume(mesh: &Mesh) -> f64 {
+    let p = |i: u32| -> [f64; 3] {
+        let i = i as usize;
+        [
+            mesh.positions[i * 3] as f64,
+            mesh.positions[i * 3 + 1] as f64,
+            mesh.positions[i * 3 + 2] as f64,
+        ]
+    };
+    let mut v = 0.0;
+    for t in mesh.indices.chunks_exact(3) {
+        let (a, b, c) = (p(t[0]), p(t[1]), p(t[2]));
+        v += (a[0] * (b[1] * c[2] - b[2] * c[1]) - a[1] * (b[0] * c[2] - b[2] * c[0])
+            + a[2] * (b[0] * c[1] - b[1] * c[0]))
+            / 6.0;
+    }
+    v
+}
+
+/// A closed 1×1 bar subdivided into `strips` segments of `seg_len` metres each.
+/// With `seg_len` >> 1 every side triangle is a long thin sliver (aspect ≈
+/// `seg_len`), which is the shape this refinement exists to bisect. Aspect is
+/// the longest/shortest EDGE ratio, so `seg_len = 100` gives ≈100 — well over
+/// the `SLIVER_ASPECT` threshold of 8.
+fn slivered_box(strips: usize, seg_len: f32) -> Mesh {
+    let len = seg_len * strips as f32;
+    let mut positions: Vec<f32> = Vec::new();
+    let mut indices: Vec<u32> = Vec::new();
+    // Two rows of vertices along x at y=0 and y=1, at z=0 and z=1.
+    let push = |positions: &mut Vec<f32>, x: f32, y: f32, z: f32| -> u32 {
+        positions.extend_from_slice(&[x, y, z]);
+        (positions.len() / 3 - 1) as u32
+    };
+    let mut grid = vec![[0u32; 4]; strips + 1];
+    for i in 0..=strips {
+        let x = len * (i as f32) / (strips as f32);
+        grid[i] = [
+            push(&mut positions, x, 0.0, 0.0),
+            push(&mut positions, x, 1.0, 0.0),
+            push(&mut positions, x, 1.0, 1.0),
+            push(&mut positions, x, 0.0, 1.0),
+        ];
+    }
+    // Side quads between consecutive stations (4 faces around). The
+    // cross-section loop is CCW seen from +x, so [a_k, a_k2, b_k2] / [a_k,
+    // b_k2, b_k] gives an OUTWARD normal (verified: the z=0 face comes out -z).
+    for i in 0..strips {
+        let a = grid[i];
+        let b = grid[i + 1];
+        for k in 0..4 {
+            let k2 = (k + 1) % 4;
+            indices.extend_from_slice(&[a[k], a[k2], b[k2]]);
+            indices.extend_from_slice(&[a[k], b[k2], b[k]]);
+        }
+    }
+    // End caps (winding outward at each end).
+    let s = grid[0];
+    indices.extend_from_slice(&[s[0], s[2], s[1], s[0], s[3], s[2]]);
+    let e = grid[strips];
+    indices.extend_from_slice(&[e[0], e[1], e[2], e[0], e[2], e[3]]);
+    Mesh {
+        positions,
+        indices,
+        ..Default::default()
+    }
+}
+
+fn whole_mesh_box(mesh: &Mesh) -> ([f64; 3], [f64; 3]) {
+    let mut lo = [f64::INFINITY; 3];
+    let mut hi = [f64::NEG_INFINITY; 3];
+    for p in mesh.positions.chunks_exact(3) {
+        for k in 0..3 {
+            lo[k] = lo[k].min(p[k] as f64);
+            hi[k] = hi[k].max(p[k] as f64);
+        }
+    }
+    (lo, hi)
+}
+
+#[test]
+fn scoped_batched_refinement_stays_closed_and_volume_exact() {
+    let mesh = slivered_box(200, 100.0);
+    assert!(directed_closed_mesh(&mesh), "fixture must start closed");
+    let v0 = signed_volume(&mesh);
+    let region = vec![whole_mesh_box(&mesh)];
+    let out = refine_high_aspect_slivers_within(&mesh, &region);
+    assert!(
+        out.indices.len() > mesh.indices.len(),
+        "the fixture is all high-aspect — refinement must fire"
+    );
+    // Batching splits many edges per round; both triangles incident to a split
+    // edge must take the SAME snapped midpoint or the mesh unzips here.
+    assert!(
+        directed_closed_mesh(&out),
+        "batched scoped refinement broke directed-edge closure"
+    );
+    // Midpoints sit ON the original straight edge ⇒ volume is preserved.
+    let v1 = signed_volume(&out);
+    assert!(
+        (v1 - v0).abs() < 1e-6 * v0.abs().max(1.0),
+        "volume drifted: {v0} -> {v1}"
+    );
+}
+
+/// The point of scoping: geometry away from the cut is not refined. Compared
+/// against the SAME batched algorithm run over the whole mesh — comparing to
+/// the unscoped entry point would be meaningless, since that one splits a
+/// single edge per round and is bounded by MAX_BISECT_ROUNDS regardless.
+#[test]
+fn scoped_refinement_does_less_work_than_whole_mesh_region() {
+    let mesh = slivered_box(60, 100.0);
+    let (lo, hi) = whole_mesh_box(&mesh);
+    // A region covering only the first tenth of the bar's length.
+    let narrow = vec![(lo, [lo[0] + 0.1 * (hi[0] - lo[0]), hi[1], hi[2]])];
+    let whole = vec![(lo, hi)];
+    let scoped = refine_high_aspect_slivers_within(&mesh, &narrow);
+    let full = refine_high_aspect_slivers_within(&mesh, &whole);
+    assert!(
+        scoped.indices.len() < full.indices.len(),
+        "narrow region must refine strictly less than the whole-mesh region \
+         (narrow {}, whole {})",
+        scoped.indices.len(),
+        full.indices.len()
+    );
+    assert!(
+        scoped.indices.len() > mesh.indices.len(),
+        "…but it must still refine the in-region slivers"
+    );
+    assert!(directed_closed_mesh(&scoped));
+}
+
+#[test]
+fn empty_region_is_a_no_op() {
+    let mesh = slivered_box(20, 100.0);
+    let out = refine_high_aspect_slivers_within(&mesh, &[]);
+    assert_eq!(out.indices, mesh.indices, "no boxes ⇒ nothing to refine");
+    assert_eq!(out.positions, mesh.positions);
+}
+
+#[test]
+fn scoped_refinement_is_deterministic() {
+    let mesh = slivered_box(120, 100.0);
+    let region = vec![whole_mesh_box(&mesh)];
+    let a = refine_high_aspect_slivers_within(&mesh, &region);
+    let b = refine_high_aspect_slivers_within(&mesh, &region);
+    assert_eq!(a.indices, b.indices, "index stream must be reproducible");
+    assert_eq!(a.positions, b.positions, "positions must be reproducible");
+}
+
+/// A zero-length edge gives `aspect` = INFINITY; bisecting it never lowers the
+/// aspect, so an unguarded batched fixpoint re-qualifies it every round and
+/// doubles its fragments. The finite-aspect guard must make it a non-candidate,
+/// and the run must terminate with a closed mesh (this hung ISSUE_129 during
+/// development).
+#[test]
+fn degenerate_needle_terminates_without_exploding() {
+    let mut mesh = slivered_box(40, 100.0);
+    // Collapse one vertex onto another to manufacture a zero-length edge.
+    let n = mesh.positions.len() / 3;
+    assert!(n > 8);
+    for k in 0..3 {
+        mesh.positions[3 * 4 + k] = mesh.positions[k];
+    }
+    let region = vec![whole_mesh_box(&mesh)];
+    let before = mesh.indices.len();
+    let out = refine_high_aspect_slivers_within(&mesh, &region);
+    // Bounded by the scoped split budget (2048 splits ⇒ ≤2 new tris each), not
+    // by an exponential cascade.
+    assert!(
+        out.indices.len() <= before + 2 * 2048 * 3,
+        "scoped split budget did not bind: {} -> {}",
+        before,
+        out.indices.len()
+    );
+}
+
+

--- a/rust/geometry/src/router/voids/prism_cut.rs
+++ b/rust/geometry/src/router/voids/prism_cut.rs
@@ -2943,6 +2943,13 @@ impl GeometryRouter {
 
         // ── Sequential analytic cuts ────────────────────────────────────────
         let mut committed_ops = 0usize;
+        // AABB (host-local frame) of every COMMITTED cutter prism, captured
+        // post-extension: the region the cut actually re-triangulated. Feeds the
+        // scoped sliver refinement below (#1007 targets rim slivers, not the
+        // host's own authored long-thin faces). 1 mm pad = the batch/veto margin,
+        // comfortably covering the seam vertices shared with kept host fragments.
+        const REFINE_REGION_PAD: f64 = 1.0e-3;
+        let mut refine_boxes: Vec<([f64; 3], [f64; 3])> = Vec::new();
         for (cand, veto) in cands.iter().zip(&vetoed) {
             let mut ok = false;
             if *veto {
@@ -2994,6 +3001,33 @@ impl GeometryRouter {
                                 tris = outcome.tris;
                                 committed_ops += cand.ops.len();
                                 ok = true;
+                                // Committed-cutter AABB (extended pf): lift the
+                                // 4 profile-bb corners at both depth planes.
+                                let mut lo = [f64::INFINITY; 3];
+                                let mut hi = [f64::NEG_INFINITY; 3];
+                                for &uu in &[pf.bb.0[0], pf.bb.1[0]] {
+                                    for &vv in &[pf.bb.0[1], pf.bb.1[1]] {
+                                        for &w in &[pf.d0(), pf.d1()] {
+                                            let p = pf.lift(uu, vv, w);
+                                            for k in 0..3 {
+                                                lo[k] = lo[k].min(p[k]);
+                                                hi[k] = hi[k].max(p[k]);
+                                            }
+                                        }
+                                    }
+                                }
+                                refine_boxes.push((
+                                    [
+                                        lo[0] - REFINE_REGION_PAD,
+                                        lo[1] - REFINE_REGION_PAD,
+                                        lo[2] - REFINE_REGION_PAD,
+                                    ],
+                                    [
+                                        hi[0] + REFINE_REGION_PAD,
+                                        hi[1] + REFINE_REGION_PAD,
+                                        hi[2] + REFINE_REGION_PAD,
+                                    ],
+                                ));
                             }
                             Err(reason) => defer(reason),
                         }
@@ -3037,19 +3071,39 @@ impl GeometryRouter {
         // grid — so accept the refined mesh only when it is STRICTLY closed
         // and a cleaned probe stays at least hairline-closed.
         if residual_idx.is_empty() && directed_closed(&out) {
-            let mut refined = out.clone();
-            for _ in 0..6 {
-                let next = crate::facet_weld::refine_high_aspect_slivers(&refined);
-                if next.indices.len() == refined.indices.len() {
-                    break;
+            // SCOPED to the committed cutters' padded AABBs: #1007's target is
+            // the high-aspect corner sliver the CUT emits at an opening rim, and
+            // every rim-incident sliver touches its cutter's box. The unscoped
+            // pass also bisected the host's own authored long-thin faces (a thin
+            // steel wall is legitimately full of >8:1 quads), inflating output
+            // triangles and paying the full lockstep fixpoint on every
+            // analytic-cut host (the Holter 4.1.x regression).
+            //
+            // Refine straight off `out` first: the scoped pass returns the input
+            // unchanged when no in-region sliver fires (the common clean-cut
+            // case), and for a NO-OP fixpoint `refined == out` byte-for-byte, so
+            // the upfront clone, the probe clean, and the closure audits decided
+            // nothing. Only a fixpoint that actually split an edge pays the
+            // probe + self-check audits. Same 6-refine budget as before
+            // (1 here + up to 5 below).
+            let mut refined =
+                crate::facet_weld::refine_high_aspect_slivers_within(&out, &refine_boxes);
+            if refined.indices.len() != out.indices.len() {
+                for _ in 0..5 {
+                    let next =
+                        crate::facet_weld::refine_high_aspect_slivers_within(&refined, &refine_boxes);
+                    if next.indices.len() == refined.indices.len() {
+                        break;
+                    }
+                    refined = next;
                 }
-                refined = next;
-            }
-            let mut probe = refined.clone();
-            probe.clean_degenerate();
-            if directed_closed(&refined) && (directed_closed(&probe) || closed_or_hairline(&probe))
-            {
-                out = refined;
+                let mut probe = refined.clone();
+                probe.clean_degenerate();
+                if directed_closed(&refined)
+                    && (directed_closed(&probe) || closed_or_hairline(&probe))
+                {
+                    out = refined;
+                }
             }
         }
         // Never emit a cut that is not a consistently-wound closed surface. The

--- a/rust/geometry/tests/wall_opening_cut_regression.rs
+++ b/rust/geometry/tests/wall_opening_cut_regression.rs
@@ -162,7 +162,14 @@ fn wall_552611_2_openings_matches_ios() {
     // deterministic CDT / i_overlay, BTreeMap bucket order. Load-bearing
     // invariants remain the bbox + oracle volume above. Feature-off
     // (IFC_LITE_PRISM_CUT=0) routes back through the exact kernel: 188.
-    let expect_tris = if prism_cut_enabled() { 204 } else { 188 };
+    // Re-pinned 204 -> 158 when the prism path's post-cut sliver refinement
+    // became REGION-SCOPED to the committed cutter boxes: it no longer bisects
+    // the host's own authored long-thin faces away from the cut, so the count
+    // moves back TOWARD the IOS/Manifold 60 rather than away from it. The rim
+    // itself is refined exactly as before (every rim sliver lies inside its
+    // cutter's box). Feature-off is unchanged at 188 — the exact kernel still
+    // takes the unscoped, byte-pinned pass.
+    let expect_tris = if prism_cut_enabled() { 158 } else { 188 };
     assert_eq!(
         mesh.indices.len() / 3,
         expect_tris,
@@ -181,7 +188,9 @@ fn wall_552761_2_openings_matches_ios() {
     // Re-pinned 188 -> 196 for the analytic-prism void path (see wall_552611's
     // pin note); bbox + oracle volume are the load-bearing invariants.
     // Feature-off (IFC_LITE_PRISM_CUT=0) routes back through the exact kernel: 188.
-    let expect_tris = if prism_cut_enabled() { 196 } else { 188 };
+    // Re-pinned 196 -> 168 for the region-scoped sliver refinement (see
+    // wall_552611's pin note); feature-off unchanged at 188.
+    let expect_tris = if prism_cut_enabled() { 168 } else { 188 };
     assert_eq!(mesh.indices.len() / 3, expect_tris);
     let _ = mx; // not used; presence of non-empty mesh is the assertion
 }
@@ -199,7 +208,9 @@ fn wall_555082_1_opening_matches_ios() {
     // Re-pinned 138 -> 130 for the analytic-prism void path (see wall_552611's
     // pin note) — the analytic cut consolidates BELOW the exact kernel here.
     // Feature-off (IFC_LITE_PRISM_CUT=0) routes back through the exact kernel: 138.
-    let expect_tris = if prism_cut_enabled() { 130 } else { 138 };
+    // Re-pinned 130 -> 88 for the region-scoped sliver refinement (see
+    // wall_552611's pin note); feature-off unchanged at 138.
+    let expect_tris = if prism_cut_enabled() { 88 } else { 138 };
     assert_eq!(mesh.indices.len() / 3, expect_tris);
 }
 
@@ -248,8 +259,14 @@ fn wall_553010_opening_does_not_empty_wall() {
     // Cut produced a real wall-with-slot mesh, not the uncut host (12 tris).
     // Kernel-native count: 138 (`refine_high_aspect_slivers` splits the tall
     // wall faces around the slot); IOS produces 40 with coarser tessellation.
+    // Re-pinned 138 -> 82 (prism path only) for the region-scoped sliver
+    // refinement: the tall wall faces AWAY from the slot are no longer bisected,
+    // only the slot's own rim (see wall_552611's pin note). Now gated like its
+    // sibling pins in this file — feature-off (IFC_LITE_PRISM_CUT=0) still
+    // routes through the exact kernel's unscoped pass and stays at 138.
     let tris = mesh.indices.len() / 3;
-    assert_eq!(tris, 138, "wall-with-slot triangle count");
+    let expect_tris = if prism_cut_enabled() { 82 } else { 138 };
+    assert_eq!(tris, expect_tris, "wall-with-slot triangle count");
 }
 
 /// Wall #612315 (MW 11.5, 3 openings) used to collapse to a 4.22 m fragment

--- a/rust/processing/tests/module_size_allowlist.txt
+++ b/rust/processing/tests/module_size_allowlist.txt
@@ -43,7 +43,17 @@
     1078 rust/geometry/src/extrusion.rs
 # +4: refine_high_aspect_slivers routes its rebuild through Mesh::rebuilt_like so a slivered host keeps its local-frame origin + #1474 placement capture (B7 metadata-loss fix).
 # +1: SNAP_GRID/NORMAL_QUANT single-homed to kernel::mesh_bridge / crate::grid (import replaces local const; doc rewrap costs a line).
-          778 rust/geometry/src/facet_weld.rs
+# +150: Holter void fast-path perf — raw no-sliver pre-scan (skips the O(V) canonicalization on
+# clean cuts), region-scoped refine_high_aspect_slivers_within (prism path refines only the
+# cut region, batching disjoint splits per round with a finite-aspect guard + hard split
+# budget so a degenerate needle can't double its fragments every round; unscoped callers
+# keep the byte-pinned one-edge-per-round behavior).
+# +24: the raw pre-scan needs its OWN wider region padding (2x EDGE_SLACK) than the
+# canonical scans, because canonicalization can move a vertex one dedup cell INTO the
+# region — with a single padding the pre-scan could wrongly early-out on a triangle the
+# canonical scan would refine. Plus the #[cfg(test)] include for facet_weld_scoped_tests.rs
+# (the test file itself is ratchet-exempt).
+          952 rust/geometry/src/facet_weld.rs
 # +2: mix64 made pub(crate); doc-comment noting the shared use by router::content_hash.
      410 rust/geometry/src/geom_hash.rs
      633 rust/geometry/src/kernel/arrangement/classify.rs
@@ -141,7 +151,11 @@
 # analytic hit-rate on the dense faceted-reveal walls). Plus a positions/indices
 # %3 malformed-mesh guard at the top of ptris_from_mesh and the PROFILE_FUSE_TOL
 # (8·SNAP_GRID) weld for profile-equality fusion.
-    3106 rust/geometry/src/router/voids/prism_cut.rs
+# +54: Holter perf — capture committed-cutter AABBs (post-extension) and run the
+# post-cut sliver refinement REGION-SCOPED (refine_high_aspect_slivers_within) so
+# only rim slivers the cut created are bisected, not the host's authored
+# long-thin faces; skip the probe/audit tail when the fixpoint was a no-op.
+    3160 rust/geometry/src/router/voids/prism_cut.rs
 # NEW: #129 coaxial footprint-union for OVERLAPPING opening clusters. One cohesive
 # algorithm: extended-AABB overlap clustering (union-find), coaxial detection, 2.5D
 # depth-slicing with per-slab i_overlay footprint union + watertight re-extrude to


### PR DESCRIPTION
## The regression

Holter Tower (ISSUE_053, steel, 61 423 jobs / 2.93 M tris) regressed on the WASM path across the 4.1.x void fast-path work. Measured in Node, single-thread, `buildPrePassOnce` + one `processGeometryBatch`:

| version | batch | vs 4.1.1 | tris |
|---|---|---|---|
| 4.1.1 | 3111–3139 ms | — | 2 925 381 |
| 4.1.2 | 5547–5682 ms | **+78%** | 2 947 035 |
| 4.1.3 | 3467–3488 ms | **+11%** | 2 944 539 |

**The +78% was already fixed by #1820, and understanding why matters.** The prism/bool2d fast paths return before the origin re-stamp in `router/voids/mod.rs`, relying on `consolidate_coplanar` to carry the host's local-frame `origin` — which it dropped pre-#1820. Holter's 289 opening-bearing walls are layered `IfcWallStandardCase`; material-layer slicing builds its interface planes from `base_mesh.origin`, so the dropped origin put those planes in the wrong frame, slicing produced <2 sub-meshes on all 159 prism-cut walls, `try_layered_sub_meshes` returned `None`, and the caller **re-ran the entire void pipeline a second time per wall**. Reverting only the #1820 hunk reproduces 4.1.2 exactly (4872 ms, 2 947 035 tris, `sliced 552, 159 NOT sliced`). It is WASM-only because native runs world-frame (`origin == 0`) — which is exactly why the native harness never saw it.

This PR addresses the remaining **+11%**.

## The cause

`refine_high_aspect_slivers` repairs the high-aspect corner slivers a cut emits at an opening rim (#1007), but the prism path ran it over the **whole host**. A thin steel wall is legitimately full of >8:1 authored quads, so the pass bisected geometry the cut never created — inflating output triangles and paying the full lockstep fixpoint on every analytic-cut host. Instrumented native split: `try_prism_cut` 330 ms vs 87 ms for the exact-path inner it replaced, of which **166–216 ms was this refinement**.

## The change

Scope the refinement to the padded AABBs of the committed cutter prisms. Every rim-incident sliver touches its own cutter's box, so the #1007 bar is unchanged; what stops is refining the host's far field. Plus a raw allocation-free no-sliver pre-scan (skips the O(V) canonicalization on clean cuts — also helps the exact-kernel caller), and batched disjoint splits per round in scoped mode.

Unscoped callers keep the byte-pinned one-edge-per-round behaviour. **`IFC_LITE_PRISM_CUT=0` reproduces every previously pinned triangle count exactly** — that is the evidence this is confined to the prism path.

Scoped mode has two independent guards against a degenerate needle bisection cannot improve (aspect INFINITY re-qualifies forever, doubling fragments each round — this hung ISSUE_129 during development): finite-aspect candidacy, and a hard 2048-split budget.

## Results

Holter, interleaved reps (machine under load, so absolute times inflated — ratios hold): 4.1.1 4852 ms · 4.1.3 5240 ms (+8.0%) · **this 5014 ms (+3.3%)** — ~59% of the regression removed, tris 2 944 539 → 2 934 427.

No model regressed: **ISSUE_129 −24%** (6171 → 4759 ms), **duplex −12%**, AC20-FZK-Haus neutral. Natively the author measured ISSUE_098 −19%.

## Re-pinned triangle counts

Four pins in `wall_opening_cut_regression.rs` move (204→158, 196→168, 130→88, 138→82; the last is now gated on the feature flag like its siblings). These are explicitly **not** parity pins — the file documents IOS at 60 and names bbox + oracle volume as the load-bearing invariants, both of which still pass. Fewer far-field splits moves the count back *toward* IOS. Each carries a pin note in the file's established style.

## Verification

- `cargo test -p ifc-lite-geometry --no-fail-fast` — 80 binaries green. The sole failure, `production_smiley_all_host_walls_have_holes`, **fails identically on clean `origin/main`** (3/190 hosts, same express ids #126734/#31561/#83005) — pre-existing, worth triaging separately.
- `cargo test -p ifc-lite-processing --no-fail-fast` — green, including `mesh_determinism` (the pinned battery does not exercise the scoped path, so no manifest re-pin) and the module-size ratchet.
- `cargo clippy -p ifc-lite-geometry --all-targets` clean; `pnpm test:wasm-contract` 27/27 against a wasm built from this branch.
- New `facet_weld_scoped_tests.rs` pins the properties the new machinery must hold: position-canonical directed-edge closure and exact volume preservation under batched splitting, narrow-region < whole-mesh-region work, empty-region no-op, determinism, and needle termination inside budget.

An adversarial verifier ran the local-frame case explicitly (the #1806 trap): with `origin != 0` forced — Holter origins like (45.87, 58.50, 142.50), ISSUE_129 at ~8.1 M coordinates — box↔mesh AABB contact is 100% on every host and results are byte-identical to the world-frame run. It also measured **zero** hosts with a remaining in-region >8:1 triangle across advanced_model, Smiley and Holter, matching the unscoped result.

## Known trade

Bisection can orphan the far half of a rim sliver just outside the box, so out-of-region >8:1 counts rise slightly (measured on advanced_model: 6→8, 10→14, 14→20). The rim side is fully repaired; the counts are bounded. Geometry was verified, not pixels.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved prism-based wall and void cuts so refinement is limited to geometry affected by the cut.
  * Prevented unrelated geometry from being modified during sliver cleanup.
  * Preserved watertightness, volume, and deterministic results, including for empty or degenerate regions.

* **Performance**
  * Reduced unnecessary triangle generation and computation during analytic prism cuts.
  * Refined multiple independent areas efficiently while retaining existing behavior for unscoped operations.

* **Tests**
  * Added coverage for scoped refinement, geometry integrity, determinism, and regression cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->