### PR TITLE
fix(create,encoding): reject out-of-range Timestamps and correct the RNG docs

### DIFF
--- a/.changeset/determinism-timestamp-range.md
+++ b/.changeset/determinism-timestamp-range.md
@@ -1,0 +1,6 @@
+---
+"@ifc-lite/create": patch
+"@ifc-lite/encoding": patch
+---
+
+Reject `IfcCreator` `Timestamp` values that are finite but outside the ±8.64e15 ms Date range. They previously cleared the `Number.isFinite` guard and failed much later as a `RangeError` from `toISOString()` while writing the file header; they are now rejected in the constructor, where the error can still name the parameter. Also corrects the `RandomSource` documentation: the unseeded path uses Web Crypto when the runtime provides it and falls back to `Math.random` when it does not, rather than guaranteeing a platform CSPRNG.

--- a/packages/create/src/ifc-creator.test.ts
+++ b/packages/create/src/ifc-creator.test.ts
@@ -666,6 +666,10 @@ describe('IfcCreator deterministic output (Timestamp + GuidSource)', () => {
   it('rejects an invalid Timestamp', () => {
     expect(() => new IfcCreator({ Timestamp: Number.NaN })).toThrow(/Timestamp/);
     expect(() => new IfcCreator({ Timestamp: new Date('nonsense') })).toThrow(/Timestamp/);
+    // Finite but past the ±8.64e15 ms Date range: caught here rather than
+    // surfacing as a RangeError from toISOString() while writing the header.
+    expect(() => new IfcCreator({ Timestamp: 1e16 })).toThrow(/Timestamp/);
+    expect(() => new IfcCreator({ Timestamp: -1e16 })).toThrow(/Timestamp/);
   });
 
   it('rejects a GuidSource returning invalid GlobalIds', () => {

--- a/packages/create/src/ifc-creator.test.ts
+++ b/packages/create/src/ifc-creator.test.ts
@@ -666,8 +666,9 @@ describe('IfcCreator deterministic output (Timestamp + GuidSource)', () => {
   it('rejects an invalid Timestamp', () => {
     expect(() => new IfcCreator({ Timestamp: Number.NaN })).toThrow(/Timestamp/);
     expect(() => new IfcCreator({ Timestamp: new Date('nonsense') })).toThrow(/Timestamp/);
-    // Finite but past the ±8.64e15 ms Date range: caught here rather than
-    // surfacing as a RangeError from toISOString() while writing the header.
+    // Regression, PR #1882 (follow-up to #1879): finite but past the
+    // ±8.64e15 ms Date range. Caught here rather than surfacing later as a
+    // RangeError from toISOString() while writing the header.
     expect(() => new IfcCreator({ Timestamp: 1e16 })).toThrow(/Timestamp/);
     expect(() => new IfcCreator({ Timestamp: -1e16 })).toThrow(/Timestamp/);
   });

--- a/packages/create/src/ifc-creator.ts
+++ b/packages/create/src/ifc-creator.ts
@@ -129,8 +129,13 @@ export class IfcCreator {
     this.fixedTimestampMs = params.Timestamp === undefined
       ? null
       : typeof params.Timestamp === 'number' ? params.Timestamp : params.Timestamp.getTime();
-    if (this.fixedTimestampMs !== null && !Number.isFinite(this.fixedTimestampMs)) {
-      throw new Error('IfcCreator: Timestamp must be a finite epoch-milliseconds number or a valid Date');
+    // Finite is not enough: epoch-ms past ±8.64e15 is outside the Date range,
+    // so it survives `Number.isFinite` and only blows up later in
+    // `toISOString()` while writing the header. Reject it here, where the
+    // message can still name the offending parameter.
+    if (this.fixedTimestampMs !== null
+      && (!Number.isFinite(this.fixedTimestampMs) || Number.isNaN(new Date(this.fixedTimestampMs).getTime()))) {
+      throw new Error('IfcCreator: Timestamp must be a finite epoch-milliseconds number within the Date range, or a valid Date');
     }
     this.guidSource = params.GuidSource ?? null;
     this.buildPreamble(params);

--- a/packages/encoding/src/guid.test.ts
+++ b/packages/encoding/src/guid.test.ts
@@ -67,8 +67,21 @@ describe('guid', () => {
     expect(generateUuid(() => 0)).toBe('00000000-0000-4000-8000-000000000000');
   });
 
-  it('keeps the default path random', () => {
-    expect(generateUuid()).not.toBe(generateUuid());
-    expect(generateIfcGuid()).not.toBe(generateIfcGuid());
+  it('keeps the default path valid and non-repeating', () => {
+    // Assert the CONTRACT (well-formed, distinct across a run) rather than a
+    // single inequality: two draws colliding is astronomically unlikely but is
+    // a property of the generator, not something a pair-wise compare proves.
+    const uuids = new Set<string>();
+    const guids = new Set<string>();
+    for (let i = 0; i < 100; i++) {
+      const u = generateUuid();
+      expect(u).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i);
+      uuids.add(u);
+      const g = generateIfcGuid();
+      expect(isValidIfcGuid(g)).toBe(true);
+      guids.add(g);
+    }
+    expect(uuids.size).toBe(100);
+    expect(guids.size).toBe(100);
   });
 });

--- a/packages/encoding/src/guid.ts
+++ b/packages/encoding/src/guid.ts
@@ -87,7 +87,8 @@ export function ifcGuidToUuid(ifcGuid: string): string {
  * Optional randomness source for GUID generation: a `Math.random`-style
  * function returning floats in `[0, 1)`. Pass a seeded generator to make GUID
  * generation reproducible (e.g. for byte-deterministic file output); omit it
- * for the default platform CSPRNG. A seeded source trades global uniqueness
+ * to use Web Crypto when the runtime provides it, falling back to
+ * `Math.random` when it does not. A seeded source trades global uniqueness
  * for reproducibility - only use one where that is the point.
  */
 export type RandomSource = () => number;


### PR DESCRIPTION
Follow-up to #1879, which merged from a stale PR head — these three fixes were pushed to the branch but GitHub's PR object had not caught up, so the squash landed without them.

Found by a local CodeRabbit CLI pass on #1879 that the hosted review did not surface (the hosted review was clean).

## Fixes

- **`IfcCreator` accepted a finite `Timestamp` outside the Date range.** Epoch-ms past ±8.64e15 cleared `Number.isFinite` and then failed much later as a `RangeError` from `toISOString()` while writing the header. Now rejected in the constructor, where the message can still name the parameter.
- **`RandomSource` doc was wrong.** It promised "the default platform CSPRNG", but the unseeded path falls back to `Math.random` when Web Crypto is absent.
- **The default-path GUID test asserted luck, not contract.** It compared two draws for inequality; it now pins well-formedness (v4 version/variant, valid IFC GUID) and distinctness across 100 draws.

## Verification

- `@ifc-lite/encoding` 51 pass, `@ifc-lite/create` 103 pass.
- Adversarial probe against the seeded path (hostile `RandomSource` returning NaN/1/-1/1e9, a repeating `GuidSource`, Date-vs-epoch equivalence, v4 bit preservation, 2000-draw collision run): all green.
- Patch changeset included for both published packages.