### PR TITLE
chore(viewer): wire PostHog source-map upload into the Vercel build

### DIFF
--- a/apps/viewer/vite.config.ts
+++ b/apps/viewer/vite.config.ts
@@ -308,6 +308,19 @@ export default defineConfig({
   build: {
     target: 'esnext',
     chunkSizeWarningLimit: 6000,
+    // Opt-in production source maps, for PostHog error tracking. Without them
+    // every captured stack frame is unreadable minified soup ("Could not find
+    // sourcemap for source url"), which is why triaging a production crash has
+    // meant hand-fetching the deployed bundle from its immutable deployment URL.
+    //
+    // Gated on VITE_SOURCEMAP rather than always-on for two reasons: rollup's
+    // map generation for this bundle costs real build time and memory, and the
+    // Vercel builder is already tight enough that the WASM link has OOM'd it
+    // before. scripts/vercel-build.sh turns this on only when a PostHog CLI key
+    // is present - i.e. only when the maps will actually be uploaded and then
+    // deleted from the output. Declared in turbo.json's build `env` so toggling
+    // it busts the task cache instead of restoring a map-less dist.
+    sourcemap: process.env.VITE_SOURCEMAP === '1',
     rollupOptions: {
       // @ifc-lite/geometry's NativeBridge does a dynamic `import('@tauri-apps/api/event')`
       // (under isTauri(), never reached on web). Rollup still resolves it

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "@changesets/changelog-github": "^0.7.0",
     "@changesets/cli": "^2.31.1",
     "@playwright/test": "^1.61.1",
+    "@posthog/cli": "0.9.1",
     "@types/node": "^26.1.1",
     "knip": "^6.27.0",
     "tsx": "^4.23.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       '@playwright/test':
         specifier: ^1.61.1
         version: 1.61.1
+      '@posthog/cli':
+        specifier: 0.9.1
+        version: 0.9.1
       '@types/node':
         specifier: ^26.1.1
         version: 26.1.1
@@ -2140,6 +2143,11 @@ packages:
   '@playwright/test@1.61.1':
     resolution: {integrity: sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==}
     engines: {node: '>=18'}
+    hasBin: true
+
+  '@posthog/cli@0.9.1':
+    resolution: {integrity: sha512-O02l2e5wuuIUzqdF3Q1gtqgi139fK1V9uXRJn8WToxmazT48ub/ODIrB3A+G/cK+ccZPc05NuPLqcsT1VOFkgw==}
+    engines: {node: '>=14.14', npm: '>=6'}
     hasBin: true
 
   '@posthog/core@1.44.0':
@@ -6318,6 +6326,10 @@ snapshots:
   '@playwright/test@1.61.1':
     dependencies:
       playwright: 1.61.1
+
+  '@posthog/cli@0.9.1':
+    dependencies:
+      detect-libc: 2.1.2
 
   '@posthog/core@1.44.0':
     dependencies:

--- a/scripts/add-sourcemap-refs.mjs
+++ b/scripts/add-sourcemap-refs.mjs
@@ -1,0 +1,92 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Append a `//# sourceMappingURL=` comment to every built chunk that has a
+ * sibling `.map`, so PostHog's CLI can pair the two before uploading.
+ *
+ * Why this exists: the viewer builds with rolldown-vite, which writes the map
+ * files but does NOT emit the trailing sourceMappingURL comment. posthog-cli
+ * documents that it locates maps through that comment — see its
+ * `--public-path-prefix` flag ("we need to ignore it while searching for
+ * them") — so without it the upload may find no maps to pair. Adding the
+ * comment makes the pairing true by construction rather than relying on an
+ * unverified filename-convention fallback.
+ *
+ * `posthog-cli sourcemap process --delete-after` strips these comments (and
+ * deletes the maps) after uploading, so nothing ships to users with a dangling
+ * reference. The build script also sweeps any leftover `.map` regardless.
+ *
+ * Idempotent: a chunk that already carries a reference is skipped, so running
+ * twice cannot double-append.
+ *
+ * Usage:
+ *   node scripts/add-sourcemap-refs.mjs <dir>            add references
+ *   node scripts/add-sourcemap-refs.mjs <dir> --strip    remove references
+ *
+ * `--strip` is the cleanup path for when the upload did not run or failed: the
+ * build sweeps the `.map` files out of the output either way, and a chunk left
+ * pointing at a map that is no longer there makes browsers with devtools open
+ * 404 on every asset. Stripping removes ANY sourceMappingURL comment, including
+ * the ones the bundler emitted itself, which is correct once no maps remain.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+const dir = process.argv[2];
+const strip = process.argv.includes('--strip');
+if (!dir) {
+  console.error('usage: node scripts/add-sourcemap-refs.mjs <dir> [--strip]');
+  process.exit(1);
+}
+if (!fs.existsSync(dir)) {
+  console.error(`[sourcemap-refs] directory not found: ${dir}`);
+  process.exit(1);
+}
+
+// Match a sourceMappingURL comment at the start of any line, so a chunk that
+// already has one (from a bundler that does emit it) is left untouched.
+const HAS_REF = /^\/\/# sourceMappingURL=/m;
+
+let added = 0;
+let skipped = 0;
+
+function walk(current) {
+  for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
+    const full = path.join(current, entry.name);
+    if (entry.isDirectory()) {
+      walk(full);
+      continue;
+    }
+    if (!entry.name.endsWith('.js')) continue;
+
+    if (strip) {
+      const src = fs.readFileSync(full, 'utf8');
+      if (!HAS_REF.test(src)) {
+        skipped++;
+        continue;
+      }
+      fs.writeFileSync(full, src.replace(/\n?^\/\/# sourceMappingURL=.*$\n?/gm, '\n'));
+      added++;
+      continue;
+    }
+
+    if (!fs.existsSync(`${full}.map`)) continue;
+    if (HAS_REF.test(fs.readFileSync(full, 'utf8'))) {
+      skipped++;
+      continue;
+    }
+    // Relative to the chunk, so it resolves regardless of the asset base path.
+    fs.appendFileSync(full, `\n//# sourceMappingURL=${entry.name}.map\n`);
+    added++;
+  }
+}
+
+walk(dir);
+console.log(
+  strip
+    ? `[sourcemap-refs] stripped ${added} reference(s), ${skipped} had none`
+    : `[sourcemap-refs] added ${added} reference(s), ${skipped} already present`,
+);

--- a/scripts/vercel-build.sh
+++ b/scripts/vercel-build.sh
@@ -107,11 +107,11 @@ echo "   filter:    $FILTER"
 #                         -> https://eu.posthog.com/settings/user-api-keys
 #   POSTHOG_CLI_ENV_ID    PostHog project id (199147)
 #   POSTHOG_CLI_HOST      https://eu.posthog.com   (EU cloud)
-if [ -n "${POSTHOG_CLI_API_KEY:-}" ]; then
+if [ -n "${POSTHOG_CLI_API_KEY:-}" ] && [ -n "${POSTHOG_CLI_ENV_ID:-}" ]; then
   export VITE_SOURCEMAP=1
-  echo "🗺️  Source maps ENABLED (POSTHOG_CLI_API_KEY present) — will upload then delete"
+  echo "🗺️  Source maps ENABLED (POSTHOG_CLI_API_KEY + POSTHOG_CLI_ENV_ID present) — will upload then delete"
 else
-  echo "🗺️  Source maps disabled (no POSTHOG_CLI_API_KEY) — traces stay minified"
+  echo "🗺️  Source maps disabled (need both POSTHOG_CLI_API_KEY and POSTHOG_CLI_ENV_ID) — traces stay minified"
 fi
 
 npx turbo build --filter="$FILTER"
@@ -127,7 +127,7 @@ build_status=$?
 # ALWAYS sweep leftover maps out of the output afterwards — a failed upload must
 # not silently publish them.
 OUT_DIR="apps/viewer/dist"
-if [ $build_status -eq 0 ] && [ -n "${POSTHOG_CLI_API_KEY:-}" ] && [ -d "$OUT_DIR" ]; then
+if [ $build_status -eq 0 ] && [ -n "${POSTHOG_CLI_API_KEY:-}" ] && [ -n "${POSTHOG_CLI_ENV_ID:-}" ] && [ -d "$OUT_DIR" ]; then
   # This repo builds with rolldown-vite, which emits the .map files but NOT the
   # trailing `//# sourceMappingURL=` comment. posthog-cli documents that it
   # locates maps via that comment (see its --public-path-prefix flag: "we need

--- a/scripts/vercel-build.sh
+++ b/scripts/vercel-build.sh
@@ -90,8 +90,74 @@ echo "   PATH=$PATH"
 FILTER="${1:-@ifc-lite/viewer...}"
 echo "   filter:    $FILTER"
 
+# ── PostHog source maps ─────────────────────────────────────────────────────
+# Production stack traces are unreadable without them: every frame in error
+# tracking reads "Could not find sourcemap for source url", so diagnosing a
+# crash has meant hand-fetching the deployed bundle from its immutable
+# deployment URL and decoding line/column by hand.
+#
+# Strictly opt-in: map generation costs build time + memory, and this builder is
+# tight enough that the WASM link has OOM'd it before. So we only turn it on
+# when a CLI key is actually present, i.e. only when the maps will be uploaded
+# and then deleted. With no key, nothing changes from today's build at all.
+#
+# Required Vercel project env to enable:
+#   POSTHOG_CLI_API_KEY   personal API key (phx_...) with
+#                         `error tracking write` + `organization read` scopes
+#                         -> https://eu.posthog.com/settings/user-api-keys
+#   POSTHOG_CLI_ENV_ID    PostHog project id (199147)
+#   POSTHOG_CLI_HOST      https://eu.posthog.com   (EU cloud)
+if [ -n "${POSTHOG_CLI_API_KEY:-}" ]; then
+  export VITE_SOURCEMAP=1
+  echo "🗺️  Source maps ENABLED (POSTHOG_CLI_API_KEY present) — will upload then delete"
+else
+  echo "🗺️  Source maps disabled (no POSTHOG_CLI_API_KEY) — traces stay minified"
+fi
+
 npx turbo build --filter="$FILTER"
 build_status=$?
+
+# Upload + strip. `sourcemap process` injects a chunk id, uploads, and with
+# --delete-after removes the .map files AND strips the sourceMappingURL
+# comments, so maps are never served to users. Release version is the same
+# 12-char sha the viewer stamps on every event as `app_build_sha`, so symbol
+# sets line up with the events they symbolicate.
+#
+# Never fails the deploy: symbolication is diagnostics, not correctness. But we
+# ALWAYS sweep leftover maps out of the output afterwards — a failed upload must
+# not silently publish them.
+OUT_DIR="apps/viewer/dist"
+if [ $build_status -eq 0 ] && [ -n "${POSTHOG_CLI_API_KEY:-}" ] && [ -d "$OUT_DIR" ]; then
+  # This repo builds with rolldown-vite, which emits the .map files but NOT the
+  # trailing `//# sourceMappingURL=` comment. posthog-cli documents that it
+  # locates maps via that comment (see its --public-path-prefix flag: "we need
+  # to ignore it while searching for them"), so add the comment for any chunk
+  # that has a sibling map. Pairing is then guaranteed by construction instead
+  # of relying on an unverified filename-convention fallback. `--delete-after`
+  # strips these comments again after upload, so nothing ships with a dangling
+  # reference.
+  node scripts/add-sourcemap-refs.mjs "$OUT_DIR"
+  RELEASE_VERSION="$(printf '%.12s' "${VERCEL_GIT_COMMIT_SHA:-${GITHUB_SHA:-dev}}")"
+  echo "🗺️  Uploading source maps (release ${RELEASE_VERSION})…"
+  npx --yes @posthog/cli@latest sourcemap process \
+    --directory "$OUT_DIR" \
+    --release-name ifc-lite-viewer \
+    --release-version "$RELEASE_VERSION" \
+    --delete-after || echo "⚠️  Source-map upload failed — continuing (deploy is unaffected)"
+fi
+
+# Belt and braces: whatever happened above, no .map may reach the CDN.
+if [ -d "$OUT_DIR" ]; then
+  leftover=$(find "$OUT_DIR" -name '*.map' -type f 2>/dev/null | wc -l | tr -d ' ')
+  if [ "$leftover" != "0" ]; then
+    echo "🗺️  Removing $leftover source map(s) from the output (not for public serving)"
+    find "$OUT_DIR" -name '*.map' -type f -delete 2>/dev/null || true
+    # The maps are gone, so any surviving reference now points at nothing and
+    # would 404 for anyone with devtools open. Strip them (this only runs when
+    # the upload did not, since --delete-after already removes both).
+    node scripts/add-sourcemap-refs.mjs "$OUT_DIR" --strip || true
+  fi
+fi
 
 # NOTE: A previous client-side Vercel Skew Protection pin (a __vdpl cookie set
 # from apps/viewer/index.html, with the live deployment id substituted here at

--- a/scripts/vercel-build.sh
+++ b/scripts/vercel-build.sh
@@ -139,7 +139,7 @@ if [ $build_status -eq 0 ] && [ -n "${POSTHOG_CLI_API_KEY:-}" ] && [ -d "$OUT_DI
   node scripts/add-sourcemap-refs.mjs "$OUT_DIR"
   RELEASE_VERSION="$(printf '%.12s' "${VERCEL_GIT_COMMIT_SHA:-${GITHUB_SHA:-dev}}")"
   echo "🗺️  Uploading source maps (release ${RELEASE_VERSION})…"
-  npx --yes @posthog/cli@latest sourcemap process \
+  pnpm exec posthog-cli sourcemap process \
     --directory "$OUT_DIR" \
     --release-name ifc-lite-viewer \
     --release-version "$RELEASE_VERSION" \

--- a/turbo.json
+++ b/turbo.json
@@ -62,7 +62,9 @@
         "VITE_LLM_FILE_ATTACHMENT_MODELS",
         "VITE_POSTHOG_KEY",
         "VITE_POSTHOG_HOST",
-        "VITE_SOURCEMAP"
+        "VITE_SOURCEMAP",
+        "VERCEL_GIT_COMMIT_SHA",
+        "GITHUB_SHA"
       ]
     },
     "typecheck": {

--- a/turbo.json
+++ b/turbo.json
@@ -61,7 +61,8 @@
         "VITE_LLM_IMAGE_MODELS",
         "VITE_LLM_FILE_ATTACHMENT_MODELS",
         "VITE_POSTHOG_KEY",
-        "VITE_POSTHOG_HOST"
+        "VITE_POSTHOG_HOST",
+        "VITE_SOURCEMAP"
       ]
     },
     "typecheck": {


### PR DESCRIPTION
## Why

Every frame in production error tracking currently reads **"Could not find sourcemap for source url"**. Triaging this week's crashes meant pulling the exact deployed bundle from its immutable Vercel deployment URL and decoding line/column by hand. That worked — but it doesn't scale, and **any new crash is undiagnosable until this exists.**

## Strictly opt-in — OFF until a key is configured

Map generation costs build time and memory, and this builder is tight enough that the WASM link has OOM'd it before. So `VITE_SOURCEMAP` gates it, and `vercel-build.sh` sets it **only** when `POSTHOG_CLI_API_KEY` is present — i.e. only when the maps will actually be uploaded and then deleted.

**With no key, the build is exactly what it is today** — verified locally: 0 maps emitted, default path unchanged. Declared in `turbo.json`'s build `env` so toggling it busts the task cache rather than restoring a map-less `dist`.

## How the maps reach PostHog but never reach users

`posthog-cli sourcemap process --delete-after` injects chunk ids, uploads, then removes the `.map` files **and** strips the `sourceMappingURL` comments. `--release-version` is the same 12-char sha the viewer stamps on every event as `app_build_sha`, so symbol sets line up with the events they symbolicate.

Upload failure never fails the deploy (symbolication is diagnostics, not correctness), and leftover maps are swept regardless — a failed upload cannot silently publish them.

## The gotcha this turned up

**rolldown-vite emits the `.map` files but not the trailing `sourceMappingURL` comment for every chunk** — 19 of 96 were missing it, including the main `index` chunk. posthog-cli documents locating maps *through* that comment (see its `--public-path-prefix` flag: *"we need to ignore it while searching for them"*).

So `scripts/add-sourcemap-refs.mjs` fills the gaps before upload, making pairing true **by construction** rather than relying on an unverified filename-convention fallback. It's idempotent, and has a `--strip` mode used by the sweep so a skipped/failed upload can't leave chunks pointing at maps that are no longer there (which would 404 for anyone with devtools open).

## Verified locally

| Check | Result |
|---|---|
| flag off | 0 maps, default build unchanged |
| flag on | 96 maps emitted |
| ref injection | 19 added, 77 already present |
| idempotency | re-run adds 0 |
| strip round-trip | 96 stripped, **0 dangling refs** |

## What is NOT verified

**The upload itself.** posthog-cli requires a personal API key even for `inject`, so I could not exercise the network path. I've deliberately left this gated off rather than merge an unverifiable pipeline as "working".

To enable, set on the Vercel project:

```
POSTHOG_CLI_API_KEY   personal key (phx_) with `error tracking write` + `organization read`
                      → https://eu.posthog.com/settings/user-api-keys
POSTHOG_CLI_ENV_ID    199147
POSTHOG_CLI_HOST      https://eu.posthog.com
```

Note this is a **personal** key (`phx_`), not the public project key (`phc_`) that's already in the client bundle — that one can't authenticate an upload. Once it's set I'll confirm a real symbol set lands and that a live stack trace symbolicates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHqw982LVuGHpkkMQNJ78W

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Build Improvements**
  - Added opt-in production source-map generation to make debugging easier.
  - Hosted builds can now automatically upload source maps when the required API key is available, and then remove any resulting references to avoid public serving.
  - Build output now ensures missing source-map references are applied as needed and performs a cleanup pass to strip leftover references.
  - Existing build behavior remains unchanged unless source maps are explicitly enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->