### PR TITLE
fix(viewer): survive key events that carry no `key`

### DIFF
--- a/apps/viewer/src/components/viewer/tools/SpaceSketchOverlay.tsx
+++ b/apps/viewer/src/components/viewer/tools/SpaceSketchOverlay.tsx
@@ -49,6 +49,7 @@ import { X, Undo2, Redo2, Layers, Maximize, AlertTriangle, Magnet, SlidersHorizo
 import { SpaceSketchCanvas } from './space-sketch/SpaceSketchCanvas';
 import { OptionsPopover, HelpPopover } from './space-sketch/SpaceSketchPopovers';
 import type { Hover, SplitTarget, IntentTone } from './space-sketch/types';
+import { eventKey, isTextEntryTarget } from '@/lib/keyboard-event';
 
 const DEFAULT_W = 580;
 const DEFAULT_H = 460;
@@ -309,9 +310,8 @@ export function SpaceSketchOverlay() {
   // listener's lifetime is exactly the tool's.
   useEffect(() => {
     const onUndoRedo = (e: KeyboardEvent) => {
-      if (e.key.toLowerCase() !== 'z' || !(e.ctrlKey || e.metaKey)) return;
-      const t = e.target as HTMLElement | null;
-      if (t && (t.tagName === 'INPUT' || t.tagName === 'TEXTAREA' || t.isContentEditable)) return;
+      if (eventKey(e) !== 'z' || !(e.ctrlKey || e.metaKey)) return;
+      if (isTextEntryTarget(e)) return;
       e.preventDefault();
       e.stopPropagation();
       if (e.shiftKey) redo(); else undo();

--- a/apps/viewer/src/components/viewer/useKeyboardControls.ts
+++ b/apps/viewer/src/components/viewer/useKeyboardControls.ts
@@ -13,6 +13,7 @@ import type { MeshData, CoordinateInfo } from '@ifc-lite/geometry';
 import { useViewerStore, type SectionPlane } from '@/store';
 import { goHomeFromStore } from '@/store/homeView';
 import { presetViewRotation } from '@/lib/preset-view-orientation';
+import { eventKey, isTextEntryTarget } from '@/lib/keyboard-event';
 import { getEntityBounds } from '../../utils/viewportUtils.js';
 
 export interface UseKeyboardControlsParams {
@@ -81,19 +82,20 @@ export function useKeyboardControls(params: UseKeyboardControlsParams): void {
     };
 
     const handleKeyDown = (e: KeyboardEvent) => {
-      const target = e.target as HTMLElement;
-      if (
-        target.tagName === 'INPUT' ||
-        target.tagName === 'TEXTAREA' ||
-        target.isContentEditable
-      ) {
+      if (isTextEntryTarget(e)) {
         return;
       }
 
-      keyState[e.key.toLowerCase()] = true;
+      // Browsers may dispatch a key event with no `key` (autofill, synthetic
+      // events) — see lib/keyboard-event.ts. Nothing below could match such an
+      // event, so skipping it is behaviour-preserving.
+      const key = eventKey(e);
+      if (key === null) return;
+
+      keyState[key] = true;
 
       // Start movement loop when a movement key is pressed
-      if (MOVEMENT_KEYS.has(e.key.toLowerCase()) && !moveLoopRunning) {
+      if (MOVEMENT_KEYS.has(key) && !moveLoopRunning) {
         moveLoopRunning = true;
         keyboardMove();
       }
@@ -150,7 +152,15 @@ export function useKeyboardControls(params: UseKeyboardControlsParams): void {
     };
 
     const handleKeyUp = (e: KeyboardEvent) => {
-      keyState[e.key.toLowerCase()] = false;
+      // Deliberately NOT gated on isTextEntryTarget: a movement key pressed in
+      // the viewport and released after focus moved into a text field must
+      // still clear, or the fly-through keeps panning forever.
+      //
+      // A key-less event (autofill `keyup`, see lib/keyboard-event.ts) tells us
+      // nothing about which key was released, so leave `keyState` untouched —
+      // but still fall through to the held-key check, which is idempotent.
+      const key = eventKey(e);
+      if (key !== null) keyState[key] = false;
 
       // Stop movement loop when no movement keys are held
       const anyHeld = Array.from(MOVEMENT_KEYS).some(k => keyState[k]);

--- a/apps/viewer/src/hooks/useKeyboardShortcuts.ts
+++ b/apps/viewer/src/hooks/useKeyboardShortcuts.ts
@@ -11,6 +11,7 @@ import { useViewerStore } from '@/store';
 import { resetVisibilityForHomeFromStore } from '@/store/homeView';
 import { workspacePanelForShortcutCode } from '@/lib/panels/registry';
 import { closeAllPanelWindows } from '@/services/panel-windows';
+import { eventKey, isTextEntryTarget } from '@/lib/keyboard-event';
 import {
   executeBasketIsolate,
   executeBasketSet,
@@ -60,19 +61,17 @@ export function useKeyboardShortcuts(options: KeyboardShortcutsOptions = {}) {
 
   const handleKeyDown = useCallback((e: KeyboardEvent) => {
     // Ignore if typing in an input or textarea
-    const target = e.target as HTMLElement;
-    if (
-      target.tagName === 'INPUT' ||
-      target.tagName === 'TEXTAREA' ||
-      target.isContentEditable
-    ) {
+    if (isTextEntryTarget(e)) {
       return;
     }
 
     // Get modifier keys
     const ctrl = e.ctrlKey || e.metaKey;
     const shift = e.shiftKey;
-    const key = e.key.toLowerCase();
+    // Browsers may dispatch a key event with no `key` (autofill, synthetic
+    // events) — see lib/keyboard-event.ts. No shortcut below could match one.
+    const key = eventKey(e);
+    if (key === null) return;
 
     // Undo / Redo — Ctrl/Cmd+Z and Ctrl/Cmd+Shift+Z, scoped to the
     // active model's mutation stack. Always available regardless

--- a/apps/viewer/src/lib/keyboard-event.test.ts
+++ b/apps/viewer/src/lib/keyboard-event.test.ts
@@ -1,0 +1,95 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { eventKey, isTextEntryTarget } from './keyboard-event.js';
+
+/**
+ * Build a KeyboardEvent-shaped stub. The point of these helpers is exactly the
+ * cases the DOM types say cannot happen, so the stub is deliberately typed as
+ * the DOM interface only at the boundary.
+ */
+const keyEvent = (key: unknown): KeyboardEvent =>
+  ({ key } as unknown as KeyboardEvent);
+
+const eventOn = (target: unknown): Event =>
+  ({ target } as unknown as Event);
+
+describe('eventKey', () => {
+  it('lower-cases a normal key', () => {
+    assert.equal(eventKey(keyEvent('A')), 'a');
+    assert.equal(eventKey(keyEvent('w')), 'w');
+    assert.equal(eventKey(keyEvent('Escape')), 'escape');
+    assert.equal(eventKey(keyEvent('ArrowLeft')), 'arrowleft');
+  });
+
+  it('returns null when the browser omits `key` (autofill keyup)', () => {
+    // The production crash: Chromium dispatches a `keyup` with no `key` after
+    // an autofill pick, and `e.key.toLowerCase()` threw.
+    assert.equal(eventKey(keyEvent(undefined)), null);
+    assert.equal(eventKey({} as unknown as KeyboardEvent), null);
+  });
+
+  it('returns null for non-string `key` values rather than throwing', () => {
+    assert.equal(eventKey(keyEvent(null)), null);
+    assert.equal(eventKey(keyEvent(65)), null);
+    assert.equal(eventKey(keyEvent({ toLowerCase: () => 'a' })), null);
+  });
+
+  it('preserves keys that are falsy-but-valid strings', () => {
+    // A space bar keypress reports ' ', and '0' is a real key. Neither may be
+    // dropped by a truthiness check.
+    assert.equal(eventKey(keyEvent(' ')), ' ');
+    assert.equal(eventKey(keyEvent('0')), '0');
+    // The empty string is not a key any handler matches, but it is a string,
+    // so it must round-trip rather than become null.
+    assert.equal(eventKey(keyEvent('')), '');
+  });
+
+  it('does not mutate the event', () => {
+    const e = keyEvent('A');
+    eventKey(e);
+    assert.equal(e.key, 'A');
+  });
+});
+
+describe('isTextEntryTarget', () => {
+  it('detects the text-entry elements shortcuts must not fire inside', () => {
+    assert.equal(isTextEntryTarget(eventOn({ tagName: 'INPUT' })), true);
+    assert.equal(isTextEntryTarget(eventOn({ tagName: 'TEXTAREA' })), true);
+    assert.equal(
+      isTextEntryTarget(eventOn({ tagName: 'DIV', isContentEditable: true })),
+      true,
+    );
+  });
+
+  it('lets shortcuts through for ordinary targets', () => {
+    assert.equal(isTextEntryTarget(eventOn({ tagName: 'CANVAS' })), false);
+    assert.equal(
+      isTextEntryTarget(eventOn({ tagName: 'DIV', isContentEditable: false })),
+      false,
+    );
+    assert.equal(isTextEntryTarget(eventOn({ tagName: 'BUTTON' })), false);
+  });
+
+  it('returns false instead of throwing on a missing target', () => {
+    // `e.target` is null for an event dispatched at no node — the old
+    // `(e.target as HTMLElement).tagName` read threw here.
+    assert.equal(isTextEntryTarget(eventOn(null)), false);
+    assert.equal(isTextEntryTarget(eventOn(undefined)), false);
+  });
+
+  it('returns false for targets with no tagName (document, window, SVG)', () => {
+    assert.equal(isTextEntryTarget(eventOn({})), false);
+    // An SVGElement has a tagName but no isContentEditable.
+    assert.equal(isTextEntryTarget(eventOn({ tagName: 'svg' })), false);
+  });
+
+  it('is case-sensitive on tagName, matching DOM semantics', () => {
+    // HTML elements always report an upper-case tagName; a lower-case one
+    // comes from XML/SVG content, which is not a text-entry surface.
+    assert.equal(isTextEntryTarget(eventOn({ tagName: 'input' })), false);
+  });
+});

--- a/apps/viewer/src/lib/keyboard-event.ts
+++ b/apps/viewer/src/lib/keyboard-event.ts
@@ -1,0 +1,57 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Defensive readers for the two `KeyboardEvent` fields whose TypeScript types
+ * are stricter than what browsers actually dispatch.
+ *
+ * `KeyboardEvent.key` is typed `string` by the DOM lib, but it is genuinely
+ * absent on some real events:
+ *  - Chromium fires a `keyup` carrying no `key` when the user accepts a browser
+ *    autofill / password-manager suggestion (reproduced on Edge 150 / Windows).
+ *  - Events synthesised by extensions or by `dispatchEvent(new Event('keyup'))`
+ *    have no `key` either — `Event` has no `key`, and nothing stops that event
+ *    from reaching a `keyup` listener.
+ *
+ * Reading `.toLowerCase()` on that threw an uncaught
+ * `TypeError: Cannot read properties of undefined (reading 'toLowerCase')`,
+ * which aborted the rest of the handler. In the fly-through controls that left
+ * the movement loop armed on a key whose `keyup` never cleared it, so panning
+ * kept running until the next matching keypress.
+ *
+ * `event.target` is likewise `null` for an event dispatched at no node, and is
+ * not necessarily an `HTMLElement` (an `SVGElement`, `document` or `window`
+ * has no `tagName`/`isContentEditable`), so the "is the user typing?" guard
+ * every key handler opens with needs the same treatment.
+ */
+
+/**
+ * The event's `key`, lower-cased — or `null` when the browser omitted it.
+ *
+ * Callers should treat `null` as "no identifiable key" and skip the event:
+ * every comparison against a concrete key would be false anyway.
+ */
+export function eventKey(e: KeyboardEvent): string | null {
+  // Read through an untyped view: the DOM lib promises a string, the browser
+  // does not.
+  const key = (e as { key?: unknown }).key;
+  return typeof key === 'string' ? key.toLowerCase() : null;
+}
+
+/**
+ * True when the event targets a text-entry surface (`<input>`, `<textarea>` or
+ * a `contenteditable` host), i.e. the user is typing and single-key shortcuts
+ * must not fire.
+ *
+ * Returns `false` for a missing or non-HTML target rather than throwing.
+ */
+export function isTextEntryTarget(e: Event): boolean {
+  const target = e.target as (Partial<HTMLElement> | null);
+  if (!target) return false;
+  return (
+    target.tagName === 'INPUT' ||
+    target.tagName === 'TEXTAREA' ||
+    target.isContentEditable === true
+  );
+}


### PR DESCRIPTION
## What

`KeyboardEvent.key` is typed `string` by the DOM lib, but it is genuinely absent on events real browsers dispatch — Chromium fires a `keyup` with no `key` when the user accepts a browser autofill / password-manager suggestion, and extension-synthesised events carry none either.

Every viewer key handler opened with `e.key.toLowerCase()`, so those events threw an uncaught **`TypeError: Cannot read properties of undefined (reading 'toLowerCase')`** — the top unhandled exception in the viewer's PostHog error tracking, seen on Edge 150 / Windows across three separate releases (Jun 18, Jun 20, Jul 22).

## Root cause — decoded, not guessed

Production stack traces are unsymbolicated (no source maps are uploaded — separate PR). So I pulled the *exact deployed bundle* for the reporting build (`app_build_sha=9a70a18d`) from its immutable Vercel deployment and read the frame directly:

```
index-B42fho_u.js:58417:25
  u[e.key.toLowerCase()] = !1, !Array.from(gk).some((e)=>u[e]) && d && (d = !1, ...)
```

That is verbatim `useKeyboardControls.ts`'s **keyup** handler:

```ts
keyState[e.key.toLowerCase()] = false;
```

## Impact beyond the noise

The throw aborted the rest of the handler. In the fly-through controls that left `moveLoopRunning` armed on a key whose `keyup` never cleared it — panning kept running until the next matching keypress.

## Change

Adds `lib/keyboard-event.ts` with two defensive readers, and routes all five unguarded sites through them:

| Site | Was |
|---|---|
| `useKeyboardControls.ts` keydown | `e.key.toLowerCase()` ×2, `(e.target as HTMLElement).tagName` |
| `useKeyboardControls.ts` keyup | `e.key.toLowerCase()` |
| `useKeyboardShortcuts.ts` | `e.key.toLowerCase()`, `(e.target as HTMLElement).tagName` |
| `SpaceSketchOverlay.tsx` | `e.key.toLowerCase()` |

- `eventKey(e)` → lower-cased key, or `null` when the browser omitted it. Callers skip `null`. **Behaviour-preserving**: every remaining `e.key === '…'` comparison in those handlers would be `false` against `undefined` anyway, and previously the code threw before reaching them.
- `isTextEntryTarget(e)` replaces the `(e.target as HTMLElement).tagName` reads, which threw the same way for an event dispatched at no node.

`handleKeyUp` stays deliberately **un-gated** on the text-entry check — a movement key released after focus moved into a field must still clear, or the fly-through pans forever. It now leaves `keyState` untouched for a key-less event instead of writing an `undefined` slot.

## Testing

New `keyboard-event.test.ts` (10 cases) covers the adversarial edges:
- `key: undefined` / absent property (the production crash)
- non-string `key`: `null`, a number, an object with a `toLowerCase` method
- falsy-but-valid keys `' '`, `'0'`, `''` — must **not** be dropped by a truthiness check
- `target: null` / `undefined` (the old `.tagName` throw)
- targets with no `tagName` (document, window, SVG)
- lower-case `tagName` (XML/SVG) must not count as text entry

Full viewer suite: **1774 passed, 0 failed**. `tsc --noEmit` clean.

Closes the PostHog issue [Cannot read properties of undefined (reading 'toLowerCase')](https://eu.posthog.com/project/199147/error_tracking/019f8a2f-b965-7b32-bdd0-b1d516fef9ca).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHqw982LVuGHpkkMQNJ78W

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved keyboard shortcut handling across the viewer.
  - Shortcuts no longer interfere while typing in text fields or editable areas.
  - Added safer handling for browser and synthetic keyboard events with missing or unusual key values.
  - Improved consistency for undo, movement, and other keyboard controls.

- **Tests**
  - Added coverage for keyboard normalization, editable targets, missing event data, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->