### PR TITLE
feat(viewer): make the ribbon the default toolbar, with contextual tabs

### DIFF
--- a/apps/viewer/src/components/viewer/ribbon/RibbonSwitchNotice.tsx
+++ b/apps/viewer/src/components/viewer/ribbon/RibbonSwitchNotice.tsx
@@ -27,8 +27,11 @@ const NOTICE_ID = 'ribbon-default';
 function hasExplicitToolbarChoice(): boolean {
   try {
     return localStorage.getItem(TOOLBAR_STYLE_STORAGE_KEY) !== null;
-  } catch {
-    // Locked storage: treat it as "no choice recorded" and show the notice.
+  } catch (err) {
+    // Locked storage (Safari private mode): treat it as "no choice recorded"
+    // and show the notice. Logged rather than swallowed so a real storage
+    // fault is visible instead of silently re-showing the notice every load.
+    console.warn('[toolbar-style] could not read the toolbar preference; showing the switch notice', err);
     return false;
   }
 }

--- a/apps/viewer/src/components/viewer/ribbon/RibbonSwitchNotice.tsx
+++ b/apps/viewer/src/components/viewer/ribbon/RibbonSwitchNotice.tsx
@@ -38,6 +38,10 @@ function hasExplicitToolbarChoice(): boolean {
 
 export function RibbonSwitchNotice() {
   const setToolbarStyle = useViewerStore((s) => s.setToolbarStyle);
+  // `startTour` refuses to run on mobile. Offering "Show me what moved" there
+  // would retire the notice on click and then show nothing, so the invitation
+  // is only rendered where it can be honoured.
+  const isMobile = useViewerStore((s) => s.isMobile);
   const tourStatus = useTourStore((s) => s.status);
   const [dismissed, setDismissed] = useState(
     () => isNoticeDismissed(NOTICE_ID) || hasExplicitToolbarChoice(),
@@ -62,16 +66,20 @@ export function RibbonSwitchNotice() {
       <span className="min-w-0 truncate text-foreground/80">
         The tabbed ribbon is now the default toolbar. Same commands, grouped by task.
       </span>
-      <button
-        className="shrink-0 font-medium text-primary underline-offset-2 hover:underline"
-        onClick={() => {
-          close();
-          startTour('ribbon', 'invite');
-        }}
-      >
-        Show me what moved
-      </button>
-      <span aria-hidden="true" className="text-muted-foreground/40">|</span>
+      {!isMobile && (
+        <>
+          <button
+            className="shrink-0 font-medium text-primary underline-offset-2 hover:underline"
+            onClick={() => {
+              close();
+              startTour('ribbon', 'invite');
+            }}
+          >
+            Show me what moved
+          </button>
+          <span aria-hidden="true" className="text-muted-foreground/40">|</span>
+        </>
+      )}
       <button
         className="shrink-0 hover:text-foreground hover:underline"
         onClick={() => {

--- a/apps/viewer/src/components/viewer/ribbon/RibbonSwitchNotice.tsx
+++ b/apps/viewer/src/components/viewer/ribbon/RibbonSwitchNotice.tsx
@@ -1,0 +1,91 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * One-time "the toolbar changed" line under the ribbon. Same contract as
+ * `TourInvite`: never a modal, one sentence, one tour link, one way out,
+ * and gone forever once dismissed, once the ribbon tour is completed, or
+ * once the user has picked a toolbar style by hand (they already know).
+ *
+ * It also stays out of the way while a walkthrough is running - the tour
+ * spotlight owns the screen at that point.
+ */
+
+import { useMemo, useState } from 'react';
+import { PanelTop, X } from 'lucide-react';
+import { startTour } from '@/lib/tours/controller';
+import { getTour } from '@/lib/tours/registry';
+import { dismissNotice, isNoticeDismissed, isTourCompleted } from '@/lib/tours/storage';
+import { useTourStore } from '@/lib/tours/tour-store';
+import { useViewerStore } from '@/store';
+import { TOOLBAR_STYLE_STORAGE_KEY } from '@/store/constants';
+
+const NOTICE_ID = 'ribbon-default';
+
+/** True once the user has explicitly chosen a toolbar style on this browser. */
+function hasExplicitToolbarChoice(): boolean {
+  try {
+    return localStorage.getItem(TOOLBAR_STYLE_STORAGE_KEY) !== null;
+  } catch {
+    // Locked storage: treat it as "no choice recorded" and show the notice.
+    return false;
+  }
+}
+
+export function RibbonSwitchNotice() {
+  const setToolbarStyle = useViewerStore((s) => s.setToolbarStyle);
+  const tourStatus = useTourStore((s) => s.status);
+  const [dismissed, setDismissed] = useState(
+    () => isNoticeDismissed(NOTICE_ID) || hasExplicitToolbarChoice(),
+  );
+  // Re-read only when a tour ends, so finishing the ribbon tour retires the
+  // notice without re-reading localStorage on every ribbon render.
+  const tourDone = useMemo(() => {
+    const tour = getTour('ribbon');
+    return tour ? isTourCompleted(tour.id, tour.version) : false;
+  }, [tourStatus]);
+
+  if (dismissed || tourDone || tourStatus !== 'idle') return null;
+
+  const close = () => {
+    dismissNotice(NOTICE_ID);
+    setDismissed(true);
+  };
+
+  return (
+    <div className="flex items-center gap-2 border-t border-primary/25 bg-primary/5 px-3 py-1 text-[11px] text-muted-foreground">
+      <PanelTop className="h-3.5 w-3.5 shrink-0 text-primary" aria-hidden="true" />
+      <span className="min-w-0 truncate text-foreground/80">
+        The tabbed ribbon is now the default toolbar. Same commands, grouped by task.
+      </span>
+      <button
+        className="shrink-0 font-medium text-primary underline-offset-2 hover:underline"
+        onClick={() => {
+          close();
+          startTour('ribbon', 'invite');
+        }}
+      >
+        Show me what moved
+      </button>
+      <span aria-hidden="true" className="text-muted-foreground/40">|</span>
+      <button
+        className="shrink-0 hover:text-foreground hover:underline"
+        onClick={() => {
+          close();
+          setToolbarStyle('classic');
+        }}
+      >
+        Keep the classic bar
+      </button>
+      <div className="flex-1" />
+      <button
+        aria-label="Dismiss toolbar notice"
+        className="shrink-0 rounded p-0.5 text-muted-foreground/60 hover:bg-muted hover:text-muted-foreground"
+        onClick={close}
+      >
+        <X className="h-3 w-3" />
+      </button>
+    </div>
+  );
+}

--- a/apps/viewer/src/components/viewer/ribbon/RibbonToolbar.tsx
+++ b/apps/viewer/src/components/viewer/ribbon/RibbonToolbar.tsx
@@ -4,25 +4,28 @@
 
 /**
  * Ribbon toolbar (issue #1686) — the tabbed, IFCFlux/Office-style
- * alternative to the classic single-strip `MainToolbar`. A slim tab
- * strip selects a command context; the band beneath lays the commands
- * out in labeled groups with visible names, trading one strip of
- * vertical space for zero-recall discovery. Selected per user via
- * `uiSlice.toolbarStyle`; both styles drive the same shared command
- * hooks so behaviour can never fork.
+ * alternative to the classic single-strip `MainToolbar`, and the default
+ * toolbar since the ribbon shipped. A slim tab strip selects a command
+ * context; the band beneath lays the commands out in labeled groups with
+ * visible names, trading one strip of vertical space for zero-recall
+ * discovery. Selected per user via `uiSlice.toolbarStyle`; both styles
+ * drive the same shared command hooks so behaviour can never fork.
  *
  * Office conventions kept: double-click the active tab (or the chevron)
  * to collapse the band to the tab strip; the collapsed state persists.
+ * The active tab also follows the working context (see
+ * `useRibbonContextualTab`), which the user can turn off in View.
  */
 
-import React, { useState } from 'react';
+import React from 'react';
 import { ChevronDown, ChevronUp, HelpCircle, Loader2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Progress } from '@/components/ui/progress';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
-import { useViewerStore } from '@/store';
+import { useViewerStore, type RibbonTabId } from '@/store';
 import { useIfc } from '@/hooks/useIfc';
 import { cn } from '@/lib/utils';
+import { TOUR_ANCHORS, tourAnchor } from '@/lib/tours/anchors';
 import { ThemeSwitch } from '../ThemeSwitch';
 import { ExportChangesButton } from '../ExportChangesButton';
 import { ExtensionToolbarSlot } from '@/components/extensions/ExtensionToolbarSlot';
@@ -33,8 +36,8 @@ import { ViewTab } from './tabs/ViewTab';
 import { ElementsTab } from './tabs/ElementsTab';
 import { AnalyzeTab } from './tabs/AnalyzeTab';
 import { AuthorTab } from './tabs/AuthorTab';
-
-type RibbonTabId = 'file' | 'home' | 'view' | 'elements' | 'analyze' | 'author';
+import { RibbonSwitchNotice } from './RibbonSwitchNotice';
+import { useRibbonContextualTab } from './useRibbonContextualTab';
 
 const RIBBON_TABS: { id: RibbonTabId; label: string }[] = [
   { id: 'file', label: 'File' },
@@ -50,10 +53,14 @@ interface RibbonToolbarProps {
 }
 
 export function RibbonToolbar({ onShowShortcuts }: RibbonToolbarProps = {} as RibbonToolbarProps) {
-  // Home first: it holds the everyday tool and camera loop.
-  const [activeTab, setActiveTab] = useState<RibbonTabId>('home');
+  // The active tab lives in the store so the contextual driver and the
+  // walkthrough can open one; it starts on Home and is never persisted.
+  const activeTab = useViewerStore((s) => s.ribbonTab);
+  const setActiveTab = useViewerStore((s) => s.setRibbonTab);
   const ribbonCollapsed = useViewerStore((s) => s.ribbonCollapsed);
   const setRibbonCollapsed = useViewerStore((s) => s.setRibbonCollapsed);
+
+  useRibbonContextualTab();
 
   // Shared command surface — registers the global load listeners and the
   // hidden file inputs exactly once for this toolbar style.
@@ -76,7 +83,12 @@ export function RibbonToolbar({ onShowShortcuts }: RibbonToolbarProps = {} as Ri
 
       {/* ── Tab strip ── */}
       <div className="flex h-10 items-center gap-0.5 border-b border-zinc-200/70 px-2 dark:border-zinc-800/70">
-        <div role="tablist" aria-label="Ribbon tabs" className="flex h-full items-end gap-0.5">
+        <div
+          role="tablist"
+          aria-label="Ribbon tabs"
+          className="flex h-full items-end gap-0.5"
+          {...tourAnchor(TOUR_ANCHORS.ribbonTabs)}
+        >
           {RIBBON_TABS.map((tab) => {
             const isActive = tab.id === activeTab;
             return (
@@ -175,6 +187,7 @@ export function RibbonToolbar({ onShowShortcuts }: RibbonToolbarProps = {} as Ri
                 aria-label={ribbonCollapsed ? 'Expand the ribbon' : 'Collapse the ribbon'}
                 aria-expanded={!ribbonCollapsed}
                 onClick={() => setRibbonCollapsed(!ribbonCollapsed)}
+                {...tourAnchor(TOUR_ANCHORS.ribbonCollapse)}
               >
                 {ribbonCollapsed ? <ChevronDown className="h-4 w-4" /> : <ChevronUp className="h-4 w-4" />}
               </Button>
@@ -199,6 +212,10 @@ export function RibbonToolbar({ onShowShortcuts }: RibbonToolbarProps = {} as Ri
           {activeTab === 'author' && <AuthorTab />}
         </div>
       )}
+
+      {/* One-time "the toolbar changed" line, with the way back. Sits under
+          the band so it never displaces a command the user is reaching for. */}
+      <RibbonSwitchNotice />
     </div>
   );
 }

--- a/apps/viewer/src/components/viewer/ribbon/contextual-tabs.test.ts
+++ b/apps/viewer/src/components/viewer/ribbon/contextual-tabs.test.ts
@@ -1,0 +1,104 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The contextual-tab policy is the part of the ribbon that moves without
+ * being asked, so every rule (and every rule's refusal to fire) is pinned
+ * here rather than left to a live browser.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { decideRibbonTab, NO_TAB_MEMORY, type RibbonContext } from './contextual-tabs.js';
+
+const EMPTY: RibbonContext = { hasModel: false, hasSelection: false, editEnabled: false };
+const LOADED: RibbonContext = { hasModel: true, hasSelection: false, editEnabled: false };
+const SELECTED: RibbonContext = { hasModel: true, hasSelection: true, editEnabled: false };
+const EDITING: RibbonContext = { hasModel: true, hasSelection: false, editEnabled: true };
+
+describe('decideRibbonTab — landing tab', () => {
+  it('opens File on a first pass with no model', () => {
+    const d = decideRibbonTab(null, EMPTY, 'home', NO_TAB_MEMORY);
+    assert.deepEqual(d, { tab: 'file', memory: { autoOpened: 'file', returnTo: 'home' } });
+  });
+
+  it('leaves a first pass alone when a model is already loaded', () => {
+    assert.equal(decideRibbonTab(null, LOADED, 'home', NO_TAB_MEMORY), null);
+  });
+
+  it('leaves a first pass alone when the user is not on the default tab', () => {
+    // Switching over from the classic toolbar mid-session must not yank the
+    // tab out from under a deliberate choice.
+    assert.equal(decideRibbonTab(null, EMPTY, 'analyze', NO_TAB_MEMORY), null);
+  });
+});
+
+describe('decideRibbonTab — model set', () => {
+  it('moves File to Home once the first model lands', () => {
+    const d = decideRibbonTab(EMPTY, LOADED, 'file', { autoOpened: 'file', returnTo: 'home' });
+    assert.deepEqual(d, { tab: 'home', memory: NO_TAB_MEMORY });
+  });
+
+  it('leaves any other tab alone when a model lands', () => {
+    assert.equal(decideRibbonTab(EMPTY, LOADED, 'analyze', NO_TAB_MEMORY), null);
+  });
+
+  it('falls back to File when the scene empties out', () => {
+    const d = decideRibbonTab(LOADED, EMPTY, 'elements', NO_TAB_MEMORY);
+    assert.deepEqual(d, { tab: 'file', memory: NO_TAB_MEMORY });
+  });
+});
+
+describe('decideRibbonTab — selection', () => {
+  it('opens Elements on the rising edge from a neutral tab', () => {
+    const d = decideRibbonTab(LOADED, SELECTED, 'home', NO_TAB_MEMORY);
+    assert.deepEqual(d, { tab: 'elements', memory: { autoOpened: 'elements', returnTo: 'home' } });
+  });
+
+  it('does not steal a deliberate tab', () => {
+    for (const tab of ['view', 'analyze', 'author'] as const) {
+      assert.equal(decideRibbonTab(LOADED, SELECTED, tab, NO_TAB_MEMORY), null, tab);
+    }
+  });
+
+  it('does not re-fire while the selection merely changes', () => {
+    // Element A to element B: still "something selected", no edge.
+    assert.equal(decideRibbonTab(SELECTED, SELECTED, 'elements', NO_TAB_MEMORY), null);
+  });
+
+  it('hands the tab back when the selection clears', () => {
+    const d = decideRibbonTab(SELECTED, LOADED, 'elements', { autoOpened: 'elements', returnTo: 'view' });
+    assert.deepEqual(d, { tab: 'view', memory: NO_TAB_MEMORY });
+  });
+
+  it('keeps Elements when the user opened it themselves', () => {
+    // No memory means the tab is the user's own: clearing a selection must
+    // not move them.
+    assert.equal(decideRibbonTab(SELECTED, LOADED, 'elements', NO_TAB_MEMORY), null);
+  });
+
+  it('does not return when the user has since moved to another tab', () => {
+    const d = decideRibbonTab(SELECTED, LOADED, 'analyze', { autoOpened: 'elements', returnTo: 'home' });
+    assert.equal(d, null);
+  });
+});
+
+describe('decideRibbonTab — edit mode', () => {
+  it('opens Author when edit mode comes on', () => {
+    const d = decideRibbonTab(LOADED, EDITING, 'home', NO_TAB_MEMORY);
+    assert.deepEqual(d, { tab: 'author', memory: { autoOpened: 'author', returnTo: 'home' } });
+  });
+
+  it('hands the tab back when edit mode goes off', () => {
+    const d = decideRibbonTab(EDITING, LOADED, 'author', { autoOpened: 'author', returnTo: 'home' });
+    assert.deepEqual(d, { tab: 'home', memory: NO_TAB_MEMORY });
+  });
+
+  it('outranks selection: no Elements switch while authoring', () => {
+    const editingWithSelection: RibbonContext = { hasModel: true, hasSelection: true, editEnabled: true };
+    assert.equal(decideRibbonTab(EDITING, editingWithSelection, 'author', NO_TAB_MEMORY), null);
+    // Even from a neutral tab, an authoring session keeps its context.
+    assert.equal(decideRibbonTab(EDITING, editingWithSelection, 'home', NO_TAB_MEMORY), null);
+  });
+});

--- a/apps/viewer/src/components/viewer/ribbon/contextual-tabs.test.ts
+++ b/apps/viewer/src/components/viewer/ribbon/contextual-tabs.test.ts
@@ -27,6 +27,24 @@ describe('decideRibbonTab — landing tab', () => {
     assert.equal(decideRibbonTab(null, LOADED, 'home', NO_TAB_MEMORY), null);
   });
 
+  // Switching over from the classic toolbar mid-session is a first pass with
+  // live context (PR #1880 review).
+  it('opens Author on a first pass while edit mode is already on', () => {
+    const d = decideRibbonTab(null, EDITING, 'home', NO_TAB_MEMORY);
+    assert.deepEqual(d, { tab: 'author', memory: { autoOpened: 'author', returnTo: 'home' } });
+  });
+
+  it('opens Elements on a first pass with something already selected', () => {
+    const d = decideRibbonTab(null, SELECTED, 'home', NO_TAB_MEMORY);
+    assert.deepEqual(d, { tab: 'elements', memory: { autoOpened: 'elements', returnTo: 'home' } });
+  });
+
+  it('lets edit mode outrank selection on a first pass', () => {
+    const both: RibbonContext = { hasModel: true, hasSelection: true, editEnabled: true };
+    const d = decideRibbonTab(null, both, 'home', NO_TAB_MEMORY);
+    assert.deepEqual(d, { tab: 'author', memory: { autoOpened: 'author', returnTo: 'home' } });
+  });
+
   it('leaves a first pass alone when the user is not on the default tab', () => {
     // Switching over from the classic toolbar mid-session must not yank the
     // tab out from under a deliberate choice.

--- a/apps/viewer/src/components/viewer/ribbon/contextual-tabs.test.ts
+++ b/apps/viewer/src/components/viewer/ribbon/contextual-tabs.test.ts
@@ -102,6 +102,27 @@ describe('decideRibbonTab — selection', () => {
   });
 });
 
+describe('decideRibbonTab — edit outranks selection (PR #1880 review)', () => {
+  it('does not hand the tab back when a selection clears while still editing', () => {
+    const editingWithSelection: RibbonContext = {
+      hasModel: true, hasSelection: true, editEnabled: true,
+    };
+    const memory = { autoOpened: 'elements' as const, returnTo: 'home' as const };
+    // Selection goes away but edit mode is still on: Author remains the
+    // context, so nothing may be handed back out from under the user.
+    assert.equal(
+      decideRibbonTab(editingWithSelection, EDITING, 'author', memory),
+      null,
+    );
+  });
+
+  it('still hands back once editing is off', () => {
+    const memory = { autoOpened: 'elements' as const, returnTo: 'home' as const };
+    const d = decideRibbonTab(SELECTED, LOADED, 'elements', memory);
+    assert.deepEqual(d, { tab: 'home', memory: NO_TAB_MEMORY });
+  });
+});
+
 describe('decideRibbonTab — edit mode', () => {
   it('opens Author when edit mode comes on', () => {
     const d = decideRibbonTab(LOADED, EDITING, 'home', NO_TAB_MEMORY);

--- a/apps/viewer/src/components/viewer/ribbon/contextual-tabs.ts
+++ b/apps/viewer/src/components/viewer/ribbon/contextual-tabs.ts
@@ -94,6 +94,13 @@ export function decideRibbonTab(
   // user already made this session.
   if (!prev) {
     if (!next.hasModel && tab === 'home') return takeOver('file', 'home');
+    // Switching over from the classic toolbar mid-session is also a first
+    // pass, and the context that was already live has to count: landing on
+    // Home while edit mode is on (or something is selected) would contradict
+    // the same precedence the edge branches below apply. Edit outranks
+    // selection here too.
+    if (tab === 'home' && next.editEnabled) return takeOver('author', 'home');
+    if (tab === 'home' && next.hasSelection) return takeOver('elements', 'home');
     return null;
   }
 

--- a/apps/viewer/src/components/viewer/ribbon/contextual-tabs.ts
+++ b/apps/viewer/src/components/viewer/ribbon/contextual-tabs.ts
@@ -128,7 +128,10 @@ export function decideRibbonTab(
   if (!prev.hasSelection && next.hasSelection && !next.editEnabled) {
     return NEUTRAL_TABS.includes(tab) ? takeOver('elements', tab) : null;
   }
-  if (prev.hasSelection && !next.hasSelection) {
+  // Same edit-outranks-selection guard as the opening branch above: while
+  // authoring, Author is the context, so clearing a selection must not hand
+  // the tab back out from under the user mid-edit.
+  if (prev.hasSelection && !next.hasSelection && !next.editEnabled) {
     return handBack('elements', tab, memory);
   }
 

--- a/apps/viewer/src/components/viewer/ribbon/contextual-tabs.ts
+++ b/apps/viewer/src/components/viewer/ribbon/contextual-tabs.ts
@@ -1,0 +1,129 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Contextual ribbon tabs — which tab opens itself, and when.
+ *
+ * The CAD precedent (Revit's "Modify | Walls", Office's contextual tabs) is
+ * that the ribbon follows what you are working on and gives the tab back
+ * when that work ends. Copied here with three hard rules, because a toolbar
+ * that moves under the cursor is worse than one that never moves:
+ *
+ *  1. Only a RISING EDGE of a real context switches a tab. Continuous state
+ *     ("something is selected") never re-fires, so clicking element after
+ *     element never re-flips anything.
+ *  2. Auto-switching only ever steals a NEUTRAL tab (Home, File). A user
+ *     sitting on View, Analyze or Author is mid-task and is left alone.
+ *  3. Everything is returnable: the tab we replaced is remembered and
+ *     restored when the context drops. The moment the user picks a tab by
+ *     hand that memory is dropped (the caller detects the divergence), so
+ *     an explicit choice is never undone behind their back.
+ *
+ * This module is pure so the whole policy is unit-testable without a DOM;
+ * `useRibbonContextualTab` owns the edges and the store writes.
+ */
+
+import type { RibbonTabId } from '@/store';
+
+/** The working context the ribbon reacts to. */
+export interface RibbonContext {
+  /** At least one model is in the scene. */
+  hasModel: boolean;
+  /** At least one entity is selected. */
+  hasSelection: boolean;
+  /** Global edit mode is on. */
+  editEnabled: boolean;
+}
+
+/** What we opened on the user's behalf, and where to put them back. */
+export interface RibbonTabMemory {
+  /** Tab this module opened; null when the current tab is the user's own. */
+  autoOpened: RibbonTabId | null;
+  /** Tab that was showing before we took over. */
+  returnTo: RibbonTabId | null;
+}
+
+export interface RibbonTabDecision {
+  tab: RibbonTabId;
+  memory: RibbonTabMemory;
+}
+
+export const NO_TAB_MEMORY: RibbonTabMemory = { autoOpened: null, returnTo: null };
+
+/**
+ * Tabs an auto-switch may replace. Home is the everyday landing and File is
+ * a transient errand; the other three mean the user went somewhere on
+ * purpose and expects to stay there.
+ */
+const NEUTRAL_TABS: readonly RibbonTabId[] = ['home', 'file'];
+
+function takeOver(tab: RibbonTabId, from: RibbonTabId): RibbonTabDecision {
+  return { tab, memory: { autoOpened: tab, returnTo: from } };
+}
+
+/** Hand the tab back if (and only if) we are the one holding it. */
+function handBack(
+  expected: RibbonTabId,
+  tab: RibbonTabId,
+  memory: RibbonTabMemory,
+): RibbonTabDecision | null {
+  if (memory.autoOpened !== expected || tab !== expected || !memory.returnTo) return null;
+  return { tab: memory.returnTo, memory: NO_TAB_MEMORY };
+}
+
+/**
+ * Decide the next ribbon tab for a context change.
+ *
+ * @param prev Context at the previous evaluation, or null on the first pass
+ *   (mount, or the user switching over from the classic toolbar).
+ * @param next Context now.
+ * @param tab  Tab currently showing.
+ * @param memory What we opened last, and the tab to return.
+ * @returns The tab + memory to apply, or null to leave the ribbon alone.
+ */
+export function decideRibbonTab(
+  prev: RibbonContext | null,
+  next: RibbonContext,
+  tab: RibbonTabId,
+  memory: RibbonTabMemory,
+): RibbonTabDecision | null {
+  // First pass: pick the landing tab. With no model loaded, every tab but
+  // File is disabled buttons — so land on the one that can actually do
+  // something. Only ever moves off the default tab, never off a choice the
+  // user already made this session.
+  if (!prev) {
+    if (!next.hasModel && tab === 'home') return takeOver('file', 'home');
+    return null;
+  }
+
+  // Model set: an empty scene is the File context; the first model that
+  // lands ends it. Both directions clear the memory - a load is a big
+  // enough state change that an older "return to" is stale.
+  if (!prev.hasModel && next.hasModel) {
+    return tab === 'file' ? { tab: 'home', memory: NO_TAB_MEMORY } : null;
+  }
+  if (prev.hasModel && !next.hasModel) {
+    return tab === 'file' ? null : { tab: 'file', memory: NO_TAB_MEMORY };
+  }
+
+  // Edit mode outranks selection: while authoring, the Author tab is the
+  // context even with something selected.
+  if (!prev.editEnabled && next.editEnabled) {
+    return NEUTRAL_TABS.includes(tab) ? takeOver('author', tab) : null;
+  }
+  if (prev.editEnabled && !next.editEnabled) {
+    return handBack('author', tab, memory);
+  }
+
+  // Selection: the Elements tab is where Isolate / Hide / Focus / Copy guid
+  // live, so a fresh selection is exactly when it is worth showing.
+  if (!prev.hasSelection && next.hasSelection && !next.editEnabled) {
+    return NEUTRAL_TABS.includes(tab) ? takeOver('elements', tab) : null;
+  }
+  if (prev.hasSelection && !next.hasSelection) {
+    return handBack('elements', tab, memory);
+  }
+
+  return null;
+}

--- a/apps/viewer/src/components/viewer/ribbon/tabs/ViewTab.tsx
+++ b/apps/viewer/src/components/viewer/ribbon/tabs/ViewTab.tsx
@@ -7,10 +7,11 @@
  * (Cesium / sun / SpaceMouse), and interface options.
  */
 
-import { Globe2, Move, PanelTop, } from 'lucide-react';
+import { Globe2, MousePointerClick, Move, PanelTop, } from 'lucide-react';
 import { TopView, BottomView, FrontView, BackView, LeftView, RightView, ZoomIn, ZoomOut, IsometricView, Orthographic, Viewpoint, SpaceMouse, Lighting, FitAll, RotateLeft, RotateRight } from '@/icons';
 import { useViewerStore } from '@/store';
 import { goHomeFromStore } from '@/store/homeView';
+import { TOUR_ANCHORS, tourAnchor } from '@/lib/tours/anchors';
 import {
   RibbonGroup,
   RibbonGroupDivider,
@@ -24,6 +25,8 @@ export function ViewTab() {
   const projectionMode = useViewerStore((state) => state.projectionMode);
   const toggleProjectionMode = useViewerStore((state) => state.toggleProjectionMode);
   const setToolbarStyle = useViewerStore((state) => state.setToolbarStyle);
+  const ribbonContextualTabs = useViewerStore((state) => state.ribbonContextualTabs);
+  const setRibbonContextualTabs = useViewerStore((state) => state.setRibbonContextualTabs);
 
   // Cesium 3D overlay state
   const cesiumAvailable = useViewerStore((state) => state.cesiumAvailable);
@@ -198,10 +201,19 @@ export function ViewTab() {
         />
         <RibbonSmallStack>
           <RibbonSmallButton
+            icon={MousePointerClick}
+            label="Follow work"
+            tooltip="Open the Elements tab on selection and Author in edit mode, then hand the tab back"
+            active={ribbonContextualTabs}
+            onClick={() => setRibbonContextualTabs(!ribbonContextualTabs)}
+            {...tourAnchor(TOUR_ANCHORS.ribbonFollowWork)}
+          />
+          <RibbonSmallButton
             icon={PanelTop}
             label="Classic bar"
-            tooltip="Switch back to the classic single-strip toolbar"
+            tooltip="Switch back to the classic single-strip toolbar (remembered on this browser)"
             onClick={() => setToolbarStyle('classic')}
+            {...tourAnchor(TOUR_ANCHORS.ribbonClassicSwitch)}
           />
         </RibbonSmallStack>
       </RibbonGroup>

--- a/apps/viewer/src/components/viewer/ribbon/useRibbonContextualTab.ts
+++ b/apps/viewer/src/components/viewer/ribbon/useRibbonContextualTab.ts
@@ -27,7 +27,12 @@ export function useRibbonContextualTab(): void {
   const ribbonTab = useViewerStore((s) => s.ribbonTab);
   const setRibbonTab = useViewerStore((s) => s.setRibbonTab);
   const hasModel = useViewerStore((s) => s.models.size > 0);
-  const hasSelection = useViewerStore((s) => s.selectedEntityIds.size > 0);
+  // BOTH selection channels: an ordinary single-entity viewport pick calls
+  // `setSelectedEntityId`, which does not populate `selectedEntityIds`. Reading
+  // only the set would leave the contextual Elements switch firing for
+  // multi/bulk selection but never for the commonest interaction there is
+  // (ElementsTab already falls back to the scalar for the same reason).
+  const hasSelection = useViewerStore((s) => s.selectedEntityIds.size > 0 || s.selectedEntityId !== null);
   const editEnabled = useViewerStore((s) => s.editEnabled);
   // A running walkthrough drives the tabs itself; contextual switching would
   // fight it (and move the spotlight target mid-step).

--- a/apps/viewer/src/components/viewer/ribbon/useRibbonContextualTab.ts
+++ b/apps/viewer/src/components/viewer/ribbon/useRibbonContextualTab.ts
@@ -1,0 +1,61 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Drives `decideRibbonTab` from live store state. Mounted by RibbonToolbar,
+ * so the classic strip pays nothing for it.
+ *
+ * Two things live here rather than in the pure policy: the edge detection
+ * (previous context in a ref) and "the user took the wheel" — any tab change
+ * we did not make ourselves drops the return memory, so a hand-picked tab is
+ * never yanked back when the selection clears.
+ */
+
+import { useEffect, useRef } from 'react';
+import { useViewerStore } from '@/store';
+import { useTourStore } from '@/lib/tours/tour-store';
+import {
+  decideRibbonTab,
+  NO_TAB_MEMORY,
+  type RibbonContext,
+  type RibbonTabMemory,
+} from './contextual-tabs';
+
+export function useRibbonContextualTab(): void {
+  const enabled = useViewerStore((s) => s.ribbonContextualTabs);
+  const ribbonTab = useViewerStore((s) => s.ribbonTab);
+  const setRibbonTab = useViewerStore((s) => s.setRibbonTab);
+  const hasModel = useViewerStore((s) => s.models.size > 0);
+  const hasSelection = useViewerStore((s) => s.selectedEntityIds.size > 0);
+  const editEnabled = useViewerStore((s) => s.editEnabled);
+  // A running walkthrough drives the tabs itself; contextual switching would
+  // fight it (and move the spotlight target mid-step).
+  const tourIdle = useTourStore((s) => s.status === 'idle');
+
+  const prevRef = useRef<RibbonContext | null>(null);
+  const memoryRef = useRef<RibbonTabMemory>(NO_TAB_MEMORY);
+
+  useEffect(() => {
+    const next: RibbonContext = { hasModel, hasSelection, editEnabled };
+
+    // Keep the baseline current even while suspended, so re-enabling never
+    // replays a stale edge (e.g. a selection made during a tour).
+    if (!enabled || !tourIdle) {
+      prevRef.current = next;
+      memoryRef.current = NO_TAB_MEMORY;
+      return;
+    }
+
+    // The user moved off the tab we opened: their choice now owns the strip.
+    if (memoryRef.current.autoOpened && memoryRef.current.autoOpened !== ribbonTab) {
+      memoryRef.current = NO_TAB_MEMORY;
+    }
+
+    const decision = decideRibbonTab(prevRef.current, next, ribbonTab, memoryRef.current);
+    prevRef.current = next;
+    if (!decision) return;
+    memoryRef.current = decision.memory;
+    if (decision.tab !== ribbonTab) setRibbonTab(decision.tab);
+  }, [enabled, tourIdle, hasModel, hasSelection, editEnabled, ribbonTab, setRibbonTab]);
+}

--- a/apps/viewer/src/lib/tours/anchors.ts
+++ b/apps/viewer/src/lib/tours/anchors.ts
@@ -95,6 +95,14 @@ export const TOUR_ANCHORS = {
   bcfCaptureViewpoint: 'bcf-capture-viewpoint',
   /** BCFPanel header Export BCF button (disabled until a topic exists). */
   bcfExport: 'bcf-export',
+  /** RibbonToolbar tab strip (ribbon style only; the classic strip has none). */
+  ribbonTabs: 'ribbon-tabs',
+  /** Ribbon collapse/expand chevron in the tab strip. */
+  ribbonCollapse: 'ribbon-collapse',
+  /** ViewTab "Classic bar" button (only while the View tab is open). */
+  ribbonClassicSwitch: 'ribbon-classic-switch',
+  /** ViewTab "Follow work" contextual-tabs toggle (View tab open). */
+  ribbonFollowWork: 'ribbon-follow-work',
 } as const;
 
 /** Activity-bar rail button for a panel (one templated attribute serves

--- a/apps/viewer/src/lib/tours/registry.ts
+++ b/apps/viewer/src/lib/tours/registry.ts
@@ -16,12 +16,14 @@ import { IDS_TOUR } from './tours/ids';
 import { LAYERS_TOUR } from './tours/layers';
 import { LENS_TOUR } from './tours/lens';
 import { MEASURE_SECTION_TOUR } from './tours/measure-section';
+import { RIBBON_TOUR } from './tours/ribbon';
 import { SCRIPTING_TOUR } from './tours/scripting';
 import { WELCOME_TOUR } from './tours/welcome';
 import type { TourDefinition, TourId } from './types';
 
 export const TOUR_REGISTRY: readonly TourDefinition[] = [
   WELCOME_TOUR,
+  RIBBON_TOUR,
   MEASURE_SECTION_TOUR,
   IDS_TOUR,
   CLASH_TOUR,

--- a/apps/viewer/src/lib/tours/snapshot.ts
+++ b/apps/viewer/src/lib/tours/snapshot.ts
@@ -54,6 +54,8 @@ export function captureUiSnapshot(store: ViewerStoreApi): UiSnapshot {
       custom: s.sectionPlane.custom ? structuredClone(s.sectionPlane.custom) : undefined,
     },
     activeLensId: s.activeLensId,
+    toolbarStyle: s.toolbarStyle,
+    ribbonTab: s.ribbonTab,
     camera: s.cameraCallbacks.getViewpoint?.() ?? null,
     modelIdsAtStart: [...s.models.keys()],
   };
@@ -143,6 +145,16 @@ export function restoreUiSnapshot(
 
   if (!keep.has('propertiesActiveTab')) {
     s.setPropertiesActiveTab(snapshot.propertiesActiveTab);
+  }
+
+  // Toolbar: only written when a tour actually moved it. setToolbarStyle
+  // persists, and an unconditional write would silently pin the preference
+  // of every user who ever finished any tour.
+  if (!keep.has('toolbarStyle') && store.getState().toolbarStyle !== snapshot.toolbarStyle) {
+    s.setToolbarStyle(snapshot.toolbarStyle);
+  }
+  if (!keep.has('ribbonTab') && store.getState().ribbonTab !== snapshot.ribbonTab) {
+    s.setRibbonTab(snapshot.ribbonTab);
   }
 
   // Sidebar mode + collapse flags LAST, after showWorkspacePanel and the

--- a/apps/viewer/src/lib/tours/snapshot.ts
+++ b/apps/viewer/src/lib/tours/snapshot.ts
@@ -147,11 +147,14 @@ export function restoreUiSnapshot(
     s.setPropertiesActiveTab(snapshot.propertiesActiveTab);
   }
 
-  // Toolbar: only written when a tour actually moved it. setToolbarStyle
-  // persists, and an unconditional write would silently pin the preference
-  // of every user who ever finished any tour.
+  // Toolbar: restored TRANSIENTLY (setState, not setToolbarStyle) so a tour
+  // never writes the stored preference. Tours move the toolbar to teach it,
+  // which is a preview, not a choice — localStorage must only ever change
+  // when the user works the toolbar control themselves. Restoring through
+  // the persisting setter would also overwrite a deliberate switch made
+  // DURING the tour with the pre-tour value.
   if (!keep.has('toolbarStyle') && store.getState().toolbarStyle !== snapshot.toolbarStyle) {
-    s.setToolbarStyle(snapshot.toolbarStyle);
+    store.setState({ toolbarStyle: snapshot.toolbarStyle });
   }
   if (!keep.has('ribbonTab') && store.getState().ribbonTab !== snapshot.ribbonTab) {
     s.setRibbonTab(snapshot.ribbonTab);

--- a/apps/viewer/src/lib/tours/snapshot.ts
+++ b/apps/viewer/src/lib/tours/snapshot.ts
@@ -56,6 +56,7 @@ export function captureUiSnapshot(store: ViewerStoreApi): UiSnapshot {
     activeLensId: s.activeLensId,
     toolbarStyle: s.toolbarStyle,
     ribbonTab: s.ribbonTab,
+    ribbonCollapsed: s.ribbonCollapsed,
     camera: s.cameraCallbacks.getViewpoint?.() ?? null,
     modelIdsAtStart: [...s.models.keys()],
   };
@@ -158,6 +159,13 @@ export function restoreUiSnapshot(
   }
   if (!keep.has('ribbonTab') && store.getState().ribbonTab !== snapshot.ribbonTab) {
     s.setRibbonTab(snapshot.ribbonTab);
+  }
+  // `setRibbonCollapsed` persists as well, so restore it transiently for the
+  // same reason as the toolbar above — the ribbon tour expands the band to
+  // point at things in it, and that preview must not overwrite the choice of
+  // someone who keeps it collapsed.
+  if (!keep.has('ribbonCollapsed') && store.getState().ribbonCollapsed !== snapshot.ribbonCollapsed) {
+    store.setState({ ribbonCollapsed: snapshot.ribbonCollapsed });
   }
 
   // Sidebar mode + collapse flags LAST, after showWorkspacePanel and the

--- a/apps/viewer/src/lib/tours/storage.ts
+++ b/apps/viewer/src/lib/tours/storage.ts
@@ -22,6 +22,8 @@ interface TourRecord {
 
 interface TourStorage {
   inviteDismissedAt?: string;
+  /** One-time UI notices (what-changed lines), by notice id. */
+  notices?: Record<string, string>;
   tours: Record<string, TourRecord>;
 }
 
@@ -31,7 +33,11 @@ function read(): TourStorage {
     const raw = window.localStorage.getItem(STORAGE_KEY);
     if (!raw) return { tours: {} };
     const parsed = JSON.parse(raw) as Partial<TourStorage>;
-    return { inviteDismissedAt: parsed.inviteDismissedAt, tours: parsed.tours ?? {} };
+    return {
+      inviteDismissedAt: parsed.inviteDismissedAt,
+      notices: parsed.notices ?? {},
+      tours: parsed.tours ?? {},
+    };
   } catch {
     // Privacy modes throw on localStorage access and malformed JSON is not
     // worth surfacing - both degrade to "no tour history".
@@ -55,6 +61,20 @@ export function isInviteDismissed(): boolean {
 export function dismissInvite(): void {
   const s = read();
   s.inviteDismissedAt = new Date().toISOString();
+  write(s);
+}
+
+/**
+ * One-time notices ("this part of the UI changed"). Same best-effort
+ * contract as the invite: a browser that cannot store just shows it again.
+ */
+export function isNoticeDismissed(id: string): boolean {
+  return Boolean(read().notices?.[id]);
+}
+
+export function dismissNotice(id: string): void {
+  const s = read();
+  s.notices = { ...(s.notices ?? {}), [id]: new Date().toISOString() };
   write(s);
 }
 

--- a/apps/viewer/src/lib/tours/tours/ribbon.ts
+++ b/apps/viewer/src/lib/tours/tours/ribbon.ts
@@ -31,7 +31,12 @@ export const RIBBON_TOUR: TourDefinition = {
       title: 'Commands live in tabs now',
       body: 'Everything from the old single strip is here, grouped by task: File, Home, View, Elements, Analyze, Author. Nothing was removed, and every shortcut still works.',
       prepare: (store) => {
-        store.getState().setToolbarStyle('ribbon');
+        // Transient on purpose: `setToolbarStyle` PERSISTS, so a classic-bar
+        // user who reloads or closes the browser mid-tour would find their
+        // stored choice already replaced by a preview they never asked to
+        // keep. The tour only needs the ribbon on screen, and the snapshot
+        // restores the pre-tour value when it ends.
+        store.setState({ toolbarStyle: 'ribbon' });
         store.getState().setRibbonCollapsed(false);
         store.getState().setRibbonTab('home');
       },

--- a/apps/viewer/src/lib/tours/tours/ribbon.ts
+++ b/apps/viewer/src/lib/tours/tours/ribbon.ts
@@ -1,0 +1,77 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Ribbon tour: what changed when the tabbed ribbon became the default
+ * toolbar. Orientation, not training - where the commands went, how the
+ * tabs follow your work, how to reclaim the vertical space, and the way
+ * back to the classic strip. Target: about a minute, no model needed.
+ *
+ * The first step switches the toolbar style so the tour also works when
+ * started from the Learn hub in classic mode; the snapshot restores the
+ * user's own style on finish or abort.
+ */
+
+import { TOUR_ANCHORS } from '../anchors';
+import type { TourDefinition } from '../types';
+
+export const RIBBON_TOUR: TourDefinition = {
+  id: 'ribbon',
+  title: 'The new ribbon',
+  description: 'Where the toolbar commands went, how tabs follow your work, and how to switch back.',
+  minutes: 1,
+  version: 1,
+  steps: [
+    {
+      id: 'tabs',
+      kind: 'passive',
+      anchor: TOUR_ANCHORS.ribbonTabs,
+      placement: 'bottom',
+      title: 'Commands live in tabs now',
+      body: 'Everything from the old single strip is here, grouped by task: File, Home, View, Elements, Analyze, Author. Nothing was removed, and every shortcut still works.',
+      prepare: (store) => {
+        store.getState().setToolbarStyle('ribbon');
+        store.getState().setRibbonCollapsed(false);
+        store.getState().setRibbonTab('home');
+      },
+    },
+    {
+      id: 'open-view',
+      kind: 'action',
+      anchor: TOUR_ANCHORS.ribbonTabs,
+      placement: 'bottom',
+      title: 'Open the View tab',
+      body: 'Click View. Each tab swaps the band beneath it for its own groups.',
+      gate: { predicate: (s) => s.ribbonTab === 'view' },
+    },
+    {
+      id: 'follow-work',
+      kind: 'passive',
+      anchor: TOUR_ANCHORS.ribbonFollowWork,
+      placement: 'bottom',
+      // Idempotent re-open: the anchors below live in the View band, and the
+      // user may have skipped the step that opened it.
+      prepare: (store) => store.getState().setRibbonTab('view'),
+      title: 'Tabs follow your work',
+      body: 'Select something in 3D and the Elements tab opens itself; clear the selection and you land back where you were. Turning on edit mode does the same for Author. Follow work switches that off if you would rather steer by hand.',
+    },
+    {
+      id: 'classic',
+      kind: 'passive',
+      anchor: TOUR_ANCHORS.ribbonClassicSwitch,
+      placement: 'bottom',
+      prepare: (store) => store.getState().setRibbonTab('view'),
+      title: 'The way back',
+      body: 'Prefer the old strip? Classic bar brings it back and this browser remembers the choice. Its View menu has the way here again, so nothing is one-way.',
+    },
+    {
+      id: 'collapse',
+      kind: 'passive',
+      anchor: TOUR_ANCHORS.ribbonCollapse,
+      placement: 'bottom',
+      title: 'Reclaim the height',
+      body: 'Collapse the band to the tab strip with this chevron, or by double-clicking the active tab. That is remembered too, so the ribbon costs you one strip at most.',
+    },
+  ],
+};

--- a/apps/viewer/src/lib/tours/tours/ribbon.ts
+++ b/apps/viewer/src/lib/tours/tours/ribbon.ts
@@ -57,6 +57,17 @@ export const RIBBON_TOUR: TourDefinition = {
       body: 'Select something in 3D and the Elements tab opens itself; clear the selection and you land back where you were. Turning on edit mode does the same for Author. Follow work switches that off if you would rather steer by hand.',
     },
     {
+      id: 'collapse',
+      kind: 'passive',
+      anchor: TOUR_ANCHORS.ribbonCollapse,
+      placement: 'bottom',
+      title: 'Reclaim the height',
+      body: 'Collapse the band to the tab strip with this chevron, or by double-clicking the active tab. That is remembered too, so the ribbon costs you one strip at most.',
+    },
+    // LAST on purpose (PR #1880 review): this step spotlights the Classic bar
+    // switch, and acting on it unmounts RibbonToolbar. Any step after it would
+    // lose its ribbon-hosted anchor and auto-skip with a broken-anchor report.
+    {
       id: 'classic',
       kind: 'passive',
       anchor: TOUR_ANCHORS.ribbonClassicSwitch,
@@ -64,14 +75,6 @@ export const RIBBON_TOUR: TourDefinition = {
       prepare: (store) => store.getState().setRibbonTab('view'),
       title: 'The way back',
       body: 'Prefer the old strip? Classic bar brings it back and this browser remembers the choice. Its View menu has the way here again, so nothing is one-way.',
-    },
-    {
-      id: 'collapse',
-      kind: 'passive',
-      anchor: TOUR_ANCHORS.ribbonCollapse,
-      placement: 'bottom',
-      title: 'Reclaim the height',
-      body: 'Collapse the band to the tab strip with this chevron, or by double-clicking the active tab. That is remembered too, so the ribbon costs you one strip at most.',
     },
   ],
 };

--- a/apps/viewer/src/lib/tours/tours/ribbon.ts
+++ b/apps/viewer/src/lib/tours/tours/ribbon.ts
@@ -36,8 +36,10 @@ export const RIBBON_TOUR: TourDefinition = {
         // stored choice already replaced by a preview they never asked to
         // keep. The tour only needs the ribbon on screen, and the snapshot
         // restores the pre-tour value when it ends.
-        store.setState({ toolbarStyle: 'ribbon' });
-        store.getState().setRibbonCollapsed(false);
+        // Both transient for the same reason: `setRibbonCollapsed` persists
+        // too, so expanding the band to point at things in it would
+        // permanently undo the choice of a user who keeps it collapsed.
+        store.setState({ toolbarStyle: 'ribbon', ribbonCollapsed: false });
         store.getState().setRibbonTab('home');
       },
     },

--- a/apps/viewer/src/lib/tours/types.ts
+++ b/apps/viewer/src/lib/tours/types.ts
@@ -11,7 +11,7 @@
  * skippable, so a tour can never trap the user.
  */
 
-import type { ViewerState, EntityRef, CameraViewpoint, SectionPlaneAxis } from '@/store';
+import type { ViewerState, EntityRef, CameraViewpoint, RibbonTabId, SectionPlaneAxis, ToolbarStyle } from '@/store';
 import type { SidebarMode } from '@/store';
 import type { WorkspacePanelId, BottomPanelId } from '@/lib/panels/registry';
 import type { TourAnchorId } from './anchors';
@@ -185,6 +185,13 @@ export interface UiSnapshot {
     custom: ViewerState['sectionPlane']['custom'];
   };
   activeLensId: string | null;
+  /**
+   * Toolbar style + open ribbon tab. Captured because the ribbon tour
+   * switches both to teach them: a classic-toolbar user who starts it from
+   * the Learn hub gets their strip back when it ends.
+   */
+  toolbarStyle: ToolbarStyle;
+  ribbonTab: RibbonTabId;
   /** May be null before the renderer registered camera callbacks. */
   camera: CameraViewpoint | null;
   /** Restore of camera/selection is skipped when this set changed mid-run. */

--- a/apps/viewer/src/lib/tours/types.ts
+++ b/apps/viewer/src/lib/tours/types.ts
@@ -186,12 +186,14 @@ export interface UiSnapshot {
   };
   activeLensId: string | null;
   /**
-   * Toolbar style + open ribbon tab. Captured because the ribbon tour
-   * switches both to teach them: a classic-toolbar user who starts it from
-   * the Learn hub gets their strip back when it ends.
+   * Toolbar style, open ribbon tab, and collapsed state. Captured because
+   * the ribbon tour moves all three to teach them: a classic-toolbar user
+   * who starts it from the Learn hub gets their strip back when it ends,
+   * and someone who keeps the band collapsed gets it collapsed again.
    */
   toolbarStyle: ToolbarStyle;
   ribbonTab: RibbonTabId;
+  ribbonCollapsed: boolean;
   /** May be null before the renderer registered camera callbacks. */
   camera: CameraViewpoint | null;
   /** Restore of camera/selection is skipped when this set changed mid-run. */

--- a/apps/viewer/src/store/constants.ts
+++ b/apps/viewer/src/store/constants.ts
@@ -332,16 +332,50 @@ export const TOOLBAR_STYLE_STORAGE_KEY = 'ifc-lite-toolbar-style';
 
 export type ToolbarStyle = 'classic' | 'ribbon';
 
-/** Resolve the initial toolbar style from localStorage; default `classic`. */
-function getInitialToolbarStyle(): ToolbarStyle {
-  if (typeof window === 'undefined') return 'classic';
+/**
+ * Resolve the initial toolbar style from localStorage; default `ribbon`.
+ *
+ * The ribbon is the default toolbar. Only an explicitly stored `classic`
+ * wins, so a user who switched back keeps the classic strip forever while
+ * everyone else (and every new browser) lands on the ribbon. Exported for
+ * the unit test - the module-level `UI_DEFAULTS` is computed once at import
+ * and cannot be re-seeded from a test.
+ */
+export function resolveInitialToolbarStyle(): ToolbarStyle {
+  if (typeof window === 'undefined') return 'ribbon';
   try {
-    return localStorage.getItem(TOOLBAR_STYLE_STORAGE_KEY) === 'ribbon' ? 'ribbon' : 'classic';
+    return localStorage.getItem(TOOLBAR_STYLE_STORAGE_KEY) === 'classic' ? 'classic' : 'ribbon';
   } catch (err) {
     // Blocked storage (Safari private mode): fall back to the default so the
     // toolbar still renders, but say why the preference didn't stick.
-    console.warn('[toolbar-style] storage unavailable; using classic', err);
-    return 'classic';
+    console.warn('[toolbar-style] storage unavailable; using ribbon', err);
+    return 'ribbon';
+  }
+}
+
+/** Ribbon tab strip contexts, in strip order. */
+export type RibbonTabId = 'file' | 'home' | 'view' | 'elements' | 'analyze' | 'author';
+
+/** Home first: it holds the everyday tool and camera loop. */
+export const RIBBON_DEFAULT_TAB: RibbonTabId = 'home';
+
+/**
+ * localStorage key for contextual ribbon tabs (Revit-style: a selection
+ * opens Elements, edit mode opens Author, and clearing the context returns
+ * you to where you were). On by default; the escape hatch lives in the
+ * ribbon's View tab because auto-switching under the cursor is exactly the
+ * kind of help some people want turned off.
+ */
+export const RIBBON_CONTEXTUAL_TABS_STORAGE_KEY = 'ifc-lite-ribbon-contextual-tabs';
+
+/** Resolve contextual tab following from localStorage; default on. */
+function getInitialRibbonContextualTabs(): boolean {
+  if (typeof window === 'undefined') return true;
+  try {
+    return localStorage.getItem(RIBBON_CONTEXTUAL_TABS_STORAGE_KEY) !== 'false';
+  } catch (err) {
+    console.warn('[ribbon-contextual-tabs] storage unavailable; using on', err);
+    return true;
   }
 }
 
@@ -401,13 +435,17 @@ export const UI_DEFAULTS = {
    */
   GEOMETRY_MODE: getInitialGeometryMode(),
   /**
-   * Desktop toolbar style (issue #1686): `classic` single strip or the
-   * tabbed `ribbon`. Read from localStorage on boot so the choice
-   * survives reloads.
+   * Desktop toolbar style (issue #1686): the tabbed `ribbon` (default) or
+   * the original `classic` single strip. Read from localStorage on boot so
+   * the choice survives reloads.
    */
-  TOOLBAR_STYLE: getInitialToolbarStyle(),
+  TOOLBAR_STYLE: resolveInitialToolbarStyle(),
   /** Ribbon band collapsed to the tab strip only. */
   RIBBON_COLLAPSED: getInitialRibbonCollapsed(),
+  /** Ribbon tab open on boot; session-local, never persisted. */
+  RIBBON_TAB: RIBBON_DEFAULT_TAB,
+  /** Ribbon tabs follow the working context (selection, edit mode, model). */
+  RIBBON_CONTEXTUAL_TABS: getInitialRibbonContextualTabs(),
 } as const;
 
 // ============================================================================

--- a/apps/viewer/src/store/index.ts
+++ b/apps/viewer/src/store/index.ts
@@ -68,6 +68,7 @@ export type * from './types.js';
 // Explicitly re-export multi-model types that need to be imported by name
 export type { EntityRef, SchemaVersion, FederatedModel, MeasurementConstraintEdge, OrthogonalAxis, SectionCapStyle, SectionCapHatchId, SectionPlane, SectionPlaneAxis } from './types.js';
 export type { HierarchyMode } from './slices/uiSlice.js';
+export type { RibbonTabId, ToolbarStyle } from './constants.js';
 
 // Re-export utility functions for entity references
 export { entityRefToString, stringToEntityRef, entityRefEquals, isIfcxDataStore } from './types.js';

--- a/apps/viewer/src/store/slices/uiSlice.toolbar-style.test.ts
+++ b/apps/viewer/src/store/slices/uiSlice.toolbar-style.test.ts
@@ -15,6 +15,7 @@ interface MutableStorage {
 
 const STYLE_KEY = 'ifc-lite-toolbar-style';
 const COLLAPSED_KEY = 'ifc-lite-ribbon-collapsed';
+const CONTEXTUAL_KEY = 'ifc-lite-ribbon-contextual-tabs';
 
 function installLocalStorage(initial: Record<string, string> = {}): MutableStorage {
   const handle: MutableStorage = { store: { ...initial } };
@@ -140,6 +141,38 @@ describe('UISlice — toolbar style (issue #1686)', () => {
     (slice.state.setToolbarStyle as (v: string) => void)('classic');
     assert.strictEqual(slice.state.toolbarStyle, 'classic');
     assert.strictEqual(storage!.store[STYLE_KEY], 'classic');
+  });
+
+  it('defaults to the ribbon, and only an explicit classic wins', async () => {
+    const { resolveInitialToolbarStyle } = await import('../constants.js');
+    // Fresh browser: the ribbon is the default toolbar.
+    assert.strictEqual(resolveInitialToolbarStyle(), 'ribbon');
+    // A user who switched back keeps the classic strip across reloads.
+    storage!.store[STYLE_KEY] = 'classic';
+    assert.strictEqual(resolveInitialToolbarStyle(), 'classic');
+    // Anything else (stale / corrupt value) falls back to the default.
+    storage!.store[STYLE_KEY] = 'ribbon';
+    assert.strictEqual(resolveInitialToolbarStyle(), 'ribbon');
+    storage!.store[STYLE_KEY] = 'nonsense';
+    assert.strictEqual(resolveInitialToolbarStyle(), 'ribbon');
+  });
+
+  it('setRibbonTab opens a tab without touching storage', async () => {
+    const slice = await buildSlice();
+    (slice.state.setRibbonTab as (v: string) => void)('elements');
+    assert.strictEqual(slice.state.ribbonTab, 'elements');
+    // Session-local by design: every session starts on Home again.
+    assert.ok(!Object.keys(storage!.store).some((k) => k.includes('ribbon-tab')));
+  });
+
+  it('setRibbonContextualTabs flips and persists the follow-work opt-out', async () => {
+    const slice = await buildSlice();
+    assert.strictEqual(slice.state.ribbonContextualTabs, true);
+    (slice.state.setRibbonContextualTabs as (v: boolean) => void)(false);
+    assert.strictEqual(slice.state.ribbonContextualTabs, false);
+    assert.strictEqual(storage!.store[CONTEXTUAL_KEY], 'false');
+    (slice.state.setRibbonContextualTabs as (v: boolean) => void)(true);
+    assert.strictEqual(storage!.store[CONTEXTUAL_KEY], 'true');
   });
 
   it('setRibbonCollapsed flips and persists the collapsed flag', async () => {

--- a/apps/viewer/src/store/slices/uiSlice.ts
+++ b/apps/viewer/src/store/slices/uiSlice.ts
@@ -13,8 +13,10 @@ import {
   HIERARCHY_MODE_STORAGE_KEY,
   TOOLBAR_STYLE_STORAGE_KEY,
   RIBBON_COLLAPSED_STORAGE_KEY,
+  RIBBON_CONTEXTUAL_TABS_STORAGE_KEY,
   UI_DEFAULTS,
   type GeometryMode,
+  type RibbonTabId,
   type ToolbarStyle,
 } from '../constants.js';
 import type { ContactShadingQuality, SeparationLinesQuality } from '@ifc-lite/renderer';
@@ -142,13 +144,27 @@ export interface UISlice {
   /** True after the user flipped `geometryMode` while a model was loaded. */
   geometryModePendingReload: boolean;
   /**
-   * Desktop toolbar style (issue #1686): the original `classic` strip
-   * or the tabbed, IFCFlux-style `ribbon`. Persisted preference — the
-   * mobile toolbar is orthogonal (`isMobile` wins on small screens).
+   * Desktop toolbar style (issue #1686): the tabbed, IFCFlux-style
+   * `ribbon` (the default) or the original `classic` strip. Persisted
+   * preference — the mobile toolbar is orthogonal (`isMobile` wins on
+   * small screens).
    */
   toolbarStyle: ToolbarStyle;
   /** Ribbon collapsed to its tab strip (Office-style double-click). */
   ribbonCollapsed: boolean;
+  /**
+   * Ribbon tab showing in the band. Lives in the store rather than the
+   * component so non-React drivers (the ribbon walkthrough, the command
+   * palette) can open a tab; deliberately NOT persisted, so every session
+   * still starts on Home.
+   */
+  ribbonTab: RibbonTabId;
+  /**
+   * Ribbon tabs follow the working context: a selection opens Elements,
+   * edit mode opens Author, an empty scene opens File, and dropping the
+   * context returns the user to the tab they came from. Persisted opt-out.
+   */
+  ribbonContextualTabs: boolean;
 
   // Actions
   setLeftPanelCollapsed: (collapsed: boolean) => void;
@@ -188,6 +204,10 @@ export interface UISlice {
   setToolbarStyle: (style: ToolbarStyle) => void;
   /** Collapse/expand the ribbon band and persist the choice. */
   setRibbonCollapsed: (collapsed: boolean) => void;
+  /** Open a ribbon tab (session-local). */
+  setRibbonTab: (tab: RibbonTabId) => void;
+  /** Turn contextual tab following on/off and persist the choice. */
+  setRibbonContextualTabs: (enabled: boolean) => void;
 }
 
 /** Apply the correct CSS classes on <html> for the given theme */
@@ -236,6 +256,8 @@ export const createUISlice: StateCreator<UISlice & UICrossSliceState, [], [], UI
   geometryModePendingReload: false,
   toolbarStyle: UI_DEFAULTS.TOOLBAR_STYLE,
   ribbonCollapsed: UI_DEFAULTS.RIBBON_COLLAPSED,
+  ribbonTab: UI_DEFAULTS.RIBBON_TAB,
+  ribbonContextualTabs: UI_DEFAULTS.RIBBON_CONTEXTUAL_TABS,
 
   // Actions
   setLeftPanelCollapsed: (leftPanelCollapsed) => set({ leftPanelCollapsed }),
@@ -393,7 +415,7 @@ export const createUISlice: StateCreator<UISlice & UICrossSliceState, [], [], UI
 
   setToolbarStyle: (toolbarStyle) => {
     // Persist eagerly so the next page-load boots straight into the chosen
-    // style (constants.ts `getInitialToolbarStyle`). Wrap in try/catch —
+    // style (constants.ts `resolveInitialToolbarStyle`). Wrap in try/catch —
     // Safari private mode / locked storage throws.
     try {
       localStorage.setItem(TOOLBAR_STYLE_STORAGE_KEY, toolbarStyle);
@@ -410,5 +432,16 @@ export const createUISlice: StateCreator<UISlice & UICrossSliceState, [], [], UI
       console.warn('[ribbon-collapsed] persist failed; in-memory only', err);
     }
     set({ ribbonCollapsed });
+  },
+
+  setRibbonTab: (ribbonTab) => set({ ribbonTab }),
+
+  setRibbonContextualTabs: (ribbonContextualTabs) => {
+    try {
+      localStorage.setItem(RIBBON_CONTEXTUAL_TABS_STORAGE_KEY, String(ribbonContextualTabs));
+    } catch (err) {
+      console.warn('[ribbon-contextual-tabs] persist failed; in-memory only', err);
+    }
+    set({ ribbonContextualTabs });
   },
 });


### PR DESCRIPTION
Recovered from an uncommitted worktree after a machine crash (the work was complete, just never committed).

## Product decision needed

This **flips the default toolbar from `classic` to `ribbon` for everyone**. That is a user-facing default change, so it wants your call rather than a rubber stamp — the code is ready either way.

Only an explicitly stored `classic` now wins, so anyone who deliberately switched back keeps the classic strip; every new browser lands on the ribbon.

## Change

- `resolveInitialToolbarStyle()` defaults to `ribbon` (exported so the store default is testable — `UI_DEFAULTS` is computed once at import and can't be re-seeded from a test).
- **Contextual tabs (Revit-style):** a selection opens Elements, edit mode opens Author, and clearing the context returns you to the tab you were on. On by default, opt-out in the ribbon's View tab, persisted under `ifc-lite-ribbon-contextual-tabs`.
- **`RibbonSwitchNotice`:** one-time notice for users carried over from the classic strip.
- **Guided ribbon tour** plus the tour anchors/registry/snapshot/storage plumbing it needs.

## Verification

- `pnpm test` in `apps/viewer`: 1853 pass, 0 fail, 2 skipped.
- `tsc --noEmit`: clean.
- New coverage in `contextual-tabs.test.ts` and the extended `uiSlice.toolbar-style.test.ts`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rolled out a new ribbon toolbar experience by default, including support for restoring ribbon tab and collapsed state after tours.
  * Added “Tabs follow your work” contextual tabs that react to model, selection, and edit mode (with a toggle to follow work).
  * Added ribbon guided walkthrough plus a one-time under-ribbon “switch notice” with actions to dismiss, start the tour, or return to the classic toolbar.
  * Remembered toolbar and contextual-tab preferences across sessions.

* **Bug Fixes**
  * Improved tour UI state restoration to avoid overwriting existing toolbar/tab preferences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->