### PR TITLE
feat(wasm,geometry): expose general 2D Boolean ops over contour sets (#1863)

### DIFF
--- a/.changeset/general-2d-booleans-wasm.md
+++ b/.changeset/general-2d-booleans-wasm.md
@@ -1,0 +1,35 @@
+---
+'@ifc-lite/wasm': minor
+---
+
+Expose general 2D boolean operations over contour sets: `union2d`,
+`difference2d`, `intersection2d`, `resolve2d` and the `Contours2D` handle they
+operate on.
+
+Until now the only `i_overlay` capability crossing the wasm boundary was the
+fixed-purpose `meshOutline2d`, which unions one mesh's projected triangles into
+a silhouette. Anything that needed to combine two silhouettes — analytic
+hidden-surface removal, screen tiling, footprint overlap — had to bolt a second
+2D geometry engine onto the same pipeline, with different winding, precision and
+robustness semantics than the outlines it was consuming.
+
+`Contours2D.fromMeshOutline(outline)` adopts a `meshOutline2d` result directly,
+so an outline round-trips through a boolean without leaving the library.
+
+The results keep **every** disjoint output shape with its holes, grouped via
+`shapeOffsets()`. That is the difference from the internal `subtract_2d`, which
+collapses to the largest shape — correct for the single extrusion profile it
+serves, silent geometry loss for a difference that splits its subject into
+islands (a wall seen past a column is two visible slivers, not one).
+
+Winding is the contract: counter-clockwise rings cover area, clockwise rings
+remove it, the fill rule is always NonZero, and input winding is respected
+rather than normalised. That matches what `meshOutline2d` emits and what SVG
+`fill-rule="nonzero"` renders, so holes survive a round trip. Callers holding
+raw, arbitrarily-wound contours must normalise them CCW first.
+
+Degenerate input is dropped, not fatal: rings under 3 vertices or carrying any
+non-finite coordinate are discarded, an explicitly repeated closing vertex is
+tolerated, and every empty-operand combination has a defined answer.
+
+Resolves #1863.

--- a/.changeset/general-2d-booleans-wasm.md
+++ b/.changeset/general-2d-booleans-wasm.md
@@ -22,11 +22,13 @@ collapses to the largest shape — correct for the single extrusion profile it
 serves, silent geometry loss for a difference that splits its subject into
 islands (a wall seen past a column is two visible slivers, not one).
 
-Winding is the contract: counter-clockwise rings cover area, clockwise rings
-remove it, the fill rule is always NonZero, and input winding is respected
-rather than normalised. That matches what `meshOutline2d` emits and what SVG
-`fill-rule="nonzero"` renders, so holes survive a round trip. Callers holding
-raw, arbitrarily-wound contours must normalise them CCW first.
+Winding is the contract: the fill rule is always NonZero and input winding is
+respected rather than normalised. Because it is NonZero, winding is relative — a
+counter-clockwise ring covers area, and a clockwise ring creates a hole only
+where it cancels positive winding (a lone clockwise ring still fills). That
+matches what `meshOutline2d` emits and what SVG `fill-rule="nonzero"` renders, so
+holes survive a round trip. Callers holding raw, arbitrarily-wound contours that
+all mean "covered" must normalise them CCW first.
 
 Degenerate input is dropped, not fatal: rings under 3 vertices or carrying any
 non-finite coordinate are discarded, an explicitly repeated closing vertex is

--- a/docs/api/wasm.md
+++ b/docs/api/wasm.md
@@ -197,7 +197,7 @@ General union / difference / intersection over 2D contour sets, backed by the sa
 class Contours2D {
   // Build from flat [x0,y0,x1,y1,…] coords + per-ring VERTEX counts.
   // Throws if the counts don't sum to coords.length / 2. Degenerate rings
-  // (< 3 vertices, non-finite, or zero-area) are dropped at construction.
+  // (< 3 vertices, non-finite, or exactly collinear) are dropped at construction.
   constructor(coords: Float64Array, ringLengths: Uint32Array);
 
   // Adopt a meshOutline2d result directly (widens its f32 coords to f64).

--- a/docs/api/wasm.md
+++ b/docs/api/wasm.md
@@ -221,7 +221,7 @@ function intersection2d(a: Contours2D, b: Contours2D): Contours2D;  // a ∩ b
 function resolve2d(a: Contours2D): Contours2D;  // self-union a ring soup into shapes
 ```
 
-**Winding is the contract.** Counter-clockwise rings cover area, clockwise rings subtract it (a CW ring nested in a CCW ring is a hole), the fill rule is always `nonzero`, and input winding is respected — matching `meshOutline2d` output and SVG `fill-rule="nonzero"`, so holes survive a round trip. Raw contours that all mean "covered" (e.g. projected triangles) must be wound CCW before use.
+**Winding is the contract.** The fill rule is always `nonzero`, and input winding is respected — matching `meshOutline2d` output and SVG `fill-rule="nonzero"`, so holes survive a round trip. Because it is NonZero, winding is relative to the rings around a point, not absolute: a counter-clockwise ring covers area, and a clockwise ring subtracts only where it overlaps positive winding — so a CW ring nested inside a CCW ring is a hole, but a *lone* CW ring still fills (it has non-zero winding). Raw contours that all mean "covered" (e.g. projected triangles) must be wound CCW before use.
 
 **Results keep every disjoint shape.** `difference2d` that splits its subject returns one shape per island (grouped via `shapeOffsets()`) — a wall seen past a column is two visible slivers, not one. `difference2d` also takes any number of clip rings; they subtract as their union, so there is no separate "difference against many".
 

--- a/docs/api/wasm.md
+++ b/docs/api/wasm.md
@@ -223,7 +223,7 @@ function resolve2d(a: Contours2D): Contours2D;  // self-union a ring soup into s
 
 **Winding is the contract.** The fill rule is always `nonzero`, and input winding is respected — matching `meshOutline2d` output and SVG `fill-rule="nonzero"`, so holes survive a round trip. Because it is NonZero, winding is relative to the rings around a point, not absolute: a counter-clockwise ring covers area, and a clockwise ring subtracts only where it overlaps positive winding — so a CW ring nested inside a CCW ring is a hole, but a *lone* CW ring still fills (it has non-zero winding). Raw contours that all mean "covered" (e.g. projected triangles) must be wound CCW before use.
 
-**Results keep every disjoint shape.** `difference2d` that splits its subject returns one shape per island (grouped via `shapeOffsets()`) — a wall seen past a column is two visible slivers, not one. `difference2d` also takes any number of clip rings; they subtract as their union, so there is no separate "difference against many".
+**Results keep every disjoint shape.** `difference2d` that splits its subject returns one shape per island (grouped via `shapeOffsets()`) — a wall seen past a column is two visible slivers, not one. The `b` contour set may itself hold any number of clip rings; they subtract as their union, so there is no separate "difference against many" overload — collect the clips into one `Contours2D` and pass it as `b`.
 
 **Manual freeing.** Every returned `Contours2D` owns wasm memory and the operations return **new** handles without mutating their operands. An accumulating loop must `free()` the handle it replaces:
 

--- a/docs/api/wasm.md
+++ b/docs/api/wasm.md
@@ -187,7 +187,63 @@ readonly is_ready: boolean; // true once the API is initialized
 
 ### Other Exported Classes
 
-Beyond `IfcAPI` and the mesh types below, the module exports `ClashSession` / `ClashRunResult` (native clash detection over ingested mesh buffers), `GridAxisCollection` / `GridAxisJs` (parsed grid axes), `ProfileCollection` / `ProfileEntryJs`, `PartitionedBatch`, `MeshOutlineJs`, `SpacePlateHandle` (interactive space-sketch topology), and the `Symbolic*` classes (`SymbolicRepresentationCollection`, `SymbolicPolyline`, `SymbolicCircle`, `SymbolicText`, `SymbolicFillArea`). See `packages/wasm/pkg/ifc-lite.d.ts` for their full definitions.
+Beyond `IfcAPI` and the mesh types below, the module exports `ClashSession` / `ClashRunResult` (native clash detection over ingested mesh buffers), `GridAxisCollection` / `GridAxisJs` (parsed grid axes), `ProfileCollection` / `ProfileEntryJs`, `PartitionedBatch`, `MeshOutlineJs`, `SpacePlateHandle` (interactive space-sketch topology), `Contours2D` (see below), and the `Symbolic*` classes (`SymbolicRepresentationCollection`, `SymbolicPolyline`, `SymbolicCircle`, `SymbolicText`, `SymbolicFillArea`). See `packages/wasm/pkg/ifc-lite.d.ts` for their full definitions.
+
+### 2D Boolean Operations (contour sets)
+
+General union / difference / intersection over 2D contour sets, backed by the same `i_overlay` engine the void/CSG paths use. This is the general form of `meshOutline2d`: where that unions one mesh's projected triangles into a silhouette, these combine two silhouettes. Use them for analytic hidden-surface removal (subtract an accumulated occluder from each element's outline), screen tiling, or any downstream 2D CSG.
+
+```typescript
+class Contours2D {
+  // Build from flat [x0,y0,x1,y1,…] coords + per-ring VERTEX counts.
+  // Throws if the counts don't sum to coords.length / 2. Degenerate rings
+  // (< 3 vertices, non-finite, or zero-area) are dropped at construction.
+  constructor(coords: Float64Array, ringLengths: Uint32Array);
+
+  // Adopt a meshOutline2d result directly (widens its f32 coords to f64).
+  static fromMeshOutline(outline: MeshOutlineJs): Contours2D;
+
+  readonly ringCount: number;   // total boundary rings across all shapes
+  readonly shapeCount: number;  // disjoint shapes; 0 for a raw, unresolved set
+  readonly isEmpty: boolean;
+
+  shapeOffsets(): Uint32Array;  // ring index where each shape's OUTER ring starts
+  ring(index: number): Float64Array | undefined;  // one ring, flat [x,y,…]
+  coords(): Float64Array;       // every ring concatenated (one boundary crossing)
+  ringLengths(): Uint32Array;   // vertex count per ring, matching coords()
+  bounds(): Float64Array | undefined;  // [minX, minY, maxX, maxY]
+  free(): void;
+}
+
+function union2d(a: Contours2D, b: Contours2D): Contours2D;         // a ∪ b
+function difference2d(a: Contours2D, b: Contours2D): Contours2D;    // a − b
+function intersection2d(a: Contours2D, b: Contours2D): Contours2D;  // a ∩ b
+function resolve2d(a: Contours2D): Contours2D;  // self-union a ring soup into shapes
+```
+
+**Winding is the contract.** Counter-clockwise rings cover area, clockwise rings subtract it (a CW ring nested in a CCW ring is a hole), the fill rule is always `nonzero`, and input winding is respected — matching `meshOutline2d` output and SVG `fill-rule="nonzero"`, so holes survive a round trip. Raw contours that all mean "covered" (e.g. projected triangles) must be wound CCW before use.
+
+**Results keep every disjoint shape.** `difference2d` that splits its subject returns one shape per island (grouped via `shapeOffsets()`) — a wall seen past a column is two visible slivers, not one. `difference2d` also takes any number of clip rings; they subtract as their union, so there is no separate "difference against many".
+
+**Manual freeing.** Every returned `Contours2D` owns wasm memory and the operations return **new** handles without mutating their operands. An accumulating loop must `free()` the handle it replaces:
+
+```typescript
+import { Contours2D, difference2d, union2d } from '@ifc-lite/wasm';
+
+let occluders = new Contours2D(new Float64Array(), new Uint32Array()); // empty
+for (const outline of frontToBackOutlines) {
+  const visible = difference2d(outline, occluders); // may split into islands
+  const grown = union2d(occluders, outline);
+  occluders.free();          // free the handle we're replacing
+  occluders = grown;
+  emitSvgPath(visible);      // fill-rule="nonzero"
+  visible.free();
+  outline.free();
+}
+occluders.free();
+```
+
+`bounds()` is cheap enough to gate the boolean itself: skip the difference when an accumulated occluder's bounds miss the next element.
 
 ## Data Types
 

--- a/packages/wasm/pkg/ifc-lite.d.ts
+++ b/packages/wasm/pkg/ifc-lite.d.ts
@@ -66,7 +66,7 @@ export class Contours2D {
    * Shape grouping is a property of boolean *results*: a set built here is
    * an unstructured ring soup, so `shapeCount` reports 0 until it has been
    * through an operation (`resolve2d` alone is enough). Degenerate rings
-   * (under 3 vertices or carrying a non-finite coordinate) are dropped at
+   * (under 3 vertices, non-finite, or exactly collinear) are dropped at
    * construction, so `isEmpty`/`bounds()` report the same rings a later
    * boolean would keep rather than exposing an unsanitised soup.
    */

--- a/packages/wasm/pkg/ifc-lite.d.ts
+++ b/packages/wasm/pkg/ifc-lite.d.ts
@@ -35,6 +35,71 @@ export class ClashSession {
   runRule(group_a: Uint32Array, group_b: Uint32Array, mode: number, tolerance: number, clearance: number, report_touch: boolean): ClashRunResult;
 }
 
+export class Contours2D {
+  free(): void;
+  [Symbol.dispose](): void;
+  /**
+   * Vertex count of each ring, in the same order as `coords()`.
+   */
+  ringLengths(): Uint32Array;
+  /**
+   * Ring index at which each shape starts. Entry `s` is shape `s`'s OUTER
+   * ring; the rings up to the next entry (or `ringCount`) are its holes.
+   */
+  shapeOffsets(): Uint32Array;
+  /**
+   * Adopt the rings of a `meshOutline2d` result, widening its f32
+   * coordinates to the f64 the boolean engine works in.
+   *
+   * The outline's `axisMin`/`axisMax` are dropped — they describe the cut
+   * axis, which a 2D boolean has no notion of; keep them on the JS side if
+   * the caller still needs them for band classification.
+   */
+  static fromMeshOutline(outline: MeshOutlineJs): Contours2D;
+  /**
+   * Build a contour set from flat coordinates plus per-ring vertex counts.
+   *
+   * `coords` is `[x0, y0, x1, y1, …]` with every ring concatenated in order;
+   * `ringLengths[i]` is the VERTEX count (not the float count) of ring `i`.
+   * Throws when the counts do not add up to `coords.length / 2`.
+   *
+   * Shape grouping is a property of boolean *results*: a set built here is
+   * an unstructured ring soup, so `shapeCount` reports 0 until it has been
+   * through an operation (`resolve2d` alone is enough).
+   */
+  constructor(coords: Float64Array, ring_lengths: Uint32Array);
+  /**
+   * Ring `index` as a flat `[x0, y0, x1, y1, …]` array, or `undefined` when
+   * out of range.
+   */
+  ring(index: number): Float64Array | undefined;
+  /**
+   * Axis-aligned bounds as `[minX, minY, maxX, maxY]`, or `undefined` when
+   * empty. Cheap enough to gate the boolean itself: an accumulated occluder
+   * whose bounds miss the next element needs no difference at all.
+   */
+  bounds(): Float64Array | undefined;
+  /**
+   * Every ring's coordinates concatenated. Paired with `ringLengths()` this
+   * is the exact inverse of the constructor, and it reads a whole result
+   * back in one boundary crossing instead of one per ring.
+   */
+  coords(): Float64Array;
+  /**
+   * Total number of boundary rings across every shape.
+   */
+  readonly ringCount: number;
+  /**
+   * Number of disjoint shapes, or 0 for a set that has not been through an
+   * operation yet (see the constructor).
+   */
+  readonly shapeCount: number;
+  /**
+   * True when the set covers no area.
+   */
+  readonly isEmpty: boolean;
+}
+
 export class GridAxisCollection {
   private constructor();
   free(): void;
@@ -1266,6 +1331,18 @@ export class SymbolicText {
 }
 
 /**
+ * `a - b`, keeping EVERY disjoint remnant.
+ *
+ * This is the operation the existing `subtract_2d` could not stand in for: it
+ * returns one shape per island, where `subtract_2d` collapses to the largest
+ * (correct for a single extrusion profile, silent geometry loss anywhere else).
+ *
+ * `b` may hold any number of rings; they subtract as their union, so there is
+ * no separate "difference against many" entry point.
+ */
+export function difference2d(a: Contours2D, b: Contours2D): Contours2D;
+
+/**
  * Get WASM memory to allow JavaScript to create TypedArray views
  */
 export function get_memory(): any;
@@ -1277,6 +1354,11 @@ export function get_memory(): any;
  * It sets up panic hooks for better error messages in the browser console.
  */
 export function init(): void;
+
+/**
+ * `a ∩ b`.
+ */
+export function intersection2d(a: Contours2D, b: Contours2D): Contours2D;
 
 /**
  * Compute the winding-robust 2D footprint outline of a triangle mesh.
@@ -1296,6 +1378,18 @@ export function init(): void;
  * ```
  */
 export function meshOutline2d(positions: Float32Array, indices: Uint32Array, axis: number, flipped: boolean): MeshOutlineJs | undefined;
+
+/**
+ * Resolve a ring soup into disjoint outer/hole shapes without changing the
+ * area it covers (a self-union). Use it to give a hand-built set — or a
+ * `meshOutline2d` result — the shape grouping the operations produce.
+ */
+export function resolve2d(a: Contours2D): Contours2D;
+
+/**
+ * `a ∪ b`.
+ */
+export function union2d(a: Contours2D, b: Contours2D): Contours2D;
 
 /**
  * Get the version of IFC-Lite.
@@ -1318,6 +1412,7 @@ export interface InitOutput {
   readonly memory: WebAssembly.Memory;
   readonly __wbg_clashrunresult_free: (a: number, b: number) => void;
   readonly __wbg_clashsession_free: (a: number, b: number) => void;
+  readonly __wbg_contours2d_free: (a: number, b: number) => void;
   readonly __wbg_gridaxiscollection_free: (a: number, b: number) => void;
   readonly __wbg_gridaxisjs_free: (a: number, b: number) => void;
   readonly __wbg_ifcapi_free: (a: number, b: number) => void;
@@ -1343,6 +1438,17 @@ export interface InitOutput {
   readonly clashsession_ingest: (a: number, b: number, c: number, d: number, e: number, f: number, g: number, h: number, i: number, j: number, k: number) => void;
   readonly clashsession_new: () => number;
   readonly clashsession_runRule: (a: number, b: number, c: number, d: number, e: number, f: number, g: number, h: number, i: number) => number;
+  readonly contours2d_bounds: (a: number) => number;
+  readonly contours2d_coords: (a: number) => number;
+  readonly contours2d_fromMeshOutline: (a: number) => number;
+  readonly contours2d_isEmpty: (a: number) => number;
+  readonly contours2d_new: (a: number, b: number, c: number, d: number, e: number) => void;
+  readonly contours2d_ring: (a: number, b: number) => number;
+  readonly contours2d_ringCount: (a: number) => number;
+  readonly contours2d_ringLengths: (a: number) => number;
+  readonly contours2d_shapeCount: (a: number) => number;
+  readonly contours2d_shapeOffsets: (a: number) => number;
+  readonly difference2d: (a: number, b: number) => number;
   readonly gridaxiscollection_getAxis: (a: number, b: number) => number;
   readonly gridaxiscollection_isEmpty: (a: number) => number;
   readonly gridaxiscollection_length: (a: number) => number;
@@ -1401,6 +1507,7 @@ export interface InitOutput {
   readonly ifcapi_setTessellationQuality: (a: number, b: number, c: number, d: number) => void;
   readonly ifcapi_simplifyMeshes: (a: number, b: number, c: number, d: number, e: number, f: number, g: number, h: number, i: number, j: number, k: number, l: number, m: number, n: number, o: number, p: number, q: number, r: number, s: number, t: number, u: number, v: number, w: number, x: number, y: number, z: number, a1: number) => void;
   readonly ifcapi_version: (a: number, b: number) => void;
+  readonly intersection2d: (a: number, b: number) => number;
   readonly meshOutline2d: (a: number, b: number, c: number, d: number, e: number, f: number) => number;
   readonly meshcollection_buildingRotation: (a: number, b: number) => void;
   readonly meshcollection_diagnostics: (a: number) => number;
@@ -1441,7 +1548,6 @@ export interface InitOutput {
   readonly meshoutlinejs_axisMax: (a: number) => number;
   readonly meshoutlinejs_axisMin: (a: number) => number;
   readonly meshoutlinejs_contour: (a: number, b: number) => number;
-  readonly meshoutlinejs_contourCount: (a: number) => number;
   readonly partitionedbatch_instancedOccurrences: (a: number) => number;
   readonly partitionedbatch_takeMeshes: (a: number) => number;
   readonly partitionedbatch_takeShard: (a: number, b: number) => void;
@@ -1456,6 +1562,7 @@ export interface InitOutput {
   readonly profileentryjs_modelIndex: (a: number) => number;
   readonly profileentryjs_outerPoints: (a: number) => number;
   readonly profileentryjs_transform: (a: number) => number;
+  readonly resolve2d: (a: number) => number;
   readonly simplifiedmeshes_cavitiesDropped: (a: number, b: number) => void;
   readonly simplifiedmeshes_elementIds: (a: number, b: number) => void;
   readonly simplifiedmeshes_indexCounts: (a: number, b: number) => void;
@@ -1541,8 +1648,10 @@ export interface InitOutput {
   readonly symbolictext_ifcType: (a: number, b: number) => void;
   readonly symbolictext_repIdentifier: (a: number, b: number) => void;
   readonly symbolictext_targetPx: (a: number) => number;
+  readonly union2d: (a: number, b: number) => number;
   readonly version: (a: number) => void;
   readonly init: () => void;
+  readonly meshoutlinejs_contourCount: (a: number) => number;
   readonly symbolicpolyline_pointCount: (a: number) => number;
   readonly get_memory: () => number;
   readonly symbolicfillarea_expressId: (a: number) => number;

--- a/packages/wasm/pkg/ifc-lite.d.ts
+++ b/packages/wasm/pkg/ifc-lite.d.ts
@@ -65,7 +65,10 @@ export class Contours2D {
    *
    * Shape grouping is a property of boolean *results*: a set built here is
    * an unstructured ring soup, so `shapeCount` reports 0 until it has been
-   * through an operation (`resolve2d` alone is enough).
+   * through an operation (`resolve2d` alone is enough). Degenerate rings
+   * (under 3 vertices or carrying a non-finite coordinate) are dropped at
+   * construction, so `isEmpty`/`bounds()` report the same rings a later
+   * boolean would keep rather than exposing an unsanitised soup.
    */
   constructor(coords: Float64Array, ring_lengths: Uint32Array);
   /**
@@ -81,8 +84,10 @@ export class Contours2D {
   bounds(): Float64Array | undefined;
   /**
    * Every ring's coordinates concatenated. Paired with `ringLengths()` this
-   * is the exact inverse of the constructor, and it reads a whole result
-   * back in one boundary crossing instead of one per ring.
+   * reconstructs the set through the constructor, and reads a whole result
+   * back in one boundary crossing instead of one per ring. It round-trips the
+   * constructor's *sanitised* rings — degenerate rings and explicit closing
+   * vertices are dropped at construction, so those are not echoed back.
    */
   coords(): Float64Array;
   /**
@@ -95,7 +100,9 @@ export class Contours2D {
    */
   readonly shapeCount: number;
   /**
-   * True when the set covers no area.
+   * True when the set holds no rings. Degenerate rings are dropped at
+   * construction and never emitted by an operation, so this also means the
+   * set covers no area.
    */
   readonly isEmpty: boolean;
 }

--- a/rust/geometry/src/contour_bool2d.rs
+++ b/rust/geometry/src/contour_bool2d.rs
@@ -64,7 +64,7 @@ impl ContourSet {
     /// True when the set holds no boundary rings. Every `ContourSet` produced
     /// by this module — a boolean result, or a soup that has been through
     /// [`sanitize`] (which the WASM constructor applies) — has had its
-    /// non-contributing rings (under 3 vertices, non-finite, or zero-area)
+    /// non-contributing rings (under 3 vertices, non-finite, or exactly collinear)
     /// dropped, so for those this also means it covers no area.
     pub fn is_empty(&self) -> bool {
         self.rings.is_empty()

--- a/rust/geometry/src/contour_bool2d.rs
+++ b/rust/geometry/src/contour_bool2d.rs
@@ -1,0 +1,232 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! General 2D boolean operations over **contour sets** (issue #1863).
+//!
+//! [`bool2d`](crate::bool2d) solves one fixed problem: subtract void footprints
+//! from a single [`Profile2D`](crate::profile::Profile2D) before extrusion. Its
+//! results are collapsed to the largest output shape, which is right there (a
+//! profile is one region) and wrong for anything else.
+//!
+//! This module is the general form: union / difference / intersection over
+//! arbitrary ring sets, keeping **every** disjoint output shape with its holes.
+//! It exists for analytic hidden-surface removal, whose core loop is
+//!
+//! ```text
+//! visible   = outline(e) - occluders      // may split into many islands
+//! occluders = occluders ∪ outline(e)
+//! ```
+//!
+//! where collapsing to the largest shape would silently delete visible
+//! geometry: a wall seen behind a column is two visible slivers, not one.
+//!
+//! ## Winding is the contract
+//!
+//! Every operation uses [`FillRule::NonZero`] and **respects the input ring
+//! winding**: counter-clockwise rings add coverage, clockwise rings remove it.
+//! That is the convention
+//! [`mesh_outline_2d`](crate::projection_outline::mesh_outline_2d) emits, so an
+//! outline's rings feed straight back in and its holes survive the round trip,
+//! and it is what SVG `fill-rule="nonzero"` renders. A caller holding raw,
+//! arbitrarily-wound contours (projected triangles, say) must normalise them
+//! CCW first — see [`ensure_ccw`](crate::ensure_ccw). This layer will not
+//! guess, because guessing is precisely what destroys holes.
+
+use i_overlay::core::fill_rule::FillRule;
+use i_overlay::core::overlay_rule::OverlayRule;
+use i_overlay::float::single::SingleFloatOverlay;
+
+/// A closed ring: 2D points in order, WITHOUT a duplicated closing vertex.
+pub type Ring2D = Vec<[f64; 2]>;
+
+/// The result of a contour-set boolean: rings grouped into disjoint shapes.
+///
+/// Unlike [`Profile2D`](crate::profile::Profile2D) this holds any number of
+/// shapes, so a difference that splits its subject into islands loses nothing.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct ContourSet {
+    /// Every boundary ring, laid out shape by shape.
+    pub rings: Vec<Ring2D>,
+    /// `shape_offsets[s]` is the index in [`rings`](Self::rings) of shape `s`'s
+    /// OUTER ring; the rings from there to the next offset (or the end) are
+    /// that shape's holes. Length == number of disjoint shapes.
+    pub shape_offsets: Vec<usize>,
+}
+
+impl ContourSet {
+    /// True when the set covers no area at all.
+    pub fn is_empty(&self) -> bool {
+        self.rings.is_empty()
+    }
+
+    /// Number of disjoint shapes.
+    pub fn shape_count(&self) -> usize {
+        self.shape_offsets.len()
+    }
+
+    /// Rings of shape `s` (outer boundary first, then its holes), or `None`
+    /// when `s` is out of range.
+    pub fn shape(&self, s: usize) -> Option<&[Ring2D]> {
+        let start = *self.shape_offsets.get(s)?;
+        let end = self
+            .shape_offsets
+            .get(s + 1)
+            .copied()
+            .unwrap_or(self.rings.len());
+        self.rings.get(start..end)
+    }
+
+    /// Axis-aligned bounds `[min_x, min_y, max_x, max_y]`, `None` when empty.
+    ///
+    /// Cheap enough to be the first test in an occlusion loop: an accumulated
+    /// occluder that does not overlap the next element's outline needs no
+    /// boolean at all.
+    pub fn bounds(&self) -> Option<[f64; 4]> {
+        let mut b = [
+            f64::INFINITY,
+            f64::INFINITY,
+            f64::NEG_INFINITY,
+            f64::NEG_INFINITY,
+        ];
+        for p in self.rings.iter().flatten() {
+            b[0] = b[0].min(p[0]);
+            b[1] = b[1].min(p[1]);
+            b[2] = b[2].max(p[0]);
+            b[3] = b[3].max(p[1]);
+        }
+        (b[0] <= b[2]).then_some(b)
+    }
+}
+
+/// Which boolean to apply in [`boolean_2d`].
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum BooleanOp2D {
+    /// `subject ∪ clip`.
+    Union,
+    /// `subject - clip`.
+    Difference,
+    /// `subject ∩ clip`.
+    Intersection,
+}
+
+impl BooleanOp2D {
+    /// Decode the 0/1/2 = union/difference/intersection convention used across
+    /// the WASM boundary.
+    pub fn from_u8(v: u8) -> Option<Self> {
+        match v {
+            0 => Some(BooleanOp2D::Union),
+            1 => Some(BooleanOp2D::Difference),
+            2 => Some(BooleanOp2D::Intersection),
+            _ => None,
+        }
+    }
+}
+
+/// Drop rings that cannot contribute, so no input can panic or hang the
+/// overlay: fewer than 3 vertices, or ANY non-finite coordinate (a NaN makes
+/// i_overlay's segment ordering meaningless, so the whole ring goes rather than
+/// the offending point — dropping single points would silently deform the
+/// boundary instead). A trailing vertex equal to the first is stripped, so a
+/// caller that closes its rings explicitly does not feed in a zero-length edge.
+fn sanitize(rings: &[Ring2D]) -> Vec<Vec<[f64; 2]>> {
+    rings
+        .iter()
+        .filter_map(|ring| {
+            if ring.iter().any(|p| !p[0].is_finite() || !p[1].is_finite()) {
+                return None;
+            }
+            let mut path = ring.clone();
+            while path.len() >= 2 && path[path.len() - 1] == path[0] {
+                path.pop();
+            }
+            (path.len() >= 3).then_some(path)
+        })
+        .collect()
+}
+
+/// Flatten i_overlay's `shapes -> contours -> points` output into a
+/// [`ContourSet`], preserving the shape grouping (which
+/// `mesh_outline_2d` throws away).
+fn collect(shapes: Vec<Vec<Vec<[f64; 2]>>>) -> ContourSet {
+    let mut out = ContourSet::default();
+    for shape in shapes {
+        // i_overlay emits each shape's outer boundary first; a shape whose
+        // outer ring degenerated has nothing to contribute, holes included.
+        match shape.first() {
+            Some(outer) if outer.len() >= 3 => {}
+            _ => continue,
+        }
+        out.shape_offsets.push(out.rings.len());
+        for ring in shape {
+            if ring.len() >= 3 {
+                out.rings.push(ring);
+            }
+        }
+    }
+    out
+}
+
+/// Self-union: overlay against an empty clip so overlapping subject rings
+/// dissolve into disjoint shapes without changing the covered area.
+fn resolve(subject: &[Vec<[f64; 2]>]) -> ContourSet {
+    let empty: Vec<Vec<[f64; 2]>> = Vec::new();
+    collect(subject.overlay(&empty, OverlayRule::Union, FillRule::NonZero))
+}
+
+/// Apply a boolean operation to two contour sets.
+///
+/// Ring winding carries outer-vs-hole (see the module docs); the fill rule is
+/// always NonZero. Never panics: degenerate rings are dropped and every empty
+/// combination has a defined answer —
+///
+/// | subject | clip  | union | difference | intersection |
+/// |---------|-------|-------|------------|--------------|
+/// | empty   | any   | clip  | empty      | empty        |
+/// | any     | empty | subj  | subj       | empty        |
+///
+/// where "clip"/"subj" mean that operand resolved into disjoint shapes.
+pub fn boolean_2d(subject: &[Ring2D], clip: &[Ring2D], op: BooleanOp2D) -> ContourSet {
+    let subject = sanitize(subject);
+    let clip = sanitize(clip);
+    match op {
+        BooleanOp2D::Union => {
+            if subject.is_empty() {
+                return resolve(&clip);
+            }
+            if clip.is_empty() {
+                return resolve(&subject);
+            }
+            collect(subject.overlay(&clip, OverlayRule::Union, FillRule::NonZero))
+        }
+        BooleanOp2D::Difference => {
+            if subject.is_empty() {
+                return ContourSet::default();
+            }
+            // Subtracting nothing is the identity, but the subject may still
+            // self-overlap; resolve it so the result is always disjoint shapes.
+            if clip.is_empty() {
+                return resolve(&subject);
+            }
+            collect(subject.overlay(&clip, OverlayRule::Difference, FillRule::NonZero))
+        }
+        BooleanOp2D::Intersection => {
+            if subject.is_empty() || clip.is_empty() {
+                return ContourSet::default();
+            }
+            collect(subject.overlay(&clip, OverlayRule::Intersect, FillRule::NonZero))
+        }
+    }
+}
+
+/// Resolve a ring set into disjoint shapes without changing the area it covers
+/// (a self-union). Canonicalises a hand-built contour set — or the flattened
+/// rings of a [`MeshOutline`](crate::projection_outline::MeshOutline) — into
+/// grouped outer/hole shapes.
+pub fn resolve_2d(rings: &[Ring2D]) -> ContourSet {
+    boolean_2d(rings, &[], BooleanOp2D::Union)
+}
+
+#[cfg(test)]
+#[path = "contour_bool2d_tests.rs"]
+mod tests;

--- a/rust/geometry/src/contour_bool2d.rs
+++ b/rust/geometry/src/contour_bool2d.rs
@@ -133,27 +133,40 @@ impl BooleanOp2D {
     }
 }
 
-/// Exactly-zero signed (shoelace) area of a ring — a fully collinear loop.
-/// Used only to drop rings that provably cover nothing; a genuinely thin
-/// sliver has non-zero area and is left for i_overlay to judge, so this never
-/// discards real coverage.
-fn is_zero_area(path: &[[f64; 2]]) -> bool {
-    let n = path.len();
-    let mut a = 0.0;
-    for i in 0..n {
-        let j = (i + 1) % n;
-        a += path[i][0] * path[j][1] - path[j][0] * path[i][1];
-    }
-    a == 0.0
+/// True when every vertex lies on one straight line — a ring with no interior
+/// at all. This is deliberately NOT a zero-*area* test: a self-intersecting
+/// bow-tie has zero signed (shoelace) area yet i_overlay fills both its lobes
+/// under NonZero, so dropping by area would silently discard real coverage.
+/// Collinearity is exact (`== 0.0` cross product), so it fires only on
+/// provably-degenerate input; a genuinely thin sliver is not exactly collinear
+/// and is left for i_overlay to judge, exactly as before this filter existed.
+fn is_collinear(path: &[[f64; 2]]) -> bool {
+    let p0 = path[0];
+    // Direction from p0 to the first vertex that differs from it.
+    let dir = path.iter().find_map(|p| {
+        let d = [p[0] - p0[0], p[1] - p0[1]];
+        (d != [0.0, 0.0]).then_some(d)
+    });
+    // All vertices identical → no interior.
+    let Some(dir) = dir else {
+        return true;
+    };
+    // Every vertex on the p0 + t·dir line: cross(dir, p - p0) == 0.
+    path.iter().all(|p| {
+        let d = [p[0] - p0[0], p[1] - p0[1]];
+        dir[0] * d[1] - dir[1] * d[0] == 0.0
+    })
 }
 
 /// Drop rings that cannot contribute, so no input can panic or hang the
 /// overlay: fewer than 3 vertices, ANY non-finite coordinate (a NaN makes
 /// i_overlay's segment ordering meaningless, so the whole ring goes rather than
 /// the offending point — dropping single points would silently deform the
-/// boundary instead), or an exactly-zero (collinear) area. A trailing vertex
-/// equal to the first is stripped, so a caller that closes its rings explicitly
-/// does not feed in a zero-length edge.
+/// boundary instead), or all vertices collinear (a ring with no interior). A
+/// trailing vertex equal to the first is stripped, so a caller that closes its
+/// rings explicitly does not feed in a zero-length edge. Note this drops only
+/// provably-collinear rings, NOT by area: a zero-signed-area bow-tie still
+/// carries coverage under NonZero and is left for i_overlay.
 ///
 /// Re-exported (as `sanitize_contours`) so the WASM `Contours2D` constructor
 /// can hold the same invariant its accessors document, rather than exposing a
@@ -171,7 +184,7 @@ pub fn sanitize(rings: &[Ring2D]) -> Vec<Vec<[f64; 2]>> {
             while path.len() >= 2 && path[path.len() - 1] == path[0] {
                 path.pop();
             }
-            if path.len() < 3 || is_zero_area(&path) {
+            if path.len() < 3 || is_collinear(&path) {
                 return None;
             }
             Some(path)

--- a/rust/geometry/src/contour_bool2d.rs
+++ b/rust/geometry/src/contour_bool2d.rs
@@ -24,14 +24,20 @@
 //! ## Winding is the contract
 //!
 //! Every operation uses [`FillRule::NonZero`] and **respects the input ring
-//! winding**: counter-clockwise rings add coverage, clockwise rings remove it.
-//! That is the convention
-//! [`mesh_outline_2d`](crate::projection_outline::mesh_outline_2d) emits, so an
+//! winding**: counter-clockwise rings add coverage, clockwise rings remove it
+//! *from the region they overlap*. So a clockwise ring nested inside a
+//! counter-clockwise one is a hole, which is the convention
+//! [`mesh_outline_2d`](crate::projection_outline::mesh_outline_2d) emits — an
 //! outline's rings feed straight back in and its holes survive the round trip,
-//! and it is what SVG `fill-rule="nonzero"` renders. A caller holding raw,
-//! arbitrarily-wound contours (projected triangles, say) must normalise them
-//! CCW first — see [`ensure_ccw`](crate::ensure_ccw). This layer will not
-//! guess, because guessing is precisely what destroys holes.
+//! and it is what SVG `fill-rule="nonzero"` renders. NonZero is literal here:
+//! winding matters relative to the rings around a point, not in the absolute.
+//! A *lone* clockwise ring still has non-zero winding inside it, so it fills
+//! (and comes back counter-clockwise) rather than staying "negative" — a bare
+//! hole with no outer to subtract from is not a meaningful input. A caller
+//! holding raw, arbitrarily-wound contours (projected triangles, say) that all
+//! mean "covered" must normalise them CCW first — see
+//! [`ensure_ccw`](crate::ensure_ccw). This layer will not guess, because
+//! guessing is precisely what destroys the holes of a well-formed set.
 
 use i_overlay::core::fill_rule::FillRule;
 use i_overlay::core::overlay_rule::OverlayRule;
@@ -55,7 +61,11 @@ pub struct ContourSet {
 }
 
 impl ContourSet {
-    /// True when the set covers no area at all.
+    /// True when the set holds no boundary rings. Every `ContourSet` produced
+    /// by this module — a boolean result, or a soup that has been through
+    /// [`sanitize`] (which the WASM constructor applies) — has had its
+    /// non-contributing rings (under 3 vertices, non-finite, or zero-area)
+    /// dropped, so for those this also means it covers no area.
     pub fn is_empty(&self) -> bool {
         self.rings.is_empty()
     }
@@ -123,13 +133,34 @@ impl BooleanOp2D {
     }
 }
 
+/// Exactly-zero signed (shoelace) area of a ring — a fully collinear loop.
+/// Used only to drop rings that provably cover nothing; a genuinely thin
+/// sliver has non-zero area and is left for i_overlay to judge, so this never
+/// discards real coverage.
+fn is_zero_area(path: &[[f64; 2]]) -> bool {
+    let n = path.len();
+    let mut a = 0.0;
+    for i in 0..n {
+        let j = (i + 1) % n;
+        a += path[i][0] * path[j][1] - path[j][0] * path[i][1];
+    }
+    a == 0.0
+}
+
 /// Drop rings that cannot contribute, so no input can panic or hang the
-/// overlay: fewer than 3 vertices, or ANY non-finite coordinate (a NaN makes
+/// overlay: fewer than 3 vertices, ANY non-finite coordinate (a NaN makes
 /// i_overlay's segment ordering meaningless, so the whole ring goes rather than
 /// the offending point — dropping single points would silently deform the
-/// boundary instead). A trailing vertex equal to the first is stripped, so a
-/// caller that closes its rings explicitly does not feed in a zero-length edge.
-fn sanitize(rings: &[Ring2D]) -> Vec<Vec<[f64; 2]>> {
+/// boundary instead), or an exactly-zero (collinear) area. A trailing vertex
+/// equal to the first is stripped, so a caller that closes its rings explicitly
+/// does not feed in a zero-length edge.
+///
+/// Re-exported (as `sanitize_contours`) so the WASM `Contours2D` constructor
+/// can hold the same invariant its accessors document, rather than exposing a
+/// raw ring soup that a later boolean would silently disagree with: after this,
+/// a set's rings are exactly the ones a boolean would keep, so `is_empty`/
+/// `bounds` cannot report a collinear or degenerate ring that covers nothing.
+pub fn sanitize(rings: &[Ring2D]) -> Vec<Vec<[f64; 2]>> {
     rings
         .iter()
         .filter_map(|ring| {
@@ -140,7 +171,10 @@ fn sanitize(rings: &[Ring2D]) -> Vec<Vec<[f64; 2]>> {
             while path.len() >= 2 && path[path.len() - 1] == path[0] {
                 path.pop();
             }
-            (path.len() >= 3).then_some(path)
+            if path.len() < 3 || is_zero_area(&path) {
+                return None;
+            }
+            Some(path)
         })
         .collect()
 }

--- a/rust/geometry/src/contour_bool2d_tests.rs
+++ b/rust/geometry/src/contour_bool2d_tests.rs
@@ -1,0 +1,348 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Unit tests for [`super`] (general contour-set 2D booleans, issue #1863).
+//! Split into a `*_tests.rs` file (module-size-ratchet exempt) and attached via
+//! `#[path]`.
+
+use super::*;
+use crate::projection_outline::{mesh_outline_2d, ProjectionAxis};
+
+/// Axis-aligned rectangle, counter-clockwise (positive area = covered region).
+fn rect_ccw(x0: f64, y0: f64, x1: f64, y1: f64) -> Ring2D {
+    vec![[x0, y0], [x1, y0], [x1, y1], [x0, y1]]
+}
+
+/// Axis-aligned rectangle, clockwise (negative area = hole under NonZero).
+fn rect_cw(x0: f64, y0: f64, x1: f64, y1: f64) -> Ring2D {
+    vec![[x0, y0], [x0, y1], [x1, y1], [x1, y0]]
+}
+
+fn signed_area(ring: &Ring2D) -> f64 {
+    let n = ring.len();
+    let mut a = 0.0;
+    for i in 0..n {
+        let j = (i + 1) % n;
+        a += ring[i][0] * ring[j][1] - ring[j][0] * ring[i][1];
+    }
+    a * 0.5
+}
+
+/// Total covered area: outer rings add, hole rings subtract, which is exactly
+/// what summing the signed areas does when winding carries outer-vs-hole.
+fn covered_area(set: &ContourSet) -> f64 {
+    set.rings.iter().map(signed_area).sum()
+}
+
+const TOL: f64 = 1e-9;
+
+// ---------------------------------------------------------------------------
+// Union
+// ---------------------------------------------------------------------------
+
+#[test]
+fn union_of_overlapping_squares_merges_into_one_shape() {
+    let a = vec![rect_ccw(0.0, 0.0, 2.0, 2.0)];
+    let b = vec![rect_ccw(1.0, 1.0, 3.0, 3.0)];
+    let out = boolean_2d(&a, &b, BooleanOp2D::Union);
+    assert_eq!(out.shape_count(), 1, "overlapping squares are one region");
+    assert_eq!(out.rings.len(), 1, "an L-shape has no holes");
+    // 4 + 4 - 1 overlap.
+    assert!((covered_area(&out) - 7.0).abs() < TOL, "{}", covered_area(&out));
+}
+
+#[test]
+fn union_of_disjoint_squares_keeps_both_shapes() {
+    let a = vec![rect_ccw(0.0, 0.0, 1.0, 1.0)];
+    let b = vec![rect_ccw(5.0, 5.0, 6.0, 6.0)];
+    let out = boolean_2d(&a, &b, BooleanOp2D::Union);
+    assert_eq!(out.shape_count(), 2, "disjoint islands must both survive");
+    assert_eq!(out.shape_offsets, vec![0, 1]);
+    assert!((covered_area(&out) - 2.0).abs() < TOL);
+}
+
+#[test]
+fn union_closing_a_ring_leaves_a_hole() {
+    // Four bars forming a square annulus: the enclosed middle is a hole.
+    let bars = vec![
+        rect_ccw(0.0, 0.0, 10.0, 1.0),
+        rect_ccw(0.0, 9.0, 10.0, 10.0),
+        rect_ccw(0.0, 0.0, 1.0, 10.0),
+        rect_ccw(9.0, 0.0, 10.0, 10.0),
+    ];
+    let out = resolve_2d(&bars);
+    assert_eq!(out.shape_count(), 1);
+    assert_eq!(out.rings.len(), 2, "outer boundary + one hole");
+    let shape = out.shape(0).expect("shape 0");
+    assert!(signed_area(&shape[0]) > 0.0, "outer ring must be CCW");
+    assert!(signed_area(&shape[1]) < 0.0, "hole ring must be CW");
+    // 100 total minus the 8x8 middle.
+    assert!((covered_area(&out) - 36.0).abs() < TOL, "{}", covered_area(&out));
+}
+
+// ---------------------------------------------------------------------------
+// Difference — the case the Profile2D-shaped `subtract_2d` cannot express
+// ---------------------------------------------------------------------------
+
+#[test]
+fn difference_splitting_the_subject_keeps_every_island() {
+    // A wide bar cut by a vertical strip through its middle: two visible
+    // slivers. `subtract_2d` would return only the larger one.
+    let bar = vec![rect_ccw(0.0, 0.0, 10.0, 1.0)];
+    let cutter = vec![rect_ccw(4.0, -1.0, 6.0, 2.0)];
+    let out = boolean_2d(&bar, &cutter, BooleanOp2D::Difference);
+    assert_eq!(out.shape_count(), 2, "both remnants must survive the cut");
+    assert!((covered_area(&out) - 8.0).abs() < TOL, "{}", covered_area(&out));
+}
+
+#[test]
+fn difference_into_the_interior_makes_a_hole() {
+    let outer = vec![rect_ccw(0.0, 0.0, 10.0, 10.0)];
+    let inner = vec![rect_ccw(4.0, 4.0, 6.0, 6.0)];
+    let out = boolean_2d(&outer, &inner, BooleanOp2D::Difference);
+    assert_eq!(out.shape_count(), 1);
+    assert_eq!(out.rings.len(), 2, "outer boundary + punched hole");
+    assert!(signed_area(&out.rings[1]) < 0.0, "punched hole must be CW");
+    assert!((covered_area(&out) - 96.0).abs() < TOL);
+}
+
+#[test]
+fn difference_covering_the_subject_is_empty() {
+    let a = vec![rect_ccw(1.0, 1.0, 2.0, 2.0)];
+    let b = vec![rect_ccw(0.0, 0.0, 10.0, 10.0)];
+    let out = boolean_2d(&a, &b, BooleanOp2D::Difference);
+    assert!(out.is_empty(), "a fully occluded element contributes nothing");
+    assert_eq!(out.shape_count(), 0);
+}
+
+#[test]
+fn difference_against_many_clip_rings_subtracts_their_union() {
+    // A caller does not need a `differenceMultiple2d`: several subtrahends in
+    // one clip set union implicitly under NonZero, including where they overlap.
+    let bar = vec![rect_ccw(0.0, 0.0, 10.0, 1.0)];
+    let cutters = vec![
+        rect_ccw(2.0, -1.0, 4.0, 2.0),
+        rect_ccw(3.0, -1.0, 5.0, 2.0), // overlaps the previous one
+        rect_ccw(8.0, -1.0, 9.0, 2.0),
+    ];
+    let out = boolean_2d(&bar, &cutters, BooleanOp2D::Difference);
+    // Removed: x in [2,5] (3 wide, the overlap counted once) and [8,9] (1 wide).
+    assert!((covered_area(&out) - 6.0).abs() < TOL, "{}", covered_area(&out));
+    assert_eq!(out.shape_count(), 3, "remnants at [0,2], [5,8] and [9,10]");
+}
+
+// ---------------------------------------------------------------------------
+// Intersection
+// ---------------------------------------------------------------------------
+
+#[test]
+fn intersection_is_the_shared_region() {
+    let a = vec![rect_ccw(0.0, 0.0, 2.0, 2.0)];
+    let b = vec![rect_ccw(1.0, 1.0, 3.0, 3.0)];
+    let out = boolean_2d(&a, &b, BooleanOp2D::Intersection);
+    assert_eq!(out.shape_count(), 1);
+    assert!((covered_area(&out) - 1.0).abs() < TOL);
+    let bounds = out.bounds().expect("bounds");
+    assert!((bounds[0] - 1.0).abs() < TOL && (bounds[2] - 2.0).abs() < TOL);
+}
+
+#[test]
+fn intersection_of_disjoint_sets_is_empty() {
+    let a = vec![rect_ccw(0.0, 0.0, 1.0, 1.0)];
+    let b = vec![rect_ccw(5.0, 5.0, 6.0, 6.0)];
+    assert!(boolean_2d(&a, &b, BooleanOp2D::Intersection).is_empty());
+}
+
+#[test]
+fn intersecting_a_tile_clips_a_holed_subject_and_keeps_the_hole() {
+    // Screen tiling against a frame: the tile covers the frame's left half,
+    // including part of its hole, so the hole must survive the clip.
+    let frame = vec![rect_ccw(0.0, 0.0, 10.0, 10.0), rect_cw(3.0, 3.0, 7.0, 7.0)];
+    let tile = vec![rect_ccw(-1.0, -1.0, 5.0, 11.0)];
+    let out = boolean_2d(&frame, &tile, BooleanOp2D::Intersection);
+    // Left half of the frame: 5x10 minus the 2x4 slice of hole inside the tile.
+    assert!((covered_area(&out) - 42.0).abs() < TOL, "{}", covered_area(&out));
+}
+
+// ---------------------------------------------------------------------------
+// Winding contract
+// ---------------------------------------------------------------------------
+
+#[test]
+fn input_hole_winding_is_respected_not_normalised() {
+    // The CW inner ring is a hole, so the set covers 100 - 16 = 84, and a
+    // union with an unrelated island must not "repair" it into 100.
+    let frame = vec![rect_ccw(0.0, 0.0, 10.0, 10.0), rect_cw(3.0, 3.0, 7.0, 7.0)];
+    let island = vec![rect_ccw(20.0, 20.0, 21.0, 21.0)];
+    let out = boolean_2d(&frame, &island, BooleanOp2D::Union);
+    assert_eq!(out.shape_count(), 2);
+    assert!((covered_area(&out) - 85.0).abs() < TOL, "{}", covered_area(&out));
+}
+
+#[test]
+fn a_result_round_trips_through_another_boolean_unchanged() {
+    // The output winding must be valid input winding, or an accumulating
+    // occluder loop drifts after its first iteration.
+    let frame = vec![rect_ccw(0.0, 0.0, 10.0, 10.0), rect_cw(3.0, 3.0, 7.0, 7.0)];
+    let once = resolve_2d(&frame);
+    let twice = resolve_2d(&once.rings);
+    assert_eq!(once.shape_offsets, twice.shape_offsets);
+    assert!((covered_area(&once) - covered_area(&twice)).abs() < TOL);
+    assert!((covered_area(&twice) - 84.0).abs() < TOL);
+}
+
+#[test]
+fn accumulating_an_occluder_matches_a_single_union() {
+    // The hidden-surface-removal loop shape: fold elements one at a time into
+    // one accumulator, and it must equal unioning them all at once.
+    let elements = [
+        rect_ccw(0.0, 0.0, 4.0, 4.0),
+        rect_ccw(3.0, 3.0, 7.0, 7.0),
+        rect_ccw(6.0, 0.0, 9.0, 9.0),
+        rect_ccw(20.0, 0.0, 21.0, 1.0),
+    ];
+    let mut acc = ContourSet::default();
+    for e in &elements {
+        acc = boolean_2d(&acc.rings, std::slice::from_ref(e), BooleanOp2D::Union);
+    }
+    let all: Vec<Ring2D> = elements.to_vec();
+    let at_once = resolve_2d(&all);
+    assert_eq!(acc.shape_count(), at_once.shape_count());
+    assert!((covered_area(&acc) - covered_area(&at_once)).abs() < TOL);
+}
+
+// ---------------------------------------------------------------------------
+// Interop with mesh_outline_2d
+// ---------------------------------------------------------------------------
+
+#[test]
+fn mesh_outline_rings_feed_straight_back_in() {
+    // Two triangles forming the unit square in the z=0 plane, viewed down Z.
+    let positions: Vec<f32> = vec![
+        0.0, 0.0, 0.0, //
+        1.0, 0.0, 0.0, //
+        1.0, 1.0, 0.0, //
+        0.0, 1.0, 0.0,
+    ];
+    let indices: Vec<u32> = vec![0, 1, 2, 0, 2, 3];
+    let outline =
+        mesh_outline_2d(&positions, &indices, ProjectionAxis::Z, false).expect("outline");
+    let rings: Vec<Ring2D> = outline
+        .contours
+        .iter()
+        .map(|ring| ring.iter().map(|p| [p[0] as f64, p[1] as f64]).collect())
+        .collect();
+
+    let resolved = resolve_2d(&rings);
+    assert_eq!(resolved.shape_count(), 1);
+    assert!(
+        (covered_area(&resolved) - 1.0).abs() < 1e-6,
+        "outline area must survive the round trip: {}",
+        covered_area(&resolved)
+    );
+
+    // And it differences like any other subject.
+    let cutter = vec![rect_ccw(0.25, -1.0, 0.75, 2.0)];
+    let cut = boolean_2d(&rings, &cutter, BooleanOp2D::Difference);
+    assert_eq!(cut.shape_count(), 2, "the strip splits the square in two");
+    assert!((covered_area(&cut) - 0.5).abs() < 1e-6);
+}
+
+// ---------------------------------------------------------------------------
+// Degenerate input never panics
+// ---------------------------------------------------------------------------
+
+#[test]
+fn empty_operands_have_defined_answers() {
+    let a = vec![rect_ccw(0.0, 0.0, 1.0, 1.0)];
+    let none: Vec<Ring2D> = Vec::new();
+
+    assert!((covered_area(&boolean_2d(&a, &none, BooleanOp2D::Union)) - 1.0).abs() < TOL);
+    assert!((covered_area(&boolean_2d(&none, &a, BooleanOp2D::Union)) - 1.0).abs() < TOL);
+    assert!((covered_area(&boolean_2d(&a, &none, BooleanOp2D::Difference)) - 1.0).abs() < TOL);
+    assert!(boolean_2d(&none, &a, BooleanOp2D::Difference).is_empty());
+    assert!(boolean_2d(&a, &none, BooleanOp2D::Intersection).is_empty());
+    assert!(boolean_2d(&none, &a, BooleanOp2D::Intersection).is_empty());
+    assert!(boolean_2d(&none, &none, BooleanOp2D::Union).is_empty());
+    assert!(resolve_2d(&none).is_empty());
+    assert!(resolve_2d(&none).bounds().is_none());
+}
+
+#[test]
+fn undersized_and_non_finite_rings_are_dropped_not_fatal() {
+    let good = rect_ccw(0.0, 0.0, 1.0, 1.0);
+    let subject = vec![
+        good.clone(),
+        vec![[0.0, 0.0], [1.0, 0.0]],                        // 2 points
+        vec![[5.0, 5.0], [f64::NAN, 6.0], [6.0, 5.0]],       // NaN
+        vec![[7.0, 7.0], [f64::INFINITY, 8.0], [8.0, 7.0]],  // inf
+        vec![],                                              // empty
+    ];
+    let out = resolve_2d(&subject);
+    assert_eq!(out.shape_count(), 1, "only the valid ring survives");
+    assert!((covered_area(&out) - 1.0).abs() < TOL);
+}
+
+#[test]
+fn explicitly_closed_rings_are_accepted() {
+    // A caller that repeats the first vertex to close the ring must get the
+    // same answer as one that does not (no zero-length edge into the overlay).
+    let open = rect_ccw(0.0, 0.0, 2.0, 2.0);
+    let mut closed = open.clone();
+    closed.push(open[0]);
+    let a = resolve_2d(&[open]);
+    let b = resolve_2d(&[closed]);
+    assert_eq!(a.shape_count(), b.shape_count());
+    assert!((covered_area(&a) - covered_area(&b)).abs() < TOL);
+    assert!((covered_area(&b) - 4.0).abs() < TOL);
+}
+
+#[test]
+fn a_zero_area_ring_contributes_nothing() {
+    let collinear = vec![[0.0, 0.0], [1.0, 0.0], [2.0, 0.0]];
+    let out = resolve_2d(&[collinear]);
+    assert!(out.is_empty(), "a collapsed ring covers no area");
+}
+
+// ---------------------------------------------------------------------------
+// Accessors
+// ---------------------------------------------------------------------------
+
+#[test]
+fn shape_accessor_groups_outer_with_its_holes() {
+    // One holed shape plus a plain island; the grouping must not run them
+    // together (the flaw in `mesh_outline_2d`'s flattened contour list).
+    let holed = vec![rect_ccw(0.0, 0.0, 10.0, 10.0), rect_cw(3.0, 3.0, 7.0, 7.0)];
+    let island = vec![rect_ccw(20.0, 20.0, 21.0, 21.0)];
+    let out = boolean_2d(&holed, &island, BooleanOp2D::Union);
+
+    assert_eq!(out.shape_count(), 2);
+    assert_eq!(out.rings.len(), 3);
+    let mut sizes: Vec<usize> = (0..out.shape_count())
+        .map(|s| out.shape(s).expect("shape").len())
+        .collect();
+    sizes.sort_unstable();
+    assert_eq!(sizes, vec![1, 2], "one plain island, one outer + hole");
+    assert!(out.shape(2).is_none(), "out-of-range shape index");
+}
+
+#[test]
+fn bounds_span_every_shape() {
+    let a = vec![rect_ccw(-3.0, -2.0, 1.0, 1.0)];
+    let b = vec![rect_ccw(5.0, 5.0, 6.0, 8.0)];
+    let out = boolean_2d(&a, &b, BooleanOp2D::Union);
+    let bounds = out.bounds().expect("bounds");
+    assert!((bounds[0] + 3.0).abs() < TOL, "min x {}", bounds[0]);
+    assert!((bounds[1] + 2.0).abs() < TOL, "min y {}", bounds[1]);
+    assert!((bounds[2] - 6.0).abs() < TOL, "max x {}", bounds[2]);
+    assert!((bounds[3] - 8.0).abs() < TOL, "max y {}", bounds[3]);
+}
+
+#[test]
+fn op_codes_decode_and_reject() {
+    assert_eq!(BooleanOp2D::from_u8(0), Some(BooleanOp2D::Union));
+    assert_eq!(BooleanOp2D::from_u8(1), Some(BooleanOp2D::Difference));
+    assert_eq!(BooleanOp2D::from_u8(2), Some(BooleanOp2D::Intersection));
+    assert_eq!(BooleanOp2D::from_u8(3), None);
+}

--- a/rust/geometry/src/contour_bool2d_tests.rs
+++ b/rust/geometry/src/contour_bool2d_tests.rs
@@ -307,11 +307,37 @@ fn a_zero_area_ring_contributes_nothing() {
     let collinear = vec![[0.0, 0.0], [1.0, 0.0], [2.0, 0.0]];
     assert!(
         sanitize(std::slice::from_ref(&collinear)).is_empty(),
-        "sanitize must drop a zero-area ring, not just the overlay"
+        "sanitize must drop a collinear ring, not just the overlay"
     );
     let out = resolve_2d(&[collinear]);
     assert!(out.is_empty(), "a collapsed ring covers no area");
     assert!(out.bounds().is_none(), "bounds must agree with is_empty");
+}
+
+#[test]
+fn a_zero_signed_area_bowtie_is_kept_not_dropped() {
+    // A self-intersecting bow-tie has zero SIGNED (shoelace) area, but its two
+    // lobes both fill under NonZero — i_overlay covers area 2 here. Sanitation
+    // must judge degeneracy by collinearity, NOT by area, or this real coverage
+    // vanishes (the trap in an area-based drop).
+    let bowtie = vec![[0.0, 0.0], [2.0, 2.0], [2.0, 0.0], [0.0, 2.0]];
+    assert_eq!(
+        signed_area(&bowtie),
+        0.0,
+        "precondition: the bow-tie's signed area is exactly zero"
+    );
+    assert_eq!(
+        sanitize(std::slice::from_ref(&bowtie)).len(),
+        1,
+        "sanitize must keep a bow-tie — it is not collinear"
+    );
+    let out = resolve_2d(&[bowtie]);
+    assert!(!out.is_empty(), "the bow-tie's lobes must survive");
+    assert!(
+        (covered_area(&out) - 2.0).abs() < TOL,
+        "both lobes fill under NonZero: {}",
+        covered_area(&out)
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/rust/geometry/src/contour_bool2d_tests.rs
+++ b/rust/geometry/src/contour_bool2d_tests.rs
@@ -300,9 +300,18 @@ fn explicitly_closed_rings_are_accepted() {
 
 #[test]
 fn a_zero_area_ring_contributes_nothing() {
+    // A 3-vertex collinear ring is structurally valid (>= 3 finite vertices)
+    // but covers nothing. `sanitize` must drop it, so a set built from ONLY
+    // such rings is genuinely empty — its `is_empty`/`bounds` cannot then
+    // disagree with what a boolean keeps.
     let collinear = vec![[0.0, 0.0], [1.0, 0.0], [2.0, 0.0]];
+    assert!(
+        sanitize(std::slice::from_ref(&collinear)).is_empty(),
+        "sanitize must drop a zero-area ring, not just the overlay"
+    );
     let out = resolve_2d(&[collinear]);
     assert!(out.is_empty(), "a collapsed ring covers no area");
+    assert!(out.bounds().is_none(), "bounds must agree with is_empty");
 }
 
 // ---------------------------------------------------------------------------

--- a/rust/geometry/src/lib.rs
+++ b/rust/geometry/src/lib.rs
@@ -138,7 +138,9 @@ pub use bool2d::{
     compute_signed_area, ensure_ccw, ensure_cw, is_valid_contour, point_in_contour, subtract_2d,
     subtract_multiple_2d, subtract_multiple_2d_counted,
 };
-pub use contour_bool2d::{boolean_2d, resolve_2d, BooleanOp2D, ContourSet, Ring2D};
+pub use contour_bool2d::{
+    boolean_2d, resolve_2d, sanitize as sanitize_contours, BooleanOp2D, ContourSet, Ring2D,
+};
 pub use csg::{calculate_normals, ClippingProcessor, Plane, Triangle};
 pub use diagnostics::{BoolFailure, BoolFailureReason, BoolOp};
 pub use error::{Error, Result};

--- a/rust/geometry/src/lib.rs
+++ b/rust/geometry/src/lib.rs
@@ -76,6 +76,11 @@
 // re-exports below, so those modules are `pub(crate)` (see #C3.2).
 pub(crate) mod alignment;
 pub(crate) mod bool2d;
+/// General 2D booleans over contour sets (union/difference/intersection),
+/// keeping every disjoint output shape. Distinct from `bool2d`, which is the
+/// fixed single-`Profile2D` void-subtraction path. Reached through the
+/// root-level re-exports below, so it stays `pub(crate)` per #C3.2.
+pub(crate) mod contour_bool2d;
 /// Deterministic Constrained Delaunay Triangulation + bounded Ruppert
 /// min-angle refinement. Backs the quality triangulators in `triangulation`.
 mod cdt;
@@ -133,6 +138,7 @@ pub use bool2d::{
     compute_signed_area, ensure_ccw, ensure_cw, is_valid_contour, point_in_contour, subtract_2d,
     subtract_multiple_2d, subtract_multiple_2d_counted,
 };
+pub use contour_bool2d::{boolean_2d, resolve_2d, BooleanOp2D, ContourSet, Ring2D};
 pub use csg::{calculate_normals, ClippingProcessor, Plane, Triangle};
 pub use diagnostics::{BoolFailure, BoolFailureReason, BoolOp};
 pub use error::{Error, Result};

--- a/rust/wasm-bindings/src/api/bool2d.rs
+++ b/rust/wasm-bindings/src/api/bool2d.rs
@@ -62,7 +62,7 @@ impl Contours2D {
     /// Shape grouping is a property of boolean *results*: a set built here is
     /// an unstructured ring soup, so `shapeCount` reports 0 until it has been
     /// through an operation (`resolve2d` alone is enough). Degenerate rings
-    /// (under 3 vertices or carrying a non-finite coordinate) are dropped at
+    /// (under 3 vertices, non-finite, or exactly collinear) are dropped at
     /// construction, so `isEmpty`/`bounds()` report the same rings a later
     /// boolean would keep rather than exposing an unsanitised soup.
     #[wasm_bindgen(constructor)]

--- a/rust/wasm-bindings/src/api/bool2d.rs
+++ b/rust/wasm-bindings/src/api/bool2d.rs
@@ -34,7 +34,9 @@
 //! full contract.
 
 use super::mesh_outline::MeshOutlineJs;
-use ifc_lite_geometry::{boolean_2d, resolve_2d, BooleanOp2D, ContourSet, Ring2D};
+use ifc_lite_geometry::{
+    boolean_2d, resolve_2d, sanitize_contours, BooleanOp2D, ContourSet, Ring2D,
+};
 use wasm_bindgen::prelude::*;
 
 /// A set of closed 2D rings, grouped into disjoint shapes.
@@ -59,16 +61,27 @@ impl Contours2D {
     ///
     /// Shape grouping is a property of boolean *results*: a set built here is
     /// an unstructured ring soup, so `shapeCount` reports 0 until it has been
-    /// through an operation (`resolve2d` alone is enough).
+    /// through an operation (`resolve2d` alone is enough). Degenerate rings
+    /// (under 3 vertices or carrying a non-finite coordinate) are dropped at
+    /// construction, so `isEmpty`/`bounds()` report the same rings a later
+    /// boolean would keep rather than exposing an unsanitised soup.
     #[wasm_bindgen(constructor)]
     pub fn new(coords: &[f64], ring_lengths: &[u32]) -> Result<Contours2D, JsValue> {
         if coords.len() % 2 != 0 {
             return Err(js_sys::Error::new("Contours2D: coords length must be even").into());
         }
-        let expected: usize = ring_lengths.iter().map(|n| *n as usize).sum();
-        if expected * 2 != coords.len() {
+        // Checked arithmetic: on wasm32 `usize` is 32-bit, so a crafted
+        // `ringLengths` could otherwise overflow the vertex total (or its ×2)
+        // past the length check and then panic slicing `coords` below.
+        let expected = ring_lengths
+            .iter()
+            .try_fold(0usize, |acc, n| acc.checked_add(*n as usize))
+            .and_then(|v| v.checked_mul(2))
+            .ok_or_else(|| js_sys::Error::new("Contours2D: ringLengths overflow"))?;
+        if expected != coords.len() {
             return Err(js_sys::Error::new(&format!(
-                "Contours2D: ringLengths sum to {expected} vertices but coords hold {}",
+                "Contours2D: ringLengths sum to {} vertices but coords hold {}",
+                expected / 2,
                 coords.len() / 2
             ))
             .into());
@@ -86,7 +99,7 @@ impl Contours2D {
         }
         Ok(Contours2D {
             set: ContourSet {
-                rings,
+                rings: sanitize_contours(&rings),
                 shape_offsets: Vec::new(),
             },
         })
@@ -100,9 +113,12 @@ impl Contours2D {
     /// the caller still needs them for band classification.
     #[wasm_bindgen(js_name = fromMeshOutline)]
     pub fn from_mesh_outline(outline: &MeshOutlineJs) -> Contours2D {
+        // `meshOutline2d` rings are already valid (>= 3 vertices, finite,
+        // unclosed), so `sanitize` is a near no-op here — applied only to hold
+        // the same raw-accessor invariant the constructor documents.
         Contours2D {
             set: ContourSet {
-                rings: outline.rings_f64(),
+                rings: sanitize_contours(&outline.rings_f64()),
                 shape_offsets: Vec::new(),
             },
         }
@@ -121,7 +137,9 @@ impl Contours2D {
         self.set.shape_count()
     }
 
-    /// True when the set covers no area.
+    /// True when the set holds no rings. Degenerate rings are dropped at
+    /// construction and never emitted by an operation, so this also means the
+    /// set covers no area.
     #[wasm_bindgen(getter, js_name = isEmpty)]
     pub fn is_empty(&self) -> bool {
         self.set.is_empty()
@@ -153,8 +171,10 @@ impl Contours2D {
     }
 
     /// Every ring's coordinates concatenated. Paired with `ringLengths()` this
-    /// is the exact inverse of the constructor, and it reads a whole result
-    /// back in one boundary crossing instead of one per ring.
+    /// reconstructs the set through the constructor, and reads a whole result
+    /// back in one boundary crossing instead of one per ring. It round-trips the
+    /// constructor's *sanitised* rings — degenerate rings and explicit closing
+    /// vertices are dropped at construction, so those are not echoed back.
     pub fn coords(&self) -> js_sys::Float64Array {
         let total: usize = self.set.rings.iter().map(|r| r.len() * 2).sum();
         let mut flat = Vec::with_capacity(total);

--- a/rust/wasm-bindings/src/api/bool2d.rs
+++ b/rust/wasm-bindings/src/api/bool2d.rs
@@ -1,0 +1,226 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! WASM API: general 2D boolean operations over contour sets (issue #1863).
+//!
+//! Until now the only `i_overlay` capability crossing the boundary was the
+//! fixed-purpose [`meshOutline2d`](super::mesh_outline). Downstream analytic
+//! hidden-surface removal needs the general form, or it has to bolt a second
+//! 2D geometry engine (with different winding and precision semantics) onto
+//! the same pipeline:
+//!
+//! ```javascript
+//! let occluders = new Contours2D(new Float64Array(), new Uint32Array()); // empty
+//! for (const el of frontToBack) {
+//!   const outline = Contours2D.fromMeshOutline(meshOutline2d(...));
+//!   const visible = difference2d(outline, occluders);   // may split into islands
+//!   const grown = union2d(occluders, outline);
+//!   occluders.free();
+//!   occluders = grown;
+//!   emitSvgPath(visible);                                // fill-rule="nonzero"
+//!   visible.free();
+//!   outline.free();
+//! }
+//! ```
+//!
+//! Every handle returned here owns wasm memory: `free()` it, and note that the
+//! operations return NEW handles rather than mutating their operands, so an
+//! accumulating loop must free the handle it replaces (as above).
+//!
+//! Winding carries outer-vs-hole (CCW covers, CW subtracts) and the fill rule
+//! is always NonZero, matching `meshOutline2d`'s output and SVG
+//! `fill-rule="nonzero"`. See `ifc_lite_geometry::contour_bool2d` for the
+//! full contract.
+
+use super::mesh_outline::MeshOutlineJs;
+use ifc_lite_geometry::{boolean_2d, resolve_2d, BooleanOp2D, ContourSet, Ring2D};
+use wasm_bindgen::prelude::*;
+
+/// A set of closed 2D rings, grouped into disjoint shapes.
+///
+/// Rings carry no duplicated closing vertex (connect the last point back to
+/// the first). Winding is meaningful: a counter-clockwise ring covers area, a
+/// clockwise one removes it, so an outer boundary and its holes are
+/// distinguishable without any extra tagging — the property
+/// `meshOutline2d`'s flattened contour list relies on too.
+#[wasm_bindgen]
+pub struct Contours2D {
+    set: ContourSet,
+}
+
+#[wasm_bindgen]
+impl Contours2D {
+    /// Build a contour set from flat coordinates plus per-ring vertex counts.
+    ///
+    /// `coords` is `[x0, y0, x1, y1, …]` with every ring concatenated in order;
+    /// `ringLengths[i]` is the VERTEX count (not the float count) of ring `i`.
+    /// Throws when the counts do not add up to `coords.length / 2`.
+    ///
+    /// Shape grouping is a property of boolean *results*: a set built here is
+    /// an unstructured ring soup, so `shapeCount` reports 0 until it has been
+    /// through an operation (`resolve2d` alone is enough).
+    #[wasm_bindgen(constructor)]
+    pub fn new(coords: &[f64], ring_lengths: &[u32]) -> Result<Contours2D, JsValue> {
+        if coords.len() % 2 != 0 {
+            return Err(js_sys::Error::new("Contours2D: coords length must be even").into());
+        }
+        let expected: usize = ring_lengths.iter().map(|n| *n as usize).sum();
+        if expected * 2 != coords.len() {
+            return Err(js_sys::Error::new(&format!(
+                "Contours2D: ringLengths sum to {expected} vertices but coords hold {}",
+                coords.len() / 2
+            ))
+            .into());
+        }
+        let mut rings: Vec<Ring2D> = Vec::with_capacity(ring_lengths.len());
+        let mut at = 0usize;
+        for n in ring_lengths {
+            let n = *n as usize;
+            let ring = coords[at * 2..(at + n) * 2]
+                .chunks_exact(2)
+                .map(|p| [p[0], p[1]])
+                .collect();
+            rings.push(ring);
+            at += n;
+        }
+        Ok(Contours2D {
+            set: ContourSet {
+                rings,
+                shape_offsets: Vec::new(),
+            },
+        })
+    }
+
+    /// Adopt the rings of a `meshOutline2d` result, widening its f32
+    /// coordinates to the f64 the boolean engine works in.
+    ///
+    /// The outline's `axisMin`/`axisMax` are dropped — they describe the cut
+    /// axis, which a 2D boolean has no notion of; keep them on the JS side if
+    /// the caller still needs them for band classification.
+    #[wasm_bindgen(js_name = fromMeshOutline)]
+    pub fn from_mesh_outline(outline: &MeshOutlineJs) -> Contours2D {
+        Contours2D {
+            set: ContourSet {
+                rings: outline.rings_f64(),
+                shape_offsets: Vec::new(),
+            },
+        }
+    }
+
+    /// Total number of boundary rings across every shape.
+    #[wasm_bindgen(getter, js_name = ringCount)]
+    pub fn ring_count(&self) -> usize {
+        self.set.rings.len()
+    }
+
+    /// Number of disjoint shapes, or 0 for a set that has not been through an
+    /// operation yet (see the constructor).
+    #[wasm_bindgen(getter, js_name = shapeCount)]
+    pub fn shape_count(&self) -> usize {
+        self.set.shape_count()
+    }
+
+    /// True when the set covers no area.
+    #[wasm_bindgen(getter, js_name = isEmpty)]
+    pub fn is_empty(&self) -> bool {
+        self.set.is_empty()
+    }
+
+    /// Ring index at which each shape starts. Entry `s` is shape `s`'s OUTER
+    /// ring; the rings up to the next entry (or `ringCount`) are its holes.
+    #[wasm_bindgen(js_name = shapeOffsets)]
+    pub fn shape_offsets(&self) -> js_sys::Uint32Array {
+        let v: Vec<u32> = self
+            .set
+            .shape_offsets
+            .iter()
+            .map(|o| *o as u32)
+            .collect();
+        js_sys::Uint32Array::from(&v[..])
+    }
+
+    /// Ring `index` as a flat `[x0, y0, x1, y1, …]` array, or `undefined` when
+    /// out of range.
+    pub fn ring(&self, index: usize) -> Option<js_sys::Float64Array> {
+        let ring = self.set.rings.get(index)?;
+        let mut flat = Vec::with_capacity(ring.len() * 2);
+        for p in ring {
+            flat.push(p[0]);
+            flat.push(p[1]);
+        }
+        Some(js_sys::Float64Array::from(&flat[..]))
+    }
+
+    /// Every ring's coordinates concatenated. Paired with `ringLengths()` this
+    /// is the exact inverse of the constructor, and it reads a whole result
+    /// back in one boundary crossing instead of one per ring.
+    pub fn coords(&self) -> js_sys::Float64Array {
+        let total: usize = self.set.rings.iter().map(|r| r.len() * 2).sum();
+        let mut flat = Vec::with_capacity(total);
+        for ring in &self.set.rings {
+            for p in ring {
+                flat.push(p[0]);
+                flat.push(p[1]);
+            }
+        }
+        js_sys::Float64Array::from(&flat[..])
+    }
+
+    /// Vertex count of each ring, in the same order as `coords()`.
+    #[wasm_bindgen(js_name = ringLengths)]
+    pub fn ring_lengths(&self) -> js_sys::Uint32Array {
+        let v: Vec<u32> = self.set.rings.iter().map(|r| r.len() as u32).collect();
+        js_sys::Uint32Array::from(&v[..])
+    }
+
+    /// Axis-aligned bounds as `[minX, minY, maxX, maxY]`, or `undefined` when
+    /// empty. Cheap enough to gate the boolean itself: an accumulated occluder
+    /// whose bounds miss the next element needs no difference at all.
+    pub fn bounds(&self) -> Option<js_sys::Float64Array> {
+        self.set
+            .bounds()
+            .map(|b| js_sys::Float64Array::from(&b[..]))
+    }
+}
+
+/// `a ∪ b`.
+#[wasm_bindgen(js_name = union2d)]
+pub fn union_2d(a: &Contours2D, b: &Contours2D) -> Contours2D {
+    Contours2D {
+        set: boolean_2d(&a.set.rings, &b.set.rings, BooleanOp2D::Union),
+    }
+}
+
+/// `a - b`, keeping EVERY disjoint remnant.
+///
+/// This is the operation the existing `subtract_2d` could not stand in for: it
+/// returns one shape per island, where `subtract_2d` collapses to the largest
+/// (correct for a single extrusion profile, silent geometry loss anywhere else).
+///
+/// `b` may hold any number of rings; they subtract as their union, so there is
+/// no separate "difference against many" entry point.
+#[wasm_bindgen(js_name = difference2d)]
+pub fn difference_2d(a: &Contours2D, b: &Contours2D) -> Contours2D {
+    Contours2D {
+        set: boolean_2d(&a.set.rings, &b.set.rings, BooleanOp2D::Difference),
+    }
+}
+
+/// `a ∩ b`.
+#[wasm_bindgen(js_name = intersection2d)]
+pub fn intersection_2d(a: &Contours2D, b: &Contours2D) -> Contours2D {
+    Contours2D {
+        set: boolean_2d(&a.set.rings, &b.set.rings, BooleanOp2D::Intersection),
+    }
+}
+
+/// Resolve a ring soup into disjoint outer/hole shapes without changing the
+/// area it covers (a self-union). Use it to give a hand-built set — or a
+/// `meshOutline2d` result — the shape grouping the operations produce.
+#[wasm_bindgen(js_name = resolve2d)]
+pub fn resolve_2d_js(a: &Contours2D) -> Contours2D {
+    Contours2D {
+        set: resolve_2d(&a.set.rings),
+    }
+}

--- a/rust/wasm-bindings/src/api/mesh_outline.rs
+++ b/rust/wasm-bindings/src/api/mesh_outline.rs
@@ -55,6 +55,22 @@ impl MeshOutlineJs {
     }
 }
 
+impl MeshOutlineJs {
+    /// Rings as f64 `[x, y]` pairs, widened from the stored f32 flat form, for
+    /// the 2D boolean bindings (`Contours2D::fromMeshOutline`). Not exported to
+    /// JS — the accessor above is the JS-facing shape.
+    pub(crate) fn rings_f64(&self) -> Vec<Vec<[f64; 2]>> {
+        self.contours
+            .iter()
+            .map(|flat| {
+                flat.chunks_exact(2)
+                    .map(|p| [p[0] as f64, p[1] as f64])
+                    .collect()
+            })
+            .collect()
+    }
+}
+
 /// Compute the winding-robust 2D footprint outline of a triangle mesh.
 ///
 /// `positions` is flat XYZ; `indices` is flat triangle indices. `axis` is

--- a/rust/wasm-bindings/src/api/mod.rs
+++ b/rust/wasm-bindings/src/api/mod.rs
@@ -7,6 +7,7 @@
 //! Modern async/await API for parsing IFC files.
 
 mod alignment_lines;
+mod bool2d;
 mod clash;
 mod csg_diagnostics;
 mod diagnose;

--- a/scripts/api-surface.json
+++ b/scripts/api-surface.json
@@ -4031,6 +4031,7 @@
   "@ifc-lite/wasm": [
     "ClashRunResult: class",
     "ClashSession: class",
+    "Contours2D: class",
     "GridAxisCollection: class",
     "GridAxisJs: class",
     "IfcAPI: class",
@@ -4051,10 +4052,14 @@
     "SymbolicText: class",
     "SyncInitInput: type",
     "default: function",
+    "difference2d: function",
     "get_memory: function",
     "init: function",
     "initSync: function",
+    "intersection2d: function",
     "meshOutline2d: function",
+    "resolve2d: function",
+    "union2d: function",
     "version: function"
   ],
   "create-ifc-lite": []

--- a/scripts/test-wasm-contract.mjs
+++ b/scripts/test-wasm-contract.mjs
@@ -891,6 +891,48 @@ test('Contours2D rejects coords that disagree with ringLengths', () => {
   );
 });
 
+test('the constructor drops degenerate rings so accessors stay consistent', () => {
+  // A raw set built from a soup must not report state a later boolean would
+  // disagree with: an all-degenerate input is empty, and isEmpty must agree
+  // with bounds() (a 2-vertex ring is not "one ring" that bounds() can't cover).
+  const coords = Float64Array.from([
+    ...[0, 0, 1, 0], // 2-vertex ring — degenerate
+    ...rectCcw(0, 0, 1, 1), // one real ring
+  ]);
+  const set = new Contours2D(coords, Uint32Array.from([2, 4]));
+  try {
+    assert.equal(set.ringCount, 1, 'the 2-vertex ring must be dropped');
+    assert.equal(set.isEmpty, false);
+    assert.ok(Math.abs(coveredArea(set) - 1) < 1e-9);
+  } finally {
+    set.free();
+  }
+
+  const empty = new Contours2D(Float64Array.from([0, 0, 1, 0]), Uint32Array.from([2]));
+  try {
+    assert.equal(empty.ringCount, 0, 'an all-degenerate set holds no rings');
+    assert.equal(empty.isEmpty, true, 'isEmpty must agree with the dropped ring');
+    assert.equal(empty.bounds(), undefined, 'bounds() must agree with isEmpty');
+  } finally {
+    empty.free();
+  }
+
+  // A 3-vertex COLLINEAR ring is structurally valid but covers zero area; it
+  // must not slip past sanitation and leave isEmpty/bounds disagreeing with a
+  // later boolean (the adversarial edge case behind the constructor sanitation).
+  const collinear = new Contours2D(
+    Float64Array.from([0, 0, 1, 0, 2, 0]),
+    Uint32Array.from([3]),
+  );
+  try {
+    assert.equal(collinear.ringCount, 0, 'a zero-area ring must be dropped');
+    assert.equal(collinear.isEmpty, true);
+    assert.equal(collinear.bounds(), undefined, 'bounds() must not span a dropped ring');
+  } finally {
+    collinear.free();
+  }
+});
+
 test('coords/ringLengths round-trip the constructor across the boundary', () => {
   const ring = rectCcw(0, 0, 2, 3);
   const set = contours(ring);
@@ -923,7 +965,7 @@ test('difference2d keeps every disjoint island', () => {
   }
 });
 
-test('union2d punches a hole and difference2d reports it as one shape', () => {
+test('difference2d punches a hole and reports the holed shape as one region', () => {
   const outer = contours(rectCcw(0, 0, 10, 10));
   const inner = contours(rectCcw(4, 4, 6, 6));
   const holed = difference2d(outer, inner);

--- a/scripts/test-wasm-contract.mjs
+++ b/scripts/test-wasm-contract.mjs
@@ -10,7 +10,16 @@ import { readFileSync, existsSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import assert from 'node:assert/strict';
-import { initSync, IfcAPI } from '../packages/wasm/pkg/ifc-lite.js';
+import {
+  initSync,
+  IfcAPI,
+  Contours2D,
+  union2d,
+  difference2d,
+  intersection2d,
+  resolve2d,
+  meshOutline2d,
+} from '../packages/wasm/pkg/ifc-lite.js';
 import { parseMeshesViaPrePass } from './lib/mesh-via-prepass.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -833,6 +842,184 @@ test('setEntityIndex resets pipeline diagnostics like a fresh load, and installs
       'the post-setEntityIndex batch must start a fresh accumulator at 1, not accumulate onto the prior load');
   } finally {
     entityIdxApi.clearPrePassCache();
+  }
+});
+
+// ===== 2D boolean contour sets (issue #1863) =====
+console.log('\n📋 2D boolean contour sets');
+
+/** CCW axis-aligned rectangle as a flat ring. */
+function rectCcw(x0, y0, x1, y1) {
+  return [x0, y0, x1, y0, x1, y1, x0, y1];
+}
+
+/** Build a Contours2D from an array of flat rings. */
+function contours(...rings) {
+  const coords = Float64Array.from(rings.flat());
+  const lengths = Uint32Array.from(rings.map((r) => r.length / 2));
+  return new Contours2D(coords, lengths);
+}
+
+/**
+ * Covered area read back ACROSS the boundary: sum of signed ring areas, which
+ * is the total only because winding carries outer-vs-hole. If the boundary ever
+ * normalised winding, holes would start adding area and this would catch it.
+ */
+function coveredArea(set) {
+  const coords = set.coords();
+  const lengths = set.ringLengths();
+  let at = 0;
+  let total = 0;
+  for (const n of lengths) {
+    let a = 0;
+    for (let i = 0; i < n; i++) {
+      const j = (i + 1) % n;
+      a += coords[(at + i) * 2] * coords[(at + j) * 2 + 1]
+        - coords[(at + j) * 2] * coords[(at + i) * 2 + 1];
+    }
+    total += a / 2;
+    at += n;
+  }
+  return total;
+}
+
+test('Contours2D rejects coords that disagree with ringLengths', () => {
+  assert.throws(
+    () => new Contours2D(Float64Array.from(rectCcw(0, 0, 1, 1)), Uint32Array.from([5])),
+    /ringLengths/,
+    'a length mismatch must throw, not silently truncate the ring',
+  );
+});
+
+test('coords/ringLengths round-trip the constructor across the boundary', () => {
+  const ring = rectCcw(0, 0, 2, 3);
+  const set = contours(ring);
+  try {
+    assert.deepEqual(Array.from(set.coords()), ring);
+    assert.deepEqual(Array.from(set.ringLengths()), [4]);
+    assert.equal(set.ringCount, 1);
+    assert.equal(set.isEmpty, false);
+    // A raw ring soup carries no shape grouping until an op resolves it.
+    assert.equal(set.shapeCount, 0);
+  } finally {
+    set.free();
+  }
+});
+
+test('difference2d keeps every disjoint island', () => {
+  // The guarantee `subtract_2d` cannot give: a bar cut in two by a strip must
+  // come back as TWO shapes, not just the larger remnant.
+  const bar = contours(rectCcw(0, 0, 10, 1));
+  const cutter = contours(rectCcw(4, -1, 6, 2));
+  const out = difference2d(bar, cutter);
+  try {
+    assert.equal(out.shapeCount, 2, 'both remnants must survive');
+    assert.deepEqual(Array.from(out.shapeOffsets()), [0, 1]);
+    assert.ok(Math.abs(coveredArea(out) - 8) < 1e-9, `area ${coveredArea(out)}`);
+  } finally {
+    out.free();
+    cutter.free();
+    bar.free();
+  }
+});
+
+test('union2d punches a hole and difference2d reports it as one shape', () => {
+  const outer = contours(rectCcw(0, 0, 10, 10));
+  const inner = contours(rectCcw(4, 4, 6, 6));
+  const holed = difference2d(outer, inner);
+  try {
+    assert.equal(holed.shapeCount, 1);
+    assert.equal(holed.ringCount, 2, 'outer boundary + hole');
+    assert.deepEqual(Array.from(holed.shapeOffsets()), [0]);
+    // Hole ring is CW, so it subtracts: 100 - 4.
+    assert.ok(Math.abs(coveredArea(holed) - 96) < 1e-9, `area ${coveredArea(holed)}`);
+    const bounds = holed.bounds();
+    assert.deepEqual(Array.from(bounds), [0, 0, 10, 10]);
+    // ring() must agree with the bulk coords() readout.
+    assert.deepEqual(Array.from(holed.ring(0)), Array.from(holed.coords()).slice(0, 8));
+    assert.equal(holed.ring(2), undefined, 'out-of-range ring index');
+  } finally {
+    holed.free();
+    inner.free();
+    outer.free();
+  }
+});
+
+test('intersection2d clips to the shared region', () => {
+  const a = contours(rectCcw(0, 0, 2, 2));
+  const b = contours(rectCcw(1, 1, 3, 3));
+  const out = intersection2d(a, b);
+  try {
+    assert.equal(out.shapeCount, 1);
+    assert.ok(Math.abs(coveredArea(out) - 1) < 1e-9);
+  } finally {
+    out.free();
+    b.free();
+    a.free();
+  }
+});
+
+test('an empty operand has a defined answer, not a crash', () => {
+  const a = contours(rectCcw(0, 0, 1, 1));
+  const empty = new Contours2D(new Float64Array(), new Uint32Array());
+  const u = union2d(empty, a);
+  const d = difference2d(empty, a);
+  const i = intersection2d(a, empty);
+  try {
+    assert.equal(empty.isEmpty, true);
+    assert.equal(empty.bounds(), undefined);
+    assert.ok(Math.abs(coveredArea(u) - 1) < 1e-9, 'union with empty is identity');
+    assert.equal(d.isEmpty, true, 'nothing minus something is nothing');
+    assert.equal(i.isEmpty, true, 'intersection with empty is empty');
+  } finally {
+    i.free();
+    d.free();
+    u.free();
+    empty.free();
+    a.free();
+  }
+});
+
+test('Contours2D.fromMeshOutline feeds a real meshOutline2d result into a boolean', () => {
+  // Two triangles forming the unit square in z=0, viewed down Z (axis 2).
+  const positions = Float32Array.from([0, 0, 0, 1, 0, 0, 1, 1, 0, 0, 1, 0]);
+  const indices = Uint32Array.from([0, 1, 2, 0, 2, 3]);
+  const outline = meshOutline2d(positions, indices, 2, false);
+  assert.ok(outline, 'meshOutline2d must produce a footprint');
+
+  const adopted = Contours2D.fromMeshOutline(outline);
+  const resolved = resolve2d(adopted);
+  const cutter = contours(rectCcw(0.25, -1, 0.75, 2));
+  const cut = difference2d(adopted, cutter);
+  try {
+    assert.equal(adopted.ringCount, outline.contourCount, 'every ring must be adopted');
+    assert.ok(Math.abs(coveredArea(resolved) - 1) < 1e-6, 'outline area survives adoption');
+    assert.equal(cut.shapeCount, 2, 'the strip splits the footprint in two');
+    assert.ok(Math.abs(coveredArea(cut) - 0.5) < 1e-6, `area ${coveredArea(cut)}`);
+  } finally {
+    cut.free();
+    cutter.free();
+    resolved.free();
+    adopted.free();
+    outline.free();
+  }
+});
+
+test('operations return new handles and leave their operands usable', () => {
+  // The accumulating occluder loop depends on this: freeing the result must
+  // not invalidate the operands, and the operands must be unmodified.
+  const a = contours(rectCcw(0, 0, 2, 2));
+  const b = contours(rectCcw(1, 1, 3, 3));
+  const first = union2d(a, b);
+  first.free();
+  const second = union2d(a, b);
+  try {
+    assert.ok(Math.abs(coveredArea(second) - 7) < 1e-9, 'operands survive an op + free');
+    assert.ok(Math.abs(coveredArea(a) - 4) < 1e-9, 'union2d must not mutate its subject');
+  } finally {
+    second.free();
+    b.free();
+    a.free();
   }
 });
 


### PR DESCRIPTION
Closes #1863.

## What

Exposes general 2D boolean operations over **contour sets** from `@ifc-lite/wasm`: `union2d`, `difference2d`, `intersection2d`, `resolve2d`, and the `Contours2D` handle they operate on. `Contours2D.fromMeshOutline(outline)` adopts a `meshOutline2d` result directly.

Until now the only `i_overlay` capability crossing the wasm boundary was the fixed-purpose `meshOutline2d` (unions one mesh's projected triangles into a silhouette). @mehmet-ylcnky's analytic HSR renderer ("Design 2", a front-to-back cumulative occluder) needs to combine two silhouettes — `vis = outline(e) - C`, `C = C ∪ outline(e)`, `clip = outline(e) ∩ tile` — which forced a second JS geometry engine (`polygon-clipping`) with different winding/precision semantics alongside the outlines it consumes.

## The one design decision worth flagging

The internal `bool2d::subtract_2d` / `subtract_multiple_2d` are **not** wrapped directly. They are `Profile2D`-shaped and collapse their result to the largest output shape (`shapes_to_profile`). That is right for the single extrusion profile they serve and **silent geometry loss** for HSR: a wall seen behind a column is two visible slivers, and `outline(e) - C` legitimately splits into many disjoint islands. So this adds a general layer (`contour_bool2d.rs`) that keeps **every** disjoint output shape with its holes, grouped via `shapeOffsets()`.

## Contract (per the acceptance criteria in #1863)

- [x] Union / difference / intersection over contour sets, callable from `@ifc-lite/wasm`.
- [x] I/O uses `Contours2D`, interoperable with `meshOutline2d` output (`fromMeshOutline`), so a result feeds straight into another boolean.
- [x] Multi-polygons with holes and disjoint islands preserved; winding stays `fill-rule="nonzero"`-compatible (CCW covers, CW subtracts, input winding **respected not normalised** — normalising is exactly what destroys holes).
- [x] Degenerate input (empty operands, < 3 vertices, non-finite coords, explicit closing vertex) returns empty rather than panicking; every empty-operand combination has a defined answer.
- [x] TS typings shipped (committed `pkg/ifc-lite.d.ts`).
- [x] **Target release**: `@ifc-lite/wasm` **minor** (changeset included). Pin the submodule to the release that ships from this once merged.

`difference2d` takes any number of clip rings (they subtract as their union under NonZero), so there is no separate `differenceMultiple2d` — one entry point covers it.

## Memory ownership

Operations return **new** `Contours2D` handles and never mutate their operands. An accumulating occluder loop must `free()` the handle it replaces; the JS doc comment on the module shows the pattern. `bounds()` is provided as a cheap pre-test (skip the boolean when an accumulated occluder's bounds miss the next element).

## Tests

- 21 Rust unit tests (`contour_bool2d_tests.rs`): union/difference/intersection, island preservation, hole punching + winding, accumulator == single-union, round-trip stability, `meshOutline2d` interop, degenerate input, accessors.
- 8 real-boundary cases in `test-wasm-contract.mjs` — area is read back **across** the wasm boundary as the sum of signed ring areas, which is the covered total only if winding still carries outer-vs-hole, so a boundary that ever normalised winding would fail these.

Rust: `cargo test -p ifc-lite-geometry --lib` 532 pass. Boundary: `test-wasm-contract.mjs` 35 pass. Gates: api-surface snapshot updated (+5 exports), committed wasm d.ts regenerated, wasm-free typecheck 33/33, module-size ratchet green (both new files < 400 lines).

## Perf verdict

No hot-path change. `contour_bool2d` is a new leaf module reached only through the new wasm exports; nothing in the parse/geometry batch pipeline calls it. The operations are `i_overlay` (the same engine the void/CSG paths already use), f64, deterministic (native == wasm byte-identical).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `Contours2D` for building/inspecting 2D contour ring sets and managing WASM memory (`free`/dispose).
  * Added general 2D contour boolean operations: `union2d`, `difference2d`, `intersection2d`, and `resolve2d`.
  * Added conversion from `meshOutline2d` to `Contours2D` for boolean workflows.
* **Bug Fixes**
  * Improved handling of empty and degenerate inputs with well-defined, non-crashing results.
* **Tests**
  * Added unit and WASM contract coverage for winding/holes, disjoint islands, and empty cases.
* **Documentation**
  * Updated WASM API docs with the new `Contours2D` section and operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->