### PR TITLE
feat(viewer,lists): location zones — classify elements by user-defined 3D zone boxes (#1810)

### DIFF
--- a/.changeset/zone-column-source-1810.md
+++ b/.changeset/zone-column-source-1810.md
@@ -1,0 +1,15 @@
+---
+'@ifc-lite/lists': minor
+---
+
+Add a `zone` column/condition source (issue #1810): location-zone
+classification (which user-defined 3D zone box an element falls into, plus a
+"straddles" flag when its bounds cross a zone boundary) can now be surfaced as
+a list column, grouped/sorted/exported, and used as a filter condition.
+
+`ColumnDefinition.source` / `PropertyCondition.source` gain a `'zone'` variant
+(`psetName` holds the zone-SET id, `propertyName` selects `Zone` (default) or
+`Straddles`). `ListDataProvider` gains two new OPTIONAL accessors,
+`getZoneAssignment` and `getZoneSetNames` — providers built before this change
+simply resolve every `zone` column to `null`, so this is purely additive and
+backward compatible.

--- a/apps/viewer/src/components/viewer/PropertiesPanel.tsx
+++ b/apps/viewer/src/components/viewer/PropertiesPanel.tsx
@@ -19,6 +19,7 @@ import {
   ArrowUpDown,
   PenLine,
   Crosshair,
+  Box,
 } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { EditToolbar } from './PropertyEditor';
@@ -150,6 +151,8 @@ export function PropertiesPanel() {
   const selectedEntityId = useViewerStore((s) => s.selectedEntityId);
   const selectedEntity = useViewerStore((s) => s.selectedEntity);
   const selectedEntities = useViewerStore((s) => s.selectedEntities);
+  const zoneSets = useViewerStore((s) => s.zoneSets);
+  const zoneAssignments = useViewerStore((s) => s.zoneAssignments);
   const selectedModelId = useViewerStore((s) => s.selectedModelId);
   const cameraCallbacks = useViewerStore((s) => s.cameraCallbacks);
   const toggleEntityVisibility = useViewerStore((s) => s.toggleEntityVisibility);
@@ -971,6 +974,31 @@ export function PropertiesPanel() {
     return stats.length > 0 ? stats : null;
   }, [selectedEntity, model, ifcDataStore]);
 
+  // Location-zone membership (issue #1810): which zone this element falls in
+  // per defined zone set, read straight from the last-computed assignment
+  // (`zoneAssignments`, keyed by the SAME global id the renderer highlight
+  // uses — `selectedEntityId`). Shown for ANY selected element (not gated to
+  // spatial containers like `spatialContainment` above), since zones classify
+  // ordinary building elements.
+  const zoneMembership = useMemo(() => {
+    if (selectedEntityId === null || zoneSets.length === 0) return null;
+    const record = zoneAssignments.get(selectedEntityId);
+    const rows: Array<{ label: string; value: string }> = [];
+    for (const zs of zoneSets) {
+      const assignment = record?.[zs.id];
+      if (!assignment) continue;
+      if (assignment.straddles) {
+        const touched = assignment.touchedZoneIds
+          .map((zoneId) => zs.zones.find((z) => z.id === zoneId)?.name)
+          .filter((n): n is string => !!n);
+        rows.push({ label: zs.name, value: touched.length > 0 ? `${touched.join(', ')} (straddles)` : 'straddles' });
+      } else if (assignment.zoneName) {
+        rows.push({ label: zs.name, value: assignment.zoneName });
+      }
+    }
+    return rows.length > 0 ? rows : null;
+  }, [selectedEntityId, zoneSets, zoneAssignments]);
+
   // Separate occurrence (instance) and inherited type properties.
   // Occurrence properties are displayed first, type properties in a separate section.
   // All type property sets are always shown in the inherited section so users can see
@@ -1485,6 +1513,29 @@ export function PropertiesPanel() {
                 <div key={item.label} className="grid grid-cols-[minmax(80px,1fr)_minmax(0,2fr)] gap-2 px-3 py-1.5 text-sm">
                   <span className="text-muted-foreground truncate" title={item.label}>{item.label}</span>
                   <span className="font-medium font-mono">{item.value}</span>
+                </div>
+              ))}
+            </div>
+          </CollapsibleContent>
+        </Collapsible>
+      )}
+
+      {/* Location zones (issue #1810) — which user-defined zone box(es) this
+          element falls in, per zone set. Read-only: editing zones happens in
+          the Zones panel, not here. */}
+      {zoneMembership && (
+        <Collapsible defaultOpen className="border-b">
+          <CollapsibleTrigger className="flex items-center gap-2 w-full p-3 hover:bg-muted/50 text-left">
+            <Box className="h-4 w-4 text-amber-600" />
+            <span className="font-medium text-sm">Zones</span>
+            <span className="text-xs text-muted-foreground ml-auto">{zoneMembership.length}</span>
+          </CollapsibleTrigger>
+          <CollapsibleContent>
+            <div className="divide-y border-t">
+              {zoneMembership.map((item) => (
+                <div key={item.label} className="grid grid-cols-[minmax(80px,1fr)_minmax(0,2fr)] gap-2 px-3 py-1.5 text-sm">
+                  <span className="text-muted-foreground truncate" title={item.label}>{item.label}</span>
+                  <span className="font-medium font-mono truncate" title={item.value}>{item.value}</span>
                 </div>
               ))}
             </div>

--- a/apps/viewer/src/components/viewer/PropertiesPanel.tsx
+++ b/apps/viewer/src/components/viewer/PropertiesPanel.tsx
@@ -983,7 +983,11 @@ export function PropertiesPanel() {
   const zoneMembership = useMemo(() => {
     if (selectedEntityId === null || zoneSets.length === 0) return null;
     const record = zoneAssignments.get(selectedEntityId);
-    const rows: Array<{ label: string; value: string }> = [];
+    // `setId` (durable, unique) keys the rendered rows — `label` is the set's
+    // display NAME, which is "unique-by-convention but not enforced" (see
+    // `ZoneSet.name`), so two same-named sets would collide as React keys
+    // (CodeRabbit review of PR #1869).
+    const rows: Array<{ setId: string; label: string; value: string }> = [];
     for (const zs of zoneSets) {
       const assignment = record?.[zs.id];
       if (!assignment) continue;
@@ -991,9 +995,9 @@ export function PropertiesPanel() {
         const touched = assignment.touchedZoneIds
           .map((zoneId) => zs.zones.find((z) => z.id === zoneId)?.name)
           .filter((n): n is string => !!n);
-        rows.push({ label: zs.name, value: touched.length > 0 ? `${touched.join(', ')} (straddles)` : 'straddles' });
+        rows.push({ setId: zs.id, label: zs.name, value: touched.length > 0 ? `${touched.join(', ')} (straddles)` : 'straddles' });
       } else if (assignment.zoneName) {
-        rows.push({ label: zs.name, value: assignment.zoneName });
+        rows.push({ setId: zs.id, label: zs.name, value: assignment.zoneName });
       }
     }
     return rows.length > 0 ? rows : null;
@@ -1533,7 +1537,7 @@ export function PropertiesPanel() {
           <CollapsibleContent>
             <div className="divide-y border-t">
               {zoneMembership.map((item) => (
-                <div key={item.label} className="grid grid-cols-[minmax(80px,1fr)_minmax(0,2fr)] gap-2 px-3 py-1.5 text-sm">
+                <div key={item.setId} className="grid grid-cols-[minmax(80px,1fr)_minmax(0,2fr)] gap-2 px-3 py-1.5 text-sm">
                   <span className="text-muted-foreground truncate" title={item.label}>{item.label}</span>
                   <span className="font-medium font-mono truncate" title={item.value}>{item.value}</span>
                 </div>

--- a/apps/viewer/src/components/viewer/ViewportContainer.tsx
+++ b/apps/viewer/src/components/viewer/ViewportContainer.tsx
@@ -17,6 +17,7 @@ import { MergeLayersBanner } from './MergeLayersBanner';
 import { GeometryModeBanner } from './GeometryModeBanner';
 import { LevelDisplayIndicator } from './LevelDisplayIndicator';
 import { ToolOverlays } from './ToolOverlays';
+import { ZoneOverlay, ZoneAssignmentSyncMount } from './tools/ZoneOverlay';
 import { AnnotationLayer } from './annotations/AnnotationLayer';
 import { CollabPresenceLayer } from './CollabPresenceLayer';
 import { Section2DPanel } from './Section2DPanel';
@@ -1406,6 +1407,8 @@ export function ViewportContainer() {
       <GeometryModeBanner onReload={handleGeometryModeReload} />
       <LevelDisplayIndicator />
       <ToolOverlays />
+      <ZoneOverlay />
+      <ZoneAssignmentSyncMount />
       <BasketPresentationDock />
       <Section2DPanel
         mergedGeometry={mergedGeometryResult}

--- a/apps/viewer/src/components/viewer/ZonesPanel.tsx
+++ b/apps/viewer/src/components/viewer/ZonesPanel.tsx
@@ -1,0 +1,354 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * ZonesPanel — author + manage location zones (issue #1810 v1).
+ *
+ * Zone sets are independent named collections of oriented boxes ("Sections",
+ * "Takt areas", ...). Per zone set: toggle 3D visibility, add/remove zones,
+ * edit a zone numerically or via the 3D gizmo (`ZoneOverlay`, entered via
+ * "Edit in 3D"), generate a whole set from the loaded model's storeys, jump
+ * the 3D selection to everything in a zone, and export/import the set as a
+ * small JSON file (the only persistence beyond the localStorage auto-save
+ * `zonesSlice` already does).
+ */
+
+import { useCallback, useRef, useState } from 'react';
+import {
+  Box,
+  Plus,
+  Trash2,
+  Eye,
+  EyeOff,
+  Layers3,
+  Download,
+  Upload,
+  MousePointerClick,
+  Pencil,
+  X,
+} from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
+import { useViewerStore } from '@/store';
+import { downloadFile, sanitizeFilename } from '@/lib/export/download';
+import { toast } from '@/components/ui/toast';
+import { generateZonesFromStoreys } from '@/hooks/useZoneStoreyGeneration';
+import { selectElementsInZone } from '@/hooks/useZoneSelection';
+import type { Zone } from '@/lib/zones';
+
+interface ZonesPanelProps {
+  onClose?: () => void;
+}
+
+const DEG = 180 / Math.PI;
+
+function toDeg(rad: number): number {
+  return Math.round((rad * DEG) % 360 * 10) / 10;
+}
+
+function fromDeg(deg: number): number {
+  return (Number(deg) || 0) / DEG;
+}
+
+/** Numeric input that commits on blur/Enter rather than every keystroke, so
+ *  typing "-1.5" doesn't briefly parse "-1" mid-edit and fight the drag
+ *  handles for the same field. Resyncs its draft from `value` whenever the
+ *  field ISN'T focused, so a live 3D-gizmo drag (which updates `value` every
+ *  frame) is visible in the panel instead of only after a refocus. */
+function NumberField({
+  value, onCommit, className, title,
+}: { value: number; onCommit: (v: number) => void; className?: string; title?: string }) {
+  const round = (v: number) => String(Math.round(v * 1000) / 1000);
+  const [draft, setDraft] = useState(round(value));
+  const inputRef = useRef<HTMLInputElement>(null);
+  const lastValueRef = useRef(value);
+  if (value !== lastValueRef.current) {
+    lastValueRef.current = value;
+    if (typeof document === 'undefined' || document.activeElement !== inputRef.current) {
+      // Safe to update synchronously during render: this only fires when an
+      // EXTERNAL value change (gizmo drag / another user in future collab)
+      // arrives while unfocused, not in response to this component's own state.
+      if (draft !== round(value)) setDraft(round(value));
+    }
+  }
+  return (
+    <Input
+      ref={inputRef}
+      value={draft}
+      title={title}
+      onChange={(e) => setDraft(e.target.value)}
+      onFocus={() => setDraft(round(value))}
+      onBlur={() => {
+        const n = Number(draft);
+        if (Number.isFinite(n)) onCommit(n);
+        else setDraft(round(value));
+      }}
+      onKeyDown={(e) => { if (e.key === 'Enter') (e.target as HTMLInputElement).blur(); }}
+      className={className ?? 'h-6 w-16 px-1 text-[11px]'}
+    />
+  );
+}
+
+function ZoneRow({
+  setId, zone, editing, onEdit, onUpdate, onRemove, onSelect,
+}: {
+  setId: string;
+  zone: Zone;
+  editing: boolean;
+  onEdit: () => void;
+  onUpdate: (patch: Partial<Omit<Zone, 'id'>>) => void;
+  onRemove: () => void;
+  onSelect: () => void;
+}) {
+  return (
+    <div className={`rounded-md border p-2 text-xs space-y-1.5 ${editing ? 'border-amber-500 bg-amber-500/5' : 'border-border/60'}`}>
+      <div className="flex items-center gap-1.5">
+        <Input
+          value={zone.name}
+          onChange={(e) => onUpdate({ name: e.target.value })}
+          className="h-6 flex-1 px-1.5 text-xs font-medium"
+        />
+        <Button
+          variant={editing ? 'default' : 'ghost'}
+          size="icon"
+          className="h-6 w-6"
+          title={editing ? 'Stop editing in 3D' : 'Edit in 3D (move / resize / rotate handles)'}
+          onClick={onEdit}
+        >
+          <Pencil className="h-3 w-3" />
+        </Button>
+        <Button variant="ghost" size="icon" className="h-6 w-6" title="Select elements in this zone" onClick={onSelect}>
+          <MousePointerClick className="h-3 w-3" />
+        </Button>
+        <Button variant="ghost" size="icon" className="h-6 w-6 text-destructive" title="Delete zone" onClick={onRemove}>
+          <Trash2 className="h-3 w-3" />
+        </Button>
+      </div>
+      <div className="grid grid-cols-3 gap-1">
+        {(['Center X', 'Center Y', 'Center Z'] as const).map((label, i) => (
+          <label key={label} className="flex flex-col gap-0.5">
+            <span className="text-muted-foreground">{label}</span>
+            <NumberField
+              value={zone.center[i]}
+              onCommit={(v) => {
+                const center: [number, number, number] = [...zone.center];
+                center[i] = v;
+                onUpdate({ center });
+              }}
+            />
+          </label>
+        ))}
+        {(['Width (X)', 'Height (Y)', 'Depth (Z)'] as const).map((label, i) => (
+          <label key={label} className="flex flex-col gap-0.5">
+            <span className="text-muted-foreground">{label}</span>
+            <NumberField
+              value={zone.size[i]}
+              onCommit={(v) => {
+                const size: [number, number, number] = [...zone.size];
+                size[i] = Math.max(0.05, v);
+                onUpdate({ size });
+              }}
+            />
+          </label>
+        ))}
+        <label className="flex flex-col gap-0.5">
+          <span className="text-muted-foreground">Rotation (°)</span>
+          <NumberField value={toDeg(zone.rotationY)} onCommit={(v) => onUpdate({ rotationY: fromDeg(v) })} />
+        </label>
+      </div>
+    </div>
+  );
+}
+
+export function ZonesPanel({ onClose }: ZonesPanelProps) {
+  const zoneSets = useViewerStore((s) => s.zoneSets);
+  const editingZone = useViewerStore((s) => s.editingZone);
+  const zoneAssignmentTiming = useViewerStore((s) => s.zoneAssignmentTiming);
+  const createZoneSet = useViewerStore((s) => s.createZoneSet);
+  const removeZoneSet = useViewerStore((s) => s.removeZoneSet);
+  const renameZoneSet = useViewerStore((s) => s.renameZoneSet);
+  const setZoneSetVisible = useViewerStore((s) => s.setZoneSetVisible);
+  const addZone = useViewerStore((s) => s.addZone);
+  const updateZone = useViewerStore((s) => s.updateZone);
+  const removeZone = useViewerStore((s) => s.removeZone);
+  const setEditingZone = useViewerStore((s) => s.setEditingZone);
+  const replaceZonesInSet = useViewerStore((s) => s.replaceZonesInSet);
+  const exportZoneSetsJSON = useViewerStore((s) => s.exportZoneSetsJSON);
+  const importZoneSetsJSON = useViewerStore((s) => s.importZoneSetsJSON);
+
+  const [newSetName, setNewSetName] = useState('');
+  const importInputRef = useRef<HTMLInputElement>(null);
+
+  const handleAddSet = useCallback(() => {
+    const name = newSetName.trim() || 'Untitled set';
+    createZoneSet(name);
+    setNewSetName('');
+  }, [newSetName, createZoneSet]);
+
+  const handleGenerateFromStoreys = useCallback(() => {
+    const result = generateZonesFromStoreys();
+    if (!result.ok) {
+      toast.error(`Could not generate zones from storeys: ${result.error}`);
+      return;
+    }
+    const id = createZoneSet('Storeys');
+    replaceZonesInSet(id, result.zones);
+    toast.success(`Generated ${result.zones.length} zone(s) from storeys`);
+  }, [createZoneSet, replaceZonesInSet]);
+
+  const handleExport = useCallback(() => {
+    const json = exportZoneSetsJSON();
+    downloadFile(json, `${sanitizeFilename('zone-sets')}.json`, 'application/json');
+  }, [exportZoneSetsJSON]);
+
+  const handleImportFile = useCallback(async (file: File | null | undefined) => {
+    if (!file) return;
+    try {
+      const text = await file.text();
+      const result = importZoneSetsJSON(text);
+      if (!result.ok) {
+        toast.error(`Import failed: ${result.error}`);
+      } else {
+        toast.success('Zone sets imported');
+      }
+    } catch (error) {
+      toast.error(`Import failed: ${error instanceof Error ? error.message : String(error)}`);
+    } finally {
+      if (importInputRef.current) importInputRef.current.value = '';
+    }
+  }, [importZoneSetsJSON]);
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex items-center gap-2 border-b p-3">
+        <Box className="h-4 w-4 text-amber-600" />
+        <span className="font-medium text-sm flex-1">Location zones</span>
+        {onClose && (
+          <Button variant="ghost" size="icon" className="h-6 w-6" onClick={onClose}>
+            <X className="h-3.5 w-3.5" />
+          </Button>
+        )}
+      </div>
+
+      <div className="flex items-center gap-1.5 border-b p-2">
+        <Input
+          value={newSetName}
+          onChange={(e) => setNewSetName(e.target.value)}
+          placeholder="New zone set name…"
+          className="h-7 flex-1 text-xs"
+          onKeyDown={(e) => { if (e.key === 'Enter') handleAddSet(); }}
+        />
+        <Button size="sm" className="h-7" onClick={handleAddSet}>
+          <Plus className="h-3.5 w-3.5" /> Set
+        </Button>
+      </div>
+
+      <div className="flex items-center gap-1.5 border-b p-2">
+        <Button variant="outline" size="sm" className="h-7 flex-1" onClick={handleGenerateFromStoreys}>
+          <Layers3 className="h-3.5 w-3.5" /> Generate from storeys
+        </Button>
+        <Button variant="ghost" size="icon" className="h-7 w-7" title="Export zone sets as JSON" onClick={handleExport}>
+          <Download className="h-3.5 w-3.5" />
+        </Button>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-7 w-7"
+          title="Import zone sets from JSON"
+          onClick={() => importInputRef.current?.click()}
+        >
+          <Upload className="h-3.5 w-3.5" />
+        </Button>
+        <input
+          ref={importInputRef}
+          type="file"
+          accept=".json,application/json"
+          className="hidden"
+          onChange={(e) => { void handleImportFile(e.target.files?.[0]); }}
+        />
+      </div>
+
+      <div className="flex-1 overflow-y-auto p-2 space-y-2">
+        {zoneSets.length === 0 && (
+          <p className="p-3 text-xs text-muted-foreground">
+            No zone sets yet. Create one above, or generate one from the model&apos;s storeys.
+          </p>
+        )}
+        {zoneSets.map((zs) => (
+          <Collapsible key={zs.id} defaultOpen className="rounded-md border">
+            <div className="flex items-center gap-1 p-1.5">
+              <CollapsibleTrigger className="flex-1 flex items-center gap-1.5 px-1 py-0.5 text-left">
+                <span className="font-medium text-xs">{zs.name}</span>
+                <span className="text-[10px] text-muted-foreground">{zs.zones.length} zone{zs.zones.length === 1 ? '' : 's'}</span>
+              </CollapsibleTrigger>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-6 w-6"
+                title={zs.visible ? 'Hide in 3D view' : 'Show in 3D view'}
+                onClick={() => setZoneSetVisible(zs.id, !zs.visible)}
+              >
+                {zs.visible ? <Eye className="h-3.5 w-3.5" /> : <EyeOff className="h-3.5 w-3.5" />}
+              </Button>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-6 w-6"
+                title="Add zone"
+                onClick={() => addZone(zs.id, { name: `Zone ${zs.zones.length + 1}` })}
+              >
+                <Plus className="h-3.5 w-3.5" />
+              </Button>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-6 w-6 text-destructive"
+                title="Delete zone set"
+                onClick={() => removeZoneSet(zs.id)}
+              >
+                <Trash2 className="h-3.5 w-3.5" />
+              </Button>
+            </div>
+            <CollapsibleContent className="space-y-1.5 border-t p-1.5">
+              <Input
+                value={zs.name}
+                onChange={(e) => renameZoneSet(zs.id, e.target.value)}
+                className="h-6 text-[11px] text-muted-foreground"
+                placeholder="Set name"
+              />
+              {zs.zones.map((zone) => (
+                <ZoneRow
+                  key={zone.id}
+                  setId={zs.id}
+                  zone={zone}
+                  editing={editingZone?.setId === zs.id && editingZone.zoneId === zone.id}
+                  onEdit={() => setEditingZone(
+                    editingZone?.setId === zs.id && editingZone.zoneId === zone.id
+                      ? null
+                      : { setId: zs.id, zoneId: zone.id },
+                  )}
+                  onUpdate={(patch) => updateZone(zs.id, zone.id, patch)}
+                  onRemove={() => removeZone(zs.id, zone.id)}
+                  onSelect={() => {
+                    const count = selectElementsInZone(zs.id, zone.id);
+                    if (count > 0) toast.success(`Selected ${count} element(s)`);
+                    else toast.info('No elements in this zone');
+                  }}
+                />
+              ))}
+            </CollapsibleContent>
+          </Collapsible>
+        ))}
+      </div>
+
+      {zoneAssignmentTiming && (
+        <div className="border-t p-2 text-[10px] text-muted-foreground">
+          Last assignment: {zoneAssignmentTiming.elementCount.toLocaleString()} element(s) x{' '}
+          {zoneAssignmentTiming.zoneSetCount} set(s) in {zoneAssignmentTiming.elapsedMs.toFixed(1)}ms
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/viewer/src/components/viewer/ZonesPanel.tsx
+++ b/apps/viewer/src/components/viewer/ZonesPanel.tsx
@@ -14,7 +14,7 @@
  * `zonesSlice` already does).
  */
 
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   Box,
   Plus,
@@ -181,6 +181,20 @@ export function ZonesPanel({ onClose }: ZonesPanelProps) {
   const [newSetName, setNewSetName] = useState('');
   const importInputRef = useRef<HTMLInputElement>(null);
 
+  // `ZoneOverlay` is mounted independently at the viewport root, so an edit
+  // session left behind when this panel goes away would keep live gizmo
+  // handles intercepting pointer events with no UI left to stop them
+  // (PR #1869 review, P2). Clear on unmount (panel switch) — the explicit
+  // close button below clears eagerly too.
+  useEffect(() => () => {
+    useViewerStore.getState().setEditingZone(null);
+  }, []);
+
+  const handleClose = useCallback(() => {
+    setEditingZone(null);
+    onClose?.();
+  }, [setEditingZone, onClose]);
+
   const handleAddSet = useCallback(() => {
     const name = newSetName.trim() || 'Untitled set';
     createZoneSet(name);
@@ -226,7 +240,7 @@ export function ZonesPanel({ onClose }: ZonesPanelProps) {
         <Box className="h-4 w-4 text-amber-600" />
         <span className="font-medium text-sm flex-1">Location zones</span>
         {onClose && (
-          <Button variant="ghost" size="icon" className="h-6 w-6" onClick={onClose}>
+          <Button variant="ghost" size="icon" className="h-6 w-6" onClick={handleClose}>
             <X className="h-3.5 w-3.5" />
           </Button>
         )}

--- a/apps/viewer/src/components/viewer/lists/ListBuilder.tsx
+++ b/apps/viewer/src/components/viewer/lists/ListBuilder.tsx
@@ -37,6 +37,8 @@ import type {
   ConditionOperator,
 } from '@ifc-lite/lists';
 import { discoverColumns, ENTITY_ATTRIBUTES, groupingColumnIds } from '@ifc-lite/lists';
+import { useViewerStore } from '@/store';
+import type { ZoneSet } from '@/lib/zones';
 import { collectScopeTypes } from '@/lib/lists/scope-types';
 import {
   isEditableColumn,
@@ -90,7 +92,14 @@ function discoverConditionValues(stores: IfcDataStore[]): ListConditionValues {
 }
 
 /** Column descriptor shared by the quick-add grid. */
-interface CommonColumn { id: string; source: ColumnDefinition['source']; propertyName: string; label: string }
+interface CommonColumn {
+  id: string;
+  source: ColumnDefinition['source'];
+  /** Zone-SET id for `source: 'zone'` columns; unused otherwise. */
+  psetName?: string;
+  propertyName: string;
+  label: string;
+}
 
 /** Spatial-container levels a `spatial` column / filter can target, fine to
  *  coarse: Container is the element's IMMEDIATE container (any level); Storey
@@ -222,6 +231,12 @@ export function ListBuilder({ providers, stores, initial, onSave, onCancel, onEx
     for (const p of providers) { const n = p.getModelName?.(); if (n) set.add(n); }
     return Array.from(set).sort();
   }, [providers]);
+
+  // Location zones (issue #1810): every currently-defined zone set, for the
+  // quick-add column chips and the `zone` filter's set-picker + value
+  // suggestions. Read directly from the store rather than round-tripping
+  // through a provider — zone sets are viewer state, not IFC-model data.
+  const zoneSets = useViewerStore((s) => s.zoneSets);
   // Ordered group-by columns, outermost first (multi-criteria grouping #1790).
   const [groupByColumnIds, setGroupByColumnIds] = useState<string[]>(
     () => groupingColumnIds(initial?.grouping)
@@ -462,6 +477,7 @@ export function ListBuilder({ providers, stores, initial, onSave, onCancel, onEx
               values={conditionValues}
               spatialNames={spatialNamesByLevel}
               modelNames={modelNames}
+              zoneSets={zoneSets}
               onAdd={addCondition}
               onUpdate={updateCondition}
               onRemove={removeCondition}
@@ -482,6 +498,7 @@ export function ListBuilder({ providers, stores, initial, onSave, onCancel, onEx
             )}
             <ColumnPicker
               discovered={discovered}
+              zoneSets={zoneSets}
               selectedIds={selectedColumnIds}
               onAdd={addColumn}
               onToggle={toggleColumn}
@@ -681,12 +698,15 @@ const SOURCE_TAG: Record<ColumnDefinition['source'], string> = {
   classification: 'cls',
   spatial: 'storey',
   model: 'model',
+  zone: 'zone',
 };
 
 /** A `spatial` column's tag reflects its level (storey / building / site /
- *  project); everything else uses the flat per-source tag. */
+ *  project); a `zone` column's tag reflects its display mode (zone /
+ *  straddles); everything else uses the flat per-source tag. */
 function colSourceTag(col: ColumnDefinition): string {
   if (col.source === 'spatial') return (col.propertyName || 'Storey').toLowerCase();
+  if (col.source === 'zone') return (col.propertyName || 'Zone').toLowerCase();
   return SOURCE_TAG[col.source];
 }
 
@@ -704,13 +724,16 @@ function ColSourceTag({ col }: { col: ColumnDefinition }) {
 
 interface ColumnPickerProps {
   discovered: DiscoveredColumns;
+  /** Every currently-defined zone set (issue #1810) — one quick-add chip per
+   *  set, so "Zone: Sections" is as reachable as Material / Storey. */
+  zoneSets: ZoneSet[];
   selectedIds: Set<string>;
   onAdd: (col: ColumnDefinition) => void;
   onToggle: (col: ColumnDefinition) => void;
   isDuplicate: (draft: ColumnDraft, excludeId?: string) => boolean;
 }
 
-function ColumnPicker({ discovered, selectedIds, onAdd, onToggle, isDuplicate }: ColumnPickerProps) {
+function ColumnPicker({ discovered, zoneSets, selectedIds, onAdd, onToggle, isDuplicate }: ColumnPickerProps) {
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
   const toggleSection = (id: string) =>
     setExpanded(prev => {
@@ -729,17 +752,30 @@ function ColumnPicker({ discovered, selectedIds, onAdd, onToggle, isDuplicate }:
     [discovered.quantities],
   );
 
+  // One quick-add column per zone set (issue #1810), appended after the
+  // static first-class columns since zone sets are user-defined + dynamic.
+  const zoneColumns = useMemo<CommonColumn[]>(
+    () => zoneSets.map((zs) => ({
+      id: `col-zone-${zs.id}`,
+      source: 'zone' as const,
+      psetName: zs.id,
+      propertyName: 'Zone',
+      label: `Zone: ${zs.name}`,
+    })),
+    [zoneSets],
+  );
+
   return (
     <div className="space-y-2">
       {/* Quick-add grid of the first-class columns */}
       <div className="flex flex-wrap gap-1.5">
-        {COMMON_COLUMNS.map(({ id, source, propertyName, label }) => {
+        {[...COMMON_COLUMNS, ...zoneColumns].map(({ id, source, psetName, propertyName, label }) => {
           const selected = selectedIds.has(id);
           return (
             <Chip
               key={id}
               selected={selected}
-              onClick={() => onToggle({ id, source, propertyName, label })}
+              onClick={() => onToggle({ id, source, psetName, propertyName, label })}
             >
               {selected && <Check className="h-3 w-3" />}
               {label}
@@ -1112,6 +1148,7 @@ const CONDITION_SOURCES: { source: ConditionSource; label: string }[] = [
   { source: 'classification', label: 'Classification' },
   { source: 'spatial', label: 'Spatial' },
   { source: 'model', label: 'Model' },
+  { source: 'zone', label: 'Zone' },
 ];
 
 const OPERATOR_LABEL: Record<ConditionOperator, string> = {
@@ -1137,7 +1174,10 @@ function operatorsFor(source: ConditionSource): ConditionOperator[] {
   }
 }
 
-function defaultConditionFor(source: ConditionSource): PropertyCondition {
+/** `zoneSets` supplies the default zone-SET id for a fresh `zone` condition
+ *  (the first defined set, so switching the source dropdown to Zone lands
+ *  on something usable rather than an empty set-picker). */
+function defaultConditionFor(source: ConditionSource, zoneSets: ZoneSet[] = []): PropertyCondition {
   switch (source) {
     case 'property':
       return { source, psetName: '', propertyName: '', operator: 'equals', value: '' };
@@ -1151,6 +1191,8 @@ function defaultConditionFor(source: ConditionSource): PropertyCondition {
       return { source, propertyName: 'Storey', operator: 'equals', value: '' };
     case 'model':
       return { source, propertyName: 'Model', operator: 'equals', value: '' };
+    case 'zone':
+      return { source, psetName: zoneSets[0]?.id ?? '', propertyName: 'Zone', operator: 'equals', value: '' };
     case 'attribute':
     default:
       return { source: 'attribute', propertyName: 'Name', operator: 'contains', value: '' };
@@ -1166,6 +1208,7 @@ function ConditionsBody({
   values,
   spatialNames,
   modelNames,
+  zoneSets,
   onAdd,
   onUpdate,
   onRemove,
@@ -1175,6 +1218,7 @@ function ConditionsBody({
   values: ListConditionValues | null;
   spatialNames: Record<string, string[]>;
   modelNames: string[];
+  zoneSets: ZoneSet[];
   onAdd: (condition: PropertyCondition) => void;
   onUpdate: (idx: number, condition: PropertyCondition) => void;
   onRemove: (idx: number) => void;
@@ -1189,6 +1233,7 @@ function ConditionsBody({
           values={values}
           spatialNames={spatialNames}
           modelNames={modelNames}
+          zoneSets={zoneSets}
           onChange={(next) => onUpdate(idx, next)}
           onRemove={() => onRemove(idx)}
         />
@@ -1209,6 +1254,7 @@ function ConditionRow({
   values,
   spatialNames,
   modelNames,
+  zoneSets,
   onChange,
   onRemove,
 }: {
@@ -1217,6 +1263,7 @@ function ConditionRow({
   values: ListConditionValues | null;
   spatialNames: Record<string, string[]>;
   modelNames: string[];
+  zoneSets: ZoneSet[];
   onChange: (next: PropertyCondition) => void;
   onRemove: () => void;
 }) {
@@ -1225,6 +1272,7 @@ function ConditionRow({
   const isProperty = condition.source === 'property';
   const isQuantity = condition.source === 'quantity';
   const isSpatial = condition.source === 'spatial';
+  const isZone = condition.source === 'zone';
   const showSetFields = isProperty || isQuantity;
 
   const setNameOptions = useMemo<string[]>(() => {
@@ -1240,6 +1288,12 @@ function ConditionRow({
     return [];
   }, [discovered, condition.psetName, isProperty, isQuantity]);
 
+  const zoneNameOptions = useMemo<string[]>(() => {
+    if (!isZone) return [];
+    const set = zoneSets.find((zs) => zs.id === condition.psetName);
+    return set ? set.zones.map((z) => z.name) : [];
+  }, [isZone, zoneSets, condition.psetName]);
+
   const valueOptions = useMemo<readonly string[]>(() => {
     switch (condition.source) {
       case 'property':
@@ -1248,22 +1302,24 @@ function ConditionRow({
       case 'classification': return values?.classifications ?? NO_OPTIONS;
       case 'spatial': return spatialNames[condition.propertyName] ?? spatialNames.Storey ?? NO_OPTIONS;
       case 'model': return modelNames;
+      case 'zone': return condition.propertyName === 'Straddles' ? ['true', 'false'] : zoneNameOptions;
       default: return NO_OPTIONS;
     }
-  }, [condition.source, condition.psetName, condition.propertyName, values, spatialNames, modelNames]);
+  }, [condition.source, condition.psetName, condition.propertyName, values, spatialNames, modelNames, zoneNameOptions]);
 
   const valuePlaceholder =
     condition.source === 'spatial' ? `${(condition.propertyName || 'Storey').toLowerCase()} name`
       : condition.source === 'model' ? 'model / file'
         : condition.source === 'material' ? 'material'
           : condition.source === 'classification' ? 'code or name'
-            : 'value';
+            : condition.source === 'zone' ? (condition.propertyName === 'Straddles' ? 'true / false' : 'zone name')
+              : 'value';
 
   return (
     <div className="flex flex-wrap items-center gap-1.5 rounded-md border border-border/60 bg-card px-2 py-1.5 text-xs">
       <select
         value={condition.source}
-        onChange={(e) => onChange(defaultConditionFor(e.target.value as ConditionSource))}
+        onChange={(e) => onChange(defaultConditionFor(e.target.value as ConditionSource, zoneSets))}
         className={SELECT_CLASS}
         aria-label="Filter dimension"
       >
@@ -1296,6 +1352,31 @@ function ConditionRow({
             <option key={level} value={level}>{level}</option>
           ))}
         </select>
+      )}
+
+      {isZone && (
+        <>
+          <select
+            value={condition.psetName ?? ''}
+            onChange={(e) => onChange({ ...condition, psetName: e.target.value, value: '' })}
+            className={SELECT_CLASS}
+            aria-label="Zone set"
+          >
+            {zoneSets.length === 0 && <option value="">(no zone sets)</option>}
+            {zoneSets.map((zs) => (
+              <option key={zs.id} value={zs.id}>{zs.name}</option>
+            ))}
+          </select>
+          <select
+            value={condition.propertyName || 'Zone'}
+            onChange={(e) => onChange({ ...condition, propertyName: e.target.value, value: '' })}
+            className={SELECT_CLASS}
+            aria-label="Zone display mode"
+          >
+            <option value="Zone">Zone</option>
+            <option value="Straddles">Straddles</option>
+          </select>
+        </>
       )}
 
       {showSetFields && (

--- a/apps/viewer/src/components/viewer/lists/ListPanel.tsx
+++ b/apps/viewer/src/components/viewer/lists/ListPanel.tsx
@@ -81,6 +81,13 @@ export function ListPanel({ onClose }: ListPanelProps) {
 
   const importInputRef = React.useRef<HTMLInputElement>(null);
 
+  // Zone assignment (issue #1810) is shared across every model's provider —
+  // `zoneAssignments` is already keyed by federated global id, so each
+  // model's provider just needs ITS OWN `toGlobalId` closure.
+  const zoneSets = useViewerStore((s) => s.zoneSets);
+  const zoneAssignments = useViewerStore((s) => s.zoneAssignments);
+  const toGlobalId = useViewerStore((s) => s.toGlobalId);
+
   // Build the {modelId, provider} pairs in a single pass so the two
   // arrays can never drift out of alignment (skipping a model without
   // an ifcDataStore must not shift every later model's provider index).
@@ -91,13 +98,15 @@ export function ListPanel({ onClose }: ListPanelProps) {
         // Skip native-metadata models — they don't have a parsed
         // IfcDataStore, so the list provider can't query them.
         if (!model.ifcDataStore) continue;
-        pairs.push({ modelId, provider: createListDataProvider(model.ifcDataStore, model.name), store: model.ifcDataStore });
+        const zoneContext = { zoneSets, zoneAssignments, toGlobalId: (expressId: number) => toGlobalId(modelId, expressId) };
+        pairs.push({ modelId, provider: createListDataProvider(model.ifcDataStore, model.name, zoneContext), store: model.ifcDataStore });
       }
     } else if (ifcDataStore) {
-      pairs.push({ modelId: 'default', provider: createListDataProvider(ifcDataStore), store: ifcDataStore });
+      const zoneContext = { zoneSets, zoneAssignments, toGlobalId: (expressId: number) => toGlobalId('default', expressId) };
+      pairs.push({ modelId: 'default', provider: createListDataProvider(ifcDataStore, '', zoneContext), store: ifcDataStore });
     }
     return pairs;
-  }, [models, ifcDataStore]);
+  }, [models, ifcDataStore, zoneSets, zoneAssignments, toGlobalId]);
 
   const allProviders = useMemo(() => modelProviderPairs.map((p) => p.provider), [modelProviderPairs]);
   const allStores = useMemo(() => modelProviderPairs.map((p) => p.store), [modelProviderPairs]);

--- a/apps/viewer/src/components/viewer/tools/ZoneOverlay.tsx
+++ b/apps/viewer/src/components/viewer/tools/ZoneOverlay.tsx
@@ -22,9 +22,8 @@ import { useViewerStore } from '@/store';
 import { useCameraTickSubscription } from '@/hooks/useCameraTickSubscription';
 import { useZoneAssignmentSync } from '@/hooks/useZoneAssignmentSync';
 import { zoneColorForIndex, zoneWorldCorners, type Zone } from '@/lib/zones';
+import { computeZoneDragPatch, type DragKind, type DragState, type Vec2, type Vec3 } from './zoneDrag';
 
-type Vec2 = { x: number; y: number };
-type Vec3 = { x: number; y: number; z: number };
 type Project = (worldPos: Vec3) => Vec2 | null;
 
 /** Wireframe edges as pairs of corner indices, matching `zoneWorldCorners`'
@@ -90,26 +89,6 @@ function projectZones(
   return out;
 }
 
-type DragKind =
-  | { kind: 'move'; axis: 'x' | 'y' | 'z' }
-  | { kind: 'resize'; axis: 'x' | 'y' | 'z' }
-  | { kind: 'rotate' };
-
-interface DragState {
-  op: DragKind;
-  setId: string;
-  zoneId: string;
-  cursorStart: Vec2;
-  /** Screen-space (dx, dy) for a +1 world-unit probe along the relevant
-   *  direction, captured at drag start. */
-  screenPerUnit: Vec2;
-  /** Zone snapshot at drag start (so deltas apply against a fixed base,
-   *  not the previous frame's already-mutated zone). */
-  startCenter: [number, number, number];
-  startSize: [number, number, number];
-  startRotationY: number;
-}
-
 const HANDLE_HIT_RADIUS = 10;
 
 export function ZoneOverlay() {
@@ -120,15 +99,21 @@ export function ZoneOverlay() {
   const getViewpoint = useViewerStore((s) => s.cameraCallbacks.getViewpoint);
 
   const anyVisible = zoneSets.some((zs) => zs.visible && zs.zones.length > 0);
-  useCameraTickSubscription(getViewpoint, anyVisible);
+  // The returned frame tick MUST participate in the projection memo below:
+  // `projectToScreen` is a stable callback, so without the tick an orbit/pan/
+  // zoom re-render would reuse the memoized screen coordinates and the boxes
+  // would visibly detach from the model (PR #1869 review, P1).
+  const frameTick = useCameraTickSubscription(getViewpoint, anyVisible);
 
   const dragRef = useRef<DragState | null>(null);
 
   const projected = useMemo(() => {
     if (!projectToScreen || !anyVisible) return [];
     return projectZones(projectToScreen as Project, zoneSets);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [zoneSets, projectToScreen, anyVisible, getViewpoint]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- frameTick is the
+    // camera-motion signal: it isn't read inside, but a new tick means the
+    // same world corners project to new screen positions.
+  }, [zoneSets, projectToScreen, anyVisible, frameTick]);
 
   if (!anyVisible || !projectToScreen) return null;
   const project = projectToScreen as Project;
@@ -167,6 +152,7 @@ export function ZoneOverlay() {
       zoneId: entry.zone.id,
       cursorStart: { x: e.clientX, y: e.clientY },
       screenPerUnit,
+      probeDir,
       startCenter: entry.zone.center,
       startSize: entry.zone.size,
       startRotationY: entry.zone.rotationY,
@@ -176,50 +162,21 @@ export function ZoneOverlay() {
   const onDragMove = (e: React.PointerEvent<SVGElement>) => {
     const drag = dragRef.current;
     if (!drag) return;
-    const cursorDelta: Vec2 = { x: e.clientX - drag.cursorStart.x, y: e.clientY - drag.cursorStart.y };
-
-    // Every op's `screenPerUnit` was probed against a UNIT world-space
-    // direction (a translation axis, a resize axis, or — for rotate — the
-    // handle's tangent direction), so this single dot-product decomposition
-    // gives "how many world metres along that unit direction does the
-    // cursor delta correspond to" regardless of which op is active.
-    const ax = drag.screenPerUnit;
-    const denom = ax.x * ax.x + ax.y * ax.y;
-    if (denom < 1e-6) return;
-    const metres = (cursorDelta.x * ax.x + cursorDelta.y * ax.y) / denom;
-
-    if (drag.op.kind === 'rotate') {
-      // Tangential arc-length (metres) at the handle's radius converts to an
-      // angle via the standard arc-length formula theta = s / r. Screen-space
-      // rotation isn't a perfect proxy for a world Y-axis rotation under an
-      // oblique camera, but it's exact in top/near-top view and a reasonable
-      // approximation otherwise (documented v1 limitation).
-      const radius = drag.startSize[0] / 2 + 1.2;
-      if (radius < 1e-3) return;
-      const rotationY = drag.startRotationY + metres / radius;
-      updateZone(drag.setId, drag.zoneId, { rotationY });
-      return;
-    }
-
-    if (drag.op.kind === 'move') {
-      const idx = drag.op.axis === 'x' ? 0 : drag.op.axis === 'y' ? 1 : 2;
-      const center: [number, number, number] = [...drag.startCenter];
-      center[idx] = drag.startCenter[idx] + metres;
-      updateZone(drag.setId, drag.zoneId, { center });
-      return;
-    }
-
-    // resize: symmetric about center along the given local axis.
-    const idx = drag.op.axis === 'x' ? 0 : drag.op.axis === 'y' ? 1 : 2;
-    const nextHalf = Math.max(0.05, drag.startSize[idx] / 2 + metres);
-    const size: [number, number, number] = [...drag.startSize];
-    size[idx] = nextHalf * 2;
-    updateZone(drag.setId, drag.zoneId, { size });
+    // All the drag math is in `computeZoneDragPatch` (pure, unit-tested —
+    // see zoneDrag.test.ts for the rotated-zone cases from PR #1869).
+    const patch = computeZoneDragPatch(drag, { x: e.clientX, y: e.clientY });
+    if (patch) updateZone(drag.setId, drag.zoneId, patch);
   };
 
   const onDragEnd = (e: React.PointerEvent<SVGElement>) => {
     if (!dragRef.current) return;
-    try { (e.target as SVGElement).releasePointerCapture(e.pointerId); } catch { /* already released */ }
+    try {
+      (e.target as SVGElement).releasePointerCapture(e.pointerId);
+    } catch (error) {
+      // Expected when capture was already released (e.g. pointercancel then
+      // pointerup); logged so a genuine capture bug can't hide here.
+      console.debug('[zones] releasePointerCapture after drag was a no-op', error);
+    }
     dragRef.current = null;
   };
 
@@ -271,7 +228,7 @@ export function ZoneOverlay() {
             key: 'move-x',
             world: { x: center.x + localX.x * (zone.size[0] / 2 + 0.6), y: center.y, z: center.z + localX.z * (zone.size[0] / 2 + 0.6) },
             color: '#ef4444',
-            op: { kind: 'move', axis: 'x' },
+            op: { kind: 'move' },
             probeOrigin: center,
             probeDir: localX,
           },
@@ -279,7 +236,7 @@ export function ZoneOverlay() {
             key: 'move-z',
             world: { x: center.x + localZ.x * (zone.size[2] / 2 + 0.6), y: center.y, z: center.z + localZ.z * (zone.size[2] / 2 + 0.6) },
             color: '#3b82f6',
-            op: { kind: 'move', axis: 'z' },
+            op: { kind: 'move' },
             probeOrigin: center,
             probeDir: localZ,
           },
@@ -287,7 +244,7 @@ export function ZoneOverlay() {
             key: 'move-y',
             world: { x: center.x, y: center.y + zone.size[1] / 2 + 0.6, z: center.z },
             color: '#10b981',
-            op: { kind: 'move', axis: 'y' },
+            op: { kind: 'move' },
             probeOrigin: center,
             probeDir: worldY,
           },

--- a/apps/viewer/src/components/viewer/tools/ZoneOverlay.tsx
+++ b/apps/viewer/src/components/viewer/tools/ZoneOverlay.tsx
@@ -1,0 +1,367 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * 3D display + interactive editing for location zones (issue #1810 v1).
+ *
+ * Follows the SAME hand-rolled SVG-overlay technique as `GizmoOverlay.tsx`
+ * (the renderer has no react-three-fiber/drei — see that file's header):
+ * `projectToScreen` turns world points into screen pixels, and per-axis drag
+ * math reduces to a dot product against the cursor's screen delta because a
+ * probe at +1 world unit gives "screen pixels per metre" directly.
+ *
+ * Picking contract: the root `<svg>` is `pointer-events: none` always (so
+ * zone boxes never intercept clicks on model elements). Only the currently
+ * `editingZone`'s handles turn pointer-events back on for themselves — every
+ * other zone box (and this one outside of edit mode) is decorative only.
+ */
+
+import { useMemo, useRef } from 'react';
+import { useViewerStore } from '@/store';
+import { useCameraTickSubscription } from '@/hooks/useCameraTickSubscription';
+import { useZoneAssignmentSync } from '@/hooks/useZoneAssignmentSync';
+import { zoneColorForIndex, zoneWorldCorners, type Zone } from '@/lib/zones';
+
+type Vec2 = { x: number; y: number };
+type Vec3 = { x: number; y: number; z: number };
+type Project = (worldPos: Vec3) => Vec2 | null;
+
+/** Wireframe edges as pairs of corner indices, matching `zoneWorldCorners`'
+ *  bottom-face-then-top-face order (0-3 bottom, 4-7 top). */
+const BOX_EDGES: ReadonlyArray<readonly [number, number]> = [
+  [0, 1], [1, 2], [2, 3], [3, 0], // bottom
+  [4, 5], [5, 6], [6, 7], [7, 4], // top
+  [0, 4], [1, 5], [2, 6], [3, 7], // verticals
+];
+
+function rgbToCss([r, g, b]: readonly [number, number, number], alpha: number): string {
+  return `rgba(${Math.round(r * 255)}, ${Math.round(g * 255)}, ${Math.round(b * 255)}, ${alpha})`;
+}
+
+/** One rendered box: projected corner screen positions + the zone/colour it
+ *  came from. `null` corners (offscreen / behind camera) drop the whole box
+ *  from rendering rather than drawing a corrupted hull. */
+interface ProjectedZone {
+  setId: string;
+  setName: string;
+  zone: Zone;
+  color: readonly [number, number, number];
+  corners: Vec2[];
+  labelAnchor: Vec2;
+}
+
+function projectZones(
+  project: Project,
+  zoneSets: ReadonlyArray<{ id: string; name: string; visible: boolean; zones: Zone[] }>,
+): ProjectedZone[] {
+  const out: ProjectedZone[] = [];
+  for (const set of zoneSets) {
+    if (!set.visible) continue;
+    set.zones.forEach((zone, index) => {
+      const worldCorners = zoneWorldCorners(zone);
+      const corners: Vec2[] = [];
+      let ok = true;
+      for (const [x, y, z] of worldCorners) {
+        const p = project({ x, y, z });
+        if (!p) { ok = false; break; }
+        corners.push(p);
+      }
+      if (!ok) return;
+      // Label anchors above the top face's center (average of corners 4-7).
+      const top = worldCorners.slice(4);
+      const topCenter: Vec3 = {
+        x: top.reduce((s, c) => s + c[0], 0) / 4,
+        y: top.reduce((s, c) => s + c[1], 0) / 4 + 0.3,
+        z: top.reduce((s, c) => s + c[2], 0) / 4,
+      };
+      const labelAnchor = project(topCenter);
+      if (!labelAnchor) return;
+      out.push({
+        setId: set.id,
+        setName: set.name,
+        zone,
+        color: zone.color ?? zoneColorForIndex(index),
+        corners,
+        labelAnchor,
+      });
+    });
+  }
+  return out;
+}
+
+type DragKind =
+  | { kind: 'move'; axis: 'x' | 'y' | 'z' }
+  | { kind: 'resize'; axis: 'x' | 'y' | 'z' }
+  | { kind: 'rotate' };
+
+interface DragState {
+  op: DragKind;
+  setId: string;
+  zoneId: string;
+  cursorStart: Vec2;
+  /** Screen-space (dx, dy) for a +1 world-unit probe along the relevant
+   *  direction, captured at drag start. */
+  screenPerUnit: Vec2;
+  /** Zone snapshot at drag start (so deltas apply against a fixed base,
+   *  not the previous frame's already-mutated zone). */
+  startCenter: [number, number, number];
+  startSize: [number, number, number];
+  startRotationY: number;
+}
+
+const HANDLE_HIT_RADIUS = 10;
+
+export function ZoneOverlay() {
+  const zoneSets = useViewerStore((s) => s.zoneSets);
+  const editingZone = useViewerStore((s) => s.editingZone);
+  const updateZone = useViewerStore((s) => s.updateZone);
+  const projectToScreen = useViewerStore((s) => s.cameraCallbacks.projectToScreen);
+  const getViewpoint = useViewerStore((s) => s.cameraCallbacks.getViewpoint);
+
+  const anyVisible = zoneSets.some((zs) => zs.visible && zs.zones.length > 0);
+  useCameraTickSubscription(getViewpoint, anyVisible);
+
+  const dragRef = useRef<DragState | null>(null);
+
+  const projected = useMemo(() => {
+    if (!projectToScreen || !anyVisible) return [];
+    return projectZones(projectToScreen as Project, zoneSets);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [zoneSets, projectToScreen, anyVisible, getViewpoint]);
+
+  if (!anyVisible || !projectToScreen) return null;
+  const project = projectToScreen as Project;
+
+  const editingEntry = editingZone
+    ? projected.find((p) => p.setId === editingZone.setId && p.zone.id === editingZone.zoneId)
+    : undefined;
+
+  /** Probe `+1` world unit along `dir` from `origin`, returning screen
+   *  pixels-per-metre in that direction (or null if degenerate/offscreen). */
+  const probeScreenPerUnit = (origin: Vec3, dir: Vec3): Vec2 | null => {
+    const originScreen = project(origin);
+    const tipScreen = project({ x: origin.x + dir.x, y: origin.y + dir.y, z: origin.z + dir.z });
+    if (!originScreen || !tipScreen) return null;
+    const d = { x: tipScreen.x - originScreen.x, y: tipScreen.y - originScreen.y };
+    if (Math.hypot(d.x, d.y) < 1e-3) return null;
+    return d;
+  };
+
+  const startDrag = (
+    e: React.PointerEvent<SVGElement>,
+    entry: ProjectedZone,
+    op: DragKind,
+    probeOrigin: Vec3,
+    probeDir: Vec3,
+  ) => {
+    e.stopPropagation();
+    e.preventDefault();
+    const screenPerUnit = probeScreenPerUnit(probeOrigin, probeDir);
+    if (!screenPerUnit) return;
+    (e.target as SVGElement).setPointerCapture(e.pointerId);
+
+    dragRef.current = {
+      op,
+      setId: entry.setId,
+      zoneId: entry.zone.id,
+      cursorStart: { x: e.clientX, y: e.clientY },
+      screenPerUnit,
+      startCenter: entry.zone.center,
+      startSize: entry.zone.size,
+      startRotationY: entry.zone.rotationY,
+    };
+  };
+
+  const onDragMove = (e: React.PointerEvent<SVGElement>) => {
+    const drag = dragRef.current;
+    if (!drag) return;
+    const cursorDelta: Vec2 = { x: e.clientX - drag.cursorStart.x, y: e.clientY - drag.cursorStart.y };
+
+    // Every op's `screenPerUnit` was probed against a UNIT world-space
+    // direction (a translation axis, a resize axis, or — for rotate — the
+    // handle's tangent direction), so this single dot-product decomposition
+    // gives "how many world metres along that unit direction does the
+    // cursor delta correspond to" regardless of which op is active.
+    const ax = drag.screenPerUnit;
+    const denom = ax.x * ax.x + ax.y * ax.y;
+    if (denom < 1e-6) return;
+    const metres = (cursorDelta.x * ax.x + cursorDelta.y * ax.y) / denom;
+
+    if (drag.op.kind === 'rotate') {
+      // Tangential arc-length (metres) at the handle's radius converts to an
+      // angle via the standard arc-length formula theta = s / r. Screen-space
+      // rotation isn't a perfect proxy for a world Y-axis rotation under an
+      // oblique camera, but it's exact in top/near-top view and a reasonable
+      // approximation otherwise (documented v1 limitation).
+      const radius = drag.startSize[0] / 2 + 1.2;
+      if (radius < 1e-3) return;
+      const rotationY = drag.startRotationY + metres / radius;
+      updateZone(drag.setId, drag.zoneId, { rotationY });
+      return;
+    }
+
+    if (drag.op.kind === 'move') {
+      const idx = drag.op.axis === 'x' ? 0 : drag.op.axis === 'y' ? 1 : 2;
+      const center: [number, number, number] = [...drag.startCenter];
+      center[idx] = drag.startCenter[idx] + metres;
+      updateZone(drag.setId, drag.zoneId, { center });
+      return;
+    }
+
+    // resize: symmetric about center along the given local axis.
+    const idx = drag.op.axis === 'x' ? 0 : drag.op.axis === 'y' ? 1 : 2;
+    const nextHalf = Math.max(0.05, drag.startSize[idx] / 2 + metres);
+    const size: [number, number, number] = [...drag.startSize];
+    size[idx] = nextHalf * 2;
+    updateZone(drag.setId, drag.zoneId, { size });
+  };
+
+  const onDragEnd = (e: React.PointerEvent<SVGElement>) => {
+    if (!dragRef.current) return;
+    try { (e.target as SVGElement).releasePointerCapture(e.pointerId); } catch { /* already released */ }
+    dragRef.current = null;
+  };
+
+  return (
+    <svg className="absolute inset-0 pointer-events-none z-20" style={{ overflow: 'visible' }}>
+      {projected.map((entry) => {
+        const isEditing = editingZone?.setId === entry.setId && editingZone.zoneId === entry.zone.id;
+        const stroke = rgbToCss(entry.color, isEditing ? 1 : 0.85);
+        const fill = rgbToCss(entry.color, isEditing ? 0.18 : 0.1);
+        const topFace = [entry.corners[4], entry.corners[5], entry.corners[6], entry.corners[7]]
+          .map((p) => `${p.x},${p.y}`).join(' ');
+        return (
+          <g key={`${entry.setId}:${entry.zone.id}`}>
+            <polygon points={topFace} fill={fill} stroke="none" />
+            {BOX_EDGES.map(([a, b], i) => (
+              <line
+                key={i}
+                x1={entry.corners[a].x} y1={entry.corners[a].y}
+                x2={entry.corners[b].x} y2={entry.corners[b].y}
+                stroke={stroke}
+                strokeWidth={isEditing ? 2 : 1.25}
+                strokeDasharray={isEditing ? undefined : '4,3'}
+              />
+            ))}
+            <g transform={`translate(${entry.labelAnchor.x}, ${entry.labelAnchor.y})`}>
+              <rect x={-2} y={-14} width={entry.zone.name.length * 6.4 + 12} height={18} rx={4}
+                fill="rgba(15, 23, 42, 0.85)" />
+              <text x={4} y={-1} fontSize={11} fill="#fff">
+                {entry.setName} / {entry.zone.name}
+              </text>
+            </g>
+          </g>
+        );
+      })}
+
+      {editingEntry && (() => {
+        const zone = editingEntry.zone;
+        const center: Vec3 = { x: zone.center[0], y: zone.center[1], z: zone.center[2] };
+        const cos = Math.cos(zone.rotationY);
+        const sin = Math.sin(zone.rotationY);
+        const localX: Vec3 = { x: cos, y: 0, z: sin };
+        const localZ: Vec3 = { x: -sin, y: 0, z: cos };
+        const worldY: Vec3 = { x: 0, y: 1, z: 0 };
+
+        const handles: Array<{
+          key: string; world: Vec3; color: string; op: DragKind; probeOrigin: Vec3; probeDir: Vec3;
+        }> = [
+          {
+            key: 'move-x',
+            world: { x: center.x + localX.x * (zone.size[0] / 2 + 0.6), y: center.y, z: center.z + localX.z * (zone.size[0] / 2 + 0.6) },
+            color: '#ef4444',
+            op: { kind: 'move', axis: 'x' },
+            probeOrigin: center,
+            probeDir: localX,
+          },
+          {
+            key: 'move-z',
+            world: { x: center.x + localZ.x * (zone.size[2] / 2 + 0.6), y: center.y, z: center.z + localZ.z * (zone.size[2] / 2 + 0.6) },
+            color: '#3b82f6',
+            op: { kind: 'move', axis: 'z' },
+            probeOrigin: center,
+            probeDir: localZ,
+          },
+          {
+            key: 'move-y',
+            world: { x: center.x, y: center.y + zone.size[1] / 2 + 0.6, z: center.z },
+            color: '#10b981',
+            op: { kind: 'move', axis: 'y' },
+            probeOrigin: center,
+            probeDir: worldY,
+          },
+          {
+            key: 'resize-x',
+            world: { x: center.x + localX.x * (zone.size[0] / 2), y: center.y, z: center.z + localX.z * (zone.size[0] / 2) },
+            color: '#fca5a5',
+            op: { kind: 'resize', axis: 'x' },
+            probeOrigin: center,
+            probeDir: localX,
+          },
+          {
+            key: 'resize-z',
+            world: { x: center.x + localZ.x * (zone.size[2] / 2), y: center.y, z: center.z + localZ.z * (zone.size[2] / 2) },
+            color: '#93c5fd',
+            op: { kind: 'resize', axis: 'z' },
+            probeOrigin: center,
+            probeDir: localZ,
+          },
+          {
+            key: 'resize-y',
+            world: { x: center.x, y: center.y + zone.size[1] / 2, z: center.z },
+            color: '#6ee7b7',
+            op: { kind: 'resize', axis: 'y' },
+            probeOrigin: center,
+            probeDir: worldY,
+          },
+          {
+            key: 'rotate',
+            world: {
+              x: center.x + localX.x * (zone.size[0] / 2 + 1.2),
+              y: center.y,
+              z: center.z + localX.z * (zone.size[0] / 2 + 1.2),
+            },
+            color: '#facc15',
+            op: { kind: 'rotate' },
+            probeOrigin: center,
+            probeDir: { x: -localX.z, y: 0, z: localX.x }, // tangent direction at the handle
+          },
+        ];
+
+        return (
+          <g style={{ pointerEvents: 'auto' }}>
+            {handles.map((h) => {
+              const screen = project(h.world);
+              if (!screen) return null;
+              return (
+                <circle
+                  key={h.key}
+                  cx={screen.x}
+                  cy={screen.y}
+                  r={HANDLE_HIT_RADIUS}
+                  fill={h.color}
+                  stroke="#18181b"
+                  strokeWidth={1.5}
+                  style={{ cursor: h.op.kind === 'rotate' ? 'grab' : 'move' }}
+                  onPointerDown={(e) => startDrag(e, editingEntry, h.op, h.probeOrigin, h.probeDir)}
+                  onPointerMove={onDragMove}
+                  onPointerUp={onDragEnd}
+                  onPointerCancel={onDragEnd}
+                />
+              );
+            })}
+          </g>
+        );
+      })()}
+    </svg>
+  );
+}
+
+/** Mounts the assignment-recompute wiring (`useZoneAssignmentSync`) without
+ *  rendering anything. Mount once near `ZoneOverlay` (same lifetime as the
+ *  renderer) so `zoneAssignments` stays live as models/zones change. */
+export function ZoneAssignmentSyncMount() {
+  useZoneAssignmentSync();
+  return null;
+}

--- a/apps/viewer/src/components/viewer/tools/zoneDrag.test.ts
+++ b/apps/viewer/src/components/viewer/tools/zoneDrag.test.ts
@@ -1,0 +1,94 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { computeZoneDragPatch, MIN_RESIZE_HALF_M, type DragState, type Vec3 } from './zoneDrag.js';
+
+/** Drag state for a top-down camera where +1 world metre along `probeDir`
+ *  projects to `screenPerUnit` pixels. */
+function makeDrag(overrides: Partial<DragState>): DragState {
+  return {
+    op: { kind: 'move' },
+    setId: 's1',
+    zoneId: 'z1',
+    cursorStart: { x: 100, y: 100 },
+    screenPerUnit: { x: 10, y: 0 },
+    probeDir: { x: 1, y: 0, z: 0 },
+    startCenter: [0, 0, 0],
+    startSize: [10, 3, 10],
+    startRotationY: 0,
+    ...overrides,
+  };
+}
+
+function approxEqual(actual: readonly number[], expected: readonly number[], eps = 1e-9): void {
+  assert.strictEqual(actual.length, expected.length);
+  for (let i = 0; i < actual.length; i++) {
+    assert.ok(Math.abs(actual[i] - expected[i]) < eps, `component ${i}: ${actual[i]} != ${expected[i]}`);
+  }
+}
+
+describe('zones/zoneDrag (PR #1869 review: rotated-zone drag math)', () => {
+  it('unrotated move along local X moves the world X center only', () => {
+    const drag = makeDrag({});
+    // Cursor moved +20px along the probe's screen direction => +2 metres.
+    const patch = computeZoneDragPatch(drag, { x: 120, y: 100 })!;
+    approxEqual(patch.center!, [2, 0, 0]);
+  });
+
+  it('at 90° rotation the local-X handle moves the box along world Z, not world X', () => {
+    // rotationY = 90°: localX = (cos, 0, sin) = (0, 0, 1) — the handle points
+    // down world +Z and the probe measured screen pixels along world +Z.
+    const localX: Vec3 = { x: 0, y: 0, z: 1 };
+    const drag = makeDrag({
+      probeDir: localX,
+      startRotationY: Math.PI / 2,
+      screenPerUnit: { x: 0, y: -8 }, // +1m world Z projects 8px up on screen
+    });
+    const patch = computeZoneDragPatch(drag, { x: 100, y: 100 - 24 })!; // 24px up => +3m
+    // The center must move along the probed LOCAL direction (world Z here);
+    // the old code wrote the scalar into center[0] (world X) instead.
+    approxEqual(patch.center!, [0, 0, 3]);
+  });
+
+  it('at 45° rotation the delta lands on the rotated axis, split across world X and Z', () => {
+    const c = Math.SQRT1_2;
+    const localX: Vec3 = { x: c, y: 0, z: c };
+    const drag = makeDrag({ probeDir: localX, startRotationY: Math.PI / 4, screenPerUnit: { x: 10, y: 0 } });
+    const patch = computeZoneDragPatch(drag, { x: 120, y: 100 })!; // +2 metres along localX
+    approxEqual(patch.center!, [2 * c, 0, 2 * c]);
+  });
+
+  it('vertical move applies along world Y regardless of rotation', () => {
+    const drag = makeDrag({
+      probeDir: { x: 0, y: 1, z: 0 },
+      startRotationY: 1.234,
+      screenPerUnit: { x: 0, y: -12 },
+      startCenter: [5, 2, -3],
+    });
+    const patch = computeZoneDragPatch(drag, { x: 100, y: 100 - 12 })!; // +1m up
+    approxEqual(patch.center!, [5, 3, -3]);
+  });
+
+  it('resize adjusts the LOCAL size component symmetrically and never collapses below the floor', () => {
+    const drag = makeDrag({ op: { kind: 'resize', axis: 'x' }, screenPerUnit: { x: 10, y: 0 } });
+    const grow = computeZoneDragPatch(drag, { x: 110, y: 100 })!; // +1m half-extent
+    approxEqual(grow.size!, [12, 3, 10]);
+    const collapse = computeZoneDragPatch(drag, { x: 100 - 1000, y: 100 })!;
+    approxEqual(collapse.size!, [MIN_RESIZE_HALF_M * 2, 3, 10]);
+  });
+
+  it('rotate converts tangential metres to an angle via arc length at the handle radius', () => {
+    const drag = makeDrag({ op: { kind: 'rotate' }, screenPerUnit: { x: 10, y: 0 }, startSize: [10, 3, 10] });
+    const radius = 10 / 2 + 1.2;
+    const patch = computeZoneDragPatch(drag, { x: 110, y: 100 })!; // 1 metre of arc
+    assert.ok(Math.abs((patch.rotationY ?? 0) - 1 / radius) < 1e-9);
+  });
+
+  it('returns null for a degenerate probe instead of a garbage patch', () => {
+    const drag = makeDrag({ screenPerUnit: { x: 0, y: 0 } });
+    assert.strictEqual(computeZoneDragPatch(drag, { x: 500, y: 500 }), null);
+  });
+});

--- a/apps/viewer/src/components/viewer/tools/zoneDrag.ts
+++ b/apps/viewer/src/components/viewer/tools/zoneDrag.ts
@@ -1,0 +1,102 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Pure drag math for `ZoneOverlay`'s move/resize/rotate handles, extracted so
+ * it's unit-testable without pointer events or a renderer (same pattern as
+ * `useGanttBarDrag`'s `snapDeltaMs`/`pxPerMs`). The overlay probes "screen
+ * pixels per +1 world metre along the handle's direction" at drag start;
+ * everything here is closed-form arithmetic on that probe.
+ *
+ * Move handles are displayed along the zone's LOCAL axes (rotated by
+ * `rotationY`), so the scalar delta must be applied along the SAME probed
+ * world-space direction — writing it into a single world center component
+ * made rotated zones diverge from the cursor (PR #1869 review, P1).
+ */
+
+import type { Zone } from '@/lib/zones';
+
+export type Vec2 = { x: number; y: number };
+export type Vec3 = { x: number; y: number; z: number };
+
+export type DragKind =
+  | { kind: 'move' }
+  | { kind: 'resize'; axis: 'x' | 'y' | 'z' }
+  | { kind: 'rotate' };
+
+export interface DragState {
+  op: DragKind;
+  setId: string;
+  zoneId: string;
+  cursorStart: Vec2;
+  /** Screen-space (dx, dy) for a +1 world-unit probe along `probeDir`,
+   *  captured at drag start. */
+  screenPerUnit: Vec2;
+  /** Unit world-space direction the probe measured along. Move ops apply the
+   *  scalar delta along this exact direction (local axis for X/Z handles,
+   *  world Y for the vertical handle). */
+  probeDir: Vec3;
+  /** Zone snapshot at drag start (so deltas apply against a fixed base,
+   *  not the previous frame's already-mutated zone). */
+  startCenter: [number, number, number];
+  startSize: [number, number, number];
+  startRotationY: number;
+}
+
+/** Minimum zone half-extent (metres) a resize drag can shrink to. */
+export const MIN_RESIZE_HALF_M = 0.05;
+
+/**
+ * Convert a cursor movement since drag start into a zone patch, or `null`
+ * when the drag is degenerate (probe collapsed to <1px per metre).
+ *
+ * Every op's `screenPerUnit` was probed against a UNIT world-space direction
+ * (a translation axis, a resize axis, or — for rotate — the handle's tangent
+ * direction), so a single dot-product decomposition gives "how many world
+ * metres along that unit direction does the cursor delta correspond to"
+ * regardless of which op is active.
+ */
+export function computeZoneDragPatch(
+  drag: DragState,
+  cursor: Vec2,
+): Partial<Omit<Zone, 'id'>> | null {
+  const cursorDelta: Vec2 = { x: cursor.x - drag.cursorStart.x, y: cursor.y - drag.cursorStart.y };
+  const ax = drag.screenPerUnit;
+  const denom = ax.x * ax.x + ax.y * ax.y;
+  if (denom < 1e-6) return null;
+  const metres = (cursorDelta.x * ax.x + cursorDelta.y * ax.y) / denom;
+
+  if (drag.op.kind === 'rotate') {
+    // Tangential arc-length (metres) at the handle's radius converts to an
+    // angle via the standard arc-length formula theta = s / r. Screen-space
+    // rotation isn't a perfect proxy for a world Y-axis rotation under an
+    // oblique camera, but it's exact in top/near-top view and a reasonable
+    // approximation otherwise (documented v1 limitation).
+    const radius = drag.startSize[0] / 2 + 1.2;
+    if (radius < 1e-3) return null;
+    return { rotationY: drag.startRotationY + metres / radius };
+  }
+
+  if (drag.op.kind === 'move') {
+    // Apply the delta along the probed world-space direction itself, NOT a
+    // single world component: the X/Z handles point along the zone's local
+    // (rotated) axes, so at e.g. 90° rotation the local-X handle must move
+    // the box along world Z.
+    return {
+      center: [
+        drag.startCenter[0] + metres * drag.probeDir.x,
+        drag.startCenter[1] + metres * drag.probeDir.y,
+        drag.startCenter[2] + metres * drag.probeDir.z,
+      ],
+    };
+  }
+
+  // resize: symmetric about center along the given LOCAL axis (the probe ran
+  // along the same local axis, so `metres` is already a local-frame length).
+  const idx = drag.op.axis === 'x' ? 0 : drag.op.axis === 'y' ? 1 : 2;
+  const nextHalf = Math.max(MIN_RESIZE_HALF_M, drag.startSize[idx] / 2 + metres);
+  const size: [number, number, number] = [...drag.startSize];
+  size[idx] = nextHalf * 2;
+  return { size };
+}

--- a/apps/viewer/src/hooks/useZoneAssignmentSync.ts
+++ b/apps/viewer/src/hooks/useZoneAssignmentSync.ts
@@ -1,0 +1,101 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Orchestrates zone assignment (issue #1810 v1): gathers a world-space AABB
+ * for every element across EVERY loaded model (mirrors `useClash` owning
+ * clash's gather-and-run step while `clashSlice` only holds state), runs
+ * the pure `assignElementsToZoneSets` engine, and writes the result into
+ * `zonesSlice`.
+ *
+ * Recomputes when:
+ *  - the federation's model set changes (a model was added/removed) —
+ *    `models` gets a fresh Map reference on every mutation
+ *    (`modelSlice.ts`), so referential inequality is exactly "federation
+ *    changed";
+ *  - `geometryUpdateTick` bumps — geometry for a model can finish uploading
+ *    to the `Scene` AFTER the model entry itself appears (streamed/async
+ *    load), so relying on `models` alone would compute against incomplete
+ *    bounding boxes;
+ *  - `zoneSets` changes — any zone create/edit/delete/move.
+ *
+ * Debounced by `RECOMPUTE_DEBOUNCE_MS` so a burst of geometry ticks during a
+ * big streamed load coalesces into one recompute instead of one per tick.
+ * Mount once near the viewport root (`ZoneAssignmentSync` below), same
+ * lifetime as the renderer.
+ */
+
+import { useEffect, useRef } from 'react';
+import { useViewerStore } from '@/store';
+import { getGlobalRenderer } from './useBCF.js';
+import { assignElementsToZoneSets, type ElementAABB } from '../lib/zones/index.js';
+
+const RECOMPUTE_DEBOUNCE_MS = 200;
+
+/** Gather a world-space AABB for every entity the renderer's `Scene` has
+ *  mesh data for — this already includes every loaded model (the scene is
+ *  shared across federation) and already folds `MeshData.origin` (see
+ *  `Scene.getEntityBoundingBox`), so no separate per-model AABB folding is
+ *  needed here. */
+function gatherElementBounds(): ElementAABB[] {
+  const renderer = getGlobalRenderer();
+  const scene = renderer?.getScene();
+  if (!scene) return [];
+  const elements: ElementAABB[] = [];
+  for (const globalId of scene.getAllMeshDataExpressIds()) {
+    const bbox = scene.getEntityBoundingBox(globalId);
+    if (!bbox) continue;
+    elements.push({
+      globalId,
+      min: [bbox.min.x, bbox.min.y, bbox.min.z],
+      max: [bbox.max.x, bbox.max.y, bbox.max.z],
+    });
+  }
+  return elements;
+}
+
+/** Run the assignment engine once, synchronously, and write the result +
+ *  timing into the store. Exported for tests / manual re-trigger (e.g. a
+ * "recompute now" button); `useZoneAssignmentSync` is the auto-recompute
+ * wiring. */
+export function recomputeZoneAssignmentsNow(): void {
+  const state = useViewerStore.getState();
+  if (state.zoneSets.length === 0) {
+    if (state.zoneAssignments.size > 0 || state.zoneAssignmentTiming !== null) {
+      state.setZoneAssignments(new Map(), { elapsedMs: 0, elementCount: 0, zoneSetCount: 0, computedAt: Date.now() });
+    }
+    return;
+  }
+  const elements = gatherElementBounds();
+  const t0 = performance.now();
+  const assignments = assignElementsToZoneSets(elements, state.zoneSets);
+  const elapsedMs = performance.now() - t0;
+  state.setZoneAssignments(assignments, {
+    elapsedMs,
+    elementCount: elements.length,
+    zoneSetCount: state.zoneSets.length,
+    computedAt: Date.now(),
+  });
+}
+
+/** Mount once (e.g. in `ViewportContainer`) to keep `zoneAssignments` live
+ *  as models load/unload and zones are authored. Renders nothing. */
+export function useZoneAssignmentSync(): void {
+  const models = useViewerStore((s) => s.models);
+  const geometryUpdateTick = useViewerStore((s) => s.geometryUpdateTick);
+  const zoneSets = useViewerStore((s) => s.zoneSets);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (timerRef.current !== null) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => {
+      timerRef.current = null;
+      recomputeZoneAssignmentsNow();
+    }, RECOMPUTE_DEBOUNCE_MS);
+    return () => {
+      if (timerRef.current !== null) clearTimeout(timerRef.current);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [models, geometryUpdateTick, zoneSets]);
+}

--- a/apps/viewer/src/hooks/useZoneSelection.test.ts
+++ b/apps/viewer/src/hooks/useZoneSelection.test.ts
@@ -1,0 +1,55 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { resolveZoneSelection } from './useZoneSelection.js';
+import type { ZoneAssignment, ZoneAssignmentsByElement } from '@/lib/zones/types';
+
+function assignment(overrides: Partial<ZoneAssignment>): ZoneAssignment {
+  return { zoneId: null, zoneName: null, straddles: false, touchedZoneIds: [], ...overrides };
+}
+
+const SET = 'set-1';
+
+function makeAssignments(): ZoneAssignmentsByElement {
+  return new Map([
+    [1, { [SET]: assignment({ zoneId: 'a', zoneName: 'A', touchedZoneIds: ['a'] }) }],
+    [2, { [SET]: assignment({ zoneId: 'b', zoneName: 'B', straddles: true, touchedZoneIds: ['a', 'b'] }) }],
+    [3, { [SET]: assignment({}) }], // unassigned bucket
+    [4, { [SET]: assignment({ zoneId: 'a', zoneName: 'A', touchedZoneIds: ['a'] }) }],
+  ]);
+}
+
+const resolveAll = (globalId: number) => ({ modelId: 'm1', expressId: globalId });
+
+describe('zones/resolveZoneSelection (PR #1869 review: channels must not diverge)', () => {
+  it('selects direct members plus straddlers touching the zone', () => {
+    const { globalIds, refs } = resolveZoneSelection(makeAssignments(), SET, 'a', resolveAll);
+    assert.deepStrictEqual(globalIds, [1, 2, 4]);
+    assert.deepStrictEqual(refs.map((r) => r.expressId), [1, 2, 4]);
+  });
+
+  it('zoneId null selects only the unassigned bucket', () => {
+    const { globalIds } = resolveZoneSelection(makeAssignments(), SET, null, resolveAll);
+    assert.deepStrictEqual(globalIds, [3]);
+  });
+
+  it('drops unresolvable ids from BOTH channels so the count matches what is highlighted', () => {
+    // Element 2's model was unloaded: fromGlobalId no longer resolves it.
+    const resolveExcept2 = (globalId: number) => (globalId === 2 ? null : resolveAll(globalId));
+    const { globalIds, refs } = resolveZoneSelection(makeAssignments(), SET, 'a', resolveExcept2);
+    // Previously globalIds kept 2 (highlight channel + toast count) while
+    // refs silently dropped it (model-aware channel) — the channels diverged.
+    assert.deepStrictEqual(globalIds, [1, 4]);
+    assert.strictEqual(refs.length, globalIds.length);
+    assert.deepStrictEqual(refs.map((r) => r.expressId), [1, 4]);
+  });
+
+  it('an unknown zone set matches nothing', () => {
+    const { globalIds, refs } = resolveZoneSelection(makeAssignments(), 'nope', 'a', resolveAll);
+    assert.deepStrictEqual(globalIds, []);
+    assert.deepStrictEqual(refs, []);
+  });
+});

--- a/apps/viewer/src/hooks/useZoneSelection.ts
+++ b/apps/viewer/src/hooks/useZoneSelection.ts
@@ -1,0 +1,57 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * "Select elements in zone X" (issue #1810). Reads the last-computed
+ * `zoneAssignments` (recomputed by `useZoneAssignmentSync`) and drives BOTH
+ * selection channels the same way every other multi-model selection entry
+ * point does (`ListResultsTable`, `useEntityListMultiSelect`): the
+ * renderer-highlight global-id set (`setSelectedEntityIds`) plus the
+ * model-aware ref set (`addEntitiesToSelection`), after clearing whatever
+ * was selected before.
+ *
+ * Not a React hook (no component state) — a plain function reading/writing
+ * the store directly, same shape as `recomputeZoneAssignmentsNow` in
+ * `useZoneAssignmentSync.ts`.
+ */
+
+import { useViewerStore } from '@/store';
+import type { EntityRef } from '@/store/types';
+
+/**
+ * Select every element assigned to `zoneId` within zone set `setId`.
+ * `zoneId: null` selects every element the set's assignment recorded as
+ * touching NO zone at all (the "unassigned" bucket) — distinct from an
+ * element that straddles multiple zones, which IS included when `zoneId`
+ * matches one of its `touchedZoneIds` (so "select zone A" also picks up
+ * elements straddling A and B, matching what the Lists `zone` column shows
+ * for that row).
+ *
+ * Returns the number of elements selected.
+ */
+export function selectElementsInZone(setId: string, zoneId: string | null): number {
+  const state = useViewerStore.getState();
+  const globalIds: number[] = [];
+  for (const [globalId, record] of state.zoneAssignments) {
+    const assignment = record[setId];
+    if (!assignment) continue;
+    const matches = zoneId === null
+      ? assignment.touchedZoneIds.length === 0
+      : assignment.zoneId === zoneId || assignment.touchedZoneIds.includes(zoneId);
+    if (matches) globalIds.push(globalId);
+  }
+
+  state.clearEntitySelection();
+  if (globalIds.length === 0) return 0;
+
+  const refs: EntityRef[] = [];
+  for (const globalId of globalIds) {
+    const lookup = state.fromGlobalId(globalId);
+    if (lookup) refs.push({ modelId: lookup.modelId, expressId: lookup.expressId });
+  }
+
+  state.setSelectedEntityIds(globalIds);
+  state.addEntitiesToSelection(refs);
+  return globalIds.length;
+}

--- a/apps/viewer/src/hooks/useZoneSelection.ts
+++ b/apps/viewer/src/hooks/useZoneSelection.ts
@@ -18,6 +18,49 @@
 
 import { useViewerStore } from '@/store';
 import type { EntityRef } from '@/store/types';
+import type { ZoneAssignmentsByElement } from '@/lib/zones/types';
+
+export interface ZoneSelectionResolution {
+  /** Global ids that matched AND resolved through `fromGlobalId` — feeds
+   *  `setSelectedEntityIds` (the channel that drives highlight and
+   *  frameSelection). */
+  globalIds: number[];
+  /** The same elements as `globalIds`, as model-aware refs for
+   *  `addEntitiesToSelection`. Always the same length as `globalIds`. */
+  refs: EntityRef[];
+}
+
+/**
+ * Pure core of {@link selectElementsInZone}, extracted for unit tests.
+ *
+ * A matched assignment whose global id no longer resolves through
+ * `fromGlobalId` (e.g. the model was unloaded between the last assignment
+ * recompute and this call) is dropped from BOTH outputs — the two selection
+ * channels must never diverge, and the caller's "Selected N element(s)"
+ * toast must count what was actually selected (PR #1869 review).
+ */
+export function resolveZoneSelection(
+  zoneAssignments: ZoneAssignmentsByElement,
+  setId: string,
+  zoneId: string | null,
+  fromGlobalId: (globalId: number) => { modelId: string; expressId: number } | null | undefined,
+): ZoneSelectionResolution {
+  const globalIds: number[] = [];
+  const refs: EntityRef[] = [];
+  for (const [globalId, record] of zoneAssignments) {
+    const assignment = record[setId];
+    if (!assignment) continue;
+    const matches = zoneId === null
+      ? assignment.touchedZoneIds.length === 0
+      : assignment.zoneId === zoneId || assignment.touchedZoneIds.includes(zoneId);
+    if (!matches) continue;
+    const lookup = fromGlobalId(globalId);
+    if (!lookup) continue;
+    globalIds.push(globalId);
+    refs.push({ modelId: lookup.modelId, expressId: lookup.expressId });
+  }
+  return { globalIds, refs };
+}
 
 /**
  * Select every element assigned to `zoneId` within zone set `setId`.
@@ -28,28 +71,19 @@ import type { EntityRef } from '@/store/types';
  * elements straddling A and B, matching what the Lists `zone` column shows
  * for that row).
  *
- * Returns the number of elements selected.
+ * Returns the number of elements actually selected (matched AND resolved).
  */
 export function selectElementsInZone(setId: string, zoneId: string | null): number {
   const state = useViewerStore.getState();
-  const globalIds: number[] = [];
-  for (const [globalId, record] of state.zoneAssignments) {
-    const assignment = record[setId];
-    if (!assignment) continue;
-    const matches = zoneId === null
-      ? assignment.touchedZoneIds.length === 0
-      : assignment.zoneId === zoneId || assignment.touchedZoneIds.includes(zoneId);
-    if (matches) globalIds.push(globalId);
-  }
+  const { globalIds, refs } = resolveZoneSelection(
+    state.zoneAssignments,
+    setId,
+    zoneId,
+    (globalId) => state.fromGlobalId(globalId),
+  );
 
   state.clearEntitySelection();
   if (globalIds.length === 0) return 0;
-
-  const refs: EntityRef[] = [];
-  for (const globalId of globalIds) {
-    const lookup = state.fromGlobalId(globalId);
-    if (lookup) refs.push({ modelId: lookup.modelId, expressId: lookup.expressId });
-  }
 
   state.setSelectedEntityIds(globalIds);
   state.addEntitiesToSelection(refs);

--- a/apps/viewer/src/hooks/useZoneStoreyGeneration.ts
+++ b/apps/viewer/src/hooks/useZoneStoreyGeneration.ts
@@ -4,7 +4,8 @@
 
 /**
  * "Generate a zone set from storeys" (issue #1810 generation path (b)):
- * one zone per building storey, spanning the model's XY bounds.
+ * one zone per building storey, spanning the model's horizontal X-Z
+ * footprint bounds (the viewer is Y-up).
  *
  * Storey collection reuses `elevationKey`/`compareStoreyEntries` from the
  * hierarchy tree builder — the SAME 0.5m-tolerance elevation-matching
@@ -61,7 +62,8 @@ function collectStoreysAcrossModels(): StoreyInfo[] {
 
 /**
  * Generate one zone per distinct storey elevation, spanning the union of
- * every loaded model's XY bounds (from the renderer's `Scene`, so it
+ * every loaded model's horizontal X-Z footprint bounds (from the renderer's
+ * Y-up `Scene`, so it
  * reflects everything currently loaded, federated or legacy single-model).
  */
 export function generateZonesFromStoreys(): GenerateStoreyZonesResult {

--- a/apps/viewer/src/hooks/useZoneStoreyGeneration.ts
+++ b/apps/viewer/src/hooks/useZoneStoreyGeneration.ts
@@ -1,0 +1,85 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * "Generate a zone set from storeys" (issue #1810 generation path (b)):
+ * one zone per building storey, spanning the model's XY bounds.
+ *
+ * Storey collection reuses `elevationKey`/`compareStoreyEntries` from the
+ * hierarchy tree builder — the SAME 0.5m-tolerance elevation-matching
+ * `buildUnifiedStoreys` uses to merge one federated storey across several
+ * models into a single row — so "Ground Floor" split across two federated
+ * files still yields ONE zone, not two overlapping ones. That function only
+ * activates for `models.size > 1`, so this re-implements the same key/merge
+ * logic to also cover the single/legacy-model path.
+ *
+ * The actual box math (spanning storeys → `Zone[]`) is the pure, unit-tested
+ * `generateStoreyZones` in `lib/zones`; this module is purely the "gather
+ * inputs from the loaded model(s) + renderer" glue, mirroring
+ * `useZoneAssignmentSync`'s gather-then-call-the-pure-engine shape.
+ */
+
+import { useViewerStore } from '@/store';
+import { elevationKey } from '@/components/viewer/hierarchy/treeDataBuilder';
+import { getGlobalRenderer } from './useBCF.js';
+import { generateStoreyZones, type Zone, type StoreyInfo } from '../lib/zones/index.js';
+
+export type GenerateStoreyZonesResult =
+  | { ok: true; zones: Zone[] }
+  | { ok: false; error: string };
+
+/** Union of every storey across every loaded model, deduplicated by
+ *  elevation (0.5m tolerance). When two models both declare a storey at the
+ *  same elevation, the shorter of the two names wins (matches
+ *  `buildUnifiedStoreys`' tie-break). */
+function collectStoreysAcrossModels(): StoreyInfo[] {
+  const state = useViewerStore.getState();
+  const byKey = new Map<string, StoreyInfo>();
+
+  const consider = (dataStore: { spatialHierarchy?: { storeyElevations: Map<number, number> } | null; entities: { getName(id: number): string } } | null | undefined) => {
+    const hierarchy = dataStore?.spatialHierarchy;
+    if (!hierarchy) return;
+    for (const [storeyId, elevation] of hierarchy.storeyElevations) {
+      const key = elevationKey(elevation);
+      const name = dataStore!.entities.getName(storeyId) || `Storey #${storeyId}`;
+      const existing = byKey.get(key);
+      if (!existing || name.length < existing.name.length) {
+        byKey.set(key, { id: key, name, elevation });
+      }
+    }
+  };
+
+  if (state.models.size > 0) {
+    for (const [, model] of state.models) consider(model.ifcDataStore);
+  } else if (state.ifcDataStore) {
+    consider(state.ifcDataStore);
+  }
+
+  return Array.from(byKey.values());
+}
+
+/**
+ * Generate one zone per distinct storey elevation, spanning the union of
+ * every loaded model's XY bounds (from the renderer's `Scene`, so it
+ * reflects everything currently loaded, federated or legacy single-model).
+ */
+export function generateZonesFromStoreys(): GenerateStoreyZonesResult {
+  const storeys = collectStoreysAcrossModels();
+  if (storeys.length === 0) {
+    return { ok: false, error: 'No building storeys found in the loaded model(s).' };
+  }
+
+  const scene = getGlobalRenderer()?.getScene();
+  const bounds = scene?.getBounds();
+  if (!bounds) {
+    return { ok: false, error: 'Model bounds are not available yet — wait for geometry to finish loading.' };
+  }
+
+  const zones = generateStoreyZones(
+    storeys,
+    { minX: bounds.min.x, maxX: bounds.max.x, minZ: bounds.min.z, maxZ: bounds.max.z },
+    () => crypto.randomUUID(),
+  );
+  return { ok: true, zones };
+}

--- a/apps/viewer/src/lib/lists/adapter.ts
+++ b/apps/viewer/src/lib/lists/adapter.ts
@@ -27,6 +27,21 @@ import { ENTITY_ATTRIBUTES } from '@ifc-lite/lists';
 import type { ListDataProvider, ListClassificationRef, DiscoveredColumns } from '@ifc-lite/lists';
 import { resolveEntityPredefinedType } from '../entity-predefined-type.js';
 import { buildSpatialAncestryIndex, type SpatialAncestryIndex } from '../../utils/spatialHierarchy.js';
+import type { ZoneSet, ZoneAssignmentsByElement } from '../zones/index.js';
+
+/**
+ * Zone assignment data (issue #1810), threaded in from the store so the
+ * `zone` column/condition source can resolve without the adapter knowing
+ * anything about how zones are authored. `toGlobalId` converts THIS model's
+ * local express id to the federated global id `zoneAssignments` is keyed by
+ * (single-model fallback: `globalId === expressId`, same contract as
+ * `FederationRegistry`).
+ */
+export interface ZoneListContext {
+  zoneSets: ZoneSet[];
+  zoneAssignments: ZoneAssignmentsByElement;
+  toGlobalId: (expressId: number) => number;
+}
 
 /** Collect every material-name string an element exposes — top-level
  *  material plus layer / constituent / profile names and list members. */
@@ -50,8 +65,17 @@ function materialNamesOf(info: MaterialInfo | null): string[] {
  * federation-identity column; pass the `FederatedModel.name` so a list over
  * several models can tell which file each row came from. Defaults to '' for the
  * single-model legacy path where there's nothing to disambiguate.
+ *
+ * `zoneContext`, when supplied, enables the `zone` column/condition source
+ * (issue #1810). Omit it (the default) and every `zone` column simply
+ * resolves to `null` — the same graceful-degradation contract every other
+ * optional `ListDataProvider` accessor follows.
  */
-export function createListDataProvider(store: IfcDataStore, modelName = ''): ListDataProvider {
+export function createListDataProvider(
+  store: IfcDataStore,
+  modelName = '',
+  zoneContext?: ZoneListContext,
+): ListDataProvider {
   // Cache for on-demand attribute extraction (description, objectType, tag)
   // These are not stored during initial parse to keep load times fast,
   // but are needed for list display. Cache avoids re-parsing per column.
@@ -343,5 +367,21 @@ export function createListDataProvider(store: IfcDataStore, modelName = ''): Lis
       };
       return columnsCache;
     },
+
+    ...(zoneContext ? {
+      getZoneAssignment(expressId: number, zoneSetId: string) {
+        const globalId = zoneContext.toGlobalId(expressId);
+        const assignment = zoneContext.zoneAssignments.get(globalId)?.[zoneSetId];
+        if (!assignment) return null;
+        const zoneSet = zoneContext.zoneSets.find((zs) => zs.id === zoneSetId);
+        const touchedZoneNames = assignment.touchedZoneIds
+          .map((zoneId) => zoneSet?.zones.find((z) => z.id === zoneId)?.name)
+          .filter((n): n is string => !!n);
+        return { zoneName: assignment.zoneName, straddles: assignment.straddles, touchedZoneNames };
+      },
+      getZoneSetNames() {
+        return zoneContext.zoneSets.map((zs) => ({ id: zs.id, name: zs.name }));
+      },
+    } : {}),
   };
 }

--- a/apps/viewer/src/lib/panels/registry.ts
+++ b/apps/viewer/src/lib/panels/registry.ts
@@ -31,6 +31,7 @@ import {
   ListTree,
   Users,
   Layers as LayersIcon,
+  Box,
   type LucideIcon,
 } from 'lucide-react';
 
@@ -52,7 +53,8 @@ export type WorkspacePanelId =
   | 'gantt'
   | 'lists'
   | 'collab'
-  | 'layers';
+  | 'layers'
+  | 'zones';
 
 /** Activity-bar clustering — a divider is drawn whenever the group changes. */
 export type PanelGroup = 'navigate' | 'inspect' | 'review' | 'author' | 'work';
@@ -102,6 +104,9 @@ export const WORKSPACE_PANELS: readonly WorkspacePanelDef[] = [
   // Alt+1..0 mapping stays intact (no Alt shortcut). The activity bar only
   // surfaces it while a federated layer stack is loaded.
   { id: 'layers', title: 'Layer stack', short: 'Layers', Icon: LayersIcon, group: 'review', region: 'side' },
+  // Location zones (construction sections / takt areas, #1810). APPENDED so
+  // the frozen Alt+1..0 mapping stays intact (no Alt shortcut).
+  { id: 'zones', title: 'Location zones', short: 'Zones', Icon: Box, group: 'review', region: 'side' },
 ];
 
 /** The bottom-strip panel ids, mapped to their store visibility flag + setter

--- a/apps/viewer/src/lib/panels/renderPanelBody.tsx
+++ b/apps/viewer/src/lib/panels/renderPanelBody.tsx
@@ -25,6 +25,7 @@ import { ScriptPanel } from '@/components/viewer/ScriptPanel';
 import { GanttPanel } from '@/components/viewer/schedule/GanttPanel';
 import { ListPanel } from '@/components/viewer/lists/ListPanel';
 import { RoomPanel } from '@/components/viewer/RoomPanel';
+import { ZonesPanel } from '@/components/viewer/ZonesPanel';
 // Lazy: the Layers panel pulls in @ifc-lite/merge (engine + blake3); a
 // dynamic chunk keeps it out of the initial bundle until first opened.
 const LayersPanel = lazy(() =>
@@ -52,6 +53,7 @@ export function renderPanelBody(id: WorkspacePanelId, onClose: () => void): Reac
     case 'gantt': return <GanttPanel onClose={onClose} />;
     case 'lists': return <ListPanel onClose={onClose} />;
     case 'collab': return <RoomPanel onClose={onClose} />;
+    case 'zones': return <ZonesPanel onClose={onClose} />;
     case 'layers': return (
       <Suspense fallback={null}>
         <LayersPanel onClose={onClose} />

--- a/apps/viewer/src/lib/zones/assignment.test.ts
+++ b/apps/viewer/src/lib/zones/assignment.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
-import { assignElementsToZoneSet, assignElementsToZoneSets } from './assignment.js';
+import { assignElementsToZoneSet, assignElementsToZoneSets, STRADDLE_PENETRATION_M } from './assignment.js';
 import type { ElementAABB, Zone, ZoneSet } from './types.js';
 
 function makeZone(id: string, centerX: number, overrides: Partial<Zone> = {}): Zone {
@@ -100,5 +100,48 @@ describe('zones/assignment', () => {
     for (const id of [1, 2]) {
       assert.strictEqual(byElement.get(id)!.a.zoneId, null);
     }
+  });
+
+  // Zone sets that TILE a building (takt areas / construction sections) are
+  // the primary use case, so two zones sharing an exact boundary plane is the
+  // common case, not an edge case. An element ENDING exactly at that shared
+  // boundary (a wall or slab, very common) must not register as straddling
+  // with zero real overlap into the neighbour — that would flood the flag
+  // precisely on the models this feature targets. See STRADDLE_PENETRATION_M.
+  describe('shared zone-set boundaries (adversarial review follow-up)', () => {
+    // Zone A x=[0,10], Zone B x=[10,20] — share the boundary plane at x=10.
+    const tiledZoneSet = makeZoneSet('s1', [makeZone('a', 5), makeZone('b', 15)]);
+
+    it('an element ending exactly at the shared boundary touches only its own zone, no straddle', () => {
+      const elements = [el(1, 8, 10)]; // ends exactly at x=10, zero penetration into B
+      const result = assignElementsToZoneSet(elements, tiledZoneSet);
+      const a = result.get(1)!;
+      assert.strictEqual(a.zoneId, 'a');
+      assert.strictEqual(a.straddles, false);
+      assert.deepStrictEqual(a.touchedZoneIds, ['a']);
+    });
+
+    it('an element penetrating past the boundary by more than the threshold DOES straddle', () => {
+      // 5cm into zone B — comfortably past STRADDLE_PENETRATION_M (1mm).
+      assert.ok(0.05 > STRADDLE_PENETRATION_M);
+      const elements = [el(1, 8, 10.05)];
+      const result = assignElementsToZoneSet(elements, tiledZoneSet);
+      const a = result.get(1)!;
+      assert.strictEqual(a.straddles, true);
+      assert.deepStrictEqual(a.touchedZoneIds.sort(), ['a', 'b']);
+      assert.strictEqual(a.zoneId, 'a'); // centroid (x=9.025) is still deep inside A
+    });
+
+    it('a degenerate zero-thickness AABB lying exactly ON the boundary is UNASSIGNED, not straddling', () => {
+      // A collapsed/flattened element sitting exactly at the shared plane
+      // penetrates NEITHER neighbour by the threshold, so it touches no
+      // zone at all — documented behaviour, not an oversight.
+      const elements: ElementAABB[] = [{ globalId: 1, min: [10, -1, -1], max: [10, 1, 1] }];
+      const result = assignElementsToZoneSet(elements, tiledZoneSet);
+      const a = result.get(1)!;
+      assert.strictEqual(a.zoneId, null);
+      assert.strictEqual(a.straddles, false);
+      assert.deepStrictEqual(a.touchedZoneIds, []);
+    });
   });
 });

--- a/apps/viewer/src/lib/zones/assignment.test.ts
+++ b/apps/viewer/src/lib/zones/assignment.test.ts
@@ -1,0 +1,104 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { assignElementsToZoneSet, assignElementsToZoneSets } from './assignment.js';
+import type { ElementAABB, Zone, ZoneSet } from './types.js';
+
+function makeZone(id: string, centerX: number, overrides: Partial<Zone> = {}): Zone {
+  return {
+    id,
+    name: `Zone ${id}`,
+    center: [centerX, 0, 0],
+    size: [10, 10, 10],
+    rotationY: 0,
+    ...overrides,
+  };
+}
+
+function makeZoneSet(id: string, zones: Zone[]): ZoneSet {
+  return { id, name: `Set ${id}`, zones, visible: true, createdAt: 0, updatedAt: 0 };
+}
+
+function el(globalId: number, minX: number, maxX: number): ElementAABB {
+  return { globalId, min: [minX, -1, -1], max: [maxX, 1, 1] };
+}
+
+describe('zones/assignment', () => {
+  it('assigns an element fully inside one zone to that zone, not straddling', () => {
+    // Zone A at x=[-5,5], Zone B at x=[15,25] (adjacent zones side by side).
+    const zoneSet = makeZoneSet('s1', [makeZone('a', 0), makeZone('b', 20)]);
+    const elements = [el(1, -2, 2)];
+    const result = assignElementsToZoneSet(elements, zoneSet);
+    const a = result.get(1)!;
+    assert.strictEqual(a.zoneId, 'a');
+    assert.strictEqual(a.straddles, false);
+    assert.deepStrictEqual(a.touchedZoneIds, ['a']);
+  });
+
+  it('flags an element whose AABB crosses two zone boundaries as straddling', () => {
+    // Zone A x=[-5,5], Zone B x=[5,15] (share the x=5 boundary exactly).
+    const zoneSet = makeZoneSet('s1', [makeZone('a', 0), makeZone('b', 10)]);
+    const elements = [el(1, 3, 8)]; // spans across the shared boundary
+    const result = assignElementsToZoneSet(elements, zoneSet);
+    const a = result.get(1)!;
+    assert.strictEqual(a.straddles, true);
+    assert.deepStrictEqual(a.touchedZoneIds.sort(), ['a', 'b']);
+    // Centroid at x=5.5 falls inside zone b's [5,15] half-open reach (with
+    // the shared-boundary eps both zones technically touch x=5, but the
+    // centroid itself is unambiguously in b).
+    assert.strictEqual(a.zoneId, 'b');
+  });
+
+  it('leaves an element outside every zone unassigned, not straddling', () => {
+    const zoneSet = makeZoneSet('s1', [makeZone('a', 0)]);
+    const elements = [el(1, 100, 101)];
+    const result = assignElementsToZoneSet(elements, zoneSet);
+    const a = result.get(1)!;
+    assert.strictEqual(a.zoneId, null);
+    assert.strictEqual(a.straddles, false);
+    assert.deepStrictEqual(a.touchedZoneIds, []);
+  });
+
+  it('flags straddling when the element overlaps a zone but its centroid sits outside every zone', () => {
+    // Element spans from well inside zone A out into empty space beyond it,
+    // so its centroid lands outside A but its AABB still overlaps A.
+    const zoneSet = makeZoneSet('s1', [makeZone('a', 0)]); // x in [-5, 5]
+    const elements = [el(1, 4, 20)]; // centroid at x=12, outside A; overlaps A [4,5]
+    const result = assignElementsToZoneSet(elements, zoneSet);
+    const a = result.get(1)!;
+    assert.strictEqual(a.zoneId, null);
+    assert.strictEqual(a.straddles, true);
+    assert.deepStrictEqual(a.touchedZoneIds, ['a']);
+  });
+
+  it('an empty zone set leaves every element unassigned', () => {
+    const zoneSet = makeZoneSet('s1', []);
+    const elements = [el(1, 0, 1), el(2, 50, 51)];
+    const result = assignElementsToZoneSet(elements, zoneSet);
+    assert.strictEqual(result.get(1)!.zoneId, null);
+    assert.strictEqual(result.get(2)!.zoneId, null);
+  });
+
+  it('assignElementsToZoneSets classifies independently per set', () => {
+    const sections = makeZoneSet('sections', [makeZone('sec-a', 0)]);
+    const takt = makeZoneSet('takt', [makeZone('takt-a', 0, { size: [4, 10, 10] })]);
+    const elements = [el(1, -1, 1)]; // inside both sec-a (wide) and takt-a (narrow)
+    const byElement = assignElementsToZoneSets(elements, [sections, takt]);
+    const record = byElement.get(1)!;
+    assert.strictEqual(record.sections.zoneId, 'sec-a');
+    assert.strictEqual(record.takt.zoneId, 'takt-a');
+  });
+
+  it('is O(elements x zones): every element gets an entry for every zone set even with no overlap', () => {
+    const setA = makeZoneSet('a', [makeZone('z', 1000)]); // far away
+    const elements = [el(1, 0, 1), el(2, 2, 3)];
+    const byElement = assignElementsToZoneSets(elements, [setA]);
+    assert.strictEqual(byElement.size, 2);
+    for (const id of [1, 2]) {
+      assert.strictEqual(byElement.get(id)!.a.zoneId, null);
+    }
+  });
+});

--- a/apps/viewer/src/lib/zones/assignment.test.ts
+++ b/apps/viewer/src/lib/zones/assignment.test.ts
@@ -132,16 +132,77 @@ describe('zones/assignment', () => {
       assert.strictEqual(a.zoneId, 'a'); // centroid (x=9.025) is still deep inside A
     });
 
-    it('a degenerate zero-thickness AABB lying exactly ON the boundary is UNASSIGNED, not straddling', () => {
-      // A collapsed/flattened element sitting exactly at the shared plane
-      // penetrates NEITHER neighbour by the threshold, so it touches no
-      // zone at all — documented behaviour, not an oversight.
+    it('a degenerate zero-thickness AABB lying exactly ON the boundary picks a deterministic side, not straddling', () => {
+      // A collapsed/flattened element sitting exactly at the shared plane:
+      // its centroid lies on BOTH zones' inclusive boundary, so the home
+      // zone is the first containing zone in set order (a deterministic
+      // tie-break by zone order, never float noise). It penetrates neither
+      // neighbour past the threshold, so it does not straddle.
       const elements: ElementAABB[] = [{ globalId: 1, min: [10, -1, -1], max: [10, 1, 1] }];
       const result = assignElementsToZoneSet(elements, tiledZoneSet);
       const a = result.get(1)!;
-      assert.strictEqual(a.zoneId, null);
+      assert.strictEqual(a.zoneId, 'a');
       assert.strictEqual(a.straddles, false);
-      assert.deepStrictEqual(a.touchedZoneIds, []);
+      assert.deepStrictEqual(a.touchedZoneIds, ['a']);
+    });
+  });
+
+  // PR #1869 review: centroid membership must NOT be gated behind the
+  // straddle-penetration overlap test. A sliver-thin element hugging a
+  // zone's outer face has an in-zone centroid but an overlap depth below
+  // STRADDLE_PENETRATION_M on its thin axis; it previously fell through to
+  // UNASSIGNED. Home-zone containment is now decided independently.
+  describe('thin elements near a zone face (PR #1869 regression)', () => {
+    // Zone A spans [-5, 5] on every axis.
+    const zoneSet = makeZoneSet('s1', [
+      { id: 'a', name: 'Zone a', center: [0, 0, 0], size: [10, 10, 10], rotationY: 0 },
+    ]);
+
+    it('a 0.5mm-thick element inside the +X face is assigned, not UNASSIGNED', () => {
+      const elements: ElementAABB[] = [{ globalId: 1, min: [4.9995, -1, -1], max: [5, 1, 1] }];
+      const a = assignElementsToZoneSet(elements, zoneSet).get(1)!;
+      assert.strictEqual(a.zoneId, 'a');
+      assert.strictEqual(a.straddles, false);
+      assert.deepStrictEqual(a.touchedZoneIds, ['a']);
+    });
+
+    it('a 0.5mm-thick element inside the +Y face is assigned, not UNASSIGNED', () => {
+      const elements: ElementAABB[] = [{ globalId: 1, min: [-1, 4.9995, -1], max: [1, 5, 1] }];
+      const a = assignElementsToZoneSet(elements, zoneSet).get(1)!;
+      assert.strictEqual(a.zoneId, 'a');
+      assert.strictEqual(a.straddles, false);
+      assert.deepStrictEqual(a.touchedZoneIds, ['a']);
+    });
+
+    it('a 0.5mm-thick element inside the +Z face is assigned, not UNASSIGNED', () => {
+      const elements: ElementAABB[] = [{ globalId: 1, min: [-1, -1, 4.9995], max: [1, 1, 5] }];
+      const a = assignElementsToZoneSet(elements, zoneSet).get(1)!;
+      assert.strictEqual(a.zoneId, 'a');
+      assert.strictEqual(a.straddles, false);
+      assert.deepStrictEqual(a.touchedZoneIds, ['a']);
+    });
+
+    it('centroid in zone A while also genuinely penetrating zone B: home stays A, straddles, touches both', () => {
+      // A x=[0,10], B x=[10,20]; element x=[9, 10.05] — centroid at 9.525
+      // (inside A), penetrating 5cm into B (past the 1mm threshold).
+      const tiled = makeZoneSet('s1', [makeZone('a', 5), makeZone('b', 15)]);
+      const a = assignElementsToZoneSet([el(1, 9, 10.05)], tiled).get(1)!;
+      assert.strictEqual(a.zoneId, 'a');
+      assert.strictEqual(a.straddles, true);
+      assert.deepStrictEqual(a.touchedZoneIds.sort(), ['a', 'b']);
+    });
+
+    it('a sub-threshold sliver crossing the shared plane resolves by centroid alone, no straddle', () => {
+      // A x=[0,10], B x=[10,20]; element x=[9.9993, 10.0005]: centroid at
+      // 9.9999 (inside A), overlap depth into A (0.7mm) and into B (0.5mm)
+      // both below the 1mm penetration threshold. No zone is "penetrated",
+      // so the home zone from the centroid must decide the assignment on
+      // its own — previously this fell through to UNASSIGNED.
+      const tiled = makeZoneSet('s1', [makeZone('a', 5), makeZone('b', 15)]);
+      const a = assignElementsToZoneSet([el(1, 9.9993, 10.0005)], tiled).get(1)!;
+      assert.strictEqual(a.zoneId, 'a');
+      assert.strictEqual(a.straddles, false);
+      assert.deepStrictEqual(a.touchedZoneIds, ['a']);
     });
   });
 });

--- a/apps/viewer/src/lib/zones/assignment.ts
+++ b/apps/viewer/src/lib/zones/assignment.ts
@@ -50,11 +50,18 @@ export const STRADDLE_PENETRATION_M = 0.001;
  *  allocation in the inner loop. See `geometry.ts`'s `CompiledZone` doc for
  *  why that matters at scale.
  *
- *  A degenerate, zero-thickness AABB lying EXACTLY on a shared zone
- *  boundary (e.g. a flattened/collapsed element) penetrates neither
- *  neighbour by `STRADDLE_PENETRATION_M`, so it touches no zone and
- *  classifies UNASSIGNED rather than straddling or picking an arbitrary
- *  side — see the "zero-thickness on boundary" test in assignment.test.ts. */
+ *  The home zone is determined by centroid containment INDEPENDENTLY of the
+ *  `STRADDLE_PENETRATION_M` gate — a sliver-thin element hugging a zone's
+ *  outer face (overlap depth below the threshold on its thin axis) still has
+ *  an in-zone centroid and MUST classify into that zone, not UNASSIGNED
+ *  (review finding on PR #1869; regression tests in assignment.test.ts).
+ *  The penetration threshold only decides which ADDITIONAL zones count as
+ *  "touched" for the straddle flag.
+ *
+ *  A degenerate zero-thickness AABB lying EXACTLY on a shared zone boundary
+ *  has its centroid on both zones' inclusive boundary, so it deterministically
+ *  classifies into the first such zone in set order (ties broken by zone
+ *  order, never by float noise) — see the "zero-thickness on boundary" test. */
 export function assignElementsToZoneSet(
   elements: readonly ElementAABB[],
   zoneSet: ZoneSet,
@@ -80,16 +87,21 @@ export function assignElementsToZoneSet(
     const touched: string[] = [];
 
     for (const zone of compiled) {
-      // Real penetration only (negative eps) — see STRADDLE_PENETRATION_M.
-      // Centroid-inside implies deep overlap for any non-degenerate AABB, so
-      // this gate essentially never disagrees with the (separately, more
-      // loosely) tested home-zone containment below — except exactly the
-      // zero-thickness-on-a-boundary case documented above.
-      if (!zoneOverlapsAABBCompiled(minX, minY, minZ, maxX, maxY, maxZ, zone, -STRADDLE_PENETRATION_M)) continue;
-      touched.push(zone.id);
-      if (homeZoneId === null && isPointInCompiledZone(cx, cy, cz, zone)) {
+      // Home zone: centroid containment, decided INDEPENDENTLY of the
+      // penetration gate below. Gating it behind the straddle threshold
+      // wrongly dropped sliver-thin elements whose overlap depth on their
+      // thin axis is below STRADDLE_PENETRATION_M even though they sit
+      // wholly inside the zone (PR #1869 review).
+      const isHome = homeZoneId === null && isPointInCompiledZone(cx, cy, cz, zone);
+      if (isHome) {
         homeZoneId = zone.id;
         homeZoneName = zone.name;
+      }
+      // "Touched" demands real penetration (negative eps) so boundary-abutting
+      // elements in tiling zone sets don't flood the straddle flag — see
+      // STRADDLE_PENETRATION_M. The home zone always counts as touched.
+      if (isHome || zoneOverlapsAABBCompiled(minX, minY, minZ, maxX, maxY, maxZ, zone, -STRADDLE_PENETRATION_M)) {
+        touched.push(zone.id);
       }
     }
 

--- a/apps/viewer/src/lib/zones/assignment.ts
+++ b/apps/viewer/src/lib/zones/assignment.ts
@@ -1,0 +1,95 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Element-to-zone classification (issue #1810 v1). Pure and side-effect
+ * free so it's unit-testable without a loaded model or a renderer: callers
+ * (the viewer store) are responsible for gathering `ElementAABB[]` across
+ * every federated model and feeding it in here.
+ *
+ * Complexity is O(elements × zones-in-set) per zone set — see
+ * `zoneOverlapsAABB` for why each check is cheap (two 1-D/2-D interval
+ * tests, no matrix work). Measured cost for a synthetic 100k-element /
+ * 20-zone workload is recorded in the PR description; this runs on the main
+ * thread (no worker) because it stays well under the 100ms budget in
+ * AGENTS.md's quality bar.
+ */
+
+import { compileZone, isPointInCompiledZone, zoneOverlapsAABBCompiled } from './geometry.js';
+import type { ElementAABB, ZoneAssignment, ZoneAssignmentsByElement, ZoneSet } from './types.js';
+
+const UNASSIGNED: ZoneAssignment = {
+  zoneId: null,
+  zoneName: null,
+  straddles: false,
+  touchedZoneIds: [],
+};
+
+/** Classify every element in `elements` against every zone in `zoneSet`.
+ *  Each zone's trig/half-extents are compiled once (not once per element),
+ *  so this is `O(elements x zones-in-set)` cheap scalar arithmetic — no
+ *  allocation in the inner loop. See `geometry.ts`'s `CompiledZone` doc for
+ *  why that matters at scale. */
+export function assignElementsToZoneSet(
+  elements: readonly ElementAABB[],
+  zoneSet: ZoneSet,
+): Map<number, ZoneAssignment> {
+  const out = new Map<number, ZoneAssignment>();
+  const zones = zoneSet.zones;
+  if (zones.length === 0) {
+    for (const el of elements) out.set(el.globalId, UNASSIGNED);
+    return out;
+  }
+
+  const compiled = zones.map(compileZone);
+
+  for (const el of elements) {
+    const [minX, minY, minZ] = el.min;
+    const [maxX, maxY, maxZ] = el.max;
+    const cx = (minX + maxX) / 2;
+    const cy = (minY + maxY) / 2;
+    const cz = (minZ + maxZ) / 2;
+
+    let homeZoneId: string | null = null;
+    let homeZoneName: string | null = null;
+    const touched: string[] = [];
+
+    for (const zone of compiled) {
+      if (!zoneOverlapsAABBCompiled(minX, minY, minZ, maxX, maxY, maxZ, zone)) continue;
+      touched.push(zone.id);
+      if (homeZoneId === null && isPointInCompiledZone(cx, cy, cz, zone)) {
+        homeZoneId = zone.id;
+        homeZoneName = zone.name;
+      }
+    }
+
+    const straddles = touched.length > 1 || (touched.length === 1 && homeZoneId === null);
+    out.set(el.globalId, touched.length === 0
+      ? UNASSIGNED
+      : { zoneId: homeZoneId, zoneName: homeZoneName, straddles, touchedZoneIds: touched });
+  }
+
+  return out;
+}
+
+/** Classify every element against every zone set, keyed `globalId ->
+ *  (zoneSetId -> ZoneAssignment)`. A zone set with zero zones still gets an
+ *  entry per element (all `UNASSIGNED`) so callers (e.g. the Lists column)
+ *  can tell "the set exists but this element matched nothing" apart from
+ *  "the set doesn't exist". */
+export function assignElementsToZoneSets(
+  elements: readonly ElementAABB[],
+  zoneSets: readonly ZoneSet[],
+): ZoneAssignmentsByElement {
+  const perSet = zoneSets.map((zs) => ({ id: zs.id, result: assignElementsToZoneSet(elements, zs) }));
+  const out: ZoneAssignmentsByElement = new Map();
+  for (const el of elements) {
+    const record: Record<string, ZoneAssignment> = {};
+    for (const { id, result } of perSet) {
+      record[id] = result.get(el.globalId) ?? UNASSIGNED;
+    }
+    out.set(el.globalId, record);
+  }
+  return out;
+}

--- a/apps/viewer/src/lib/zones/assignment.ts
+++ b/apps/viewer/src/lib/zones/assignment.ts
@@ -26,11 +26,35 @@ const UNASSIGNED: ZoneAssignment = {
   touchedZoneIds: [],
 };
 
+/**
+ * Minimum overlap depth (metres) an element's AABB must penetrate a zone by,
+ * on every SAT axis, to count as "touching" that zone for straddle purposes.
+ *
+ * The primary use case is zone SETS THAT TILE the building — takt areas /
+ * construction sections sharing exact boundary planes. A wall or slab
+ * ending exactly at that shared boundary is the common case, not the
+ * exception: its AABB abuts, but does not penetrate, the neighbouring zone.
+ * `zoneOverlapsAABBCompiled`'s default epsilon is INCLUSIVE (a positive
+ * slack that treats exact/near contact as overlap, which is what the
+ * home-zone containment test wants), so using it here would flag nearly
+ * every boundary-adjacent element as straddling with zero actual overlap —
+ * flooding the flag on precisely the models this feature targets. Passing
+ * a NEGATIVE epsilon (see `zoneOverlapsAABBCompiled`'s doc) instead demands
+ * real penetration past this threshold before two zones are both "touched".
+ */
+export const STRADDLE_PENETRATION_M = 0.001;
+
 /** Classify every element in `elements` against every zone in `zoneSet`.
  *  Each zone's trig/half-extents are compiled once (not once per element),
  *  so this is `O(elements x zones-in-set)` cheap scalar arithmetic — no
  *  allocation in the inner loop. See `geometry.ts`'s `CompiledZone` doc for
- *  why that matters at scale. */
+ *  why that matters at scale.
+ *
+ *  A degenerate, zero-thickness AABB lying EXACTLY on a shared zone
+ *  boundary (e.g. a flattened/collapsed element) penetrates neither
+ *  neighbour by `STRADDLE_PENETRATION_M`, so it touches no zone and
+ *  classifies UNASSIGNED rather than straddling or picking an arbitrary
+ *  side — see the "zero-thickness on boundary" test in assignment.test.ts. */
 export function assignElementsToZoneSet(
   elements: readonly ElementAABB[],
   zoneSet: ZoneSet,
@@ -56,7 +80,12 @@ export function assignElementsToZoneSet(
     const touched: string[] = [];
 
     for (const zone of compiled) {
-      if (!zoneOverlapsAABBCompiled(minX, minY, minZ, maxX, maxY, maxZ, zone)) continue;
+      // Real penetration only (negative eps) — see STRADDLE_PENETRATION_M.
+      // Centroid-inside implies deep overlap for any non-degenerate AABB, so
+      // this gate essentially never disagrees with the (separately, more
+      // loosely) tested home-zone containment below — except exactly the
+      // zero-thickness-on-a-boundary case documented above.
+      if (!zoneOverlapsAABBCompiled(minX, minY, minZ, maxX, maxY, maxZ, zone, -STRADDLE_PENETRATION_M)) continue;
       touched.push(zone.id);
       if (homeZoneId === null && isPointInCompiledZone(cx, cy, cz, zone)) {
         homeZoneId = zone.id;

--- a/apps/viewer/src/lib/zones/colors.ts
+++ b/apps/viewer/src/lib/zones/colors.ts
@@ -1,0 +1,34 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Deterministic per-zone colour so a zone set with no explicit `Zone.color`
+ * still renders each box in a distinct, stable hue (stable across reloads
+ * because it's derived from the zone's index, not `Math.random()`).
+ */
+
+/** 8-colour palette, evenly spaced hues at fixed saturation/lightness so
+ *  every colour reads clearly against both light and dark scenes. */
+const PALETTE_HUES = [210, 25, 140, 280, 50, 190, 320, 90] as const;
+
+function hslToRgb01(h: number, s: number, l: number): [number, number, number] {
+  const c = (1 - Math.abs(2 * l - 1)) * s;
+  const hp = (h % 360) / 60;
+  const x = c * (1 - Math.abs((hp % 2) - 1));
+  let [r, g, b] = [0, 0, 0];
+  if (hp < 1) [r, g, b] = [c, x, 0];
+  else if (hp < 2) [r, g, b] = [x, c, 0];
+  else if (hp < 3) [r, g, b] = [0, c, x];
+  else if (hp < 4) [r, g, b] = [0, x, c];
+  else if (hp < 5) [r, g, b] = [x, 0, c];
+  else [r, g, b] = [c, 0, x];
+  const m = l - c / 2;
+  return [r + m, g + m, b + m];
+}
+
+/** Deterministic display colour for the zone at `index` within its set. */
+export function zoneColorForIndex(index: number): [number, number, number] {
+  const hue = PALETTE_HUES[index % PALETTE_HUES.length];
+  return hslToRgb01(hue, 0.65, 0.55);
+}

--- a/apps/viewer/src/lib/zones/geometry.test.ts
+++ b/apps/viewer/src/lib/zones/geometry.test.ts
@@ -1,0 +1,156 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import {
+  isPointInZone,
+  worldToZoneLocal,
+  zoneOverlapsAABB,
+  zoneWorldAABB,
+  zoneWorldCorners,
+} from './geometry.js';
+import type { Zone } from './types.js';
+
+function makeZone(overrides: Partial<Zone> = {}): Zone {
+  return {
+    id: 'z1',
+    name: 'Zone 1',
+    center: [0, 0, 0],
+    size: [10, 3, 10],
+    rotationY: 0,
+    ...overrides,
+  };
+}
+
+describe('zones/geometry', () => {
+  describe('isPointInZone (axis-aligned)', () => {
+    it('accepts the center', () => {
+      assert.strictEqual(isPointInZone([0, 0, 0], makeZone()), true);
+    });
+
+    it('accepts a point just inside the boundary', () => {
+      assert.strictEqual(isPointInZone([4.99, 1.49, 4.99], makeZone()), true);
+    });
+
+    it('rejects a point just outside the boundary', () => {
+      assert.strictEqual(isPointInZone([5.01, 0, 0], makeZone()), false);
+    });
+
+    it('rejects a point outside on the vertical axis', () => {
+      assert.strictEqual(isPointInZone([0, 10, 0], makeZone()), false);
+    });
+  });
+
+  describe('isPointInZone (rotated 45 degrees)', () => {
+    // A 10x10 footprint square rotated 45deg has corners at distance
+    // 10/sqrt(2) ~= 7.07 along the world axes, and its edge midpoints at
+    // distance 5 along the diagonals.
+    const zone = makeZone({ rotationY: Math.PI / 4 });
+
+    it('accepts the center', () => {
+      assert.strictEqual(isPointInZone([0, 0, 0], zone), true);
+    });
+
+    it('accepts a point along the world X axis within the rotated diamond', () => {
+      // World point (6, 0, 0): local = rotate by -45deg.
+      assert.strictEqual(isPointInZone([6, 0, 0], zone), true);
+    });
+
+    it('rejects a point along the world X axis beyond the rotated diamond', () => {
+      // Half-extent in local space is 5; along a world axis the rotated
+      // square only reaches out to 5/cos(45deg) ~= 7.07 at the diagonal,
+      // but along the pure X axis the local |x| grows faster than that —
+      // 8 world units puts local x/z well past the 5 half-extent.
+      assert.strictEqual(isPointInZone([8, 0, 0], zone), false);
+    });
+
+    it('accepts a point straight along the rotated local X axis (a diagonal in world space)', () => {
+      // Local (4.9, 0, 0) rotated by +45deg into world space.
+      const cos = Math.cos(Math.PI / 4);
+      const sin = Math.sin(Math.PI / 4);
+      const worldPoint: [number, number, number] = [4.9 * cos, 0, 4.9 * sin];
+      assert.strictEqual(isPointInZone(worldPoint, zone), true);
+    });
+  });
+
+  describe('worldToZoneLocal', () => {
+    it('is the identity (minus center) for an unrotated zone', () => {
+      const zone = makeZone({ center: [1, 2, 3] });
+      const [lx, ly, lz] = worldToZoneLocal([4, 6, 8], zone);
+      assert.ok(Math.abs(lx - 3) < 1e-9);
+      assert.ok(Math.abs(ly - 4) < 1e-9);
+      assert.ok(Math.abs(lz - 5) < 1e-9);
+    });
+
+    it('round-trips through a 90-degree rotation', () => {
+      const zone = makeZone({ center: [0, 0, 0], rotationY: Math.PI / 2 });
+      // World +X should map to local -Z (or +Z depending on sign convention)
+      // at unit magnitude — just assert the Y component passes through
+      // untouched and the horizontal magnitude is preserved (rotation is
+      // length-preserving).
+      const [lx, ly, lz] = worldToZoneLocal([5, 1, 0], zone);
+      assert.ok(Math.abs(ly - 1) < 1e-9);
+      assert.ok(Math.abs(Math.hypot(lx, lz) - 5) < 1e-9);
+    });
+  });
+
+  describe('zoneOverlapsAABB', () => {
+    it('detects an AABB fully inside an axis-aligned zone', () => {
+      const zone = makeZone();
+      assert.strictEqual(zoneOverlapsAABB([-1, -1, -1], [1, 1, 1], zone), true);
+    });
+
+    it('detects no overlap when far away', () => {
+      const zone = makeZone();
+      assert.strictEqual(zoneOverlapsAABB([100, 0, 0], [101, 1, 1], zone), false);
+    });
+
+    it('detects a boundary-straddling AABB (partially in, partially out)', () => {
+      const zone = makeZone(); // spans x in [-5, 5]
+      assert.strictEqual(zoneOverlapsAABB([4, 0, 0], [6, 1, 1], zone), true);
+    });
+
+    it('detects overlap purely on the vertical axis boundary', () => {
+      const zone = makeZone(); // spans y in [-1.5, 1.5]
+      assert.strictEqual(zoneOverlapsAABB([-1, 1.4, -1], [1, 5, 1], zone), true);
+      assert.strictEqual(zoneOverlapsAABB([-1, 2, -1], [1, 5, 1], zone), false);
+    });
+
+    it('correctly separates a rotated zone from an AABB that only overlaps its unrotated bounding box', () => {
+      // A 45deg-rotated 10x10 (footprint) zone's own AABB is ~14.14x14.14,
+      // but its corner (the diamond tip) is missing outside the true
+      // rotated shape — an AABB placed in that missing corner must NOT
+      // register as overlapping even though it sits inside the rotated
+      // zone's axis-aligned bounding box.
+      const zone = makeZone({ rotationY: Math.PI / 4 });
+      // World corner near (7, 0, 7) is well outside the rotated diamond
+      // (whose farthest extent along a world axis combination there is
+      // bounded by the local half-extent of 5).
+      assert.strictEqual(zoneOverlapsAABB([6.5, -0.1, 6.5], [7, 0.1, 7], zone), false);
+    });
+  });
+
+  describe('zoneWorldCorners / zoneWorldAABB', () => {
+    it('produces 8 corners', () => {
+      assert.strictEqual(zoneWorldCorners(makeZone()).length, 8);
+    });
+
+    it('bounding AABB of an unrotated zone matches center +/- half-extent', () => {
+      const zone = makeZone({ center: [1, 2, 3], size: [4, 6, 8] });
+      const { min, max } = zoneWorldAABB(zone);
+      assert.deepStrictEqual(min.map((v) => Math.round(v * 100) / 100), [-1, -1, -1]);
+      assert.deepStrictEqual(max.map((v) => Math.round(v * 100) / 100), [3, 5, 7]);
+    });
+
+    it('bounding AABB of a rotated zone is larger than the unrotated footprint (diagonal reach)', () => {
+      // A 10x10 footprint rotated 45deg has its axis-aligned bound reach out
+      // to the original square's half-diagonal (10/sqrt(2) per side from
+      // center), so the world AABB is wider than the unrotated 10m footprint.
+      const zone = makeZone({ size: [10, 3, 10], rotationY: Math.PI / 4 });
+      const { min, max } = zoneWorldAABB(zone);
+      assert.ok(max[0] - min[0] > 10 - 1e-6);
+    });
+  });
+});

--- a/apps/viewer/src/lib/zones/geometry.ts
+++ b/apps/viewer/src/lib/zones/geometry.ts
@@ -156,6 +156,20 @@ export function isPointInCompiledZone(
  * projected half-width is `hx*|axis.x| + hz*|axis.z|` and, projected onto
  * one of ITS OWN axes, the zone's half-width is simply its own half-extent
  * — both closed forms of the standard box/box separating-axis test.
+ *
+ * `eps` is slack added to the "not separated" threshold on every axis (and
+ * the Y interval check), so its SIGN controls what "overlap" means:
+ *  - positive (the default, 1e-6) — INCLUSIVE: two boxes that merely touch
+ *    (zero-depth contact, e.g. floating-point-exact shared edges) still
+ *    count as overlapping. Right for "does this box touch the zone at
+ *    all" queries.
+ *  - negative — a MINIMUM-PENETRATION requirement: a separating axis is
+ *    found (boxes do NOT overlap) unless the true overlap depth on every
+ *    axis exceeds `-eps`. Passing `eps = -d` demands at least `d` metres of
+ *    real penetration, which is exactly what distinguishes "elements that
+ *    end at a shared zone-set boundary" (zero penetration, common when
+ *    zone sets tile a building) from "elements that actually straddle
+ *    into the next zone" — see `assignment.ts`'s `STRADDLE_PENETRATION_M`.
  */
 export function zoneOverlapsAABBCompiled(
   minX: number,

--- a/apps/viewer/src/lib/zones/geometry.ts
+++ b/apps/viewer/src/lib/zones/geometry.ts
@@ -1,0 +1,240 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Pure oriented-box (OBB) math for zones. A zone only rotates about the
+ * vertical (Y) axis, so every test below decomposes into an independent 1-D
+ * check on Y (a plain interval overlap) plus a 2-D check in the X/Z
+ * footprint plane (a rotated rectangle vs. either a point or an
+ * axis-aligned rectangle) — there is never a need for full 3-D OBB/OBB
+ * separating-axis machinery.
+ */
+
+import type { ElementAABB, Zone } from './types.js';
+
+export interface Vec3Like {
+  0: number;
+  1: number;
+  2: number;
+}
+
+/** Rotate `(x, z)` by `-rotationY` (world → zone-local) around the origin. */
+function rotateIntoLocal(x: number, z: number, rotationY: number): [number, number] {
+  // Rotating world coordinates INTO the zone's local frame undoes the
+  // zone's own rotation, hence the negated angle.
+  const cos = Math.cos(-rotationY);
+  const sin = Math.sin(-rotationY);
+  return [x * cos - z * sin, x * sin + z * cos];
+}
+
+/** World-space point → zone-local coordinates (still metres, just
+ *  re-centred on the zone and with the footprint un-rotated). */
+export function worldToZoneLocal(point: Vec3Like, zone: Zone): [number, number, number] {
+  const dx = point[0] - zone.center[0];
+  const dy = point[1] - zone.center[1];
+  const dz = point[2] - zone.center[2];
+  const [lx, lz] = rotateIntoLocal(dx, dz, zone.rotationY);
+  return [lx, dy, lz];
+}
+
+/**
+ * Is `point` inside `zone` (inclusive of the boundary, +`eps` metres of
+ * slack so exact-boundary floating point doesn't flip-flop)?
+ */
+export function isPointInZone(point: Vec3Like, zone: Zone, eps = 1e-6): boolean {
+  return isPointInCompiledZone(point[0], point[1], point[2], compileZone(zone), eps);
+}
+
+/** Centroid of an axis-aligned world-space AABB. */
+export function aabbCentroid(box: { min: Vec3Like; max: Vec3Like }): [number, number, number] {
+  return [
+    (box.min[0] + box.max[0]) / 2,
+    (box.min[1] + box.max[1]) / 2,
+    (box.min[2] + box.max[2]) / 2,
+  ];
+}
+
+/**
+ * Does the world-space AABB `[min, max]` overlap `zone`'s oriented box?
+ *
+ * Decomposes into:
+ *  - a 1-D interval-overlap test on Y (the never-rotated vertical axis), and
+ *  - a 2-D separating-axis test in the X/Z plane between the AABB's
+ *    footprint (an axis-aligned rectangle) and the zone's footprint (a
+ *    rectangle rotated by `rotationY`). Two convex rectangles overlap iff
+ *    neither rectangle's two unique edge normals separates them, so testing
+ *    the world X/Z axes plus the zone's two local axes is exact (standard
+ *    2-D SAT for boxes) — no false positives or negatives.
+ *
+ * This is a thin per-call wrapper (compiles `zone` fresh every time) kept
+ * for API convenience and tests; the assignment engine's hot loop uses
+ * {@link compileZone} + {@link zoneOverlapsAABBCompiled} directly so it
+ * isn't re-deriving `cos`/`sin`/half-extents for the same zone on every one
+ * of the `elements × zones` checks.
+ */
+export function zoneOverlapsAABB(
+  min: Vec3Like,
+  max: Vec3Like,
+  zone: Zone,
+  eps = 1e-6,
+): boolean {
+  return zoneOverlapsAABBCompiled(min[0], min[1], min[2], max[0], max[1], max[2], compileZone(zone), eps);
+}
+
+// ============================================================================
+// Compiled zone — precomputed per-zone constants for the assignment hot
+// loop. Trig + half-extents are derived once per zone (not once per element
+// × zone check), and every projection below is closed-form arithmetic (the
+// standard "radius" trick for box/box SAT) rather than building corner
+// arrays and looping — this is the difference between the assignment engine
+// running in the tens of milliseconds vs. multiple seconds over 100k
+// elements (see the PR description for measured numbers).
+// ============================================================================
+
+export interface CompiledZone {
+  id: string;
+  name: string;
+  cx: number;
+  cy: number;
+  cz: number;
+  hx: number;
+  hy: number;
+  hz: number;
+  cos: number;
+  sin: number;
+  minY: number;
+  maxY: number;
+}
+
+/** Precompute a zone's trig + half-extents once, for reuse across every
+ *  element checked against it. */
+export function compileZone(zone: Zone): CompiledZone {
+  const cos = Math.cos(zone.rotationY);
+  const sin = Math.sin(zone.rotationY);
+  const hx = zone.size[0] / 2;
+  const hy = zone.size[1] / 2;
+  const hz = zone.size[2] / 2;
+  const cy = zone.center[1];
+  return {
+    id: zone.id,
+    name: zone.name,
+    cx: zone.center[0],
+    cy,
+    cz: zone.center[2],
+    hx,
+    hy,
+    hz,
+    cos,
+    sin,
+    minY: cy - hy,
+    maxY: cy + hy,
+  };
+}
+
+/** Point-in-box test against a precompiled zone — no trig, no allocation. */
+export function isPointInCompiledZone(
+  x: number,
+  y: number,
+  z: number,
+  zone: CompiledZone,
+  eps = 1e-6,
+): boolean {
+  if (y < zone.minY - eps || y > zone.maxY + eps) return false;
+  const dx = x - zone.cx;
+  const dz = z - zone.cz;
+  // World -> zone-local rotation by -rotationY: cos(-t)=cos(t), sin(-t)=-sin(t).
+  const lx = dx * zone.cos + dz * zone.sin;
+  const lz = -dx * zone.sin + dz * zone.cos;
+  return Math.abs(lx) <= zone.hx + eps && Math.abs(lz) <= zone.hz + eps;
+}
+
+/**
+ * AABB/OBB overlap against a precompiled zone via the closed-form
+ * projection-radius SAT (no corner arrays): for each of the 4 candidate
+ * axes (world X, world Z, the zone's two local footprint axes) the AABB's
+ * projected half-width is `hx*|axis.x| + hz*|axis.z|` and, projected onto
+ * one of ITS OWN axes, the zone's half-width is simply its own half-extent
+ * — both closed forms of the standard box/box separating-axis test.
+ */
+export function zoneOverlapsAABBCompiled(
+  minX: number,
+  minY: number,
+  minZ: number,
+  maxX: number,
+  maxY: number,
+  maxZ: number,
+  zone: CompiledZone,
+  eps = 1e-6,
+): boolean {
+  if (maxY < zone.minY - eps || minY > zone.maxY + eps) return false;
+
+  const acx = (minX + maxX) / 2;
+  const acz = (minZ + maxZ) / 2;
+  const ahx = (maxX - minX) / 2;
+  const ahz = (maxZ - minZ) / 2;
+  const dcx = acx - zone.cx;
+  const dcz = acz - zone.cz;
+  const absCos = Math.abs(zone.cos);
+  const absSin = Math.abs(zone.sin);
+
+  // World X axis (1, 0).
+  if (Math.abs(dcx) > ahx + zone.hx * absCos + zone.hz * absSin + eps) return false;
+  // World Z axis (0, 1).
+  if (Math.abs(dcz) > ahz + zone.hx * absSin + zone.hz * absCos + eps) return false;
+  // Zone local U axis (cos, sin).
+  if (Math.abs(dcx * zone.cos + dcz * zone.sin) > zone.hx + ahx * absCos + ahz * absSin + eps) return false;
+  // Zone local V axis (-sin, cos).
+  if (Math.abs(-dcx * zone.sin + dcz * zone.cos) > zone.hz + ahx * absSin + ahz * absCos + eps) return false;
+
+  return true;
+}
+
+/** World-space corners of a zone's box (for rendering a wireframe/translucent
+ *  hull). Order: bottom face (0-3) then top face (4-7), each CCW looking
+ *  down -Y, matching the common "box corner index" convention used by
+ *  `AddElementOverlay`'s box-hull projection. */
+export function zoneWorldCorners(zone: Zone): Array<[number, number, number]> {
+  const hx = zone.size[0] / 2;
+  const hy = zone.size[1] / 2;
+  const hz = zone.size[2] / 2;
+  const cos = Math.cos(zone.rotationY);
+  const sin = Math.sin(zone.rotationY);
+  const toWorld = (lx: number, ly: number, lz: number): [number, number, number] => [
+    zone.center[0] + lx * cos - lz * sin,
+    zone.center[1] + ly,
+    zone.center[2] + (lx * sin + lz * cos),
+  ];
+  return [
+    toWorld(-hx, -hy, -hz),
+    toWorld(hx, -hy, -hz),
+    toWorld(hx, -hy, hz),
+    toWorld(-hx, -hy, hz),
+    toWorld(-hx, hy, -hz),
+    toWorld(hx, hy, -hz),
+    toWorld(hx, hy, hz),
+    toWorld(-hx, hy, hz),
+  ];
+}
+
+/** World-space axis-aligned bounds of a zone's (possibly rotated) box — a
+ *  cheap conservative bound, e.g. for a quick broad-phase reject before the
+ *  exact SAT test, or for framing a zone in the viewport. */
+export function zoneWorldAABB(zone: Zone): { min: [number, number, number]; max: [number, number, number] } {
+  const corners = zoneWorldCorners(zone);
+  let minX = Infinity, minY = Infinity, minZ = Infinity;
+  let maxX = -Infinity, maxY = -Infinity, maxZ = -Infinity;
+  for (const [x, y, z] of corners) {
+    if (x < minX) minX = x;
+    if (y < minY) minY = y;
+    if (z < minZ) minZ = z;
+    if (x > maxX) maxX = x;
+    if (y > maxY) maxY = y;
+    if (z > maxZ) maxZ = z;
+  }
+  return { min: [minX, minY, minZ], max: [maxX, maxY, maxZ] };
+}
+
+/** Re-exported for callers that want the element-AABB shape without pulling
+ *  in the whole assignment module. */
+export type { ElementAABB };

--- a/apps/viewer/src/lib/zones/index.ts
+++ b/apps/viewer/src/lib/zones/index.ts
@@ -1,0 +1,41 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+export type {
+  Zone,
+  ZoneSet,
+  ElementAABB,
+  ZoneAssignment,
+  ZoneAssignmentsByElement,
+  ZoneSetFile,
+  ZoneSetFileV1,
+} from './types.js';
+export { ZONE_SET_FILE_VERSION } from './types.js';
+
+export {
+  worldToZoneLocal,
+  isPointInZone,
+  aabbCentroid,
+  zoneOverlapsAABB,
+  zoneWorldCorners,
+  zoneWorldAABB,
+  compileZone,
+  isPointInCompiledZone,
+  zoneOverlapsAABBCompiled,
+  type CompiledZone,
+} from './geometry.js';
+
+export { assignElementsToZoneSet, assignElementsToZoneSets } from './assignment.js';
+
+export {
+  generateStoreyZones,
+  DEFAULT_STOREY_ZONE_HEIGHT_M,
+  MIN_STOREY_ZONE_HEIGHT_M,
+  type StoreyInfo,
+  type XYBounds,
+} from './storey-generation.js';
+
+export { serializeZoneSets, parseZoneSetFile, type ParseZoneSetFileResult } from './persistence.js';
+
+export { zoneColorForIndex } from './colors.js';

--- a/apps/viewer/src/lib/zones/index.ts
+++ b/apps/viewer/src/lib/zones/index.ts
@@ -26,7 +26,7 @@ export {
   type CompiledZone,
 } from './geometry.js';
 
-export { assignElementsToZoneSet, assignElementsToZoneSets } from './assignment.js';
+export { assignElementsToZoneSet, assignElementsToZoneSets, STRADDLE_PENETRATION_M } from './assignment.js';
 
 export {
   generateStoreyZones,

--- a/apps/viewer/src/lib/zones/persistence.test.ts
+++ b/apps/viewer/src/lib/zones/persistence.test.ts
@@ -1,0 +1,98 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { serializeZoneSets, parseZoneSetFile } from './persistence.js';
+import type { ZoneSet } from './types.js';
+
+function makeZoneSet(): ZoneSet {
+  return {
+    id: 'set-1',
+    name: 'Sections',
+    visible: true,
+    createdAt: 1000,
+    updatedAt: 2000,
+    zones: [
+      {
+        id: 'zone-1',
+        name: 'Section A',
+        center: [1, 2, 3],
+        size: [4, 5, 6],
+        rotationY: 0.5,
+        color: [0.1, 0.2, 0.3],
+      },
+      {
+        id: 'zone-2',
+        name: 'Section B',
+        center: [-1, 0, -3],
+        size: [4, 5, 6],
+        rotationY: -1.2,
+      },
+    ],
+  };
+}
+
+describe('zones/persistence', () => {
+  it('round-trips zone sets through serialize -> JSON.stringify -> parse', () => {
+    const original = [makeZoneSet()];
+    const file = serializeZoneSets(original);
+    const json = JSON.parse(JSON.stringify(file));
+    const result = parseZoneSetFile(json);
+    assert.strictEqual(result.ok, true);
+    if (result.ok) {
+      assert.deepStrictEqual(result.zoneSets, original);
+    }
+  });
+
+  it('stamps the current schema version', () => {
+    const file = serializeZoneSets([makeZoneSet()]);
+    assert.strictEqual(file.version, 1);
+  });
+
+  it('rejects a file with the wrong version', () => {
+    const file = serializeZoneSets([makeZoneSet()]);
+    const tampered = { ...file, version: 99 };
+    const result = parseZoneSetFile(tampered);
+    assert.strictEqual(result.ok, false);
+  });
+
+  it('rejects a non-object payload', () => {
+    assert.strictEqual(parseZoneSetFile(null).ok, false);
+    assert.strictEqual(parseZoneSetFile('nope').ok, false);
+    assert.strictEqual(parseZoneSetFile(42).ok, false);
+  });
+
+  it('rejects a zone set with a malformed zone (missing size)', () => {
+    const file = serializeZoneSets([makeZoneSet()]);
+    const bad = {
+      ...file,
+      zoneSets: [{ ...file.zoneSets[0], zones: [{ id: 'z', name: 'bad', center: [0, 0, 0], rotationY: 0 }] }],
+    };
+    const result = parseZoneSetFile(bad);
+    assert.strictEqual(result.ok, false);
+  });
+
+  it('rejects a zone with a negative size component', () => {
+    const file = serializeZoneSets([makeZoneSet()]);
+    const bad = {
+      ...file,
+      zoneSets: [
+        {
+          ...file.zoneSets[0],
+          zones: [{ id: 'z', name: 'bad', center: [0, 0, 0], size: [-1, 1, 1], rotationY: 0 }],
+        },
+      ],
+    };
+    const result = parseZoneSetFile(bad);
+    assert.strictEqual(result.ok, false);
+  });
+
+  it('rejects zoneSets that is not an array', () => {
+    const file = serializeZoneSets([makeZoneSet()]);
+    const bad = { ...file, zoneSets: 'nope' };
+    const result = parseZoneSetFile(bad);
+    assert.strictEqual(result.ok, false);
+  });
+});

--- a/apps/viewer/src/lib/zones/persistence.test.ts
+++ b/apps/viewer/src/lib/zones/persistence.test.ts
@@ -95,4 +95,47 @@ describe('zones/persistence', () => {
     const result = parseZoneSetFile(bad);
     assert.strictEqual(result.ok, false);
   });
+
+  // PR #1869 review: object spreads left center/size/color aliased to live
+  // Zustand state, so mutating the serialized result mutated the store
+  // outside an action.
+  it('serializeZoneSets deep-copies vector tuples so mutating the result cannot touch the input', () => {
+    const original = [makeZoneSet()];
+    const file = serializeZoneSets(original);
+    file.zoneSets[0].zones[0].center[0] = 999;
+    file.zoneSets[0].zones[0].size[1] = 999;
+    file.zoneSets[0].zones[0].color![2] = 999;
+    assert.deepStrictEqual(original[0].zones[0].center, [1, 2, 3]);
+    assert.deepStrictEqual(original[0].zones[0].size, [4, 5, 6]);
+    assert.deepStrictEqual(original[0].zones[0].color, [0.1, 0.2, 0.3]);
+  });
+
+  // PR #1869 review: duplicate ids in an imported file made id-addressed
+  // store actions (removeZoneSet/renameZoneSet/updateZone/removeZone)
+  // silently affect multiple entries.
+  describe('duplicate-id rejection on import', () => {
+    it('rejects duplicate zone-set ids', () => {
+      const file = serializeZoneSets([makeZoneSet(), makeZoneSet()]); // both id 'set-1'
+      const result = parseZoneSetFile(JSON.parse(JSON.stringify(file)));
+      assert.strictEqual(result.ok, false);
+      if (!result.ok) assert.match(result.error, /duplicate zone-set id/);
+    });
+
+    it('rejects duplicate zone ids within one set', () => {
+      const set = makeZoneSet();
+      set.zones[1].id = set.zones[0].id; // 'zone-1' twice in the same set
+      const result = parseZoneSetFile(JSON.parse(JSON.stringify(serializeZoneSets([set]))));
+      assert.strictEqual(result.ok, false);
+      if (!result.ok) assert.match(result.error, /duplicate zone id/);
+    });
+
+    it('accepts the same zone id in two DIFFERENT sets (ids are per-set for zones)', () => {
+      const a = makeZoneSet();
+      const b = { ...makeZoneSet(), id: 'set-2' };
+      // zone ids are identical across a and b — updateZone is scoped by
+      // setId, so this is unambiguous and must import fine.
+      const result = parseZoneSetFile(JSON.parse(JSON.stringify(serializeZoneSets([a, b]))));
+      assert.strictEqual(result.ok, true);
+    });
+  });
 });

--- a/apps/viewer/src/lib/zones/persistence.ts
+++ b/apps/viewer/src/lib/zones/persistence.ts
@@ -1,0 +1,86 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Versioned JSON persistence for zone sets (issue #1810 v1). Zones live in
+ * viewer state, not the IFC model, so this is the ONLY durability story for
+ * them: export/import a small JSON file. Pure + DOM-free (no `downloadFile`/
+ * `File` here) so it's testable under `node:test`; the store slice wires
+ * this into the browser download/file-picker flow.
+ */
+
+import { ZONE_SET_FILE_VERSION, type Zone, type ZoneSet, type ZoneSetFile } from './types.js';
+
+export type ParseZoneSetFileResult =
+  | { ok: true; zoneSets: ZoneSet[] }
+  | { ok: false; error: string };
+
+/** Build the on-disk file shape from live zone sets. Pure — no clock/DOM
+ *  side effect except reading `Date.now()` for the informational timestamp. */
+export function serializeZoneSets(zoneSets: readonly ZoneSet[]): ZoneSetFile {
+  return {
+    version: ZONE_SET_FILE_VERSION,
+    exportedAt: new Date().toISOString(),
+    zoneSets: zoneSets.map((zs) => ({
+      ...zs,
+      zones: zs.zones.map((z) => ({ ...z })),
+    })),
+  };
+}
+
+function isFiniteNumber(v: unknown): v is number {
+  return typeof v === 'number' && Number.isFinite(v);
+}
+
+function isVec3(v: unknown): v is [number, number, number] {
+  return Array.isArray(v) && v.length === 3 && v.every(isFiniteNumber);
+}
+
+function isValidZone(v: unknown): v is Zone {
+  if (!v || typeof v !== 'object') return false;
+  const z = v as Record<string, unknown>;
+  if (typeof z.id !== 'string' || z.id.length === 0) return false;
+  if (typeof z.name !== 'string') return false;
+  if (!isVec3(z.center)) return false;
+  if (!isVec3(z.size)) return false;
+  if (!isFiniteNumber(z.rotationY)) return false;
+  if (z.size[0] < 0 || z.size[1] < 0 || z.size[2] < 0) return false;
+  if (z.color !== undefined && !isVec3(z.color)) return false;
+  return true;
+}
+
+function isValidZoneSet(v: unknown): v is ZoneSet {
+  if (!v || typeof v !== 'object') return false;
+  const zs = v as Record<string, unknown>;
+  return (
+    typeof zs.id === 'string' && zs.id.length > 0 &&
+    typeof zs.name === 'string' &&
+    Array.isArray(zs.zones) && zs.zones.every(isValidZone) &&
+    typeof zs.visible === 'boolean' &&
+    isFiniteNumber(zs.createdAt) &&
+    isFiniteNumber(zs.updatedAt)
+  );
+}
+
+/**
+ * Parse a previously-exported zone-set file. Rejects anything that isn't
+ * the recognised versioned shape rather than guessing — a corrupted or
+ * hand-edited file should fail loudly, not silently drop zones.
+ */
+export function parseZoneSetFile(json: unknown): ParseZoneSetFileResult {
+  if (!json || typeof json !== 'object') {
+    return { ok: false, error: 'Not a zone-set file (expected a JSON object).' };
+  }
+  const obj = json as Record<string, unknown>;
+  if (obj.version !== ZONE_SET_FILE_VERSION) {
+    return {
+      ok: false,
+      error: `Unsupported zone-set file version ${String(obj.version)} (expected ${ZONE_SET_FILE_VERSION}).`,
+    };
+  }
+  if (!Array.isArray(obj.zoneSets) || !obj.zoneSets.every(isValidZoneSet)) {
+    return { ok: false, error: 'Malformed zone-set file: `zoneSets` is missing or invalid.' };
+  }
+  return { ok: true, zoneSets: obj.zoneSets as ZoneSet[] };
+}

--- a/apps/viewer/src/lib/zones/persistence.ts
+++ b/apps/viewer/src/lib/zones/persistence.ts
@@ -16,15 +16,28 @@ export type ParseZoneSetFileResult =
   | { ok: true; zoneSets: ZoneSet[] }
   | { ok: false; error: string };
 
+function copyVec3(v: readonly [number, number, number]): [number, number, number] {
+  return [v[0], v[1], v[2]];
+}
+
 /** Build the on-disk file shape from live zone sets. Pure — no clock/DOM
- *  side effect except reading `Date.now()` for the informational timestamp. */
+ *  side effect except reading `Date.now()` for the informational timestamp.
+ *  The vector tuples are deep-copied too: a shallow spread would leave
+ *  `center`/`size`/`color` aliased to live Zustand state, so a caller
+ *  mutating the serialized result would mutate the store outside an action
+ *  (PR #1869 review). */
 export function serializeZoneSets(zoneSets: readonly ZoneSet[]): ZoneSetFile {
   return {
     version: ZONE_SET_FILE_VERSION,
     exportedAt: new Date().toISOString(),
     zoneSets: zoneSets.map((zs) => ({
       ...zs,
-      zones: zs.zones.map((z) => ({ ...z })),
+      zones: zs.zones.map((z) => ({
+        ...z,
+        center: copyVec3(z.center),
+        size: copyVec3(z.size),
+        ...(z.color !== undefined ? { color: copyVec3(z.color) } : {}),
+      })),
     })),
   };
 }
@@ -82,5 +95,24 @@ export function parseZoneSetFile(json: unknown): ParseZoneSetFileResult {
   if (!Array.isArray(obj.zoneSets) || !obj.zoneSets.every(isValidZoneSet)) {
     return { ok: false, error: 'Malformed zone-set file: `zoneSets` is missing or invalid.' };
   }
-  return { ok: true, zoneSets: obj.zoneSets as ZoneSet[] };
+  const zoneSets = obj.zoneSets as ZoneSet[];
+  // Ids must be unique (set ids globally, zone ids within their set): the
+  // store actions (`removeZoneSet`/`renameZoneSet`/`updateZone`/`removeZone`)
+  // address by id, so importing duplicates would make a single edit silently
+  // affect multiple entries (PR #1869 review).
+  const setIds = new Set<string>();
+  for (const zs of zoneSets) {
+    if (setIds.has(zs.id)) {
+      return { ok: false, error: `Malformed zone-set file: duplicate zone-set id "${zs.id}".` };
+    }
+    setIds.add(zs.id);
+    const zoneIds = new Set<string>();
+    for (const zone of zs.zones) {
+      if (zoneIds.has(zone.id)) {
+        return { ok: false, error: `Malformed zone-set file: duplicate zone id "${zone.id}" in set "${zs.name}".` };
+      }
+      zoneIds.add(zone.id);
+    }
+  }
+  return { ok: true, zoneSets };
 }

--- a/apps/viewer/src/lib/zones/storey-generation.test.ts
+++ b/apps/viewer/src/lib/zones/storey-generation.test.ts
@@ -1,0 +1,90 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import {
+  generateStoreyZones,
+  DEFAULT_STOREY_ZONE_HEIGHT_M,
+  MIN_STOREY_ZONE_HEIGHT_M,
+  type StoreyInfo,
+} from './storey-generation.js';
+
+function makeIdSequence(): () => string {
+  let n = 0;
+  return () => `id-${n++}`;
+}
+
+const BOUNDS = { minX: -10, maxX: 10, minZ: -5, maxZ: 5 };
+
+describe('zones/storey-generation', () => {
+  it('produces one zone per storey', () => {
+    const storeys: StoreyInfo[] = [
+      { id: 's1', name: 'Ground', elevation: 0 },
+      { id: 's2', name: 'Level 1', elevation: 3.5 },
+    ];
+    const zones = generateStoreyZones(storeys, BOUNDS, makeIdSequence());
+    assert.strictEqual(zones.length, 2);
+  });
+
+  it('spans the given XY bounds exactly, unrotated', () => {
+    const storeys: StoreyInfo[] = [{ id: 's1', name: 'Ground', elevation: 0 }];
+    const [zone] = generateStoreyZones(storeys, BOUNDS, makeIdSequence());
+    assert.strictEqual(zone.rotationY, 0);
+    assert.strictEqual(zone.size[0], 20); // maxX - minX
+    assert.strictEqual(zone.size[2], 10); // maxZ - minZ
+    assert.strictEqual(zone.center[0], 0);
+    assert.strictEqual(zone.center[2], 0);
+  });
+
+  it('sets each zone height to the gap to the next storey up', () => {
+    const storeys: StoreyInfo[] = [
+      { id: 's1', name: 'Ground', elevation: 0 },
+      { id: 's2', name: 'Level 1', elevation: 4 },
+    ];
+    const [ground] = generateStoreyZones(storeys, BOUNDS, makeIdSequence());
+    assert.strictEqual(ground.size[1], 4);
+    assert.strictEqual(ground.center[1], 2); // 0 + 4/2
+  });
+
+  it('falls back to the default height for the topmost storey', () => {
+    const storeys: StoreyInfo[] = [{ id: 's1', name: 'Roof', elevation: 20 }];
+    const [zone] = generateStoreyZones(storeys, BOUNDS, makeIdSequence());
+    assert.strictEqual(zone.size[1], DEFAULT_STOREY_ZONE_HEIGHT_M);
+  });
+
+  it('sorts storeys by elevation regardless of input order', () => {
+    const storeys: StoreyInfo[] = [
+      { id: 'top', name: 'Level 2', elevation: 8 },
+      { id: 'bottom', name: 'Ground', elevation: 0 },
+      { id: 'mid', name: 'Level 1', elevation: 4 },
+    ];
+    const zones = generateStoreyZones(storeys, BOUNDS, makeIdSequence());
+    assert.deepStrictEqual(zones.map((z) => z.name), ['Ground', 'Level 1', 'Level 2']);
+  });
+
+  it('clamps a degenerate (duplicate or inverted) elevation gap to the minimum height', () => {
+    const storeys: StoreyInfo[] = [
+      { id: 's1', name: 'A', elevation: 0 },
+      { id: 's2', name: 'B', elevation: 0 }, // duplicate elevation
+    ];
+    const zones = generateStoreyZones(storeys, BOUNDS, makeIdSequence());
+    assert.strictEqual(zones[0].size[1], MIN_STOREY_ZONE_HEIGHT_M);
+  });
+
+  it('names an unnamed storey from its elevation', () => {
+    const storeys: StoreyInfo[] = [{ id: 's1', name: '', elevation: 3 }];
+    const [zone] = generateStoreyZones(storeys, BOUNDS, makeIdSequence());
+    assert.ok(zone.name.includes('3.00'));
+  });
+
+  it('assigns a fresh id per zone via the injected generator', () => {
+    const storeys: StoreyInfo[] = [
+      { id: 's1', name: 'A', elevation: 0 },
+      { id: 's2', name: 'B', elevation: 3 },
+    ];
+    const zones = generateStoreyZones(storeys, BOUNDS, makeIdSequence());
+    assert.notStrictEqual(zones[0].id, zones[1].id);
+  });
+});

--- a/apps/viewer/src/lib/zones/storey-generation.ts
+++ b/apps/viewer/src/lib/zones/storey-generation.ts
@@ -1,0 +1,73 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Generate one zone per building storey, spanning the model's XY bounds
+ * (issue #1810 v1, generation path (b)). Pure — callers gather the storey
+ * list + bounds from the loaded model(s) (see the store slice for how that
+ * uses `@ifc-lite/data`'s canonical storey-elevation contract, PR #1857) and
+ * hand them in here.
+ *
+ * A storey's zone height is the gap to the next storey up; the topmost
+ * storey (no "next" to measure against) falls back to
+ * `DEFAULT_STOREY_ZONE_HEIGHT_M` since a raw IFC storey list carries no
+ * "roof height" — a known v1 simplification, easy to override afterwards
+ * via numeric editing.
+ */
+
+import type { Zone } from './types.js';
+
+/** Minimal per-storey input: caller-chosen identity (e.g. a federated global
+ *  id, or `${modelId}:${expressId}` for cross-model uniqueness) plus name +
+ *  elevation in the viewer's world frame (Y-up), metres. */
+export interface StoreyInfo {
+  id: string;
+  name: string;
+  elevation: number;
+}
+
+/** World-space XY (X/Z in viewer Y-up terms) footprint to span. */
+export interface XYBounds {
+  minX: number;
+  maxX: number;
+  minZ: number;
+  maxZ: number;
+}
+
+export const DEFAULT_STOREY_ZONE_HEIGHT_M = 3.5;
+/** Floor so a degenerate/duplicate elevation can't produce a zero-thickness
+ *  (or inverted) box. */
+export const MIN_STOREY_ZONE_HEIGHT_M = 0.1;
+
+/**
+ * One axis-aligned (rotationY = 0) zone per storey, sorted by elevation,
+ * each spanning `bounds` in X/Z and `[elevation, elevation + height)` in Y.
+ * `makeId` is injectable so callers can supply `crypto.randomUUID` in the
+ * browser and a deterministic generator in tests.
+ */
+export function generateStoreyZones(
+  storeys: readonly StoreyInfo[],
+  bounds: XYBounds,
+  makeId: () => string,
+): Zone[] {
+  const sorted = [...storeys].sort((a, b) => a.elevation - b.elevation);
+  const width = Math.max(0, bounds.maxX - bounds.minX);
+  const depth = Math.max(0, bounds.maxZ - bounds.minZ);
+  const centerX = (bounds.minX + bounds.maxX) / 2;
+  const centerZ = (bounds.minZ + bounds.maxZ) / 2;
+
+  return sorted.map((storey, i) => {
+    const next = sorted[i + 1];
+    const gap = next ? next.elevation - storey.elevation : DEFAULT_STOREY_ZONE_HEIGHT_M;
+    const height = Math.max(MIN_STOREY_ZONE_HEIGHT_M, gap);
+    const centerY = storey.elevation + height / 2;
+    return {
+      id: makeId(),
+      name: storey.name || `Storey (${storey.elevation.toFixed(2)}m)`,
+      center: [centerX, centerY, centerZ],
+      size: [width, height, depth],
+      rotationY: 0,
+    };
+  });
+}

--- a/apps/viewer/src/lib/zones/storey-generation.ts
+++ b/apps/viewer/src/lib/zones/storey-generation.ts
@@ -3,8 +3,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 /**
- * Generate one zone per building storey, spanning the model's XY bounds
- * (issue #1810 v1, generation path (b)). Pure — callers gather the storey
+ * Generate one zone per building storey, spanning the model's horizontal X-Z
+ * footprint bounds — the viewer frame is Y-up — (issue #1810 v1, generation path (b)). Pure — callers gather the storey
  * list + bounds from the loaded model(s) (see the store slice for how that
  * uses `@ifc-lite/data`'s canonical storey-elevation contract, PR #1857) and
  * hand them in here.

--- a/apps/viewer/src/lib/zones/types.ts
+++ b/apps/viewer/src/lib/zones/types.ts
@@ -79,8 +79,10 @@ export interface ZoneAssignment {
    *  centroid is in no zone but the element still pokes into one). Geometry
    *  is never split in v1 — this is purely an informational flag. */
   straddles: boolean;
-  /** Every zone id whose box overlaps the element's AABB (including the
-   *  `zoneId` above, when set). Empty when the element touches no zone at
+  /** Every zone id whose box the element's AABB genuinely penetrates (past
+   *  `STRADDLE_PENETRATION_M`), plus the home `zoneId` above when set (the
+   *  home zone counts as touched even when the element is too thin to clear
+   *  the penetration threshold). Empty when the element touches no zone at
    *  all. */
   touchedZoneIds: string[];
 }

--- a/apps/viewer/src/lib/zones/types.ts
+++ b/apps/viewer/src/lib/zones/types.ts
@@ -1,0 +1,107 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Types for the "location zones" feature (issue #1810): user-defined 3D
+ * boxes (construction sections, takt areas, ...) that elements get
+ * classified into. Coordinates are in the VIEWER's world frame (Y-up,
+ * see AGENTS.md "IFC is Z-up, the viewer is Y-up") because zones are
+ * authored interactively against the rendered scene, not the IFC model.
+ *
+ * V1 is deliberately scoped: a zone is an oriented box (rotation about the
+ * vertical/Y axis only — no pitch/roll), assignment is per-element
+ * centroid-in-box with a "straddles" flag when the element's AABB crosses
+ * a zone boundary, and no geometry is ever split. See `docs/design` (or the
+ * PR description) for the full list of v1 exclusions.
+ */
+
+/** A single oriented box within a `ZoneSet`. */
+export interface Zone {
+  /** Stable id (UUID), unique across the whole app — element references use
+   *  this, not array position, so reordering/renaming zones never silently
+   *  re-targets an assignment. */
+  id: string;
+  /** Display name, e.g. "Section A" or "Level 03". */
+  name: string;
+  /** World-space center, viewer frame (Y-up), metres. */
+  center: [x: number, y: number, z: number];
+  /**
+   * Full extents (not half-extents) along the box's own LOCAL axes, metres.
+   * `size[1]` (the vertical/Y extent) is never rotated — `rotationY` only
+   * spins the box's footprint (X/Z) around its center.
+   */
+  size: [dx: number, dy: number, dz: number];
+  /** Rotation about the vertical (Y) axis, radians. Positive = counter-clockwise
+   *  looking down the -Y axis (matches the renderer's right-handed Y-up frame). */
+  rotationY: number;
+  /** Optional display colour (0-1 RGB). Falls back to the parent set's
+   *  palette-derived colour when absent. */
+  color?: [r: number, g: number, b: number];
+}
+
+/** A named, independent collection of zones (e.g. "Sections", "Takt areas").
+ *  Multiple zone sets coexist; assignment runs per set independently, so an
+ *  element can simultaneously belong to "Section 2" AND "Takt Area B". */
+export interface ZoneSet {
+  /** Stable id (UUID). */
+  id: string;
+  /** Display name, unique-by-convention but not enforced (last write wins in
+   *  the UI; ids are what actually disambiguate). */
+  name: string;
+  zones: Zone[];
+  /** Whether this set's boxes render in the 3D view. Independent of whether
+   *  assignment runs — assignment always runs for every zone set so Lists /
+   *  selection stay live even while the set's boxes are hidden. */
+  visible: boolean;
+  createdAt: number;
+  updatedAt: number;
+}
+
+/** World-space axis-aligned bounding box of one element, the minimal input
+ *  the assignment engine needs. `globalId` is the FederationRegistry id
+ *  (stable across every loaded model; single-model fallback
+ *  `globalId === expressId`). */
+export interface ElementAABB {
+  globalId: number;
+  min: [x: number, y: number, z: number];
+  max: [x: number, y: number, z: number];
+}
+
+/** Result of classifying one element against one zone set. */
+export interface ZoneAssignment {
+  /** The zone whose box contains the element's AABB centroid, or `null` when
+   *  the centroid falls outside every zone in the set. */
+  zoneId: string | null;
+  zoneName: string | null;
+  /** True when the element's AABB overlaps more than one zone in the set, or
+   *  overlaps a zone other than the one containing its centroid (e.g. the
+   *  centroid is in no zone but the element still pokes into one). Geometry
+   *  is never split in v1 — this is purely an informational flag. */
+  straddles: boolean;
+  /** Every zone id whose box overlaps the element's AABB (including the
+   *  `zoneId` above, when set). Empty when the element touches no zone at
+   *  all. */
+  touchedZoneIds: string[];
+}
+
+/** Per-element assignment across every zone set, keyed by zone-set id. */
+export type ZoneAssignmentsByElement = Map<number, Record<string, ZoneAssignment>>;
+
+// ============================================================================
+// Persistence (versioned JSON, kept out of the IFC model in v1)
+// ============================================================================
+
+/** Current on-disk schema version. Bump whenever the shape of `Zone` /
+ *  `ZoneSet` changes in a way older readers can't tolerate, and add a
+ *  migration in `persistence.ts` rather than breaking old exports. */
+export const ZONE_SET_FILE_VERSION = 1 as const;
+
+export interface ZoneSetFileV1 {
+  version: 1;
+  /** ISO timestamp of export, informational only. */
+  exportedAt: string;
+  zoneSets: ZoneSet[];
+}
+
+export type ZoneSetFile = ZoneSetFileV1;

--- a/apps/viewer/src/store/index.ts
+++ b/apps/viewer/src/store/index.ts
@@ -56,6 +56,7 @@ import { createPointCloudSlice, type PointCloudSlice, POINT_CLOUD_DEFAULTS } fro
 import { createUnitDisplaySlice, type UnitDisplaySlice } from './slices/unitDisplaySlice.js';
 import { createSpaceMouseSlice, type SpaceMouseSlice } from './slices/spaceMouseSlice.js';
 import { createLayerStackSlice, type LayerStackSlice } from './slices/layerStackSlice.js';
+import { createZonesSlice, type ZonesSlice } from './slices/zonesSlice.js';
 import { invalidateVisibleBasketCache } from './basketVisibleSet.js';
 
 // Import constants for reset function
@@ -170,6 +171,7 @@ export type ViewerState = LoadingSlice &
   PointCloudSlice &
   UnitDisplaySlice &
   SpaceMouseSlice &
+  ZonesSlice &
   ExtensionsSlice & {
     resetViewerState: () => void;
     /**
@@ -257,6 +259,7 @@ const createViewerStore = () => create<ViewerState>()((...args) => ({
   ...createPointCloudSlice(...args),
   ...createUnitDisplaySlice(...args),
   ...createSpaceMouseSlice(...args),
+  ...createZonesSlice(...args),
   ...createExtensionsSlice(...args),
 
   // Reset all viewer state when loading new file

--- a/apps/viewer/src/store/index.ts
+++ b/apps/viewer/src/store/index.ts
@@ -327,6 +327,10 @@ const createViewerStore = () => create<ViewerState>()((...args) => ({
       // above; `useZoneAssignmentSync` recomputes against the new scene.
       zoneAssignments: new Map(),
       zoneAssignmentTiming: null,
+      // ... and drop any in-flight zone-edit session: leaving `editingZone`
+      // set would hand the incoming model live gizmo handles + picking for
+      // a zone the user was editing against the outgoing model.
+      editingZone: null,
 
       // Hover/Context
       hoverState: { entityId: null, screenX: 0, screenY: 0 },

--- a/apps/viewer/src/store/index.ts
+++ b/apps/viewer/src/store/index.ts
@@ -318,6 +318,16 @@ const createViewerStore = () => create<ViewerState>()((...args) => ({
       compareRunning: false,
       compareError: null,
 
+      // Zones (#1810): keep the user-authored zone SETS (they persist across
+      // model loads, like clash presets), but drop the computed assignments —
+      // they're keyed by the OUTGOING model's global ids, and the single-model
+      // fallback (globalId === expressId) means the incoming model's ids can
+      // collide and read the old model's zone membership until the debounced
+      // recompute fires. Same stale-model-reference class as compareResult
+      // above; `useZoneAssignmentSync` recomputes against the new scene.
+      zoneAssignments: new Map(),
+      zoneAssignmentTiming: null,
+
       // Hover/Context
       hoverState: { entityId: null, screenX: 0, screenY: 0 },
       contextMenu: { isOpen: false, entityId: null, screenX: 0, screenY: 0 },

--- a/apps/viewer/src/store/slices/zonesSlice.test.ts
+++ b/apps/viewer/src/store/slices/zonesSlice.test.ts
@@ -1,0 +1,91 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `editingZone` dangling-reference invariant (CodeRabbit review of PR #1869):
+ * every action that can remove the zone an edit session points at must clear
+ * (or re-validate) `editingZone` — `removeZoneSet`/`removeZone` always did,
+ * but `replaceZonesInSet` ("generate from storeys") and `importZoneSetsJSON`
+ * (replaces every set) left it dangling on a zone that no longer exists.
+ */
+
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert';
+import { createZonesSlice, type ZonesSlice } from './zonesSlice.js';
+import type { Zone, ZoneSet } from '../../lib/zones/types.js';
+
+function makeZone(id: string, name = id): Zone {
+  return { id, name, center: [0, 0, 0], size: [5, 3, 5], rotationY: 0 };
+}
+
+function makeSet(id: string, zones: Zone[], name = id): ZoneSet {
+  return { id, name, zones, visible: true, createdAt: 1, updatedAt: 1 };
+}
+
+function importFileJSON(zoneSets: ZoneSet[]): string {
+  return JSON.stringify({ version: 1, exportedAt: new Date(0).toISOString(), zoneSets });
+}
+
+describe('ZonesSlice editingZone lifecycle', () => {
+  let state: ZonesSlice;
+
+  beforeEach(() => {
+    const setState = (
+      partial: Partial<ZonesSlice> | ((s: ZonesSlice) => Partial<ZonesSlice>),
+    ): void => {
+      const updates = typeof partial === 'function' ? partial(state) : partial;
+      state = { ...state, ...updates };
+    };
+    const getState = (): ZonesSlice => state;
+    state = createZonesSlice(setState as never, getState as never, {} as never);
+    // Seed one set with two zones and start an edit session on zone "a".
+    state = { ...state, zoneSets: [makeSet('set-1', [makeZone('a'), makeZone('b')])] };
+    state.setEditingZone({ setId: 'set-1', zoneId: 'a' });
+  });
+
+  describe('replaceZonesInSet', () => {
+    it('clears editingZone when the edited zone is not among the replacement zones', () => {
+      state.replaceZonesInSet('set-1', [makeZone('storey-0'), makeZone('storey-1')]);
+      assert.strictEqual(state.editingZone, null);
+    });
+
+    it('keeps editingZone when the replacement zones still contain the edited zone id', () => {
+      state.replaceZonesInSet('set-1', [makeZone('a'), makeZone('c')]);
+      assert.deepStrictEqual(state.editingZone, { setId: 'set-1', zoneId: 'a' });
+    });
+
+    it('keeps an edit session in an UNRELATED set untouched', () => {
+      state = { ...state, zoneSets: [...state.zoneSets, makeSet('set-2', [makeZone('x')])] };
+      state.setEditingZone({ setId: 'set-2', zoneId: 'x' });
+      state.replaceZonesInSet('set-1', []);
+      assert.deepStrictEqual(state.editingZone, { setId: 'set-2', zoneId: 'x' });
+    });
+  });
+
+  describe('importZoneSetsJSON', () => {
+    it('clears editingZone when the imported data no longer contains the edited set', () => {
+      const result = state.importZoneSetsJSON(importFileJSON([makeSet('other-set', [makeZone('z')])]));
+      assert.deepStrictEqual(result, { ok: true });
+      assert.strictEqual(state.editingZone, null);
+    });
+
+    it('clears editingZone when the set survives but the edited zone id does not', () => {
+      const result = state.importZoneSetsJSON(importFileJSON([makeSet('set-1', [makeZone('b')])]));
+      assert.deepStrictEqual(result, { ok: true });
+      assert.strictEqual(state.editingZone, null);
+    });
+
+    it('keeps editingZone when the imported data still contains the exact set + zone', () => {
+      const result = state.importZoneSetsJSON(importFileJSON([makeSet('set-1', [makeZone('a')])]));
+      assert.deepStrictEqual(result, { ok: true });
+      assert.deepStrictEqual(state.editingZone, { setId: 'set-1', zoneId: 'a' });
+    });
+
+    it('leaves editingZone alone when the import is rejected', () => {
+      const result = state.importZoneSetsJSON('{"version": 99}');
+      assert.strictEqual(result.ok, false);
+      assert.deepStrictEqual(state.editingZone, { setId: 'set-1', zoneId: 'a' });
+    });
+  });
+});

--- a/apps/viewer/src/store/slices/zonesSlice.ts
+++ b/apps/viewer/src/store/slices/zonesSlice.ts
@@ -1,0 +1,208 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Location zones (issue #1810 v1): user-defined oriented boxes ("Sections",
+ * "Takt areas", ...) that elements get classified into. This slice owns the
+ * zone-set CRUD + the last-computed per-element assignment cache; the actual
+ * classification math lives in `lib/zones` (pure, unit-tested) and the
+ * orchestration that gathers world-space element bounds across every
+ * federated model and calls it lives in `useZoneAssignmentSync` (mirrors how
+ * `useClash` owns clash's gather-and-run step while `clashSlice` only holds
+ * state).
+ *
+ * Zone sets auto-persist to localStorage (survives a reload) in addition to
+ * the explicit JSON export/import path (survives moving to another machine
+ * or sharing with a teammate) — same two-tier persistence as clash presets.
+ */
+
+import type { StateCreator } from 'zustand';
+import type { Zone, ZoneSet, ZoneAssignmentsByElement } from '../../lib/zones/types.js';
+import { serializeZoneSets, parseZoneSetFile } from '../../lib/zones/persistence.js';
+
+const ZONE_SETS_STORAGE_KEY = 'ifc-lite:zone-sets';
+
+function loadPersistedZoneSets(): ZoneSet[] {
+  if (typeof window === 'undefined') return [];
+  try {
+    const raw = window.localStorage.getItem(ZONE_SETS_STORAGE_KEY);
+    if (!raw) return [];
+    const result = parseZoneSetFile(JSON.parse(raw));
+    return result.ok ? result.zoneSets : [];
+  } catch (error) {
+    console.warn('[zones] failed to load persisted zone sets', error);
+    return [];
+  }
+}
+
+function savePersistedZoneSets(zoneSets: ZoneSet[]): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(ZONE_SETS_STORAGE_KEY, JSON.stringify(serializeZoneSets(zoneSets)));
+  } catch (error) {
+    // Quota exceeded / private mode — best effort; the explicit JSON export
+    // is the durable path for anyone who needs guarantees.
+    console.warn('[zones] failed to persist zone sets to localStorage', error);
+  }
+}
+
+/** Diagnostics from the last `setZoneAssignments` call — surfaced in the
+ *  zones panel so the "off the interaction path" quality bar is visible,
+ *  not just asserted. */
+export interface ZoneAssignmentTiming {
+  elapsedMs: number;
+  elementCount: number;
+  zoneSetCount: number;
+  computedAt: number;
+}
+
+export interface ZonesSlice {
+  zoneSets: ZoneSet[];
+  /** Last computed classification, keyed by federated global id ->
+   *  (zoneSetId -> assignment). Recomputed by `useZoneAssignmentSync`
+   *  whenever the loaded models or the zone sets change. */
+  zoneAssignments: ZoneAssignmentsByElement;
+  zoneAssignmentTiming: ZoneAssignmentTiming | null;
+  /** Which single zone is currently being interactively edited (move/resize/
+   *  rotate gizmo). Non-null gates the 3D handles on AND stops the zone
+   *  overlay from being pass-through for picking, so it must be cleared on
+   *  tool switch / Escape / commit. */
+  editingZone: { setId: string; zoneId: string } | null;
+
+  createZoneSet: (name: string) => string;
+  removeZoneSet: (setId: string) => void;
+  renameZoneSet: (setId: string, name: string) => void;
+  setZoneSetVisible: (setId: string, visible: boolean) => void;
+  /** Replace every zone in a set at once (e.g. "generate from storeys"). */
+  replaceZonesInSet: (setId: string, zones: Zone[]) => void;
+  /** Any field omitted from `zone` falls back to a sane default (a 5x3x5m
+   *  unrotated box at the world origin), so a UI "+ Add zone" button can call
+   *  this with just `{ name }` and let the user reposition afterwards. */
+  addZone: (setId: string, zone?: Partial<Omit<Zone, 'id'>>) => string | null;
+  updateZone: (setId: string, zoneId: string, patch: Partial<Omit<Zone, 'id'>>) => void;
+  removeZone: (setId: string, zoneId: string) => void;
+  setEditingZone: (target: { setId: string; zoneId: string } | null) => void;
+  /** Written by `useZoneAssignmentSync` after it gathers element bounds and
+   *  runs the (pure) assignment engine. Not meant to be called with
+   *  hand-computed data from a UI component. */
+  setZoneAssignments: (assignments: ZoneAssignmentsByElement, timing: ZoneAssignmentTiming) => void;
+  exportZoneSetsJSON: () => string;
+  importZoneSetsJSON: (json: string) => { ok: true } | { ok: false; error: string };
+  clearAllZoneSets: () => void;
+}
+
+const DEFAULT_ZONE: Omit<Zone, 'id'> = {
+  name: 'New zone',
+  center: [0, 0, 0],
+  size: [5, 3, 5],
+  rotationY: 0,
+};
+
+export const createZonesSlice: StateCreator<ZonesSlice, [], [], ZonesSlice> = (set, get) => ({
+  zoneSets: loadPersistedZoneSets(),
+  zoneAssignments: new Map(),
+  zoneAssignmentTiming: null,
+  editingZone: null,
+
+  createZoneSet: (name) => {
+    const id = crypto.randomUUID();
+    const now = Date.now();
+    const zoneSet: ZoneSet = { id, name: name.trim() || 'Untitled set', zones: [], visible: true, createdAt: now, updatedAt: now };
+    set((state) => {
+      const zoneSets = [...state.zoneSets, zoneSet];
+      savePersistedZoneSets(zoneSets);
+      return { zoneSets };
+    });
+    return id;
+  },
+
+  removeZoneSet: (setId) => set((state) => {
+    const zoneSets = state.zoneSets.filter((zs) => zs.id !== setId);
+    savePersistedZoneSets(zoneSets);
+    const editingZone = state.editingZone?.setId === setId ? null : state.editingZone;
+    return { zoneSets, editingZone };
+  }),
+
+  renameZoneSet: (setId, name) => set((state) => {
+    const trimmed = name.trim();
+    if (!trimmed) return state;
+    const zoneSets = state.zoneSets.map((zs) => (zs.id === setId ? { ...zs, name: trimmed, updatedAt: Date.now() } : zs));
+    savePersistedZoneSets(zoneSets);
+    return { zoneSets };
+  }),
+
+  setZoneSetVisible: (setId, visible) => set((state) => {
+    const zoneSets = state.zoneSets.map((zs) => (zs.id === setId ? { ...zs, visible } : zs));
+    savePersistedZoneSets(zoneSets);
+    return { zoneSets };
+  }),
+
+  replaceZonesInSet: (setId, zones) => set((state) => {
+    const zoneSets = state.zoneSets.map((zs) => (zs.id === setId ? { ...zs, zones, updatedAt: Date.now() } : zs));
+    savePersistedZoneSets(zoneSets);
+    return { zoneSets };
+  }),
+
+  addZone: (setId, zone) => {
+    const zoneSet = get().zoneSets.find((zs) => zs.id === setId);
+    if (!zoneSet) return null;
+    const id = crypto.randomUUID();
+    const newZone: Zone = { ...DEFAULT_ZONE, ...zone, id };
+    set((state) => {
+      const zoneSets = state.zoneSets.map((zs) => (zs.id === setId ? { ...zs, zones: [...zs.zones, newZone], updatedAt: Date.now() } : zs));
+      savePersistedZoneSets(zoneSets);
+      return { zoneSets };
+    });
+    return id;
+  },
+
+  updateZone: (setId, zoneId, patch) => set((state) => {
+    const zoneSets = state.zoneSets.map((zs) => {
+      if (zs.id !== setId) return zs;
+      return {
+        ...zs,
+        zones: zs.zones.map((z) => (z.id === zoneId ? { ...z, ...patch } : z)),
+        updatedAt: Date.now(),
+      };
+    });
+    savePersistedZoneSets(zoneSets);
+    return { zoneSets };
+  }),
+
+  removeZone: (setId, zoneId) => set((state) => {
+    const zoneSets = state.zoneSets.map((zs) => (zs.id === setId
+      ? { ...zs, zones: zs.zones.filter((z) => z.id !== zoneId), updatedAt: Date.now() }
+      : zs));
+    savePersistedZoneSets(zoneSets);
+    const editingZone = state.editingZone?.setId === setId && state.editingZone.zoneId === zoneId ? null : state.editingZone;
+    return { zoneSets, editingZone };
+  }),
+
+  setEditingZone: (target) => set({ editingZone: target }),
+
+  setZoneAssignments: (assignments, timing) => set({ zoneAssignments: assignments, zoneAssignmentTiming: timing }),
+
+  exportZoneSetsJSON: () => JSON.stringify(serializeZoneSets(get().zoneSets), null, 2),
+
+  importZoneSetsJSON: (json) => {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(json);
+    } catch {
+      return { ok: false, error: 'Not valid JSON.' };
+    }
+    const result = parseZoneSetFile(parsed);
+    if (!result.ok) return { ok: false, error: result.error };
+    set(() => {
+      savePersistedZoneSets(result.zoneSets);
+      return { zoneSets: result.zoneSets };
+    });
+    return { ok: true };
+  },
+
+  clearAllZoneSets: () => set(() => {
+    savePersistedZoneSets([]);
+    return { zoneSets: [], zoneAssignments: new Map(), zoneAssignmentTiming: null, editingZone: null };
+  }),
+});

--- a/apps/viewer/src/store/slices/zonesSlice.ts
+++ b/apps/viewer/src/store/slices/zonesSlice.ts
@@ -189,7 +189,10 @@ export const createZonesSlice: StateCreator<ZonesSlice, [], [], ZonesSlice> = (s
     let parsed: unknown;
     try {
       parsed = JSON.parse(json);
-    } catch {
+    } catch (error) {
+      // Keep the structured user-facing error, but never swallow silently
+      // (house rule): the console carries the actual parse failure.
+      console.warn('[zones] failed to parse imported zone-set JSON', error);
       return { ok: false, error: 'Not valid JSON.' };
     }
     const result = parseZoneSetFile(parsed);

--- a/apps/viewer/src/store/slices/zonesSlice.ts
+++ b/apps/viewer/src/store/slices/zonesSlice.ts
@@ -141,7 +141,15 @@ export const createZonesSlice: StateCreator<ZonesSlice, [], [], ZonesSlice> = (s
   replaceZonesInSet: (setId, zones) => set((state) => {
     const zoneSets = state.zoneSets.map((zs) => (zs.id === setId ? { ...zs, zones, updatedAt: Date.now() } : zs));
     savePersistedZoneSets(zoneSets);
-    return { zoneSets };
+    // Replacing a set's zones wholesale (e.g. "generate from storeys") can
+    // remove the zone an edit session points at — same invariant as
+    // `removeZone`: never leave `editingZone` dangling on a zone that no
+    // longer exists (CodeRabbit review of PR #1869).
+    const editing = state.editingZone;
+    const editingZone = editing?.setId === setId && !zones.some((z) => z.id === editing.zoneId)
+      ? null
+      : editing;
+    return { zoneSets, editingZone };
   }),
 
   addZone: (setId, zone) => {
@@ -197,9 +205,19 @@ export const createZonesSlice: StateCreator<ZonesSlice, [], [], ZonesSlice> = (s
     }
     const result = parseZoneSetFile(parsed);
     if (!result.ok) return { ok: false, error: result.error };
-    set(() => {
+    set((state) => {
       savePersistedZoneSets(result.zoneSets);
-      return { zoneSets: result.zoneSets };
+      // Import replaces every set — clear an edit session unless the imported
+      // data still contains the exact set + zone it points at (CodeRabbit
+      // review of PR #1869; same dangling-`editingZone` invariant as
+      // `removeZoneSet`/`removeZone`).
+      const editing = state.editingZone;
+      const editingZone = editing !== null && result.zoneSets.some(
+        (zs) => zs.id === editing.setId && zs.zones.some((z) => z.id === editing.zoneId),
+      )
+        ? editing
+        : null;
+      return { zoneSets: result.zoneSets, editingZone };
     });
     return { ok: true };
   },

--- a/docs/guide/lists.md
+++ b/docs/guide/lists.md
@@ -100,7 +100,7 @@ const csv = listResultToCSV(result);
 
 ## The Data Provider
 
-`executeList` reads model data through the `ListDataProvider` interface, so the package has no hard dependency on how you parsed the model. Required methods include `getEntitiesByType`, `getEntityName`, `getEntityGlobalId`, `getPropertySets`, and `getQuantitySets`; optional methods (`getMaterialNames`, `getClassifications`, `getStoreyName`, `getProjectName`, `getZoneAssignment`, ...) unlock the `material`, `classification`, `spatial`, `model`, and `zone` column sources, and the engine degrades gracefully when they are absent (a `zone` column simply resolves to `null` on a provider without zone data).
+`executeList` reads model data through the `ListDataProvider` interface, so the package has no hard dependency on how you parsed the model. Required methods include `getEntitiesByType`, `getEntityName`, `getEntityGlobalId`, `getPropertySets`, and `getQuantitySets`; optional methods (`getMaterialNames`, `getClassifications`, `getStoreyName`, `getProjectName`, `getZoneAssignment`, `getZoneSetNames`, ...) unlock the `material`, `classification`, `spatial`, `model`, and `zone` column sources, and the engine degrades gracefully when they are absent (a `zone` column simply resolves to `null` on a provider without zone data).
 
 ## Discovering Columns
 

--- a/docs/guide/lists.md
+++ b/docs/guide/lists.md
@@ -42,6 +42,7 @@ Each `ColumnDefinition` has a `source` that says where the value comes from:
 | `classification` | Classification references (joined with `", "`) | `Uniclass Ss_25_10` |
 | `spatial` | Containing spatial element name; `propertyName` picks the level (`Storey` (default), `Building`, `Site`, `Project`) | `Level 2` |
 | `model` | Source file name | `office.ifc` |
+| `zone` | Location-zone assignment (user-defined 3D zone boxes, viewer-computed); `psetName` holds the zone-set id, `propertyName` picks `Zone` (default, the zone name — straddling elements show every touched zone joined with `", "`) or `Straddles` (boolean) | `Section A` |
 
 A column looks like:
 
@@ -99,7 +100,7 @@ const csv = listResultToCSV(result);
 
 ## The Data Provider
 
-`executeList` reads model data through the `ListDataProvider` interface, so the package has no hard dependency on how you parsed the model. Required methods include `getEntitiesByType`, `getEntityName`, `getEntityGlobalId`, `getPropertySets`, and `getQuantitySets`; optional methods (`getMaterialNames`, `getClassifications`, `getStoreyName`, `getProjectName`, ...) unlock the `material`, `classification`, `spatial`, and `model` column sources, and the engine degrades gracefully when they are absent.
+`executeList` reads model data through the `ListDataProvider` interface, so the package has no hard dependency on how you parsed the model. Required methods include `getEntitiesByType`, `getEntityName`, `getEntityGlobalId`, `getPropertySets`, and `getQuantitySets`; optional methods (`getMaterialNames`, `getClassifications`, `getStoreyName`, `getProjectName`, `getZoneAssignment`, ...) unlock the `material`, `classification`, `spatial`, `model`, and `zone` column sources, and the engine degrades gracefully when they are absent (a `zone` column simply resolves to `null` on a provider without zone data).
 
 ## Discovering Columns
 

--- a/packages/lists/src/engine.ts
+++ b/packages/lists/src/engine.ts
@@ -317,9 +317,35 @@ function getConditionValue(
       return getSpatialValue(entityId, condition.propertyName, provider);
     case 'model':
       return provider.getModelName?.() || null;
+    case 'zone':
+      return getZoneValue(entityId, condition.psetName ?? '', condition.propertyName, provider);
     default:
       return null;
   }
+}
+
+/**
+ * Resolve a `zone` column/condition (issue #1810): `zoneSetId` identifies
+ * which zone set (durable id, not display name — sets can be renamed);
+ * `mode` selects `Zone` (default — the zone name, or every straddled zone's
+ * name joined when the element crosses a boundary) or `Straddles` (boolean),
+ * matched case-insensitively like `spatial`'s level selector. `null` when the
+ * provider has no zone data (no zones defined, or this element was never
+ * classified).
+ */
+function getZoneValue(
+  entityId: number,
+  zoneSetId: string,
+  mode: string,
+  provider: ListDataProvider,
+): CellValue {
+  const assignment = provider.getZoneAssignment?.(entityId, zoneSetId);
+  if (!assignment) return null;
+  if (mode.toLowerCase() === 'straddles') return assignment.straddles;
+  if (assignment.straddles && assignment.touchedZoneNames.length > 0) {
+    return uniqueJoin(assignment.touchedZoneNames);
+  }
+  return assignment.zoneName;
 }
 
 /**
@@ -475,6 +501,9 @@ function extractColumnValues(
         break;
       case 'model':
         values[i] = provider.getModelName?.() || null;
+        break;
+      case 'zone':
+        values[i] = getZoneValue(entityId, col.psetName ?? '', col.propertyName, provider);
         break;
       default:
         values[i] = null;

--- a/packages/lists/src/engine.zone.test.ts
+++ b/packages/lists/src/engine.zone.test.ts
@@ -1,0 +1,117 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Location-zone column/condition support (issue #1810). The `zone` source
+ * bridges a viewer-computed classification (which zone box each element's
+ * centroid falls into, plus a "straddles" flag when its bounds cross a
+ * boundary) into a list column/filter, entirely independent of IFC pset
+ * data — the assignment math itself is unit-tested in
+ * `apps/viewer/src/lib/zones`; this only exercises the engine's resolution
+ * of the `getZoneAssignment` provider hook.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { IfcTypeEnum } from '@ifc-lite/data';
+import { executeList } from './engine.js';
+import type { ListDataProvider, ListDefinition } from './types.js';
+
+type Assignment = { zoneName: string | null; straddles: boolean; touchedZoneNames: string[] };
+
+function createProvider(assignments: Map<number, Assignment>): ListDataProvider {
+  return {
+    getEntitiesByType: (t) => (t === IfcTypeEnum.IfcWall ? [1, 2, 3] : []),
+    getEntityName: (id) => `Wall-${id}`,
+    getEntityGlobalId: (id) => `guid-${id}`,
+    getEntityDescription: () => '',
+    getEntityObjectType: () => '',
+    getEntityTag: () => '',
+    getEntityTypeName: () => 'IfcWall',
+    getPropertySets: () => [],
+    getQuantitySets: () => [],
+    getZoneAssignment: (id, setId) => (setId === 'sections' ? assignments.get(id) ?? null : null),
+    getZoneSetNames: () => [{ id: 'sections', name: 'Sections' }],
+  };
+}
+
+function walls(columns: ListDefinition['columns'], conditions: ListDefinition['conditions'] = []): ListDefinition {
+  return { id: 't', name: 'T', createdAt: 0, updatedAt: 0, entityTypes: [IfcTypeEnum.IfcWall], conditions, columns };
+}
+
+describe('zone column/condition (#1810)', () => {
+  const assignments = new Map<number, Assignment>([
+    [1, { zoneName: 'Section A', straddles: false, touchedZoneNames: [] }],
+    [2, { zoneName: null, straddles: true, touchedZoneNames: ['Section A', 'Section B'] }],
+    [3, { zoneName: null, straddles: false, touchedZoneNames: [] }], // unassigned
+  ]);
+
+  it('resolves the zone name for a cleanly-assigned element', () => {
+    const result = executeList(
+      walls([{ id: 'z', source: 'zone', psetName: 'sections', propertyName: 'Zone' }]),
+      createProvider(assignments),
+    );
+    expect(result.rows.find(r => r.entityId === 1)!.values[0]).toBe('Section A');
+  });
+
+  it('joins the touched zone names when the element straddles a boundary', () => {
+    const result = executeList(
+      walls([{ id: 'z', source: 'zone', psetName: 'sections', propertyName: 'Zone' }]),
+      createProvider(assignments),
+    );
+    expect(result.rows.find(r => r.entityId === 2)!.values[0]).toBe('Section A, Section B');
+  });
+
+  it('resolves null for an unassigned element', () => {
+    const result = executeList(
+      walls([{ id: 'z', source: 'zone', psetName: 'sections', propertyName: 'Zone' }]),
+      createProvider(assignments),
+    );
+    expect(result.rows.find(r => r.entityId === 3)!.values[0]).toBe(null);
+  });
+
+  it('resolves the Straddles boolean column independent of the Zone column', () => {
+    const result = executeList(
+      walls([{ id: 's', source: 'zone', psetName: 'sections', propertyName: 'Straddles' }]),
+      createProvider(assignments),
+    );
+    expect(result.rows.map(r => r.values[0])).toEqual([false, true, false]);
+  });
+
+  it('an unknown zone-set id resolves to null (provider has no data for it)', () => {
+    const result = executeList(
+      walls([{ id: 'z', source: 'zone', psetName: 'takt', propertyName: 'Zone' }]),
+      createProvider(assignments),
+    );
+    expect(result.rows.every(r => r.values[0] === null)).toBe(true);
+  });
+
+  it('filters rows via a zone equals condition', () => {
+    const result = executeList(
+      walls([{ id: 'z', source: 'zone', psetName: 'sections', propertyName: 'Zone' }], [
+        { source: 'zone', psetName: 'sections', propertyName: 'Zone', operator: 'equals', value: 'Section A' },
+      ]),
+      createProvider(assignments),
+    );
+    expect(result.rows.map(r => r.entityId)).toEqual([1]);
+  });
+
+  it('a provider with no getZoneAssignment resolves every zone column to null (backward compatible)', () => {
+    const provider: ListDataProvider = {
+      getEntitiesByType: (t) => (t === IfcTypeEnum.IfcWall ? [1] : []),
+      getEntityName: () => 'Wall-1',
+      getEntityGlobalId: () => 'guid-1',
+      getEntityDescription: () => '',
+      getEntityObjectType: () => '',
+      getEntityTag: () => '',
+      getEntityTypeName: () => 'IfcWall',
+      getPropertySets: () => [],
+      getQuantitySets: () => [],
+    };
+    const result = executeList(
+      walls([{ id: 'z', source: 'zone', psetName: 'sections', propertyName: 'Zone' }]),
+      provider,
+    );
+    expect(result.rows[0].values[0]).toBe(null);
+  });
+});

--- a/packages/lists/src/types.ts
+++ b/packages/lists/src/types.ts
@@ -124,6 +124,24 @@ export interface ListDataProvider {
    * when absent, callers fall back to the type-sampled `discoverColumns()`.
    */
   discoverAllColumns?(): DiscoveredColumns;
+
+  /**
+   * Location-zone assignment (issue #1810) for `zoneSetId` — a viewer-side
+   * classification computed from 3D boxes the user draws, not from IFC pset
+   * data. `null` when no assignment has been computed yet (e.g. no zones
+   * defined) or `zoneSetId` doesn't resolve. `touchedZoneNames` lists every
+   * zone the element's bounds overlap, in the same order the assignment
+   * engine found them — non-empty only when `straddles` is true. Optional:
+   * providers built before zones existed simply have no `zone` column data.
+   */
+  getZoneAssignment?(expressId: number, zoneSetId: string): {
+    zoneName: string | null;
+    straddles: boolean;
+    touchedZoneNames: string[];
+  } | null;
+  /** Every zone set currently defined, for the column/condition picker to
+   *  offer by name while storing the durable id. */
+  getZoneSetNames?(): Array<{ id: string; name: string }>;
 }
 
 /** A classification reference exposed to the list engine (code + name). */
@@ -197,12 +215,17 @@ export interface PropertyCondition {
    * - `spatial` — a spatial-container name; `propertyName` selects the level
    *   (`Container`, `Storey` (default), `Building`, `Site`, or `Project`)
    * - `model` — the source model / file name (federation identity)
+   * - `zone` — a location-zone assignment (issue #1810); `psetName` holds the
+   *   zone-SET id, `propertyName` selects `Zone` (default, the zone name —
+   *   or the straddled zones joined when the element crosses a boundary) or
+   *   `Straddles` (boolean)
    */
-  source: 'attribute' | 'property' | 'quantity' | 'material' | 'classification' | 'spatial' | 'model';
-  /** Property set name (for property/quantity sources) */
+  source: 'attribute' | 'property' | 'quantity' | 'material' | 'classification' | 'spatial' | 'model' | 'zone';
+  /** Property set name (for property/quantity sources); the zone-SET id for `zone`. */
   psetName?: string;
-  /** Attribute / property / quantity name, or the spatial level for `spatial`
-   *  (`Container` | `Storey` | `Building` | `Site` | `Project`). Ignored for
+  /** Attribute / property / quantity name, the spatial level for `spatial`
+   *  (`Container` | `Storey` | `Building` | `Site` | `Project`), or the zone
+   *  display mode for `zone` (`Zone` (default) | `Straddles`). Ignored for
    *  material/classification/model. */
   propertyName: string;
   operator: ConditionOperator;
@@ -230,13 +253,16 @@ export interface ColumnDefinition {
    * multi-valued (joined with ", "); `spatial` is a spatial-container name at
    * the level named by `propertyName` (`Container` | `Storey` (default) |
    * `Building` | `Site` | `Project`); `model` is the source model / file name
-   * (federation identity).
+   * (federation identity); `zone` is a location-zone assignment (issue
+   * #1810) — see `PropertyCondition.source` for the exact `psetName`/
+   * `propertyName` contract, shared verbatim between conditions and columns.
    */
-  source: 'attribute' | 'property' | 'quantity' | 'material' | 'classification' | 'spatial' | 'model';
-  /** For property: pset name. For quantity: qset name. */
+  source: 'attribute' | 'property' | 'quantity' | 'material' | 'classification' | 'spatial' | 'model' | 'zone';
+  /** For property: pset name. For quantity: qset name. For zone: the zone-SET id. */
   psetName?: string;
-  /** Attribute / property / quantity name, or the spatial level for `spatial`
-   *  (`Container` | `Storey` | `Building` | `Site` | `Project`). Ignored for
+  /** Attribute / property / quantity name, the spatial level for `spatial`
+   *  (`Container` | `Storey` | `Building` | `Site` | `Project`), or the zone
+   *  display mode for `zone` (`Zone` (default) | `Straddles`). Ignored for
    *  material/classification/model. */
   propertyName: string;
   /** Display label override */


### PR DESCRIPTION
## What the issue asked for, and how much this delivers

#1810 (from discussion #1763) asks to split/assign model elements by custom 3D zones (construction sections, takt areas): define volumes, figure out which volume(s) each element falls into, handle boundary-crossers by **either geometric splitting or a per-zone quantity breakdown**, support several zone sets at once, and end with a filterable/exportable per-element property. Louis's comment adds: it must work across multiple loaded models at once.

**Delivered (v1):**
- User-defined 3D zones as oriented boxes (Y-axis rotation only): numeric editing, 3D drag gizmo (move/resize/rotate), auto-generation from building storeys, JSON export/import + localStorage auto-persist.
- Per-element classification across every loaded (federated) model at once, recomputed automatically as models load/unload and zones change.
- Multiple independent zone sets ("Sections" AND "Takt areas") that never interfere.
- A `zone` column/condition source in `@ifc-lite/lists` (filter, group, CSV-export by zone), zone membership in the Properties panel, and "select everything in this zone".

**Not delivered (honest gaps vs the ask):** no geometric splitting at zone boundaries, and no pro-rated per-zone **quantity breakdown** for boundary-crossing elements — a straddler is flagged (`straddles`, with every touched zone listed) but its quantities are not apportioned. Zone volumes are boxes only (no arbitrary prisms / imported volumes), and the assignment is not written back into the IFC as a pset. Hence **Refs #1810**, not Closes.

## Design

- `apps/viewer/src/lib/zones/` — pure, unit-tested core: OBB math (`geometry.ts`), assignment engine (`assignment.ts`), storey generation (`storey-generation.ts`), versioned JSON persistence (`persistence.ts`, `version: 1` + strict validation, migrations required for future shape changes).
- `zonesSlice` holds zone-set CRUD + the computed assignment cache; `useZoneAssignmentSync` gathers world-space element AABBs from the renderer `Scene` (which already folds `MeshData.origin`, so local-frame elements far from the origin are correct) and runs the pure engine, debounced 200ms.
- Scene mesh ids are **federated global ids** (`mesh.expressId + idOffset` at upload), so assignments are namespaced per model; unloading a model removes its entries on the next recompute, and `resetViewerState` now drops the assignment cache so a newly loaded model can't briefly read the old model's zone membership through colliding ids.
- All coordinates are the viewer's world frame (Y-up, **metres** regardless of the source file's units — unit scaling happens in the geometry pipeline), so the fixed epsilons are scale-correct.
- Storey generation reuses the canonical `spatialHierarchy.storeyElevations` (metres, the single storey-elevation channel consolidated in #1857) plus the hierarchy tree's `elevationKey` 0.5m merge so a storey split across federated files yields ONE zone. It does not add another `findStoreyByElevation` implementation.

## Zone-assignment semantics (plain terms)

- An element's **home zone** is the zone containing its AABB centroid.
- An element **touches** a zone only when its box really penetrates it by > 1mm (`STRADDLE_PENETRATION_M`) — implemented as a negative epsilon on the SAT overlap test. This is deliberate: takt areas / sections **tile** the building sharing exact boundary planes, and a wall ending exactly at a shared boundary must not be flagged as straddling with zero actual overlap (that was the bug the last commit fixed; the flag would have flooded on precisely the models this feature targets).
- `straddles` = touches more than one zone, or touches a zone without its centroid being in any.
- Geometry is never split; the flag + touched-zone list is informational.

## Adversarial testing done

- **Boundary/penetration edges:** element ending exactly on a shared boundary (no straddle — tested), element penetrating 5cm past it (straddles — tested), degenerate zero-thickness AABB exactly on a boundary (unassigned, documented + tested), thin element deep inside a zone (still assigned — the negative-eps SAT only penalizes faces within 1mm of a zone face, not thin extents; verified by hand-tracing the interval math), huge AABB fully containing a zone (counts as touching; straddle when it spans several), rotated-zone false-positive corner case (SAT-exact, tested), zero-size and negative-size zones (negative sizes rejected on import, clamped to 0.05m minimum in both the panel and the gizmo; a degenerate zone matches nothing rather than crashing).
- **Mutation check:** flipped the negative epsilon back to positive (reverting the essence of the last commit) — `assignment.test.ts` fails 2 tests; restored. The tests test behaviour, not the implementation.
- **Local-frame origin:** verified `Scene.getEntityBoundingBox` adds `piece.origin` per piece (scene.ts) and caches instanced-occurrence AABBs at upload, so element bounds and zone boxes are compared in the same world space.
- **Multi-model:** verified the upload path offsets mesh ids into the federated global-id space before the scene sees them; assignments are fully replaced on every recompute keyed off the `models` map reference + `geometryUpdateTick`, so unloading a model leaves no stale entries. Found and fixed the model-RESET hole (new commit): `resetViewerState` cleared every other model-derived cache but kept `zoneAssignments`.
- **Lists multi-valued semantics:** zero zones -> `null` cell; straddler -> touched names joined `", "` (same convention as the material source), so `equals "Section A"` intentionally excludes straddlers (use `contains`); `Straddles` is a separate boolean column; providers without zone data resolve to `null` (backward compatible, tested).
- **Persistence:** versioned (`version: 1`), strict field validation, wrong-version/corrupt files fail loudly with a message instead of silently dropping zones (tested). Future shape changes must bump + migrate (documented in `types.ts`).

## Gates (actual results)

- `pnpm typecheck` — 33/33 tasks successful.
- `pnpm --filter @ifc-lite/viewer test` — 1878 pass, 0 fail, 2 skipped.
- `pnpm --filter @ifc-lite/lists test` — 112 pass (5 files).
- `node scripts/check-test-wiring.mjs` — pass.
- `node scripts/check-api-surface.mjs` — pass (37 packages, 3945 exports; no new top-level exports, only members inside existing `@ifc-lite/lists` types).
- `pnpm docs:check-samples` — 246 snippets clean.
- Changeset: `.changeset/zone-column-source-1810.md`, `@ifc-lite/lists` **minor** (additive on a 1.x package). `docs/guide/lists.md` updated in this PR.

## Known limitations

- Straddlers are flagged, not split or quantity-apportioned (the biggest remaining piece of the original ask).
- Rotation gizmo drag is screen-space-approximate under oblique cameras (exact in top view; numeric field is always exact).
- Elements with no geometry (no scene mesh) are not classified — zone assignment is geometric by design.
- Zone boxes only (no prisms / imported volumes); assignment lives in viewer state + JSON export, not IFC psets.

Refs #1810

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M76mvdz8Hz7WHEoxwn694V


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added location zones for grouping model elements into customizable 3D zone sets.
  * Create, rename, edit, delete, show, hide, import, and export zones.
  * Generate zones automatically from building storeys.
  * Select elements within a zone and view zone assignments in the Properties panel.
  * Use zone names and straddling status in list columns and filters.
* **Documentation**
  * Documented zone-based list columns, filters, and data-provider behavior.
* **Tests**
  * Added coverage for zone geometry, assignments, persistence, and list integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->