### PR TITLE
fix(export): serialize integral REAL-typed attributes with a decimal point (#1839)

### DIFF
--- a/.changeset/real-typed-attr-serialization.md
+++ b/.changeset/real-typed-attr-serialization.md
@@ -1,0 +1,12 @@
+---
+"@ifc-lite/export": patch
+"@ifc-lite/mutations": patch
+---
+
+Serialize whole numbers on REAL-typed STEP attributes with a decimal point.
+`setPositionalAttribute`, `addEntity`, and the in-store builders' own emitted
+geometry now consult the schema registry, so an integral value in a REAL-backed
+slot (`IfcLengthMeasure` coordinates, profile dimensions, extrusion depth, …)
+exports as `450.` rather than a bare `450` INTEGER literal that strict
+validators (`ifcopenshell.validate`) reject. Integer-typed slots are left
+untouched; the `{ real }` marker still works for genuinely ambiguous selects.

--- a/.changeset/real-typed-attr-serialization.md
+++ b/.changeset/real-typed-attr-serialization.md
@@ -1,5 +1,6 @@
 ---
 "@ifc-lite/export": patch
+"@ifc-lite/parser": minor
 "@ifc-lite/mutations": patch
 ---
 
@@ -10,3 +11,6 @@ slot (`IfcLengthMeasure` coordinates, profile dimensions, extrusion depth, …)
 exports as `450.` rather than a bare `450` INTEGER literal that strict
 validators (`ifcopenshell.validate`) reject. Integer-typed slots are left
 untouched; the `{ real }` marker still works for genuinely ambiguous selects.
+Positional names resolve across the schema union so IFC4X3-only alignment/civil
+entities are covered too. Exposes `getAttributeNamesAcrossSchemas` from
+`@ifc-lite/parser`.

--- a/packages/export/src/attribute-real-slots.ts
+++ b/packages/export/src/attribute-real-slots.ts
@@ -1,0 +1,95 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Schema-aware detection of REAL-typed STEP attribute slots.
+ *
+ * ISO 10303-21 requires a REAL-typed attribute (`IfcLengthMeasure` and every
+ * other `<real>`-backed defined type) to carry a decimal point — `450.`, never
+ * `450`. A bare JavaScript number is ambiguous at the value level (it could be
+ * an `IfcInteger`), so `serializeStepValue` defaults to emitting whole numbers
+ * as STEP INTEGER literals. That default silently produces strict-invalid files
+ * whenever a whole number lands in a REAL slot — the natural
+ * `setPositionalAttribute(profId, 3, 450)` call, `addEntity` args, and the
+ * geometry the in-store builders emit themselves (millimetre models round to
+ * whole numbers, making this the common case). See LTplus-AG/ifc-lite#1839.
+ *
+ * The slot's declared type is statically known from the schema registry, so we
+ * resolve it once per (entity, version) and force a REAL literal on those slots
+ * at serialization time — no caller change, no `{ real }` marker required.
+ */
+
+import type { IfcAttributeValue } from '@ifc-lite/parser';
+import { getAttributeNames } from '@ifc-lite/parser';
+import { getAttributeXsdTypes, type IfcSchemaVersion as DataSchemaVersion } from '@ifc-lite/data';
+import type { IfcSchemaVersion } from './schema-converter.js';
+import { serializeStepValue } from './step-serialization.js';
+
+/**
+ * Map the exporter's schema tag to the version the attribute XSD index is keyed
+ * by. `IFC4X3_ADD2` is not an exporter tag; `IFC5` has no bundled XSD table.
+ * REAL-vs-INTEGER of a geometry slot is version-invariant, so any unmapped tag
+ * falls back to IFC4 — a slot missing from that version simply won't be forced.
+ */
+function toDataSchemaVersion(v: IfcSchemaVersion): DataSchemaVersion {
+  switch (v) {
+    case 'IFC2X3':
+      return 'IFC2X3';
+    case 'IFC4X3':
+      return 'IFC4X3';
+    case 'IFC4':
+      return 'IFC4';
+    default:
+      return 'IFC4';
+  }
+}
+
+// Memoized `version|ENTITY` → set of positional slot indices that are
+// unambiguously REAL-backed. Keyed by upper-case type so `IfcColumn`/`IFCCOLUMN`
+// collapse to one entry.
+const realSlotCache = new Map<string, Set<number>>();
+
+/**
+ * The set of zero-based positional attribute indices on `entityType` whose
+ * declared type is unambiguously REAL-backed (`xs:double`, and NOT also
+ * `xs:integer`). An index that also admits an integer — a genuine
+ * `SELECT(IfcInteger, IfcReal)` — stays out of the set: it is truly ambiguous,
+ * and the explicit `{ real }` marker is the caller's way to disambiguate it.
+ *
+ * Returns an empty set for entities the registry does not know (vendor
+ * extensions, unmapped schema), preserving the historical default there.
+ */
+export function getRealTypedSlots(entityType: string, version: IfcSchemaVersion): Set<number> {
+  const dataVersion = toDataSchemaVersion(version);
+  const upperType = entityType.toUpperCase();
+  const key = `${dataVersion}|${upperType}`;
+  const cached = realSlotCache.get(key);
+  if (cached) return cached;
+
+  const names = getAttributeNames(entityType);
+  const slots = new Set<number>();
+  for (let i = 0; i < names.length; i++) {
+    const xsd = getAttributeXsdTypes(dataVersion, upperType, names[i]);
+    if (xsd && xsd.includes('xs:double') && !xsd.includes('xs:integer')) {
+      slots.add(i);
+    }
+  }
+  realSlotCache.set(key, slots);
+  return slots;
+}
+
+/**
+ * Serialize a full positional attribute list for an entity to a STEP body,
+ * forcing a REAL literal (decimal point) on every unambiguously double-backed
+ * slot. Used for freshly-emitted overlay entities (`addEntity`, the in-store
+ * builders) whose numbers never pass through a source token.
+ */
+export function serializeEntityArgs(
+  entityType: string,
+  values: readonly IfcAttributeValue[],
+  version: IfcSchemaVersion,
+): string {
+  const realSlots = getRealTypedSlots(entityType, version);
+  return values.map((value, i) => serializeStepValue(value, realSlots.has(i))).join(',');
+}

--- a/packages/export/src/attribute-real-slots.ts
+++ b/packages/export/src/attribute-real-slots.ts
@@ -21,7 +21,7 @@
  */
 
 import type { IfcAttributeValue } from '@ifc-lite/parser';
-import { getAttributeNames } from '@ifc-lite/parser';
+import { getAttributeNamesAcrossSchemas } from '@ifc-lite/parser';
 import { getAttributeXsdTypes, type IfcSchemaVersion as DataSchemaVersion } from '@ifc-lite/data';
 import type { IfcSchemaVersion } from './schema-converter.js';
 import { serializeStepValue } from './step-serialization.js';
@@ -67,7 +67,12 @@ export function getRealTypedSlots(entityType: string, version: IfcSchemaVersion)
   const cached = realSlotCache.get(key);
   if (cached) return cached;
 
-  const names = getAttributeNames(entityType);
+  // Resolve positional names across the bundled schema union (2X3 + 4 + 4X3),
+  // not just the parser's IFC4-pinned registry — otherwise IFC4X3-only leaves
+  // (IfcAlignmentHorizontalSegment and the civil/alignment geometry this fix
+  // targets) return no names, and their REAL slots (StartDirection,
+  // SegmentLength, …) would still emit bare INTEGER literals.
+  const names = getAttributeNamesAcrossSchemas(entityType);
   const slots = new Set<number>();
   for (let i = 0; i < names.length; i++) {
     const xsd = getAttributeXsdTypes(dataVersion, upperType, names[i]);

--- a/packages/export/src/step-exporter.test.ts
+++ b/packages/export/src/step-exporter.test.ts
@@ -411,8 +411,11 @@ describe('StepExporter', () => {
 
     expect(point.expressId).toBe(11);
     expect(content).toContain('#10=IFCCARTESIANPOINT((0.,0.,0.));');
-    expect(content).toContain('#11=IFCCARTESIANPOINT((1,2,3));');
-    expect(content).toContain('#12=IFCDIRECTION((0,0,1));');
+    // Coordinates / DirectionRatios are REAL-backed slots, so whole numbers
+    // serialize with a decimal point (#1839) — a bare `(1,2,3)` is a STEP type
+    // violation strict validators reject.
+    expect(content).toContain('#11=IFCCARTESIANPOINT((1.,2.,3.));');
+    expect(content).toContain('#12=IFCDIRECTION((0.,0.,1.));');
     expect(result.stats.newEntityCount).toBe(2);
   });
 
@@ -451,6 +454,73 @@ describe('StepExporter', () => {
     expect(result.stats.modifiedEntityCount).toBe(1);
   });
 
+  // Regression #1839: a WHOLE number written into a REAL-backed positional slot
+  // (IfcRectangleProfileDef.XDim : IfcPositiveLengthMeasure) must serialize with
+  // a decimal point. Previously it came out as a bare INTEGER (`...,1,0.4`) and
+  // strict validators (ifcopenshell.validate) rejected the file.
+  it('serializes an integral edit of a REAL-typed positional slot as a STEP REAL', () => {
+    const dataStore = buildMockDataStore([
+      [35, 'IFCRECTANGLEPROFILEDEF', '#35=IFCRECTANGLEPROFILEDEF(.AREA.,$,#34,0.4,0.4);'],
+    ]);
+    const view = new LiveMutablePropertyView(null, 'm1');
+    view.setPositionalAttribute(35, 3, 1); // XDim := 1.0
+
+    const result = new StepExporter(dataStore, view).export({
+      schema: 'IFC4',
+      applyMutations: true,
+    });
+    const content = decode(result.content);
+
+    expect(content).toContain('#35=IFCRECTANGLEPROFILEDEF(.AREA.,$,#34,1.,0.4);');
+    expect(content).not.toContain('#34,1,0.4');
+  });
+
+  // Regression #1839: the in-store builders emit their own geometry as overlay
+  // entities with whole-number lengths (millimetre models are the common case).
+  // Every REAL-backed slot on a freshly-added entity must carry a decimal point.
+  it('forces REAL literals on whole-number lengths of overlay-created geometry', () => {
+    const dataStore = buildMockDataStore([
+      [10, 'IFCCARTESIANPOINT', '#10=IFCCARTESIANPOINT((0.,0.,0.));'],
+    ]);
+    const view = new LiveMutablePropertyView(null, 'm1');
+    view.setExpressIdWatermark(10);
+    // #11 profile: XDim/YDim are REAL; #12 extruded solid: Depth (index 3) is REAL.
+    view.createEntity('IFCRECTANGLEPROFILEDEF', ['.AREA.', null, '#34', 400, 400]);
+    view.createEntity('IFCEXTRUDEDAREASOLID', ['#11', '#20', '#21', 3000]);
+
+    const result = new StepExporter(dataStore, view).export({
+      schema: 'IFC4',
+      applyMutations: true,
+    });
+    const content = decode(result.content);
+
+    expect(content).toContain('#11=IFCRECTANGLEPROFILEDEF(.AREA.,$,#34,400.,400.);');
+    expect(content).toContain('#12=IFCEXTRUDEDAREASOLID(#11,#20,#21,3000.);');
+  });
+
+  // Guard against over-forcing: an INTEGER-typed slot keeps its integer form.
+  // IfcQuantityCount.CountValue is a pure IfcCountMeasure (xs:integer), so a
+  // whole-number value must NOT gain a decimal point. Uses the new-entity path
+  // (no source token) so only the schema signal is in play.
+  it('leaves integer-typed slots as INTEGER literals', () => {
+    const dataStore = buildMockDataStore([
+      [1, 'IFCCARTESIANPOINT', '#1=IFCCARTESIANPOINT((0.,0.,0.));'],
+    ]);
+    const view = new LiveMutablePropertyView(null, 'm1');
+    view.setExpressIdWatermark(1);
+    // Name, Description, Unit, CountValue (integer), Formula
+    view.createEntity('IFCQUANTITYCOUNT', ['n', null, null, 5, null]);
+
+    const result = new StepExporter(dataStore, view).export({
+      schema: 'IFC4',
+      applyMutations: true,
+    });
+    const content = decode(result.content);
+
+    expect(content).toContain("#2=IFCQUANTITYCOUNT('n',$,$,5,$);");
+    expect(content).not.toContain('5.');
+  });
+
   // Regression: the deltaOnly early-return previously fired before the
   // overlay-entities pass, so `createEntity()`-only edits were silently
   // dropped from delta exports.
@@ -469,7 +539,7 @@ describe('StepExporter', () => {
     });
     const content = decode(result.content);
 
-    expect(content).toContain('#2=IFCDIRECTION((1,0,0));');
+    expect(content).toContain('#2=IFCDIRECTION((1.,0.,0.));');
     expect(content).not.toContain('#1=IFCCARTESIANPOINT');
     expect(result.stats.newEntityCount).toBe(1);
   });

--- a/packages/export/src/step-exporter.test.ts
+++ b/packages/export/src/step-exporter.test.ts
@@ -498,6 +498,34 @@ describe('StepExporter', () => {
     expect(content).toContain('#12=IFCEXTRUDEDAREASOLID(#11,#20,#21,3000.);');
   });
 
+  // Regression #1839 (Codex review): IFC4X3-only entities are absent from the
+  // parser's IFC4-pinned registry, so positional names must resolve across the
+  // schema union — otherwise alignment/civil REAL slots (StartDirection,
+  // SegmentLength, …) fall back to bare INTEGER literals.
+  it('forces REAL literals on IFC4X3-only entity slots (alignment geometry)', () => {
+    const dataStore = buildMockDataStore([
+      [5, 'IFCCARTESIANPOINT', '#5=IFCCARTESIANPOINT((0.,0.));'],
+    ]);
+    (dataStore as unknown as { schemaVersion: string }).schemaVersion = 'IFC4X3';
+    const view = new LiveMutablePropertyView(null, 'm1');
+    view.setExpressIdWatermark(5);
+    // StartTag, EndTag, StartPoint, StartDirection, StartRadiusOfCurvature,
+    // EndRadiusOfCurvature, SegmentLength, GravityCenterLineHeight, PredefinedType
+    view.createEntity('IFCALIGNMENTHORIZONTALSEGMENT', [
+      null, null, '#5', 0, 0, 0, 5000, 0, '.LINE.',
+    ]);
+
+    const result = new StepExporter(dataStore, view).export({
+      schema: 'IFC4X3',
+      applyMutations: true,
+    });
+    const content = decode(result.content);
+
+    expect(content).toContain(
+      '#6=IFCALIGNMENTHORIZONTALSEGMENT($,$,#5,0.,0.,0.,5000.,0.,.LINE.);',
+    );
+  });
+
   // Guard against over-forcing: an INTEGER-typed slot keeps its integer form.
   // IfcQuantityCount.CountValue is a pure IfcCountMeasure (xs:integer), so a
   // whole-number value must NOT gain a decimal point. Uses the new-entity path

--- a/packages/export/src/step-exporter.ts
+++ b/packages/export/src/step-exporter.ts
@@ -34,12 +34,13 @@ import {
   quantityTypeToIfcType,
   serializePropertyValue,
   serializeAttributeValue,
-  serializeStepArgs,
   serializeStepValue,
+  tokenIsRealLiteral,
   splitTopLevelArgs,
   splitTopLevelStepArguments,
   assembleStepBytes,
 } from './step-serialization.js';
+import { getRealTypedSlots, serializeEntityArgs } from './attribute-real-slots.js';
 
 /**
  * Options for STEP export
@@ -640,7 +641,7 @@ export class StepExporter {
           ? this.mutationView!.getPositionalMutationsForEntity(expressId)
           : null;
         if (positional && positional.size > 0) {
-          nextEntityText = this.applyPositionalMutations(nextEntityText, positional);
+          nextEntityText = this.applyPositionalMutations(nextEntityText, positional, workingType, sourceSchema);
           if (!modifiedEntities.has(expressId)) {
             modifiedEntities.add(expressId);
             modifiedEntityCount++;
@@ -750,7 +751,12 @@ export class StepExporter {
         // (e.g. setEntityType(id, 'IfcColumn', 'PILASTER')).
         let argsText: string;
         if (typeMut) {
-          const srcTokens = entity.attributes.map(serializeStepValue);
+          // Serialize against the AUTHORED layout (`entity.type`); retypeArgTokens
+          // then re-lays the tokens out by name up to the effective class.
+          const authoredRealSlots = getRealTypedSlots(entity.type, sourceSchema);
+          const srcTokens = entity.attributes.map(
+            (value, i) => serializeStepValue(value, authoredRealSlots.has(i)),
+          );
           const { tokens } = retypeArgTokens(
             srcTokens,
             entity.type,
@@ -760,7 +766,7 @@ export class StepExporter {
           );
           argsText = tokens.join(',');
         } else {
-          argsText = serializeStepArgs(entity.attributes);
+          argsText = serializeEntityArgs(entity.type, entity.attributes, sourceSchema);
         }
         const line = `#${entity.expressId}=${upperType}(${argsText});`;
         if (converting) {
@@ -1035,16 +1041,24 @@ export class StepExporter {
   private applyPositionalMutations(
     entityText: string,
     positionals: Map<number, IfcAttributeValue>,
+    entityType: string,
+    schemaVersion: IfcSchemaVersion,
   ): string {
     const openParen = entityText.indexOf('(');
     const closeParen = entityText.lastIndexOf(');');
     if (openParen < 0 || closeParen < openParen) return entityText;
 
     const args = splitTopLevelArgs(entityText.slice(openParen + 1, closeParen));
+    const realSlots = getRealTypedSlots(entityType, schemaVersion);
     let changed = false;
     for (const [index, value] of positionals) {
       if (index < 0 || index >= args.length) continue;
-      args[index] = serializeStepValue(value);
+      // Force a REAL literal when the slot's declared type is REAL-backed. The
+      // current token is a secondary signal: editing a value that was already a
+      // REAL (`0.4`, `1.5E-7`) keeps it REAL even for entities the XSD index
+      // doesn't cover, so a whole-number edit can't silently downgrade the slot.
+      const forceReal = realSlots.has(index) || tokenIsRealLiteral(args[index]);
+      args[index] = serializeStepValue(value, forceReal);
       changed = true;
     }
     if (!changed) return entityText;

--- a/packages/export/src/step-serialization.test.ts
+++ b/packages/export/src/step-serialization.test.ts
@@ -9,8 +9,23 @@ import {
   assembleStepBytes,
   serializePropertyValue,
   serializeAttributeValue,
+  tokenIsRealLiteral,
   toStepReal,
 } from './step-serialization.js';
+
+describe('tokenIsRealLiteral', () => {
+  it('recognizes REAL literals with either sign', () => {
+    for (const t of ['0.4', '-0.4', '+0.4', '4.', '1.5E-7', '+1E3', '-2.E+5']) {
+      expect(tokenIsRealLiteral(t)).toBe(true);
+    }
+  });
+
+  it('rejects INTEGER literals and non-numeric tokens', () => {
+    for (const t of ['4', '-4', '+4', '#42', '.AREA.', '$', "'x'", '']) {
+      expect(tokenIsRealLiteral(t)).toBe(false);
+    }
+  });
+});
 
 /** A conforming STEP REAL: mantissa carries a decimal point, exponent (if any)
  *  is uppercase `E`. Rejects the invalid `5e-8.` / lowercase-`e` forms. */

--- a/packages/export/src/step-serialization.ts
+++ b/packages/export/src/step-serialization.ts
@@ -104,13 +104,14 @@ export function serializePropertyValue(value: unknown, type: PropertyValueType):
 
 /**
  * True when a STEP source token is a REAL literal — a numeric token carrying a
- * decimal point or an exponent (`0.4`, `1.5E-7`, `4.`). Used to preserve
- * REAL-ness when a positional edit replaces such a value with a whole number,
- * so `1` written over `0.4` re-emits as `1.` rather than a bare INTEGER.
+ * decimal point or an exponent (`0.4`, `+0.4`, `1.5E-7`, `4.`). Used to
+ * preserve REAL-ness when a positional edit replaces such a value with a whole
+ * number, so `1` written over `0.4` re-emits as `1.` rather than a bare INTEGER.
+ * A leading `+` is a valid ISO 10303-21 sign, so it is accepted alongside `-`.
  */
 export function tokenIsRealLiteral(token: string): boolean {
   const t = token.trim();
-  return /^-?\d+(?:\.\d*)?(?:E[+-]?\d+)?$/i.test(t) && (t.includes('.') || /E/i.test(t));
+  return /^[+-]?\d+(?:\.\d*)?(?:E[+-]?\d+)?$/i.test(t) && (t.includes('.') || /E/i.test(t));
 }
 
 /**

--- a/packages/export/src/step-serialization.ts
+++ b/packages/export/src/step-serialization.ts
@@ -103,6 +103,17 @@ export function serializePropertyValue(value: unknown, type: PropertyValueType):
 }
 
 /**
+ * True when a STEP source token is a REAL literal — a numeric token carrying a
+ * decimal point or an exponent (`0.4`, `1.5E-7`, `4.`). Used to preserve
+ * REAL-ness when a positional edit replaces such a value with a whole number,
+ * so `1` written over `0.4` re-emits as `1.` rather than a bare INTEGER.
+ */
+export function tokenIsRealLiteral(token: string): boolean {
+  const t = token.trim();
+  return /^-?\d+(?:\.\d*)?(?:E[+-]?\d+)?$/i.test(t) && (t.includes('.') || /E/i.test(t));
+}
+
+/**
  * Serialize a root attribute value for STEP, inferring the format from the
  * existing token (enum, boolean, number, string, etc.).
  */
@@ -156,16 +167,24 @@ export function serializeAttributeValue(value: string, currentToken: string): st
  *   (callers tag references as the string `"#42"` or via `entityRef(42)`)
  * - other strings are emitted as quoted STEP strings
  * - arrays are emitted as STEP lists `(a,b,c)`, recursing on each element
+ *
+ * `forceReal` makes whole numbers serialize as REAL literals (`450.`, not
+ * `450`) and propagates into nested lists — used by the schema-aware export
+ * path for attribute slots statically known to be REAL-backed (coordinates,
+ * `IfcLengthMeasure` dimensions, …), where a bare INTEGER literal is an ISO
+ * 10303-21 type violation strict validators reject (LTplus-AG/ifc-lite#1839).
+ * It never overrides the explicit `{ real }` marker, which is always REAL.
  */
-export function serializeStepValue(value: IfcAttributeValue): string {
+export function serializeStepValue(value: IfcAttributeValue, forceReal = false): string {
   if (value === null || value === undefined) return '$';
   if (typeof value === 'boolean') return value ? '.T.' : '.F.';
   if (typeof value === 'number') {
     if (!Number.isFinite(value)) return '$';
+    if (forceReal) return toStepReal(value);
     return Number.isInteger(value) ? String(value) : toStepReal(value);
   }
   if (Array.isArray(value)) {
-    return `(${value.map(serializeStepValue).join(',')})`;
+    return `(${value.map(v => serializeStepValue(v, forceReal)).join(',')})`;
   }
   if (typeof value === 'object' && 'real' in value) {
     // Write-only typed-real marker (see `IfcAttributeValue`): always a REAL
@@ -177,14 +196,6 @@ export function serializeStepValue(value: IfcAttributeValue): string {
   if (/^#\d+$/.test(trimmed)) return trimmed;
   if (/^\.[A-Z0-9_]+\.$/i.test(trimmed)) return trimmed.toUpperCase();
   return `'${escapeStepString(String(value))}'`;
-}
-
-/**
- * Serialize an attribute list to a STEP entity body.
- * Example: `[1, '.AREA.', null]` → `1,.AREA.,$`
- */
-export function serializeStepArgs(values: IfcAttributeValue[]): string {
-  return values.map(serializeStepValue).join(',');
 }
 
 /** Tag a number as a STEP entity reference (`#N`) for `serializeStepValue`. */

--- a/packages/mutations/README.md
+++ b/packages/mutations/README.md
@@ -60,6 +60,26 @@ Edits accumulate in the same overlay used by `setProperty` / `setAttribute`
 and materialise the next time you call
 `StepExporter.export({ applyMutations: true })`.
 
+### Whole numbers on REAL-typed attributes
+
+ISO 10303-21 requires a REAL-typed attribute (`IfcLengthMeasure` coordinates,
+profile dimensions, `IfcExtrudedAreaSolid.Depth`, …) to carry a decimal point —
+`450.`, never `450`. The exporter is schema-aware: when a slot's declared type
+is unambiguously REAL-backed, a whole-number value is serialized with the
+decimal point automatically, so the natural call just works:
+
+```typescript
+editor.setPositionalAttribute(profile.expressId, 3, 1);  // XDim → 1.  (dotted)
+```
+
+For the rare slot that a bare value genuinely can't disambiguate — a
+`SELECT(IfcInteger, IfcReal)` where you specifically want the REAL member — wrap
+the number in the write-only `{ real }` marker to force a REAL literal:
+
+```typescript
+editor.addEntity('IfcQuantityLength', ['L', null, unitRef, { real: 3 }]); // → IFCLENGTHMEASURE-safe 3.
+```
+
 ## Mutation history (for undo / export)
 
 ```typescript

--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -124,7 +124,7 @@ export {
 } from './generated/serializers.js';
 
 export * from './types.js';
-export { getAttributeNames, getAttributeNameAt, isKnownType, normalizeIfcTypeName } from './ifc-schema.js';
+export { getAttributeNames, getAttributeNamesAcrossSchemas, getAttributeNameAt, isKnownType, normalizeIfcTypeName } from './ifc-schema.js';
 
 import type { IfcEntity, ParseResult } from './types.js';
 import { EntityIndexBuilder } from './entity-index.js';

--- a/scripts/api-surface.json
+++ b/scripts/api-surface.json
@@ -3436,6 +3436,7 @@
     "getAllAttributesForEntity: function",
     "getAttributeNameAt: function",
     "getAttributeNames: function",
+    "getAttributeNamesAcrossSchemas: function",
     "getClassificationCodeForElement: function",
     "getClassificationPath: function",
     "getClassificationsForElement: function",


### PR DESCRIPTION
Closes #1839.

## Problem

A whole JS number reaching the STEP overlay writer — via `StoreEditor.setPositionalAttribute`, `addEntity` args, or the **in-store builders' own emitted geometry** — was serialized as a bare INTEGER literal (`450`, not `450.`). ISO 10303-21 requires REAL-typed attributes (`IfcLengthMeasure` coordinates, profile dimensions, `IfcExtrudedAreaSolid.Depth`, …) to carry a decimal point, so `python -m ifcopenshell.validate` rejects every such instance. Millimetre-unit models (where `toNativeLength` rounding lands on whole numbers) make this the common case — the issue reports 9 flagged instances on a single added column.

## Fix

Made the export serializer **schema-aware** at the file-format boundary. For every freshly-serialized attribute slot, the declared type is resolved from the schema registry (`getAttributeNames` × `getAttributeXsdTypes`, already in the tree for IDS validation) and a REAL literal is forced — recursively into coordinate lists — on slots that are **unambiguously** double-backed (`xs:double` and not also `xs:integer`).

- A slot that also admits `xs:integer` (a genuine `SELECT(IfcInteger, IfcReal)`) stays ambiguous and defers to the explicit `{ real }` marker.
- Integer-typed slots (`CountValue`, `NumberOfRisers`, …) are left as INTEGER literals.
- On positional edits, the current source token is a secondary signal: replacing a value that was already REAL (`0.4`, `1.5E-7`) keeps it REAL even for entities the XSD index doesn't cover, so a whole-number edit can't silently downgrade the slot.

All three reported vectors are fixed at one place with **no caller change** — the in-store builders route their `addEntity` geometry through the same new-entity serialization path. Untouched existing entities are still emitted byte-faithfully from source (roundtrip byte-identity preserved); only freshly-created and explicitly-mutated slots are re-serialized.

## Verification

- End-to-end repro from the issue (IfcCreator → parse → `setPositionalAttribute(profId, 3, 1)` → export): the edited slot now emits `#35=IFCRECTANGLEPROFILEDEF(.AREA.,$,#34,1.,0.4);`, and a whole-model geometry scan finds **0** bare-integer coordinate/length instances.
- New regression tests cover: integral positional edit of a REAL slot → `1.`; overlay-created geometry with whole-number lengths → `400.` / `3000.`; and the guard that integer-typed slots stay INTEGER.
- Three existing `step-exporter` assertions that encoded the old buggy output (`((1,2,3))`, `((0,0,1))`) are corrected to the conforming REAL form.
- `@ifc-lite/export` (233), `@ifc-lite/mutations` (73), `@ifc-lite/create` (97), `@ifc-lite/sdk` (51) suites green.

The follow-up comment's broader ask — schema-aware type-qualification of **SELECT members** (`IFCBOOLEAN(.T.)`) and the whole `IfcValue` family — is a separate, larger class that needs richer schema metadata than the current XSD table carries; this PR closes the titled integer→REAL bug and leaves that as a tracked follow-up.

## Docs

`@ifc-lite/mutations` README now notes that whole numbers on REAL slots dot automatically, with `{ real }` as the escape hatch for ambiguous selects.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed STEP export formatting for REAL-typed IFC positional attributes so whole-number values now include a trailing decimal (e.g., `450.`) instead of exporting as integers.
  - Ensured consistent behavior for edited, newly created, and geometry-generated attributes, while keeping true integer-typed slots unchanged.
  - Preserved existing handling for ambiguous numeric `SELECT` cases.
- **Documentation**
  - Added release guidance on how REAL literals are serialized and when explicit forcing is required.
- **New Features**
  - Exposed `getAttributeNamesAcrossSchemas` from the parser API for cross-schema positional name resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->