### PR TITLE
test(geometry): fold mesh origin before world-space void ray-casts

### DIFF
--- a/rust/geometry/tests/voids_common/production.rs
+++ b/rust/geometry/tests/voids_common/production.rs
@@ -149,17 +149,20 @@ pub fn count_ray_hits(mesh: &Mesh, ray_origin: [f32; 3], ray_dir: [f32; 3]) -> u
 }
 
 /// Compute the AABB of an opening as seen by the production void path —
-/// `process_element` on the opening then take its bounds.
+/// `process_element` on the opening then take its bounds. The mesh origin is
+/// folded first so the result is genuinely WORLD-space (`Mesh::bounds` only
+/// looks at `positions`, which are local-frame whenever `origin != 0`).
 pub fn opening_world_aabb(
     router: &GeometryRouter,
     opening_id: u32,
     decoder: &mut EntityDecoder,
 ) -> Option<([f32; 3], [f32; 3])> {
     let opening = decoder.decode_by_id(opening_id).ok()?;
-    let mesh = router.process_element(&opening, decoder).ok()?;
+    let mut mesh = router.process_element(&opening, decoder).ok()?;
     if mesh.is_empty() {
         return None;
     }
+    fold_origin(&mut mesh);
     let (min, max) = mesh.bounds();
     Some(([min.x, min.y, min.z], [max.x, max.y, max.z]))
 }
@@ -230,7 +233,9 @@ pub fn count_hits_through_opening(
 }
 
 /// Drive a single host wall through the production code path
-/// (`process_element_with_voids`) and return the resulting mesh.
+/// (`process_element_with_voids`) and return the resulting mesh in WORLD
+/// coordinates (origin folded — see [`fold_origin`]), which is what the
+/// ray-cast helpers here assume.
 pub fn process_host_like_production(
     content: &str,
     host_id: u32,
@@ -240,9 +245,11 @@ pub fn process_host_like_production(
     let mut decoder = EntityDecoder::with_index(content, entity_index);
     let entity = decoder.decode_by_id(host_id).ok()?;
     let router = GeometryRouter::with_scale(1.0);
-    router
+    let mut mesh = router
         .process_element_with_voids(&entity, &mut decoder, void_index)
-        .ok()
+        .ok()?;
+    fold_origin(&mut mesh);
+    Some(mesh)
 }
 
 /// Fold `mesh.origin` into the positions (world = origin + position), leaving

--- a/rust/geometry/tests/voids_production_test.rs
+++ b/rust/geometry/tests/voids_production_test.rs
@@ -28,7 +28,7 @@ mod voids_common;
 use ifc_lite_core::{build_entity_index, EntityDecoder};
 use ifc_lite_geometry::GeometryRouter;
 use voids_common::production::{
-    build_void_index_like_production, count_hits_through_opening, find_entity_by_guid,
+    build_void_index_like_production, count_hits_through_opening, find_entity_by_guid, fold_origin,
     load_fixture, opening_world_aabb, process_host_like_production,
 };
 
@@ -189,15 +189,21 @@ fn production_smiley_all_host_walls_have_holes() {
         }
         total_hosts += 1;
 
-        let wall_mesh = match router.process_element_with_voids(&entity, &mut decoder, &void_index)
-        {
-            Ok(m) => m,
-            Err(_) => continue,
-        };
+        let mut wall_mesh =
+            match router.process_element_with_voids(&entity, &mut decoder, &void_index) {
+                Ok(m) => m,
+                Err(_) => continue,
+            };
         if wall_mesh.is_empty() {
             empty_meshes += 1;
             continue;
         }
+        // The void path may return a LOCAL-FRAME mesh (`origin != 0`, e.g. the
+        // parametric rect fast path). `opening_world_aabb` and the ray grid are
+        // world-space, so fold the origin in before ray-casting — otherwise the
+        // rays are cast through the host in the wrong frame and a correctly cut
+        // host reads as uncut (or, worse, an uncut one reads as cut).
+        fold_origin(&mut wall_mesh);
 
         let mut host_total_hits = 0usize;
         let mut host_checked = 0usize;


### PR DESCRIPTION
## The failure was in the test, not the kernel

`production_smiley_all_host_walls_have_holes` reported 3 of 190 hosts (`#126734`, `#31561`, `#83005`) as having no hole cut. Those three are cut correctly. The sweep was comparing a **local-frame** host mesh against **world-space** opening AABBs.

All three are `IFCSLAB(.FLOOR.)` with one `'Slab Opening'` each, so `process_element_with_voids` returns them through the parametric rect fast path — which emits the documented local-frame contract (`Mesh.origin != 0`, positions relative to it). For `#126734`:

- uncut: `tris=12 origin=[0,0,0] bounds=(-0.050,-0.050,5.050)-(7.475,6.960,5.230)`
- cut:   `tris=32 origin=[3.7125,3.455,5.140] bounds=(-3.762,-3.505,-0.090)-(3.762,3.505,0.090)`

`origin + bounds` reproduces the uncut world bounds exactly, and 12 -> 32 triangles is the hole.

The test never folded that origin. `Mesh::bounds()` (`rust/geometry/src/mesh.rs:585`) reads only `positions` and ignores `origin`, so `count_hits_through_opening` built its ray grid in the host's local frame while `opening_world_aabb` was genuinely world-space. The rays therefore pierced solid slab away from the hole. No kernel predicate rejected anything; the cut ran.

`fold_origin` already existed in the same helper file with a doc comment stating exactly this rule, and two sibling tests already call it — `voids_production_test.rs` simply never did.

## The old test also had silent false passes

An instrumented sweep found **29 of 190** cut hosts return `origin != 0`. Only 3 produced a false failure; for the other 26 the wrong-frame rays missed the geometry entirely and scored 0 hits, i.e. they passed for the wrong reason. This closes those too.

## Changes (test-side only, no kernel code)

- `voids_production_test.rs` — `fold_origin(&mut wall_mesh)` before ray-casting, with a comment explaining the frame contract.
- `voids_common/production.rs::opening_world_aabb` — fold before `bounds()` so the name is truthful (no behaviour change today; openings already have `origin = 0`).
- `voids_common/production.rs::process_host_like_production` — returns a folded (world) mesh, matching what the ray helpers assume.

## Proof the assertion keeps its teeth

With the fold in place but the void cut **deliberately skipped** (`process_element` instead of `process_element_with_voids`), the sweep flags **190/190** hosts as uncut. With the cut applied, **0/190**. Folding did not simply make the rays miss.

`cargo test -p ifc-lite-geometry --no-fail-fast`, 81 test binaries both runs:
- before: 670 passed, **1 failed**, 17 ignored (`production_smiley_all_host_walls_have_holes`)
- after: 671 passed, **0 failed**, 17 ignored

`cargo test --workspace --no-fail-fast` on main had exactly one failing target, this one; it is now green. `rustfmt --check` and `cargo clippy -p ifc-lite-geometry --tests` clean on both touched files.

## Follow-ups deliberately not done here

- **`issue_635_boolean_clipping_test.rs` has the same latent bug.** It carries private copies of `process_host_like_production` and `opening_world_aabb`, neither of which folds the origin. It passes today, but on its fixtures that may be for the wrong reason. Fixing it could surface a real failure, which belongs in its own change — it should point at the shared `voids_common` helpers.
- **Why this was green in CI is still unexplained.** `.github/workflows/test.yml:452` does run `fetch-fixtures.mjs` before `cargo test --workspace`, and the fixture is in the manifest, so "fixture absent" is not a sufficient explanation. A stale `ci-fixtures-*` cache key or a silent fetch failure (the test then just `return`s) are the plausible candidates. Worth a look independently of this PR.
- **`cargo test --release` does not build in a fresh worktree**: the root `.cargo/config.toml` `[unstable] build-std` plus the release profile's `panic = 'abort'` gives `E0152 duplicate lang item in crate core`. Everything here ran in the dev/test profile, which is what CI uses.

No changeset: test-only, no published surface changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected production geometry validation to consistently use world-space coordinates.
  * Fixed opening and host mesh handling so origin offsets are applied before bounds checks and ray-casting.
  * Improved reliability of wall-opening verification for production fixtures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->