### PR TITLE
fix(viewer): a failed GPU upload no longer blanks the canvas

### DIFF
--- a/.changeset/renderer-lost-device-returns-null.md
+++ b/.changeset/renderer-lost-device-returns-null.md
@@ -24,3 +24,6 @@ empty — array. Callers that contain the throw to keep the canvas alive would
 therefore have turned a crash into a silently blank model. On failure the
 previous drawables are restored (their GPU resources are still live, since the
 destroy step never runs) and the error is rethrown for the caller to handle.
+Batches the failed attempt had already created are freed, while anything that
+predates it — including cold shells aliased into both the old and the new array
+— is left alone.

--- a/.changeset/renderer-lost-device-returns-null.md
+++ b/.changeset/renderer-lost-device-returns-null.md
@@ -1,0 +1,18 @@
+---
+'@ifc-lite/renderer': patch
+---
+
+`Renderer.getGPUDevice()` now returns `null` once the GPU device has been lost,
+instead of handing back a zombie device.
+
+A lost device is not torn down: `WebGPUDevice.destroy()` is the only thing that
+nulls the handle, and it is never called for an involuntary loss (Windows TDR,
+GPU-process crash, driver reset). `isInitialized()` therefore stayed `true` and
+the accessor kept returning the dead `GPUDevice`, so callers went on calling
+`createBuffer()` on it — throwing a `RangeError`, and bypassing both
+`render()`'s own `deviceLost` guard and every `onDeviceLost` listener.
+
+Returning `null` routes into the `if (!device) return` check that call sites
+already have, so a lost device degrades to "stop uploading" rather than an
+uncaught throw. `isDeviceLost()` / `onDeviceLost()` are unchanged and remain the
+recovery contract.

--- a/.changeset/renderer-lost-device-returns-null.md
+++ b/.changeset/renderer-lost-device-returns-null.md
@@ -16,3 +16,11 @@ Returning `null` routes into the `if (!device) return` check that call sites
 already have, so a lost device degrades to "stop uploading" rather than an
 uncaught throw. `isDeviceLost()` / `onDeviceLost()` are unchanged and remain the
 recovery contract.
+
+`finalizeStreaming()` is now rollback-safe. It detaches the old fragments and
+batches before the replacement GPU buffers exist, so a `createBuffer` failure
+part-way through the rebuild left the scene rendering a half-built — often
+empty — array. Callers that contain the throw to keep the canvas alive would
+therefore have turned a crash into a silently blank model. On failure the
+previous drawables are restored (their GPU resources are still live, since the
+destroy step never runs) and the error is rethrown for the caller to handle.

--- a/apps/viewer/src/components/viewer/gpu-upload-guard.test.ts
+++ b/apps/viewer/src/components/viewer/gpu-upload-guard.test.ts
@@ -1,0 +1,76 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { runGpuUpload, resetGpuUploadGuardForTests } from './gpu-upload-guard.js';
+
+// The production failure this contains, verbatim from error tracking.
+const GPU_OOM =
+  "Failed to execute 'createBuffer' on 'GPUDevice': createBuffer failed, " +
+  'size (193836) is too large for the implementation when mappedAtCreation == true';
+
+let warnings: unknown[][] = [];
+const realWarn = console.warn;
+
+beforeEach(() => {
+  resetGpuUploadGuardForTests();
+  warnings = [];
+  console.warn = (...args: unknown[]) => { warnings.push(args); };
+});
+
+afterEach(() => {
+  console.warn = realWarn;
+});
+
+describe('runGpuUpload', () => {
+  it('returns the callback value when the upload succeeds', () => {
+    assert.equal(runGpuUpload('site', () => 42), 42);
+    assert.equal(warnings.length, 0);
+  });
+
+  it('does not swallow a falsy-but-real return value', () => {
+    // `flushPending` returns a boolean the caller acts on — `false` must stay
+    // `false` and must not be confused with the "it threw" signal.
+    assert.equal(runGpuUpload('site', () => false), false);
+    assert.equal(runGpuUpload('site', () => 0), 0);
+  });
+
+  it('contains a throw instead of letting it reach React or the rAF loop', () => {
+    const out = runGpuUpload('appendToBatches:non-streaming', () => {
+      throw new RangeError(GPU_OOM);
+    });
+    // undefined, NOT a rethrow: an uncaught throw here unmounts the canvas.
+    assert.equal(out, undefined);
+  });
+
+  it('keeps running after a failure — one bad batch is not a dead session', () => {
+    runGpuUpload('site', () => { throw new Error('boom'); });
+    assert.equal(runGpuUpload('site', () => 'still working'), 'still working');
+  });
+
+  it('warns once per call site, not once per frame', () => {
+    // These failures repeat every frame; unthrottled they flood the console.
+    for (let i = 0; i < 50; i++) {
+      runGpuUpload('flushPending:raf', () => { throw new Error('boom'); });
+    }
+    assert.equal(warnings.length, 1);
+  });
+
+  it('warns separately for a different call site', () => {
+    runGpuUpload('flushPending:raf', () => { throw new Error('boom'); });
+    runGpuUpload('rebuildPendingBatches:removals', () => { throw new Error('boom'); });
+    assert.equal(warnings.length, 2);
+  });
+
+  it('names the failing site in the warning so triage does not need a stack', () => {
+    runGpuUpload('rebuildPendingBatches:rotations', () => { throw new Error('boom'); });
+    assert.match(String(warnings[0][0]), /rebuildPendingBatches:rotations/);
+  });
+
+  it('rethrows nothing even for a non-Error throwable', () => {
+    assert.equal(runGpuUpload('site', () => { throw 'a string'; }), undefined);
+    assert.equal(runGpuUpload('site', () => { throw null; }), undefined);
+  });
+});

--- a/apps/viewer/src/components/viewer/gpu-upload-guard.ts
+++ b/apps/viewer/src/components/viewer/gpu-upload-guard.ts
@@ -1,0 +1,78 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { posthog } from '@/lib/analytics';
+import { classifyLoadError } from '@/lib/load-errors';
+
+/**
+ * Containment for GPU upload work (`createBuffer` and friends).
+ *
+ * Uploading a batch can throw for reasons entirely outside the app's control:
+ * the GPU device was lost (Windows TDR, GPU-process crash, driver reset), or
+ * the browser could not map host memory for a new buffer. Chromium reports the
+ * latter as
+ *
+ *   RangeError: Failed to execute 'createBuffer' on 'GPUDevice': createBuffer
+ *   failed, size (193836) is too large for the implementation when
+ *   mappedAtCreation == true
+ *
+ * — misleading wording, since 193 KB is nowhere near any device limit.
+ *
+ * Where such a throw lands decides how bad it is, and both landing sites are
+ * fatal to the viewport:
+ *  - inside a React effect, an uncaught throw unmounts the tree — the <canvas>
+ *    goes with it and the user is left with a blank viewer;
+ *  - inside the rAF callback, it skips the tail-position
+ *    `requestAnimationFrame(animate)` that re-arms the loop, so rendering stops
+ *    permanently with no further frames.
+ *
+ * Neither is recoverable by the user without a reload, and neither is worth it:
+ * a batch that fails to upload should cost that batch, not the session. This
+ * helper swallows the failure, keeps a console breadcrumb, and reports ONCE per
+ * session to error tracking — once, because these failures repeat every frame
+ * and would otherwise flood both the console and the exception quota.
+ */
+
+// Session-scoped latches. Module state is deliberate: the failure is a property
+// of the device, not of any one component instance, so remounting must not
+// re-open the floodgates.
+let reportedToErrorTracking = false;
+const loggedLabels = new Set<string>();
+
+/** Reset the once-per-session latches. Test seam — not used in production. */
+export function resetGpuUploadGuardForTests(): void {
+  reportedToErrorTracking = false;
+  loggedLabels.clear();
+}
+
+/**
+ * Run GPU upload work, containing any throw.
+ *
+ * @param label Call site identifier, used to de-duplicate console warnings.
+ * @param run   The upload work.
+ * @returns The callback's value, or `undefined` if it threw.
+ */
+export function runGpuUpload<T>(label: string, run: () => T): T | undefined {
+  try {
+    return run();
+  } catch (err) {
+    if (!loggedLabels.has(label)) {
+      loggedLabels.add(label);
+      console.warn(
+        `[gpu] ${label} failed (device lost or out of GPU memory); ` +
+        'skipping this batch and continuing to render:',
+        err,
+      );
+    }
+    if (!reportedToErrorTracking) {
+      reportedToErrorTracking = true;
+      posthog.captureException(err, {
+        context: 'gpu_upload',
+        gpu_upload_site: label,
+        error_kind: classifyLoadError(err),
+      });
+    }
+    return undefined;
+  }
+}

--- a/apps/viewer/src/components/viewer/gpu-upload-guard.ts
+++ b/apps/viewer/src/components/viewer/gpu-upload-guard.ts
@@ -72,6 +72,17 @@ export function runGpuUpload<T>(label: string, run: () => T): T | undefined {
         gpu_upload_site: label,
         error_kind: classifyLoadError(err),
       });
+      // Tell the user once. Containment keeps the session alive, but a lost
+      // device does not come back on its own and the affected batches will not
+      // draw — silently showing an incomplete model would be worse than the
+      // crash this replaces. Imported lazily to keep the render-path module
+      // free of UI imports (same pattern as useKeyboardShortcuts).
+      void import('@/components/ui/toast').then((m) => {
+        m.toast.error(
+          'The graphics device stopped accepting new geometry, so part of the ' +
+          'model may not be drawn. Reload the page to restore full rendering.',
+        );
+      }).catch(() => { /* toast is best-effort; never mask the original failure */ });
     }
     return undefined;
   }

--- a/apps/viewer/src/components/viewer/useAnimationLoop.ts
+++ b/apps/viewer/src/components/viewer/useAnimationLoop.ts
@@ -23,6 +23,7 @@ import type { SectionPlane } from '@/store';
 import { projectToCssScreen } from '../../utils/projectScreen.js';
 import { getContributionCullConfig } from '../../utils/renderCullConfig.js';
 import { getLodScreenPx } from '../../utils/lodConfig.js';
+import { runGpuUpload } from './gpu-upload-guard';
 
 export interface UseAnimationLoopParams {
   canvasRef: RefObject<HTMLCanvasElement | null>;
@@ -165,7 +166,10 @@ export function useAnimationLoop(params: UseAnimationLoopParams): void {
         const device = renderer.getGPUDevice();
         const pipeline = renderer.getPipeline();
         if (device && pipeline) {
-          queueFlushed = scene.flushPending(device, pipeline);
+          // Contained like the residency drain below: an uncaught throw here
+          // skips the tail-position requestAnimationFrame(animate) that re-arms
+          // this loop, so rendering would stop permanently.
+          queueFlushed = runGpuUpload('flushPending:raf', () => scene.flushPending(device, pipeline)) ?? false;
           if (queueFlushed) {
             renderer.clearCaches();
           }

--- a/apps/viewer/src/components/viewer/useGeometryStreaming.ts
+++ b/apps/viewer/src/components/viewer/useGeometryStreaming.ts
@@ -343,6 +343,8 @@ export function useGeometryStreaming(params: UseGeometryStreamingParams): void {
 
     // ── Extract new meshes ──
     let newMeshes: MeshData[];
+    const claimedMeshKeys: string[] = [];
+    let appendFailed = false;
     if (isStreaming || isIncremental) {
       // Fast path: new meshes are always appended at end
       const start = lastGeometryLengthRef.current;
@@ -355,7 +357,11 @@ export function useGeometryStreaming(params: UseGeometryStreamingParams): void {
         const compoundKey = `${meshData.expressId}:${i}`;
         if (!processedMeshIdsRef.current.has(compoundKey)) {
           newMeshes.push(meshData);
+          // Marked processed BEFORE the upload runs, so the keys are kept to
+          // roll back if it fails — otherwise a failed batch would be recorded
+          // as done and never retried (silently missing geometry).
           processedMeshIdsRef.current.add(compoundKey);
+          claimedMeshKeys.push(compoundKey);
         }
       }
     }
@@ -376,15 +382,30 @@ export function useGeometryStreaming(params: UseGeometryStreamingParams): void {
           // The production crash path: this effect is where a failed
           // createBuffer escaped into React's commit phase and unmounted the
           // viewport, blanking the canvas.
-          runGpuUpload('appendToBatches:non-streaming', () => {
+          const uploaded = runGpuUpload('appendToBatches:non-streaming', () => {
             scene.appendToBatches(newMeshes, device, pipeline, false);
-          });
-          renderer.clearCaches();
+            return true;
+          }) ?? false;
+          if (uploaded) {
+            renderer.clearCaches();
+          } else {
+            appendFailed = true;
+            // Release the claim so a later pass retries these meshes rather
+            // than leaving a permanent hole in the model.
+            for (const key of claimedMeshKeys) {
+              processedMeshIdsRef.current.delete(key);
+            }
+          }
         }
       }
     }
 
-    lastGeometryLengthRef.current = currentLength;
+    // The incremental/fast path tracks progress by length rather than by
+    // key, so it needs the same rollback: leaving this un-advanced is what
+    // makes the failed append retryable there.
+    if (!appendFailed) {
+      lastGeometryLengthRef.current = currentLength;
+    }
 
     // ── Fit camera ──
     //
@@ -663,7 +684,13 @@ export function useGeometryStreaming(params: UseGeometryStreamingParams): void {
     if (pendingMeshRemovals.size > 0) {
       scene.removeMeshesForEntities(pendingMeshRemovals);
       if (scene.hasPendingBatches()) {
-        runGpuUpload('rebuildPendingBatches:removals', () => scene.rebuildPendingBatches(device, pipeline));
+        const rebuilt = runGpuUpload(
+          'rebuildPendingBatches:removals',
+          () => { scene.rebuildPendingBatches(device, pipeline); return true; },
+        ) ?? false;
+        // Leave the pending map intact on failure so the next mutation retries
+        // this rebuild instead of dropping it.
+        if (!rebuilt) return;
       }
       renderer.requestRender();
     }
@@ -721,7 +748,13 @@ export function useGeometryStreaming(params: UseGeometryStreamingParams): void {
     if (pendingMeshTranslations.size > 0) {
       scene.translateMeshesForEntities(pendingMeshTranslations);
       if (scene.hasPendingBatches()) {
-        runGpuUpload('rebuildPendingBatches:translations', () => scene.rebuildPendingBatches(device, pipeline));
+        const rebuilt = runGpuUpload(
+          'rebuildPendingBatches:translations',
+          () => { scene.rebuildPendingBatches(device, pipeline); return true; },
+        ) ?? false;
+        // Leave the pending map intact on failure so the next mutation retries
+        // this rebuild instead of dropping it.
+        if (!rebuilt) return;
       }
       // An element appended during streaming (e.g. an authored IfcSpace) lingers
       // as a streaming fragment at its ORIGINAL position on top of its now-moved
@@ -729,7 +762,11 @@ export function useGeometryStreaming(params: UseGeometryStreamingParams): void {
       // buckets (no-op once none remain). Skipped in ephemeral mode, where no
       // geometry is retained to rebuild the batches from.
       if (scene.hasStreamingFragments() && !scene.isEphemeralStreaming()) {
-        runGpuUpload('finalizeStreaming:translations', () => scene.finalizeStreaming(device, pipeline));
+        const finalized = runGpuUpload(
+          'finalizeStreaming:translations',
+          () => { scene.finalizeStreaming(device, pipeline); return true; },
+        ) ?? false;
+        if (!finalized) return;
       }
       renderer.requestRender();
     }
@@ -751,10 +788,20 @@ export function useGeometryStreaming(params: UseGeometryStreamingParams): void {
     if (pendingMeshRotations.size > 0) {
       scene.rotateMeshesForEntities(pendingMeshRotations);
       if (scene.hasPendingBatches()) {
-        runGpuUpload('rebuildPendingBatches:rotations', () => scene.rebuildPendingBatches(device, pipeline));
+        const rebuilt = runGpuUpload(
+          'rebuildPendingBatches:rotations',
+          () => { scene.rebuildPendingBatches(device, pipeline); return true; },
+        ) ?? false;
+        // Leave the pending map intact on failure so the next mutation retries
+        // this rebuild instead of dropping it.
+        if (!rebuilt) return;
       }
       if (scene.hasStreamingFragments() && !scene.isEphemeralStreaming()) {
-        runGpuUpload('finalizeStreaming:rotations', () => scene.finalizeStreaming(device, pipeline));
+        const finalized = runGpuUpload(
+          'finalizeStreaming:rotations',
+          () => { scene.finalizeStreaming(device, pipeline); return true; },
+        ) ?? false;
+        if (!finalized) return;
       }
       renderer.requestRender();
     }

--- a/apps/viewer/src/components/viewer/useGeometryStreaming.ts
+++ b/apps/viewer/src/components/viewer/useGeometryStreaming.ts
@@ -23,6 +23,7 @@ import type { Renderer } from '@ifc-lite/renderer';
 import type { MeshData, CoordinateInfo } from '@ifc-lite/geometry';
 import { decodeInstancedShard } from '@ifc-lite/geometry';
 import { toast } from '../ui/toast.js';
+import { runGpuUpload } from './gpu-upload-guard';
 
 // Session-scoped flag so the linear-infrastructure hint fires at most once
 // per page load (model swaps included). Stored at module scope rather than
@@ -176,7 +177,7 @@ export function useGeometryStreaming(params: UseGeometryStreamingParams): void {
       const pipeline = renderer.getPipeline();
       const scene = renderer.getScene();
       if (!device || !pipeline || !scene.hasQueuedMeshes()) return;
-      const flushed = scene.flushPending(device, pipeline);
+      const flushed = runGpuUpload('flushPending:pump', () => scene.flushPending(device, pipeline)) ?? false;
       if (flushed) {
         renderer.clearCaches();
         renderer.requestRender();
@@ -372,7 +373,12 @@ export function useGeometryStreaming(params: UseGeometryStreamingParams): void {
           ensureQueuePump();
         } else {
           // Non-streaming: process immediately (visibility toggles, etc.)
-          scene.appendToBatches(newMeshes, device, pipeline, false);
+          // The production crash path: this effect is where a failed
+          // createBuffer escaped into React's commit phase and unmounted the
+          // viewport, blanking the canvas.
+          runGpuUpload('appendToBatches:non-streaming', () => {
+            scene.appendToBatches(newMeshes, device, pipeline, false);
+          });
           renderer.clearCaches();
         }
       }
@@ -657,7 +663,7 @@ export function useGeometryStreaming(params: UseGeometryStreamingParams): void {
     if (pendingMeshRemovals.size > 0) {
       scene.removeMeshesForEntities(pendingMeshRemovals);
       if (scene.hasPendingBatches()) {
-        scene.rebuildPendingBatches(device, pipeline);
+        runGpuUpload('rebuildPendingBatches:removals', () => scene.rebuildPendingBatches(device, pipeline));
       }
       renderer.requestRender();
     }
@@ -715,7 +721,7 @@ export function useGeometryStreaming(params: UseGeometryStreamingParams): void {
     if (pendingMeshTranslations.size > 0) {
       scene.translateMeshesForEntities(pendingMeshTranslations);
       if (scene.hasPendingBatches()) {
-        scene.rebuildPendingBatches(device, pipeline);
+        runGpuUpload('rebuildPendingBatches:translations', () => scene.rebuildPendingBatches(device, pipeline));
       }
       // An element appended during streaming (e.g. an authored IfcSpace) lingers
       // as a streaming fragment at its ORIGINAL position on top of its now-moved
@@ -723,7 +729,7 @@ export function useGeometryStreaming(params: UseGeometryStreamingParams): void {
       // buckets (no-op once none remain). Skipped in ephemeral mode, where no
       // geometry is retained to rebuild the batches from.
       if (scene.hasStreamingFragments() && !scene.isEphemeralStreaming()) {
-        scene.finalizeStreaming(device, pipeline);
+        runGpuUpload('finalizeStreaming:translations', () => scene.finalizeStreaming(device, pipeline));
       }
       renderer.requestRender();
     }
@@ -745,10 +751,10 @@ export function useGeometryStreaming(params: UseGeometryStreamingParams): void {
     if (pendingMeshRotations.size > 0) {
       scene.rotateMeshesForEntities(pendingMeshRotations);
       if (scene.hasPendingBatches()) {
-        scene.rebuildPendingBatches(device, pipeline);
+        runGpuUpload('rebuildPendingBatches:rotations', () => scene.rebuildPendingBatches(device, pipeline));
       }
       if (scene.hasStreamingFragments() && !scene.isEphemeralStreaming()) {
-        scene.finalizeStreaming(device, pipeline);
+        runGpuUpload('finalizeStreaming:rotations', () => scene.finalizeStreaming(device, pipeline));
       }
       renderer.requestRender();
     }

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -3414,10 +3414,24 @@ export class Renderer {
     }
 
     /**
-     * Get the GPU device (returns null if not initialized)
+     * Get the GPU device (returns null if not initialized, or if the device
+     * has been lost).
+     *
+     * The device-lost check is load-bearing, not defensive tidiness. A lost
+     * device is NOT torn down: `WebGPUDevice.destroy()` is the only thing that
+     * nulls the handle and it is never called for an involuntary loss (TDR /
+     * GPU-process crash / driver reset), so `isInitialized()` stays true and
+     * this used to keep handing out a zombie `GPUDevice`. Every caller then
+     * called `createBuffer()` on it, which throws — bypassing both `render()`'s
+     * own deviceLost guard and the `onDeviceLost` listeners entirely.
+     *
+     * Returning null instead routes into the `if (!device) return` check that
+     * every call site already has, so a lost device degrades to "stop
+     * uploading" rather than an uncaught throw. See `isDeviceLost()` /
+     * `onDeviceLost()` for the recovery contract.
      */
     getGPUDevice(): GPUDevice | null {
-        if (!this.device.isInitialized()) {
+        if (!this.device.isInitialized() || this.deviceLost) {
             return null;
         }
         return this.device.getDevice();

--- a/packages/renderer/src/scene-finalize-rollback.test.ts
+++ b/packages/renderer/src/scene-finalize-rollback.test.ts
@@ -73,21 +73,36 @@ describe('Scene.finalizeStreaming — GPU-failure rollback', () => {
     assert.deepStrictEqual(scene['batchedMeshes'], [batch]);
   });
 
-  it('destroys nothing on the failure path — the restored arrays still point at it', () => {
+  it('frees the batches the failed attempt created, but nothing that predates it', () => {
     const scene = new Scene();
     const fragment = fakeBatch(1);
     const batch = fakeBatch(2);
+    // A cold shell carried through the rebuild: aliased into BOTH the old and
+    // the new array. Freeing it would leave the restored array pointing at
+    // dead buffers.
+    const carriedCold = fakeBatch(3);
+    const partiallyBuilt = fakeBatch(4);
     scene['streamingFragments'] = [fragment];
-    scene['batchedMeshes'] = [batch];
-    scene['rebuildPendingBatches'] = () => { throw new Error('boom'); };
+    scene['batchedMeshes'] = [batch, carriedCold];
+
+    // Realistic partial rebuild: some batches land, then createBuffer throws.
+    scene['rebuildPendingBatches'] = () => {
+      scene['batchedMeshes'].push(carriedCold, partiallyBuilt);
+      throw new RangeError("createBuffer failed");
+    };
 
     assert.throws(() => scene.finalizeStreaming(device, pipeline));
 
-    // Freeing these would leave the restored arrays pointing at dead buffers.
+    // Created by the doomed attempt and referenced by nothing else → freed.
+    assert.strictEqual(partiallyBuilt.vertexBuffer.destroyed, 1);
+    assert.strictEqual(partiallyBuilt.indexBuffer.destroyed, 1);
+    // Pre-existing drawables (including the aliased cold shell) → untouched.
+    assert.strictEqual(carriedCold.vertexBuffer.destroyed, 0);
     assert.strictEqual(fragment.vertexBuffer.destroyed, 0);
-    assert.strictEqual(fragment.indexBuffer.destroyed, 0);
     assert.strictEqual(batch.vertexBuffer.destroyed, 0);
-    assert.strictEqual(batch.indexBuffer.destroyed, 0);
+    // …and still on screen.
+    assert.deepStrictEqual(scene['streamingFragments'], [fragment]);
+    assert.deepStrictEqual(scene['batchedMeshes'], [batch, carriedCold]);
   });
 
   it('clears the in-progress flag even when the rebuild throws', () => {
@@ -100,20 +115,28 @@ describe('Scene.finalizeStreaming — GPU-failure rollback', () => {
     assert.strictEqual(scene.isFinalizeInProgress(), false);
   });
 
-  it('still swaps in the new batches and frees the old ones on success', () => {
+  it('keeps the replacement and frees the old drawables on success', () => {
     const scene = new Scene();
     const fragment = fakeBatch(1);
     const batch = fakeBatch(2);
+    const replacement = fakeBatch(3);
     scene['streamingFragments'] = [fragment];
     scene['batchedMeshes'] = [batch];
-    scene['rebuildPendingBatches'] = () => { /* succeeds, builds nothing */ };
+    scene['rebuildPendingBatches'] = () => {
+      scene['batchedMeshes'].push(replacement);
+    };
 
     scene.finalizeStreaming(device, pipeline);
 
+    // The replacement is installed and must NOT be caught by any cleanup.
+    assert.deepStrictEqual(scene['batchedMeshes'], [replacement]);
+    assert.strictEqual(replacement.vertexBuffer.destroyed, 0);
+    assert.strictEqual(replacement.indexBuffer.destroyed, 0);
     assert.deepStrictEqual(scene['streamingFragments'], []);
-    assert.deepStrictEqual(scene['batchedMeshes'], []);
-    // The rollback must not have suppressed the normal cleanup.
+    // The rollback must not have suppressed the normal cleanup of the old ones.
     assert.strictEqual(fragment.vertexBuffer.destroyed, 1);
+    assert.strictEqual(fragment.indexBuffer.destroyed, 1);
     assert.strictEqual(batch.vertexBuffer.destroyed, 1);
+    assert.strictEqual(batch.indexBuffer.destroyed, 1);
   });
 });

--- a/packages/renderer/src/scene-finalize-rollback.test.ts
+++ b/packages/renderer/src/scene-finalize-rollback.test.ts
@@ -105,6 +105,41 @@ describe('Scene.finalizeStreaming — GPU-failure rollback', () => {
     assert.deepStrictEqual(scene['batchedMeshes'], [batch, carriedCold]);
   });
 
+  it('keeps cached partial batches alive when the rebuild throws', () => {
+    // Partial batches back an active hide/isolate view. Dropping them before
+    // the rebuild destroyed their GPU resources, and the rollback cannot bring
+    // them back — the view lost its visible subset and had to rebuild it
+    // against the device that just failed.
+    const scene = new Scene();
+    const partial = fakeBatch(9);
+    scene['streamingFragments'] = [fakeBatch(1)];
+    scene['partialBatchCache'].set('src:v1', partial);
+    scene['partialBatchCacheKeys'].set('src', 'src:v1');
+    scene['rebuildPendingBatches'] = () => { throw new Error('boom'); };
+
+    assert.throws(() => scene.finalizeStreaming(device, pipeline));
+
+    assert.strictEqual(partial.vertexBuffer.destroyed, 0);
+    assert.strictEqual(partial.indexBuffer.destroyed, 0);
+    assert.strictEqual(scene['partialBatchCache'].get('src:v1'), partial);
+  });
+
+  it('drops cached partial batches once the replacement build succeeds', () => {
+    const scene = new Scene();
+    const partial = fakeBatch(9);
+    scene['streamingFragments'] = [fakeBatch(1)];
+    scene['partialBatchCache'].set('src:v1', partial);
+    scene['partialBatchCacheKeys'].set('src', 'src:v1');
+    scene['rebuildPendingBatches'] = () => { /* succeeds */ };
+
+    scene.finalizeStreaming(device, pipeline);
+
+    // Their colorKeys are stale against the new batches, so they must go.
+    assert.strictEqual(partial.vertexBuffer.destroyed, 1);
+    assert.strictEqual(scene['partialBatchCache'].size, 0);
+    assert.strictEqual(scene['partialBatchCacheKeys'].size, 0);
+  });
+
   it('clears the in-progress flag even when the rebuild throws', () => {
     const scene = new Scene();
     scene['streamingFragments'] = [fakeBatch(1)];

--- a/packages/renderer/src/scene-finalize-rollback.test.ts
+++ b/packages/renderer/src/scene-finalize-rollback.test.ts
@@ -1,0 +1,119 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { Scene } from './scene.js';
+import type { BatchedMesh, RenderPipeline } from './types.js';
+
+/**
+ * `finalizeStreamingInner` detaches the old drawables (streamingFragments = [],
+ * batchedMeshes = []) BEFORE the replacement GPU buffers exist. Callers contain
+ * a failed GPU upload to keep the canvas alive, so without a rollback that
+ * containment would leave the scene rendering a half-built — often empty —
+ * array: a silently blank model instead of a crash.
+ *
+ * The rebuild itself needs a real GPUDevice, so it is stubbed here; what is
+ * under test is the state restoration around it.
+ */
+
+function fakeBuffer(): GPUBuffer & { destroyed: number } {
+  const buf = {
+    size: 0,
+    destroyed: 0,
+    destroy() { this.destroyed++; },
+  };
+  return buf as unknown as GPUBuffer & { destroyed: number };
+}
+
+function fakeBatch(id: number): BatchedMesh & {
+  vertexBuffer: GPUBuffer & { destroyed: number };
+  indexBuffer: GPUBuffer & { destroyed: number };
+} {
+  return {
+    id,
+    colorKey: `c${id}`,
+    vertexBuffer: fakeBuffer(),
+    indexBuffer: fakeBuffer(),
+    indexCount: 3,
+    color: [0, 0, 0, 1],
+    expressIds: [],
+  } as unknown as BatchedMesh & {
+    vertexBuffer: GPUBuffer & { destroyed: number };
+    indexBuffer: GPUBuffer & { destroyed: number };
+  };
+}
+
+const device = {} as GPUDevice;
+const pipeline = {} as RenderPipeline;
+
+describe('Scene.finalizeStreaming — GPU-failure rollback', () => {
+  it('restores the previous drawables when the rebuild throws', () => {
+    const scene = new Scene();
+    const fragment = fakeBatch(1);
+    const batch = fakeBatch(2);
+    scene['streamingFragments'] = [fragment];
+    scene['batchedMeshes'] = [batch];
+
+    // The production failure: createBuffer throws part-way through the rebuild.
+    scene['rebuildPendingBatches'] = () => {
+      throw new RangeError(
+        "Failed to execute 'createBuffer' on 'GPUDevice': createBuffer failed",
+      );
+    };
+
+    assert.throws(
+      () => scene.finalizeStreaming(device, pipeline),
+      /createBuffer failed/,
+    );
+
+    // Exactly what was on screen before, still on screen.
+    assert.deepStrictEqual(scene['streamingFragments'], [fragment]);
+    assert.deepStrictEqual(scene['batchedMeshes'], [batch]);
+  });
+
+  it('destroys nothing on the failure path — the restored arrays still point at it', () => {
+    const scene = new Scene();
+    const fragment = fakeBatch(1);
+    const batch = fakeBatch(2);
+    scene['streamingFragments'] = [fragment];
+    scene['batchedMeshes'] = [batch];
+    scene['rebuildPendingBatches'] = () => { throw new Error('boom'); };
+
+    assert.throws(() => scene.finalizeStreaming(device, pipeline));
+
+    // Freeing these would leave the restored arrays pointing at dead buffers.
+    assert.strictEqual(fragment.vertexBuffer.destroyed, 0);
+    assert.strictEqual(fragment.indexBuffer.destroyed, 0);
+    assert.strictEqual(batch.vertexBuffer.destroyed, 0);
+    assert.strictEqual(batch.indexBuffer.destroyed, 0);
+  });
+
+  it('clears the in-progress flag even when the rebuild throws', () => {
+    const scene = new Scene();
+    scene['streamingFragments'] = [fakeBatch(1)];
+    scene['rebuildPendingBatches'] = () => { throw new Error('boom'); };
+
+    assert.throws(() => scene.finalizeStreaming(device, pipeline));
+    // A stuck flag would wedge every settle-sensitive consumer for the session.
+    assert.strictEqual(scene.isFinalizeInProgress(), false);
+  });
+
+  it('still swaps in the new batches and frees the old ones on success', () => {
+    const scene = new Scene();
+    const fragment = fakeBatch(1);
+    const batch = fakeBatch(2);
+    scene['streamingFragments'] = [fragment];
+    scene['batchedMeshes'] = [batch];
+    scene['rebuildPendingBatches'] = () => { /* succeeds, builds nothing */ };
+
+    scene.finalizeStreaming(device, pipeline);
+
+    assert.deepStrictEqual(scene['streamingFragments'], []);
+    assert.deepStrictEqual(scene['batchedMeshes'], []);
+    // The rollback must not have suppressed the normal cleanup.
+    assert.strictEqual(fragment.vertexBuffer.destroyed, 1);
+    assert.strictEqual(batch.vertexBuffer.destroyed, 1);
+  });
+});

--- a/packages/renderer/src/scene.ts
+++ b/packages/renderer/src/scene.ts
@@ -1930,6 +1930,7 @@ export class Scene {
     const oldFragments = this.streamingFragments;
     const oldBatches = this.batchedMeshes;
     const fragmentSet = new Set(oldFragments);
+    const oldBatchSet = new Set(oldBatches);
     // Steps 1-4 detach the old drawables (streamingFragments = [],
     // batchedMeshes = []) BEFORE the replacement GPU buffers exist. If a
     // createBuffer fails part-way through, callers that CONTAIN the throw to
@@ -1993,13 +1994,18 @@ export class Scene {
       rebuilt = true;
     } finally {
       if (!rebuilt) {
+        // Free ONLY what this attempt created. Carried cold shells are aliased
+        // into BOTH the old and the new array, so anything that was already
+        // live before the rebuild must be left alone — destroying it would
+        // leave the restored arrays pointing at dead buffers.
+        for (const created of this.batchedMeshes) {
+          if (!oldBatchSet.has(created) && !fragmentSet.has(created)) {
+            destroyGpuResources(created);
+          }
+        }
         // Step 5 never ran, so every old fragment/batch is still a live GPU
         // resource: putting the arrays back restores exactly what was on
-        // screen. Deliberately does NOT destroy the partially-rebuilt
-        // batches — carried cold shells are aliased into BOTH arrays, so
-        // destroying them would free buffers the restored array still points
-        // at. A bounded leak on a device that just failed to allocate is the
-        // lesser evil, and the caller tells the user to reload.
+        // screen.
         this.streamingFragments = oldFragments;
         this.batchedMeshes = oldBatches;
       }

--- a/packages/renderer/src/scene.ts
+++ b/packages/renderer/src/scene.ts
@@ -1930,59 +1930,81 @@ export class Scene {
     const oldFragments = this.streamingFragments;
     const oldBatches = this.batchedMeshes;
     const fragmentSet = new Set(oldFragments);
-    this.streamingFragments = [];
+    // Steps 1-4 detach the old drawables (streamingFragments = [],
+    // batchedMeshes = []) BEFORE the replacement GPU buffers exist. If a
+    // createBuffer fails part-way through, callers that CONTAIN the throw to
+    // keep the canvas alive would otherwise be left rendering a half-built —
+    // often empty — scene, turning a crash into a silently blank model.
+    let rebuilt = false;
+    try {
+      this.streamingFragments = [];
 
-    // 1. Collect ALL accumulated meshData before clearing state.
-    //    Cold buckets (issue #1682 phase 3b) hold NO meshData — their
-    //    geometry lives on disk — so they are carried through the rebuild as
-    //    sealed shells instead of being re-grouped (re-grouping would
-    //    silently drop them).
-    const allMeshData: MeshData[] = [];
-    const carriedCold: Array<[string, BatchBucket]> = [];
-    for (const [key, bucket] of this.buckets) {
-      if (this.coldBuckets.has(key) && bucket.meshData.length === 0 && bucket.batchedMesh) {
-        carriedCold.push([key, bucket]);
-        continue;
+      // 1. Collect ALL accumulated meshData before clearing state.
+      //    Cold buckets (issue #1682 phase 3b) hold NO meshData — their
+      //    geometry lives on disk — so they are carried through the rebuild as
+      //    sealed shells instead of being re-grouped (re-grouping would
+      //    silently drop them).
+      const allMeshData: MeshData[] = [];
+      const carriedCold: Array<[string, BatchBucket]> = [];
+      for (const [key, bucket] of this.buckets) {
+        if (this.coldBuckets.has(key) && bucket.meshData.length === 0 && bucket.batchedMesh) {
+          carriedCold.push([key, bucket]);
+          continue;
+        }
+        for (const md of bucket.meshData) allMeshData.push(md);
       }
-      for (const md of bucket.meshData) allMeshData.push(md);
+
+      // 2. Clear all bucket/batch state for a clean rebuild
+      // NOTE: batchedMeshes keeps the OLD array reference — the renderer
+      // continues to draw from it until we swap in the new array below.
+      this.buckets.clear();
+      this.meshDataBucket = new Map();
+      this.activeBucketKey.clear();
+      this.lastDrawnFrame.clear();
+      this.residencyRestoreQueue.clear();
+      this.pendingBatchKeys.clear();
+      // Destroy cached partial batches — their colorKeys are now stale
+      this.dropAllPartialCaches();
+
+      // Re-seat the carried cold shells in the fresh bucket map (their GPU
+      // shells re-enter the flat array via rebuildPendingBatches below).
+      for (const [key, bucket] of carriedCold) this.buckets.set(key, bucket);
+
+      // 3. Re-group ALL meshData by their CURRENT color (and grid cell).
+      //    meshData.color may have been mutated in-place since the mesh was
+      //    first bucketed, so the original bucket key is stale. Re-grouping
+      //    by current color ensures batches render with correct colors.
+      for (const meshData of allMeshData) {
+        const baseKey = this.bucketBaseKey(meshData);
+        const bucketKey = this.resolveActiveBucket(baseKey, meshData);
+        let bucket = this.buckets.get(bucketKey);
+        if (!bucket) {
+          bucket = { key: bucketKey, meshData: [], batchedMesh: null, vertexBytes: 0 };
+          this.buckets.set(bucketKey, bucket);
+        }
+        bucket.meshData.push(meshData);
+        this.meshDataBucket.set(meshData, bucket);
+        this.pendingBatchKeys.add(bucketKey);
+      }
+
+      // 4. Build new proper batches into a fresh array
+      this.batchedMeshes = [];
+      this.rebuildPendingBatches(device, pipeline);
+      rebuilt = true;
+    } finally {
+      if (!rebuilt) {
+        // Step 5 never ran, so every old fragment/batch is still a live GPU
+        // resource: putting the arrays back restores exactly what was on
+        // screen. Deliberately does NOT destroy the partially-rebuilt
+        // batches — carried cold shells are aliased into BOTH arrays, so
+        // destroying them would free buffers the restored array still points
+        // at. A bounded leak on a device that just failed to allocate is the
+        // lesser evil, and the caller tells the user to reload.
+        this.streamingFragments = oldFragments;
+        this.batchedMeshes = oldBatches;
+      }
     }
 
-    // 2. Clear all bucket/batch state for a clean rebuild
-    // NOTE: batchedMeshes keeps the OLD array reference — the renderer
-    // continues to draw from it until we swap in the new array below.
-    this.buckets.clear();
-    this.meshDataBucket = new Map();
-    this.activeBucketKey.clear();
-    this.lastDrawnFrame.clear();
-    this.residencyRestoreQueue.clear();
-    this.pendingBatchKeys.clear();
-    // Destroy cached partial batches — their colorKeys are now stale
-    this.dropAllPartialCaches();
-
-    // Re-seat the carried cold shells in the fresh bucket map (their GPU
-    // shells re-enter the flat array via rebuildPendingBatches below).
-    for (const [key, bucket] of carriedCold) this.buckets.set(key, bucket);
-
-    // 3. Re-group ALL meshData by their CURRENT color (and grid cell).
-    //    meshData.color may have been mutated in-place since the mesh was
-    //    first bucketed, so the original bucket key is stale. Re-grouping
-    //    by current color ensures batches render with correct colors.
-    for (const meshData of allMeshData) {
-      const baseKey = this.bucketBaseKey(meshData);
-      const bucketKey = this.resolveActiveBucket(baseKey, meshData);
-      let bucket = this.buckets.get(bucketKey);
-      if (!bucket) {
-        bucket = { key: bucketKey, meshData: [], batchedMesh: null, vertexBytes: 0 };
-        this.buckets.set(bucketKey, bucket);
-      }
-      bucket.meshData.push(meshData);
-      this.meshDataBucket.set(meshData, bucket);
-      this.pendingBatchKeys.add(bucketKey);
-    }
-
-    // 4. Build new proper batches into a fresh array
-    this.batchedMeshes = [];
-    this.rebuildPendingBatches(device, pipeline);
 
     // 5. NOW destroy old fragment/batch GPU resources (new batches are live)
     for (const fragment of oldFragments) destroyGpuResources(fragment);

--- a/packages/renderer/src/scene.ts
+++ b/packages/renderer/src/scene.ts
@@ -1964,8 +1964,6 @@ export class Scene {
       this.lastDrawnFrame.clear();
       this.residencyRestoreQueue.clear();
       this.pendingBatchKeys.clear();
-      // Destroy cached partial batches — their colorKeys are now stale
-      this.dropAllPartialCaches();
 
       // Re-seat the carried cold shells in the fresh bucket map (their GPU
       // shells re-enter the flat array via rebuildPendingBatches below).
@@ -1992,6 +1990,15 @@ export class Scene {
       this.batchedMeshes = [];
       this.rebuildPendingBatches(device, pipeline);
       rebuilt = true;
+
+      // Cached partial (filtered-visibility) batches are keyed by their SOURCE
+      // batch, so they only go stale once the replacement batches are live.
+      // Dropping them up in step 2 destroyed their GPU resources BEFORE the
+      // rebuild could fail, and the rollback cannot bring them back — an active
+      // hide/isolate view lost its visible subset and had to recreate it
+      // against the very device that just failed. On the failure path they now
+      // survive, still matching the restored batches.
+      this.dropAllPartialCaches();
     } finally {
       if (!rebuilt) {
         // Free ONLY what this attempt created. Carried cold shells are aliased


### PR DESCRIPTION
Production reported an **unhandled** exception that kills the viewport:

```
RangeError: Failed to execute 'createBuffer' on 'GPUDevice': createBuffer failed,
size (193836) is too large for the implementation when mappedAtCreation == true
```

Chromium's wording is misleading. **193 KB is nowhere near any device limit** — `device.ts` raises `requiredLimits` to the adapter maximum. What actually failed is mapping *host* memory for the new buffer: the device was lost, or could no longer service allocations. The same session also reported `OperationError: Instance dropped in popErrorScope`, which `index.ts` already documents as the signature of a dropped device.

## How I pinned it

Stack traces are unsymbolicated. I pulled the exact deployed bundle for the reporting build (`app_build_sha=9a70a18d`) from its immutable Vercel deployment and read the frames directly:

```
store-CcfUOECO.js:4914  e.appendToBatches        → this.rebuildPendingBatches(n, r);
store-CcfUOECO.js:4925  e.rebuildPendingBatches  → r.batchedMesh = this.createBatchedMesh(...);
store-CcfUOECO.js:5410  e.createBatchedMesh      → l ? (c = n.createBuffer({ ... mappedAtCreation: !0 })
```

and the frames **above** `appendToBatches`:

```
index-B42fho_u.js:5449/5457/5491   React commitPassiveMountEffects recursion + Fc(9, t)
index-B42fho_u.js:59072            t && (s ? (u.queueMeshes(g), I()) : (u.appendToBatches(g, i, t, !1), e.clearCaches()))
```

That last line is verbatim `useGeometryStreaming.ts:375`. So the throw escaped through **React's commit phase** — with no error boundary around the viewport, React unmounts the tree and the `<canvas>` goes with it.

## Two root causes

### 1. The renderer kept handing out a dead device

A lost device is never torn down — `WebGPUDevice.destroy()` is the only thing that nulls the handle, and it is **not** called for an involuntary loss (Windows TDR / GPU-process crash / driver reset). So `isInitialized()` stayed `true` and `getGPUDevice()` returned the zombie `GPUDevice`. Callers kept calling `createBuffer()` on it, bypassing both `render()`'s own `deviceLost` guard **and** every `onDeviceLost` listener.

It now returns `null` when the device is lost, which routes into the `if (!device) return` check every call site already has. (Also worth knowing: nothing in `apps/viewer` currently subscribes to `renderer.onDeviceLost(...)` at all — the recovery API exists but is unwired. Out of scope here; this PR makes the unwired case degrade safely instead of crashing.)

### 2. Seven GPU-upload call sites were unguarded

Where the throw lands is what makes it fatal:

| Site | Landing | Consequence |
|---|---|---|
| `useGeometryStreaming` `appendToBatches` | React passive effect | tree unmounts → **blank canvas** (the reported crash) |
| `useAnimationLoop` `flushPending` | rAF callback | skips the tail-position `requestAnimationFrame(animate)` → **rendering stops permanently** |

Both failure modes were **already understood in this file**. The residency-restore block directly below `flushPending` carries a `try/catch` and the comment *"an uncaught throw here (e.g. buffer creation on a lost device) would kill the rAF loop and blank the canvas"*; the instanced-shard effect carries an equivalent one. The remaining sites simply never got the same treatment.

## Change

Adds `runGpuUpload(label, fn)`, which contains the throw, keeps a console breadcrumb **de-duplicated per call site**, and reports **once per session** to error tracking — these failures repeat every frame and would otherwise flood both the console and the exception quota. A batch that fails to upload now costs that batch, not the session.

Applied to all seven sites: `flushPending` (rAF + queue pump), `appendToBatches`, `rebuildPendingBatches` (removals / translations / rotations), `finalizeStreaming` (translations / rotations).

## Testing

8 new cases, aimed at the ways this could go wrong rather than the happy path:
- **the falsy-return trap** — `flushPending` returns a boolean the caller acts on, so `false` must stay `false` and must not read as "it threw"
- containment returns `undefined` rather than rethrowing
- the guard keeps working after a failure (one bad batch ≠ dead session)
- warn-once-per-site across 50 consecutive failures, but separately per site
- non-`Error` throwables (`throw 'string'`, `throw null`)

Viewer suite **1772 passed**, renderer suite **300 passed**, `tsc --noEmit` clean. Changeset included for `@ifc-lite/renderer` (patch).

> Pairs with #1855, which classifies this error into the `out_of_memory` family so it groups and gets the right user guidance. The two are independent and can land in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHqw982LVuGHpkkMQNJ78W

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented rendering errors after unexpected GPU device loss by safely stopping GPU uploads.
  - Kept the viewer and animation loop running when GPU uploads fail.
  - Added user notifications and diagnostics for GPU upload failures.
  - Preserved pending geometry changes so failed uploads can be retried.
  - Prevented streaming finalization failures from leaving the scene blank or partially rebuilt.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->