### PR TITLE
feat(cli): validate detects dangling #N references (reference-integrity rule)

### DIFF
--- a/.changeset/validate-dangling-refs.md
+++ b/.changeset/validate-dangling-refs.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/cli": patch
+---
+
+`ifc-lite validate` gains a reference-integrity rule: every `#N` attribute reference is checked against the parsed entity index, and each reference to a nonexistent expressId is reported as an error with the referencing entity id, attribute slot, and missing target (additive issue fields; existing issue shape unchanged). The validation rules are also exported as `computeValidationIssues(store)` for programmatic reuse.

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -781,6 +781,7 @@ Checks:
 - Building storeys existence
 - GlobalId uniqueness
 - Named elements
+- Reference integrity (every `#N` attribute reference must point at an entity that exists in the file; each dangling reference is reported with the referencing entity, attribute slot, and missing target)
 
 Returns exit code 0 (valid) or 1 (errors found).
 

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -781,7 +781,7 @@ Checks:
 - Building storeys existence
 - GlobalId uniqueness
 - Named elements
-- Reference integrity (every `#N` attribute reference must point at an entity that exists in the file; each dangling reference is reported with the referencing entity, attribute slot, and missing target)
+- Reference integrity (every `#N` attribute reference must point at an entity that exists in the file; each dangling reference is reported with the referencing entity, attribute slot, and missing target — detailed up to the first 50, after which a single rollup issue reports the count of remaining dangling references)
 
 Returns exit code 0 (valid) or 1 (errors found).
 

--- a/packages/cli/src/commands/validate.test.ts
+++ b/packages/cli/src/commands/validate.test.ts
@@ -1,0 +1,109 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Reference-integrity validation rule: `#N` references that point at an
+ * expressId with no entity in the file must be reported (per referencing
+ * entity, attribute slot, and missing target), while `#N`-looking sequences
+ * inside string literals must not. Proven gap: a text scan caught planted
+ * dangling refs that `ifc-lite validate` missed entirely.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { IfcParser, type IfcDataStore } from '@ifc-lite/parser';
+import { computeValidationIssues, collectDanglingReferences } from './validate.js';
+
+function buildIfc(dataLines: string[]): string {
+  return [
+    'ISO-10303-21;',
+    'HEADER;',
+    "FILE_DESCRIPTION((''),'2;1');",
+    "FILE_NAME('t.ifc','2026-01-01T00:00:00',(''),(''),'','','');",
+    "FILE_SCHEMA(('IFC4'));",
+    'ENDSEC;',
+    'DATA;',
+    ...dataLines,
+    'ENDSEC;',
+    'END-ISO-10303-21;',
+    '',
+  ].join('\n');
+}
+
+async function parse(content: string): Promise<IfcDataStore> {
+  const bytes = new TextEncoder().encode(content);
+  const buffer = bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
+  return new IfcParser().parseColumnar(buffer);
+}
+
+const CLEAN_LINES = [
+  "#1=IFCPROJECT('0Project_GUID_000001',$,'Project',$,$,$,$,$,$);",
+  "#2=IFCSITE('0Site_GUID_00000001',$,'Site',$,$,$,$,$,$,$,$,$,$,$);",
+  "#3=IFCBUILDING('0Bldg_GUID_00000001',$,'Building',$,$,$,$,$,$,$,$,$);",
+  "#4=IFCBUILDINGSTOREY('0Storey_GUID_000001',$,'Storey',$,$,$,$,$,.ELEMENT.,0.);",
+  // Name contains '#123' and an escaped quote before '#77': neither is a reference.
+  "#5=IFCWALL('0Wall_GUID_00000001',$,'It''s wall #123 and #77',$,$,$,$,$,$);",
+  '#6=IFCRELAGGREGATES(\'0RelAgg_GUID_000001\',$,$,$,#1,(#2,#3));',
+];
+
+const DANGLING_LINES = [
+  "#1=IFCPROJECT('0Project_GUID_000001',$,'Project',$,$,$,$,$,$);",
+  "#2=IFCSITE('0Site_GUID_00000001',$,'Site',$,$,$,$,$,$,$,$,$,$,$);",
+  "#3=IFCBUILDING('0Bldg_GUID_00000001',$,'Building',$,$,$,$,$,$,$,$,$);",
+  "#4=IFCBUILDINGSTOREY('0Storey_GUID_000001',$,'Storey',$,$,$,$,$,.ELEMENT.,0.);",
+  // OwnerHistory (attribute slot 1) points at #9999, which does not exist.
+  "#5=IFCWALL('0Wall_GUID_00000001',#9999,'Wall #123',$,$,$,$,$,$);",
+  // RelatedObjects list (attribute slot 5) contains dangling #8888.
+  '#6=IFCRELAGGREGATES(\'0RelAgg_GUID_000001\',$,$,$,#1,(#2,#8888));',
+];
+
+describe('collectDanglingReferences', () => {
+  it('finds each dangling reference with entity id, attribute slot, and missing target', async () => {
+    const store = await parse(buildIfc(DANGLING_LINES));
+    const dangling = collectDanglingReferences(store)
+      .sort((a, b) => a.entityId - b.entityId);
+
+    expect(dangling).toHaveLength(2);
+    expect(dangling[0]).toMatchObject({
+      entityId: 5,
+      entityType: 'IFCWALL',
+      attributeIndex: 1,
+      target: 9999,
+    });
+    expect(dangling[1]).toMatchObject({
+      entityId: 6,
+      entityType: 'IFCRELAGGREGATES',
+      attributeIndex: 5,
+      target: 8888,
+    });
+  });
+
+  it('reports nothing on a clean file (and ignores #N inside string literals)', async () => {
+    const store = await parse(buildIfc(CLEAN_LINES));
+    expect(collectDanglingReferences(store)).toHaveLength(0);
+  });
+});
+
+describe('computeValidationIssues reference-integrity rule', () => {
+  it('emits one error per dangling reference and flips the file invalid', async () => {
+    const store = await parse(buildIfc(DANGLING_LINES));
+    const issues = computeValidationIssues(store);
+    const refIssues = issues.filter(i => i.rule === 'reference-integrity');
+
+    expect(refIssues).toHaveLength(2);
+    for (const issue of refIssues) {
+      expect(issue.severity).toBe('error');
+      expect(issue.message).toContain('references missing entity');
+    }
+    const targets = refIssues.map(i => i.target).sort();
+    expect(targets).toEqual([8888, 9999]);
+    // Errors present means the validate command reports the file as invalid.
+    expect(issues.some(i => i.severity === 'error')).toBe(true);
+  });
+
+  it('stays quiet on the clean twin', async () => {
+    const store = await parse(buildIfc(CLEAN_LINES));
+    const issues = computeValidationIssues(store);
+    expect(issues.filter(i => i.rule === 'reference-integrity')).toHaveLength(0);
+  });
+});

--- a/packages/cli/src/commands/validate.test.ts
+++ b/packages/cli/src/commands/validate.test.ts
@@ -8,6 +8,9 @@
  * entity, attribute slot, and missing target), while `#N`-looking sequences
  * inside string literals must not. Proven gap: a text scan caught planted
  * dangling refs that `ifc-lite validate` missed entirely.
+ *
+ * Regression suite for PR #1868 (world-gym benchmark surfaced the gap: the
+ * kernel-oracle baseline scored F1=0 on 94 planted dangling refs).
  */
 
 import { describe, it, expect } from 'vitest';
@@ -95,6 +98,9 @@ describe('computeValidationIssues reference-integrity rule', () => {
       expect(issue.severity).toBe('error');
       expect(issue.message).toContain('references missing entity');
     }
+    // Display names render in IFC PascalCase, not the raw STEP token.
+    expect(refIssues.map(i => i.message).join('\n')).toContain('IfcWall');
+    expect(refIssues.map(i => i.message).join('\n')).not.toContain('IFCWALL');
     const targets = refIssues.map(i => i.target).sort();
     expect(targets).toEqual([8888, 9999]);
     // Errors present means the validate command reports the file as invalid.

--- a/packages/cli/src/commands/validate.ts
+++ b/packages/cli/src/commands/validate.ts
@@ -265,10 +265,13 @@ export function computeValidationIssues(store: IfcDataStore): ValidationIssue[] 
   // it reports as an error like unique-globalid does.
   const dangling = collectDanglingReferences(store);
   for (const d of dangling.slice(0, DANGLING_REF_ISSUE_CAP)) {
+    // Display names render in IFC PascalCase (IfcWall, not IFCWALL); the
+    // collector carries the raw STEP token, so resolve through the table.
+    const typeName = store.entities.getTypeName(d.entityId) || d.entityType;
     issues.push({
       severity: 'error',
       rule: 'reference-integrity',
-      message: `#${d.entityId} ${d.entityType} attribute ${d.attributeIndex} references missing entity #${d.target}`,
+      message: `#${d.entityId} ${typeName} attribute ${d.attributeIndex} references missing entity #${d.target}`,
       entityId: d.entityId,
       attributeIndex: d.attributeIndex,
       target: d.target,

--- a/packages/cli/src/commands/validate.ts
+++ b/packages/cli/src/commands/validate.ts
@@ -11,26 +11,159 @@
  * - Spatial structure completeness
  * - Orphan entity detection
  * - GlobalId uniqueness
+ * - Reference integrity (#N references that point at no entity)
  */
 
 import { loadIfcFile } from '../loader.js';
 import { hasFlag, fatal, printJson } from '../output.js';
 import { EntityNode } from '@ifc-lite/query';
-import { getInheritanceChainForEntity } from '@ifc-lite/parser';
+import { getInheritanceChainForEntity, type IfcDataStore, type EntityRef } from '@ifc-lite/parser';
 
-interface ValidationIssue {
+export interface ValidationIssue {
   severity: 'error' | 'warning' | 'info';
   rule: string;
   message: string;
+  /** Referencing entity's expressId (set by per-reference rules like reference-integrity). */
+  entityId?: number;
+  /** Zero-based top-level attribute slot of the offending value within the referencing entity. */
+  attributeIndex?: number;
+  /** The referenced expressId that does not exist in the file. */
+  target?: number;
 }
 
-export async function validateCommand(args: string[]): Promise<void> {
-  const filePath = args.find(a => !a.startsWith('-'));
-  if (!filePath) fatal('Usage: ifc-lite validate <file.ifc> [--json]');
+/** One `#N` reference whose target expressId does not exist in the file. */
+interface DanglingReference {
+  /** expressId of the entity containing the reference. */
+  entityId: number;
+  /** STEP type name of the referencing entity (UPPERCASE, as scanned). */
+  entityType: string;
+  /** Zero-based top-level attribute slot the reference sits in (nested refs report their containing slot). */
+  attributeIndex: number;
+  /** The missing expressId being referenced. */
+  target: number;
+}
 
-  const jsonOutput = hasFlag(args, '--json');
+/** Cap on individually-reported dangling references; the remainder is rolled into one summary issue. */
+const DANGLING_REF_ISSUE_CAP = 50;
 
-  const store = await loadIfcFile(filePath);
+const CH_QUOTE = 0x27; // '
+const CH_LPAREN = 0x28; // (
+const CH_RPAREN = 0x29; // )
+const CH_COMMA = 0x2c; // ,
+const CH_HASH = 0x23; // #
+const CH_SLASH = 0x2f; // /
+const CH_STAR = 0x2a; // *
+
+/**
+ * Scan one entity record's source bytes for `#N` attribute references and
+ * report the ones whose target expressId is not indexed. Operates directly on
+ * the raw bytes the parser already indexed (`store.entityIndex.byId` spans),
+ * so it is a single pass over each record with no string allocation. Quote
+ * tracking (including STEP's doubled-quote escape) keeps `#N` sequences inside
+ * string literals from being read as references; embedded STEP comments are
+ * skipped.
+ */
+function scanEntityForDanglingRefs(
+  source: Uint8Array,
+  ref: EntityRef,
+  exists: (id: number) => boolean,
+  out: DanglingReference[],
+): void {
+  const end = ref.byteOffset + ref.byteLength;
+  // References only occur inside the attribute list; skip the "#id = TYPE" prefix.
+  let i = ref.byteOffset;
+  while (i < end && source[i] !== CH_LPAREN) i++;
+  if (i >= end) return; // malformed record, nothing to scan
+
+  let depth = 1; // we are inside the outermost '(' now
+  let attrIndex = 0;
+  i++;
+
+  while (i < end) {
+    const c = source[i];
+    if (c === CH_QUOTE) {
+      // String literal: skip to the closing quote, honouring '' escapes.
+      i++;
+      while (i < end) {
+        if (source[i] === CH_QUOTE) {
+          if (i + 1 < end && source[i + 1] === CH_QUOTE) {
+            i += 2; // escaped quote, still inside the string
+            continue;
+          }
+          break; // closing quote
+        }
+        i++;
+      }
+    } else if (c === CH_SLASH && i + 1 < end && source[i + 1] === CH_STAR) {
+      // STEP comment inside a record (rare but legal): skip to closing marker.
+      i += 2;
+      while (i + 1 < end && !(source[i] === CH_STAR && source[i + 1] === CH_SLASH)) i++;
+      i++; // lands on '/', loop increment moves past it
+    } else if (c === CH_LPAREN) {
+      depth++;
+    } else if (c === CH_RPAREN) {
+      depth--;
+      if (depth === 0) return; // end of attribute list
+    } else if (c === CH_COMMA && depth === 1) {
+      attrIndex++;
+    } else if (c === CH_HASH) {
+      let id = 0;
+      let digits = 0;
+      let j = i + 1;
+      while (j < end) {
+        const d = source[j] - 0x30;
+        if (d < 0 || d > 9) break;
+        id = id * 10 + d;
+        digits++;
+        j++;
+      }
+      if (digits > 0) {
+        if (!exists(id)) {
+          out.push({ entityId: ref.expressId, entityType: ref.type, attributeIndex: attrIndex, target: id });
+        }
+        i = j - 1; // loop increment moves past the last digit
+      }
+    }
+    i++;
+  }
+}
+
+/**
+ * Walk every indexed entity record and collect `#N` references whose target
+ * does not exist in the file (rule `reference-integrity`). Uses the parsed
+ * entity index for both iteration and existence checks; entities held in the
+ * deferred index (lazily-parsed property entities) count as existing and are
+ * scanned too.
+ */
+export function collectDanglingReferences(store: IfcDataStore): DanglingReference[] {
+  const source = store.source;
+  const byId = store.entityIndex.byId;
+  const deferred = store.deferredEntityIndex;
+  if (!source || source.byteLength === 0 || !byId) return [];
+
+  const exists = (id: number): boolean => byId.has(id) || deferred?.has(id) === true;
+
+  const out: DanglingReference[] = [];
+  for (const ref of byId.values()) {
+    scanEntityForDanglingRefs(source, ref, exists, out);
+  }
+  if (deferred) {
+    for (const ref of deferred.values()) {
+      if (byId.has(ref.expressId)) continue; // already scanned above
+      scanEntityForDanglingRefs(source, ref, exists, out);
+    }
+  }
+  return out;
+}
+
+/**
+ * Run the structural validation checks (required entities, storeys, GlobalId
+ * uniqueness, naming, schema version, quantity completeness, reference
+ * integrity) against an already-parsed store. Pulled out of
+ * {@link validateCommand} so other consumers (tests, harnesses) reuse the
+ * exact same rules instead of re-implementing them.
+ */
+export function computeValidationIssues(store: IfcDataStore): ValidationIssue[] {
   const issues: ValidationIssue[] = [];
 
   // 1. Check required spatial entities
@@ -125,6 +258,41 @@ export async function validateCommand(args: string[]): Promise<void> {
       message: `${withoutQuantities}/${totalQuantifiable} building elements (${pct}%) have no quantity sets — quantity-based analysis may be incomplete`,
     });
   }
+
+  // 7. Reference integrity: every #N attribute reference must resolve to an
+  // entity that exists in the file. A dangling reference is structurally
+  // broken data (consumers following it get nothing, or worse, garbage), so
+  // it reports as an error like unique-globalid does.
+  const dangling = collectDanglingReferences(store);
+  for (const d of dangling.slice(0, DANGLING_REF_ISSUE_CAP)) {
+    issues.push({
+      severity: 'error',
+      rule: 'reference-integrity',
+      message: `#${d.entityId} ${d.entityType} attribute ${d.attributeIndex} references missing entity #${d.target}`,
+      entityId: d.entityId,
+      attributeIndex: d.attributeIndex,
+      target: d.target,
+    });
+  }
+  if (dangling.length > DANGLING_REF_ISSUE_CAP) {
+    issues.push({
+      severity: 'error',
+      rule: 'reference-integrity',
+      message: `${dangling.length - DANGLING_REF_ISSUE_CAP} more dangling reference(s) not listed (${dangling.length} total)`,
+    });
+  }
+
+  return issues;
+}
+
+export async function validateCommand(args: string[]): Promise<void> {
+  const filePath = args.find(a => !a.startsWith('-'));
+  if (!filePath) fatal('Usage: ifc-lite validate <file.ifc> [--json]');
+
+  const jsonOutput = hasFlag(args, '--json');
+
+  const store = await loadIfcFile(filePath);
+  const issues = computeValidationIssues(store);
 
   const summary = {
     file: filePath,


### PR DESCRIPTION
## Problem

`ifc-lite validate` cannot detect a STEP reference `#N` pointing at an entity id that does not exist in the file. The world-gym benchmark (moonshot branch `worktree-moonshot-tech-2026-07-24`, `tools/world-gym/README.md` gap list) proved this the hard way: the kernel-oracle baseline scored **F1 = 0 on 94 planted dangling-ref defects** while a dumb text scan caught them all.

## Change

- New validation rule `reference-integrity` (rule 7): walks every indexed entity record's source bytes via the parsed entity index (`entityIndex.byId` spans plus the deferred index), single pass per record, quote-aware (STEP doubled-quote escapes included) and embedded-comment-aware, so `#N` sequences inside string literals are never misread as references. No text rescan, no re-tokenization: iteration and existence checks both go through the existing parsed index.
- Each dangling reference reports as an **error** (matching `unique-globalid` severity: structurally broken data) carrying the referencing entity id, zero-based attribute slot, and missing target id, both in the message and as **additive optional fields** (`entityId`, `attributeIndex`, `target`) on `ValidationIssue` - the existing issue/summary JSON shape is unchanged, so downstream consumers keep working.
- Detail issues capped at 50 per file with one rollup issue for the remainder.
- The rule set is extracted into an exported `computeValidationIssues(store)` so tests and harnesses (e.g. the world-gym in-process schema channel) run the exact same rules without spawning the CLI. `@ifc-lite/cli`'s package-entry API surface is unchanged (it exports nothing; `scripts/api-surface.json` stays `[]`).
- Docs: `docs/guide/cli.md` validate checks list updated. Changeset: patch (additive).

## Tests

- `packages/cli/src/commands/validate.test.ts` (new, synthetic in-memory models, no fixture dependency):
  - dangling ref in a direct attribute slot (`IFCWALL` OwnerHistory `#9999`) and inside a list (`IFCRELAGGREGATES` RelatedObjects `#8888`) are each reported with the right entity id, attribute slot, and target;
  - clean twin stays clean, including names containing `#123` / escaped-quote strings with `#77` (negative controls for the quote tracking);
  - `computeValidationIssues` emits one error per dangling ref and flips the file invalid.
- `pnpm vitest run` in `packages/cli`: **12 files, 186 tests passed**.
- `pnpm exec tsc --noEmit` in `packages/cli`: clean.

## Adversarial verification (real models)

- No false positives on AC20-FZK-Haus, AC-20-Smiley-West, duplex, FM_ARC_DigitalHub, and the 169 MB / 2.8M-entity Holter tower (`ISSUE_053`), which validates in 3.4 s total including parse.
- Deleting one entity (`#136`) from a FZK-Haus copy is detected: `[ERR] reference-integrity: #137 IFCFACE attribute 0 references missing entity #136`, exit code 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)