### PR TITLE
feat(lists,viewer): Count column + schedule/pivot view for grouped lists

### DIFF
--- a/.changeset/lists-schedule-count-pivot.md
+++ b/.changeset/lists-schedule-count-pivot.md
@@ -1,0 +1,20 @@
+---
+'@ifc-lite/lists': minor
+---
+
+Add `toScheduleRows()`: project a grouped `ListResult` down to a Bonsai-style
+schedule / pivot presentation — one row per group-value tuple (leaf group),
+carrying its Count aggregate and configured sums as first-class fields,
+instead of the nested tree `ListGroup[]` already returned.
+
+Follow-up to the multi-criteria grouping added for issue #1790: the reporter
+came back asking for Count as its own column (not a badge next to the group
+label) and a pivot/schedule table (grouping columns become leading columns,
+one row per combination) matching Bonsai's own output — plus a CSV export
+that mirrors that arrangement.
+
+`ListGrouping` gains an optional `view?: 'nested' | 'schedule'` field
+(`undefined` keeps the existing nested-tree behaviour, so persisted lists are
+unaffected) and a new `ListScheduleRow` type describes each schedule row.
+The viewer's Lists panel and its CSV/XLSX/PDF export now offer a schedule
+(pivot) view alongside the existing nested tree.

--- a/apps/viewer/src/components/viewer/lists/ListBuilder.tsx
+++ b/apps/viewer/src/components/viewer/lists/ListBuilder.tsx
@@ -38,6 +38,7 @@ import type {
 } from '@ifc-lite/lists';
 import { discoverColumns, ENTITY_ATTRIBUTES, groupingColumnIds } from '@ifc-lite/lists';
 import { collectScopeTypes } from '@/lib/lists/scope-types';
+import { rebuildGrouping } from './list-table-utils';
 import {
   isEditableColumn,
   draftFromColumn,
@@ -357,13 +358,11 @@ export function ListBuilder({ providers, stores, initial, onSave, onCancel, onEx
     const sumCols = columns.filter(c => sumColumnIds.has(c.id)).map(c => c.id);
     // Keep grouping when there's a valid group column OR any sum column — sums
     // alone still produce grand totals, and may have been set from the table.
-    // `columnId` mirrors the first level for pre-multi-level consumers. The
-    // Builder form has no `view` control of its own (that toggle lives on the
-    // results table, issue #1790 round 2) — carry the existing schedule/nested
-    // choice through so editing OTHER settings here doesn't silently reset it.
-    const grouping = (validGroupIds.length > 0 || sumCols.length > 0)
-      ? { columnId: validGroupIds[0] ?? '', columnIds: validGroupIds, sumColumnIds: sumCols, view: initial?.grouping?.view }
-      : undefined;
+    // The Builder form has no `view` control of its own (that toggle lives on
+    // the results table, issue #1790 round 2) — `rebuildGrouping` spreads
+    // `initial?.grouping` first, so `view` (and any future field) survives
+    // instead of being silently reset when other settings are edited here.
+    const grouping = rebuildGrouping(initial?.grouping, validGroupIds, sumCols);
     return {
       id: initial?.id ?? crypto.randomUUID(),
       name: name || 'Untitled List',

--- a/apps/viewer/src/components/viewer/lists/ListBuilder.tsx
+++ b/apps/viewer/src/components/viewer/lists/ListBuilder.tsx
@@ -357,9 +357,12 @@ export function ListBuilder({ providers, stores, initial, onSave, onCancel, onEx
     const sumCols = columns.filter(c => sumColumnIds.has(c.id)).map(c => c.id);
     // Keep grouping when there's a valid group column OR any sum column — sums
     // alone still produce grand totals, and may have been set from the table.
-    // `columnId` mirrors the first level for pre-multi-level consumers.
+    // `columnId` mirrors the first level for pre-multi-level consumers. The
+    // Builder form has no `view` control of its own (that toggle lives on the
+    // results table, issue #1790 round 2) — carry the existing schedule/nested
+    // choice through so editing OTHER settings here doesn't silently reset it.
     const grouping = (validGroupIds.length > 0 || sumCols.length > 0)
-      ? { columnId: validGroupIds[0] ?? '', columnIds: validGroupIds, sumColumnIds: sumCols }
+      ? { columnId: validGroupIds[0] ?? '', columnIds: validGroupIds, sumColumnIds: sumCols, view: initial?.grouping?.view }
       : undefined;
     return {
       id: initial?.id ?? crypto.randomUUID(),

--- a/apps/viewer/src/components/viewer/lists/ListGroupingBar.tsx
+++ b/apps/viewer/src/components/viewer/lists/ListGroupingBar.tsx
@@ -8,7 +8,8 @@
  * the connective tissue between the table and the list definition.
  */
 
-import { Group, Sigma, X, ChevronsDownUp, ChevronsUpDown } from 'lucide-react';
+import { Group, Sigma, X, ChevronsDownUp, ChevronsUpDown, ListTree, Table2 } from 'lucide-react';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { cn } from '@/lib/utils';
 
 interface ListGroupingBarProps {
@@ -21,6 +22,12 @@ interface ListGroupingBarProps {
   onRemoveGroup: (id: string) => void;
   onRemoveSum: (id: string) => void;
   onToggleExpandAll: () => void;
+  /** Result presentation (issue #1790 round 2): `nested` (default, collapsible
+   *  tree) or `schedule` (Bonsai-style pivot table — one row per group-value
+   *  tuple with Count as its own column). Omitted callers keep the nested-only
+   *  toggle hidden (back-compat with call sites built before this existed). */
+  view?: 'nested' | 'schedule';
+  onViewChange?: (view: 'nested' | 'schedule') => void;
 }
 
 function Chip({ icon, children, onRemove, removeLabel = 'Remove' }: { icon: React.ReactNode; children: React.ReactNode; onRemove: () => void; removeLabel?: string }) {
@@ -42,11 +49,31 @@ function Chip({ icon, children, onRemove, removeLabel = 'Remove' }: { icon: Reac
 export function ListGroupingBar({
   groups, sums, groupCount, count, allExpanded,
   onRemoveGroup, onRemoveSum, onToggleExpandAll,
+  view = 'nested', onViewChange,
 }: ListGroupingBarProps) {
   const grouped = groups.length > 0;
+  const scheduleMode = view === 'schedule';
   return (
     <div className="flex flex-wrap items-center gap-1.5 border-b bg-muted/30 px-3 py-1.5 text-xs">
-      {grouped && (
+      {grouped && onViewChange && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              onClick={() => onViewChange(scheduleMode ? 'nested' : 'schedule')}
+              aria-pressed={scheduleMode}
+              aria-label={scheduleMode ? 'Switch to nested tree view' : 'Switch to schedule (pivot) table view'}
+              className={cn(
+                'mr-0.5 inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-[11px] hover:bg-muted hover:text-foreground',
+                scheduleMode ? 'text-primary' : 'text-muted-foreground',
+              )}
+            >
+              {scheduleMode ? <Table2 className="h-3.5 w-3.5" /> : <ListTree className="h-3.5 w-3.5" />}
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>{scheduleMode ? 'Showing schedule (pivot) table — switch to nested tree' : 'Showing nested tree — switch to schedule (pivot) table'}</TooltipContent>
+        </Tooltip>
+      )}
+      {grouped && !scheduleMode && (
         <button
           onClick={onToggleExpandAll}
           className="mr-0.5 inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-[11px] text-muted-foreground hover:bg-muted hover:text-foreground"

--- a/apps/viewer/src/components/viewer/lists/ListResultsTable.tsx
+++ b/apps/viewer/src/components/viewer/lists/ListResultsTable.tsx
@@ -33,9 +33,10 @@ import { columnToAutoColor } from '@/lib/lists/columnToAutoColor';
 import { AUTO_COLOR_FROM_LIST_ID } from '@/store/slices/lensSlice';
 import { ColumnHeaderMenu } from './ColumnHeaderMenu';
 import { ListGroupingBar } from './ListGroupingBar';
+import { ListScheduleTable } from './ListScheduleTable';
 import {
   formatCellValue, compareCells, detectNumericColumns, autoColumnWidth,
-  buildGroupedView, flatTotals, buildScheduleRows, blankRepeatedPathValues, rebuildGrouping,
+  buildGroupedView, flatTotals, buildScheduleRows, rebuildGrouping,
   type DisplayItem, type Totals, type ScheduleRow,
 } from './list-table-utils';
 
@@ -168,38 +169,8 @@ export function ListResultsTable({ result, listName, grouping, onGroupingChange,
       sort,
     );
   }, [scheduleMode, displayRows, columns, groupColumnIds, sumColumnIds, sortCol, sortDir]);
-  // Bonsai-style blank-on-repeat: display sugar ONLY — export keeps full values.
-  const scheduleDisplayPaths = useMemo(() => blankRepeatedPathValues(scheduleRows), [scheduleRows]);
-  // Header for the pivot table: one column per grouping level, a first-class
-  // Count column, then the configured sum columns.
-  //
-  // "Group by" and "Sum" are independent menu actions, so the SAME column can
-  // be both a grouping key and a summed column. Keying these entries by `id`
-  // alone then emits duplicate React keys across header/body/footer, and every
-  // `sumColumnIds.includes(col.id)` test matches the group-role cell too — it
-  // grows a stray Σ marker and renders the grand total that belongs to the
-  // sum-role cell (PR #1867 review). Each entry therefore carries a
-  // role-qualified `key` for rendering, while `id` stays the original column
-  // id that widths, sorting and `totals.sums` address columns by.
-  const scheduleColumns = useMemo(
-    () => [
-      ...groupChips.map((c) => ({ ...c, key: `group:${c.id}`, role: 'group' as const })),
-      { id: '__count', label: 'Count', key: '__count', role: 'count' as const },
-      ...sumChips.map((c) => ({ ...c, key: `sum:${c.id}`, role: 'sum' as const })),
-    ],
-    [groupChips, sumChips]);
-  const scheduleColumnWidths = useMemo(() => scheduleColumns.map((c, i) => {
-    if (widthOverrides[c.id] !== undefined) return widthOverrides[c.id];
-    if (i >= groupChips.length) return c.role === 'count' ? 90 : 130; // Count / sum columns
-    // Group-value columns: size to the widest value actually shown.
-    let maxLen = c.label.length;
-    for (const row of scheduleRows) {
-      const len = (row.path[i] ?? '').length;
-      if (len > maxLen) maxLen = len;
-    }
-    return Math.max(90, Math.min(320, maxLen * 7 + 34));
-  }), [scheduleColumns, groupChips.length, scheduleRows, widthOverrides]);
-  const scheduleTotalWidth = useMemo(() => scheduleColumnWidths.reduce((a, b) => a + b, 0), [scheduleColumnWidths]);
+  // The pivot header/body/footer live in `ListScheduleTable` — see the note
+  // there on role-qualified column keys.
 
   const handleViewChange = useCallback((next: 'nested' | 'schedule') => {
     if (!onGroupingChange || !grouping) return;
@@ -421,103 +392,20 @@ export function ListResultsTable({ result, listName, grouping, onGroupingChange,
       {/* Table */}
       <div ref={parentRef} className="flex-1 overflow-auto min-h-0">
       {scheduleMode ? (
-        <div style={{ minWidth: scheduleTotalWidth }}>
-          {/* Schedule (pivot) header: grouping columns, then a first-class
-              Count column, then any configured sums (issue #1790 round 2). */}
-          <div className="flex sticky top-0 z-10 bg-muted/80 backdrop-blur-sm border-b">
-            {scheduleColumns.map((col, colIdx) => {
-              const isCount = col.role === 'count';
-              const isSum = col.role === 'sum';
-              // Sort state rides the ORIGINAL column index space (shared with
-              // the nested view), so toggling between views keeps the same
-              // sort. Count has no original column — it IS the null-sort
-              // default (count-descending), so it's shown but not clickable.
-              const originalIdx = isCount ? -1 : columns.findIndex((c) => c.id === col.id);
-              return (
-                <div
-                  key={col.key}
-                  className={cn(
-                    'relative flex items-center gap-0.5 border-r border-border/50 px-2 py-1.5 text-xs font-medium shrink-0',
-                    (isCount || isSum) ? 'text-foreground' : 'text-muted-foreground',
-                  )}
-                  style={{ width: scheduleColumnWidths[colIdx] }}
-                >
-                  {originalIdx >= 0 ? (
-                    <button className="flex min-w-0 flex-1 items-center gap-1 hover:text-foreground" onClick={() => handleHeaderClick(originalIdx)}>
-                      <span className="truncate">{col.label}</span>
-                      {isSum && <span className="text-primary">Σ</span>}
-                      {sortCol === originalIdx && (sortDir === 'asc' ? <ArrowUp className="h-3 w-3 shrink-0" /> : <ArrowDown className="h-3 w-3 shrink-0" />)}
-                    </button>
-                  ) : (
-                    <span className="truncate flex-1" title="Count aggregate — the default sort order">{col.label}</span>
-                  )}
-                  <div
-                    onMouseDown={(e) => startResize(e, col.id, scheduleColumnWidths[colIdx])}
-                    onDoubleClick={() => setWidthOverrides((p) => { const n = { ...p }; delete n[col.id]; return n; })}
-                    className="absolute right-0 top-0 h-full w-1.5 cursor-col-resize hover:bg-primary/40"
-                    title="Drag to resize · double-click to auto-fit"
-                  />
-                </div>
-              );
-            })}
-          </div>
-
-          {/* One row per group-value tuple — no per-element detail rows. */}
-          <div style={{ height: `${virtualizer.getTotalSize()}px`, width: '100%', position: 'relative' }}>
-            {virtualizer.getVirtualItems().map((vRow) => {
-              const row = scheduleRows[vRow.index];
-              if (!row) return null;
-              const displayPath = scheduleDisplayPaths[vRow.index];
-              const transform = `translateY(${vRow.start}px)`;
-              return (
-                <div
-                  key={vRow.key}
-                  className="absolute left-0 top-0 flex w-full border-b border-border/30 hover:bg-muted/40"
-                  style={{ transform }}
-                >
-                  {groupChips.map((c, i) => (
-                    <div
-                      key={`group:${c.id}`}
-                      className="border-r border-border/20 px-2 py-1 text-xs truncate shrink-0"
-                      style={{ width: scheduleColumnWidths[i] }}
-                      title={row.path[i]}
-                    >
-                      {displayPath[i]}
-                    </div>
-                  ))}
-                  <div
-                    className="border-r border-border/20 px-2 py-1 text-xs text-right font-mono tabular-nums shrink-0"
-                    style={{ width: scheduleColumnWidths[groupChips.length] }}
-                  >
-                    {row.count.toLocaleString()}
-                  </div>
-                  {sumChips.map((s, i) => (
-                    <div
-                      key={`sum:${s.id}`}
-                      className="border-r border-border/20 px-2 py-1 text-xs text-right font-mono tabular-nums shrink-0"
-                      style={{ width: scheduleColumnWidths[groupChips.length + 1 + i] }}
-                    >
-                      {formatCellValue(row.sums[s.id])}
-                    </div>
-                  ))}
-                </div>
-              );
-            })}
-          </div>
-
-          {/* Grand-totals footer (sticky, aligned under columns) */}
-          <div className="flex sticky bottom-0 z-10 border-t-2 border-border bg-muted/90 backdrop-blur-sm">
-            {scheduleColumns.map((col, colIdx) => (
-              <div key={col.key} className="flex items-center border-r border-border/30 px-2 py-1 text-xs font-semibold shrink-0" style={{ width: scheduleColumnWidths[colIdx] }}>
-                {colIdx === 0 && <span className="text-muted-foreground">Total · {scheduleRows.length.toLocaleString()} group{scheduleRows.length === 1 ? '' : 's'}</span>}
-                {col.role === 'count' && <span className="ml-auto font-mono tabular-nums text-foreground">{totals.count.toLocaleString()}</span>}
-                {col.role === 'sum' && (
-                  <span className="ml-auto font-mono tabular-nums text-foreground">{formatCellValue(totals.sums[col.id])}</span>
-                )}
-              </div>
-            ))}
-          </div>
-        </div>
+        <ListScheduleTable
+          scheduleRows={scheduleRows}
+          groupChips={groupChips}
+          sumChips={sumChips}
+          columns={columns}
+          sortCol={sortCol}
+          sortDir={sortDir}
+          totals={totals}
+          widthOverrides={widthOverrides}
+          setWidthOverrides={setWidthOverrides}
+          startResize={startResize}
+          onHeaderClick={handleHeaderClick}
+          virtualizer={virtualizer}
+        />
       ) : (
         <div style={{ minWidth: totalWidth }}>
           {/* Header */}

--- a/apps/viewer/src/components/viewer/lists/ListResultsTable.tsx
+++ b/apps/viewer/src/components/viewer/lists/ListResultsTable.tsx
@@ -35,7 +35,8 @@ import { ColumnHeaderMenu } from './ColumnHeaderMenu';
 import { ListGroupingBar } from './ListGroupingBar';
 import {
   formatCellValue, compareCells, detectNumericColumns, autoColumnWidth,
-  buildGroupedView, flatTotals, type DisplayItem, type Totals,
+  buildGroupedView, flatTotals, buildScheduleRows, blankRepeatedPathValues,
+  type DisplayItem, type Totals, type ScheduleRow,
 } from './list-table-utils';
 
 interface ListResultsTableProps {
@@ -145,6 +146,52 @@ export function ListResultsTable({ result, listName, grouping, onGroupingChange,
       return { id, label: c ? (c.label ?? c.propertyName) : id };
     }),
     [groupColumnIds, columns]);
+  const sumChips = useMemo(
+    () => sumColumnIds.map((id) => {
+      const c = columns.find((c) => c.id === id);
+      return { id, label: c ? (c.label ?? c.propertyName) : id };
+    }),
+    [sumColumnIds, columns]);
+  const showSumRow = sumColumnIds.length > 0;
+
+  // Result presentation (issue #1790 round 2): `schedule` swaps the nested
+  // collapsible tree for a Bonsai-style pivot table — one row per group-value
+  // tuple, grouping columns first, then a first-class Count column, then any
+  // configured sums. Only meaningful once grouped.
+  const scheduleMode = isGrouped && grouping?.view === 'schedule';
+  const scheduleRows = useMemo<ScheduleRow[]>(() => {
+    if (!scheduleMode) return [];
+    const sort = sortCol === null ? null : { colIdx: sortCol, dir: sortDir };
+    return buildScheduleRows(
+      displayRows, columns,
+      { columnId: groupColumnIds[0], columnIds: groupColumnIds, sumColumnIds },
+      sort,
+    );
+  }, [scheduleMode, displayRows, columns, groupColumnIds, sumColumnIds, sortCol, sortDir]);
+  // Bonsai-style blank-on-repeat: display sugar ONLY — export keeps full values.
+  const scheduleDisplayPaths = useMemo(() => blankRepeatedPathValues(scheduleRows), [scheduleRows]);
+  // Header for the pivot table: one column per grouping level, a first-class
+  // Count column, then the configured sum columns.
+  const scheduleColumns = useMemo(
+    () => [...groupChips, { id: '__count', label: 'Count' }, ...sumChips],
+    [groupChips, sumChips]);
+  const scheduleColumnWidths = useMemo(() => scheduleColumns.map((c, i) => {
+    if (widthOverrides[c.id] !== undefined) return widthOverrides[c.id];
+    if (i >= groupChips.length) return c.id === '__count' ? 90 : 130; // Count / sum columns
+    // Group-value columns: size to the widest value actually shown.
+    let maxLen = c.label.length;
+    for (const row of scheduleRows) {
+      const len = (row.path[i] ?? '').length;
+      if (len > maxLen) maxLen = len;
+    }
+    return Math.max(90, Math.min(320, maxLen * 7 + 34));
+  }), [scheduleColumns, groupChips.length, scheduleRows, widthOverrides]);
+  const scheduleTotalWidth = useMemo(() => scheduleColumnWidths.reduce((a, b) => a + b, 0), [scheduleColumnWidths]);
+
+  const handleViewChange = useCallback((next: 'nested' | 'schedule') => {
+    if (!onGroupingChange || !grouping) return;
+    onGroupingChange({ ...grouping, view: next });
+  }, [onGroupingChange, grouping]);
 
   const { items, groupCount, totals, groupKeys } = useMemo<{
     items: DisplayItem[]; groupCount: number; totals: Totals; groupKeys: string[];
@@ -172,11 +219,12 @@ export function ListResultsTable({ result, listName, grouping, onGroupingChange,
   const totalWidth = useMemo(() => columnWidths.reduce((a, b) => a + b, 0), [columnWidths]);
 
   const virtualizer = useVirtualizer({
-    count: items.length,
+    count: scheduleMode ? scheduleRows.length : items.length,
     getScrollElement: () => parentRef.current,
-    estimateSize: (i) => (items[i]?.kind === 'group' ? 30 : 28),
+    estimateSize: (i) => (scheduleMode ? 28 : (items[i]?.kind === 'group' ? 30 : 28)),
     overscan: 18,
     getItemKey: (i) => {
+      if (scheduleMode) return `s:${scheduleRows[i]?.key ?? i}`;
       const it = items[i];
       if (it?.kind === 'group') return `g:${it.key}`;
       const r = (it as { row: ListRow }).row;
@@ -226,10 +274,12 @@ export function ListResultsTable({ result, listName, grouping, onGroupingChange,
     setExpandedGroups(allExpanded ? new Set() : new Set(groupKeys));
   }, [allExpanded, groupKeys]);
 
-  const startResize = useCallback((e: React.MouseEvent, colId: string, colIdx: number) => {
+  // `startWidth` is passed in (rather than looked up here) so the SAME
+  // resize handler works for both the normal column header and the schedule
+  // (pivot) header, which index into different width arrays.
+  const startResize = useCallback((e: React.MouseEvent, colId: string, startWidth: number) => {
     e.preventDefault(); e.stopPropagation();
     const startX = e.clientX;
-    const startWidth = columnWidths[colIdx];
     const onMove = (ev: MouseEvent) => setWidthOverrides((p) => ({ ...p, [colId]: Math.max(56, startWidth + (ev.clientX - startX)) }));
     const onUp = () => {
       window.removeEventListener('mousemove', onMove); window.removeEventListener('mouseup', onUp);
@@ -237,7 +287,7 @@ export function ListResultsTable({ result, listName, grouping, onGroupingChange,
     };
     window.addEventListener('mousemove', onMove); window.addEventListener('mouseup', onUp);
     document.body.style.cursor = 'col-resize'; document.body.style.userSelect = 'none';
-  }, [columnWidths]);
+  }, []);
 
   // Export honours the on-screen view: configured columns, the active
   // grouping (sections + per-group count/sums), and the grand totals.
@@ -291,14 +341,6 @@ export function ListResultsTable({ result, listName, grouping, onGroupingChange,
     if (idx === undefined) return;
     onMultiSelect(selectableItems, idx, e);
   }, [rowIndexByKey, selectableItems, onMultiSelect]);
-
-  const sumChips = useMemo(
-    () => sumColumnIds.map((id) => {
-      const c = columns.find((c) => c.id === id);
-      return { id, label: c ? (c.label ?? c.propertyName) : id };
-    }),
-    [sumColumnIds, columns]);
-  const showSumRow = sumColumnIds.length > 0;
 
   return (
     <div className="flex-1 flex flex-col min-h-0">
@@ -358,11 +400,112 @@ export function ListResultsTable({ result, listName, grouping, onGroupingChange,
           onRemoveGroup={(id) => toggleGroupBy(id)}
           onRemoveSum={(id) => toggleSum(id)}
           onToggleExpandAll={toggleExpandAll}
+          view={isGrouped ? (grouping?.view ?? 'nested') : undefined}
+          onViewChange={isGrouped ? handleViewChange : undefined}
         />
       )}
 
       {/* Table */}
       <div ref={parentRef} className="flex-1 overflow-auto min-h-0">
+      {scheduleMode ? (
+        <div style={{ minWidth: scheduleTotalWidth }}>
+          {/* Schedule (pivot) header: grouping columns, then a first-class
+              Count column, then any configured sums (issue #1790 round 2). */}
+          <div className="flex sticky top-0 z-10 bg-muted/80 backdrop-blur-sm border-b">
+            {scheduleColumns.map((col, colIdx) => {
+              const isCount = col.id === '__count';
+              const isSum = sumColumnIds.includes(col.id);
+              // Sort state rides the ORIGINAL column index space (shared with
+              // the nested view), so toggling between views keeps the same
+              // sort. Count has no original column — it IS the null-sort
+              // default (count-descending), so it's shown but not clickable.
+              const originalIdx = isCount ? -1 : columns.findIndex((c) => c.id === col.id);
+              return (
+                <div
+                  key={col.id}
+                  className={cn(
+                    'relative flex items-center gap-0.5 border-r border-border/50 px-2 py-1.5 text-xs font-medium shrink-0',
+                    (isCount || isSum) ? 'text-foreground' : 'text-muted-foreground',
+                  )}
+                  style={{ width: scheduleColumnWidths[colIdx] }}
+                >
+                  {originalIdx >= 0 ? (
+                    <button className="flex min-w-0 flex-1 items-center gap-1 hover:text-foreground" onClick={() => handleHeaderClick(originalIdx)}>
+                      <span className="truncate">{col.label}</span>
+                      {isSum && <span className="text-primary">Σ</span>}
+                      {sortCol === originalIdx && (sortDir === 'asc' ? <ArrowUp className="h-3 w-3 shrink-0" /> : <ArrowDown className="h-3 w-3 shrink-0" />)}
+                    </button>
+                  ) : (
+                    <span className="truncate flex-1" title="Count aggregate — the default sort order">{col.label}</span>
+                  )}
+                  <div
+                    onMouseDown={(e) => startResize(e, col.id, scheduleColumnWidths[colIdx])}
+                    onDoubleClick={() => setWidthOverrides((p) => { const n = { ...p }; delete n[col.id]; return n; })}
+                    className="absolute right-0 top-0 h-full w-1.5 cursor-col-resize hover:bg-primary/40"
+                    title="Drag to resize · double-click to auto-fit"
+                  />
+                </div>
+              );
+            })}
+          </div>
+
+          {/* One row per group-value tuple — no per-element detail rows. */}
+          <div style={{ height: `${virtualizer.getTotalSize()}px`, width: '100%', position: 'relative' }}>
+            {virtualizer.getVirtualItems().map((vRow) => {
+              const row = scheduleRows[vRow.index];
+              if (!row) return null;
+              const displayPath = scheduleDisplayPaths[vRow.index];
+              const transform = `translateY(${vRow.start}px)`;
+              return (
+                <div
+                  key={vRow.key}
+                  className="absolute left-0 top-0 flex w-full border-b border-border/30 hover:bg-muted/40"
+                  style={{ transform }}
+                >
+                  {groupChips.map((c, i) => (
+                    <div
+                      key={c.id}
+                      className="border-r border-border/20 px-2 py-1 text-xs truncate shrink-0"
+                      style={{ width: scheduleColumnWidths[i] }}
+                      title={row.path[i]}
+                    >
+                      {displayPath[i]}
+                    </div>
+                  ))}
+                  <div
+                    className="border-r border-border/20 px-2 py-1 text-xs text-right font-mono tabular-nums shrink-0"
+                    style={{ width: scheduleColumnWidths[groupChips.length] }}
+                  >
+                    {row.count.toLocaleString()}
+                  </div>
+                  {sumChips.map((s, i) => (
+                    <div
+                      key={s.id}
+                      className="border-r border-border/20 px-2 py-1 text-xs text-right font-mono tabular-nums shrink-0"
+                      style={{ width: scheduleColumnWidths[groupChips.length + 1 + i] }}
+                    >
+                      {formatCellValue(row.sums[s.id])}
+                    </div>
+                  ))}
+                </div>
+              );
+            })}
+          </div>
+
+          {/* Grand-totals footer (sticky, aligned under columns) */}
+          <div className="flex sticky bottom-0 z-10 border-t-2 border-border bg-muted/90 backdrop-blur-sm">
+            {scheduleColumns.map((col, colIdx) => (
+              <div key={col.id} className="flex items-center border-r border-border/30 px-2 py-1 text-xs font-semibold shrink-0" style={{ width: scheduleColumnWidths[colIdx] }}>
+                {colIdx === 0 && <span className="text-muted-foreground">Total · {scheduleRows.length.toLocaleString()} group{scheduleRows.length === 1 ? '' : 's'}</span>}
+                {col.id === '__count' && <span className="ml-auto font-mono tabular-nums text-foreground">{totals.count.toLocaleString()}</span>}
+                {sumColumnIds.includes(col.id) && (
+                  <span className="ml-auto font-mono tabular-nums text-foreground">{formatCellValue(totals.sums[col.id])}</span>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      ) : (
         <div style={{ minWidth: totalWidth }}>
           {/* Header */}
           <div className="flex sticky top-0 z-10 bg-muted/80 backdrop-blur-sm border-b">
@@ -407,7 +550,7 @@ export function ListResultsTable({ result, listName, grouping, onGroupingChange,
                     />
                   )}
                   <div
-                    onMouseDown={(e) => startResize(e, col.id, colIdx)}
+                    onMouseDown={(e) => startResize(e, col.id, columnWidths[colIdx])}
                     onClick={(e) => e.stopPropagation()}
                     onDoubleClick={() => setWidthOverrides((p) => { const n = { ...p }; delete n[col.id]; return n; })}
                     className="absolute right-0 top-0 h-full w-1.5 cursor-col-resize hover:bg-primary/40"
@@ -497,6 +640,7 @@ export function ListResultsTable({ result, listName, grouping, onGroupingChange,
             </div>
           )}
         </div>
+      )}
       </div>
     </div>
   );

--- a/apps/viewer/src/components/viewer/lists/ListResultsTable.tsx
+++ b/apps/viewer/src/components/viewer/lists/ListResultsTable.tsx
@@ -172,12 +172,25 @@ export function ListResultsTable({ result, listName, grouping, onGroupingChange,
   const scheduleDisplayPaths = useMemo(() => blankRepeatedPathValues(scheduleRows), [scheduleRows]);
   // Header for the pivot table: one column per grouping level, a first-class
   // Count column, then the configured sum columns.
+  //
+  // "Group by" and "Sum" are independent menu actions, so the SAME column can
+  // be both a grouping key and a summed column. Keying these entries by `id`
+  // alone then emits duplicate React keys across header/body/footer, and every
+  // `sumColumnIds.includes(col.id)` test matches the group-role cell too — it
+  // grows a stray Σ marker and renders the grand total that belongs to the
+  // sum-role cell (PR #1867 review). Each entry therefore carries a
+  // role-qualified `key` for rendering, while `id` stays the original column
+  // id that widths, sorting and `totals.sums` address columns by.
   const scheduleColumns = useMemo(
-    () => [...groupChips, { id: '__count', label: 'Count' }, ...sumChips],
+    () => [
+      ...groupChips.map((c) => ({ ...c, key: `group:${c.id}`, role: 'group' as const })),
+      { id: '__count', label: 'Count', key: '__count', role: 'count' as const },
+      ...sumChips.map((c) => ({ ...c, key: `sum:${c.id}`, role: 'sum' as const })),
+    ],
     [groupChips, sumChips]);
   const scheduleColumnWidths = useMemo(() => scheduleColumns.map((c, i) => {
     if (widthOverrides[c.id] !== undefined) return widthOverrides[c.id];
-    if (i >= groupChips.length) return c.id === '__count' ? 90 : 130; // Count / sum columns
+    if (i >= groupChips.length) return c.role === 'count' ? 90 : 130; // Count / sum columns
     // Group-value columns: size to the widest value actually shown.
     let maxLen = c.label.length;
     for (const row of scheduleRows) {
@@ -413,8 +426,8 @@ export function ListResultsTable({ result, listName, grouping, onGroupingChange,
               Count column, then any configured sums (issue #1790 round 2). */}
           <div className="flex sticky top-0 z-10 bg-muted/80 backdrop-blur-sm border-b">
             {scheduleColumns.map((col, colIdx) => {
-              const isCount = col.id === '__count';
-              const isSum = sumColumnIds.includes(col.id);
+              const isCount = col.role === 'count';
+              const isSum = col.role === 'sum';
               // Sort state rides the ORIGINAL column index space (shared with
               // the nested view), so toggling between views keeps the same
               // sort. Count has no original column — it IS the null-sort
@@ -422,7 +435,7 @@ export function ListResultsTable({ result, listName, grouping, onGroupingChange,
               const originalIdx = isCount ? -1 : columns.findIndex((c) => c.id === col.id);
               return (
                 <div
-                  key={col.id}
+                  key={col.key}
                   className={cn(
                     'relative flex items-center gap-0.5 border-r border-border/50 px-2 py-1.5 text-xs font-medium shrink-0',
                     (isCount || isSum) ? 'text-foreground' : 'text-muted-foreground',
@@ -464,7 +477,7 @@ export function ListResultsTable({ result, listName, grouping, onGroupingChange,
                 >
                   {groupChips.map((c, i) => (
                     <div
-                      key={c.id}
+                      key={`group:${c.id}`}
                       className="border-r border-border/20 px-2 py-1 text-xs truncate shrink-0"
                       style={{ width: scheduleColumnWidths[i] }}
                       title={row.path[i]}
@@ -480,7 +493,7 @@ export function ListResultsTable({ result, listName, grouping, onGroupingChange,
                   </div>
                   {sumChips.map((s, i) => (
                     <div
-                      key={s.id}
+                      key={`sum:${s.id}`}
                       className="border-r border-border/20 px-2 py-1 text-xs text-right font-mono tabular-nums shrink-0"
                       style={{ width: scheduleColumnWidths[groupChips.length + 1 + i] }}
                     >
@@ -495,10 +508,10 @@ export function ListResultsTable({ result, listName, grouping, onGroupingChange,
           {/* Grand-totals footer (sticky, aligned under columns) */}
           <div className="flex sticky bottom-0 z-10 border-t-2 border-border bg-muted/90 backdrop-blur-sm">
             {scheduleColumns.map((col, colIdx) => (
-              <div key={col.id} className="flex items-center border-r border-border/30 px-2 py-1 text-xs font-semibold shrink-0" style={{ width: scheduleColumnWidths[colIdx] }}>
+              <div key={col.key} className="flex items-center border-r border-border/30 px-2 py-1 text-xs font-semibold shrink-0" style={{ width: scheduleColumnWidths[colIdx] }}>
                 {colIdx === 0 && <span className="text-muted-foreground">Total · {scheduleRows.length.toLocaleString()} group{scheduleRows.length === 1 ? '' : 's'}</span>}
-                {col.id === '__count' && <span className="ml-auto font-mono tabular-nums text-foreground">{totals.count.toLocaleString()}</span>}
-                {sumColumnIds.includes(col.id) && (
+                {col.role === 'count' && <span className="ml-auto font-mono tabular-nums text-foreground">{totals.count.toLocaleString()}</span>}
+                {col.role === 'sum' && (
                   <span className="ml-auto font-mono tabular-nums text-foreground">{formatCellValue(totals.sums[col.id])}</span>
                 )}
               </div>

--- a/apps/viewer/src/components/viewer/lists/ListResultsTable.tsx
+++ b/apps/viewer/src/components/viewer/lists/ListResultsTable.tsx
@@ -35,7 +35,7 @@ import { ColumnHeaderMenu } from './ColumnHeaderMenu';
 import { ListGroupingBar } from './ListGroupingBar';
 import {
   formatCellValue, compareCells, detectNumericColumns, autoColumnWidth,
-  buildGroupedView, flatTotals, buildScheduleRows, blankRepeatedPathValues,
+  buildGroupedView, flatTotals, buildScheduleRows, blankRepeatedPathValues, rebuildGrouping,
   type DisplayItem, type Totals, type ScheduleRow,
 } from './list-table-utils';
 
@@ -247,24 +247,24 @@ export function ListResultsTable({ result, listName, grouping, onGroupingChange,
 
   // Toggling a column in/out of the grouping: a second (third, …) column adds
   // a nesting level (multi-criteria grouping, issue #1790). `columnId` is kept
-  // in sync with the first level for pre-multi-level consumers.
+  // in sync with the first level for pre-multi-level consumers. `rebuildGrouping`
+  // spreads the previous grouping so fields it doesn't touch — `view`, issue
+  // #1790 round 2 — survive instead of silently resetting (bug found in QA:
+  // removing a grouping level or toggling a sum column used to drop the
+  // active schedule view back to nested).
   const toggleGroupBy = useCallback((colId: string) => {
     if (!onGroupingChange) return;
     const next = groupColumnIds.includes(colId)
       ? groupColumnIds.filter((x) => x !== colId)
       : [...groupColumnIds, colId];
-    onGroupingChange((next.length || sumColumnIds.length)
-      ? { columnId: next[0] ?? '', columnIds: next, sumColumnIds }
-      : undefined);
-  }, [onGroupingChange, groupColumnIds, sumColumnIds]);
+    onGroupingChange(rebuildGrouping(grouping, next, sumColumnIds));
+  }, [onGroupingChange, grouping, groupColumnIds, sumColumnIds]);
 
   const toggleSum = useCallback((colId: string) => {
     if (!onGroupingChange) return;
     const next = sumColumnIds.includes(colId) ? sumColumnIds.filter((x) => x !== colId) : [...sumColumnIds, colId];
-    onGroupingChange((groupColumnIds.length || next.length)
-      ? { columnId: groupColumnIds[0] ?? '', columnIds: groupColumnIds, sumColumnIds: next }
-      : undefined);
-  }, [onGroupingChange, groupColumnIds, sumColumnIds]);
+    onGroupingChange(rebuildGrouping(grouping, groupColumnIds, next));
+  }, [onGroupingChange, grouping, groupColumnIds, sumColumnIds]);
 
   const toggleGroupExpand = useCallback((key: string) => {
     setExpandedGroups((prev) => { const n = new Set(prev); if (n.has(key)) n.delete(key); else n.add(key); return n; });

--- a/apps/viewer/src/components/viewer/lists/ListScheduleTable.tsx
+++ b/apps/viewer/src/components/viewer/lists/ListScheduleTable.tsx
@@ -1,0 +1,200 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * ListScheduleTable — the Bonsai-style schedule (pivot) presentation of a
+ * grouped list: ONE row per group-value tuple (leaf groups only) instead of
+ * the nested collapsible tree, with a first-class Count column and the
+ * configured sum columns (issue #1790 round 2).
+ *
+ * Split out of `ListResultsTable` (PR #1867 review): the pivot header,
+ * virtualized body and totals footer are a self-contained presentation, and
+ * inlining them compounded an already oversized module.
+ *
+ * The virtualizer is owned by the PARENT — it scrolls the shared container and
+ * its row count switches between this view and the nested one — so it arrives
+ * as a prop, already counting `scheduleRows`.
+ */
+
+import React, { useMemo } from 'react';
+import type { Virtualizer } from '@tanstack/react-virtual';
+import { ArrowUp, ArrowDown } from 'lucide-react';
+import type { ColumnDefinition } from '@ifc-lite/lists';
+import { cn } from '@/lib/utils';
+import {
+  formatCellValue, blankRepeatedPathValues,
+  type Totals, type ScheduleRow,
+} from './list-table-utils';
+
+/** A group-by or summed column reduced to what the pivot header renders. */
+export interface ScheduleChip {
+  id: string;
+  label: string;
+}
+
+interface ListScheduleTableProps {
+  /** Leaf-group rows, already ordered for display. */
+  scheduleRows: ScheduleRow[];
+  /** Group-by columns, outermost first. */
+  groupChips: ScheduleChip[];
+  /** Configured sum columns, in menu order. */
+  sumChips: ScheduleChip[];
+  /** Full column set — resolves a pivot column back to its original index so
+   *  sorting stays in the nested view's index space. */
+  columns: ColumnDefinition[];
+  sortCol: number | null;
+  sortDir: 'asc' | 'desc';
+  /** Grand totals for the footer. */
+  totals: Totals;
+  /** Manual column-width overrides, keyed by ORIGINAL column id (shared with
+   *  the nested view, so a resize carries across the view toggle). */
+  widthOverrides: Record<string, number>;
+  setWidthOverrides: React.Dispatch<React.SetStateAction<Record<string, number>>>;
+  /** Shared resize handler; `startWidth` is passed because the pivot header
+   *  and the nested header index into different width arrays. */
+  startResize: (e: React.MouseEvent, colId: string, startWidth: number) => void;
+  onHeaderClick: (colIndex: number) => void;
+  virtualizer: Virtualizer<HTMLDivElement, Element>;
+}
+
+export function ListScheduleTable({
+  scheduleRows, groupChips, sumChips, columns, sortCol, sortDir, totals,
+  widthOverrides, setWidthOverrides, startResize, onHeaderClick, virtualizer,
+}: ListScheduleTableProps) {
+  // Bonsai-style blank-on-repeat: display sugar ONLY — export keeps full values.
+  const scheduleDisplayPaths = useMemo(() => blankRepeatedPathValues(scheduleRows), [scheduleRows]);
+
+  // One column per grouping level, a first-class Count column, then the sums.
+  //
+  // "Group by" and "Sum" are independent menu actions, so the SAME column can
+  // be both a grouping key and a summed column. Keying these entries by `id`
+  // alone then emits duplicate React keys across header/body/footer, and every
+  // `sumColumnIds.includes(col.id)` test matches the group-role cell too — it
+  // grows a stray Σ marker and renders the grand total that belongs to the
+  // sum-role cell (PR #1867 review). Each entry therefore carries a
+  // role-qualified `key` for rendering, while `id` stays the original column
+  // id that widths, sorting and `totals.sums` address columns by.
+  const scheduleColumns = useMemo(
+    () => [
+      ...groupChips.map((c) => ({ ...c, key: `group:${c.id}`, role: 'group' as const })),
+      { id: '__count', label: 'Count', key: '__count', role: 'count' as const },
+      ...sumChips.map((c) => ({ ...c, key: `sum:${c.id}`, role: 'sum' as const })),
+    ],
+    [groupChips, sumChips]);
+
+  const scheduleColumnWidths = useMemo(() => scheduleColumns.map((c, i) => {
+    if (widthOverrides[c.id] !== undefined) return widthOverrides[c.id];
+    if (i >= groupChips.length) return c.role === 'count' ? 90 : 130; // Count / sum columns
+    // Group-value columns: size to the widest value actually shown.
+    let maxLen = c.label.length;
+    for (const row of scheduleRows) {
+      const len = (row.path[i] ?? '').length;
+      if (len > maxLen) maxLen = len;
+    }
+    return Math.max(90, Math.min(320, maxLen * 7 + 34));
+  }), [scheduleColumns, groupChips.length, scheduleRows, widthOverrides]);
+
+  const scheduleTotalWidth = useMemo(
+    () => scheduleColumnWidths.reduce((a, b) => a + b, 0),
+    [scheduleColumnWidths]);
+
+  return (
+    <div style={{ minWidth: scheduleTotalWidth }}>
+      {/* Schedule (pivot) header */}
+      <div className="flex sticky top-0 z-10 bg-muted/80 backdrop-blur-sm border-b">
+        {scheduleColumns.map((col, colIdx) => {
+          const isCount = col.role === 'count';
+          const isSum = col.role === 'sum';
+          // Sort state rides the ORIGINAL column index space (shared with
+          // the nested view), so toggling between views keeps the same
+          // sort. Count has no original column — it IS the null-sort
+          // default (count-descending), so it's shown but not clickable.
+          const originalIdx = isCount ? -1 : columns.findIndex((c) => c.id === col.id);
+          return (
+            <div
+              key={col.key}
+              className={cn(
+                'relative flex items-center gap-0.5 border-r border-border/50 px-2 py-1.5 text-xs font-medium shrink-0',
+                (isCount || isSum) ? 'text-foreground' : 'text-muted-foreground',
+              )}
+              style={{ width: scheduleColumnWidths[colIdx] }}
+            >
+              {originalIdx >= 0 ? (
+                <button className="flex min-w-0 flex-1 items-center gap-1 hover:text-foreground" onClick={() => onHeaderClick(originalIdx)}>
+                  <span className="truncate">{col.label}</span>
+                  {isSum && <span className="text-primary">Σ</span>}
+                  {sortCol === originalIdx && (sortDir === 'asc' ? <ArrowUp className="h-3 w-3 shrink-0" /> : <ArrowDown className="h-3 w-3 shrink-0" />)}
+                </button>
+              ) : (
+                <span className="truncate flex-1" title="Count aggregate — the default sort order">{col.label}</span>
+              )}
+              <div
+                onMouseDown={(e) => startResize(e, col.id, scheduleColumnWidths[colIdx])}
+                onDoubleClick={() => setWidthOverrides((p) => { const n = { ...p }; delete n[col.id]; return n; })}
+                className="absolute right-0 top-0 h-full w-1.5 cursor-col-resize hover:bg-primary/40"
+                title="Drag to resize · double-click to auto-fit"
+              />
+            </div>
+          );
+        })}
+      </div>
+
+      {/* One row per group-value tuple — no per-element detail rows. */}
+      <div style={{ height: `${virtualizer.getTotalSize()}px`, width: '100%', position: 'relative' }}>
+        {virtualizer.getVirtualItems().map((vRow) => {
+          const row = scheduleRows[vRow.index];
+          if (!row) return null;
+          const displayPath = scheduleDisplayPaths[vRow.index];
+          const transform = `translateY(${vRow.start}px)`;
+          return (
+            <div
+              key={vRow.key}
+              className="absolute left-0 top-0 flex w-full border-b border-border/30 hover:bg-muted/40"
+              style={{ transform }}
+            >
+              {groupChips.map((c, i) => (
+                <div
+                  key={`group:${c.id}`}
+                  className="border-r border-border/20 px-2 py-1 text-xs truncate shrink-0"
+                  style={{ width: scheduleColumnWidths[i] }}
+                  title={row.path[i]}
+                >
+                  {displayPath[i]}
+                </div>
+              ))}
+              <div
+                className="border-r border-border/20 px-2 py-1 text-xs text-right font-mono tabular-nums shrink-0"
+                style={{ width: scheduleColumnWidths[groupChips.length] }}
+              >
+                {row.count.toLocaleString()}
+              </div>
+              {sumChips.map((s, i) => (
+                <div
+                  key={`sum:${s.id}`}
+                  className="border-r border-border/20 px-2 py-1 text-xs text-right font-mono tabular-nums shrink-0"
+                  style={{ width: scheduleColumnWidths[groupChips.length + 1 + i] }}
+                >
+                  {formatCellValue(row.sums[s.id])}
+                </div>
+              ))}
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Grand-totals footer (sticky, aligned under columns) */}
+      <div className="flex sticky bottom-0 z-10 border-t-2 border-border bg-muted/90 backdrop-blur-sm">
+        {scheduleColumns.map((col, colIdx) => (
+          <div key={col.key} className="flex items-center border-r border-border/30 px-2 py-1 text-xs font-semibold shrink-0" style={{ width: scheduleColumnWidths[colIdx] }}>
+            {colIdx === 0 && <span className="text-muted-foreground">Total · {scheduleRows.length.toLocaleString()} group{scheduleRows.length === 1 ? '' : 's'}</span>}
+            {col.role === 'count' && <span className="ml-auto font-mono tabular-nums text-foreground">{totals.count.toLocaleString()}</span>}
+            {col.role === 'sum' && (
+              <span className="ml-auto font-mono tabular-nums text-foreground">{formatCellValue(totals.sums[col.id])}</span>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/viewer/src/components/viewer/lists/ListScheduleTable.tsx
+++ b/apps/viewer/src/components/viewer/lists/ListScheduleTable.tsx
@@ -17,7 +17,7 @@
  * as a prop, already counting `scheduleRows`.
  */
 
-import React, { useMemo } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import type { Virtualizer } from '@tanstack/react-virtual';
 import { ArrowUp, ArrowDown } from 'lucide-react';
 import type { ColumnDefinition } from '@ifc-lite/lists';
@@ -83,8 +83,19 @@ export function ListScheduleTable({
     ],
     [groupChips, sumChips]);
 
+  // Width-override key. Normally the ORIGINAL column id, so a resize carries
+  // across the schedule/nested view toggle. A column that is BOTH grouped and
+  // summed appears twice though, and sharing one key there would make dragging
+  // the sigma column silently resize the group column too — so only that
+  // second, sum-role instance gets its own key (PR #1867 review).
+  const widthKey = useCallback(
+    (col: { id: string; role: 'group' | 'count' | 'sum' }) =>
+      col.role === 'sum' && groupChips.some((g) => g.id === col.id) ? `sum:${col.id}` : col.id,
+    [groupChips]);
+
   const scheduleColumnWidths = useMemo(() => scheduleColumns.map((c, i) => {
-    if (widthOverrides[c.id] !== undefined) return widthOverrides[c.id];
+    const wk = c.role === 'sum' && groupChips.some((g) => g.id === c.id) ? `sum:${c.id}` : c.id;
+    if (widthOverrides[wk] !== undefined) return widthOverrides[wk];
     if (i >= groupChips.length) return c.role === 'count' ? 90 : 130; // Count / sum columns
     // Group-value columns: size to the widest value actually shown.
     let maxLen = c.label.length;
@@ -130,8 +141,8 @@ export function ListScheduleTable({
                 <span className="truncate flex-1" title="Count aggregate — the default sort order">{col.label}</span>
               )}
               <div
-                onMouseDown={(e) => startResize(e, col.id, scheduleColumnWidths[colIdx])}
-                onDoubleClick={() => setWidthOverrides((p) => { const n = { ...p }; delete n[col.id]; return n; })}
+                onMouseDown={(e) => startResize(e, widthKey(col), scheduleColumnWidths[colIdx])}
+                onDoubleClick={() => setWidthOverrides((p) => { const n = { ...p }; delete n[widthKey(col)]; return n; })}
                 className="absolute right-0 top-0 h-full w-1.5 cursor-col-resize hover:bg-primary/40"
                 title="Drag to resize · double-click to auto-fit"
               />

--- a/apps/viewer/src/components/viewer/lists/list-table-utils.test.ts
+++ b/apps/viewer/src/components/viewer/lists/list-table-utils.test.ts
@@ -5,7 +5,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
 import { groupPathKey, type ColumnDefinition, type ListRow } from '@ifc-lite/lists';
-import { buildGroupedView, compareCells, type GroupSort } from './list-table-utils';
+import { buildGroupedView, buildScheduleRows, blankRepeatedPathValues, compareCells, type GroupSort } from './list-table-utils';
 
 const columns: ColumnDefinition[] = [
   { id: 'cat', source: 'attribute', propertyName: 'Category' },
@@ -190,6 +190,90 @@ describe('buildGroupedView multi-criteria grouping (#1790)', () => {
       view.items.map((i) => (i.kind === 'group' ? [i.level, i.label, i.count] : 'row')),
       [[0, 'A', 3], 'row', 'row', 'row', [0, 'B', 1]],
     );
+  });
+});
+
+// Schedule / pivot presentation (issue #1790 round 2): one row per group-value
+// tuple instead of the nested collapsible tree.
+describe('buildScheduleRows', () => {
+  const cols: ColumnDefinition[] = [
+    { id: 'building', source: 'spatial', propertyName: 'Building' },
+    { id: 'storey', source: 'spatial', propertyName: 'Storey' },
+    { id: 'qty', source: 'quantity', propertyName: 'Qty' },
+  ];
+  const mkRows = (...tuples: [string, string, number][]): ListRow[] =>
+    tuples.map(([b, s, q], i) => ({ entityId: i + 1, modelId: 'm', values: [b, s, q] }));
+  // Building A: 3 rows over 2 storeys; Building B: 1 row.
+  const sample = mkRows(['A', 'L0', 1], ['A', 'L0', 2], ['A', 'L1', 3], ['B', 'L0', 4]);
+  const grouping = { columnId: 'building', columnIds: ['building', 'storey'], sumColumnIds: ['qty'] };
+
+  it('emits one row per leaf tuple, contiguous per outer group, with count + sums', () => {
+    const rows = buildScheduleRows(sample, cols, grouping, null);
+    assert.deepStrictEqual(rows.map((r) => [r.path, r.count, r.sums.qty]), [
+      [['A', 'L0'], 2, 3],
+      [['A', 'L1'], 1, 3],
+      [['B', 'L0'], 1, 4],
+    ]);
+  });
+
+  it('every row key is the collision-free path encoding and all keys are unique', () => {
+    const rows = buildScheduleRows(sample, cols, grouping, null);
+    for (const r of rows) assert.strictEqual(r.key, groupPathKey(r.path));
+    assert.strictEqual(new Set(rows.map((r) => r.key)).size, rows.length);
+  });
+
+  it('single-criterion grouping: every top-level group IS a leaf row', () => {
+    const rows = buildScheduleRows(sample, cols, { columnId: 'building', sumColumnIds: ['qty'] }, null);
+    assert.deepStrictEqual(rows.map((r) => [r.path, r.count, r.sums.qty]), [
+      [['A'], 3, 6],
+      [['B'], 1, 4],
+    ]);
+  });
+
+  it('returns [] when there is no grouping configured', () => {
+    assert.deepStrictEqual(buildScheduleRows(sample, cols, { columnId: '', sumColumnIds: [] }, null), []);
+  });
+
+  it('returns [] for an empty row set', () => {
+    assert.deepStrictEqual(buildScheduleRows([], cols, grouping, null), []);
+  });
+
+  it('honours the active header sort like the nested view does', () => {
+    const asc = buildScheduleRows(sample, cols, grouping, { colIdx: 0, dir: 'asc' });
+    // 'A' before 'B' either way (only two top groups); sort matters for the
+    // sub-level ordering within 'A' (L0 sums 3, L1 sums 3 -> tie by label).
+    assert.deepStrictEqual(asc.map((r) => r.path), [['A', 'L0'], ['A', 'L1'], ['B', 'L0']]);
+    const desc = buildScheduleRows(sample, cols, grouping, { colIdx: 0, dir: 'desc' });
+    assert.deepStrictEqual(desc.map((r) => r.path), [['B', 'L0'], ['A', 'L0'], ['A', 'L1']]);
+  });
+});
+
+describe('blankRepeatedPathValues (Bonsai-style repeat blanking, issue #1790 round 2)', () => {
+  it('blanks a level only when its entire prefix matches the row above', () => {
+    const rows = [
+      { path: ['A', 'L0', 'Wall'] },
+      { path: ['A', 'L0', 'Door'] }, // building + storey repeat -> blanked; type differs -> shown
+      { path: ['A', 'L1', 'Wall'] }, // building repeats -> blanked; storey differs -> shown (and so does type)
+      { path: ['B', 'L0', 'Wall'] }, // nothing repeats
+    ];
+    assert.deepStrictEqual(blankRepeatedPathValues(rows), [
+      ['A', 'L0', 'Wall'],
+      ['', '', 'Door'],
+      ['', 'L1', 'Wall'],
+      ['B', 'L0', 'Wall'],
+    ]);
+  });
+
+  it('never blanks the first row', () => {
+    assert.deepStrictEqual(blankRepeatedPathValues([{ path: ['A', 'B'] }]), [['A', 'B']]);
+  });
+
+  it('is a no-op for single-criterion (single-column) schedules', () => {
+    const rows = [{ path: ['A'] }, { path: ['A'] }, { path: ['B'] }];
+    // Single-level tuples are already unique rows (a repeat here would mean
+    // two IDENTICAL leaf tuples, which buildScheduleRows never produces), but
+    // the helper still blanks on a literal match — documented, not a bug.
+    assert.deepStrictEqual(blankRepeatedPathValues(rows), [['A'], [''], ['B']]);
   });
 });
 

--- a/apps/viewer/src/components/viewer/lists/list-table-utils.test.ts
+++ b/apps/viewer/src/components/viewer/lists/list-table-utils.test.ts
@@ -5,7 +5,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
 import { groupPathKey, type ColumnDefinition, type ListRow } from '@ifc-lite/lists';
-import { buildGroupedView, buildScheduleRows, blankRepeatedPathValues, compareCells, type GroupSort } from './list-table-utils';
+import { buildGroupedView, buildScheduleRows, blankRepeatedPathValues, rebuildGrouping, compareCells, type GroupSort } from './list-table-utils';
 
 const columns: ColumnDefinition[] = [
   { id: 'cat', source: 'attribute', propertyName: 'Category' },
@@ -274,6 +274,57 @@ describe('blankRepeatedPathValues (Bonsai-style repeat blanking, issue #1790 rou
     // two IDENTICAL leaf tuples, which buildScheduleRows never produces), but
     // the helper still blanks on a literal match — documented, not a bug.
     assert.deepStrictEqual(blankRepeatedPathValues(rows), [['A'], [''], ['B']]);
+  });
+});
+
+// Regression: removing/adding a grouping level or sum column from the results
+// table (grouping-bar chip "x", column-header-menu toggles) used to build a
+// BRAND NEW ListGrouping literal that dropped `view` (issue #1790 round 2 QA
+// finding) — silently reverting an active schedule view to nested. Both
+// `toggleGroupBy` and `toggleSum` in ListResultsTable now go through this
+// helper, which spreads the previous grouping so unrelated fields survive.
+describe('rebuildGrouping (schedule-view drop regression, #1790 round 2)', () => {
+  const scheduleGrouping = { columnId: 'a', columnIds: ['a', 'b'], sumColumnIds: ['s'], view: 'schedule' as const };
+
+  it('removing one of two grouping columns preserves view="schedule"', () => {
+    const next = rebuildGrouping(scheduleGrouping, ['a'], ['s']);
+    assert.deepStrictEqual(next, { columnId: 'a', columnIds: ['a'], sumColumnIds: ['s'], view: 'schedule' });
+  });
+
+  it('toggling a sum column on preserves view="schedule"', () => {
+    const base = { columnId: 'a', columnIds: ['a'], sumColumnIds: [], view: 'schedule' as const };
+    const next = rebuildGrouping(base, ['a'], ['s']);
+    assert.deepStrictEqual(next, { columnId: 'a', columnIds: ['a'], sumColumnIds: ['s'], view: 'schedule' });
+  });
+
+  it('toggling a sum column off preserves view="schedule"', () => {
+    const next = rebuildGrouping(scheduleGrouping, ['a', 'b'], []);
+    assert.deepStrictEqual(next, { columnId: 'a', columnIds: ['a', 'b'], sumColumnIds: [], view: 'schedule' });
+  });
+
+  it('removing the LAST grouping column (sums remain) still returns a grouping and keeps view — harmless: scheduleMode requires isGrouped, so it has no visible effect until a group column is re-added', () => {
+    const next = rebuildGrouping(scheduleGrouping, [], ['s']);
+    assert.deepStrictEqual(next, { columnId: '', columnIds: [], sumColumnIds: ['s'], view: 'schedule' });
+  });
+
+  it('clearing everything (no group columns, no sums) returns undefined — grouping is gone, so there is nothing to preserve `view` on', () => {
+    assert.strictEqual(rebuildGrouping(scheduleGrouping, [], []), undefined);
+  });
+
+  it('the nested (non-schedule) view is equally preserved, not just schedule', () => {
+    const nested = { columnId: 'a', columnIds: ['a', 'b'], sumColumnIds: [], view: 'nested' as const };
+    const next = rebuildGrouping(nested, ['a'], []);
+    assert.strictEqual(next?.view, 'nested');
+  });
+
+  it('building a grouping from scratch (no previous grouping) has no view, matching legacy behaviour', () => {
+    const next = rebuildGrouping(undefined, ['a'], ['s']);
+    // Checked BEFORE deepStrictEqual: Node's `assert.deepStrictEqual<T>` is a
+    // `asserts actual is T` type-narrowing signature, so calling it first
+    // would narrow `next`'s type to the (view-less) expected literal and make
+    // a later `next?.view` a compile error, not just a runtime check.
+    assert.strictEqual(next?.view, undefined);
+    assert.deepStrictEqual(next, { columnId: 'a', columnIds: ['a'], sumColumnIds: ['s'] });
   });
 });
 

--- a/apps/viewer/src/components/viewer/lists/list-table-utils.ts
+++ b/apps/viewer/src/components/viewer/lists/list-table-utils.ts
@@ -15,6 +15,26 @@ import { buildNestedGroupBuckets, compareCells, orderGroups, type GroupSort, typ
 export { compareCells, orderGroups };
 export type { GroupSort, OrderableGroup };
 
+/**
+ * Rebuild a `ListGrouping` after changing the group-by columns and/or sum
+ * columns from the results table (a grouping-bar chip's "x", or a column
+ * header menu's "Group by" / "Sum" toggle). SPREADS the previous grouping
+ * first, then overrides only the fields this rebuild actually changes
+ * (`columnId`, `columnIds`, `sumColumnIds`) — so a field neither caller
+ * knows about (e.g. `view`, issue #1790 round 2) survives instead of being
+ * silently dropped back to its default. Returns `undefined` when there is
+ * nothing left to track (no group columns AND no sum columns), matching the
+ * existing "clear grouping entirely" behaviour.
+ */
+export function rebuildGrouping(
+  previous: ListGrouping | undefined,
+  columnIds: string[],
+  sumColumnIds: string[],
+): ListGrouping | undefined {
+  if (columnIds.length === 0 && sumColumnIds.length === 0) return undefined;
+  return { ...previous, columnId: columnIds[0] ?? '', columnIds, sumColumnIds };
+}
+
 export function formatCellValue(value: CellValue): string {
   if (value === null || value === undefined) return '';
   if (typeof value === 'boolean') return value ? 'Yes' : 'No';

--- a/apps/viewer/src/components/viewer/lists/list-table-utils.ts
+++ b/apps/viewer/src/components/viewer/lists/list-table-utils.ts
@@ -136,6 +136,73 @@ export function buildGroupedView(
   return { items, groupCount, totals, groupKeys };
 }
 
+/** One row of the `schedule` / pivot presentation (issue #1790 round 2) — a
+ *  single group-value tuple (a leaf group combination) with its Count and
+ *  configured sums, display-unit-converted like the rest of the on-screen
+ *  table. Unlike `DisplayItem`'s `group` kind, there is no tree here: every
+ *  row IS a leaf, one per distinct combination of group-by values. */
+export interface ScheduleRow {
+  /** Collision-free key — `groupPathKey(path)`. */
+  key: string;
+  /** Group-by values, outermost first — one per active grouping level. */
+  path: string[];
+  count: number;
+  sums: Record<string, number>;
+}
+
+/**
+ * Bonsai-style pivot/schedule table (issue #1790 round 2): the grouping
+ * criteria become leading columns and each row is one group-value tuple
+ * (Building | Storey | Type | Count | Sum(...)), instead of per-element rows
+ * nested under collapsible group headers. Reuses `buildNestedGroupBuckets` —
+ * the SAME bucket-building `buildGroupedView` uses — so the schedule can
+ * never disagree with the nested view on which rows land in which group or
+ * how groups are ordered; this just keeps the leaf buckets and drops the
+ * parent levels (pre-order flattening already keeps a parent's leaves
+ * contiguous, so no re-sorting is needed here).
+ */
+export function buildScheduleRows(
+  rows: ListRow[],
+  columns: ColumnDefinition[],
+  grouping: ListGrouping,
+  sort: GroupSort = null,
+): ScheduleRow[] {
+  const groupIds = groupingColumnIds(grouping).filter((id) => columns.some((c) => c.id === id));
+  if (groupIds.length === 0) return [];
+  const levelIndices = groupIds.map((id) => columns.findIndex((c) => c.id === id));
+  const sums = sumIndices(columns, grouping.sumColumnIds);
+  const nested = buildNestedGroupBuckets(rows, levelIndices, sums, (r, idx) => r.values[idx], formatCellValue, sort);
+  const leafLevel = levelIndices.length - 1;
+  return nested
+    .filter((g) => g.level === leafLevel)
+    .map((g) => ({ key: g.key, path: g.path, count: g.count, sums: g.sums }));
+}
+
+/**
+ * Blank out a schedule row's leading group-value cells where they repeat the
+ * row above (Bonsai-style: "P01 / Wall / 12" then "· / Door / 4" — the
+ * building doesn't repeat once shown). Purely a display convenience for the
+ * on-screen table: only a value whose ENTIRE prefix up to and including this
+ * level matches the previous row is blanked, so a change at an outer level
+ * always re-shows every level nested inside it. CSV/XLSX/PDF exports keep
+ * the full repeated values (machine-friendly, matches Bonsai's own CSV).
+ */
+export function blankRepeatedPathValues(rows: { path: string[] }[]): string[][] {
+  const out: string[][] = [];
+  let prev: string[] | null = null;
+  for (const r of rows) {
+    const display: string[] = new Array(r.path.length);
+    let matched = true;
+    for (let j = 0; j < r.path.length; j++) {
+      matched = matched && prev !== null && prev[j] === r.path[j];
+      display[j] = matched ? '' : r.path[j];
+    }
+    out.push(display);
+    prev = r.path;
+  }
+  return out;
+}
+
 /** Grand totals for the flat (ungrouped) view when sum columns are active. */
 export function flatTotals(rows: ListRow[], columns: ColumnDefinition[], sumColumnIds: string[]): Totals {
   const sums = sumIndices(columns, sumColumnIds);

--- a/apps/viewer/src/lib/lists/export/csv.test.ts
+++ b/apps/viewer/src/lib/lists/export/csv.test.ts
@@ -1,0 +1,91 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import type { ColumnDefinition, ListRow } from '@ifc-lite/lists';
+import { buildExportModel } from './model';
+import { toCsv } from './csv';
+
+const cols3: ColumnDefinition[] = [
+  { id: 'building', source: 'spatial', propertyName: 'Building' },
+  { id: 'storey', source: 'spatial', propertyName: 'Storey' },
+  { id: 'type', source: 'attribute', propertyName: 'Class' },
+  { id: 'area', source: 'quantity', propertyName: 'Area' },
+];
+const rows3: ListRow[] = ([
+  ['P01', 'Level 0', 'IfcWall', 10],
+  ['P01', 'Level 0', 'IfcWall', 12],
+  ['P01', 'Level 1', 'IfcDoor', 4],
+  ['P02', 'Level 0', 'IfcWall', 8],
+] as [string, string, string, number][]).map(([b, s, t, a], i) => ({ entityId: i + 1, modelId: 'm', values: [b, s, t, a] }));
+
+// Bonsai's own CSV mirrors its schedule table (Building | Storey | Type |
+// Count | Area), not a per-element flat table — this is the exact arrangement
+// steverugi asked for in issue #1790's round-2 comment.
+describe('toCsv schedule (pivot) arrangement (#1790 round 2)', () => {
+  const base = {
+    title: 'Schedule',
+    columns: cols3,
+    rows: rows3,
+    numericCols: [false, false, false, true],
+    columnWidths: [120, 120, 120, 120],
+    generatedAt: 'now',
+  };
+
+  it('one row per group-value tuple: group columns, Count, then sums — full values, never blanked', () => {
+    const model = buildExportModel({
+      ...base,
+      grouping: { columnId: 'building', columnIds: ['building', 'storey', 'type'], sumColumnIds: ['area'], view: 'schedule' },
+    });
+    const csv = toCsv(model);
+    const lines = csv.split('\r\n');
+    assert.strictEqual(lines[0], 'Building,Storey,Class,Count,Area');
+    assert.deepStrictEqual(lines.slice(1, 4), [
+      'P01,Level 0,IfcWall,2,22',
+      'P01,Level 1,IfcDoor,1,4',
+      'P02,Level 0,IfcWall,1,8',
+    ]);
+    // Grand total row.
+    assert.strictEqual(lines[4], 'TOTAL (4),,,4,34');
+  });
+
+  it('the flat per-element CSV (no schedule view) still exports the old Group-path arrangement unchanged', () => {
+    const model = buildExportModel({
+      ...base,
+      grouping: { columnId: 'building', columnIds: ['building', 'storey'], sumColumnIds: ['area'] },
+    });
+    const csv = toCsv(model);
+    const lines = csv.split('\r\n');
+    assert.strictEqual(lines[0], 'Group,Building,Storey,Class,Area');
+    // One CSV row PER ELEMENT (4 elements), grouped rows carry the full path.
+    assert.strictEqual(lines.length, 1 + rows3.length + 1); // header + 4 rows + TOTAL
+    assert.ok(lines[1].startsWith('P01 / Level 0,'));
+  });
+
+  it('single-criterion schedule: every top-level group is a leaf row', () => {
+    const model = buildExportModel({
+      ...base,
+      grouping: { columnId: 'building', sumColumnIds: ['area'], view: 'schedule' },
+    });
+    const csv = toCsv(model);
+    assert.deepStrictEqual(csv.split('\r\n'), [
+      'Building,Count,Area',
+      'P01,3,26',
+      'P02,1,8',
+      'TOTAL (4),4,34',
+    ]);
+  });
+
+  it('schedule view without sums still emits a Count-only pivot', () => {
+    const model = buildExportModel({
+      ...base,
+      grouping: { columnId: 'building', columnIds: ['building', 'storey'], sumColumnIds: [], view: 'schedule' },
+    });
+    const csv = toCsv(model);
+    assert.strictEqual(csv.split('\r\n')[0], 'Building,Storey,Count');
+    // No sum columns configured -> no TOTAL row (matches the flat-view behaviour).
+    assert.strictEqual(csv.split('\r\n').length, 1 + 3);
+  });
+});

--- a/apps/viewer/src/lib/lists/export/csv.ts
+++ b/apps/viewer/src/lib/lists/export/csv.ts
@@ -18,8 +18,32 @@ function esc(s: string, delim: string): string {
  * ordered by group, and a TOTAL row carries the grand count + sums. With
  * multi-criteria grouping the Group cell carries the full path ("Building /
  * Storey") so nested grouping survives as flat data.
+ *
+ * Schedule / pivot presentation (issue #1790 round 2): when `model.schedule`
+ * is present the CSV mirrors it INSTEAD — grouping columns first (full,
+ * repeated values; no blank-on-repeat, that's on-screen-only sugar), then
+ * Count, then any configured sums — one row per group-value tuple, matching
+ * Bonsai's own schedule CSV arrangement.
  */
 export function toCsv(model: ExportModel, delimiter = ','): string {
+  if (model.schedule) {
+    const cols = model.schedule.columns;
+    const lines = [cols.map((c) => esc(c.label, delimiter)).join(delimiter)];
+    for (const row of model.schedule.rows) {
+      lines.push(cols.map((_, i) => esc(displayCell(row[i]), delimiter)).join(delimiter));
+    }
+    if (model.sumColumnIds.length > 0) {
+      const totalLabel = `TOTAL (${model.totals.count})`;
+      lines.push(cols.map((c, i) => {
+        if (i === 0) return esc(totalLabel, delimiter);
+        if (c.id === '__count') return esc(displayCell(model.totals.count), delimiter);
+        if (c.summed) return esc(displayCell(model.totals.sums[c.id]), delimiter);
+        return '';
+      }).join(delimiter));
+    }
+    return lines.join('\r\n');
+  }
+
   const grouped = model.groups !== null;
   const header = [...(grouped ? ['Group'] : []), ...model.columns.map((c) => c.label)];
   const lines = [header.map((h) => esc(h, delimiter)).join(delimiter)];

--- a/apps/viewer/src/lib/lists/export/model.test.ts
+++ b/apps/viewer/src/lib/lists/export/model.test.ts
@@ -99,6 +99,60 @@ describe('buildExportModel multi-criteria grouping (#1790)', () => {
     assert.deepStrictEqual(m.groups?.map((g) => [g.level, g.label, g.rows.length]), [[0, 'A', 3], [0, 'B', 1]]);
     assert.deepStrictEqual(m.groupColumnIds, ['building']);
   });
+
+  it('schedule is null when grouping.view is not "schedule" (default nested behaviour unchanged)', () => {
+    const m = buildExportModel({ ...input });
+    assert.strictEqual(m.schedule, null);
+  });
+});
+
+// Schedule / pivot presentation (issue #1790 round 2): grouping columns
+// become leading columns, one row per group-value tuple, Count as a
+// first-class column — the CSV/XLSX/PDF arrangement the reporter asked for.
+describe('buildExportModel schedule view (#1790 round 2)', () => {
+  const cols3: ColumnDefinition[] = [
+    { id: 'building', source: 'spatial', propertyName: 'Building' },
+    { id: 'storey', source: 'spatial', propertyName: 'Storey' },
+    { id: 'qty', source: 'quantity', propertyName: 'Qty' },
+  ];
+  const rows3: ListRow[] = ([
+    ['A', 'L0', 1], ['A', 'L0', 2], ['A', 'L1', 3], ['B', 'L0', 4],
+  ] as [string, string, number][]).map(([b, s, q], i) => ({ entityId: i + 1, modelId: 'm', values: [b, s, q] }));
+  const input = {
+    title: 'List',
+    columns: cols3,
+    rows: rows3,
+    numericCols: [false, false, true],
+    columnWidths: [120, 120, 120],
+    generatedAt: 'now',
+    grouping: { columnId: 'building', columnIds: ['building', 'storey'], sumColumnIds: ['qty'], view: 'schedule' as const },
+  };
+
+  it('emits one row per LEAF group-value tuple: group columns, Count, then sums', () => {
+    const m = buildExportModel(input);
+    assert.deepStrictEqual(m.schedule?.columns.map((c) => c.label), ['Building', 'Storey', 'Count', 'Qty']);
+    assert.deepStrictEqual(m.schedule?.rows, [
+      ['A', 'L0', 2, 3],
+      ['A', 'L1', 1, 3],
+      ['B', 'L0', 1, 4],
+    ]);
+  });
+
+  it('does not lose the nested `groups` field either — both are populated so a caller can choose', () => {
+    const m = buildExportModel(input);
+    assert.ok(m.groups && m.groups.length > 0);
+  });
+
+  it('single-criterion schedule: every top-level group IS a leaf row', () => {
+    const m = buildExportModel({ ...input, grouping: { columnId: 'building', sumColumnIds: ['qty'], view: 'schedule' as const } });
+    assert.deepStrictEqual(m.schedule?.rows, [['A', 3, 6], ['B', 1, 4]]);
+  });
+
+  it('schedule view with no sum columns still carries the Count column', () => {
+    const m = buildExportModel({ ...input, grouping: { columnId: 'building', columnIds: ['building', 'storey'], sumColumnIds: [], view: 'schedule' as const } });
+    assert.deepStrictEqual(m.schedule?.columns.map((c) => c.label), ['Building', 'Storey', 'Count']);
+    assert.deepStrictEqual(m.schedule?.rows, [['A', 'L0', 2], ['A', 'L1', 1], ['B', 'L0', 1]]);
+  });
 });
 
 // #1573: quantity/measure columns export converted into the user's

--- a/apps/viewer/src/lib/lists/export/model.ts
+++ b/apps/viewer/src/lib/lists/export/model.ts
@@ -58,6 +58,17 @@ export interface ExportModel {
   groupColumnIds: string[];
   sumColumnIds: string[];
   totals: { count: number; sums: Record<string, number> };
+  /**
+   * Present when the grouping's presentation is `schedule` (issue #1790
+   * round 2): a Bonsai-style pivot table — one row per group-value tuple
+   * (leaf group), grouping columns first, then a first-class `Count` column,
+   * then any configured sums. Every writer renders THIS instead of
+   * `groups`/`rows` when it is present, so the export always mirrors exactly
+   * what the on-screen schedule view shows. Cell values already carry the
+   * FULL (repeated) group-value tuple — no blank-on-repeat here, that's
+   * on-screen-only sugar; a re-importable CSV/XLSX needs every row complete.
+   */
+  schedule: { columns: ExportColumn[]; rows: CellValue[][] } | null;
 }
 
 export interface BuildModelInput {
@@ -171,20 +182,22 @@ export function buildExportModel(input: BuildModelInput): ExportModel {
   const groupColumnId = groupColumnIds[0] ?? null;
 
   let groups: ExportGroup[] | null = null;
+  let schedule: ExportModel['schedule'] = null;
   if (groupColumnIds.length > 0) {
     const levelIndices = groupColumnIds.map((id) => columns.findIndex((c) => c.id === id));
     const leafLevel = levelIndices.length - 1;
     // Bucket + subtotal via the shared helper so the sections match the table
     // exactly (multi-criteria grouping nests one section level per group
     // column), then project each LEAF group's member rows to display values.
-    groups = buildNestedGroupBuckets(
+    const nested = buildNestedGroupBuckets(
       convertedRows,
       levelIndices,
       sumIdx,
       (r, idx) => r.values[idx],
       displayCell,
       sort ?? null,
-    ).map((g) => ({
+    );
+    groups = nested.map((g) => ({
       label: g.label,
       count: g.count,
       sums: g.sums,
@@ -192,7 +205,26 @@ export function buildExportModel(input: BuildModelInput): ExportModel {
       path: g.path,
       rows: g.level === leafLevel ? g.rows.map((r) => r.values) : [],
     }));
+
+    // Schedule / pivot presentation (issue #1790 round 2): one row per
+    // group-value tuple (leaf group), grouping columns first, then a
+    // first-class Count column, then the configured sums — the same leaf
+    // buckets, just flattened into a single tuple row instead of a section.
+    if (grouping?.view === 'schedule') {
+      const scheduleCols: ExportColumn[] = [
+        ...groupColumnIds.map((id) => {
+          const i = columns.findIndex((c) => c.id === id);
+          return { id, label: exportCols[i]?.label ?? id, numeric: false, summed: false, width: exportCols[i]?.width ?? 120 };
+        }),
+        { id: '__count', label: 'Count', numeric: true, summed: false, width: 80 },
+        ...sumIdx.map((s) => exportCols[s.idx]),
+      ];
+      const scheduleRows: CellValue[][] = nested
+        .filter((g) => g.level === leafLevel)
+        .map((g) => [...g.path, g.count, ...sumIdx.map((s) => g.sums[s.id])]);
+      schedule = { columns: scheduleCols, rows: scheduleRows };
+    }
   }
 
-  return { title, generatedAt, columns: exportCols, groups, rows: flatRows, groupColumnId, groupColumnIds, sumColumnIds, totals };
+  return { title, generatedAt, columns: exportCols, groups, rows: flatRows, groupColumnId, groupColumnIds, sumColumnIds, totals, schedule };
 }

--- a/apps/viewer/src/lib/lists/export/pdf.ts
+++ b/apps/viewer/src/lib/lists/export/pdf.ts
@@ -12,7 +12,11 @@ export async function toPdf(model: ExportModel): Promise<Blob> {
   const { jsPDF } = await import('jspdf');
   const autoTable = (await import('jspdf-autotable')).default;
 
-  const landscape = model.columns.length > 5;
+  // Schedule / pivot presentation (issue #1790 round 2): grouping columns
+  // become leading columns, one row per group-value tuple, then Count and
+  // any configured sums — matching the on-screen schedule view exactly.
+  const cols = model.schedule?.columns ?? model.columns;
+  const landscape = cols.length > 5;
   const doc = new jsPDF({ orientation: landscape ? 'landscape' : 'portrait', unit: 'pt', format: 'a4' });
 
   doc.setFont('helvetica', 'bold'); doc.setFontSize(14);
@@ -21,11 +25,13 @@ export async function toPdf(model: ExportModel): Promise<Blob> {
   doc.text(`${model.totals.count.toLocaleString()} elements · ${model.generatedAt}`, 40, 58);
   doc.setTextColor(0);
 
-  const head = [model.columns.map((c) => c.label)];
+  const head = [cols.map((c) => c.label)];
   const cell = (vals: CellValue[], i: number) => displayCell(vals[i]);
   const body: Array<Array<string | { content: string; styles: Record<string, unknown> }>> = [];
 
-  if (model.groups) {
+  if (model.schedule) {
+    for (const r of model.schedule.rows) body.push(cols.map((_, i) => cell(r, i)));
+  } else if (model.groups) {
     // Nested (multi-criteria) grouping: sub-group headers indent one step per
     // level and carry their own count; member rows sit on leaf groups only.
     for (const g of model.groups) {
@@ -40,11 +46,15 @@ export async function toPdf(model: ExportModel): Promise<Blob> {
   }
 
   const foot = model.sumColumnIds.length > 0
-    ? [model.columns.map((c, i) => (c.summed ? displayCell(model.totals.sums[c.id]) : (i === 0 ? `Total (${model.totals.count})` : '')))]
+    ? [cols.map((c, i) => {
+        if (i === 0) return `Total (${model.totals.count})`;
+        if (model.schedule && c.id === '__count') return displayCell(model.totals.count);
+        return c.summed ? displayCell(model.totals.sums[c.id]) : '';
+      })]
     : undefined;
 
   const columnStyles: Record<number, { halign: 'right' }> = {};
-  model.columns.forEach((c, i) => { if (c.numeric) columnStyles[i] = { halign: 'right' }; });
+  cols.forEach((c, i) => { if (c.numeric) columnStyles[i] = { halign: 'right' }; });
 
   autoTable(doc, {
     head,

--- a/apps/viewer/src/lib/lists/export/xlsx.ts
+++ b/apps/viewer/src/lib/lists/export/xlsx.ts
@@ -29,7 +29,10 @@ export async function toXlsx(model: ExportModel): Promise<Blob> {
     views: [{ state: 'frozen', ySplit: 4 }],
   });
 
-  const cols = model.columns;
+  // Schedule / pivot presentation (issue #1790 round 2): grouping columns
+  // become leading columns, one row per group-value tuple, then Count and any
+  // configured sums — matching the on-screen schedule view exactly.
+  const cols = model.schedule?.columns ?? model.columns;
   const ncol = cols.length;
 
   // Title + meta.
@@ -62,7 +65,9 @@ export async function toXlsx(model: ExportModel): Promise<Blob> {
     if (outline) r.outlineLevel = outline;
   };
 
-  if (model.groups) {
+  if (model.schedule) {
+    for (const row of model.schedule.rows) addDataRow(row);
+  } else if (model.groups) {
     // Nested (multi-criteria) grouping: sub-group headers indent one step per
     // level and carry their own count; member rows sit on leaf groups only.
     // Outline levels are clamped to Excel's maximum of 8.
@@ -81,7 +86,11 @@ export async function toXlsx(model: ExportModel): Promise<Blob> {
 
   // Grand total.
   if (model.sumColumnIds.length > 0) {
-    const tr = ws.addRow(cols.map((c, i) => (c.summed ? model.totals.sums[c.id] : (i === 0 ? `Total (${model.totals.count})` : null))));
+    const tr = ws.addRow(cols.map((c, i) => {
+      if (i === 0) return `Total (${model.totals.count})`;
+      if (model.schedule && c.id === '__count') return model.totals.count;
+      return c.summed ? model.totals.sums[c.id] : null;
+    }));
     tr.font = { bold: true };
     tr.eachCell((cell) => { cell.border = { top: { style: 'double', color: { argb: 'FF334155' } } }; });
   }

--- a/docs/guide/lists.md
+++ b/docs/guide/lists.md
@@ -97,6 +97,42 @@ const csv = listResultToCSV(result);
 
 `listResultToCSV` guards against spreadsheet formula injection (CWE-1236): any cell that starts with `=`, `+`, `-`, `@`, tab, or carriage return is prefixed with a single quote so Excel and Google Sheets treat it as text rather than a formula. Standard CSV quoting (double quotes, `""` escaping) is applied on top.
 
+## Grouping, Aggregation & Schedules
+
+Set `grouping` on a `ListDefinition` to bucket rows by one or more columns (outermost first) and sum numeric columns per group:
+
+```typescript
+import { executeList, summariseListRows, toScheduleRows, LIST_PRESETS } from '@ifc-lite/lists';
+
+const definition = {
+  ...LIST_PRESETS[0], // Wall Schedule
+  grouping: {
+    columnId: 'attr-name',       // legacy single-column field, kept in sync with columnIds[0]
+    columnIds: ['attr-name'],    // ordered group-by columns, outermost first
+    sumColumnIds: ['quant-qto_wallbasequantities-length'],
+  },
+};
+
+const result = executeList(definition, provider);
+
+// result.groups is a flat PRE-ORDER list: each parent group is immediately
+// followed by its subgroups. Every group carries a Count aggregate (`count`)
+// and per-column sums (`sums`).
+for (const group of result.groups ?? []) {
+  console.log(group.label, group.count, group.sums);
+}
+
+// A Bonsai-style schedule/pivot table — one row per group-value tuple (the
+// LEAF groups only) instead of a nested tree. `levelCount` is the number of
+// active grouping columns.
+const scheduleRows = toScheduleRows(result.groups, definition.grouping.columnIds.length);
+for (const row of scheduleRows) {
+  console.log(row.path, row.count, row.sums); // e.g. ["Wall-01"], 1, { ... }
+}
+```
+
+`summariseListRows(definition, rows)` is what `executeList` calls internally to build `groups`/`summary`; call it directly when you already have rows from elsewhere (e.g. merged across federated models) and just need to re-derive the grouping.
+
 ## The Data Provider
 
 `executeList` reads model data through the `ListDataProvider` interface, so the package has no hard dependency on how you parsed the model. Required methods include `getEntitiesByType`, `getEntityName`, `getEntityGlobalId`, `getPropertySets`, and `getQuantitySets`; optional methods (`getMaterialNames`, `getClassifications`, `getStoreyName`, `getProjectName`, ...) unlock the `material`, `classification`, `spatial`, and `model` column sources, and the engine degrades gracefully when they are absent.
@@ -134,7 +170,9 @@ Conditions and lookups that match by name accept either an exact string or a reg
 |--------|-------------|
 | `executeList(definition, provider, modelId?)` | Run a list definition, returns `ListResult` |
 | `listResultToCSV(result, delimiter?)` | CSV export with formula-injection guard |
-| `summariseListRows` | Aggregate rows into group summaries |
+| `summariseListRows` | Aggregate rows into group summaries (`ListGroup[]` + whole-result `ListSummary`) |
+| `groupingColumnIds(grouping)` | Resolve a grouping config's ordered group-by column ids |
+| `toScheduleRows(groups, levelCount)` | Project grouped `ListGroup[]` to a schedule/pivot `ListScheduleRow[]` — one row per group-value tuple |
 | `discoverColumns(providers, entityTypes)` | Sample available attributes/properties/quantities |
 | `compileNameMatcher(pattern)` / `isNamePattern(pattern)` | Exact-or-regex name matching |
 | `LIST_PRESETS` | Built-in schedule definitions |

--- a/docs/guide/lists.md
+++ b/docs/guide/lists.md
@@ -123,9 +123,16 @@ for (const group of result.groups ?? []) {
 }
 
 // A Bonsai-style schedule/pivot table — one row per group-value tuple (the
-// LEAF groups only) instead of a nested tree. `levelCount` is the number of
-// active grouping columns.
-const scheduleRows = toScheduleRows(result.groups, definition.grouping.columnIds.length);
+// LEAF groups only) instead of a nested tree. `levelCount` must be the number
+// of grouping columns that were ACTUALLY applied: the engine drops grouping
+// ids whose column is no longer in the definition (a stale persisted grouping
+// is the common case), so passing the raw `columnIds.length` can ask for a
+// deeper leaf level than the groups have — and `toScheduleRows` then matches
+// nothing and returns no rows.
+const activeGroupIds = definition.grouping.columnIds.filter(
+  (id) => definition.columns.some((c) => c.id === id),
+);
+const scheduleRows = toScheduleRows(result.groups, activeGroupIds.length);
 for (const row of scheduleRows) {
   console.log(row.path, row.count, row.sums); // e.g. ["Wall-01"], 1, { ... }
 }

--- a/packages/lists/src/engine.test.ts
+++ b/packages/lists/src/engine.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, it, expect } from 'vitest';
 import { IfcTypeEnum } from '@ifc-lite/data';
-import { executeList, listResultToCSV, summariseListRows, groupPathKey } from './engine.js';
+import { executeList, listResultToCSV, summariseListRows, groupPathKey, toScheduleRows } from './engine.js';
 import { discoverColumns } from './discovery.js';
 import { LIST_PRESETS } from './presets.js';
 import type { ListDataProvider, ListDefinition } from './types.js';
@@ -851,6 +851,84 @@ describe('grouping & summary', () => {
     const result = executeList(def, provider);
     expect(result.groups).toBeUndefined();
     expect(result.summary).toBeUndefined();
+  });
+});
+
+// Schedule/pivot presentation (issue #1790 round 2): one row per group-value
+// tuple (leaf group), Count + sums as first-class fields — the projection
+// that feeds the viewer's Bonsai-style "Building | Storey | Type | Count"
+// table and its CSV export.
+describe('toScheduleRows', () => {
+  it('single-criterion grouping: every group IS a leaf, one schedule row each', () => {
+    const provider = createMockProvider();
+    const def: ListDefinition = {
+      id: 'sched-1',
+      name: 'Test',
+      createdAt: 0,
+      updatedAt: 0,
+      entityTypes: [IfcTypeEnum.IfcWall, IfcTypeEnum.IfcSlab],
+      conditions: [],
+      columns: [
+        { id: 'class', source: 'attribute', propertyName: 'Class' },
+        { id: 'len', source: 'quantity', psetName: 'Qto_WallBaseQuantities', propertyName: 'Length' },
+      ],
+      grouping: { columnId: 'class', sumColumnIds: ['len'] },
+    };
+    const result = executeList(def, provider);
+    const rows = toScheduleRows(result.groups, 1);
+    expect(rows).toEqual([
+      { key: groupPathKey(['IfcWall']), path: ['IfcWall'], count: 2, sums: { len: expect.closeTo(8.5) } },
+      { key: groupPathKey(['IfcSlab']), path: ['IfcSlab'], count: 1, sums: { len: 0 } },
+    ]);
+  });
+
+  it('multi-criteria grouping: only LEAF (deepest-level) tuples become rows, contiguous per parent', () => {
+    const provider = createMockProvider();
+    const def: ListDefinition = {
+      id: 'sched-multi',
+      name: 'Test',
+      createdAt: 0,
+      updatedAt: 0,
+      entityTypes: [IfcTypeEnum.IfcWall, IfcTypeEnum.IfcSlab],
+      conditions: [],
+      columns: [
+        { id: 'class', source: 'attribute', propertyName: 'Class' },
+        { id: 'name', source: 'attribute', propertyName: 'Name' },
+        { id: 'len', source: 'quantity', psetName: 'Qto_WallBaseQuantities', propertyName: 'Length' },
+      ],
+      grouping: { columnId: 'class', columnIds: ['class', 'name'], sumColumnIds: ['len'] },
+    };
+    const result = executeList(def, provider);
+    const rows = toScheduleRows(result.groups, 2);
+
+    // Parent-level ('IfcWall'/'IfcSlab' alone) groups are dropped — only the
+    // 2-level tuples remain, and they stay grouped by their parent (Wall rows
+    // before the Slab row) even though the tree itself is never rendered.
+    expect(rows.map(r => r.path)).toEqual([
+      ['IfcWall', 'Wall-01'],
+      ['IfcWall', 'Wall-02'],
+      ['IfcSlab', 'Slab-01'],
+    ]);
+    expect(rows.every(r => r.count === 1)).toBe(true);
+    expect(rows.find(r => r.path[1] === 'Wall-01')?.sums.len).toBeCloseTo(5.0);
+    // Every row's key matches the collision-free path encoding, and all keys
+    // in the schedule are unique (tuple-key stability).
+    for (const r of rows) expect(r.key).toBe(groupPathKey(r.path));
+    expect(new Set(rows.map(r => r.key)).size).toBe(rows.length);
+  });
+
+  it('returns [] when there is no grouping (levelCount 0) even if groups happen to be present', () => {
+    expect(toScheduleRows([{ key: 'x', label: 'x', count: 1, sums: {}, level: 0, path: ['x'] }], 0)).toEqual([]);
+  });
+
+  it('returns [] for an empty/absent group list', () => {
+    expect(toScheduleRows(undefined, 2)).toEqual([]);
+    expect(toScheduleRows([], 1)).toEqual([]);
+  });
+
+  it('a group with no path falls back to a single-entry path built from its label (defensive for older callers)', () => {
+    const rows = toScheduleRows([{ key: 'k', label: 'Solo', count: 4, sums: {}, level: 0 }], 1);
+    expect(rows).toEqual([{ key: 'k', path: ['Solo'], count: 4, sums: {} }]);
   });
 });
 

--- a/packages/lists/src/engine.ts
+++ b/packages/lists/src/engine.ts
@@ -223,7 +223,12 @@ export function toScheduleRows(groups: ListGroup[] | undefined, levelCount: numb
   if (!groups || levelCount <= 0) return [];
   const leafLevel = levelCount - 1;
   return groups
-    .filter((g) => (g.level ?? 0) === leafLevel)
+    // `level` is optional on ListGroup. Defaulting a missing one to 0 would
+    // put EVERY group at level 0, so a hand-built multi-level set (the public
+    // API allows one — `summariseListRows` always fills `level` in) would
+    // match no leaf at all and pivot to nothing. Fall back to the depth its
+    // own `path` implies before assuming the outermost level.
+    .filter((g) => (g.level ?? (g.path ? g.path.length - 1 : 0)) === leafLevel)
     .map((g) => ({ key: g.key, path: g.path ?? [g.label], count: g.count, sums: g.sums }));
 }
 

--- a/packages/lists/src/engine.ts
+++ b/packages/lists/src/engine.ts
@@ -20,6 +20,7 @@ import type {
   ListGroup,
   ListGrouping,
   ListSummary,
+  ListScheduleRow,
   CellValue,
   PropertyCondition,
   ColumnDefinition,
@@ -202,6 +203,28 @@ export function summariseListRows(
  */
 export function groupPathKey(path: string[]): string {
   return JSON.stringify(path);
+}
+
+/**
+ * Project a flat pre-order `ListGroup[]` (as returned by `summariseListRows`)
+ * down to a `schedule` / pivot presentation (issue #1790 round 2): ONE row
+ * per group-value tuple — the LEAF groups only, in the same order they
+ * appear in `groups`. Because `groups` is a pre-order flattening of the
+ * group tree, every parent's leaf descendants stay contiguous, so the result
+ * is already in the right order for a Bonsai-style schedule table (rows for
+ * one outer group value sit together) without re-sorting here.
+ *
+ * `levelCount` is the number of active grouping columns — typically
+ * `groupingColumnIds(grouping).filter(id => columns still has id).length`.
+ * With 0 levels (nothing to pivot on) or no `groups` at all, this returns
+ * `[]` rather than inventing a single all-rows row.
+ */
+export function toScheduleRows(groups: ListGroup[] | undefined, levelCount: number): ListScheduleRow[] {
+  if (!groups || levelCount <= 0) return [];
+  const leafLevel = levelCount - 1;
+  return groups
+    .filter((g) => (g.level ?? 0) === leafLevel)
+    .map((g) => ({ key: g.key, path: g.path ?? [g.label], count: g.count, sums: g.sums }));
 }
 
 // ============================================================================

--- a/packages/lists/src/index.ts
+++ b/packages/lists/src/index.ts
@@ -16,13 +16,16 @@ export type {
   ListGrouping,
   ListGroup,
   ListSummary,
+  ListScheduleRow,
   DiscoveredColumns,
   EntityAttribute,
 } from './types.js';
 export { ENTITY_ATTRIBUTES } from './types.js';
 
 // Engine
-export { executeList, listResultToCSV, summariseListRows, groupingColumnIds, groupPathKey } from './engine.js';
+export {
+  executeList, listResultToCSV, summariseListRows, groupingColumnIds, groupPathKey, toScheduleRows,
+} from './engine.js';
 
 // Name pattern matching (Bonsai-style `/regex/` set/property names)
 export { compileNameMatcher, isNamePattern } from './name-pattern.js';

--- a/packages/lists/src/types.ts
+++ b/packages/lists/src/types.ts
@@ -181,6 +181,21 @@ export interface ListGrouping {
   columnIds?: string[];
   /** Column ids whose numeric values are summed per group and overall. */
   sumColumnIds: string[];
+  /**
+   * Result presentation for a grouped list (issue #1790 round 2 — the
+   * reporter's follow-up: Count as a first-class column, and a pivot/schedule
+   * layout like Bonsai's, not a nested tree):
+   * - `nested` (default) — the existing collapsible tree: one header per
+   *   (sub)group with a count badge next to the label, per-element rows
+   *   underneath.
+   * - `schedule` — a pivot/schedule table: ONE row per group-value tuple (a
+   *   leaf group combination), the grouping columns repeated as leading
+   *   columns, followed by a first-class `Count` column and any configured
+   *   sums. No per-element detail rows.
+   * Optional so lists persisted before this existed keep their prior (nested)
+   * behaviour — `undefined` is treated as `nested`.
+   */
+  view?: 'nested' | 'schedule';
 }
 
 // ============================================================================
@@ -301,6 +316,25 @@ export interface ListGroup {
 /** Whole-result aggregates. */
 export interface ListSummary {
   count: number;
+  sums: Record<string, number>;
+}
+
+/**
+ * One row of the `schedule` presentation (issue #1790 round 2) — a single
+ * group-value tuple (a leaf group combination) carrying its Count and sums,
+ * projected from the LEAF entries of `ListGroup[]` (see `toScheduleRows`).
+ * Unlike `ListGroup`, a schedule row is never a parent: there is exactly one
+ * row per distinct combination of group-by values, matching Bonsai's
+ * "Building | Storey | Type | Count" schedule format.
+ */
+export interface ListScheduleRow {
+  /** Collision-free key — `groupPathKey(path)`, matching the source `ListGroup.key`. */
+  key: string;
+  /** Group-by values, outermost first — one per active grouping level. */
+  path: string[];
+  /** Count aggregate: number of matched elements in this group combination. */
+  count: number;
+  /** columnId -> summed numeric value, for the configured sum columns. */
   sums: Record<string, number>;
 }
 

--- a/scripts/api-surface.json
+++ b/scripts/api-surface.json
@@ -2032,6 +2032,7 @@
     "ListGrouping: interface",
     "ListResult: interface",
     "ListRow: interface",
+    "ListScheduleRow: interface",
     "ListSummary: interface",
     "PropertyCondition: interface",
     "compileNameMatcher: function",
@@ -2041,7 +2042,8 @@
     "groupingColumnIds: function",
     "isNamePattern: function",
     "listResultToCSV: function",
-    "summariseListRows: function"
+    "summariseListRows: function",
+    "toScheduleRows: function"
   ],
   "@ifc-lite/mcp": [
     "AllowAllAuth: class",


### PR DESCRIPTION
Closes #1790 (round 2 — follow-up from steverugi's comment).

## What

- **Count as a first-class column**: grouped lists now surface each group's element count as a dedicated `Count` column (previously only a badge next to the group label).
- **Schedule / pivot view**: a new presentation mode for grouped lists, Bonsai-style — one row per group-value tuple, grouping criteria as leading columns, then `Count`, then any configured sums. Multi-level grouping (e.g. Building → Storey → Type) supported; repeated parent values are blanked on-screen (visual sugar only). Toggled from the grouping bar; the existing nested tree remains the default.
- **CSV/XLSX/PDF mirror the schedule**: exports render exactly what the schedule view shows — full (repeated) group values, `Count`, sums, and a `TOTAL` row when sums are configured. Matches Bonsai's own schedule CSV arrangement.
- New SDK surface on `@ifc-lite/lists`: `toScheduleRows()` + `ListScheduleRow` (documented in `docs/guide/lists.md` with a typechecked snippet); changeset (minor) + api-surface snapshot included.

## Design notes

- Pure client-side presentation over the existing grouping engine — the server lists path (`values_json` cache) is untouched.
- `ListGrouping.view` is optional; lists persisted before this field exist restore as nested (backward compat verified by browser QA).
- All export cells route through the existing CWE-1236 formula-injection guard.
- In-table grouping/sum toggles now rebuild the grouping via a shared `rebuildGrouping` helper that spreads the previous object, so `view` (and any future field) can't be silently dropped (regression found by adversarial browser QA, fixed with 7 regression tests).

## Verification

- `@ifc-lite/lists` 112 tests, viewer suite 1860/1862 (2 pre-existing fixture skips), full-workspace typecheck, api-surface + test-wiring + doc-samples checks all green.
- Adversarial browser QA (Playwright, real UI): 2-level grouping + sums + CSV `TOTAL` row verified byte-level; '(none)' bucket counts sum exactly to the total element count (no undercount); removing one/all grouping columns while in schedule view; zero-match filters; 10x rapid view toggling; reload persistence for both `view='schedule'` and legacy no-`view` lists — all pass, zero feature-attributable console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GccMEQapsyDW183u17Pq62

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a schedule/pivot view for grouped lists (leaf rows) with Count and configured sum columns, plus a new schedule table UI.
  * Added a toggle to switch between nested and schedule views.
  * Added schedule support for CSV, XLSX, and PDF exports, and exposed schedule rows via the lists API.
* **Bug Fixes**
  * Preserved the selected grouping view when updating grouping and sum settings.
* **Documentation**
  * Updated the lists guide with schedule/pivot usage and examples.
* **Tests**
  * Added coverage for schedule-row generation, CSV formatting, and grouping persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->