### PR TITLE
feat(viewer): retry a resource-limit load once at lower detail before giving up

### DIFF
--- a/apps/viewer/src/hooks/useIfcLoader.ts
+++ b/apps/viewer/src/hooks/useIfcLoader.ts
@@ -29,7 +29,9 @@ import {
   type MeshData,
   type CoordinateInfo,
   type GeometryResult,
+  type TessellationQuality,
 } from '@ifc-lite/geometry';
+import { resolveResourceRetryTier } from '../lib/resource-retry.js';
 import { acquireFileBuffer, type AcquiredBuffer } from '../utils/acquireFileBuffer.js';
 import { buildSpatialIndexGuarded, buildSpatialIndexForModel } from '../utils/loadingUtils.js';
 import { buildGeometryCacheKey } from './geometryCacheKey.js';
@@ -58,7 +60,7 @@ import { extractModelGeoref, alignGeometryToReference, findReferenceGeorefModel 
 import { toast } from '../components/ui/toast.js';
 import { posthog } from '../lib/analytics.js';
 import { reportRenderStats } from '../utils/renderStatsReport.js';
-import { classifyLoadError, formatLoadError } from '../lib/load-errors.js';
+import { classifyLoadError, formatLoadError, type LoadErrorKind } from '../lib/load-errors.js';
 
 /**
  * The skip-tiny-cuts flag is no longer a hard constant: it is derived per-load
@@ -182,7 +184,18 @@ export function useIfcLoader() {
   // Latest `loadFile`, so the background revalidation can reload without being a
   // dependency of `loadFile` itself (avoids a definition cycle). Kept current by
   // the effect below.
-  const loadFileRef = useRef<((file: File, target?: LoadTarget) => Promise<void>) | null>(null);
+  const loadFileRef = useRef<
+    | ((
+        file: File,
+        target?: LoadTarget,
+        options?: {
+          sourceHandle?: FileSystemFileHandle;
+          tierOverride?: TessellationQuality;
+          isResourceRetry?: boolean;
+        },
+      ) => Promise<void>)
+    | null
+  >(null);
 
   /**
    * Background revalidation for a SERVED source-decoupled (mesh-only) cache hit:
@@ -224,7 +237,14 @@ export function useIfcLoader() {
   const loadFile = useCallback(async (
     file: File,
     target: LoadTarget = { kind: 'primary' },
-    options?: { sourceHandle?: FileSystemFileHandle },
+    options?: {
+      sourceHandle?: FileSystemFileHandle;
+      // Auto-retry-at-lower-detail (resource-retry.ts): when a resource-limit
+      // failure re-invokes loadFile, it forces this tier and marks the attempt
+      // so a second failure surfaces instead of looping.
+      tierOverride?: TessellationQuality;
+      isResourceRetry?: boolean;
+    },
   ) => {
     const { resetViewerState, clearAllModels } = useViewerStore.getState();
     // Only a primary (destructive, replace-everything) load bumps the session.
@@ -259,6 +279,62 @@ export function useIfcLoader() {
 
     // Track total elapsed time for complete user experience
     const totalStartTime = performance.now();
+
+    // Records the tier the WASM tessellation path actually ran at, for the
+    // resource-retry decision in the catch. Declared out here (not in the try)
+    // so the catch can read it. Stays `null` until that path runs (a GLB /
+    // point-cloud / server / cache load never sets it), so a lower IFC tier is
+    // never pointlessly retried for a load it cannot help.
+    let attemptedTessellationTier: TessellationQuality | null | undefined = null;
+
+    /**
+     * Resource-limit recovery, shared by BOTH failure paths.
+     *
+     * The geometry-streaming loop has its own inner catch (it must close the
+     * WASM iterator and swallow the orphaned parser promise), and it RETURNS
+     * rather than rethrowing — so the stall / worker-crash failures this
+     * recovery exists for never reach the outer catch. Both call sites go
+     * through here so the policy lives in one place.
+     *
+     * Returns true when a retry was started, in which case the caller must
+     * return immediately: the retry owns the model's terminal state.
+     */
+    const tryResourceRetry = async (
+      err: unknown,
+      kind: LoadErrorKind,
+      context: string,
+    ): Promise<boolean> => {
+      const retryTier = resolveResourceRetryTier({
+        kind,
+        attemptedTier: attemptedTessellationTier,
+        isPrimary: target.kind === 'primary',
+        alreadyRetried: options?.isResourceRetry === true,
+      });
+      if (retryTier === null) return false;
+      // Still report the original failure so the memory wall stays visible in
+      // analytics — the retry only gives the user a shot at a result first.
+      posthog.captureException(err, { context, error_kind: kind, resource_retry: retryTier });
+      void import('@/components/ui/toast')
+        .then((m) => {
+          m.toast.info(
+            `"${file.name}" was too detailed for this device — retrying at lower detail…`,
+          );
+        })
+        // Best-effort notice; a failed chunk load must never turn into an
+        // unhandled rejection that masks the retry itself.
+        .catch(() => { /* no toast — the retry still proceeds */ });
+      setGeometryStreamingActive(false);
+      // Awaited, not fire-and-forget: callers await loadFile to know the load
+      // finished, so the original promise must stay pending until the
+      // replacement load settles. loadFile never rethrows (both its catches
+      // return), so this cannot throw back into the caller.
+      await loadFileRef.current?.(file, target, {
+        ...options,
+        tierOverride: retryTier,
+        isResourceRetry: true,
+      });
+      return true;
+    };
 
     try {
       // Reset all viewer state before loading new file — PRIMARY ONLY. A
@@ -725,7 +801,13 @@ export function useIfcLoader() {
       // model-weight signal available pre-geometry, so the key stays
       // deterministic at cache-check time). `undefined` = engine default
       // (medium). `exact` never auto-lowers.
-      const loadTessellationTier = resolveLoadTessellationTier(fileSizeMB, geometryModeAtLoad);
+      // An auto-retry after a resource-limit failure forces the tier (lowest);
+      // otherwise resolve it from the mode + file size as usual. Forcing it here
+      // (before the cache key) keeps the key and the live tessellation in
+      // agreement, so the retry re-meshes at the lower density instead of
+      // serving the failed attempt's cached bytes.
+      const loadTessellationTier = options?.tierOverride ??
+        resolveLoadTessellationTier(fileSizeMB, geometryModeAtLoad);
       // Desktop Tauri cache commands only accept [A-Za-z0-9_-], so the key
       // stays filename-safe and independent of the original filename. Pinned
       // to FORMAT_VERSION so a format bump invalidates stale entries (e.g. v5
@@ -868,6 +950,11 @@ export function useIfcLoader() {
       if (target.kind === 'primary') {
         setGeometryStreamingActive(true);
       }
+
+      // From here the WASM tessellation path runs, so a resource-limit failure
+      // downstream (stall / worker crash / OOM) is one a lower tier can help —
+      // record the tier we attempted for the retry decision in the catch.
+      attemptedTessellationTier = loadTessellationTier;
 
       // Initialize geometry processor first (WASM init is fast if already loaded)
       // Reuses the merge-layers snapshot taken above for the cache key so the
@@ -1545,6 +1632,9 @@ export function useIfcLoader() {
         // here as a cryptic `compile on 'WebAssembly'` TypeError — humanise it
         // and tag the captured exception so it is filterable in error tracking.
         const kind = classifyLoadError(err);
+        // The stall / worker-crash / OOM failures land HERE, not in the outer
+        // catch — retry once at lower detail before surfacing a dead end.
+        if (await tryResourceRetry(err, kind, 'geometry_processing')) return;
         setError(formatLoadError(err, file.name));
         // Flat properties: posthog-js spreads this object onto the event, so a
         // wrapper key would bury `error_kind` in an unfilterable nested blob.
@@ -1634,6 +1724,12 @@ export function useIfcLoader() {
       console.error(`[useIfc] loadFile THREW (session=${currentSession}, current=${loadSessionRef.current}):`, err);
       if (loadSessionRef.current !== currentSession) return;
       const kind = classifyLoadError(err);
+
+      // Resource-limit recovery — see tryResourceRetry. A failure that reaches
+      // this outer catch (rather than the streaming loop's inner one) still
+      // qualifies, e.g. an allocation failure outside the stream.
+      if (await tryResourceRetry(err, kind, 'ifc_model_load')) return;
+
       const friendly = formatLoadError(err, file.name);
       updateModel(modelId, {
         loadState: 'error',

--- a/apps/viewer/src/lib/resource-retry.test.ts
+++ b/apps/viewer/src/lib/resource-retry.test.ts
@@ -1,0 +1,60 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { resolveResourceRetryTier, type ResourceRetryInputs } from './resource-retry.js';
+
+const base: ResourceRetryInputs = {
+  kind: 'out_of_memory',
+  attemptedTier: undefined, // engine default (medium)
+  isPrimary: true,
+  alreadyRetried: false,
+};
+
+describe('resolveResourceRetryTier', () => {
+  it('retries at lowest for each resource-limit kind on a primary WASM load', () => {
+    for (const kind of ['out_of_memory', 'geometry_worker_crash', 'geometry_stream_stalled'] as const) {
+      assert.equal(resolveResourceRetryTier({ ...base, kind }), 'lowest', kind);
+    }
+  });
+
+  it('retries from an already-lowered tier that is still above lowest', () => {
+    assert.equal(resolveResourceRetryTier({ ...base, attemptedTier: 'low' }), 'lowest');
+    assert.equal(resolveResourceRetryTier({ ...base, attemptedTier: 'medium' }), 'lowest');
+    assert.equal(resolveResourceRetryTier({ ...base, attemptedTier: 'high' }), 'lowest');
+  });
+
+  it('does NOT retry when already at the lowest tier — nowhere lower to go', () => {
+    assert.equal(resolveResourceRetryTier({ ...base, attemptedTier: 'lowest' }), null);
+  });
+
+  it('does NOT retry a load that never ran the WASM tessellation path', () => {
+    // GLB / point-cloud / server / cache loads leave attemptedTier null: a
+    // lower IFC tier cannot change their memory, so retrying just repeats work.
+    assert.equal(resolveResourceRetryTier({ ...base, attemptedTier: null }), null);
+  });
+
+  it('does NOT retry a federated add (must not downgrade the whole federation)', () => {
+    assert.equal(resolveResourceRetryTier({ ...base, isPrimary: false }), null);
+  });
+
+  it('does NOT retry twice — a failing lowest-tier attempt surfaces', () => {
+    assert.equal(resolveResourceRetryTier({ ...base, alreadyRetried: true }), null);
+  });
+
+  it('does NOT retry a non-resource failure', () => {
+    for (const kind of ['wasm_engine_load', 'file_unreadable', 'cancelled', 'unknown'] as const) {
+      assert.equal(resolveResourceRetryTier({ ...base, kind }), null, kind);
+    }
+  });
+
+  it('the guards compose — every disqualifier wins over a qualifying kind', () => {
+    // A resource kind that would retry, but each guard independently blocks it.
+    assert.equal(resolveResourceRetryTier({ ...base, kind: 'out_of_memory', isPrimary: false }), null);
+    assert.equal(resolveResourceRetryTier({ ...base, kind: 'out_of_memory', alreadyRetried: true }), null);
+    assert.equal(resolveResourceRetryTier({ ...base, kind: 'out_of_memory', attemptedTier: null }), null);
+    assert.equal(resolveResourceRetryTier({ ...base, kind: 'out_of_memory', attemptedTier: 'lowest' }), null);
+  });
+});

--- a/apps/viewer/src/lib/resource-retry.ts
+++ b/apps/viewer/src/lib/resource-retry.ts
@@ -1,0 +1,81 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import type { TessellationQuality } from '@ifc-lite/geometry';
+import type { LoadErrorKind } from './load-errors.js';
+
+/**
+ * Decide whether a failed model load should be auto-retried at a lower
+ * tessellation tier, and at which one.
+ *
+ * A load can fail because the model is genuinely too heavy for the device's
+ * memory: the geometry stream watchdog fires (`geometry_stream_stalled`), a
+ * worker is OOM-killed (`geometry_worker_crash`), or a JS/ArrayBuffer
+ * allocation fails (`out_of_memory`). These are the three biggest error-tracking
+ * families and today they dead-end with a "close tabs / load something smaller"
+ * message. But the engine can tessellate the SAME model far more cheaply — the
+ * `lowest` tier drops parametric fillets to sharp corners and coarsens curves,
+ * cutting triangle count (and therefore peak memory) dramatically. A model that
+ * OOM'd at the default density has a real chance to load at `lowest`.
+ *
+ * So on one of these resource failures we retry the same in-memory file once at
+ * `lowest`. Deciding this is a pure function so the policy is unit-tested; the
+ * `useIfcLoader` catch is a thin call site.
+ *
+ * Guard rails encoded here:
+ *  - Only the three resource-exhaustion kinds qualify. A parse error, a cancel,
+ *    or an engine-load failure is not made better by less detail.
+ *  - Only when the failing load actually ran the WASM tessellation path
+ *    (`attemptedTier` is set). A GLB / point-cloud / server load is not
+ *    re-tessellated by our engine, so a lower IFC tier would not change its
+ *    memory and must not trigger a pointless reload of work.
+ *  - Only for a PRIMARY load. A federated add must never silently downgrade the
+ *    whole federation's detail.
+ *  - Only once: `alreadyRetried` short-circuits so the `lowest`-tier attempt,
+ *    if it also fails, surfaces the error instead of looping.
+ *  - Only when we are not already at `lowest` — there is nowhere lower to go.
+ */
+
+/** The tessellation kinds whose failure a lower tier can plausibly fix. */
+const RESOURCE_LIMIT_KINDS: ReadonlySet<LoadErrorKind> = new Set<LoadErrorKind>([
+  'out_of_memory',
+  'geometry_worker_crash',
+  'geometry_stream_stalled',
+]);
+
+export interface ResourceRetryInputs {
+  /** Classified failure kind (see classifyLoadError). */
+  kind: LoadErrorKind;
+  /**
+   * The tessellation tier the failing load actually used, or `null` if the
+   * failing load never ran the WASM tessellation path (GLB / point-cloud /
+   * server / cache — a lower IFC tier cannot help those). `undefined` means the
+   * WASM path ran at the engine default (medium).
+   */
+  attemptedTier: TessellationQuality | null | undefined;
+  /** True for a destructive primary load; false for a federated add. */
+  isPrimary: boolean;
+  /** True if this load is ITSELF an auto-retry, so we don't loop. */
+  alreadyRetried: boolean;
+}
+
+/**
+ * The tier to retry at, or `null` to not retry (surface the error normally).
+ *
+ * Always `lowest` when a retry is warranted: it is the maximal memory reduction
+ * in one step, so a single retry gives the best chance to fit rather than
+ * grinding the user through medium → low → lowest across several failed loads.
+ */
+export function resolveResourceRetryTier(
+  inputs: ResourceRetryInputs,
+): TessellationQuality | null {
+  if (inputs.alreadyRetried) return null;
+  if (!inputs.isPrimary) return null;
+  if (!RESOURCE_LIMIT_KINDS.has(inputs.kind)) return null;
+  // `null` attemptedTier = the WASM tessellation path never ran → a lower tier
+  // is meaningless. `'lowest'` = nowhere lower to go.
+  if (inputs.attemptedTier === null) return null;
+  if (inputs.attemptedTier === 'lowest') return null;
+  return 'lowest';
+}


### PR DESCRIPTION
## What

The three biggest error-tracking families — `geometry_stream_stalled`, `geometry_worker_crash`, `out_of_memory` (**34 occurrences, ~25 users**) — are resource-exhaustion on models too heavy for the device's memory. Today they dead-end with a "close tabs / load something smaller" message and **the user gets nothing.**

But the engine can tessellate the *same* model far more cheaply. The `lowest` tier drops parametric fillets to sharp corners and coarsens curves, cutting triangle count — and peak memory — dramatically. A model that OOM'd at the default density has a real chance to load at `lowest`.

So on one of these failures we now **retry the same in-memory file once at `lowest`** before surfacing the error. *Something at reduced detail beats nothing.*

## Why this design (and not the obvious alternatives)

- **Not a reload.** A reload would lose the freshly-picked `File` (browsers can't persist a File handle across navigation). We re-invoke `loadFile` in-memory, keeping the file.
- **Not new UI.** It's the same bounded-once auto-recovery pattern the WASM-skew reload already uses — an informative toast, no button, no error-panel surface to build.
- **Straight to `lowest`, not stepping down.** One retry at the maximal memory reduction, rather than grinding the user through medium → low → lowest across several failed full loads of a huge model.

## Guard rails (the pure, tested part)

The decision is a pure function (`resource-retry.ts`); the `loadFile` catch is a thin call site. It retries **only** when all of these hold:

| Guard | Why |
|---|---|
| kind ∈ {stall, worker-crash, OOM} | a parse error / cancel / engine-load failure isn't helped by less detail |
| the WASM tessellation path actually ran (`attemptedTessellationTier` set) | a GLB / point-cloud / server / cache load isn't re-tessellated by our engine, so a lower IFC tier can't help it — don't repeat the work |
| primary load | a federated add must never silently downgrade the whole federation |
| not already a retry (`isResourceRetry`) | a second failure at `lowest` surfaces normally instead of looping |
| not already at `lowest` | nowhere lower to go |

## Safety / no-regression reasoning

- The retry bumps the load session and re-meshes at the lower density — the tier is folded into the cache key, so it **never** serves the failed attempt's cached bytes.
- The failed attempt's geometry and workers are torn down as the catch unwinds, freeing the peak the retry needs.
- **Worst case** (`lowest` also fails): surfaces exactly as before — no regression, no loop.
- The original failure is still captured (with a `resource_retry` property) so the memory wall stays visible in analytics; the retry just gives the user a shot at a result first.

## Testing

8 pure-decision tests covering each guard and their composition (every disqualifier wins over a qualifying kind). Full viewer suite **1826 passed**, `tsc` clean.

Improves the user outcome for the consolidated stall / worker-crash / OOM issues. Pairs with #1858 (WASM-skew noise); independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHqw982LVuGHpkkMQNJ78W

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic recovery for a subset of model-loading failures by retrying tessellation at a lower quality level.
  * Shows a user notification when a resource-based retry is triggered.
  * Ensures retries don’t leave the app stuck in an active streaming state and maintains consistent geometry across quality levels.
* **Bug Fixes**
  * Prevents unintended repeated retries by applying strict eligibility rules for when an auto-retry can occur.
* **Tests**
  * Added tests covering retry eligibility, supported failure types, quality-tier boundaries, and key guard conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->