### PR TITLE
fix(cli): clash --json emits exactly one JSON document on stdout

### DIFF
--- a/.changeset/clash-json-clean-stdout.md
+++ b/.changeset/clash-json-clean-stdout.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/cli": patch
+---
+
+`ifc-lite clash --json` now emits exactly one JSON document on stdout. Geometry and opening-pipeline diagnostics ("[IFC-LITE] ..." lines from the wasm print bindings and geometry processing) are routed to stderr for the whole clash run, in both JSON and human output modes, so consumers can `JSON.parse` stdout directly instead of scraping the trailing JSON. The JSON payload schema is unchanged.

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -522,7 +522,7 @@ ifc-lite clash model.ifc --matrix --bcf clashes.bcfzip
 | `--group <g>` | BCF topic grouping: `cluster` (default), `rule`, `typePair`, `element` |
 | `--bcf-status <s>` | Topic status for exported BCF topics |
 | `--max-topics <N>` | Cap the number of BCF topics |
-| `--json` | JSON output |
+| `--json` | JSON output (stdout carries exactly one JSON document; progress and geometry diagnostics go to stderr) |
 
 ---
 

--- a/packages/cli/src/commands/clash.test.ts
+++ b/packages/cli/src/commands/clash.test.ts
@@ -1,0 +1,87 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `ifc-lite clash --json` must emit exactly one JSON document on stdout.
+ *
+ * Regression test: the geometry/opening pipeline (including wasm print
+ * bindings) used to write "[IFC-LITE] ..." diagnostic lines to stdout via
+ * console.log/info, interleaving with the JSON payload and forcing consumers
+ * to scrape the trailing JSON. Diagnostics now go to stderr.
+ *
+ * Runs the real built CLI as a subprocess on a synthetic wall+door model.
+ * The hosted door guarantees the opening pipeline emits its "[IFC-LITE]"
+ * classifier/rect_fast diagnostics, so the test proves they land on stderr
+ * rather than proving nothing on a silent model.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { existsSync } from 'node:fs';
+import { writeFile, mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { IfcCreator } from '@ifc-lite/create';
+
+const execFileAsync = promisify(execFile);
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CLI_ENTRY = join(__dirname, '../../dist/index.js');
+const WASM_RUNTIME = join(__dirname, '../../../wasm/pkg/ifc-lite_bg.wasm');
+
+// Meshing needs the built CLI plus the wasm runtime (gitignored, rebuilt per
+// host). Skip cleanly when either is absent: build with
+// `pnpm turbo run build --filter=@ifc-lite/cli` and `scripts/build-wasm.sh`.
+const canRun = existsSync(CLI_ENTRY) && existsSync(WASM_RUNTIME);
+
+function buildClashModel(): string {
+  const creator = new IfcCreator({ Name: 'ClashJsonTest' });
+  const storey = creator.addIfcBuildingStorey({ Name: 'L1', Elevation: 0 });
+  // Wall with a hosted door: triggers the opening/void pipeline and its
+  // "[IFC-LITE]" console diagnostics during meshing.
+  const wall = creator.addIfcWall(storey, { Start: [0, 0, 0], End: [4, 0, 0], Height: 3, Thickness: 0.2 });
+  creator.addIfcWallDoor(wall, { Width: 0.9, Height: 2.1, Position: [1.5, 0, 0] });
+  // Second wall crossing the first so the run reports at least one clash.
+  creator.addIfcWall(storey, { Start: [2, -2, 0], End: [2, 2, 0], Height: 3, Thickness: 0.2 });
+  return creator.toIfc().content;
+}
+
+describe('clash --json stdout hygiene', () => {
+  it.skipIf(!canRun)(
+    'stdout is exactly one parseable JSON document; diagnostics go to stderr',
+    async () => {
+      const dir = await mkdtemp(join(tmpdir(), 'ifc-lite-clash-json-'));
+      const modelPath = join(dir, 'model.ifc');
+      try {
+        await writeFile(modelPath, buildClashModel());
+
+        const { stdout, stderr } = await execFileAsync(
+          process.execPath,
+          [CLI_ENTRY, 'clash', modelPath, '--json'],
+          { timeout: 120_000, maxBuffer: 64 * 1024 * 1024 },
+        );
+
+        // The whole of stdout must parse directly - no extractTrailingJson
+        // style scraping allowed.
+        const payload = JSON.parse(stdout) as {
+          summary: { total: number };
+          clashes: unknown[];
+        };
+        expect(stdout.trimStart().startsWith('{')).toBe(true);
+        expect(payload.summary.total).toBeGreaterThan(0);
+        expect(Array.isArray(payload.clashes)).toBe(true);
+        expect(stdout).not.toContain('[IFC-LITE]');
+
+        // The diagnostics are not swallowed - they moved to stderr. This also
+        // proves the model actually exercised the noisy opening pipeline.
+        expect(stderr).toContain('[IFC-LITE]');
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    },
+    180_000,
+  );
+});

--- a/packages/cli/src/commands/clash.test.ts
+++ b/packages/cli/src/commands/clash.test.ts
@@ -5,10 +5,11 @@
 /**
  * `ifc-lite clash --json` must emit exactly one JSON document on stdout.
  *
- * Regression test: the geometry/opening pipeline (including wasm print
- * bindings) used to write "[IFC-LITE] ..." diagnostic lines to stdout via
- * console.log/info, interleaving with the JSON payload and forcing consumers
- * to scrape the trailing JSON. Diagnostics now go to stderr.
+ * Regression test for PR #1872: the geometry/opening pipeline (including
+ * wasm print bindings) used to write "[IFC-LITE] ..." diagnostic lines to
+ * stdout via console.log/info, interleaving with the JSON payload and
+ * forcing consumers to scrape the trailing JSON (see the world-gym
+ * labeler's extractTrailingJson workaround). Diagnostics now go to stderr.
  *
  * Runs the real built CLI as a subprocess on a synthetic wall+door model.
  * The hosted door guarantees the opening pipeline emits its "[IFC-LITE]"

--- a/packages/cli/src/commands/clash.ts
+++ b/packages/cli/src/commands/clash.ts
@@ -15,7 +15,7 @@
 import { readFile, writeFile } from 'node:fs/promises';
 import { basename } from 'node:path';
 import { createHeadlessContext } from '../loader.js';
-import { getFlag, hasFlag, fatal, printJson } from '../output.js';
+import { getFlag, hasFlag, fatal, printJson, routeConsoleDiagnosticsToStderr } from '../output.js';
 import { GeometryProcessor, type MeshData } from '@ifc-lite/geometry';
 import type { IfcDataStore } from '@ifc-lite/parser';
 import {
@@ -154,6 +154,14 @@ function printHumanSummary(result: ClashResult): void {
 }
 
 export async function clashCommand(args: string[]): Promise<void> {
+  // The geometry/opening pipeline (including wasm print bindings captured at
+  // module init) writes "[IFC-LITE] ..." diagnostics via console.log/info,
+  // which land on stdout and corrupt the --json payload (consumers were forced
+  // to scrape the trailing JSON). Route ALL console diagnostics to stderr for
+  // the whole run - before any wasm init - so stdout carries exactly one JSON
+  // document (or the human summary) and nothing else.
+  routeConsoleDiagnosticsToStderr();
+
   const filePath = args.find(a => !a.startsWith('-'));
   if (!filePath) {
     fatal('Usage: ifc-lite clash <file.ifc> [--a <selector>] [--b <selector>] [--mode hard|clearance] [--tolerance N] [--clearance N] [--matrix] [--bcf <out.bcfzip>] [--group cluster|rule|typePair|element] [--bcf-status <status>] [--max-topics N] [--json]');

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -7,9 +7,36 @@
  */
 
 import { writeFile } from 'node:fs/promises';
+import { format } from 'node:util';
 import { logger } from './logger.js';
 
 export type OutputFormat = 'json' | 'table' | 'csv';
+
+let consoleRoutedToStderr = false;
+
+/**
+ * Route console diagnostics (`console.log`/`info`/`debug`) to stderr for the
+ * rest of the process, so stdout stays reserved for the command's payload
+ * (JSON or the human summary). `console.warn`/`error` already write to stderr
+ * in Node and are left untouched.
+ *
+ * Deliberately NOT scoped/restored: the wasm geometry module captures its
+ * print bindings at init time, so a restore-in-finally wrapper leaks
+ * diagnostics back onto stdout whenever the module prints through a binding
+ * taken before or outside the scope. Call this before the first
+ * GeometryProcessor init; commands print their own output via
+ * `process.stdout.write`/`printJson`, which this does not touch.
+ */
+export function routeConsoleDiagnosticsToStderr(): void {
+  if (consoleRoutedToStderr) return;
+  consoleRoutedToStderr = true;
+  const toStderr = (...parts: unknown[]) => {
+    process.stderr.write(`${format(...parts)}\n`);
+  };
+  console.log = toStderr;
+  console.info = toStderr;
+  console.debug = toStderr;
+}
 
 /**
  * Write output to stdout or a file. Bytes are written verbatim (no string


### PR DESCRIPTION
## Problem

`ifc-lite clash --json` interleaved geometry diagnostics with the JSON payload on stdout:

```
[IFC-LITE] Opening classifier: rect=1 diag=0 non_rect=0 (total=1)
[IFC-LITE] Opening pipeline: 0 CSG failures. 1 hosts with openings.
  IfcWall: hosts=1 openings=1 (rect=1 diag=0 non_rect=0)
[IFC-LITE] rect_fast: fired=1 (cut 1 openings) | deferred: ...
{
  "summary": { ...
```

The wasm print bindings (`web_sys::console::info_1` in `rust/wasm-bindings/src/api/csg_diagnostics.rs`) and geometry-processing logs go through `console.log`/`console.info`, which Node writes to **stdout**. Consumers were forced to scrape the trailing JSON (see `extractTrailingJson` in the moonshot branch's `tools/world-gym/labeler.mjs`, the workaround this breaks).

## Change

- New `routeConsoleDiagnosticsToStderr()` in `packages/cli/src/output.ts`: redirects `console.log`/`info`/`debug` to stderr for the rest of the process (`warn`/`error` already write to stderr in Node). Deliberately **not** scoped/restored: the wasm module captures its print bindings at init time, so a restore-in-finally wrapper leaks diagnostics back onto stdout whenever the module prints through a binding taken outside the scope (this exact failure mode was documented in the world-gym `withQuietConsole` notes).
- `clashCommand` calls it first thing, before any wasm init, in **both** `--json` and human modes (per "ideally always for [IFC-LITE] diagnostics"): stdout carries exactly one JSON document (or the human summary); all diagnostics/progress land on stderr, still visible, not swallowed.
- Command payloads print via `process.stdout.write`/`printJson` and are untouched. **The JSON payload schema is unchanged.** No new package-entry exports (`@ifc-lite/cli` api-surface stays `[]`).
- Docs: `--json` flag row in `docs/guide/cli.md` clash section now states the stdout contract. Changeset: patch.

## Print sites covered (survey)

- Rust wasm `[IFC-LITE]` lines (`csg_diagnostics.rs`, via `console.info`/`warn`) - the reported offender; `info` now lands on stderr, `warn` already did.
- `packages/geometry` `[stream]`/`[GeometryProcessor]` `console.log`/`info`/`warn` sites - covered by the same redirect.
- Parser console output - already captured by `loadIfcBytes` in `loader.ts` (unchanged).
- `packages/clash` engine/BCF - `console.warn` only (already stderr); progress + BCF confirmation lines already used `process.stderr.write`.

## Tests

- New `packages/cli/src/commands/clash.test.ts`: spawns the real built CLI on a synthetic wall + hosted-door + crossing-wall model (built in-test with `IfcCreator`, no fixture download). The hosted door deterministically fires the opening-pipeline diagnostics, so the test asserts (1) the whole of stdout `JSON.parse`s directly, (2) `summary.total > 0` with a clashes array, (3) no `[IFC-LITE]` on stdout, and (4) `[IFC-LITE]` **is present on stderr** (diagnostics moved, not swallowed). Skips cleanly (per AGENTS.md) when the CLI dist or the gitignored wasm runtime is absent.
- **Adversarial check:** commenting the `routeConsoleDiagnosticsToStderr()` call out of the built dist makes the test fail with a JSON parse error on the polluted stdout; restoring it goes green. The test genuinely discriminates.
- Real model: `clash AC20-FZK-Haus.ifc --matrix --json` produces stdout that parses directly, with 3 `[IFC-LITE]` lines on stderr.
- `pnpm vitest run` in `packages/cli`: **12 files, 183 tests passed** (baseline 182 + this one).
- `pnpm exec tsc --noEmit` in `packages/cli`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)