### PR TITLE
perf(parser): defer the parser worker's WASM compile when it will never run

### DIFF
--- a/.changeset/parser-defer-unused-wasm-compile.md
+++ b/.changeset/parser-defer-unused-wasm-compile.md
@@ -1,0 +1,13 @@
+---
+'@ifc-lite/parser': patch
+---
+
+Parser worker: skip the ~3.9 MB WASM scanner compile on the streaming cold-load
+path where it is never used. When the host promises an entity-index handoff
+(`waitForEntityIndex`, gated on files ≥2 MB), the geometry pre-pass builds the
+index and the entity scanner resolves from it, short-circuiting before the WASM
+scan ever runs — so eager-compiling the engine binary there only stole a core
+from the concurrent pre-pass. The compile is now deferred: eager on the
+no-handoff path, and lazy on the fallback branch if the promised index never
+arrives. Behaviour is unchanged (a new test pins that a pre-scanned index
+resolves with no `wasmApi`).

--- a/packages/parser/src/parser.worker.ts
+++ b/packages/parser/src/parser.worker.ts
@@ -223,12 +223,23 @@ self.onmessage = async (event: MessageEvent<ParserInbound>) => {
     // SAB views (e.g. Firefox's timing-attack mitigation) are filtered out
     // by the wrapper before this worker is even spawned.
     //
-    // Initialise the WASM scanner up front. `parseColumnar` prefers the
-    // WASM scan when `wasmApi` is supplied (5–10× faster on huge files —
-    // a 14 M-entity, 986 MB file goes from ~28 s of JS tokenising to ~5 s
-    // of Rust+SIMD). We start init BEFORE awaiting the entity index so the
-    // module compile happens in parallel with the host's pre-pass.
-    const wasmApiPromise = ensureWasmScanApi();
+    // Initialise the WASM scanner. `parseColumnar` prefers the WASM scan when
+    // `wasmApi` is supplied (5–10× faster on huge files — a 14 M-entity, 986 MB
+    // file goes from ~28 s of JS tokenising to ~5 s of Rust+SIMD).
+    //
+    // BUT only compile it when the WASM scan will actually RUN. When the host
+    // promised an entity-index handoff (`waitForEntityIndex`), the streaming
+    // pre-pass builds the index and hands it over, and the entity scanner
+    // short-circuits on `preScannedEntityIndex` WITHOUT ever calling the wasm
+    // scan (see entity-scanner.ts). Eager-compiling the ~3.9 MB engine binary
+    // here would then be pure waste — a multi-hundred-ms compile that steals a
+    // core from the concurrent geometry pre-pass on exactly the ≥2 MB cold
+    // loads this path serves (the host gates `waitForEntityIndex` on
+    // fileSizeMB >= 2). So defer the compile: eager only on the no-handoff
+    // path, lazy on the fallback branch below if the promised index never
+    // arrives. (#1185 shipped the parallel-compile; this trims the case where
+    // that compile is never consumed.)
+    let wasmApiPromise = waitForEntityIndex ? null : ensureWasmScanApi();
 
     // If the host promised to ship an entity index, hold here until it
     // arrives. The streaming geometry pre-pass already walked the file
@@ -242,11 +253,20 @@ self.onmessage = async (event: MessageEvent<ParserInbound>) => {
       // flag to paths that actually emit, so timeouts shouldn't fire
       // in practice.
       preScanned = await awaitEntityIndex(60_000);
+      if (!preScanned) {
+        // The promised index never came (pre-pass aborted / path mismatch):
+        // we now DO need the wasm scan, so compile it — serially here, which
+        // is acceptable on this rare fallback (it already logged a warning).
+        wasmApiPromise = ensureWasmScanApi();
+      }
     } else {
       preScanned = takeEntityIndex();
     }
 
-    const wasmApi = await wasmApiPromise;
+    // `undefined` when the handoff succeeded — parseColumnar then uses the
+    // pre-scanned index and never touches the (uncompiled) wasm scanner. If the
+    // index were somehow empty, the scanner falls through to the JS tokeniser.
+    const wasmApi = wasmApiPromise ? await wasmApiPromise : undefined;
     const parser = new IfcParser();
     // `source` is the SAB-backed payload — `parseColumnar` accepts
     // `ArrayBuffer | SharedArrayBuffer` so no cast is needed.

--- a/packages/parser/test/entity-scanner.test.ts
+++ b/packages/parser/test/entity-scanner.test.ts
@@ -137,6 +137,31 @@ describe('scanIfcEntities', () => {
       '7:IFCWALL',
     ]);
   });
+
+  // Guards parser.worker.ts's deferred-compile optimization: when a pre-scanned
+  // index is handed over, the worker skips compiling the ~3.9 MB WASM scanner
+  // entirely (no `wasmApi` supplied). The scan must still resolve from the index
+  // alone — otherwise deferring the compile would silently drop entities.
+  it('resolves from a pre-scanned index with NO wasmApi (deferred-compile path)', async () => {
+    const project = entitySpan(1);
+    const wall = entitySpan(7);
+
+    const result = await scanIfcEntities(encodeSource(), {
+      disableWorkerScan: true,
+      // wasmApi intentionally omitted — the worker never compiled it.
+      preScannedEntityIndex: {
+        ids: new Uint32Array([1, 7]),
+        starts: new Uint32Array([project.start, wall.start]),
+        lengths: new Uint32Array([project.length, wall.length]),
+      },
+    });
+
+    expect(result.scanPath).toBe('pre-scanned');
+    expect(result.entityRefs.map((ref) => `${ref.expressId}:${ref.type}`)).toEqual([
+      '1:IFCPROJECT',
+      '7:IFCWALL',
+    ]);
+  });
 });
 
 describe('IfcParser legacy ParseResult adapter', () => {


### PR DESCRIPTION
**The actual speedup** from the perf program (independent of the harness PRs #1845/#1849). A real cold-start win found by *verifying* — not trusting — the research's "compile-memo gap" framing.

## What the research claimed vs. what's actually true
The research said the parser worker "compiles the 3.9 MB binary outside the shared-module memo" and proposed sharing the compiled module. Tracing the code, the truth is sharper: **on the streaming cold-load path the parser worker compiles the 3.9 MB WASM scanner and then never uses it.**

- `useIfcLoader.ts:1028` sets `waitForEntityIndex` on **every file ≥2 MB** on the worker path.
- The parser worker (`parser.worker.ts:231`) eagerly started `ensureWasmScanApi()` (a 3.9 MB compile) in parallel with the pre-pass.
- But when the entity index is handed over, `entity-scanner.ts:57` populates `entityRefs` from `preScannedEntityIndex` and **short-circuits before the WASM scan at line 76** — the compile is pure waste, stealing a core from the concurrent geometry pre-pass.

So the fix isn't "share the module" — it's **skip the compile when it won't run**.

## The change
Defer the compile: eager only on the no-handoff path (where the WASM scan actually runs), lazy on the fallback branch if the promised index never arrives (rare — pre-pass aborted; the extra serial compile is negligible against the 60 s timeout that gates it). Non-worker and <2 MB paths unchanged.

## Verification
- **Correctness (done):** typecheck clean; full parser suite green (312). An existing test already pins that a pre-scanned index makes the WASM scan *throw if called* (proving it never runs); I added a companion asserting the index resolves with **no `wasmApi` at all** — the new deferred-compile reality — so no one "restores" the eager compile thinking it's required.
- **Safety:** worst case is a no-op. It removes provably-unused work and preserves the fallback; it cannot regress the happy path.
- **Magnitude (honest scoping):** the win is CPU-contention relief on the parse↔pre-pass overlap. It shows most on **low-core devices**; a fast multi-core dev machine barely contends, so the real number is best read from the **CI viewer benchmark (SwiftShader, constrained)** and **PostHog `ifc_model_loaded`** field data, not a local run. I am deliberately not quoting an ms figure I haven't measured cleanly.

## Changeset
`@ifc-lite/parser` patch (published package).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved parser startup by deferring WASM scanner loading when a pre-scanned entity index is available.
  * Reduced unnecessary work and potential loading delays during streaming and cold-load scenarios.

* **Bug Fixes**
  * Added a fallback that loads the scanner when a pre-scanned index is unavailable, preserving parsing behavior.
  * Confirmed that pre-scanned entity data is processed correctly without loading the WASM scanner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->