### PR TITLE
feat(viewer,drawing-2d): point-cloud scan overlay on the 2D section view (#1805)

### DIFF
--- a/.changeset/scan-section-2d-layer.md
+++ b/.changeset/scan-section-2d-layer.md
@@ -1,0 +1,12 @@
+---
+'@ifc-lite/drawing-2d': minor
+---
+
+Export `projectTo2DBasis` from the package root.
+
+It already existed in `math.ts` and is used internally by `section-cutter.ts`
+for face-picked custom-plane sections, but was never re-exported. The new
+point-cloud "scan" layer on the 2D section view (issue #1805) needs it as a
+consumer outside the package, to project retained scan points into the same
+drawing-space coordinates the section cutter produces for custom (non-cardinal)
+cut planes.

--- a/apps/viewer/src/components/viewer/Drawing2DCanvas.tsx
+++ b/apps/viewer/src/components/viewer/Drawing2DCanvas.tsx
@@ -16,6 +16,7 @@ import { drawCloudOnCanvas } from './tools/cloudPathGenerator';
 import type { PolygonArea2DResult, TextAnnotation2D, CloudAnnotation2D, Annotation2DTool, Point2D, SelectedAnnotation2D } from '@/store/slices/drawing2DSlice';
 import type { DxfUnderlayRenderData } from '@/hooks/useDxfUnderlay';
 import type { AnnotationFill2D, AnnotationText2D } from '@/hooks/useSymbolicAnnotations';
+import type { ScanBandPoint } from '@/hooks/scanSectionMath';
 
 // Fill colors for IFC types (architectural convention)
 const IFC_TYPE_FILL_COLORS: Record<string, string> = {
@@ -289,6 +290,46 @@ function drawDxfUnderlaysScreenSpace(
   }
 }
 
+/** Dot half-size in screen pixels — constant regardless of zoom, like the DXF underlay's text. */
+const SCAN_DOT_HALF_PX = 0.75;
+const SCAN_DOT_NEUTRAL_COLOR = '#8a8a8a';
+
+/**
+ * Render the point-cloud scan overlay (issue #1805), in screen pixels.
+ * `scanPoints` already live in the drawing's native 2D coordinate space —
+ * `scanSectionMath.ts` projects them with the SAME `projectTo2D` /
+ * `projectTo2DBasis` functions the section cutter uses for `cutPolygons` /
+ * `lines` — so the caller supplies the plain drawing→screen transform, same
+ * as `drawDxfUnderlaysScreenSpace`.
+ *
+ * Dots draw as tiny filled squares (`fillRect`), not circles: at up to the
+ * 500k-point render cap, skipping `beginPath`/`arc`/`fill` per point matters
+ * — `fillRect` is a single cheap call with no path tessellation, and at
+ * ~1-1.5px a square reads the same as a disc anyway. `fillStyle` is still
+ * set per point (colour varies point-to-point for RGB scans); the
+ * perf-sensitive part being avoided is the path/arc machinery, not the
+ * fillStyle assignment itself.
+ */
+function drawScanSectionScreenSpace(
+  ctx: CanvasRenderingContext2D,
+  points: readonly ScanBandPoint[] | undefined,
+  modelToScreen: (x: number, y: number) => { x: number; y: number },
+  opacity: number,
+): void {
+  if (!points || points.length === 0 || opacity <= 0) return;
+  ctx.save();
+  ctx.globalAlpha = opacity;
+  const size = SCAN_DOT_HALF_PX * 2;
+  for (const p of points) {
+    const screen = modelToScreen(p.point.x, p.point.y);
+    ctx.fillStyle = p.color
+      ? `rgb(${Math.round(p.color[0] * 255)}, ${Math.round(p.color[1] * 255)}, ${Math.round(p.color[2] * 255)})`
+      : SCAN_DOT_NEUTRAL_COLOR;
+    ctx.fillRect(screen.x - SCAN_DOT_HALF_PX, screen.y - SCAN_DOT_HALF_PX, size, size);
+  }
+  ctx.restore();
+}
+
 // Static constants to avoid creating new objects/arrays on every render
 const CANVAS_STYLE = { imageRendering: 'crisp-edges' as const };
 const EMPTY_MEASURE_RESULTS: Measure2DResultData[] = [];
@@ -339,6 +380,9 @@ interface Drawing2DCanvasProps {
   ifcAnnotationFills?: readonly AnnotationFill2D[];
   // DXF reference underlays, pre-mapped to drawing space (issue #1782)
   dxfUnderlays?: readonly DxfUnderlayRenderData[];
+  // Point-cloud scan overlay, already in drawing space (issue #1805)
+  scanPoints?: readonly ScanBandPoint[];
+  scanOpacity?: number;
 }
 
 export function Drawing2DCanvas({
@@ -372,6 +416,8 @@ export function Drawing2DCanvas({
   ifcAnnotationTexts,
   ifcAnnotationFills,
   dxfUnderlays,
+  scanPoints,
+  scanOpacity = 1,
 }: Drawing2DCanvasProps): React.ReactElement {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const [canvasSize, setCanvasSize] = useState({ width: 0, height: 0 });
@@ -907,6 +953,11 @@ export function Drawing2DCanvas({
           (mm) => Math.max(0.5, mmToScreen(mm) * 0.3),
           (worldHeight) => Math.max(8, worldHeight * drawingTransform.scaleFactor * transform.scale),
         );
+
+        // Point-cloud scan overlay (issue #1805) — drawn last, on top of the
+        // cut geometry. `scanPoints` are already in the same drawing space
+        // as `cutPolygons`/`lines`, so the same `modelToScreen` applies.
+        drawScanSectionScreenSpace(ctx, scanPoints, modelToScreen, scanOpacity);
       };
 
       drawModelContent();
@@ -1260,6 +1311,16 @@ export function Drawing2DCanvas({
         // World height directly to screen pixels through the active zoom.
         // 8 px floor so labels stay legible when zoomed way out.
         (worldHeight) => Math.max(8, worldHeight * transform.scale),
+      );
+
+      // Point-cloud scan overlay (issue #1805) — same drawing-space content
+      // as `cutPolygons`/`lines`, so it uses the identical direct scale/
+      // translate the main content used before `ctx.restore()`.
+      drawScanSectionScreenSpace(
+        ctx,
+        scanPoints,
+        (x, y) => ({ x: x * directScaleX + transform.x, y: y * directScaleY + transform.y }),
+        scanOpacity,
       );
     }
 
@@ -1715,7 +1776,7 @@ export function Drawing2DCanvas({
         }
       }
     }
-  }, [drawing, transform, showHiddenLines, canvasSize, overrideEngine, overridesEnabled, entityColorMap, useIfcMaterials, measureMode, measureStart, measureCurrent, measureResults, measureSnapPoint, sheetEnabled, activeSheet, sectionAxis, isPinned, annotation2DActiveTool, annotation2DCursorPos, polygonAreaPoints, polygonAreaResults, textAnnotations, textAnnotationEditing, cloudAnnotationPoints, cloudAnnotations, selectedAnnotation, ifcAnnotationLines, ifcAnnotationTexts, ifcAnnotationFills, dxfUnderlays]);
+  }, [drawing, transform, showHiddenLines, canvasSize, overrideEngine, overridesEnabled, entityColorMap, useIfcMaterials, measureMode, measureStart, measureCurrent, measureResults, measureSnapPoint, sheetEnabled, activeSheet, sectionAxis, isPinned, annotation2DActiveTool, annotation2DCursorPos, polygonAreaPoints, polygonAreaResults, textAnnotations, textAnnotationEditing, cloudAnnotationPoints, cloudAnnotations, selectedAnnotation, ifcAnnotationLines, ifcAnnotationTexts, ifcAnnotationFills, dxfUnderlays, scanPoints, scanOpacity]);
 
   return (
     <canvas

--- a/apps/viewer/src/components/viewer/ScanSectionPanel.tsx
+++ b/apps/viewer/src/components/viewer/ScanSectionPanel.tsx
@@ -117,9 +117,11 @@ export function ScanSectionPanel({
 
         {hasPointCloud && (
           <p className="text-[11px] text-muted-foreground border-t pt-2">
-            {renderedCount >= totalInBand
-              ? `Showing all ${totalInBand.toLocaleString()} points in band.`
-              : `Showing ${renderedCount.toLocaleString()} of ${totalInBand.toLocaleString()} points in band (decimated for display).`}
+            {!showScanSection
+              ? 'A scan is loaded but the overlay is hidden — enable "Show scan points" above.'
+              : renderedCount >= totalInBand
+                ? `Showing all ${totalInBand.toLocaleString()} points in band.`
+                : `Showing ${renderedCount.toLocaleString()} of ${totalInBand.toLocaleString()} points in band (decimated for display).`}
           </p>
         )}
       </div>

--- a/apps/viewer/src/components/viewer/ScanSectionPanel.tsx
+++ b/apps/viewer/src/components/viewer/ScanSectionPanel.tsx
@@ -47,8 +47,8 @@ export function ScanSectionPanel({
           <ScanLine className="h-5 w-5 text-primary" />
           <h2 className="font-semibold text-sm">Scan Layer</h2>
         </div>
-        <Button variant="ghost" size="icon-sm" onClick={onClose}>
-          <X className="h-4 w-4" />
+        <Button variant="ghost" size="icon-sm" onClick={onClose} aria-label="Close scan layer panel">
+          <X className="h-4 w-4" aria-hidden="true" />
         </Button>
       </div>
 
@@ -73,12 +73,13 @@ export function ScanSectionPanel({
         )}
 
         <div className="flex flex-col gap-1">
-          <Label className="text-[10px] text-muted-foreground">
+          <Label htmlFor="scan-section-thickness" className="text-[10px] text-muted-foreground">
             Band thickness: {scanSectionThickness >= 1
               ? `${scanSectionThickness.toFixed(2)} m`
               : `${Math.round(scanSectionThickness * 1000)} mm`}
           </Label>
           <input
+            id="scan-section-thickness"
             type="range"
             min={SCAN_SECTION_THICKNESS_MIN}
             max={SCAN_SECTION_THICKNESS_MAX}
@@ -91,10 +92,11 @@ export function ScanSectionPanel({
         </div>
 
         <div className="flex flex-col gap-1">
-          <Label className="text-[10px] text-muted-foreground">
+          <Label htmlFor="scan-section-opacity" className="text-[10px] text-muted-foreground">
             Dot opacity: {Math.round(scanSectionOpacity * 100)}%
           </Label>
           <input
+            id="scan-section-opacity"
             type="range"
             min={0.1}
             max={1}

--- a/apps/viewer/src/components/viewer/ScanSectionPanel.tsx
+++ b/apps/viewer/src/components/viewer/ScanSectionPanel.tsx
@@ -1,0 +1,130 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * ScanSectionPanel - controls for the point-cloud scan overlay on the 2D
+ * section view (issue #1805).
+ *
+ * A thin band of the loaded point cloud(s) around the active section plane,
+ * projected into drawing space and drawn as dots. Slide-in panel matching
+ * the DXF underlay / sheet setup panels' shape.
+ */
+
+import React from 'react';
+import { ScanLine, X } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import { useViewerStore } from '@/store';
+import {
+  SCAN_SECTION_THICKNESS_MIN,
+  SCAN_SECTION_THICKNESS_MAX,
+} from '@/hooks/scanSectionMath';
+
+interface ScanSectionPanelProps {
+  onClose: () => void;
+  hasPointCloud: boolean;
+  totalInBand: number;
+  renderedCount: number;
+}
+
+export function ScanSectionPanel({
+  onClose,
+  hasPointCloud,
+  totalInBand,
+  renderedCount,
+}: ScanSectionPanelProps): React.ReactElement {
+  const displayOptions = useViewerStore((s) => s.drawing2DDisplayOptions);
+  const updateDisplayOptions = useViewerStore((s) => s.updateDrawing2DDisplayOptions);
+
+  const { showScanSection, scanSectionThickness, scanSectionOpacity, scanSectionIncludeInExport } = displayOptions;
+
+  return (
+    <div className="flex flex-col h-full bg-background border-l">
+      {/* Header */}
+      <div className="flex items-center justify-between px-4 py-3 border-b bg-muted/50">
+        <div className="flex items-center gap-2">
+          <ScanLine className="h-5 w-5 text-primary" />
+          <h2 className="font-semibold text-sm">Scan Layer</h2>
+        </div>
+        <Button variant="ghost" size="icon-sm" onClick={onClose}>
+          <X className="h-4 w-4" />
+        </Button>
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 overflow-y-auto p-3 space-y-4">
+        <label className="flex items-center justify-between gap-2 cursor-pointer">
+          <span className="text-xs font-medium">Show scan points</span>
+          <input
+            type="checkbox"
+            checked={showScanSection}
+            onChange={(e) => updateDisplayOptions({ showScanSection: e.target.checked })}
+            className="accent-teal-600"
+          />
+        </label>
+
+        {!hasPointCloud && (
+          <p className="text-xs text-muted-foreground px-0.5">
+            No point cloud is loaded. Load a .laz/.las/.e57/.ply/.pcd scan and
+            this layer will show the points within a thin band around the
+            section plane.
+          </p>
+        )}
+
+        <div className="flex flex-col gap-1">
+          <Label className="text-[10px] text-muted-foreground">
+            Band thickness: {scanSectionThickness >= 1
+              ? `${scanSectionThickness.toFixed(2)} m`
+              : `${Math.round(scanSectionThickness * 1000)} mm`}
+          </Label>
+          <input
+            type="range"
+            min={SCAN_SECTION_THICKNESS_MIN}
+            max={SCAN_SECTION_THICKNESS_MAX}
+            step={0.01}
+            value={scanSectionThickness}
+            onChange={(e) => updateDisplayOptions({ scanSectionThickness: Number(e.target.value) })}
+            className="h-1 accent-teal-600 cursor-pointer"
+            title="Points within ± half this thickness of the section plane are shown"
+          />
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <Label className="text-[10px] text-muted-foreground">
+            Dot opacity: {Math.round(scanSectionOpacity * 100)}%
+          </Label>
+          <input
+            type="range"
+            min={0.1}
+            max={1}
+            step={0.05}
+            value={scanSectionOpacity}
+            onChange={(e) => updateDisplayOptions({ scanSectionOpacity: Number(e.target.value) })}
+            className="h-1 accent-teal-600 cursor-pointer"
+          />
+        </div>
+
+        <label className="flex items-center justify-between gap-2 cursor-pointer">
+          <span className="text-xs">Include in SVG export</span>
+          <input
+            type="checkbox"
+            checked={scanSectionIncludeInExport}
+            onChange={(e) => updateDisplayOptions({ scanSectionIncludeInExport: e.target.checked })}
+            className="accent-teal-600"
+          />
+        </label>
+
+        {hasPointCloud && (
+          <p className="text-[11px] text-muted-foreground border-t pt-2">
+            {renderedCount >= totalInBand
+              ? `Showing all ${totalInBand.toLocaleString()} points in band.`
+              : `Showing ${renderedCount.toLocaleString()} of ${totalInBand.toLocaleString()} points in band (decimated for display).`}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default ScanSectionPanel;

--- a/apps/viewer/src/components/viewer/Section2DPanel.tsx
+++ b/apps/viewer/src/components/viewer/Section2DPanel.tsx
@@ -12,7 +12,7 @@
  */
 
 import React, { useCallback, useRef, useState, useEffect, useMemo } from 'react';
-import { X, Download, FileDown, Eye, EyeOff, Maximize2, ZoomIn, ZoomOut, Loader2, Printer, GripVertical, MoreHorizontal, RefreshCw, Pin, PinOff, Palette, Ruler, Trash2, FileText, Shapes, Box, BoxSelect, PenTool, Hexagon, Type, Cloud, MousePointer2, Tag, Layers } from 'lucide-react';
+import { X, Download, FileDown, Eye, EyeOff, Maximize2, ZoomIn, ZoomOut, Loader2, Printer, GripVertical, MoreHorizontal, RefreshCw, Pin, PinOff, Palette, Ruler, Trash2, FileText, Shapes, Box, BoxSelect, PenTool, Hexagon, Type, Cloud, MousePointer2, Tag, Layers, ScanLine } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import {
   DropdownMenu,
@@ -29,6 +29,7 @@ import { GraphicOverrideEngine } from '@ifc-lite/drawing-2d';
 import { type GeometryResult } from '@ifc-lite/geometry';
 import { DrawingSettingsPanel } from './DrawingSettingsPanel';
 import { DxfUnderlayPanel } from './DxfUnderlayPanel';
+import { ScanSectionPanel } from './ScanSectionPanel';
 import { SheetSetupPanel } from './SheetSetupPanel';
 import { TitleBlockEditor } from './TitleBlockEditor';
 import { TextAnnotationEditor } from './TextAnnotationEditor';
@@ -40,6 +41,7 @@ import { useViewControls } from '@/hooks/useViewControls';
 import { useDrawingExport } from '@/hooks/useDrawingExport';
 import { useSymbolicAnnotationsForDrawing } from '@/hooks/useSymbolicAnnotations';
 import { useDxfUnderlaysForDrawing, dxfWorldShift, dxfUnderlayDrawingBounds } from '@/hooks/useDxfUnderlay';
+import { useScanSectionLayer } from '@/hooks/useScanSectionLayer';
 
 interface Section2DPanelProps {
   mergedGeometry?: GeometryResult | null;
@@ -86,6 +88,10 @@ export function Section2DPanel({
   const dxfUnderlays = useViewerStore((s) => s.dxfUnderlays);
   const updateDxfUnderlayPlacement = useViewerStore((s) => s.updateDxfUnderlayPlacement);
   const [dxfPanelOpen, setDxfPanelOpen] = useState(false);
+
+  // Point-cloud scan overlay (issue #1805)
+  const pointCloudClassMask = useViewerStore((s) => s.pointCloudClassMask);
+  const [scanPanelOpen, setScanPanelOpen] = useState(false);
 
   // Sheet state
   const activeSheet = useViewerStore((s) => s.activeSheet);
@@ -425,12 +431,27 @@ export function Section2DPanel({
     updateDxfUnderlayPlacement(id, { offsetX: modelCx - underlayCx, offsetY: modelCy - underlayCy });
   }, [dxfUnderlays, drawing, geometryResult, sectionPlane.flipped, sectionPlane.custom, updateDxfUnderlayPlacement]);
 
+  // Point-cloud scan overlay (issue #1805): a thin band of the loaded
+  // scan(s) around the active section plane, projected into the SAME
+  // drawing space the cut geometry uses (see scanSectionMath.ts) — unlike
+  // the DXF underlay, this works on plan AND vertical (front/side) sections.
+  const scanSectionLayer = useScanSectionLayer({
+    enabled: displayOptions.showScanSection && status === 'ready',
+    sectionPlane,
+    coordinateInfo: geometryResult?.coordinateInfo,
+    thickness: displayOptions.scanSectionThickness,
+    classMask: pointCloudClassMask,
+    models,
+    legacyPointClouds: geometryResult?.pointClouds,
+  });
+
   const { formatDistance, handleExportSVG, handleExportDXF, handlePrint } = useDrawingExport({
     drawing, displayOptions, sectionPlane, activePresetId,
     entityColorMap, overridesEnabled, overrideEngine,
     measure2DResults, polygonArea2DResults, textAnnotations2D, cloudAnnotations2D,
     sheetEnabled, activeSheet, dxfUnderlays: dxfUnderlayData,
     ifcDataStore, coordinateInfo: geometryResult?.coordinateInfo,
+    scanSection: scanSectionLayer,
   });
 
   // ═══════════════════════════════════════════════════════════════════════════
@@ -726,7 +747,10 @@ export function Section2DPanel({
                 onClick={() => {
                   // The right-side slide-in panels share one slot.
                   setSettingsPanelOpen((prev) => {
-                    if (!prev) setDxfPanelOpen(false);
+                    if (!prev) {
+                      setDxfPanelOpen(false);
+                      setScanPanelOpen(false);
+                    }
                     return !prev;
                   });
                 }}
@@ -745,7 +769,10 @@ export function Section2DPanel({
                 size="icon-sm"
                 onClick={() => {
                   // The right-side slide-in panels share one slot.
-                  if (!sheetPanelVisible) setDxfPanelOpen(false);
+                  if (!sheetPanelVisible) {
+                    setDxfPanelOpen(false);
+                    setScanPanelOpen(false);
+                  }
                   setSheetPanelVisible(!sheetPanelVisible);
                 }}
                 title="Drawing sheet setup"
@@ -767,6 +794,7 @@ export function Section2DPanel({
                     if (!prev) {
                       setSheetPanelVisible(false);
                       setSettingsPanelOpen(false);
+                      setScanPanelOpen(false);
                     }
                     return !prev;
                   });
@@ -776,6 +804,30 @@ export function Section2DPanel({
               >
                 <Layers className="h-4 w-4" />
                 {dxfUnderlays.length > 0 && !dxfPanelOpen && (
+                  <span className="absolute -top-0.5 -right-0.5 w-2 h-2 bg-primary rounded-full" />
+                )}
+              </Button>
+
+              {/* Point-cloud scan overlay (issue #1805) */}
+              <Button
+                variant={scanPanelOpen || displayOptions.showScanSection ? 'default' : 'ghost'}
+                size="icon-sm"
+                onClick={() => {
+                  // The right-side slide-in panels share one slot.
+                  setScanPanelOpen((prev) => {
+                    if (!prev) {
+                      setSheetPanelVisible(false);
+                      setSettingsPanelOpen(false);
+                      setDxfPanelOpen(false);
+                    }
+                    return !prev;
+                  });
+                }}
+                title="Scan layer (point cloud overlay)"
+                className="relative"
+              >
+                <ScanLine className="h-4 w-4" />
+                {scanSectionLayer.hasPointCloud && displayOptions.showScanSection && !scanPanelOpen && (
                   <span className="absolute -top-0.5 -right-0.5 w-2 h-2 bg-primary rounded-full" />
                 )}
               </Button>
@@ -924,9 +976,13 @@ export function Section2DPanel({
                     <FileText className="h-4 w-4 mr-2" />
                     Sheet Setup {sheetEnabled ? '(On)' : ''}
                   </DropdownMenuItem>
-                  <DropdownMenuItem onClick={() => { setSettingsPanelOpen(false); setSheetPanelVisible(false); setDxfPanelOpen(true); }}>
+                  <DropdownMenuItem onClick={() => { setSettingsPanelOpen(false); setSheetPanelVisible(false); setScanPanelOpen(false); setDxfPanelOpen(true); }}>
                     <Layers className="h-4 w-4 mr-2" />
                     DXF Underlays {dxfUnderlays.length > 0 ? `(${dxfUnderlays.length})` : ''}
+                  </DropdownMenuItem>
+                  <DropdownMenuItem onClick={() => { setSettingsPanelOpen(false); setSheetPanelVisible(false); setDxfPanelOpen(false); setScanPanelOpen(true); }}>
+                    <ScanLine className="h-4 w-4 mr-2" />
+                    Scan Layer {displayOptions.showScanSection ? '(On)' : ''}
                   </DropdownMenuItem>
                   <DropdownMenuSeparator />
                   <DropdownMenuItem onClick={zoomIn}>
@@ -1047,6 +1103,8 @@ export function Section2DPanel({
               ifcAnnotationTexts={ifcAnnotationData.texts}
               ifcAnnotationFills={ifcAnnotationData.fills}
               dxfUnderlays={dxfUnderlayData}
+              scanPoints={displayOptions.showScanSection ? scanSectionLayer.points : undefined}
+              scanOpacity={displayOptions.scanSectionOpacity}
             />
             {/* Subtle updating indicator - shows while regenerating without hiding the drawing */}
             {isRegenerating && (
@@ -1191,6 +1249,18 @@ export function Section2DPanel({
             onClose={() => setDxfPanelOpen(false)}
             onCenterOnModel={handleCenterDxfUnderlay}
             planViewActive={sectionPlane.axis === 'down' && sectionPlane.custom === undefined}
+          />
+        </div>
+      )}
+
+      {/* Scan Layer Panel - slides in from right (issue #1805) */}
+      {scanPanelOpen && (
+        <div className="absolute top-0 right-0 bottom-0 w-72 z-50 shadow-xl">
+          <ScanSectionPanel
+            onClose={() => setScanPanelOpen(false)}
+            hasPointCloud={scanSectionLayer.hasPointCloud}
+            totalInBand={scanSectionLayer.totalInBand}
+            renderedCount={scanSectionLayer.renderedCount}
           />
         </div>
       )}

--- a/apps/viewer/src/components/viewer/usePointCloudLifecycle.ts
+++ b/apps/viewer/src/components/viewer/usePointCloudLifecycle.ts
@@ -20,6 +20,7 @@ import { useEffect, useRef, type MutableRefObject } from 'react';
 import type { Renderer } from '@ifc-lite/renderer';
 import { useViewerStore } from '@/store';
 import { unregisterPointCloudAlignment, hasRegisteredPointCloudAlignment } from '@/hooks/ingest/pointCloudAlignment';
+import { removePointCloudScanCache } from '@/hooks/ingest/pointCloudScanCache';
 
 export interface UsePointCloudLifecycleParams {
   rendererRef: MutableRefObject<Renderer | null>;
@@ -64,6 +65,10 @@ export function usePointCloudLifecycle(params: UsePointCloudLifecycleParams): vo
         // silently does nothing for the next (e.g. PLY) scan.
         unregisterPointCloudAlignment(handleId);
         useViewerStore.getState().setPointCloudAlignmentAvailable(hasRegisteredPointCloudAlignment());
+        // Same cleanup for the 2D section scan-layer cache (issue #1805) —
+        // nothing else frees this, since streamed assets live outside the
+        // normal geometryResult/pointClouds lifecycle.
+        removePointCloudScanCache(handleId);
         decCount(-1);
       }
     }

--- a/apps/viewer/src/hooks/ingest/pointCloudIngest.ts
+++ b/apps/viewer/src/hooks/ingest/pointCloudIngest.ts
@@ -30,6 +30,11 @@ import {
   unregisterPointCloudAlignment,
   type PointCloudAlignmentTransform,
 } from './pointCloudAlignment.js';
+import {
+  addPointsToScanCache,
+  registerPointCloudScanCache,
+  removePointCloudScanCache,
+} from './pointCloudScanCache.js';
 
 export type PointCloudFormat = 'las' | 'laz' | 'ply' | 'pcd' | 'e57' | 'pts' | 'xyz';
 
@@ -95,6 +100,13 @@ export interface PointCloudIngestOptions {
   maxPointsInMemory?: number;
   /** Hard cap on file size in bytes. Default: 4 GB. */
   maxFileSize?: number;
+  /**
+   * Points retained CPU-side (reservoir-sampled) for the 2D section scan
+   * layer (issue #1805) — the GPU upload never keeps a JS-side copy, so
+   * this is the only way the section view can select an in-band slice.
+   * Default: {@link DEFAULT_SCAN_CACHE_CAPACITY}.
+   */
+  maxScanCachePoints?: number;
   /** Progress callback shared with the existing UI. */
   onProgress?: (progress: { phase: string; percent: number }) => void;
   /** Notified with +1 when streaming starts and -1 if it errors. */
@@ -324,6 +336,10 @@ export function ingestPointCloud(opts: PointCloudIngestOptions): PointCloudInges
   });
   const onCountChange = opts.onAssetCountDelta ?? (() => {});
   onCountChange(+1);
+  // Reservoir-sample a bounded CPU-side copy for the 2D section scan layer
+  // (issue #1805) — see pointCloudScanCache.ts for why this can't just read
+  // back the GPU buffer.
+  registerPointCloudScanCache(handle.id, opts.maxScanCachePoints);
 
   // IfcMapConversion alignment (issue #1804): register so the panel's
   // global toggle can flip this asset later, and push the initial matrix
@@ -414,6 +430,11 @@ export function ingestPointCloud(opts: PointCloudIngestOptions): PointCloudInges
         const yUp = swapZupChunkToYup(chunk);
         opts.renderer.appendPointCloudChunk(handle, yUp);
         opts.renderer.requestRender();
+        // Feed the SAME Y-up points into the bounded CPU reservoir the 2D
+        // section scan layer reads from (issue #1805) — must be the
+        // post-swap chunk so the retained sample and the GPU-rendered scan
+        // agree on orientation.
+        addPointsToScanCache(handle.id, yUp);
         // Classification histogram — the axis swap doesn't touch the
         // classifications buffer, so accumulate from the source chunk.
         sawClassifications = accumulateClassificationCounts(classCounts, chunk) || sawClassifications;
@@ -438,6 +459,7 @@ export function ingestPointCloud(opts: PointCloudIngestOptions): PointCloudInges
         opts.renderer.removePointCloudAsset(handle);
         opts.onClassCounts?.(handle.id, null);
         unregisterPointCloudAlignment(handle.id);
+        removePointCloudScanCache(handle.id);
         onCountChange(-1);
       },
     });
@@ -445,6 +467,7 @@ export function ingestPointCloud(opts: PointCloudIngestOptions): PointCloudInges
     opts.renderer.removePointCloudAsset(handle);
     opts.onClassCounts?.(handle.id, null);
     unregisterPointCloudAlignment(handle.id);
+    removePointCloudScanCache(handle.id);
     onCountChange(-1);
     throw err;
   }

--- a/apps/viewer/src/hooks/ingest/pointCloudScanCache.test.ts
+++ b/apps/viewer/src/hooks/ingest/pointCloudScanCache.test.ts
@@ -75,6 +75,40 @@ describe('pointCloudScanCache', () => {
     assert.strictEqual(getPointCloudScanSample(4), null);
   });
 
+  it('grows buffers geometrically instead of allocating full capacity up front', () => {
+    // Capacity above the initial 65_536-slot allocation: the positions
+    // buffer must start small and still retain every point across the
+    // growth boundary with values intact.
+    registerPointCloudScanCache(6, 200_000);
+    const before = getPointCloudScanSample(6)!;
+    assert.ok(
+      before.positions.length <= 65_536 * 3,
+      `expected initial allocation <= 65536 slots, got ${before.positions.length / 3}`,
+    );
+    addPointsToScanCache(6, makeChunk(100_000));
+    const sample = getPointCloudScanSample(6)!;
+    assert.strictEqual(sample.count, 100_000);
+    assert.ok(sample.positions.length >= sample.count * 3);
+    // Spot-check values across the growth boundary (points are x = index).
+    assert.strictEqual(sample.positions[0], 0);
+    assert.strictEqual(sample.positions[65_536 * 3], 65_536);
+    assert.strictEqual(sample.positions[99_999 * 3], 99_999);
+  });
+
+  it('backfills neutral grey for points retained before the first coloured chunk', () => {
+    registerPointCloudScanCache(7, 10);
+    addPointsToScanCache(7, { positions: new Float32Array([1, 2, 3]), pointCount: 1 });
+    addPointsToScanCache(7, {
+      positions: new Float32Array([4, 5, 6]),
+      colors: new Float32Array([1, 0, 0]),
+      pointCount: 1,
+    });
+    const sample = getPointCloudScanSample(7)!;
+    // Pre-colour point reads neutral grey (200), not zero-filled black.
+    assert.deepStrictEqual(Array.from(sample.colors!.slice(0, 3)), [200, 200, 200]);
+    assert.deepStrictEqual(Array.from(sample.colors!.slice(3, 6)), [255, 0, 0]);
+  });
+
   it('re-registering the same handle resets the reservoir', () => {
     registerPointCloudScanCache(5, 10);
     addPointsToScanCache(5, makeChunk(10));

--- a/apps/viewer/src/hooks/ingest/pointCloudScanCache.test.ts
+++ b/apps/viewer/src/hooks/ingest/pointCloudScanCache.test.ts
@@ -95,6 +95,34 @@ describe('pointCloudScanCache', () => {
     assert.strictEqual(sample.positions[99_999 * 3], 99_999);
   });
 
+  it('regrows colours and classifications across the growth boundary too', () => {
+    // The growth path reallocates three parallel arrays, not just positions —
+    // a regrow that copied only positions would silently truncate or zero the
+    // colour/class data past the 65_536-slot boundary (CodeRabbit review of
+    // PR #1874). Feed coloured+classified chunks that straddle it and assert
+    // all three survive at the same indices.
+    const total = 100_000;
+    registerPointCloudScanCache(8, 200_000);
+    const positions = new Float32Array(total * 3);
+    const colors = new Float32Array(total * 3);
+    const classifications = new Uint8Array(total);
+    for (let i = 0; i < total; i++) {
+      positions[i * 3] = i;
+      // Red channel ramps 0..1 so a truncated copy reads as 0 where it should not.
+      colors[i * 3] = (i % 256) / 255;
+      classifications[i] = i % 256;
+    }
+    addPointsToScanCache(8, { positions, colors, classifications, pointCount: total });
+
+    const sample = getPointCloudScanSample(8)!;
+    assert.strictEqual(sample.count, total);
+    for (const i of [0, 65_535, 65_536, 99_999]) {
+      assert.strictEqual(sample.positions[i * 3], i, `position at ${i}`);
+      assert.strictEqual(sample.colors![i * 3], i % 256, `colour at ${i}`);
+      assert.strictEqual(sample.classifications![i], i % 256, `class at ${i}`);
+    }
+  });
+
   it('backfills neutral grey for points retained before the first coloured chunk', () => {
     registerPointCloudScanCache(7, 10);
     addPointsToScanCache(7, { positions: new Float32Array([1, 2, 3]), pointCount: 1 });

--- a/apps/viewer/src/hooks/ingest/pointCloudScanCache.test.ts
+++ b/apps/viewer/src/hooks/ingest/pointCloudScanCache.test.ts
@@ -109,6 +109,22 @@ describe('pointCloudScanCache', () => {
     assert.deepStrictEqual(Array.from(sample.colors!.slice(3, 6)), [255, 0, 0]);
   });
 
+  it('clamps non-finite capacities to the bounded default', () => {
+    // Infinity would retain every streamed point until OOM; NaN would
+    // retain none. Both clamp to the (finite) default capacity.
+    registerPointCloudScanCache(8, Number.POSITIVE_INFINITY);
+    addPointsToScanCache(8, makeChunk(10));
+    const inf = getPointCloudScanSample(8)!;
+    assert.ok(Number.isFinite(inf.capacity) && inf.capacity >= 1);
+    assert.strictEqual(inf.count, 10);
+
+    registerPointCloudScanCache(9, Number.NaN);
+    addPointsToScanCache(9, makeChunk(10));
+    const nan = getPointCloudScanSample(9)!;
+    assert.ok(Number.isFinite(nan.capacity) && nan.capacity >= 1);
+    assert.strictEqual(nan.count, 10);
+  });
+
   it('re-registering the same handle resets the reservoir', () => {
     registerPointCloudScanCache(5, 10);
     addPointsToScanCache(5, makeChunk(10));

--- a/apps/viewer/src/hooks/ingest/pointCloudScanCache.test.ts
+++ b/apps/viewer/src/hooks/ingest/pointCloudScanCache.test.ts
@@ -1,0 +1,85 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert';
+import {
+  registerPointCloudScanCache,
+  addPointsToScanCache,
+  getPointCloudScanSample,
+  removePointCloudScanCache,
+  clearAllPointCloudScanCaches,
+} from './pointCloudScanCache.js';
+
+function makeChunk(count: number, startAt = 0): { positions: Float32Array; pointCount: number } {
+  const positions = new Float32Array(count * 3);
+  for (let i = 0; i < count; i++) {
+    positions[i * 3] = startAt + i;
+    positions[i * 3 + 1] = 0;
+    positions[i * 3 + 2] = 0;
+  }
+  return { positions, pointCount: count };
+}
+
+describe('pointCloudScanCache', () => {
+  beforeEach(() => {
+    clearAllPointCloudScanCaches();
+  });
+
+  it('returns null for an unregistered handle', () => {
+    assert.strictEqual(getPointCloudScanSample(999), null);
+  });
+
+  it('retains every point when under capacity', () => {
+    registerPointCloudScanCache(1, 100);
+    addPointsToScanCache(1, makeChunk(10));
+    const sample = getPointCloudScanSample(1);
+    assert.ok(sample);
+    assert.strictEqual(sample!.count, 10);
+    assert.strictEqual(sample!.seen, 10);
+  });
+
+  it('never exceeds capacity across many chunks (reservoir sampling)', () => {
+    registerPointCloudScanCache(2, 50);
+    for (let c = 0; c < 20; c++) {
+      addPointsToScanCache(2, makeChunk(100, c * 100));
+    }
+    const sample = getPointCloudScanSample(2);
+    assert.ok(sample);
+    assert.strictEqual(sample!.count, 50);
+    assert.strictEqual(sample!.seen, 2000);
+    assert.strictEqual(sample!.positions.length, 50 * 3);
+  });
+
+  it('carries colours and classifications alongside positions', () => {
+    registerPointCloudScanCache(3, 10);
+    const chunk = {
+      positions: new Float32Array([1, 2, 3]),
+      colors: new Float32Array([1, 0, 0]),
+      classifications: new Uint8Array([5]),
+      pointCount: 1,
+    };
+    addPointsToScanCache(3, chunk);
+    const sample = getPointCloudScanSample(3);
+    assert.ok(sample);
+    assert.deepStrictEqual(Array.from(sample!.colors!.slice(0, 3)), [255, 0, 0]);
+    assert.strictEqual(sample!.classifications![0], 5);
+  });
+
+  it('removePointCloudScanCache drops the sample', () => {
+    registerPointCloudScanCache(4, 10);
+    addPointsToScanCache(4, makeChunk(5));
+    assert.ok(getPointCloudScanSample(4));
+    removePointCloudScanCache(4);
+    assert.strictEqual(getPointCloudScanSample(4), null);
+  });
+
+  it('re-registering the same handle resets the reservoir', () => {
+    registerPointCloudScanCache(5, 10);
+    addPointsToScanCache(5, makeChunk(10));
+    assert.strictEqual(getPointCloudScanSample(5)!.count, 10);
+    registerPointCloudScanCache(5, 10);
+    assert.strictEqual(getPointCloudScanSample(5)!.count, 0);
+  });
+});

--- a/apps/viewer/src/hooks/ingest/pointCloudScanCache.ts
+++ b/apps/viewer/src/hooks/ingest/pointCloudScanCache.ts
@@ -1,0 +1,163 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * CPU-side retained sample of streamed (LAS/LAZ/...) point clouds, for the
+ * 2D section scan layer (issue #1805).
+ *
+ * Streamed scans go straight from the decode worker to the GPU
+ * (`ingestPointCloud` in `pointCloudIngest.ts`) — positions are never kept
+ * in JS, so there is nothing for the 2D section view to read back from. A
+ * full-resolution CPU copy of a multi-hundred-million-point scan isn't
+ * viable either, so this module keeps a bounded, uniformly-random SAMPLE
+ * per asset via reservoir sampling (Algorithm R): a single streaming pass,
+ * no need to know the total point count up front, and every point seen so
+ * far has equal probability of being in the final reservoir.
+ *
+ * This is a plain module-level cache (not viewer store state) — a few
+ * million points of positions/colors/classifications would be an expensive
+ * thing to push through Zustand on every streamed chunk. `useScanSectionLayer`
+ * reads it directly via {@link getPointCloudScanSample}.
+ *
+ * Lifecycle: `registerPointCloudScanCache` on stream start,
+ * `addPointsToScanCache` per chunk, `removePointCloudScanCache` on stream
+ * error or when `usePointCloudLifecycle` frees the GPU asset for a removed
+ * model — mirroring the classification-histogram cleanup already done
+ * there so this cache can't outlive its point cloud.
+ */
+
+/** Points retained per asset by default — ~16 bytes/point (pos+color+class) ≈ 32 MB at the cap. */
+export const DEFAULT_SCAN_CACHE_CAPACITY = 2_000_000;
+
+export interface RetainedPointCloudSample {
+  positions: Float32Array;
+  colors: Uint8Array | null;
+  classifications: Uint8Array | null;
+  /** Points actually held in the reservoir (<= capacity). */
+  count: number;
+  /** Total points offered to the reservoir so far (for diagnostics only). */
+  seen: number;
+  capacity: number;
+}
+
+interface ReservoirCache extends RetainedPointCloudSample {
+  hasColor: boolean;
+  hasClassifications: boolean;
+}
+
+const caches = new Map<number, ReservoirCache>();
+
+function createReservoir(capacity: number): ReservoirCache {
+  return {
+    positions: new Float32Array(capacity * 3),
+    colors: null,
+    classifications: null,
+    count: 0,
+    seen: 0,
+    capacity,
+    hasColor: false,
+    hasClassifications: false,
+  };
+}
+
+/** Start (or restart) retention for a streamed asset keyed by its renderer handle id. */
+export function registerPointCloudScanCache(
+  handleId: number,
+  capacity: number = DEFAULT_SCAN_CACHE_CAPACITY,
+): void {
+  caches.set(handleId, createReservoir(Math.max(1, Math.floor(capacity))));
+}
+
+function ensureColorBuffer(cache: ReservoirCache): Uint8Array {
+  if (!cache.colors) cache.colors = new Uint8Array(cache.capacity * 3);
+  cache.hasColor = true;
+  return cache.colors;
+}
+
+function ensureClassBuffer(cache: ReservoirCache): Uint8Array {
+  if (!cache.classifications) cache.classifications = new Uint8Array(cache.capacity);
+  cache.hasClassifications = true;
+  return cache.classifications;
+}
+
+function writePoint(
+  cache: ReservoirCache,
+  slot: number,
+  chunk: { positions: Float32Array; colors?: Float32Array; classifications?: Uint8Array },
+  srcIndex: number,
+): void {
+  cache.positions[slot * 3] = chunk.positions[srcIndex * 3];
+  cache.positions[slot * 3 + 1] = chunk.positions[srcIndex * 3 + 1];
+  cache.positions[slot * 3 + 2] = chunk.positions[srcIndex * 3 + 2];
+  if (chunk.colors) {
+    const colors = ensureColorBuffer(cache);
+    colors[slot * 3] = clampByte(chunk.colors[srcIndex * 3] * 255);
+    colors[slot * 3 + 1] = clampByte(chunk.colors[srcIndex * 3 + 1] * 255);
+    colors[slot * 3 + 2] = clampByte(chunk.colors[srcIndex * 3 + 2] * 255);
+  } else if (cache.hasColor) {
+    const colors = ensureColorBuffer(cache);
+    colors[slot * 3] = 200;
+    colors[slot * 3 + 1] = 200;
+    colors[slot * 3 + 2] = 200;
+  }
+  if (chunk.classifications) {
+    const classes = ensureClassBuffer(cache);
+    classes[slot] = chunk.classifications[srcIndex];
+  } else if (cache.hasClassifications) {
+    ensureClassBuffer(cache)[slot] = 0;
+  }
+}
+
+function clampByte(v: number): number {
+  return v < 0 ? 0 : v > 255 ? 255 : Math.round(v);
+}
+
+/**
+ * Offer one decoded chunk's points to the reservoir (Y-up frame — call this
+ * with the SAME positions already swapped Z-up→Y-up that get pushed to the
+ * GPU, so the retained sample and the rendered scan agree on orientation).
+ *
+ * Reservoir sampling (Algorithm R): for the i-th point overall (0-based),
+ * if the reservoir isn't full yet, append it; otherwise replace a
+ * uniformly-random existing slot with probability `capacity / (i + 1)`.
+ * Non-deterministic by design (the retained SET may vary run to run) — only
+ * the render-time decimation in `scanSectionMath.ts` needs to be
+ * deterministic, since that's what the "showing N of M" UI number pins.
+ */
+export function addPointsToScanCache(
+  handleId: number,
+  chunk: { positions: Float32Array; colors?: Float32Array; classifications?: Uint8Array; pointCount: number },
+): void {
+  const cache = caches.get(handleId);
+  if (!cache) return;
+  const { capacity } = cache;
+  for (let i = 0; i < chunk.pointCount; i++) {
+    const seenIndex = cache.seen++;
+    if (cache.count < capacity) {
+      writePoint(cache, cache.count, chunk, i);
+      cache.count++;
+      continue;
+    }
+    // Replace slot `j` with probability capacity/(seenIndex+1).
+    const j = Math.floor(Math.random() * (seenIndex + 1));
+    if (j < capacity) {
+      writePoint(cache, j, chunk, i);
+    }
+  }
+}
+
+/** Current retained sample for one asset, or null if never registered / already removed. */
+export function getPointCloudScanSample(handleId: number): RetainedPointCloudSample | null {
+  return caches.get(handleId) ?? null;
+}
+
+/** Drop one asset's retained sample (stream error, or model removal). */
+export function removePointCloudScanCache(handleId: number): void {
+  caches.delete(handleId);
+}
+
+/** Drop every retained sample — used only by tests / full-session resets. */
+export function clearAllPointCloudScanCaches(): void {
+  caches.clear();
+}

--- a/apps/viewer/src/hooks/ingest/pointCloudScanCache.ts
+++ b/apps/viewer/src/hooks/ingest/pointCloudScanCache.ts
@@ -44,13 +44,26 @@ export interface RetainedPointCloudSample {
 interface ReservoirCache extends RetainedPointCloudSample {
   hasColor: boolean;
   hasClassifications: boolean;
+  /** Slots currently backed by the typed arrays (grows geometrically toward `capacity`). */
+  allocated: number;
 }
 
 const caches = new Map<number, ReservoirCache>();
 
+/**
+ * Initial slot allocation. Buffers grow geometrically (double, clamped to
+ * `capacity`) as points arrive — allocating the full default capacity up
+ * front would pin ~24 MB of positions per asset even for a 50k-point PLY.
+ */
+const INITIAL_SCAN_CACHE_ALLOC = 65_536;
+
+/** Neutral grey written for colorless points once any chunk carries colour. */
+const NEUTRAL_COLOR_BYTE = 200;
+
 function createReservoir(capacity: number): ReservoirCache {
+  const allocated = Math.min(capacity, INITIAL_SCAN_CACHE_ALLOC);
   return {
-    positions: new Float32Array(capacity * 3),
+    positions: new Float32Array(allocated * 3),
     colors: null,
     classifications: null,
     count: 0,
@@ -58,7 +71,34 @@ function createReservoir(capacity: number): ReservoirCache {
     capacity,
     hasColor: false,
     hasClassifications: false,
+    allocated,
   };
+}
+
+/**
+ * Make sure `slot` is backed. Fill-phase writes are sequential
+ * (`slot === count`), so one doubling always reaches the target;
+ * replacement-phase writes only start once `count === capacity`, by which
+ * point the buffers are fully grown.
+ */
+function ensureSlotCapacity(cache: ReservoirCache, slot: number): void {
+  if (slot < cache.allocated) return;
+  const next = Math.min(cache.capacity, Math.max(cache.allocated * 2, slot + 1));
+  const positions = new Float32Array(next * 3);
+  positions.set(cache.positions);
+  cache.positions = positions;
+  if (cache.colors) {
+    const colors = new Uint8Array(next * 3);
+    colors.fill(NEUTRAL_COLOR_BYTE);
+    colors.set(cache.colors);
+    cache.colors = colors;
+  }
+  if (cache.classifications) {
+    const classes = new Uint8Array(next);
+    classes.set(cache.classifications);
+    cache.classifications = classes;
+  }
+  cache.allocated = next;
 }
 
 /** Start (or restart) retention for a streamed asset keyed by its renderer handle id. */
@@ -70,13 +110,19 @@ export function registerPointCloudScanCache(
 }
 
 function ensureColorBuffer(cache: ReservoirCache): Uint8Array {
-  if (!cache.colors) cache.colors = new Uint8Array(cache.capacity * 3);
+  if (!cache.colors) {
+    cache.colors = new Uint8Array(cache.allocated * 3);
+    // Backfill points retained BEFORE the first coloured chunk with the
+    // same neutral grey colorless points get going forward — a zero-filled
+    // buffer would render them black.
+    cache.colors.fill(NEUTRAL_COLOR_BYTE);
+  }
   cache.hasColor = true;
   return cache.colors;
 }
 
 function ensureClassBuffer(cache: ReservoirCache): Uint8Array {
-  if (!cache.classifications) cache.classifications = new Uint8Array(cache.capacity);
+  if (!cache.classifications) cache.classifications = new Uint8Array(cache.allocated);
   cache.hasClassifications = true;
   return cache.classifications;
 }
@@ -87,6 +133,7 @@ function writePoint(
   chunk: { positions: Float32Array; colors?: Float32Array; classifications?: Uint8Array },
   srcIndex: number,
 ): void {
+  ensureSlotCapacity(cache, slot);
   cache.positions[slot * 3] = chunk.positions[srcIndex * 3];
   cache.positions[slot * 3 + 1] = chunk.positions[srcIndex * 3 + 1];
   cache.positions[slot * 3 + 2] = chunk.positions[srcIndex * 3 + 2];

--- a/apps/viewer/src/hooks/ingest/pointCloudScanCache.ts
+++ b/apps/viewer/src/hooks/ingest/pointCloudScanCache.ts
@@ -106,7 +106,13 @@ export function registerPointCloudScanCache(
   handleId: number,
   capacity: number = DEFAULT_SCAN_CACHE_CAPACITY,
 ): void {
-  caches.set(handleId, createReservoir(Math.max(1, Math.floor(capacity))));
+  // Non-finite capacities are caller bugs with catastrophic failure modes
+  // (Infinity → unbounded retention until OOM; NaN → a reservoir that
+  // retains nothing). Clamp to the default rather than propagating either.
+  const bounded = Number.isFinite(capacity)
+    ? Math.max(1, Math.floor(capacity))
+    : DEFAULT_SCAN_CACHE_CAPACITY;
+  caches.set(handleId, createReservoir(bounded));
 }
 
 function ensureColorBuffer(cache: ReservoirCache): Uint8Array {

--- a/apps/viewer/src/hooks/scanSectionMath.test.ts
+++ b/apps/viewer/src/hooks/scanSectionMath.test.ts
@@ -316,13 +316,41 @@ describe('selectScanBand', () => {
 });
 
 describe('mergeScanBandSelections', () => {
+  it('enforces the render cap across merged assets, not just per asset', () => {
+    // Two "assets" each already at a 1000-point per-asset cap: the merged
+    // result must still respect a 1000-point total, deterministically.
+    const mk = (offset: number) => ({
+      points: Array.from({ length: 1000 }, (_, i) => ({ point: { x: offset + i, y: 0 } })),
+      totalInBand: 1000,
+      renderedCount: 1000,
+      stride: 1,
+    });
+    const merged = mergeScanBandSelections([mk(0), mk(10_000)], 1000);
+    assert.ok(merged.renderedCount <= 1000, `expected <= 1000, got ${merged.renderedCount}`);
+    assert.strictEqual(merged.totalInBand, 2000);
+    assert.strictEqual(merged.stride, 2);
+    const again = mergeScanBandSelections([mk(0), mk(10_000)], 1000);
+    assert.deepStrictEqual(
+      merged.points.map((p) => p.point.x),
+      again.points.map((p) => p.point.x),
+    );
+    // Both assets still represented after the merge-level decimation.
+    assert.ok(merged.points.some((p) => p.point.x < 10_000));
+    assert.ok(merged.points.some((p) => p.point.x >= 10_000));
+  });
+
   it('sums counts and reports the largest per-asset stride', () => {
     const a = { points: [{ point: { x: 0, y: 0 } }], totalInBand: 10, renderedCount: 1, stride: 10 };
-    const b = { points: [{ point: { x: 1, y: 1 } }], totalInBand: 5, renderedCount: 5, stride: 1 };
+    const b = {
+      points: Array.from({ length: 5 }, (_, i) => ({ point: { x: i + 1, y: 1 } })),
+      totalInBand: 5,
+      renderedCount: 5,
+      stride: 1,
+    };
     const merged = mergeScanBandSelections([a, b]);
     assert.strictEqual(merged.totalInBand, 15);
     assert.strictEqual(merged.renderedCount, 6);
     assert.strictEqual(merged.stride, 10);
-    assert.strictEqual(merged.points.length, 2);
+    assert.strictEqual(merged.points.length, 6);
   });
 });

--- a/apps/viewer/src/hooks/scanSectionMath.test.ts
+++ b/apps/viewer/src/hooks/scanSectionMath.test.ts
@@ -147,6 +147,25 @@ describe('signedBandDistance (custom plane)', () => {
     close(signedBandDistance({ x: 5, y: 5, z: 2 }, plane), 0);
     close(signedBandDistance({ x: 5, y: 5, z: 2.5 }, plane), 0.5);
   });
+
+  it('a degenerate zero normal excludes every point instead of admitting all', () => {
+    // `dot(p, n) - d` is 0 for every point when n is zero-length, which
+    // without a guard drops the WHOLE cloud into the band (PR #1874 review).
+    const degenerate: ScanSectionPlane = {
+      axis: 'y',
+      position: 0,
+      flipped: false,
+      custom: {
+        normal: [0, 0, 0],
+        distance: 0,
+        origin: [0, 0, 0],
+        tangent: [1, 0, 0],
+        bitangent: [0, 0, 1],
+      },
+    };
+    assert.equal(signedBandDistance({ x: 100, y: 100, z: 100 }, degenerate), Infinity);
+    assert.equal(isPointInBand({ x: 0, y: 0, z: 0 }, degenerate, 10), false);
+  });
 });
 
 describe('projectScanPoint (cardinal)', () => {

--- a/apps/viewer/src/hooks/scanSectionMath.test.ts
+++ b/apps/viewer/src/hooks/scanSectionMath.test.ts
@@ -12,6 +12,7 @@ import assert from 'node:assert';
 import {
   pointCloudRenderFrameShift,
   toRenderFrame,
+  resolveScanSectionPosition,
   signedBandDistance,
   isPointInBand,
   projectScanPoint,
@@ -65,6 +66,49 @@ describe('toRenderFrame', () => {
     close(p.x, 9);
     close(p.y, 18);
     close(p.z, 27);
+  });
+});
+
+describe('resolveScanSectionPosition', () => {
+  // Regression guard for the store contract: `SectionPlane.position` is a
+  // 0-100 PERCENTAGE of model bounds (store/types.ts), and the scan layer
+  // must resolve it over `shiftedBounds` with the exact formula
+  // `useDrawingGeneration` uses to place the cut — using the raw
+  // percentage as metres put the band on a different plane than the drawn
+  // geometry for almost every model.
+  const coordinateInfo = {
+    shiftedBounds: {
+      min: { x: -4, y: 2, z: -10 },
+      max: { x: 6, y: 12, z: 30 },
+    },
+  } as never;
+
+  it('maps 0 / 50 / 100 % onto the shifted-bounds axis range', () => {
+    close(resolveScanSectionPosition(0, 'y', coordinateInfo), 2);
+    close(resolveScanSectionPosition(50, 'y', coordinateInfo), 7);
+    close(resolveScanSectionPosition(100, 'y', coordinateInfo), 12);
+    close(resolveScanSectionPosition(25, 'z', coordinateInfo), 0); // -10 + 0.25*40
+    close(resolveScanSectionPosition(50, 'x', coordinateInfo), 1);
+  });
+
+  it('collapses to the axis minimum on degenerate/absent bounds', () => {
+    close(resolveScanSectionPosition(50, 'y', undefined), 0);
+  });
+
+  it('percentage slider selects the band at the DRAWN cut plane, not at "percent metres"', () => {
+    // Model spans y ∈ [2, 12]; slider at 30% → cut at y = 5.
+    // A point at y=5 must be in band; a point at y=30 ("percent as
+    // metres" trap) must not.
+    const positions = new Float32Array([0, 5, 0, 0, 30, 0]);
+    const sample: ScanPointSample = { positions, count: 2 };
+    const plane: ScanSectionPlane = {
+      axis: 'y',
+      position: resolveScanSectionPosition(30, 'y', coordinateInfo),
+      flipped: false,
+    };
+    const result = selectScanBand({ sample, coordinateInfo, plane, thickness: 0.2 });
+    assert.strictEqual(result.totalInBand, 1);
+    close(result.points[0].point.x, 0);
   });
 });
 

--- a/apps/viewer/src/hooks/scanSectionMath.test.ts
+++ b/apps/viewer/src/hooks/scanSectionMath.test.ts
@@ -1,0 +1,284 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Scan section-layer math (issue #1805): band selection, projection, and
+ * the render-frame shift point clouds need to line up with the section cut.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import {
+  pointCloudRenderFrameShift,
+  toRenderFrame,
+  signedBandDistance,
+  isPointInBand,
+  projectScanPoint,
+  selectScanBand,
+  mergeScanBandSelections,
+  type ScanSectionPlane,
+  type ScanPointSample,
+} from './scanSectionMath.js';
+import { dxfWorldShift } from './dxfUnderlayMath.js';
+
+const close = (a: number, b: number, eps = 1e-6) =>
+  assert.ok(Math.abs(a - b) < eps, `expected ${a} ≈ ${b}`);
+
+describe('pointCloudRenderFrameShift', () => {
+  it('matches dxfWorldShift on the plan (x, z) pair — one formula, two call sites', () => {
+    const coordinateInfo = {
+      wasmRtcOffset: { x: 1000, y: 2000, z: 5 },
+      originShift: { x: 3, y: 9, z: -7 },
+    } as never;
+    const shift = pointCloudRenderFrameShift(coordinateInfo);
+    const dxf = dxfWorldShift(coordinateInfo);
+    // dxfWorldShift.x is the plan-X shift; dxfWorldShift.y is the plan-Z
+    // shift (drawing y = -renderZ, so dxf.y = -(-shift.z) = ... see
+    // dxfUnderlayMath.ts's own derivation). Both were derived independently
+    // from reproject.ts's `computeModelCenterInIfcMeters`; this test pins
+    // them to the same numbers so a future edit to one can't silently
+    // diverge from the other.
+    close(shift.x, dxf.x);
+    close(shift.z, -dxf.y);
+  });
+
+  it('adds the elevation (Y) term absent from the plan-only DXF shift', () => {
+    const shift = pointCloudRenderFrameShift({
+      wasmRtcOffset: { x: 0, y: 0, z: 40 },
+      originShift: { x: 0, y: 5, z: 0 },
+    } as never);
+    close(shift.y, 45); // rtc.z + shift.y
+  });
+
+  it('degenerates to zero with no coordinate info', () => {
+    const shift = pointCloudRenderFrameShift(undefined);
+    close(shift.x, 0);
+    close(shift.y, 0);
+    close(shift.z, 0);
+  });
+});
+
+describe('toRenderFrame', () => {
+  it('subtracts the shift component-wise', () => {
+    const p = toRenderFrame({ x: 10, y: 20, z: 30 }, { x: 1, y: 2, z: 3 });
+    close(p.x, 9);
+    close(p.y, 18);
+    close(p.z, 27);
+  });
+});
+
+describe('signedBandDistance / isPointInBand (cardinal)', () => {
+  const plane: ScanSectionPlane = { axis: 'y', position: 5, flipped: false };
+
+  it('is zero exactly on the plane and signed off it', () => {
+    close(signedBandDistance({ x: 0, y: 5, z: 0 }, plane), 0);
+    close(signedBandDistance({ x: 0, y: 5.2, z: 0 }, plane), 0.2);
+    close(signedBandDistance({ x: 0, y: 4.7, z: 0 }, plane), -0.3);
+  });
+
+  it('band membership ignores `flipped` — flip only mirrors the projected U axis', () => {
+    const flipped: ScanSectionPlane = { ...plane, flipped: true };
+    const p = { x: 0, y: 5.1, z: 0 };
+    assert.strictEqual(isPointInBand(p, plane, 0.3), isPointInBand(p, flipped, 0.3));
+    assert.ok(isPointInBand(p, plane, 0.3));
+    assert.ok(!isPointInBand(p, plane, 0.1));
+  });
+});
+
+describe('signedBandDistance (custom plane)', () => {
+  it('matches signedDistanceToPlane against the custom normal/distance', () => {
+    const plane: ScanSectionPlane = {
+      axis: 'y',
+      position: 0,
+      flipped: false,
+      custom: {
+        normal: [0, 0, 1],
+        distance: 2,
+        origin: [0, 0, 2],
+        tangent: [1, 0, 0],
+        bitangent: [0, 1, 0],
+      },
+    };
+    close(signedBandDistance({ x: 5, y: 5, z: 2 }, plane), 0);
+    close(signedBandDistance({ x: 5, y: 5, z: 2.5 }, plane), 0.5);
+  });
+});
+
+describe('projectScanPoint (cardinal)', () => {
+  it('plan (down = y axis): x stays X, y becomes Z, matching section-cutter.ts', () => {
+    const plane: ScanSectionPlane = { axis: 'y', position: 0, flipped: false };
+    const p2 = projectScanPoint({ x: 3, y: 100, z: -4 }, plane);
+    close(p2.x, 3);
+    close(p2.y, -4);
+  });
+
+  it('flipped mirrors the U axis only', () => {
+    const plane: ScanSectionPlane = { axis: 'y', position: 0, flipped: true };
+    const p2 = projectScanPoint({ x: 3, y: 100, z: -4 }, plane);
+    close(p2.x, -3);
+    close(p2.y, -4);
+  });
+
+  it('vertical section (front = z axis): projects to (x, y)', () => {
+    const plane: ScanSectionPlane = { axis: 'z', position: 0, flipped: false };
+    const p2 = projectScanPoint({ x: 3, y: 7, z: -4 }, plane);
+    close(p2.x, 3);
+    close(p2.y, 7);
+  });
+
+  it('vertical section (side = x axis): projects to (z, y)', () => {
+    const plane: ScanSectionPlane = { axis: 'x', position: 0, flipped: false };
+    const p2 = projectScanPoint({ x: 3, y: 7, z: -4 }, plane);
+    close(p2.x, -4);
+    close(p2.y, 7);
+  });
+});
+
+describe('projectScanPoint (custom plane)', () => {
+  it('projects via dot(point - origin, tangent/bitangent)', () => {
+    const plane: ScanSectionPlane = {
+      axis: 'y',
+      position: 0,
+      flipped: false,
+      custom: {
+        normal: [0, 0, 1],
+        distance: 2,
+        origin: [1, 1, 2],
+        tangent: [1, 0, 0],
+        bitangent: [0, 1, 0],
+      },
+    };
+    const p2 = projectScanPoint({ x: 4, y: 6, z: 2 }, plane);
+    close(p2.x, 3); // 4 - origin.x(1)
+    close(p2.y, 5); // 6 - origin.y(1)
+  });
+});
+
+describe('selectScanBand', () => {
+  function sample(points: Array<[number, number, number]>, opts: {
+    colors?: Uint8Array | Float32Array;
+    classifications?: Uint8Array;
+  } = {}): ScanPointSample {
+    const positions = new Float32Array(points.length * 3);
+    points.forEach(([x, y, z], i) => {
+      positions[i * 3] = x;
+      positions[i * 3 + 1] = y;
+      positions[i * 3 + 2] = z;
+    });
+    return { positions, count: points.length, colors: opts.colors, classifications: opts.classifications };
+  }
+
+  it('keeps only points inside the band and projects them (plan section)', () => {
+    const s = sample([
+      [1, 5, 2],   // in band (y=5, position=5, thickness .3 -> [4.85,5.15])
+      [1, 5.1, 2], // in band
+      [1, 6, 2],   // out of band
+      [1, 4, 2],   // out of band
+    ]);
+    const plane: ScanSectionPlane = { axis: 'y', position: 5, flipped: false };
+    const result = selectScanBand({ sample: s, coordinateInfo: undefined, plane, thickness: 0.3 });
+    assert.strictEqual(result.totalInBand, 2);
+    assert.strictEqual(result.renderedCount, 2);
+    assert.strictEqual(result.stride, 1);
+    close(result.points[0].point.x, 1);
+    close(result.points[0].point.y, 2);
+  });
+
+  it('applies the render-frame shift before the band test', () => {
+    const s = sample([[0, 100, 0]]); // raw Y (elevation) = 100
+    const plane: ScanSectionPlane = { axis: 'y', position: 3, flipped: false };
+    // shift.y = rtc.z + originShift.y = 97 -> render Y = 100 - 97 = 3 (on-plane)
+    const coordinateInfo = { wasmRtcOffset: { x: 0, y: 0, z: 97 }, originShift: { x: 0, y: 0, z: 0 } } as never;
+    const result = selectScanBand({ sample: s, coordinateInfo, plane, thickness: 0.1 });
+    assert.strictEqual(result.totalInBand, 1);
+  });
+
+  it('vertical (front) section keeps points at the right Z depth, not Y', () => {
+    const s = sample([
+      [1, 2, 5],   // z=5, on a front-axis plane at position=5
+      [1, 9, 5.05],
+      [1, 2, 8],   // out of band
+    ]);
+    const plane: ScanSectionPlane = { axis: 'z', position: 5, flipped: false };
+    const result = selectScanBand({ sample: s, coordinateInfo: undefined, plane, thickness: 0.2 });
+    assert.strictEqual(result.totalInBand, 2);
+  });
+
+  it('mirrors the projected U axis on a flipped cardinal section', () => {
+    const s = sample([[2, 5, 0]]);
+    const unflipped = selectScanBand({
+      sample: s, coordinateInfo: undefined, thickness: 1,
+      plane: { axis: 'y', position: 5, flipped: false },
+    });
+    const flipped = selectScanBand({
+      sample: s, coordinateInfo: undefined, thickness: 1,
+      plane: { axis: 'y', position: 5, flipped: true },
+    });
+    close(unflipped.points[0].point.x, 2);
+    close(flipped.points[0].point.x, -2);
+  });
+
+  it('filters by the LAS class-visibility mask', () => {
+    const s = sample(
+      [[0, 5, 0], [1, 5, 0]],
+      { classifications: new Uint8Array([2, 7]) },
+    );
+    // Hide class 7: word0 = all bits except bit 7.
+    const mask = [0xFFFFFFFF & ~(1 << 7), 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF];
+    const result = selectScanBand({
+      sample: s, coordinateInfo: undefined, classMask: mask, thickness: 1,
+      plane: { axis: 'y', position: 5, flipped: false },
+    });
+    assert.strictEqual(result.totalInBand, 1);
+    close(result.points[0].point.x, 0);
+  });
+
+  it('carries per-point colour when the sample has it (Uint8 and Float32)', () => {
+    const s8 = sample([[0, 5, 0]], { colors: new Uint8Array([255, 0, 128]) });
+    const r8 = selectScanBand({ sample: s8, coordinateInfo: undefined, thickness: 1, plane: { axis: 'y', position: 5, flipped: false } });
+    assert.deepStrictEqual(r8.points[0].color?.map((c) => Math.round(c * 255)), [255, 0, 128]);
+
+    const sf = sample([[0, 5, 0]], { colors: new Float32Array([1, 0, 0.5]) });
+    const rf = selectScanBand({ sample: sf, coordinateInfo: undefined, thickness: 1, plane: { axis: 'y', position: 5, flipped: false } });
+    close(rf.points[0].color?.[2] ?? -1, 0.5);
+  });
+
+  it('decimates deterministically above the render cap', () => {
+    const points: Array<[number, number, number]> = [];
+    for (let i = 0; i < 1000; i++) points.push([i, 5, 0]);
+    const s = sample(points);
+    const plane: ScanSectionPlane = { axis: 'y', position: 5, flipped: false };
+    const run = () => selectScanBand({ sample: s, coordinateInfo: undefined, plane, thickness: 1, maxRendered: 100 });
+    const a = run();
+    const b = run();
+    assert.strictEqual(a.totalInBand, 1000);
+    assert.strictEqual(a.stride, 10);
+    assert.ok(a.renderedCount <= 100);
+    assert.ok(a.renderedCount > 0);
+    // Deterministic: repeated calls over the same input yield the identical set.
+    assert.deepStrictEqual(a.points.map((p) => p.point.x), b.points.map((p) => p.point.x));
+  });
+
+  it('does not decimate when under the cap', () => {
+    const s = sample([[0, 5, 0], [1, 5, 0]]);
+    const result = selectScanBand({
+      sample: s, coordinateInfo: undefined, thickness: 1, maxRendered: 500_000,
+      plane: { axis: 'y', position: 5, flipped: false },
+    });
+    assert.strictEqual(result.stride, 1);
+    assert.strictEqual(result.renderedCount, 2);
+  });
+});
+
+describe('mergeScanBandSelections', () => {
+  it('sums counts and reports the largest per-asset stride', () => {
+    const a = { points: [{ point: { x: 0, y: 0 } }], totalInBand: 10, renderedCount: 1, stride: 10 };
+    const b = { points: [{ point: { x: 1, y: 1 } }], totalInBand: 5, renderedCount: 5, stride: 1 };
+    const merged = mergeScanBandSelections([a, b]);
+    assert.strictEqual(merged.totalInBand, 15);
+    assert.strictEqual(merged.renderedCount, 6);
+    assert.strictEqual(merged.stride, 10);
+    assert.strictEqual(merged.points.length, 2);
+  });
+});

--- a/apps/viewer/src/hooks/scanSectionMath.test.ts
+++ b/apps/viewer/src/hooks/scanSectionMath.test.ts
@@ -339,6 +339,20 @@ describe('mergeScanBandSelections', () => {
     assert.ok(merged.points.some((p) => p.point.x >= 10_000));
   });
 
+  it('merges render-cap-scale selections without overflowing the call stack', () => {
+    // `push(...points)` turns every point into a call argument and throws
+    // RangeError somewhere above ~100k; the cap is 500k, so a merge at
+    // scale must use a plain loop.
+    const big = {
+      points: Array.from({ length: 300_000 }, (_, i) => ({ point: { x: i, y: 0 } })),
+      totalInBand: 300_000,
+      renderedCount: 300_000,
+      stride: 1,
+    };
+    const merged = mergeScanBandSelections([big]);
+    assert.strictEqual(merged.renderedCount, 300_000);
+  });
+
   it('sums counts and reports the largest per-asset stride', () => {
     const a = { points: [{ point: { x: 0, y: 0 } }], totalInBand: 10, renderedCount: 1, stride: 10 };
     const b = {

--- a/apps/viewer/src/hooks/scanSectionMath.ts
+++ b/apps/viewer/src/hooks/scanSectionMath.ts
@@ -208,6 +208,11 @@ export function resolveScanSectionPosition(
 export function signedBandDistance(p: Vec3, plane: ScanSectionPlane): number {
   if (plane.custom) {
     const n: Vec3 = { x: plane.custom.normal[0], y: plane.custom.normal[1], z: plane.custom.normal[2] };
+    // A degenerate (zero-length) normal makes `dot(p, n) - d` evaluate to 0
+    // for EVERY point, which would silently drop the entire cloud into the
+    // band instead of cutting it. The normal arrives straight from the
+    // store, so guard here: infinitely far is never in any slab.
+    if (Math.hypot(n.x, n.y, n.z) < 1e-12) return Infinity;
     return signedDistanceToPlane(p, n, plane.custom.distance);
   }
   return signedDistanceToPlane(p, getAxisNormal(plane.axis, false), plane.position);

--- a/apps/viewer/src/hooks/scanSectionMath.ts
+++ b/apps/viewer/src/hooks/scanSectionMath.ts
@@ -322,7 +322,10 @@ export function mergeScanBandSelections(
   for (const sel of selections) {
     totalInBand += sel.totalInBand;
     if (sel.stride > maxStride) maxStride = sel.stride;
-    points.push(...sel.points);
+    // Plain loop, not `push(...sel.points)`: spreading turns every point
+    // into a call argument, and at render-cap scale (hundreds of
+    // thousands) that overflows the call stack (RangeError).
+    for (const p of sel.points) points.push(p);
   }
   if (maxRendered !== undefined && maxRendered > 0 && points.length > maxRendered) {
     const extra = Math.ceil(points.length / maxRendered);

--- a/apps/viewer/src/hooks/scanSectionMath.ts
+++ b/apps/viewer/src/hooks/scanSectionMath.ts
@@ -302,20 +302,33 @@ export function selectScanBand(params: SelectScanBandParams): ScanBandSelection 
 
 /**
  * Merge several assets' selections into one (used when >1 scan is loaded).
- * `stride` reports the largest per-asset stride applied, for the UI's
+ * `stride` reports the largest effective stride applied, for the UI's
  * "showing N of M points" readout — each asset already decimated itself
  * independently, so this is informational only, not a re-appliable factor.
+ *
+ * When `maxRendered` is given, the MERGED result is re-decimated with the
+ * same deterministic keep-every-Nth stride — each asset's own cap bounds
+ * its individual selection, but N dense scans would otherwise concatenate
+ * to N × cap points and blow the per-redraw budget the cap exists to
+ * protect.
  */
-export function mergeScanBandSelections(selections: readonly ScanBandSelection[]): ScanBandSelection {
+export function mergeScanBandSelections(
+  selections: readonly ScanBandSelection[],
+  maxRendered?: number,
+): ScanBandSelection {
   let totalInBand = 0;
-  let renderedCount = 0;
   let maxStride = 1;
   const points: ScanBandPoint[] = [];
   for (const sel of selections) {
     totalInBand += sel.totalInBand;
-    renderedCount += sel.renderedCount;
     if (sel.stride > maxStride) maxStride = sel.stride;
     points.push(...sel.points);
   }
-  return { points, totalInBand, renderedCount, stride: maxStride };
+  if (maxRendered !== undefined && maxRendered > 0 && points.length > maxRendered) {
+    const extra = Math.ceil(points.length / maxRendered);
+    const capped: ScanBandPoint[] = [];
+    for (let i = 0; i < points.length; i += extra) capped.push(points[i]);
+    return { points: capped, totalInBand, renderedCount: capped.length, stride: maxStride * extra };
+  }
+  return { points, totalInBand, renderedCount: points.length, stride: maxStride };
 }

--- a/apps/viewer/src/hooks/scanSectionMath.ts
+++ b/apps/viewer/src/hooks/scanSectionMath.ts
@@ -1,0 +1,293 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Point-cloud "scan" layer for the 2D section view (issue #1805).
+ *
+ * Selects the points within a configurable band/thickness around the active
+ * section plane, projects them into the same 2D "drawing space" the section
+ * cutter emits for `Drawing2D.lines` / `cutPolygons`, and decimates the
+ * result to a sane render cap. Pure, store-free, and unit-tested — the
+ * `useScanSectionLayer` hook wires it to the viewer store.
+ *
+ * ── Coordinate pipeline ──────────────────────────────────────────────────
+ * Point-cloud positions arrive from `@ifc-lite/pointcloud` decoders in the
+ * file's native Z-up frame, swapped to the renderer's Y-up convention by
+ * `swapZupChunkToYup` (`hooks/ingest/pointCloudIngest.ts`) — but, unlike
+ * mesh geometry, WITHOUT the RTC/origin-shift baked in: mesh vertices are
+ * re-based near the origin by WASM before `GeometryResult.meshes` ships, so
+ * `coordinateInfo.shiftedBounds` and the section plane's `position` already
+ * live in that shifted "render frame". Point clouds need one more step to
+ * land in the same frame.
+ *
+ * `pointCloudRenderFrameShift` derives that step from the exact relationship
+ * `apps/viewer/src/lib/geo/reproject.ts` (`computeModelCenterInIfcMeters`)
+ * documents as ground truth:
+ *
+ *   world_yup = render + originShift + rtc_as_yup,  rtc_as_yup = (rtc.x, rtc.z, -rtc.y)
+ *
+ * so `render = world_yup - originShift - rtc_as_yup`. Restricted to the plan
+ * (x, z) pair this is IDENTICAL to `dxfWorldShift` in `hooks/dxfUnderlayMath.ts`
+ * — the DXF-underlay precedent this module follows — which
+ * `scanSectionMath.test.ts` cross-checks so the two can't silently drift.
+ * This module is the 3D generalisation DXF underlays never needed (they're
+ * plan-only); it doesn't replace `dxfWorldShift`, it extends the same
+ * formula to the elevation axis for vertical (front/side) sections.
+ *
+ * Once in the render frame, projection reuses `projectTo2D` /
+ * `projectTo2DBasis` from `@ifc-lite/drawing-2d` — the SAME functions
+ * `section-cutter.ts` (CPU path) and the WASM GPU cutter's `projectTo2D`
+ * (`gpu-section-cutter.ts`) use to produce `drawing.lines` / `cutPolygons`.
+ * That means scan dots land directly in the drawing's native coordinate
+ * space with no extra mirroring step — `Drawing2DCanvas` can draw them with
+ * the exact same screen transform it already uses for the cut geometry.
+ */
+
+import {
+  getAxisNormal,
+  projectTo2D,
+  projectTo2DBasis,
+  signedDistanceToPlane,
+  type Point2D,
+  type Vec3,
+} from '@ifc-lite/drawing-2d';
+import type { CoordinateInfo } from '@ifc-lite/geometry';
+import { isPointCloudClassVisible } from '@/store/slices/pointCloudSlice';
+
+// ═══════════════════════════════════════════════════════════════════════════
+// CONSTANTS
+// ═══════════════════════════════════════════════════════════════════════════
+
+/** Default slab thickness (metres) around the section plane. */
+export const DEFAULT_SCAN_SECTION_THICKNESS = 0.3;
+/** Slider bounds (metres) for the thickness control. */
+export const SCAN_SECTION_THICKNESS_MIN = 0.02;
+export const SCAN_SECTION_THICKNESS_MAX = 2.0;
+/** Default render decimation cap — points beyond this are strided out. */
+export const DEFAULT_SCAN_RENDER_CAP = 500_000;
+/** Hard cap for SVG export — keeps exported files a sane size. */
+export const DEFAULT_SCAN_SVG_CAP = 20_000;
+
+// ═══════════════════════════════════════════════════════════════════════════
+// TYPES
+// ═══════════════════════════════════════════════════════════════════════════
+
+export type ScanSectionAxis = 'x' | 'y' | 'z';
+
+/** Face-picked custom cut plane, same shape `useDrawingGeneration` builds. */
+export interface ScanCustomPlane {
+  normal: readonly [number, number, number];
+  distance: number;
+  origin: readonly [number, number, number];
+  tangent: readonly [number, number, number];
+  bitangent: readonly [number, number, number];
+}
+
+/** The active section cut, reduced to what the scan layer needs. */
+export interface ScanSectionPlane {
+  axis: ScanSectionAxis;
+  /** Cardinal plane position in shifted-render-frame metres (ignored when `custom` is set). */
+  position: number;
+  /** Mirrors the cutter's U-axis flip; irrelevant to band membership, only to projection. */
+  flipped: boolean;
+  custom?: ScanCustomPlane;
+}
+
+/** One point cloud's retained CPU-side sample, in raw (unshifted) Y-up frame. */
+export interface ScanPointSample {
+  /** [x0,y0,z0, x1,y1,z1, ...], length >= count*3. */
+  positions: Float32Array;
+  /** RGB per point — Uint8Array (0..255) or Float32Array (0..1); absent → no colour. */
+  colors?: Uint8Array | Float32Array | null;
+  /** Per-point LAS classification (0..255); absent → treated as always-visible. */
+  classifications?: Uint8Array | null;
+  count: number;
+}
+
+export interface ScanBandPoint {
+  point: Point2D;
+  /** RGB in 0..1, present only when the source sample carried colour. */
+  color?: readonly [number, number, number];
+}
+
+export interface ScanBandSelection {
+  points: ScanBandPoint[];
+  /** Points passing the band + class-mask test, before decimation. */
+  totalInBand: number;
+  /** `points.length` — equals `totalInBand` when no decimation was needed. */
+  renderedCount: number;
+  /** Deterministic keep-every-Nth stride applied (1 = no decimation). */
+  stride: number;
+}
+
+export interface SelectScanBandParams {
+  sample: ScanPointSample;
+  coordinateInfo: CoordinateInfo | undefined;
+  plane: ScanSectionPlane;
+  /** Full slab thickness in metres — band is `position ± thickness/2`. */
+  thickness: number;
+  /** 8-word LAS class-visibility mask (see `pointCloudSlice.ts`). Omitted = all visible. */
+  classMask?: readonly number[];
+  /** Cap on rendered (post-decimation) point count. */
+  maxRendered?: number;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// RENDER-FRAME SHIFT
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * The Y-up vector to SUBTRACT from a raw (Z-up-swapped-to-Y-up) point-cloud
+ * position to land it in the render frame meshes/section planes use.
+ *
+ * Derived from `reproject.ts`'s `world_yup = render + originShift + rtc_as_yup`
+ * (rtc_as_yup = (rtc.x, rtc.z, -rtc.y)): `render = world_yup - originShift - rtc_as_yup`,
+ * i.e. the vector below is `originShift + rtc_as_yup` component-wise.
+ *
+ * Known limitation: this assumes the point cloud was authored in the SAME
+ * IFC-world coordinate system as the model (the common case — a scan
+ * registered to match the building). It does not independently re-register a
+ * georeferenced scan; that already holds for the 3D viewport today (point
+ * clouds get no RTC/origin-shift treatment on ingest — see
+ * `hooks/ingest/pointCloudIngest.ts`), so the 2D scan layer is consistent
+ * with 3D, not a regression.
+ */
+export function pointCloudRenderFrameShift(coordinateInfo: CoordinateInfo | undefined): Vec3 {
+  const rtc = coordinateInfo?.wasmRtcOffset;
+  const shift = coordinateInfo?.originShift;
+  return {
+    x: (rtc?.x ?? 0) + (shift?.x ?? 0),
+    y: (rtc?.z ?? 0) + (shift?.y ?? 0),
+    z: -(rtc?.y ?? 0) + (shift?.z ?? 0),
+  };
+}
+
+/** Apply {@link pointCloudRenderFrameShift} to one point. */
+export function toRenderFrame(p: Vec3, shift: Vec3): Vec3 {
+  return { x: p.x - shift.x, y: p.y - shift.y, z: p.z - shift.z };
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// BAND TEST + PROJECTION
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * Signed distance from a render-frame point to the section plane.
+ * Band membership doesn't care about `flipped` — flip only mirrors the U
+ * axis of the projected 2D output, not which points are "in" the slab.
+ */
+export function signedBandDistance(p: Vec3, plane: ScanSectionPlane): number {
+  if (plane.custom) {
+    const n: Vec3 = { x: plane.custom.normal[0], y: plane.custom.normal[1], z: plane.custom.normal[2] };
+    return signedDistanceToPlane(p, n, plane.custom.distance);
+  }
+  return signedDistanceToPlane(p, getAxisNormal(plane.axis, false), plane.position);
+}
+
+export function isPointInBand(p: Vec3, plane: ScanSectionPlane, thickness: number): boolean {
+  return Math.abs(signedBandDistance(p, plane)) <= Math.max(thickness, 0) / 2;
+}
+
+/**
+ * Project a render-frame point into 2D drawing space — the SAME function
+ * (and, for cardinal axes, the same `flipped` U-mirror) `section-cutter.ts`
+ * uses for the cut geometry itself, so the result composites directly with
+ * `drawing.lines` / `cutPolygons` with no extra transform.
+ */
+export function projectScanPoint(p: Vec3, plane: ScanSectionPlane): Point2D {
+  if (plane.custom) {
+    const origin: Vec3 = { x: plane.custom.origin[0], y: plane.custom.origin[1], z: plane.custom.origin[2] };
+    const tangent: Vec3 = { x: plane.custom.tangent[0], y: plane.custom.tangent[1], z: plane.custom.tangent[2] };
+    const bitangent: Vec3 = { x: plane.custom.bitangent[0], y: plane.custom.bitangent[1], z: plane.custom.bitangent[2] };
+    return projectTo2DBasis(p, origin, tangent, bitangent);
+  }
+  return projectTo2D(p, plane.axis, plane.flipped);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// BAND SELECTION (band test + class-mask filter + deterministic decimation)
+// ═══════════════════════════════════════════════════════════════════════════
+
+function readColor(
+  colors: Uint8Array | Float32Array | null | undefined,
+  i: number,
+): readonly [number, number, number] | undefined {
+  if (!colors) return undefined;
+  if (colors instanceof Float32Array) {
+    return [colors[i * 3], colors[i * 3 + 1], colors[i * 3 + 2]];
+  }
+  return [colors[i * 3] / 255, colors[i * 3 + 1] / 255, colors[i * 3 + 2] / 255];
+}
+
+/**
+ * Select the points of `sample` within the section band, honour the LAS
+ * class-visibility mask, and decimate to `maxRendered` with a deterministic
+ * "keep every Nth in-band point" stride — reproducible across calls and
+ * independent of point order (a first pass counts matches before the
+ * stride is chosen, so the same input always yields the same output).
+ *
+ * Two O(n) passes over `sample.positions` (count, then collect); cheap even
+ * at a few million retained points and meant to run off the render hot path
+ * (debounced on section-plane changes), not per frame.
+ */
+export function selectScanBand(params: SelectScanBandParams): ScanBandSelection {
+  const { sample, coordinateInfo, plane, thickness, classMask, maxRendered = DEFAULT_SCAN_RENDER_CAP } = params;
+  const { positions, colors, classifications, count } = sample;
+  const shift = pointCloudRenderFrameShift(coordinateInfo);
+  const halfThickness = Math.max(thickness, 0) / 2;
+
+  const passesClassMask = (i: number): boolean => {
+    if (!classMask || !classifications) return true;
+    return isPointCloudClassVisible(classMask, classifications[i]);
+  };
+  const inBand = (i: number): boolean => {
+    const p: Vec3 = { x: positions[i * 3], y: positions[i * 3 + 1], z: positions[i * 3 + 2] };
+    const rp = toRenderFrame(p, shift);
+    return Math.abs(signedBandDistance(rp, plane)) <= halfThickness;
+  };
+
+  let totalInBand = 0;
+  for (let i = 0; i < count; i++) {
+    if (!passesClassMask(i)) continue;
+    if (inBand(i)) totalInBand++;
+  }
+
+  const stride = totalInBand > maxRendered && maxRendered > 0
+    ? Math.ceil(totalInBand / maxRendered)
+    : 1;
+
+  const points: ScanBandPoint[] = [];
+  let matchIndex = -1;
+  for (let i = 0; i < count; i++) {
+    if (!passesClassMask(i)) continue;
+    const p: Vec3 = { x: positions[i * 3], y: positions[i * 3 + 1], z: positions[i * 3 + 2] };
+    const rp = toRenderFrame(p, shift);
+    if (Math.abs(signedBandDistance(rp, plane)) > halfThickness) continue;
+    matchIndex++;
+    if (matchIndex % stride !== 0) continue;
+    points.push({ point: projectScanPoint(rp, plane), color: readColor(colors, i) });
+  }
+
+  return { points, totalInBand, renderedCount: points.length, stride };
+}
+
+/**
+ * Merge several assets' selections into one (used when >1 scan is loaded).
+ * `stride` reports the largest per-asset stride applied, for the UI's
+ * "showing N of M points" readout — each asset already decimated itself
+ * independently, so this is informational only, not a re-appliable factor.
+ */
+export function mergeScanBandSelections(selections: readonly ScanBandSelection[]): ScanBandSelection {
+  let totalInBand = 0;
+  let renderedCount = 0;
+  let maxStride = 1;
+  const points: ScanBandPoint[] = [];
+  for (const sel of selections) {
+    totalInBand += sel.totalInBand;
+    renderedCount += sel.renderedCount;
+    if (sel.stride > maxStride) maxStride = sel.stride;
+    points.push(...sel.points);
+  }
+  return { points, totalInBand, renderedCount, stride: maxStride };
+}

--- a/apps/viewer/src/hooks/scanSectionMath.ts
+++ b/apps/viewer/src/hooks/scanSectionMath.ts
@@ -168,6 +168,34 @@ export function toRenderFrame(p: Vec3, shift: Vec3): Vec3 {
   return { x: p.x - shift.x, y: p.y - shift.y, z: p.z - shift.z };
 }
 
+/**
+ * Resolve the store's cardinal section-plane `position` — a **0-100
+ * percentage of model bounds** (`SectionPlane.position` in `store/types.ts`)
+ * — into the shifted-render-frame metres {@link ScanSectionPlane.position}
+ * expects.
+ *
+ * MUST stay the exact formula `useDrawingGeneration` (and Section2DPanel's
+ * annotation slab) use to place the cut itself:
+ *
+ *   position = axisMin + (percent / 100) * (axisMax - axisMin)
+ *
+ * over `coordinateInfo.shiftedBounds` — feeding the percentage through as
+ * metres selects a band on a *different plane* than the drawn cut (the bug
+ * class this feature exists to avoid). Degenerate/absent bounds collapse to
+ * the axis minimum (0 when no coordinate info exists at all), matching the
+ * empty drawing those models produce.
+ */
+export function resolveScanSectionPosition(
+  positionPercent: number,
+  axis: ScanSectionAxis,
+  coordinateInfo: CoordinateInfo | undefined,
+): number {
+  const bounds = coordinateInfo?.shiftedBounds;
+  const axisMin = bounds?.min?.[axis] ?? 0;
+  const axisMax = bounds?.max?.[axis] ?? 0;
+  return axisMin + (positionPercent / 100) * (axisMax - axisMin);
+}
+
 // ═══════════════════════════════════════════════════════════════════════════
 // BAND TEST + PROJECTION
 // ═══════════════════════════════════════════════════════════════════════════

--- a/apps/viewer/src/hooks/useDrawingExport.ts
+++ b/apps/viewer/src/hooks/useDrawingExport.ts
@@ -26,6 +26,7 @@ import type { GeometryResult } from '@ifc-lite/geometry';
 import type { IfcDataStore } from '@ifc-lite/parser';
 import { useViewerStore } from '@/store';
 import { buildDxfExportTransform, resolveDxfExportGeoreference } from '@/hooks/dxfExportGeoref';
+import { DEFAULT_SCAN_SVG_CAP, type ScanBandPoint } from '@/hooks/scanSectionMath';
 
 /** Map a DXF vertical justification onto an SVG dominant-baseline. */
 function dxfValignToBaseline(valign: 'baseline' | 'bottom' | 'middle' | 'top'): string {
@@ -106,9 +107,44 @@ function buildDxfUnderlaySvg(
   return svg;
 }
 
+/**
+ * Render the point-cloud scan overlay as SVG circles (issue #1805), capped
+ * hard at `DEFAULT_SCAN_SVG_CAP` (independent of, and typically tighter
+ * than, the on-screen render cap) so an exported file stays a sane size —
+ * a deterministic stride, same technique `selectScanBand` uses for the
+ * render cap, keeps the exported subset reproducible.
+ */
+function buildScanSectionSvg(
+  points: readonly ScanBandPoint[],
+  mapPoint: (x: number, y: number) => { x: number; y: number },
+  radiusModelUnits: number,
+  opacity: number,
+  cap: number = DEFAULT_SCAN_SVG_CAP,
+): string {
+  if (points.length === 0 || opacity <= 0) return '';
+  const stride = points.length > cap ? Math.ceil(points.length / cap) : 1;
+  let svg = `  <g id="scan-section" opacity="${opacity.toFixed(2)}">\n`;
+  for (let i = 0; i < points.length; i += stride) {
+    const p = mapPoint(points[i].point.x, points[i].point.y);
+    const color = points[i].color;
+    const fill = color
+      ? `#${color.map((c) => Math.round(c * 255).toString(16).padStart(2, '0')).join('')}`
+      : '#8a8a8a';
+    svg += `    <circle cx="${p.x.toFixed(4)}" cy="${p.y.toFixed(4)}" r="${radiusModelUnits.toFixed(4)}" fill="${fill}" stroke="none"/>\n`;
+  }
+  svg += '  </g>\n';
+  return svg;
+}
+
 interface UseDrawingExportParams {
   drawing: Drawing2D | null;
-  displayOptions: { showHiddenLines: boolean; scale: number };
+  displayOptions: {
+    showHiddenLines: boolean;
+    scale: number;
+    showScanSection: boolean;
+    scanSectionOpacity: number;
+    scanSectionIncludeInExport: boolean;
+  };
   sectionPlane: { axis: 'down' | 'front' | 'side'; position: number; flipped: boolean; custom?: unknown };
   activePresetId: string | null;
   entityColorMap: Map<number, [number, number, number, number]>;
@@ -126,6 +162,8 @@ interface UseDrawingExportParams {
   ifcDataStore: IfcDataStore | null;
   /** Geometry coordinate info (RTC offset + origin shift), for the DXF world-coordinate re-derivation (issue #1861). */
   coordinateInfo: GeometryResult['coordinateInfo'] | undefined;
+  /** Point-cloud scan overlay, already in drawing space (issue #1805) */
+  scanSection: { points: readonly ScanBandPoint[] };
 }
 
 interface UseDrawingExportResult {
@@ -152,6 +190,7 @@ function useDrawingExport({
   dxfUnderlays,
   ifcDataStore,
   coordinateInfo,
+  scanSection,
 }: UseDrawingExportParams): UseDrawingExportResult {
   // Georef inputs for the DXF export (PR #1871 review, P1): placement edits
   // applied in CesiumPlacementEditor live in `georefMutations` (per model
@@ -506,9 +545,21 @@ function useDrawingExport({
       svg += '  </g>\n';
     }
 
+    // POINT-CLOUD SCAN OVERLAY (issue #1805) — on top, same drawing-space
+    // content as cutPolygons/lines, so it needs the same flipX/flipY the
+    // rest of this direct export applies via `transformPt`.
+    if (displayOptions.showScanSection && displayOptions.scanSectionIncludeInExport) {
+      svg += buildScanSectionSvg(
+        scanSection.points,
+        (x, y) => ({ x: flipX ? -x : x, y: flipY ? -y : y }),
+        mmToModel(0.3),
+        displayOptions.scanSectionOpacity,
+      );
+    }
+
     svg += '</svg>';
     return svg;
-  }, [drawing, displayOptions, activePresetId, entityColorMap, overridesEnabled, overrideEngine, measure2DResults, polygonArea2DResults, textAnnotations2D, cloudAnnotations2D, sectionPlane.axis, dxfUnderlays]);
+  }, [drawing, displayOptions, activePresetId, entityColorMap, overridesEnabled, overrideEngine, measure2DResults, polygonArea2DResults, textAnnotations2D, cloudAnnotations2D, sectionPlane.axis, dxfUnderlays, scanSection]);
 
   // Generate SVG with drawing sheet (frame, title block, scale bar)
   // This generates coordinates directly in paper mm space (like the canvas rendering)
@@ -724,6 +775,18 @@ function useDrawingExport({
     }
     svg += '    </g>\n';
 
+    // POINT-CLOUD SCAN OVERLAY (issue #1805) — on top, inside the clipped
+    // drawing-content group like everything else. `modelToPaper` already
+    // applies the same flip + scale/translate the rest of the sheet uses.
+    if (displayOptions.showScanSection && displayOptions.scanSectionIncludeInExport) {
+      svg += buildScanSectionSvg(
+        scanSection.points,
+        modelToPaper,
+        0.3, // mm on paper
+        displayOptions.scanSectionOpacity,
+      );
+    }
+
     svg += '  </g>\n\n';
 
     // Render frame (on top of drawing content)
@@ -751,7 +814,7 @@ function useDrawingExport({
 
     svg += '</svg>';
     return svg;
-  }, [drawing, activeSheet, displayOptions, activePresetId, entityColorMap, overridesEnabled, overrideEngine, dxfUnderlays]);
+  }, [drawing, activeSheet, displayOptions, activePresetId, entityColorMap, overridesEnabled, overrideEngine, dxfUnderlays, scanSection]);
 
   // Export SVG
   const handleExportSVG = useCallback(() => {
@@ -771,6 +834,10 @@ function useDrawingExport({
   // re-georeferenced to true IFC world coordinates (and further to
   // map/CRS coordinates when the model has an IfcMapConversion). DXF
   // reference underlays are not embedded in this export; see PR notes.
+  // The point-cloud scan overlay (issue #1805) is likewise deliberately
+  // excluded: it is a raster-like screen aid (up to tens of thousands of
+  // circles), not vector drawing content, and would bloat a CAD exchange
+  // file — SVG export carries it (opt-in) instead.
   const handleExportDXF = useCallback(() => {
     if (!drawing) return;
     const isCustomPlane = sectionPlane.custom !== undefined;

--- a/apps/viewer/src/hooks/useIfcLoader.ts
+++ b/apps/viewer/src/hooks/useIfcLoader.ts
@@ -55,6 +55,7 @@ import { useIfcServer } from './useIfcServer.js';
 import { getMaxExpressId, parseGlbViewerModel, parseIfcxViewerModel } from './ingest/viewerModelIngest.js';
 import { boundedIteratorReturn } from './ingest/streamCleanup.js';
 import { detectPointCloudFormat, ingestPointCloud } from './ingest/pointCloudIngest.js';
+import { removePointCloudScanCache } from './ingest/pointCloudScanCache.js';
 import { getGlobalRenderer } from './useBCF.js';
 import { extractModelGeoref, alignGeometryToReference, findReferenceGeorefModel } from './ingest/federationAlign.js';
 import { computePointCloudAlignment, unregisterPointCloudAlignment, hasRegisteredPointCloudAlignment } from './ingest/pointCloudAlignment.js';
@@ -713,6 +714,7 @@ export function useIfcLoader() {
             setClassCounts(ingest.rendererHandle.id, null);
             unregisterPointCloudAlignment(ingest.rendererHandle.id);
             setAlignmentAvailable(hasRegisteredPointCloudAlignment());
+            removePointCloudScanCache(ingest.rendererHandle.id);
             clearOwnedCanceller();
             return;
           }
@@ -750,6 +752,7 @@ export function useIfcLoader() {
           setClassCounts(ingest.rendererHandle.id, null);
           unregisterPointCloudAlignment(ingest.rendererHandle.id);
           setAlignmentAvailable(hasRegisteredPointCloudAlignment());
+          removePointCloudScanCache(ingest.rendererHandle.id);
           return;
         }
         // Primary owns the active-model slots; a federated add must not touch

--- a/apps/viewer/src/hooks/useScanSectionLayer.ts
+++ b/apps/viewer/src/hooks/useScanSectionLayer.ts
@@ -164,8 +164,11 @@ export function useScanSectionLayer(params: UseScanSectionLayerParams): UseScanS
   const customKey = sectionPlane.custom
     ? `${sectionPlane.custom.normal.join(',')}|${sectionPlane.custom.distance}|${sectionPlane.custom.tangent.join(',')}|${sectionPlane.custom.bitangent.join(',')}`
     : '';
+  // Includes the inline point-cloud count so a federated IFCx model whose
+  // `geometryResult.pointClouds` populates AFTER registration (same
+  // id/visible/handleId) still retriggers the recompute below.
   const modelsKey = Array.from(models.entries())
-    .map(([id, m]) => `${id}:${m.visible ? 1 : 0}:${m.pointCloudHandleId ?? ''}`)
+    .map(([id, m]) => `${id}:${m.visible ? 1 : 0}:${m.pointCloudHandleId ?? ''}:${m.geometryResult?.pointClouds?.length ?? 0}`)
     .join('|');
 
   // Cheap presence check (map lookups, no O(n) point scan) — independent of

--- a/apps/viewer/src/hooks/useScanSectionLayer.ts
+++ b/apps/viewer/src/hooks/useScanSectionLayer.ts
@@ -29,6 +29,7 @@ import { getPointCloudScanSample } from './ingest/pointCloudScanCache.js';
 import {
   selectScanBand,
   mergeScanBandSelections,
+  resolveScanSectionPosition,
   DEFAULT_SCAN_RENDER_CAP,
   type ScanBandSelection,
   type ScanPointSample,
@@ -119,16 +120,23 @@ function collectScanSources(
   return sources;
 }
 
-function toScanSectionPlane(sectionPlane: UseScanSectionLayerParams['sectionPlane']): ScanSectionPlane {
+function toScanSectionPlane(
+  sectionPlane: UseScanSectionLayerParams['sectionPlane'],
+  coordinateInfo: UseScanSectionLayerParams['coordinateInfo'],
+): ScanSectionPlane {
   const axis = SCAN_SECTION_AXIS_MAP[sectionPlane.axis];
+  // The store's `position` is a 0-100 PERCENTAGE of model bounds, not
+  // metres — resolve it exactly the way `useDrawingGeneration` places the
+  // cut, or the band sits on a different plane than the drawn geometry.
+  const position = resolveScanSectionPosition(sectionPlane.position, axis, coordinateInfo);
   if (!sectionPlane.custom) {
-    return { axis, position: sectionPlane.position, flipped: sectionPlane.flipped };
+    return { axis, position, flipped: sectionPlane.flipped };
   }
   const c = sectionPlane.custom;
   const origin = customPlaneCenter(c);
   return {
     axis,
-    position: sectionPlane.position,
+    position,
     flipped: sectionPlane.flipped,
     custom: {
       normal: c.normal,
@@ -183,7 +191,7 @@ export function useScanSectionLayer(params: UseScanSectionLayerParams): UseScanS
         setSelection(EMPTY_SELECTION);
         return;
       }
-      const plane = toScanSectionPlane(sectionPlane);
+      const plane = toScanSectionPlane(sectionPlane, coordinateInfo);
       const selections = sources.map((sample) => selectScanBand({
         sample, coordinateInfo, plane, thickness, classMask, maxRendered,
       }));
@@ -207,7 +215,10 @@ export function useScanSectionLayer(params: UseScanSectionLayerParams): UseScanS
     maxRendered,
   ]);
 
-  return { ...selection, hasPointCloud };
+  // Stable result identity: consumers put this object in dependency arrays
+  // (`useDrawingExport`'s SVG memos), so a fresh spread per render would
+  // re-create those callbacks on every unrelated parent render.
+  return useMemo(() => ({ ...selection, hasPointCloud }), [selection, hasPointCloud]);
 }
 
 export default useScanSectionLayer;

--- a/apps/viewer/src/hooks/useScanSectionLayer.ts
+++ b/apps/viewer/src/hooks/useScanSectionLayer.ts
@@ -195,7 +195,10 @@ export function useScanSectionLayer(params: UseScanSectionLayerParams): UseScanS
       const selections = sources.map((sample) => selectScanBand({
         sample, coordinateInfo, plane, thickness, classMask, maxRendered,
       }));
-      setSelection(mergeScanBandSelections(selections));
+      // Re-apply the render cap to the MERGED result: each asset caps its
+      // own selection, but several dense scans would otherwise concatenate
+      // to sources × maxRendered points per canvas redraw.
+      setSelection(mergeScanBandSelections(selections, maxRendered));
     }, RECOMPUTE_DEBOUNCE_MS);
 
     return () => {

--- a/apps/viewer/src/hooks/useScanSectionLayer.ts
+++ b/apps/viewer/src/hooks/useScanSectionLayer.ts
@@ -1,0 +1,213 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Scan section layer (issue #1805) — wires the pure band-selection math in
+ * `scanSectionMath.ts` to the viewer store, so `Section2DPanel` can overlay
+ * the loaded point cloud(s) on the 2D section/plan view.
+ *
+ * Point positions live in two different places depending on how the cloud
+ * was ingested (see `scanSectionMath.ts`'s header for the coordinate story):
+ *   - Streamed LAS/LAZ/PLY/PCD/E57 (`pointCloudIngest.ts`): GPU-only: read
+ *     the bounded CPU reservoir sample `pointCloudScanCache.ts` retains,
+ *     keyed by the model's `pointCloudHandleId`.
+ *   - Inline IFCx point clouds: already fully in memory on
+ *     `geometryResult.pointClouds[].chunk` — used directly.
+ *
+ * Recomputing the band selection is a synchronous O(retained points) pass
+ * (see `selectScanBand`) — cheap per call (tens of ms at the multi-million
+ * point retention cap) but debounced here so dragging the section slider
+ * doesn't run it on every pointer-move tick.
+ */
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import type { GeometryResult, PointCloudAsset } from '@ifc-lite/geometry';
+import type { FederatedModel, SectionPlane } from '@/store/types';
+import { customPlaneCenter } from '@/store';
+import { getPointCloudScanSample } from './ingest/pointCloudScanCache.js';
+import {
+  selectScanBand,
+  mergeScanBandSelections,
+  DEFAULT_SCAN_RENDER_CAP,
+  type ScanBandSelection,
+  type ScanPointSample,
+  type ScanSectionPlane,
+} from './scanSectionMath.js';
+
+/** Debounce window for recomputing the band selection on rapid slider drags. */
+const RECOMPUTE_DEBOUNCE_MS = 120;
+
+export const SCAN_SECTION_AXIS_MAP: Record<'down' | 'front' | 'side', 'x' | 'y' | 'z'> = {
+  down: 'y',
+  front: 'z',
+  side: 'x',
+};
+
+export interface UseScanSectionLayerParams {
+  enabled: boolean;
+  sectionPlane: Pick<SectionPlane, 'axis' | 'position' | 'flipped' | 'custom'>;
+  coordinateInfo: GeometryResult['coordinateInfo'] | undefined;
+  /** Full slab thickness in metres. */
+  thickness: number;
+  /** 8-word LAS class-visibility mask; omit to show every class. */
+  classMask?: readonly number[];
+  models: ReadonlyMap<string, FederatedModel>;
+  /** Legacy (no-federation) point clouds — `geometryResult.pointClouds`. */
+  legacyPointClouds: readonly PointCloudAsset[] | undefined;
+  maxRendered?: number;
+}
+
+export interface UseScanSectionLayerResult extends ScanBandSelection {
+  /**
+   * True when at least one point-cloud source is currently loaded/visible —
+   * independent of `enabled`/`showScanSection`, so the panel can still say
+   * "a scan is loaded, just hidden" instead of "no point cloud loaded".
+   */
+  hasPointCloud: boolean;
+}
+
+const EMPTY_SELECTION: ScanBandSelection = {
+  points: [],
+  totalInBand: 0,
+  renderedCount: 0,
+  stride: 1,
+};
+
+/** Gather every currently-loaded point cloud as a flat `ScanPointSample[]`. */
+function collectScanSources(
+  models: ReadonlyMap<string, FederatedModel>,
+  legacyPointClouds: readonly PointCloudAsset[] | undefined,
+): ScanPointSample[] {
+  const sources: ScanPointSample[] = [];
+
+  const pushInlineAsset = (asset: PointCloudAsset) => {
+    if (asset.chunk.pointCount > 0 && asset.chunk.positions.length > 0) {
+      sources.push({
+        positions: asset.chunk.positions,
+        colors: asset.chunk.colors,
+        classifications: asset.chunk.classifications,
+        count: asset.chunk.pointCount,
+      });
+    }
+  };
+
+  if (models.size > 0) {
+    for (const model of models.values()) {
+      if (!model.visible) continue;
+      if (typeof model.pointCloudHandleId === 'number') {
+        const cached = getPointCloudScanSample(model.pointCloudHandleId);
+        if (cached && cached.count > 0) {
+          sources.push({
+            positions: cached.positions,
+            colors: cached.colors ?? undefined,
+            classifications: cached.classifications ?? undefined,
+            count: cached.count,
+          });
+        }
+      }
+      for (const asset of model.geometryResult?.pointClouds ?? []) {
+        pushInlineAsset(asset);
+      }
+    }
+  } else {
+    for (const asset of legacyPointClouds ?? []) {
+      pushInlineAsset(asset);
+    }
+  }
+
+  return sources;
+}
+
+function toScanSectionPlane(sectionPlane: UseScanSectionLayerParams['sectionPlane']): ScanSectionPlane {
+  const axis = SCAN_SECTION_AXIS_MAP[sectionPlane.axis];
+  if (!sectionPlane.custom) {
+    return { axis, position: sectionPlane.position, flipped: sectionPlane.flipped };
+  }
+  const c = sectionPlane.custom;
+  const origin = customPlaneCenter(c);
+  return {
+    axis,
+    position: sectionPlane.position,
+    flipped: sectionPlane.flipped,
+    custom: {
+      normal: c.normal,
+      distance: c.distance,
+      origin,
+      tangent: c.tangent,
+      bitangent: c.bitangent,
+    },
+  };
+}
+
+export function useScanSectionLayer(params: UseScanSectionLayerParams): UseScanSectionLayerResult {
+  const {
+    enabled, sectionPlane, coordinateInfo, thickness, classMask,
+    models, legacyPointClouds, maxRendered = DEFAULT_SCAN_RENDER_CAP,
+  } = params;
+
+  const [selection, setSelection] = useState<ScanBandSelection>(EMPTY_SELECTION);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Fold every dependency the computation reads into one key so the
+  // debounce timer restarts exactly when something relevant changed —
+  // including custom-plane drags (position stays constant; normal/distance
+  // don't).
+  const customKey = sectionPlane.custom
+    ? `${sectionPlane.custom.normal.join(',')}|${sectionPlane.custom.distance}|${sectionPlane.custom.tangent.join(',')}|${sectionPlane.custom.bitangent.join(',')}`
+    : '';
+  const modelsKey = Array.from(models.entries())
+    .map(([id, m]) => `${id}:${m.visible ? 1 : 0}:${m.pointCloudHandleId ?? ''}`)
+    .join('|');
+
+  // Cheap presence check (map lookups, no O(n) point scan) — independent of
+  // `enabled` so the UI can report "a scan is loaded, just hidden".
+  const hasPointCloud = useMemo(
+    () => collectScanSources(models, legacyPointClouds).length > 0,
+    // Keyed on `modelsKey` (a stable string), not `models` identity, since
+    // the Map reference can change without any visible-content change.
+    [modelsKey, legacyPointClouds],
+  );
+
+  useEffect(() => {
+    if (timerRef.current) clearTimeout(timerRef.current);
+
+    if (!enabled) {
+      setSelection(EMPTY_SELECTION);
+      return;
+    }
+
+    timerRef.current = setTimeout(() => {
+      const sources = collectScanSources(models, legacyPointClouds);
+      if (sources.length === 0) {
+        setSelection(EMPTY_SELECTION);
+        return;
+      }
+      const plane = toScanSectionPlane(sectionPlane);
+      const selections = sources.map((sample) => selectScanBand({
+        sample, coordinateInfo, plane, thickness, classMask, maxRendered,
+      }));
+      setSelection(mergeScanBandSelections(selections));
+    }, RECOMPUTE_DEBOUNCE_MS);
+
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, [
+    enabled,
+    sectionPlane.axis,
+    sectionPlane.position,
+    sectionPlane.flipped,
+    customKey,
+    coordinateInfo,
+    thickness,
+    classMask,
+    modelsKey,
+    legacyPointClouds,
+    maxRendered,
+  ]);
+
+  return { ...selection, hasPointCloud };
+}
+
+export default useScanSectionLayer;

--- a/apps/viewer/src/store/index.ts
+++ b/apps/viewer/src/store/index.ts
@@ -25,7 +25,7 @@ import { createMeasurementSlice, type MeasurementSlice } from './slices/measurem
 import { createDataSlice, type DataSlice } from './slices/dataSlice.js';
 import { createModelSlice, type ModelSlice } from './slices/modelSlice.js';
 import { createMutationSlice, type MutationSlice } from './slices/mutationSlice.js';
-import { createDrawing2DSlice, type Drawing2DSlice } from './slices/drawing2DSlice.js';
+import { createDrawing2DSlice, getDefaultDisplayOptions, type Drawing2DSlice } from './slices/drawing2DSlice.js';
 import { createSheetSlice, type SheetSlice } from './slices/sheetSlice.js';
 import { createBcfSlice, type BCFSlice } from './slices/bcfSlice.js';
 import { createIdsSlice, type IDSSlice } from './slices/idsSlice.js';
@@ -417,16 +417,7 @@ const createViewerStore = () => create<ViewerState>()((...args) => ({
       drawing2DPanelVisible: false,
       suppressNextSection2DPanelAutoOpen: false,
       drawing2DSvgContent: null,
-      drawing2DDisplayOptions: {
-        showHiddenLines: true,
-        showHatching: true,
-        showAnnotations: true,
-        show3DOverlay: true,
-        scale: 100,
-        useSymbolicRepresentations: false,
-        showIfcAnnotations: true,
-        showConstructionProjection: false,
-      },
+      drawing2DDisplayOptions: getDefaultDisplayOptions(),
       // Graphic overrides (keep presets, reset active and custom)
       activePresetId: 'preset-3d-colors',
       customOverrideRules: [],

--- a/apps/viewer/src/store/slices/drawing2DSlice.ts
+++ b/apps/viewer/src/store/slices/drawing2DSlice.ts
@@ -12,6 +12,7 @@
 import type { StateCreator } from 'zustand';
 import type { Drawing2D, DxfPlacement, DxfUnderlay, GraphicOverrideRule, GraphicOverridePreset } from '@ifc-lite/drawing-2d';
 import { BUILT_IN_PRESETS, DEFAULT_DXF_PLACEMENT } from '@ifc-lite/drawing-2d';
+import { DEFAULT_SCAN_SECTION_THICKNESS } from '@/hooks/scanSectionMath';
 
 export type Drawing2DStatus = 'idle' | 'generating' | 'ready' | 'error';
 
@@ -122,6 +123,20 @@ export interface Drawing2DState {
      * Off by default; the section view stays cut-only until enabled.
      */
     showConstructionProjection: boolean;
+    /**
+     * Point-cloud "scan" overlay on the 2D section view (issue #1805): a
+     * thin band of loaded scan points around the cut plane, projected into
+     * drawing space and drawn as dots. Default on — with no point cloud
+     * loaded the layer contributes nothing, so the toggle only matters
+     * once a scan is present.
+     */
+    showScanSection: boolean;
+    /** Full slab thickness (metres) around the section plane. */
+    scanSectionThickness: number;
+    /** Dot opacity, 0..1. */
+    scanSectionOpacity: number;
+    /** Include the scan layer's dots in SVG export/print. */
+    scanSectionIncludeInExport: boolean;
   };
   /** Available graphic override presets */
   graphicOverridePresets: GraphicOverridePreset[];
@@ -275,7 +290,12 @@ export interface Drawing2DSlice extends Drawing2DState {
   clearDxfUnderlays: () => void;
 }
 
-const getDefaultDisplayOptions = (): Drawing2DState['drawing2DDisplayOptions'] => ({
+/**
+ * Single source of truth for `drawing2DDisplayOptions` defaults. Both the
+ * slice initializer and `resetViewerState` (`store/index.ts`) call this so
+ * the two paths can't drift — the same pattern `POINT_CLOUD_DEFAULTS` uses.
+ */
+export const getDefaultDisplayOptions = (): Drawing2DState['drawing2DDisplayOptions'] => ({
   showHiddenLines: true,
   showHatching: true,
   showAnnotations: true,
@@ -284,6 +304,10 @@ const getDefaultDisplayOptions = (): Drawing2DState['drawing2DDisplayOptions'] =
   useSymbolicRepresentations: false, // Default to section cut (Body geometry)
   showIfcAnnotations: true, // Mirror the 3D Class Visibility default
   showConstructionProjection: false, // Optional reference projection (issue #979), off by default
+  showScanSection: true, // Scan overlay (issue #1805) — on by default, no-op without a loaded point cloud
+  scanSectionThickness: DEFAULT_SCAN_SECTION_THICKNESS,
+  scanSectionOpacity: 0.9,
+  scanSectionIncludeInExport: true,
 });
 
 const getDefaultState = (): Drawing2DState => ({

--- a/packages/drawing-2d/src/index.ts
+++ b/packages/drawing-2d/src/index.ts
@@ -257,6 +257,7 @@ export {
   getAxisNormal,
   getProjectionAxes,
   projectTo2D,
+  projectTo2DBasis,
 
   // Polygon operations
   polygonSignedArea,

--- a/scripts/api-surface.json
+++ b/scripts/api-surface.json
@@ -1289,6 +1289,7 @@
     "projectPointOnLine: function",
     "projectProfiles: function",
     "projectTo2D: function",
+    "projectTo2DBasis: function",
     "propertyCriterion: function",
     "renderFrame: function",
     "renderNorthArrow: function",


### PR DESCRIPTION
## Root problem

Point clouds stream straight from the decode worker to the GPU — there is no CPU-side copy for the 2D section view to read, so scans were simply absent from section/plan drawings (#1805). The 2D view is exactly where a scan-vs-model overlay is most useful (deviation checks against the drawn cut).

## What this does

- **`pointCloudScanCache.ts`** — a bounded CPU-side reservoir sample (Algorithm R, default cap 2M points/asset, ~32 MB max) fed with the same Y-up-swapped chunks the GPU receives. Buffers start at 64k slots and grow geometrically, so a 50k-point PLY doesn't pin 24 MB. Registered/fed/removed on exactly the same paths as the GPU asset (stream start / chunk / stream error, stale-session cleanup in `useIfcLoader`, model-removal + handle-rebind cleanup in `usePointCloudLifecycle`), so the cache cannot outlive its point cloud.
- **`scanSectionMath.ts`** (pure, unit-tested) — selects the points within a configurable band (`position ± thickness/2`, default 0.3 m, inclusive boundary) around the active section plane, honours the LAS class-visibility mask, and decimates deterministically (keep-every-Nth) to a 500k render cap.
- **`useScanSectionLayer.ts`** — wires the math to the store, debounced 120 ms so slider drags don't recompute per pointer-move. Works for plan and vertical sections, flipped and unflipped, and face-picked custom planes; supports federated multi-scan setups and inline IFCx point clouds.
- **`Drawing2DCanvas` / `Section2DPanel` / `ScanSectionPanel`** — dots drawn as ~1.5 px `fillRect`s on top of the cut geometry, with a slide-in panel (toggle, band thickness, opacity, export opt-out, "showing N of M" readout) matching the DXF-underlay panel pattern.
- **`useDrawingExport.ts`** — scan dots in SVG/print export are opt-in via the panel, capped at 20k circles, and go through the exact same flip/paper transforms as the cut polygons.
- **`@ifc-lite/drawing-2d`** — re-exports `projectTo2DBasis` (existed internally; the scan layer needs it for custom planes). Minor changeset; `pnpm api-surface:update` committed.

## Coordinate contract (plain terms)

Scan points are stored raw (world Y-up, only the Z-up→Y-up swap applied — same as what the GPU renders). To land them in the drawing:

1. **World → render frame:** subtract `originShift + rtc_as_yup` (`pointCloudRenderFrameShift`), the exact inverse of the relationship `reproject.ts` documents (`world_yup = render + originShift + rtc_as_yup`). Restricted to the plan axes this is bit-identical to the DXF underlay's `dxfWorldShift`; a test pins the two so they can't drift.
2. **Slider % → metres:** the store's `SectionPlane.position` is a 0-100 percentage of model bounds; `resolveScanSectionPosition` resolves it over `shiftedBounds` with the same formula `useDrawingGeneration` uses to place the cut.
3. **3D → 2D:** the same `projectTo2D` (cardinal, incl. the `flipped ? -u : u` mirror, matching the GPU cutter's `flipU`) / `projectTo2DBasis` (custom plane, origin = `customPlaneCenter`, no flip — matching the CPU cutter) that produce `drawing.lines`/`cutPolygons`. So the dots composite into the drawing's native space and reuse the identical canvas/export transforms — no second convention.

## Adversarially tested — and what it found

- **Found + fixed (critical): percentage-vs-metres.** The layer originally fed `SectionPlane.position` (a 0-100 percentage) into the plane distance as metres — the band sat on a different plane than the drawn cut for almost every model. Fixed via `resolveScanSectionPosition`; regression test would fail on revert (verified by mutating the line: 2 tests fail, restored: green).
- **Found + fixed: eager 24 MB allocation** per asset regardless of scan size → geometric growth (test spans the growth boundary and spot-checks values).
- **Found + fixed: black backfill.** Points retained before the first coloured chunk rendered black (zero-filled buffer); now backfilled with the same neutral grey colourless points get.
- **Sign-flip mutation check:** flipping the render-frame Y shift makes the shift tests fail; restored, all 32 scan tests green.
- **Slab boundary:** inclusive `<=`; zero thickness keeps only exact-on-plane points; negative thickness clamps to 0. Flip affects only the projected U axis, never band membership (tested).
- **Cache invalidation:** keyed by renderer handle id (unique per stream session). Stream error, sync-throw during setup, stale-session completion/rejection, model removal, and same-model handle rebind all drop the reservoir (mirrors the classification-histogram cleanup). The cache stores raw points only — plane moves never touch it, so there is no stale-plane state to show.
- **Perf:** band selection is two O(retained) passes (retained ≤ 2M/asset), debounced 120 ms off the render hot path — never per frame. Canvas redraw is O(rendered dots), capped at 500k `fillRect`s.

## Gates (actual output)

- `pnpm typecheck` — 33/33 tasks successful
- `pnpm exec turbo test --filter=@ifc-lite/viewer --filter=@ifc-lite/drawing-2d --filter=@ifc-lite/pointcloud` — 34/34 tasks successful; viewer: 1869 tests, 1867 pass, 0 fail, 2 skipped
- `node scripts/check-test-wiring.mjs` — pass
- `node scripts/check-api-surface.mjs` — "API surface matches snapshot (37 packages, 58 export surfaces, 3946 exports)"
- `pnpm docs:check-samples` — "246 snippets across 40 docs" clean
- Changeset: `@ifc-lite/drawing-2d` **minor** (new export on a >=1.0 package)

## Known limitations

- **Reservoir = sample, not census.** Scans beyond the 2M-point retention show a uniform random subset; thin bands on very large scans get proportionally sparse. The "showing N of M" readout counts the retained sample, not the raw file.
- **Redraw cost at the cap:** ~500k `fillRect`s per canvas redraw is noticeable on pan/zoom on slow machines; the band rarely reaches the cap in practice, and the cap is a constant if it needs lowering.
- **Scan-only models:** a streamed cloud without an IFC has zero-size `shiftedBounds` (pre-existing — the ingest registers a placeholder geometry result), so the slider degenerates to position 0. The feature targets scan + model sections (the issue's use case); scan-only 2D sections were empty before and remain of limited use until point-cloud bounds reach `coordinateInfo` (the `feat/1804-pointcloud-mapconversion` territory).
- **Registration assumption:** assumes the scan is authored in the same world CRS as the model (the normal registered-scan case). No independent re-registration of georeferenced scans — consistent with the 3D viewport today.

Closes #1805

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M76mvdz8Hz7WHEoxwn694V


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a 2D “scan section” point-cloud overlay to section/plan views, with per-point colors, adjustable opacity, and deterministic decimation.
  * Added a Scan Layer panel to toggle visibility, adjust band thickness and dot opacity, and control whether the overlay is included in SVG exports (with updated panel open/close behavior).
  * Enabled opt-in SVG export of the scan overlay.
  * Exposed `projectTo2DBasis` from the drawing package public API.
* **Bug Fixes**
  * Improved scan cache cleanup during point-cloud teardown and failed/stale ingests.
* **Tests**
  * Added unit tests for scan cache sampling and scan-section selection/projection math.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->