### PR TITLE
refactor(data,cache,viewer): drop dead EntityTable.getGlobalIdMap() (#1853)

### DIFF
--- a/.changeset/drop-dead-getglobalidmap.md
+++ b/.changeset/drop-dead-getglobalidmap.md
@@ -1,0 +1,21 @@
+---
+'@ifc-lite/data': minor
+'@ifc-lite/cache': minor
+---
+
+Remove `EntityTable.getGlobalIdMap()`.
+
+It was added alongside `getExpressIdByGlobalId()` for BCF integration and never
+used — the BCF lookup, tier-0 scan, export adapter, embed handler and CLI
+diagnostics all call `getExpressIdByGlobalId()` (point lookups). No caller ever
+needed the materialized map.
+
+Carrying it had a real cost: every implementation returned
+`new Map(globalIdToExpressId)`, a full defensive copy that would have doubled the
+peak memory of the largest string-keyed structure in the table the moment anyone
+called it, and it froze a `Map` return type into the canonical interface that
+three builders had to keep satisfying in lockstep.
+
+Migration: use `getExpressIdByGlobalId(globalId)` for GlobalId → expressId, and
+the existing `getGlobalId(expressId)` column accessor for the reverse. Both are
+unchanged.

--- a/.changeset/drop-dead-getglobalidmap.md
+++ b/.changeset/drop-dead-getglobalidmap.md
@@ -1,6 +1,6 @@
 ---
-'@ifc-lite/data': minor
-'@ifc-lite/cache': minor
+'@ifc-lite/data': major
+'@ifc-lite/cache': major
 ---
 
 Remove `EntityTable.getGlobalIdMap()`.

--- a/apps/viewer/src/utils/serverDataModel.ts
+++ b/apps/viewer/src/utils/serverDataModel.ts
@@ -405,9 +405,6 @@ function buildEntityTable(
     getExpressIdByGlobalId: (gid) => {
       return globalIdToExpressId.get(gid) ?? -1;
     },
-    getGlobalIdMap: () => {
-      return new Map(globalIdToExpressId); // Defensive copy
-    },
   };
 
   return { entities, entityById, typeGroups };

--- a/packages/cache/src/sections/entities.ts
+++ b/packages/cache/src/sections/entities.ts
@@ -186,8 +186,5 @@ export function readEntities(reader: BufferReader, strings: StringTable): Entity
     getExpressIdByGlobalId: (gid) => {
       return globalIdToExpressId.get(gid) ?? -1;
     },
-    getGlobalIdMap: () => {
-      return new Map(globalIdToExpressId); // Defensive copy
-    },
   };
 }

--- a/packages/data/src/entity-table.ts
+++ b/packages/data/src/entity-table.ts
@@ -68,9 +68,6 @@ export interface EntityTable {
 
   /** Get expressId by IFC GlobalId string (22-char GUID). Returns -1 if not found. */
   getExpressIdByGlobalId(globalId: string): number;
-
-  /** Get all GlobalId → expressId mappings (for BCF integration) */
-  getGlobalIdMap(): Map<string, number>;
 }
 
 export class EntityTableBuilder {
@@ -347,8 +344,6 @@ export function entityTableFromColumns(
     },
 
     getExpressIdByGlobalId: (gid) => globalIdToExpressId.get(gid) ?? -1,
-
-    getGlobalIdMap: () => new Map(globalIdToExpressId),
   };
 }
 

--- a/packages/parser/test/synthetic-data-store.test.ts
+++ b/packages/parser/test/synthetic-data-store.test.ts
@@ -60,7 +60,6 @@ describe('createSyntheticDataStore', () => {
 
     // GlobalId ↔ expressId mapping (used by BCF / federation lookups).
     expect(store.entities.getExpressIdByGlobalId(`pointcloud-${expressId}`)).toBe(expressId);
-    expect(store.entities.getGlobalIdMap().get(`pointcloud-${expressId}`)).toBe(expressId);
 
     // Index wiring.
     expect(store.entityIndex.byType.get('IFCGEOGRAPHICELEMENT')).toEqual([expressId]);


### PR DESCRIPTION
Closes #1853.

## What

Removes `EntityTable.getGlobalIdMap()` from the canonical interface and all three builders in lockstep:

- `packages/data/src/entity-table.ts` (interface + `entityTableFromColumns`)
- `packages/cache/src/sections/entities.ts`
- `apps/viewer/src/utils/serverDataModel.ts`

Plus the one test assertion that exercised it, and a changeset (minor for `@ifc-lite/data` and `@ifc-lite/cache` since it is an interface-surface removal).

## Why

The method was added alongside `getExpressIdByGlobalId()` for BCF integration and never used - the BCF lookup, tier-0 scan, export adapter, embed handler and CLI diagnostics all do point lookups. Carrying it had a real cost:

- Every implementation returned `new Map(globalIdToExpressId)`, a full defensive copy that would have doubled peak memory of the largest string-keyed structure in the table the moment anyone called it.
- The `Map` return type contractually baked V8's ~2^24 entry ceiling into the shared interface (the follow-up concern CodeRabbit raised on #1848), forcing any future fix to change three builders at once.

Removing the dead method resolves the contract-level ceiling. The internal `globalIdToExpressId` point-lookup map is unchanged - only rooted entities carry a GlobalId, so its ceiling is far further out than the per-entity map #1848 fixed, and it is now an implementation detail free to be replaced per-builder if it ever matters.

## Verification

- `grep -r getGlobalIdMap` over the repo: zero remaining references.
- `@ifc-lite/parser` tests: 40 files / 312 passed (includes the synthetic-data-store contract test).
- `tsc --noEmit` clean on `packages/data`, `packages/cache`, and `apps/viewer`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L51oct1aWfLxtFeSi8enT2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **API Changes**
  - Removed the GlobalId-to-expressId map accessor.
  - Added a direct lookup method: `getExpressIdByGlobalId(globalId)`.
  - When a GlobalId is not found, the method returns `-1`.
  - Use the existing `getGlobalId(expressId)` for reverse lookups.
- **Bug Fixes**
  - Reduced unnecessary memory usage by avoiding defensive map materialization during GlobalId resolution.
- **Tests**
  - Updated assertions to validate GlobalId ↔ expressId mapping via the new direct lookup method.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->