### PR TITLE
feat(create,encoding): opt-in determinism hooks for reproducible IFC generation

### DIFF
--- a/.changeset/seeded-determinism-hooks.md
+++ b/.changeset/seeded-determinism-hooks.md
@@ -1,0 +1,6 @@
+---
+"@ifc-lite/encoding": minor
+"@ifc-lite/create": minor
+---
+
+Opt-in determinism hooks for reproducible IFC generation. `generateUuid` and `generateIfcGuid` accept an optional `RandomSource` (a `() => number` in `[0, 1)`) so GUIDs can be drawn from a seeded generator, and `IfcCreator` gains `ProjectParams.Timestamp` (fixed creation instant for the STEP header, IfcOwnerHistory and work-schedule defaults) and `ProjectParams.GuidSource` (deterministic GlobalId source). Same options twice yields byte-identical output; defaults are unchanged (wall clock + platform CSPRNG).

--- a/docs/api/typescript.md
+++ b/docs/api/typescript.md
@@ -728,7 +728,30 @@ interface ProjectParams {
   LengthUnit?: string;  // 'METRE' (default), 'MILLIMETRE', 'FOOT'
   Author?: string;
   Organization?: string;
+  Timestamp?: number | Date;   // fixed creation instant (header + owner history); default: wall clock
+  GuidSource?: () => string;   // deterministic GlobalId source; default: platform CSPRNG
 }
+```
+
+For byte-reproducible output (fixtures, snapshot tests, generated corpora), pin both entropy sources — the timestamp and the GlobalId stream:
+
+```typescript
+import { IfcCreator } from '@ifc-lite/create';
+import { generateIfcGuid, type RandomSource } from '@ifc-lite/encoding';
+
+// Any seeded () => number in [0, 1) works; a tiny LCG shown here.
+let seed = 42;
+const rng: RandomSource = () => {
+  seed = (seed * 1103515245 + 12345) % 2147483648;
+  return seed / 2147483648;
+};
+
+const creator = new IfcCreator({
+  Name: 'My Project',
+  Timestamp: Date.UTC(2024, 0, 1),
+  GuidSource: () => generateIfcGuid(rng),
+});
+// Two runs with the same seed now produce byte-identical .ifc content.
 ```
 
 Parameter interfaces for every element type live in `packages/create/src/types.ts` (e.g. `WallParams` with `Start`, `End`, `Thickness`, `Height`, optional `Openings`).

--- a/packages/create/src/ifc-creator.test.ts
+++ b/packages/create/src/ifc-creator.test.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import { describe, it, expect } from 'vitest';
-import { isValidIfcGuid, ifcGuidToUuid, uuidToIfcGuid } from '@ifc-lite/encoding';
+import { generateIfcGuid, isValidIfcGuid, ifcGuidToUuid, uuidToIfcGuid } from '@ifc-lite/encoding';
 import { IfcCreator } from './ifc-creator.js';
 
 describe('IfcCreator', () => {
@@ -604,5 +604,78 @@ describe('IfcCreator — scheduling / 4D', () => {
     const t = c.addIfcTask({ Name: 'T' });
     expect(() => c.assignProductsToTask(t, [])).toThrow(/empty/);
     expect(() => c.nestTasks(t, [])).toThrow(/empty/);
+  });
+});
+
+describe('IfcCreator deterministic output (Timestamp + GuidSource)', () => {
+  /** Simple LCG in [0, 1): same seed => same stream. */
+  const seededRng = (seed: number) => {
+    let s = seed;
+    return () => {
+      s = (s * 1103515245 + 12345) % 2147483648;
+      return s / 2147483648;
+    };
+  };
+
+  const FIXED = Date.UTC(2024, 0, 1, 0, 0, 0);
+
+  /** A representative model touching header, owner history, GUIDs and scheduling. */
+  const buildModel = (params: ConstructorParameters<typeof IfcCreator>[0]) => {
+    const c = new IfcCreator({ Name: 'Deterministic', Author: 'A', ...params });
+    const storey = c.addIfcBuildingStorey({ Name: 'GF', Elevation: 0 });
+    const wall = c.addIfcWall(storey, { Start: [0, 0, 0], End: [5, 0, 0], Thickness: 0.2, Height: 3 });
+    c.addIfcWallWindow(wall, { Width: 1, Height: 1.2, Position: [1, 0, 0.9] });
+    c.addIfcSlab(storey, { Position: [0, 0, 0], Width: 5, Depth: 5, Thickness: 0.2 });
+    c.addIfcWorkSchedule({ Name: 'S', StartTime: '2024-01-01T00:00:00' });
+    return c.toIfc().content;
+  };
+
+  it('same Timestamp + GuidSource yields byte-identical output', () => {
+    const opts = () => ({
+      Timestamp: FIXED,
+      GuidSource: (() => {
+        const rng = seededRng(42);
+        return () => generateIfcGuid(rng);
+      })(),
+    });
+    const first = buildModel(opts());
+    const second = buildModel(opts());
+    expect(second).toBe(first);
+    // The fixed instant landed in the STEP header and IfcOwnerHistory.
+    expect(first).toContain("'20240101T000000'");
+    expect(first).toContain(`,${Math.floor(FIXED / 1000)});`);
+  });
+
+  it('accepts a Date for Timestamp', () => {
+    const opts = () => ({
+      Timestamp: new Date(FIXED),
+      GuidSource: (() => {
+        const rng = seededRng(7);
+        return () => generateIfcGuid(rng);
+      })(),
+    });
+    expect(buildModel(opts())).toBe(buildModel(opts()));
+  });
+
+  it('default behavior stays random', () => {
+    // Without the hooks, GlobalIds come from the CSPRNG, so two otherwise
+    // identical builds differ.
+    expect(buildModel({})).not.toBe(buildModel({}));
+  });
+
+  it('rejects an invalid Timestamp', () => {
+    expect(() => new IfcCreator({ Timestamp: Number.NaN })).toThrow(/Timestamp/);
+    expect(() => new IfcCreator({ Timestamp: new Date('nonsense') })).toThrow(/Timestamp/);
+  });
+
+  it('rejects a GuidSource returning invalid GlobalIds', () => {
+    expect(() => new IfcCreator({ GuidSource: () => 'not-a-guid' })).toThrow(/invalid IFC GlobalId/);
+  });
+
+  it('errors instead of spinning when a GuidSource repeats forever', () => {
+    // The preamble needs several distinct GlobalIds (project/site/building), so
+    // a constant source trips the bounded-retry guard already in the constructor.
+    const constant = generateIfcGuid();
+    expect(() => new IfcCreator({ GuidSource: () => constant })).toThrow(/repeating/);
   });
 });

--- a/packages/create/src/ifc-creator.ts
+++ b/packages/create/src/ifc-creator.ts
@@ -37,7 +37,7 @@ import {
   esc, stepLine, num, vecLen, vecNorm, vecCross,
   NON_ELEMENT_TYPES,
 } from './ifc-creator-math.js';
-import { generateIfcGuid } from '@ifc-lite/encoding';
+import { generateIfcGuid, isValidIfcGuid } from '@ifc-lite/encoding';
 
 // ============================================================================
 // STEP attribute helpers (scheduling — optional strings / enums / numbers)
@@ -118,20 +118,46 @@ export class IfcCreator {
 
   private projectParams: ProjectParams;
 
+  /** Fixed creation instant (epoch ms) for header/owner-history; null = wall clock. */
+  private readonly fixedTimestampMs: number | null;
+  /** Deterministic GlobalId source; null = platform CSPRNG. */
+  private readonly guidSource: (() => string) | null;
+
   constructor(params: ProjectParams = {}) {
     this.projectParams = params;
     this.schema = params.Schema ?? 'IFC4';
+    this.fixedTimestampMs = params.Timestamp === undefined
+      ? null
+      : typeof params.Timestamp === 'number' ? params.Timestamp : params.Timestamp.getTime();
+    if (this.fixedTimestampMs !== null && !Number.isFinite(this.fixedTimestampMs)) {
+      throw new Error('IfcCreator: Timestamp must be a finite epoch-milliseconds number or a valid Date');
+    }
+    this.guidSource = params.GuidSource ?? null;
     this.buildPreamble(params);
+  }
+
+  /** The creation instant used everywhere: the fixed Timestamp when provided, else the wall clock. */
+  private nowMs(): number {
+    return this.fixedTimestampMs ?? Date.now();
   }
 
   /** Generate a spec-valid 22-character IFC GlobalId (canonical encoder from @ifc-lite/encoding). */
   private newGlobalId(): string {
-    let result: string;
-    do {
-      result = generateIfcGuid();
-    } while (this.usedGlobalIds.has(result));
-    this.usedGlobalIds.add(result);
-    return result;
+    const generate = this.guidSource ?? generateIfcGuid;
+    // Bounded retry: with the default CSPRNG a collision is astronomically
+    // unlikely; with a user GuidSource the bound turns a repeating source into
+    // a clear error instead of an infinite loop.
+    for (let attempt = 0; attempt < 100; attempt += 1) {
+      const result = generate();
+      if (this.guidSource !== null && !isValidIfcGuid(result)) {
+        throw new Error(`IfcCreator: GuidSource returned an invalid IFC GlobalId: '${result}' (must be 22 characters of the IFC base64 alphabet)`);
+      }
+      if (!this.usedGlobalIds.has(result)) {
+        this.usedGlobalIds.add(result);
+        return result;
+      }
+    }
+    throw new Error('IfcCreator: could not generate a unique GlobalId after 100 attempts - the GuidSource is repeating already-used values');
   }
 
   // ============================================================================
@@ -1718,7 +1744,7 @@ export class IfcCreator {
     const desc = optStr(params.Description);
     const objType = '$';
     const ident = optStr(params.Identification);
-    const creationDate = params.CreationDate ?? new Date().toISOString().slice(0, 19);
+    const creationDate = params.CreationDate ?? new Date(this.nowMs()).toISOString().slice(0, 19);
     const purpose = optStr(params.Purpose);
     const duration = optStr(params.Duration);
     const totalFloat = optStr(params.TotalFloat);
@@ -1766,7 +1792,7 @@ export class IfcCreator {
   }
 
   private buildHeader(): string {
-    const now = new Date().toISOString().replace(/[-:]/g, '').split('.')[0];
+    const now = new Date(this.nowMs()).toISOString().replace(/[-:]/g, '').split('.')[0];
     const desc = 'Created by ifc-lite';
     const author = this.projectParams.Author ?? '';
     const org = this.projectParams.Organization ?? '';
@@ -1800,7 +1826,7 @@ ENDSEC;
     this.line(appId, 'IFCAPPLICATION', `#${orgId},'1.0','ifc-lite','ifc-lite'`);
 
     this.ownerHistoryId = this.id();
-    const timestamp = Math.floor(Date.now() / 1000);
+    const timestamp = Math.floor(this.nowMs() / 1000);
     this.line(this.ownerHistoryId, 'IFCOWNERHISTORY',
       `#${personOrgId},#${appId},$,.NOCHANGE.,$,$,$,${timestamp}`);
 

--- a/packages/create/src/types.ts
+++ b/packages/create/src/types.ts
@@ -549,6 +549,21 @@ export interface ProjectParams {
   LengthUnit?: string;
   Author?: string;
   Organization?: string;
+  /**
+   * Fixed creation instant (epoch milliseconds or Date) used for the FILE_NAME
+   * header timestamp, IfcOwnerHistory.CreationDate, and the default
+   * work-schedule/work-plan CreationDate. Defaults to the wall clock; set it
+   * (together with GuidSource) for byte-reproducible output.
+   */
+  Timestamp?: number | Date;
+  /**
+   * Deterministic GlobalId source: called once per generated GlobalId and must
+   * return a valid 22-character IFC GUID - e.g. `() => generateIfcGuid(rng)`
+   * with a seeded `RandomSource` from `@ifc-lite/encoding`. Defaults to the
+   * platform CSPRNG. Values already used by this creator are retried, so the
+   * source must not repeat indefinitely.
+   */
+  GuidSource?: () => string;
 }
 
 /** Site-level options */

--- a/packages/encoding/src/guid.test.ts
+++ b/packages/encoding/src/guid.test.ts
@@ -34,4 +34,41 @@ describe('guid', () => {
     const uuid = generateUuid();
     expect(isValidUuid(uuid)).toBe(true);
   });
+
+  it('generates deterministic UUIDs and IFC GUIDs from a seeded RandomSource', () => {
+    // Simple LCG: same seed => same stream => same GUID.
+    const seeded = (seed: number) => {
+      let s = seed;
+      return () => {
+        s = (s * 1103515245 + 12345) % 2147483648;
+        return s / 2147483648;
+      };
+    };
+
+    const a = generateUuid(seeded(42));
+    const b = generateUuid(seeded(42));
+    expect(a).toBe(b);
+    expect(isValidUuid(a)).toBe(true);
+    // Version/variant bits are still forced (v4-shaped).
+    expect(a[14]).toBe('4');
+    expect(['8', '9', 'a', 'b']).toContain(a[19]);
+    // A different seed diverges.
+    expect(generateUuid(seeded(43))).not.toBe(a);
+
+    const g1 = generateIfcGuid(seeded(7));
+    const g2 = generateIfcGuid(seeded(7));
+    expect(g1).toBe(g2);
+    expect(isValidIfcGuid(g1)).toBe(true);
+  });
+
+  it('draws bytes from the provided source, not the CSPRNG', () => {
+    // An all-zero source pins every byte except the forced version/variant
+    // bits, so the exact output proves crypto.randomUUID was bypassed.
+    expect(generateUuid(() => 0)).toBe('00000000-0000-4000-8000-000000000000');
+  });
+
+  it('keeps the default path random', () => {
+    expect(generateUuid()).not.toBe(generateUuid());
+    expect(generateIfcGuid()).not.toBe(generateIfcGuid());
+  });
 });

--- a/packages/encoding/src/guid.ts
+++ b/packages/encoding/src/guid.ts
@@ -83,17 +83,30 @@ export function ifcGuidToUuid(ifcGuid: string): string {
   return `${hex.substring(0, 8)}-${hex.substring(8, 12)}-${hex.substring(12, 16)}-${hex.substring(16, 20)}-${hex.substring(20, 32)}`.toLowerCase();
 }
 
-export function generateIfcGuid(): string {
-  return uuidToIfcGuid(generateUuid());
+/**
+ * Optional randomness source for GUID generation: a `Math.random`-style
+ * function returning floats in `[0, 1)`. Pass a seeded generator to make GUID
+ * generation reproducible (e.g. for byte-deterministic file output); omit it
+ * for the default platform CSPRNG. A seeded source trades global uniqueness
+ * for reproducibility - only use one where that is the point.
+ */
+export type RandomSource = () => number;
+
+export function generateIfcGuid(random?: RandomSource): string {
+  return uuidToIfcGuid(generateUuid(random));
 }
 
-export function generateUuid(): string {
-  if (typeof crypto !== 'undefined' && crypto.randomUUID) {
+export function generateUuid(random?: RandomSource): string {
+  if (random === undefined && typeof crypto !== 'undefined' && crypto.randomUUID) {
     return crypto.randomUUID();
   }
 
   const bytes = new Uint8Array(16);
-  if (typeof crypto !== 'undefined' && crypto.getRandomValues) {
+  if (random !== undefined) {
+    for (let i = 0; i < 16; i++) {
+      bytes[i] = Math.floor(random() * 256) & 0xff;
+    }
+  } else if (typeof crypto !== 'undefined' && crypto.getRandomValues) {
     crypto.getRandomValues(bytes);
   } else {
     for (let i = 0; i < 16; i++) {

--- a/packages/encoding/src/index.ts
+++ b/packages/encoding/src/index.ts
@@ -11,5 +11,6 @@ export {
   isValidIfcGuid,
   isValidUuid,
 } from './guid.js';
+export type { RandomSource } from './guid.js';
 export { parsePropertyValue } from './property-value.js';
 export type { ParsedPropertyValue } from './property-value.js';

--- a/scripts/api-surface.json
+++ b/scripts/api-surface.json
@@ -1347,6 +1347,7 @@
   ],
   "@ifc-lite/encoding": [
     "ParsedPropertyValue: interface",
+    "RandomSource: type",
     "decodeIfcString: function",
     "encodeIfcString: function",
     "generateIfcGuid: function",


### PR DESCRIPTION
## Problem

Byte-deterministic IFC generation through `IfcCreator` was impossible without monkey-patching globals: `packages/create/src/ifc-creator.ts` reads the wall clock (`Date.now()` for `IfcOwnerHistory`, `new Date().toISOString()` for the STEP `FILE_NAME` header and the work-schedule `CreationDate` default), and every GlobalId comes from `@ifc-lite/encoding`'s `generateUuid()`, which calls `crypto.randomUUID()` with no seed hook. The world-gym harness (moonshot branch, `tools/world-gym/lib/deterministic-runtime.mjs`) had to temporarily replace `globalThis.Date` and `crypto.randomUUID` to get reproducible output - that shim can be deleted once this lands (world-gym itself is not on main and is deliberately not touched here).

## Change (additive, defaults unchanged)

- `@ifc-lite/encoding`: `generateUuid(random?)` / `generateIfcGuid(random?)` accept an optional `RandomSource` (`() => number` in `[0, 1)`, exported type). With a source, UUID bytes are drawn from it (v4 version/variant bits still forced); without one, the platform CSPRNG path is byte-for-byte the old code.
- `@ifc-lite/create`: `ProjectParams.Timestamp` (`number | Date`) pins the creation instant used by the header, owner history and work-schedule defaults; `ProjectParams.GuidSource` (`() => string`) supplies GlobalIds. GuidSource output is validated (`isValidIfcGuid`) and the uniqueness loop is bounded, so a repeating source raises a clear error instead of spinning forever.
- Docs: `docs/api/typescript.md` `ProjectParams` listing updated plus a self-contained reproducible-output snippet (passes `docs:check-samples`).
- `scripts/api-surface.json`: +1 entry (`RandomSource: type` on `@ifc-lite/encoding`).

## Tests

- `packages/encoding/src/guid.test.ts`: same seed => same UUID/IFC GUID, different seed diverges, version/variant bits preserved, `() => 0` pins the exact `00000000-0000-4000-8000-000000000000` (proves the CSPRNG is bypassed), default path still random.
- `packages/create/src/ifc-creator.test.ts`: same `Timestamp` + `GuidSource` => byte-identical `toIfc()` content (model with storey/wall/window/slab/work schedule; fixed instant asserted in header + owner history), `Date` accepted for `Timestamp`, defaults stay random, invalid `Timestamp` rejected, invalid GuidSource output rejected, constant GuidSource errors with the bounded-retry message.

## Verification

- `pnpm --filter @ifc-lite/encoding test`: 4 files, 51 tests passed.
- `pnpm --filter @ifc-lite/create test`: 12 files, 103 tests passed.
- Full `pnpm build` (all 37 packages, tsc typecheck) clean; `pnpm docs:check-samples` clean (246 snippets); `pnpm check:api-surface` clean after snapshot update.
- Changeset: minor for `@ifc-lite/encoding` and `@ifc-lite/create` (additive public surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)