### PR TITLE
feat(export): type-qualify SELECT and IfcValue STEP attributes (#1839 follow-up)

### DIFF
--- a/.changeset/select-typed-attr-qualification.md
+++ b/.changeset/select-typed-attr-qualification.md
@@ -1,0 +1,16 @@
+---
+"@ifc-lite/export": patch
+"@ifc-lite/mutations": patch
+"@ifc-lite/data": patch
+---
+
+Type-qualify SELECT-typed and IfcValue-family STEP attributes on export. A
+defined-type SELECT member (a boolean in an `IfcTranslationalStiffnessSelect`
+slot, a length in `IfcSizeSelect`) now serializes as the ISO 10303-21 required
+`IFCBOOLEAN(.T.)` / `IFCLENGTHMEASURE(3.)` rather than a bare `.T.` / `3` that
+strict validators reject and that loses the member type on round-trip. The
+exporter auto-qualifies unambiguous slots from the schema registry with no
+caller change; a new write-only `{ typed: { type, value } }` marker on
+`IfcAttributeValue` pins the type for ambiguous selects and the `IfcValue`
+family (`NominalValue`, quantity values) and subsumes `{ real }`. Completes the
+`setPositionalAttribute` / `addEntity` follow-up to #1839.

--- a/packages/data/src/types.ts
+++ b/packages/data/src/types.ts
@@ -565,11 +565,22 @@ export function IfcTypeEnumToString(type: IfcTypeEnum): string {
 /**
  * IFC STEP attribute value as extracted from a STEP argument list.
  *
- * The `{ real: number }` variant is a WRITE-ONLY marker (never produced by
- * extraction): entity-authoring code wraps a coordinate in it to force STEP
- * REAL serialization with a decimal point for whole numbers (`5.` not `5`),
- * which typed measures like `IfcLengthMeasure` require. Plain `number` keeps
- * the historical integer-when-whole behavior.
+ * Two WRITE-ONLY markers (never produced by extraction) let authoring code
+ * pin the exact STEP token for a value whose type a bare JS primitive cannot
+ * convey:
+ *
+ * - `{ real: number }` forces a STEP REAL literal with a decimal point for
+ *   whole numbers (`5.` not `5`), which typed measures like `IfcLengthMeasure`
+ *   require. Plain `number` keeps the historical integer-when-whole behavior.
+ *
+ * - `{ typed: { type, value } }` forces a type-QUALIFIED value
+ *   `IFC<TYPE>(<value>)` — required for a SELECT member that is a defined type
+ *   (`IFCBOOLEAN(.T.)` in an `IfcTranslationalStiffnessSelect` slot) and for the
+ *   `IfcValue` family (`IFCLABEL('x')`, `IFCLENGTHMEASURE(3.)`). `type` is the
+ *   IFC type name (`'IfcBoolean'`, `'IfcLengthMeasure'`). It generalizes
+ *   `{ real }` (`{ typed: { type: 'IfcReal', value: 450 } }`). The exporter also
+ *   auto-qualifies unambiguous SELECT slots without a marker; this is the escape
+ *   hatch for the ambiguous ones (a select with several REAL-backed members).
  */
 export type IfcAttributeValue =
   | string
@@ -577,6 +588,7 @@ export type IfcAttributeValue =
   | boolean
   | null
   | { real: number }
+  | { typed: { type: string; value: string | number | boolean } }
   | IfcAttributeValue[];
 
 export interface IfcEntity {

--- a/packages/export/src/attribute-real-slots.ts
+++ b/packages/export/src/attribute-real-slots.ts
@@ -25,6 +25,41 @@ import { getAttributeNamesAcrossSchemas } from '@ifc-lite/parser';
 import { getAttributeXsdTypes, type IfcSchemaVersion as DataSchemaVersion } from '@ifc-lite/data';
 import type { IfcSchemaVersion } from './schema-converter.js';
 import { serializeStepValue } from './step-serialization.js';
+import { serializeQualifiedSelectSlot } from './select-qualification.js';
+
+/**
+ * True for the write-only `{ real }` / `{ typed }` markers — an explicit caller
+ * intent that `serializeStepValue` handles directly and that must bypass the
+ * schema-driven SELECT/REAL inference below.
+ */
+export function isTypedMarker(value: IfcAttributeValue): boolean {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    !Array.isArray(value) &&
+    ('real' in value || 'typed' in value)
+  );
+}
+
+/**
+ * Serialize one positional attribute slot to its STEP token, composing the
+ * schema-aware passes in priority order:
+ *   1. an explicit `{ real }` / `{ typed }` marker wins outright;
+ *   2. a SELECT slot auto-qualifies an unambiguous bare value (`IFCBOOLEAN(.T.)`);
+ *   3. otherwise a REAL-backed slot forces a decimal point (#1839);
+ *   4. otherwise the default value serialization.
+ */
+export function serializeAttributeSlot(
+  entityType: string,
+  index: number,
+  value: IfcAttributeValue,
+  version: IfcSchemaVersion,
+): string {
+  if (isTypedMarker(value)) return serializeStepValue(value);
+  const qualified = serializeQualifiedSelectSlot(entityType, index, value);
+  if (qualified !== null) return qualified;
+  return serializeStepValue(value, getRealTypedSlots(entityType, version).has(index));
+}
 
 /**
  * Map the exporter's schema tag to the version the attribute XSD index is keyed
@@ -86,15 +121,14 @@ export function getRealTypedSlots(entityType: string, version: IfcSchemaVersion)
 
 /**
  * Serialize a full positional attribute list for an entity to a STEP body,
- * forcing a REAL literal (decimal point) on every unambiguously double-backed
- * slot. Used for freshly-emitted overlay entities (`addEntity`, the in-store
- * builders) whose numbers never pass through a source token.
+ * schema-aware per slot (SELECT qualification + REAL forcing). Used for
+ * freshly-emitted overlay entities (`addEntity`, the in-store builders) whose
+ * numbers never pass through a source token.
  */
 export function serializeEntityArgs(
   entityType: string,
   values: readonly IfcAttributeValue[],
   version: IfcSchemaVersion,
 ): string {
-  const realSlots = getRealTypedSlots(entityType, version);
-  return values.map((value, i) => serializeStepValue(value, realSlots.has(i))).join(',');
+  return values.map((value, i) => serializeAttributeSlot(entityType, i, value, version)).join(',');
 }

--- a/packages/export/src/select-qualification.ts
+++ b/packages/export/src/select-qualification.ts
@@ -1,0 +1,153 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Schema-driven auto-qualification of SELECT-typed STEP attribute slots.
+ *
+ * ISO 10303-21 requires a SELECT member that is a defined type (not an entity
+ * instance) to be TYPE-QUALIFIED: a boolean in an `IfcTranslationalStiffnessSelect`
+ * slot must serialize as `IFCBOOLEAN(.T.)`, not a bare `.T.`; a length in an
+ * `IfcSizeSelect` slot as `IFCLENGTHMEASURE(3.)`. A bare token is non-conformant
+ * — strict validators reject it and even ifc-lite's own reader loses the member
+ * type on round-trip. See the follow-up on LTplus-AG/ifc-lite#1839.
+ *
+ * The declared type of each slot is statically known from the schema registry.
+ * When a bare JS value maps UNAMBIGUOUSLY to exactly one defined-type member of
+ * the slot's SELECT (a boolean → the sole BOOLEAN member; a number → the sole
+ * REAL member), we emit the qualified token automatically — no caller change.
+ * A genuinely ambiguous slot (a number in `IfcValue`, which has 100+ REAL
+ * members) is left for the caller's explicit `{ typed }` marker to resolve.
+ *
+ * Registry coverage is IFC4 (`SCHEMA_REGISTRY` is the parser's IFC4 pin); SELECT
+ * definitions are highly stable across schema versions, and the `{ typed }`
+ * marker is the version-independent escape hatch, so this is best-effort: an
+ * entity the registry doesn't know simply isn't auto-qualified.
+ */
+
+import { SCHEMA_REGISTRY, getAllAttributesForEntity } from '@ifc-lite/parser';
+import type { IfcAttributeValue } from '@ifc-lite/parser';
+import { resolveExpressBase, serializeTypedMarker } from './step-serialization.js';
+
+function isSelectType(type: string): boolean {
+  return Object.prototype.hasOwnProperty.call(SCHEMA_REGISTRY.selects, type);
+}
+
+function isDefinedType(type: string): boolean {
+  return Object.prototype.hasOwnProperty.call(SCHEMA_REGISTRY.types, type);
+}
+
+// Memoized `selectName` → Map<memberTypeName, expressBase> over the select's
+// DEFINED-TYPE leaves (recursing nested selects; entity members are skipped —
+// they serialize as `#ref`, never qualified).
+const selectLeafCache = new Map<string, Map<string, string>>();
+
+function getSelectDefinedLeaves(selectName: string): Map<string, string> {
+  const cached = selectLeafCache.get(selectName);
+  if (cached) return cached;
+  const leaves = new Map<string, string>();
+  const seen = new Set<string>();
+  const walk = (sel: string): void => {
+    if (seen.has(sel)) return;
+    seen.add(sel);
+    for (const member of SCHEMA_REGISTRY.selects[sel] ?? []) {
+      if (isSelectType(member)) {
+        walk(member);
+      } else if (isDefinedType(member)) {
+        const base = resolveExpressBase(member);
+        if (base) leaves.set(member, base);
+      }
+      // else: an entity member — not qualifiable, ignore.
+    }
+  };
+  walk(selectName);
+  selectLeafCache.set(selectName, leaves);
+  return leaves;
+}
+
+// Memoized `ENTITY` → Map<slotIndex, selectName> for scalar (non-aggregate)
+// slots whose declared type is a SELECT.
+const selectSlotCache = new Map<string, Map<number, string>>();
+
+function getSelectSlots(entityType: string): Map<number, string> {
+  const key = entityType.toUpperCase();
+  const cached = selectSlotCache.get(key);
+  if (cached) return cached;
+  const slots = new Map<number, string>();
+  const attrs = getAllAttributesForEntity(entityType);
+  attrs.forEach((attr, i) => {
+    // Only scalar SELECT slots — an aggregate of a select carries a list value
+    // and is left to the default serializer.
+    if (!attr.isArray && !attr.isList && !attr.isSet && isSelectType(attr.type)) {
+      slots.set(i, attr.type);
+    }
+  });
+  selectSlotCache.set(key, slots);
+  return slots;
+}
+
+/**
+ * A value that could stand in for a defined-type SELECT member: a bare boolean,
+ * finite number, or plain string. Entity references (`#5`), null/derived
+ * markers (`$`/`*`), and enum tokens (`.X.`) are entity/other members and are
+ * never qualified.
+ */
+function isQualifiableScalar(value: IfcAttributeValue): value is boolean | number | string {
+  if (typeof value === 'boolean') return true;
+  if (typeof value === 'number') return Number.isFinite(value);
+  if (typeof value === 'string') {
+    const t = value.trim();
+    if (t === '$' || t === '*') return false;
+    if (/^#\d+$/.test(t)) return false;
+    if (/^\.[A-Za-z0-9_]+\.$/.test(t)) return false;
+    return true;
+  }
+  return false;
+}
+
+// Ordered EXPRESS-primitive preference for each JS value class. A boolean is an
+// IfcBoolean before an IfcLogical; a number is a REAL measure before an integer.
+function preferredBases(value: boolean | number | string): string[] {
+  if (typeof value === 'boolean') return ['BOOLEAN', 'LOGICAL'];
+  if (typeof value === 'number') return ['REAL', 'NUMBER', 'INTEGER'];
+  return ['STRING', 'BINARY'];
+}
+
+/**
+ * The single defined-type member of `selectName` that `value` unambiguously maps
+ * to (e.g. `IfcBoolean` for a boolean in `IfcTranslationalStiffnessSelect`), or
+ * `null` when zero or more-than-one members match — the ambiguous case the
+ * `{ typed }` marker exists for.
+ */
+function qualifyingMember(selectName: string, value: boolean | number | string): string | null {
+  const leaves = getSelectDefinedLeaves(selectName);
+  if (leaves.size === 0) return null;
+  for (const family of preferredBases(value)) {
+    const matches: string[] = [];
+    for (const [type, base] of leaves) {
+      if (base === family) matches.push(type);
+    }
+    if (matches.length === 1) return matches[0];
+    if (matches.length > 1) return null; // ambiguous within the preferred family
+  }
+  return null;
+}
+
+/**
+ * Emit the type-qualified STEP token for a SELECT slot when it can be resolved
+ * unambiguously from the schema, else `null` (the caller falls back to the
+ * default / REAL-forcing serializer). `entityType` may be PascalCase or the
+ * upper STEP form; `index` is the zero-based positional slot.
+ */
+export function serializeQualifiedSelectSlot(
+  entityType: string,
+  index: number,
+  value: IfcAttributeValue,
+): string | null {
+  const selectName = getSelectSlots(entityType).get(index);
+  if (selectName === undefined) return null;
+  if (!isQualifiableScalar(value)) return null;
+  const member = qualifyingMember(selectName, value);
+  if (member === null) return null;
+  return serializeTypedMarker(member, value);
+}

--- a/packages/export/src/step-exporter.test.ts
+++ b/packages/export/src/step-exporter.test.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import { describe, expect, it } from 'vitest';
-import { IfcParser, type IfcDataStore } from '@ifc-lite/parser';
+import { IfcParser, EntityExtractor, type IfcDataStore } from '@ifc-lite/parser';
 import type { MutablePropertyView, Mutation } from '@ifc-lite/mutations';
 import { PropertyValueType } from '@ifc-lite/data';
 import { isValidIfcGuid } from '@ifc-lite/encoding';
@@ -547,6 +547,77 @@ describe('StepExporter', () => {
 
     expect(content).toContain("#2=IFCQUANTITYCOUNT('n',$,$,5,$);");
     expect(content).not.toContain('5.');
+  });
+
+  // #1839 follow-up: SELECT-typed slots must type-qualify a defined-type member.
+  // IfcBoundaryNodeCondition.TranslationalStiffnessX : SELECT(IfcBoolean,
+  // IfcLinearStiffnessMeasure). A bare `.T.` is non-conformant (strict validators
+  // reject it; ifc-lite's own reader loses the member type).
+  it('auto-qualifies a boolean written into a SELECT slot (positional edit)', () => {
+    const dataStore = buildMockDataStore([
+      [1, 'IFCBOUNDARYNODECONDITION', "#1=IFCBOUNDARYNODECONDITION('bc',IFCLINEARSTIFFNESSMEASURE(1000.),$,$,$,$,$);"],
+    ]);
+    const view = new LiveMutablePropertyView(null, 'm1');
+    view.setPositionalAttribute(1, 1, true); // TranslationalStiffnessX := true
+
+    const content = decode(new StepExporter(dataStore, view).export({ schema: 'IFC4', applyMutations: true }).content);
+    expect(content).toContain("#1=IFCBOUNDARYNODECONDITION('bc',IFCBOOLEAN(.T.),$,$,$,$,$);");
+    expect(content).not.toMatch(/,\.T\.,/); // never a bare .T. in the slot
+  });
+
+  it('auto-qualifies boolean and number SELECT members on overlay-created entities', () => {
+    const dataStore = buildMockDataStore([
+      [1, 'IFCCARTESIANPOINT', '#1=IFCCARTESIANPOINT((0.,0.,0.));'],
+    ]);
+    const view = new LiveMutablePropertyView(null, 'm1');
+    view.setExpressIdWatermark(1);
+    // Name, TranslationalStiffnessX(bool), TranslationalStiffnessY(number), Z, Rot X/Y/Z
+    view.createEntity('IFCBOUNDARYNODECONDITION', ['bc', true, 2000, null, null, null, null]);
+
+    const content = decode(new StepExporter(dataStore, view).export({ schema: 'IFC4', applyMutations: true }).content);
+    // boolean -> IFCBOOLEAN(.T.); number -> the sole REAL member IfcLinearStiffnessMeasure
+    expect(content).toContain("#2=IFCBOUNDARYNODECONDITION('bc',IFCBOOLEAN(.T.),IFCLINEARSTIFFNESSMEASURE(2000.),$,$,$,$);");
+  });
+
+  // The emitted qualified token round-trips: ifc-lite's parser reads it back with
+  // the member type preserved (a bare `.T.` would parse as the untyped string).
+  it('emits SELECT qualification that the parser reads back with its type', () => {
+    const dataStore = buildMockDataStore([
+      [1, 'IFCBOUNDARYNODECONDITION', "#1=IFCBOUNDARYNODECONDITION('bc',$,$,$,$,$,$);"],
+    ]);
+    const view = new LiveMutablePropertyView(null, 'm1');
+    view.setPositionalAttribute(1, 1, true);
+    const content = decode(new StepExporter(dataStore, view).export({ schema: 'IFC4', applyMutations: true }).content);
+    const line = content.split(/\r?\n/).find(l => l.includes('IFCBOUNDARYNODECONDITION'))!;
+
+    const bytes = new TextEncoder().encode(line);
+    const extractor = new EntityExtractor(bytes);
+    const entity = extractor.extractEntity({
+      expressId: 1, type: 'IFCBOUNDARYNODECONDITION', byteOffset: 0, byteLength: bytes.length, lineNumber: 0,
+    })!;
+    // Typed value round-trips as [typeName, innerValue] — the member type survives.
+    expect(entity.attributes[1]).toEqual(['IFCBOOLEAN', '.T.']);
+  });
+
+  // The { typed } marker is the escape hatch for ambiguous SELECTs / the IfcValue
+  // family, where a bare value can't disambiguate the member. NominalValue is
+  // IfcValue (100+ REAL members) so a number does NOT auto-qualify.
+  it('honours the { typed } marker and leaves ambiguous selects to it', () => {
+    const dataStore = buildMockDataStore([
+      [1, 'IFCCARTESIANPOINT', '#1=IFCCARTESIANPOINT((0.,0.,0.));'],
+    ]);
+    const view = new LiveMutablePropertyView(null, 'm1');
+    view.setExpressIdWatermark(1);
+    // Name(IfcIdentifier), Description, NominalValue(IfcValue, ambiguous), Unit
+    view.createEntity('IFCPROPERTYSINGLEVALUE', [
+      'P', null, { typed: { type: 'IfcLengthMeasure', value: 3 } }, null,
+    ]);
+    // A bare number in the same ambiguous slot stays bare (needs the marker).
+    view.createEntity('IFCPROPERTYSINGLEVALUE', ['Q', null, 5, null]);
+
+    const content = decode(new StepExporter(dataStore, view).export({ schema: 'IFC4', applyMutations: true }).content);
+    expect(content).toContain("#2=IFCPROPERTYSINGLEVALUE('P',$,IFCLENGTHMEASURE(3.),$);");
+    expect(content).toContain("#3=IFCPROPERTYSINGLEVALUE('Q',$,5,$);");
   });
 
   // Regression: the deltaOnly early-return previously fired before the

--- a/packages/export/src/step-exporter.ts
+++ b/packages/export/src/step-exporter.ts
@@ -40,7 +40,8 @@ import {
   splitTopLevelStepArguments,
   assembleStepBytes,
 } from './step-serialization.js';
-import { getRealTypedSlots, serializeEntityArgs } from './attribute-real-slots.js';
+import { getRealTypedSlots, serializeEntityArgs, serializeAttributeSlot, isTypedMarker } from './attribute-real-slots.js';
+import { serializeQualifiedSelectSlot } from './select-qualification.js';
 
 /**
  * Options for STEP export
@@ -753,9 +754,8 @@ export class StepExporter {
         if (typeMut) {
           // Serialize against the AUTHORED layout (`entity.type`); retypeArgTokens
           // then re-lays the tokens out by name up to the effective class.
-          const authoredRealSlots = getRealTypedSlots(entity.type, sourceSchema);
           const srcTokens = entity.attributes.map(
-            (value, i) => serializeStepValue(value, authoredRealSlots.has(i)),
+            (value, i) => serializeAttributeSlot(entity.type, i, value, sourceSchema),
           );
           const { tokens } = retypeArgTokens(
             srcTokens,
@@ -1053,16 +1053,34 @@ export class StepExporter {
     let changed = false;
     for (const [index, value] of positionals) {
       if (index < 0 || index >= args.length) continue;
-      // Force a REAL literal when the slot's declared type is REAL-backed. The
-      // current token is a secondary signal: editing a value that was already a
-      // REAL (`0.4`, `1.5E-7`) keeps it REAL even for entities the XSD index
-      // doesn't cover, so a whole-number edit can't silently downgrade the slot.
-      const forceReal = realSlots.has(index) || tokenIsRealLiteral(args[index]);
-      args[index] = serializeStepValue(value, forceReal);
+      args[index] = this.serializePositionalOverride(entityType, index, value, args[index], realSlots, schemaVersion);
       changed = true;
     }
     if (!changed) return entityText;
     return `${entityText.slice(0, openParen + 1)}${args.join(',')}${entityText.slice(closeParen)}`;
+  }
+
+  /**
+   * Serialize one positional override, composing the schema-aware passes:
+   * explicit `{ real }`/`{ typed }` marker → SELECT auto-qualification
+   * (`IFCBOOLEAN(.T.)`) → REAL forcing. For REAL forcing the current source
+   * token is a secondary signal: replacing a value that was already a REAL
+   * (`0.4`, `1.5E-7`) keeps it REAL even for entities the XSD index doesn't
+   * cover, so a whole-number edit can't silently downgrade the slot.
+   */
+  private serializePositionalOverride(
+    entityType: string,
+    index: number,
+    value: IfcAttributeValue,
+    currentToken: string,
+    realSlots: ReadonlySet<number>,
+    schemaVersion: IfcSchemaVersion,
+  ): string {
+    if (isTypedMarker(value)) return serializeStepValue(value);
+    const qualified = serializeQualifiedSelectSlot(entityType, index, value);
+    if (qualified !== null) return qualified;
+    const forceReal = realSlots.has(index) || tokenIsRealLiteral(currentToken);
+    return serializeStepValue(value, forceReal);
   }
 
   private resolveMapUnitReference(unitName: string, newGeorefLines: string[]): number {

--- a/packages/export/src/step-serialization.test.ts
+++ b/packages/export/src/step-serialization.test.ts
@@ -48,6 +48,20 @@ describe('serializeTypedMarker', () => {
     expect(serializeStepValue({ typed: { type: 'IfcBoolean', value: true } })).toBe('IFCBOOLEAN(.T.)');
     expect(serializeStepValue({ typed: { type: 'IfcLengthMeasure', value: 3 } })).toBe('IFCLENGTHMEASURE(3.)');
   });
+
+  // The marker accepts `value: string`, so a caller may copy a STEP token or a
+  // word straight from the parser. Boolean/logical inner values must normalize
+  // rather than fall to JS truthiness (`'.F.'` is a truthy string).
+  it('normalizes string / numeric boolean and logical inner values', () => {
+    expect(serializeTypedMarker('IfcBoolean', '.F.')).toBe('IFCBOOLEAN(.F.)');
+    expect(serializeTypedMarker('IfcBoolean', 'false')).toBe('IFCBOOLEAN(.F.)');
+    expect(serializeTypedMarker('IfcBoolean', 0)).toBe('IFCBOOLEAN(.F.)');
+    expect(serializeTypedMarker('IfcBoolean', '.T.')).toBe('IFCBOOLEAN(.T.)');
+    expect(serializeTypedMarker('IfcLogical', '.T.')).toBe('IFCLOGICAL(.T.)');
+    expect(serializeTypedMarker('IfcLogical', '.F.')).toBe('IFCLOGICAL(.F.)');
+    expect(serializeTypedMarker('IfcLogical', '.U.')).toBe('IFCLOGICAL(.U.)');
+    expect(serializeTypedMarker('IfcLogical', 'UNKNOWN')).toBe('IFCLOGICAL(.U.)');
+  });
 });
 
 describe('tokenIsRealLiteral', () => {

--- a/packages/export/src/step-serialization.test.ts
+++ b/packages/export/src/step-serialization.test.ts
@@ -9,9 +9,46 @@ import {
   assembleStepBytes,
   serializePropertyValue,
   serializeAttributeValue,
+  serializeStepValue,
+  serializeTypedMarker,
+  resolveExpressBase,
   tokenIsRealLiteral,
   toStepReal,
 } from './step-serialization.js';
+
+describe('resolveExpressBase', () => {
+  it('resolves defined types to their EXPRESS primitive, following alias chains', () => {
+    expect(resolveExpressBase('IfcBoolean')).toBe('BOOLEAN');
+    expect(resolveExpressBase('IfcLogical')).toBe('LOGICAL');
+    expect(resolveExpressBase('IfcInteger')).toBe('INTEGER');
+    expect(resolveExpressBase('IfcLengthMeasure')).toBe('REAL');
+    // nested alias: IfcPositiveLengthMeasure -> IfcLengthMeasure -> REAL
+    expect(resolveExpressBase('IfcPositiveLengthMeasure')).toBe('REAL');
+    expect(resolveExpressBase('IfcLabel')).toBe('STRING');
+  });
+
+  it('returns null for unknown types and entity/select types', () => {
+    expect(resolveExpressBase('IfcWall')).toBeNull();
+    expect(resolveExpressBase('NotARealType')).toBeNull();
+  });
+});
+
+describe('serializeTypedMarker', () => {
+  it('emits a type-qualified token per the declared primitive', () => {
+    expect(serializeTypedMarker('IfcBoolean', true)).toBe('IFCBOOLEAN(.T.)');
+    expect(serializeTypedMarker('IfcBoolean', false)).toBe('IFCBOOLEAN(.F.)');
+    expect(serializeTypedMarker('IfcLengthMeasure', 3)).toBe('IFCLENGTHMEASURE(3.)');
+    expect(serializeTypedMarker('IfcInteger', 5)).toBe('IFCINTEGER(5)');
+    expect(serializeTypedMarker('IfcLabel', "O'Brien")).toBe("IFCLABEL('O''Brien')");
+    // subsumes { real }
+    expect(serializeTypedMarker('IfcReal', 450)).toBe('IFCREAL(450.)');
+  });
+
+  it('is reachable through the { typed } marker in serializeStepValue', () => {
+    expect(serializeStepValue({ typed: { type: 'IfcBoolean', value: true } })).toBe('IFCBOOLEAN(.T.)');
+    expect(serializeStepValue({ typed: { type: 'IfcLengthMeasure', value: 3 } })).toBe('IFCLENGTHMEASURE(3.)');
+  });
+});
 
 describe('tokenIsRealLiteral', () => {
   it('recognizes REAL literals with either sign', () => {

--- a/packages/export/src/step-serialization.ts
+++ b/packages/export/src/step-serialization.ts
@@ -9,8 +9,71 @@
  * and deal exclusively with converting data to ISO 10303-21 STEP format strings.
  */
 
-import { serializeValue, type IfcAttributeValue } from '@ifc-lite/parser';
+import { serializeValue, SCHEMA_REGISTRY, type IfcAttributeValue } from '@ifc-lite/parser';
 import { PropertyValueType, QuantityType, formatStepReal } from '@ifc-lite/data';
+
+/** EXPRESS base primitives a defined type ultimately resolves to. */
+const EXPRESS_PRIMITIVES = new Set(['BOOLEAN', 'LOGICAL', 'INTEGER', 'REAL', 'NUMBER', 'STRING', 'BINARY']);
+
+/**
+ * Resolve an IFC defined type (`IfcLengthMeasure`, `IfcPositiveLengthMeasure`,
+ * `IfcBoolean`, …) to its underlying EXPRESS primitive (`REAL`, `BOOLEAN`, …)
+ * by walking the schema registry's `types` alias chain. Returns `null` for a
+ * type the registry doesn't know or one that bottoms out in an entity/select.
+ */
+export function resolveExpressBase(typeName: string): string | null {
+  let cursor: string | undefined = typeName;
+  const seen = new Set<string>();
+  while (cursor && !seen.has(cursor)) {
+    seen.add(cursor);
+    const underlying: string | undefined = SCHEMA_REGISTRY.types[cursor];
+    if (!underlying) return null;
+    // Strip width qualifiers like `STRING(255)` before the primitive test.
+    const head = underlying.replace(/\(.*$/, '').trim().toUpperCase();
+    if (EXPRESS_PRIMITIVES.has(head)) return head;
+    cursor = underlying; // nested alias, e.g. IfcPositiveLengthMeasure -> IfcLengthMeasure
+  }
+  return null;
+}
+
+/**
+ * Serialize the inner value of a type-qualified token according to the resolved
+ * EXPRESS primitive of its declared type. REAL/NUMBER always carry a decimal
+ * point; BOOLEAN/LOGICAL emit `.T.`/`.F.`/`.U.`; STRING/BINARY are quoted.
+ * An unresolved base falls back to inferring from the JS value.
+ */
+function serializeInnerByBase(value: string | number | boolean, base: string | null): string {
+  switch (base) {
+    case 'REAL':
+    case 'NUMBER':
+      return toStepReal(Number(value));
+    case 'INTEGER':
+      return String(Math.trunc(Number(value)));
+    case 'BOOLEAN':
+      return value ? '.T.' : '.F.';
+    case 'LOGICAL':
+      return value === true ? '.T.' : value === false ? '.F.' : '.U.';
+    case 'STRING':
+    case 'BINARY':
+      return `'${escapeStepString(String(value))}'`;
+    default:
+      if (typeof value === 'boolean') return value ? '.T.' : '.F.';
+      if (typeof value === 'number') return Number.isInteger(value) ? String(value) : toStepReal(value);
+      return `'${escapeStepString(String(value))}'`;
+  }
+}
+
+/**
+ * Serialize a type-qualified STEP value `IFC<TYPE>(<inner>)` — the form a SELECT
+ * member that is a defined type requires (`IFCBOOLEAN(.T.)`,
+ * `IFCLENGTHMEASURE(3.)`). `type` is the IFC type name (`'IfcBoolean'`); the
+ * inner value is serialized to match that type's underlying primitive.
+ */
+export function serializeTypedMarker(type: string, value: string | number | boolean): string {
+  let token = type.toUpperCase();
+  if (!token.startsWith('IFC')) token = `IFC${token}`;
+  return `${token}(${serializeInnerByBase(value, resolveExpressBase(type))})`;
+}
 
 /**
  * Escape a string for STEP format (backslash and single-quote escaping).
@@ -191,6 +254,11 @@ export function serializeStepValue(value: IfcAttributeValue, forceReal = false):
     // Write-only typed-real marker (see `IfcAttributeValue`): always a REAL
     // literal with a decimal point, even for whole numbers.
     return toStepReal(value.real);
+  }
+  if (typeof value === 'object' && 'typed' in value) {
+    // Write-only typed-value marker (see `IfcAttributeValue`): a type-qualified
+    // token `IFC<TYPE>(<value>)` for SELECT members / the IfcValue family.
+    return serializeTypedMarker(value.typed.type, value.typed.value);
   }
   const trimmed = String(value).trim();
   if (trimmed === '$' || trimmed === '*') return trimmed;

--- a/packages/export/src/step-serialization.ts
+++ b/packages/export/src/step-serialization.ts
@@ -37,6 +37,23 @@ export function resolveExpressBase(typeName: string): string | null {
 }
 
 /**
+ * Interpret a `{ typed }` marker's boolean/logical inner value. The marker
+ * accepts `string | number | boolean`, so a caller may copy a value straight
+ * from the parser as a STEP token string (`'.T.'`/`'.F.'`/`'.U.'`) or a word
+ * (`'true'`). A plain JS truthiness test would corrupt these — `'.F.'` is a
+ * truthy string — so normalize to a tri-state: `true` / `false` / `null`
+ * (unknown, valid only for LOGICAL).
+ */
+function coerceLogical(value: string | number | boolean): boolean | null {
+  if (typeof value === 'boolean') return value;
+  if (typeof value === 'number') return value !== 0;
+  const t = value.trim().toUpperCase();
+  if (t === 'TRUE' || t === '.T.' || t === 'T' || t === '1') return true;
+  if (t === 'FALSE' || t === '.F.' || t === 'F' || t === '0') return false;
+  return null;
+}
+
+/**
  * Serialize the inner value of a type-qualified token according to the resolved
  * EXPRESS primitive of its declared type. REAL/NUMBER always carry a decimal
  * point; BOOLEAN/LOGICAL emit `.T.`/`.F.`/`.U.`; STRING/BINARY are quoted.
@@ -50,9 +67,12 @@ function serializeInnerByBase(value: string | number | boolean, base: string | n
     case 'INTEGER':
       return String(Math.trunc(Number(value)));
     case 'BOOLEAN':
-      return value ? '.T.' : '.F.';
-    case 'LOGICAL':
-      return value === true ? '.T.' : value === false ? '.F.' : '.U.';
+      // A BOOLEAN has no unknown state; an unrecognized token coerces to `.F.`.
+      return coerceLogical(value) === true ? '.T.' : '.F.';
+    case 'LOGICAL': {
+      const logical = coerceLogical(value);
+      return logical === true ? '.T.' : logical === false ? '.F.' : '.U.';
+    }
     case 'STRING':
     case 'BINARY':
       return `'${escapeStepString(String(value))}'`;

--- a/packages/mutations/README.md
+++ b/packages/mutations/README.md
@@ -80,6 +80,32 @@ the number in the write-only `{ real }` marker to force a REAL literal:
 editor.addEntity('IfcQuantityLength', ['L', null, unitRef, { real: 3 }]); // → IFCLENGTHMEASURE-safe 3.
 ```
 
+### Type-qualified values on SELECT attributes
+
+ISO 10303-21 requires a SELECT member that is a defined type to be
+type-QUALIFIED — `IFCBOOLEAN(.T.)`, not a bare `.T.`, in an
+`IfcTranslationalStiffnessSelect` slot. The exporter auto-qualifies these when
+the member is unambiguous, so the natural call just works:
+
+```typescript
+// TranslationalStiffnessX : SELECT(IfcBoolean, IfcLinearStiffnessMeasure)
+editor.setPositionalAttribute(condition.expressId, 1, true);  // → IFCBOOLEAN(.T.)
+editor.setPositionalAttribute(condition.expressId, 1, 1000);  // → IFCLINEARSTIFFNESSMEASURE(1000.)
+```
+
+When the SELECT has several members of the same primitive class (a number in
+`IfcValue`, which has 100+ REAL-backed members) auto-qualification can't choose.
+Use the write-only `{ typed: { type, value } }` marker to pin the exact type —
+it also works for the whole `IfcValue` family (`NominalValue`, etc.) and
+subsumes `{ real }`:
+
+```typescript
+// IfcPropertySingleValue: Name, Description, NominalValue (IfcValue), Unit
+editor.addEntity('IfcPropertySingleValue', [
+  'Length', null, { typed: { type: 'IfcLengthMeasure', value: 3 } }, null,
+]); // NominalValue → IFCLENGTHMEASURE(3.)
+```
+
 ## Mutation history (for undo / export)
 
 ```typescript

--- a/packages/mutations/src/types.ts
+++ b/packages/mutations/src/types.ts
@@ -14,10 +14,13 @@ import type { PropertyValueType } from '@ifc-lite/data';
  * Mirrors the parser's `IfcAttributeValue` to keep `@ifc-lite/mutations` free
  * of a `@ifc-lite/parser` dependency (parser → ifcx → mutations would cycle).
  *
- * The extra `{ real: number }` variant is a WRITE-ONLY marker (never produced
- * by extraction): it forces STEP REAL serialization with a decimal point for
- * whole numbers (`5.` not `5`), which typed measures like `IfcLengthMeasure`
- * require. Plain `number` keeps the historical integer-when-whole behavior.
+ * The extra `{ real: number }` and `{ typed: { type, value } }` variants are
+ * WRITE-ONLY markers (never produced by extraction). `{ real }` forces STEP
+ * REAL serialization with a decimal point for whole numbers (`5.` not `5`).
+ * `{ typed }` forces a type-qualified value `IFC<TYPE>(<value>)` for a SELECT
+ * member that is a defined type (`IFCBOOLEAN(.T.)`) or the `IfcValue` family;
+ * it generalizes `{ real }`. See `@ifc-lite/data`'s `IfcAttributeValue` for the
+ * full contract (kept in sync here to avoid a package cycle).
  */
 export type IfcAttributeValue =
   | string
@@ -25,6 +28,7 @@ export type IfcAttributeValue =
   | boolean
   | null
   | { real: number }
+  | { typed: { type: string; value: string | number | boolean } }
   | IfcAttributeValue[];
 
 /**

--- a/packages/mutations/src/types.ts
+++ b/packages/mutations/src/types.ts
@@ -6,7 +6,7 @@
  * Types for IFC mutation tracking
  */
 
-import type { PropertyValueType } from '@ifc-lite/data';
+import type { PropertyValueType, IfcAttributeValue as CanonicalIfcAttributeValue } from '@ifc-lite/data';
 
 /**
  * IFC STEP attribute value, as produced by `EntityExtractor.extractEntity()`.
@@ -30,6 +30,19 @@ export type IfcAttributeValue =
   | { real: number }
   | { typed: { type: string; value: string | number | boolean } }
   | IfcAttributeValue[];
+
+/**
+ * Compile-time drift guard (no runtime footprint): this mirror MUST stay
+ * structurally identical to the canonical `@ifc-lite/data` `IfcAttributeValue`
+ * — the two are hand-duplicated only to keep the documented parser-cycle
+ * boundary. If they diverge, `MutuallyAssignable` resolves to `false`, which
+ * violates `AssertTrue`'s `extends true` constraint and fails the build.
+ */
+type MutuallyAssignable<A, B> = [A] extends [B] ? ([B] extends [A] ? true : false) : false;
+type AssertTrue<T extends true> = T;
+type _IfcAttributeValueMirrorInSync = AssertTrue<
+  MutuallyAssignable<IfcAttributeValue, CanonicalIfcAttributeValue>
+>;
 
 /**
  * Property value types supported by mutations


### PR DESCRIPTION
Implements the full follow-up to #1839 (raised in that issue's comment): raw-attribute serialization was not schema-aware for **SELECT-typed** and **IfcValue-family** attributes.

## Problem

A SELECT member that is a defined type must be **type-qualified** per ISO 10303-21. Writing a boolean into a SELECT slot produced a bare token:

```js
// IfcBoundaryNodeCondition.TranslationalStiffnessX : SELECT(IfcBoolean, IfcLinearStiffnessMeasure)
editor.setPositionalAttribute(condId, 1, true)
// before:  #N=IFCBOUNDARYNODECONDITION($,.T.,...);   ← bare .T., non-conformant
```

Strict validators reject the bare `.T.`, and ifc-lite's own reader parses it as the untyped string `'.T.'` (losing the member type on round-trip). Same gap for the whole `IfcValue` family written as a raw attribute (`NominalValue`, quantity values), which need `IFCLABEL('…')` / `IFCBOOLEAN(.T.)` / `IFCLENGTHMEASURE(3.)`.

## Fix — two complementary mechanisms (mirrors the #1839 REAL-forcing pattern)

**1. Schema-driven auto-qualification** (`select-qualification.ts`). For a scalar SELECT slot, resolve the declared type from `SCHEMA_REGISTRY` (already exported by `@ifc-lite/parser`), flatten the SELECT to its defined-type leaves, resolve each to its EXPRESS primitive, and when a bare JS value maps to **exactly one** member of the matching primitive class, emit the qualified token. Fixes the reported case with **no caller change**:

```js
setPositionalAttribute(condId, 1, true)  // → IFCBOOLEAN(.T.)
setPositionalAttribute(condId, 1, 1000)  // → IFCLINEARSTIFFNESSMEASURE(1000.)
```

Conservative by design — a genuinely ambiguous slot (a number in `IfcValue`, 100+ REAL-backed members) is left alone; entity-member selects (`IfcUnit` → `#ref`) and direct non-SELECT attributes (a plain `IfcBoolean` → bare `.T.`) are untouched.

**2. A generalized `{ typed: { type, value } }` marker** on `IfcAttributeValue` (mirrored in `@ifc-lite/mutations`) for the ambiguous residue and the `IfcValue` family; it subsumes `{ real }`:

```js
addEntity('IfcPropertySingleValue', ['L', null, { typed: { type: 'IfcLengthMeasure', value: 3 } }, null])
// NominalValue → IFCLENGTHMEASURE(3.)
```

Both compose with the #1839 REAL-forcing across new overlay entities, positional edits, and the retype path (priority: explicit marker → SELECT auto-qualification → REAL forcing → default).

## Verification

- New tests: `resolveExpressBase` / `serializeTypedMarker` units; exporter auto-qualification on positional edits and overlay-created entities; the `{ typed }` marker; ambiguous-select-left-bare; and a **parser round-trip** asserting the emitted `IFCBOOLEAN(.T.)` reads back as `['IFCBOOLEAN','.T.']` (member type preserved).
- Adversarially checked: entity-refs in SELECT slots stay `#ref`; direct non-SELECT booleans stay bare; `{ real }` still works.
- `@ifc-lite/export` (244), `@ifc-lite/mutations` (73), `@ifc-lite/create` (97), `@ifc-lite/sdk` (51) green. api-surface unchanged; no new knip findings; full 39-task build clean.

## Scope note

The property-set path drops `prop.dataType` on export (a round-tripped `IfcLengthMeasure` NominalValue re-emits as `IFCREAL`) — a **separate** lossy path with broad blast radius, deliberately left out of this PR. Registry coverage is IFC4 (the parser's pin); SELECT definitions are stable across versions and the `{ typed }` marker is the version-independent escape hatch, so non-IFC4 sources fall back gracefully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Exported STEP values now automatically include required type qualifiers for unambiguous SELECT attributes.
  * Added a write-only typed marker for explicitly selecting a member type in ambiguous cases.
  * Improved round-trip preservation of SELECT and IfcValue member types.

* **Documentation**
  * Added guidance for typed SELECT serialization and the new marker format.

* **Bug Fixes**
  * Corrected serialization of boolean, length, quantity, and nominal values for validator-compatible output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->