### PR TITLE
chore(deps): resolve all three open Dependabot alerts (brace-expansion, js-yaml)

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,8 +104,10 @@
       "picomatch@>=4": "^4.0.4",
       "uuid@<11.1.1": "^11.1.1",
       "@babel/core": "^7.29.6",
-      "js-yaml@4": "^4.2.0",
-      "read-yaml-file": "^2.1.0"
+      "js-yaml@4": "^4.3.0",
+      "read-yaml-file": "^2.1.0",
+      "brace-expansion@1": "^1.1.16",
+      "brace-expansion@2": "^2.1.2"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,8 +25,10 @@ overrides:
   picomatch@>=4: ^4.0.4
   uuid@<11.1.1: ^11.1.1
   '@babel/core': ^7.29.6
-  js-yaml@4: ^4.2.0
+  js-yaml@4: ^4.3.0
   read-yaml-file: ^2.1.0
+  brace-expansion@1: ^1.1.16
+  brace-expansion@2: ^2.1.2
 
 importers:
 
@@ -3402,11 +3404,11 @@ packages:
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
-  brace-expansion@1.1.15:
-    resolution: {integrity: sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==}
+  brace-expansion@1.1.16:
+    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
 
-  brace-expansion@2.1.1:
-    resolution: {integrity: sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==}
+  brace-expansion@2.1.2:
+    resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -4001,10 +4003,6 @@ packages:
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
-
-  js-yaml@4.2.0:
-    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
-    hasBin: true
 
   js-yaml@4.3.0:
     resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
@@ -7417,12 +7415,12 @@ snapshots:
 
   boolbase@1.0.0: {}
 
-  brace-expansion@1.1.15:
+  brace-expansion@1.1.16:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@2.1.1:
+  brace-expansion@2.1.2:
     dependencies:
       balanced-match: 1.0.2
 
@@ -7581,7 +7579,7 @@ snapshots:
   cosmiconfig@8.3.6(typescript@6.0.3):
     dependencies:
       import-fresh: 3.3.1
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
       parse-json: 5.2.0
       path-type: 4.0.0
     optionalDependencies:
@@ -8049,10 +8047,6 @@ snapshots:
   jiti@2.7.0: {}
 
   js-tokens@4.0.0: {}
-
-  js-yaml@4.2.0:
-    dependencies:
-      argparse: 2.0.1
 
   js-yaml@4.3.0:
     dependencies:
@@ -8698,11 +8692,11 @@ snapshots:
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.15
+      brace-expansion: 1.1.16
 
   minimatch@5.1.9:
     dependencies:
-      brace-expansion: 2.1.1
+      brace-expansion: 2.1.2
 
   minimist@1.2.8: {}
 


### PR DESCRIPTION
Closes the three open high-severity Dependabot alerts (#82, #83, #84). All three are transitive npm packages that no direct dependency pins tightly enough to pull the fix in on its own, so they are resolved the way this repo already resolves that class of advisory: `pnpm.overrides` in the root `package.json`.

| Alert | Advisory | Package | Was | Now | Reached via |
| --- | --- | --- | --- | --- | --- |
| 82 | [GHSA-3jxr-9vmj-r5cp](https://github.com/advisories/GHSA-3jxr-9vmj-r5cp) | brace-expansion | 1.1.15 | 1.1.16 | `minimatch@3.1.5` |
| 83 | [GHSA-3jxr-9vmj-r5cp](https://github.com/advisories/GHSA-3jxr-9vmj-r5cp) | brace-expansion | 2.1.1 | 2.1.2 | `minimatch@5.1.9` |
| 84 | [GHSA-52cp-r559-cp3m](https://github.com/advisories/GHSA-52cp-r559-cp3m) | js-yaml | 4.2.0 | 4.3.0 | `@changesets/parse`, `cosmiconfig`, `read-yaml-file` |

Both advisories are DoS-by-quadratic/exponential-CPU on attacker-shaped input (`{}` group chains; YAML merge-key chains).

### Notes on the fix

- **js-yaml** already had a `js-yaml@4: ^4.2.0` override — v4 is pinned deliberately, since latest is 5.x. This only raises the floor to `^4.3.0` (`v4-legacy` dist-tag), staying on v4. It also collapses the duplicate `4.2.0` / `4.3.0` pair the tree was carrying, so the lockfile gets slightly smaller.
- **brace-expansion** gets one override per major line, matching the `picomatch@<3` / `picomatch@>=4` pattern already in this file. Both 1.x and 2.x are in the tree via different `minimatch` majors, and the fixes ship on separate maintenance lines (`maintenance-v1` = 1.1.16, `maintenance-v2` = 2.1.2) — no single range covers both.

### Scope

Lockfile-only otherwise. No direct dependency version changes, no source changes, so no changeset. Verified `pnpm install --lockfile-only` produces exactly the diff shown and that no `brace-expansion@1.1.15`, `brace-expansion@2.1.1`, or `js-yaml@4.2.0` entry remains in `pnpm-lock.yaml`.