### PR TITLE
perf(viewer): lazy-load the /mcp routes so three.js leaves the / critical path

### DIFF
--- a/apps/viewer/src/App.tsx
+++ b/apps/viewer/src/App.tsx
@@ -13,13 +13,33 @@
  */
 
 import { ViewerLayout } from './components/viewer/ViewerLayout';
-import { McpLanding } from './components/mcp/McpLanding';
-import { McpPlayground } from './components/mcp/McpPlayground';
 import { BimProvider } from './sdk/BimProvider';
 import { ExtensionHostProvider } from './sdk/ExtensionHostProvider';
 import { Toaster } from './components/ui/toast';
-import { useEffect, useState } from 'react';
+import { Suspense, lazy, useEffect, useState } from 'react';
 import { Analytics } from '@vercel/analytics/react';
+
+// The /mcp marketing surface pulls in three.js (HeroScene / PlaygroundViewer)
+// and its own component tree — none of which the main `/` viewer route needs.
+// Statically importing McpLanding/McpPlayground dragged all of it into the
+// entry's static import graph, so `/` preloaded three.js (~140 KB br) and the
+// marketing chunks on every first paint. Loading these two roots lazily moves
+// three.js + the marketing code into their own async chunks, off the `/`
+// critical path. ViewerLayout stays static — it IS the `/` route, so keeping it
+// eager avoids an extra round-trip for the overwhelmingly common case.
+const McpLanding = lazy(() =>
+  import('./components/mcp/McpLanding').then((m) => ({ default: m.McpLanding })),
+);
+const McpPlayground = lazy(() =>
+  import('./components/mcp/McpPlayground').then((m) => ({ default: m.McpPlayground })),
+);
+
+// Neutral full-viewport placeholder while a lazy MCP route chunk loads. Both
+// /mcp routes render on a near-black stage (McpLanding's `NIGHT` = #0a0a0c), so
+// matching it here means the async chunk resolves with no color flash.
+function RouteFallback() {
+  return <div style={{ minHeight: '100vh', background: '#0a0a0c' }} />;
+}
 
 export function App() {
   const [pathname, setPathname] = useState(() => window.location.pathname);
@@ -45,7 +65,9 @@ export function App() {
   if (normalizedPath === '/mcp/playground') {
     return (
       <>
-        <McpPlayground />
+        <Suspense fallback={<RouteFallback />}>
+          <McpPlayground />
+        </Suspense>
         <Toaster />
         <Analytics />
       </>
@@ -54,7 +76,9 @@ export function App() {
   if (normalizedPath === '/mcp' || normalizedPath.startsWith('/mcp/')) {
     return (
       <>
-        <McpLanding />
+        <Suspense fallback={<RouteFallback />}>
+          <McpLanding />
+        </Suspense>
         <Toaster />
         <Analytics />
       </>


### PR DESCRIPTION
## What & why

The main viewer route (`/`) was shipping the entire `/mcp` marketing surface — including **three.js** — on first paint.

`App.tsx` statically imported both `/mcp` route roots (`McpLanding`, `McpPlayground`). Those pull in `HeroScene` / `PlaygroundViewer`, which are the *only* importers of `three` in the app. Static imports land in the entry's static import graph, so Vite `modulepreload`ed three.js (~140 KB br) plus the marketing chunks on every load of `/` — code that route never renders. (`manualChunks` split them into named files but doesn't defer loading; only a dynamic import does.)

## Change

Load the two MCP roots via `React.lazy` + `Suspense`. `ViewerLayout` stays a static import — it *is* the `/` route, so keeping it eager avoids an extra round-trip for the overwhelmingly common case. Because `three` is reachable only through the MCP components, this moves it (and the marketing tree) entirely off `/`.

One file, ~30 lines.

## Measured impact

Production build, brotli `-q 11` (the wire size Vercel's edge targets), first-paint set = entry `<script>` + all `modulepreload`:

| | raw | delivered (br q11) |
|---|---|---|
| before | 19,987,022 | 2,037,690 |
| after | 18,579,018 | 1,840,316 |
| **delta** | **−1.41 MB** | **−197 KB (−9.7%)** |

On a ~4 Mbit connection that's ~0.4s less on every cold first paint of the viewer.

## Adversarial verification

Headless Playwright over the built `dist` (per-route network capture + pageerror listener):

| route | mounts | fetches `three`? | fetches mcp chunks? | page errors |
|---|---|---|---|---|
| `/` | ✅ | **no** | **no** | none |
| `/mcp` | ✅ | yes (lazy) | yes (lazy) | none |
| `/mcp/playground` | ✅ | yes (lazy) | yes (lazy) | none |

So `/` genuinely stops paying for three.js, and both MCP routes still load and render their chunks on demand. Also confirmed at the chunk-graph level: `three` has no static import in the entry, appears only in Vite's `__vite__mapDeps`, and is absent from the `modulepreload` set.

`tsc --noEmit` clean; viewer unit suite green (1763 pass / 0 fail / 2 skip).

## Scope / follow-up

This is the clean, isolated slice. A separate pass can defer the remaining eager feature chunks — the biggest is `exporters` (~282 KB br), then `sandbox`, `bcf`, `ids`, `drawing-2d`, and the DuckDB `query` wrapper. Those are woven through the SDK backend and shared hooks (not single dialog boundaries), so each needs its own careful, click-tested change rather than being bundled in here. Separately: Vercel's edge compresses static assets at ~brotli q3 vs the q11 those `delivered` numbers assume — a platform constraint (no static override), tracked independently.
