### PR TITLE
fix(pointcloud,renderer): report LAS bbox in the emitted frame; single-source the model-matrix guard (#1804 follow-up)

### DIFF
--- a/.changeset/pointcloud-bbox-decoded-frame.md
+++ b/.changeset/pointcloud-bbox-decoded-frame.md
@@ -1,0 +1,18 @@
+---
+'@ifc-lite/pointcloud': patch
+'@ifc-lite/renderer': patch
+---
+
+Report LAS/LAZ streaming bounds in the frame the points are actually emitted
+in, and single-source the point-cloud model-matrix guard.
+
+`LasStreamingSource`/`LazStreamingSource` returned the raw `header.bbox` while
+every decoded point has `originOffset` subtracted first, leaving bounds and
+points off by the full offset — at map magnitudes that misdirects scene
+framing, culling and the height-ramp colour range. Both sources now translate
+through the shared `bboxInDecodedFrame` helper.
+
+`transformAabb` and `writePointCloudUniforms` also carried separate 4x4
+validity checks, neither rejecting non-finite entries; both now share
+`isUsableModelMatrix`, so a degenerate matrix falls back to identity in both
+consumers rather than in only one.

--- a/packages/pointcloud/src/formats/las.test.ts
+++ b/packages/pointcloud/src/formats/las.test.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import { describe, it, expect } from 'vitest';
-import { decodeLasPoints, parseLasHeader, sampleMaxRgbChannel } from './las.js';
+import { bboxInDecodedFrame, decodeLasPoints, parseLasHeader, sampleMaxRgbChannel } from './las.js';
 
 function buildHeader(overrides: Partial<{
   versionMinor: number;
@@ -233,5 +233,33 @@ describe('decodeLasPoints', () => {
     const chunk = decodeLasPoints(records, h, 1, 34, 65535 / 255);
     expect(chunk.colors![0]).toBeCloseTo(1.0, 2);
     expect(chunk.colors![1]).toBeCloseTo(128 / 255, 2);
+  });
+});
+
+describe('bboxInDecodedFrame (issue #1804)', () => {
+  const bbox = { min: [-5, -10, -15] as [number, number, number], max: [10, 20, 30] as [number, number, number] };
+
+  it('returns the box unchanged when there is no origin offset', () => {
+    expect(bboxInDecodedFrame(bbox, undefined)).toBe(bbox);
+  });
+
+  it('translates both corners onto the same axes decodeLasPoints subtracts', () => {
+    // decodeLasPoints computes x - offX, y - offY, z - offZ, so the reported
+    // box must move by exactly the same vector or bounds and points end up in
+    // different frames.
+    expect(bboxInDecodedFrame(bbox, [100, 200, 300])).toEqual({
+      min: [-105, -210, -315],
+      max: [-90, -180, -270],
+    });
+  });
+
+  it('stays exact at map magnitudes', () => {
+    // The whole point of the f64 offset: a LV95-scale coordinate must not
+    // lose precision when the box is translated.
+    const swiss = { min: [2_600_000, 1_200_000, 450] as [number, number, number], max: [2_600_100, 1_200_050, 470] as [number, number, number] };
+    expect(bboxInDecodedFrame(swiss, [2_600_000, 1_200_000, 450])).toEqual({
+      min: [0, 0, 0],
+      max: [100, 50, 20],
+    });
   });
 });

--- a/packages/pointcloud/src/formats/las.ts
+++ b/packages/pointcloud/src/formats/las.ts
@@ -144,6 +144,33 @@ export function parseLasHeader(buffer: ArrayBuffer | Uint8Array): LasHeader {
  * `stride` should equal `header.pointRecordLength`. We honour any extra
  * bytes the producer tacked on by skipping them.
  */
+/**
+ * Translate a header bounding box into the same frame `decodeLasPoints`
+ * emits points in (issue #1804).
+ *
+ * `header.bbox` is in absolute native CRS coordinates, but when an
+ * `originOffset` is in play every decoded point has it subtracted in f64
+ * first. Reporting the raw header box would leave the bounds and the points
+ * they describe off by the full offset — at map magnitudes (LV95 easting
+ * ~2.6e6) that puts scene framing, culling and the height-ramp colour range
+ * nowhere near the geometry.
+ *
+ * Shared by BOTH streaming sources on purpose: LAS and LAZ decode through the
+ * same `decodeLasPoints`, so a per-source copy of this translation is exactly
+ * how one of them ends up fixed and the other left behind.
+ */
+export function bboxInDecodedFrame(
+  bbox: PointCloudBBox,
+  originOffset: readonly [number, number, number] | undefined,
+): PointCloudBBox {
+  if (!originOffset) return bbox;
+  const [ox, oy, oz] = originOffset;
+  return {
+    min: [bbox.min[0] - ox, bbox.min[1] - oy, bbox.min[2] - oz],
+    max: [bbox.max[0] - ox, bbox.max[1] - oy, bbox.max[2] - oz],
+  };
+}
+
 export function decodeLasPoints(
   bytes: Uint8Array,
   header: LasHeader,

--- a/packages/pointcloud/src/streaming/las-source.test.ts
+++ b/packages/pointcloud/src/streaming/las-source.test.ts
@@ -67,6 +67,35 @@ describe('LasStreamingSource', () => {
     expect(info.hasClassification).toBe(true);
   });
 
+  it('reports the bbox in the same frame as the points it emits (originOffset)', async () => {
+    // Every emitted point has `originOffset` subtracted in f64 before the f32
+    // narrowing (issue #1804). Reporting the raw LAS header box would leave
+    // bounds and points off by the full offset — at map magnitudes that puts
+    // framing, culling and the height ramp nowhere near the geometry.
+    const blob = buildLasFile([
+      { x: 0, y: 0, z: 0 },
+      { x: 10, y: 20, z: 30 },
+      { x: -5, y: -10, z: -15 },
+    ]);
+    const originOffset = [100, 200, 300] as const;
+    const src = new LasStreamingSource(blob, { originOffset });
+    const info = await src.open();
+    expect(info.bbox).toEqual({ min: [-105, -210, -315], max: [-90, -180, -270] });
+
+    // Cross-check against the actual emitted points: every point must fall
+    // inside the reported box, which is the invariant that was broken.
+    const chunk = await src.next(16);
+    expect(chunk).not.toBeNull();
+    const { positions, pointCount } = chunk!;
+    for (let i = 0; i < pointCount; i++) {
+      for (let axis = 0; axis < 3; axis++) {
+        const v = positions[i * 3 + axis];
+        expect(v).toBeGreaterThanOrEqual(info.bbox.min[axis]);
+        expect(v).toBeLessThanOrEqual(info.bbox.max[axis]);
+      }
+    }
+  });
+
   it('emits chunks of the requested size and stops on completion', async () => {
     const rows: Array<{ x: number; y: number; z: number }> = [];
     for (let i = 0; i < 7; i++) rows.push({ x: i, y: 0, z: 0 });

--- a/packages/pointcloud/src/streaming/las-source.ts
+++ b/packages/pointcloud/src/streaming/las-source.ts
@@ -14,6 +14,7 @@
 
 import type { DecodedPointChunk } from '../types.js';
 import {
+  bboxInDecodedFrame,
   decodeLasPoints,
   parseLasHeader,
   sampleMaxRgbChannel,
@@ -155,30 +156,11 @@ export class LasStreamingSource implements StreamingPointSource {
 
   private toInfo(header: LasHeader): PointSourceInfo {
     const stride = Math.max(1, this.downsample.stride | 0);
-    // `header.bbox` is in absolute native CRS coordinates, but every point we
-    // emit has `originOffset` subtracted in f64 first (see `decodeLasPoints`).
-    // Reporting the raw header box would leave the bounds and the points they
-    // describe in DIFFERENT frames — off by the full offset, which at map
-    // magnitudes (LV95 easting ~2.6e6) puts framing, culling and the
-    // height-ramp colour range nowhere near the actual geometry. Translate by
-    // the same offset, component-wise on the same x/y/z axes.
-    const bbox = this.originOffset
-      ? {
-        min: [
-          header.bbox.min[0] - this.originOffset[0],
-          header.bbox.min[1] - this.originOffset[1],
-          header.bbox.min[2] - this.originOffset[2],
-        ] as [number, number, number],
-        max: [
-          header.bbox.max[0] - this.originOffset[0],
-          header.bbox.max[1] - this.originOffset[1],
-          header.bbox.max[2] - this.originOffset[2],
-        ] as [number, number, number],
-      }
-      : header.bbox;
     return {
       totalPointCount: stride === 1 ? header.pointCount : Math.ceil(header.pointCount / stride),
-      bbox,
+      // Points are emitted with `originOffset` already subtracted, so the
+      // reported box must be translated to match — see `bboxInDecodedFrame`.
+      bbox: bboxInDecodedFrame(header.bbox, this.originOffset),
       hasColor: header.hasRgb,
       hasClassification: true,
       hasIntensity: true,

--- a/packages/pointcloud/src/streaming/las-source.ts
+++ b/packages/pointcloud/src/streaming/las-source.ts
@@ -155,9 +155,30 @@ export class LasStreamingSource implements StreamingPointSource {
 
   private toInfo(header: LasHeader): PointSourceInfo {
     const stride = Math.max(1, this.downsample.stride | 0);
+    // `header.bbox` is in absolute native CRS coordinates, but every point we
+    // emit has `originOffset` subtracted in f64 first (see `decodeLasPoints`).
+    // Reporting the raw header box would leave the bounds and the points they
+    // describe in DIFFERENT frames — off by the full offset, which at map
+    // magnitudes (LV95 easting ~2.6e6) puts framing, culling and the
+    // height-ramp colour range nowhere near the actual geometry. Translate by
+    // the same offset, component-wise on the same x/y/z axes.
+    const bbox = this.originOffset
+      ? {
+        min: [
+          header.bbox.min[0] - this.originOffset[0],
+          header.bbox.min[1] - this.originOffset[1],
+          header.bbox.min[2] - this.originOffset[2],
+        ] as [number, number, number],
+        max: [
+          header.bbox.max[0] - this.originOffset[0],
+          header.bbox.max[1] - this.originOffset[1],
+          header.bbox.max[2] - this.originOffset[2],
+        ] as [number, number, number],
+      }
+      : header.bbox;
     return {
       totalPointCount: stride === 1 ? header.pointCount : Math.ceil(header.pointCount / stride),
-      bbox: header.bbox,
+      bbox,
       hasColor: header.hasRgb,
       hasClassification: true,
       hasIntensity: true,

--- a/packages/pointcloud/src/streaming/laz-source.ts
+++ b/packages/pointcloud/src/streaming/laz-source.ts
@@ -15,6 +15,7 @@
 
 import type { DecodedPointChunk } from '../types.js';
 import {
+  bboxInDecodedFrame,
   decodeLasPoints,
   parseLasHeader,
   sampleMaxRgbChannel,
@@ -279,7 +280,9 @@ export class LazStreamingSource implements StreamingPointSource {
     const stride = Math.max(1, this.downsample.stride | 0);
     return {
       totalPointCount: stride === 1 ? header.pointCount : Math.ceil(header.pointCount / stride),
-      bbox: header.bbox,
+      // Points are emitted with `originOffset` already subtracted, so the
+      // reported box must be translated to match — see `bboxInDecodedFrame`.
+      bbox: bboxInDecodedFrame(header.bbox, this.originOffset),
       hasColor: header.hasRgb,
       hasClassification: true,
       hasIntensity: true,

--- a/packages/renderer/src/point-cloud-transform.test.ts
+++ b/packages/renderer/src/point-cloud-transform.test.ts
@@ -108,6 +108,39 @@ describe('transformAabb (issue #1804 world-space point-cloud bounds)', () => {
     assert.strictEqual(transformAabb(box, new Float32Array(3)), box);
   });
 
+  it('falls back to identity on a non-finite matrix, in BOTH consumers', () => {
+    // A single NaN propagates to every corner of the box and to every point
+    // on the GPU, so a degenerate matrix must fall back rather than poison
+    // the result. Critically, the AABB fold and the uniform write must agree:
+    // if one accepted a matrix the other rejected, the reported bounds would
+    // sit in a different frame from the rendered points — the exact failure
+    // this transform exists to prevent (CodeRabbit review of PR #1878).
+    const nan = new Float32Array(16);
+    nan.set([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]);
+    nan[12] = Number.NaN;
+    const inf = new Float32Array(nan);
+    inf[12] = Number.POSITIVE_INFINITY;
+
+    for (const bad of [nan, inf]) {
+      // Consumer 1: bounds fold returns the input box untouched.
+      assert.strictEqual(transformAabb(box, bad), box);
+
+      // Consumer 2: uniform write falls back to identity at floats 16..31.
+      const scratch = new Float32Array(POINT_UNIFORM_SIZE / 4);
+      const scratchU32 = new Uint32Array(scratch.buffer);
+      const node = {
+        meta: { expressId: 1 },
+        uniformBuffer: {} as GPUBuffer,
+        model: bad,
+      } as unknown as PointCloudNode;
+      writePointCloudUniforms(makeDevice(), scratch, scratchU32, node, makeInputs());
+      assert.deepStrictEqual(
+        Array.from(scratch.subarray(16, 32)),
+        [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1],
+      );
+    }
+  });
+
   it('applies a pure translation to both corners', () => {
     const m = new Float32Array([
       1, 0, 0, 0,

--- a/packages/renderer/src/pointcloud/point-cloud-node.ts
+++ b/packages/renderer/src/pointcloud/point-cloud-node.ts
@@ -81,11 +81,33 @@ export interface PointCloudNode {
  * Returns the input box unchanged for a missing/malformed matrix
  * (mirrors `writePointCloudUniforms`' identity fallback).
  */
+/**
+ * True when `model` is a usable 4x4: exactly 16 entries, all finite.
+ *
+ * Single-sourced so the two consumers of `PointCloudNode.model` — the AABB
+ * fold below and `writePointCloudUniforms`' GPU write — accept exactly the
+ * same matrices. When they disagree, a matrix one accepts and the other
+ * rejects puts the reported bounds in a different frame from the rendered
+ * points, which is the precise failure this transform exists to prevent.
+ * The finiteness check matters because a single NaN propagates to every
+ * corner of the box (and to every point on the GPU), so a degenerate matrix
+ * must fall back to identity rather than poison the result.
+ */
+export function isUsableModelMatrix(
+  model: Float32Array | undefined,
+): model is Float32Array {
+  if (!model || model.length !== 16) return false;
+  for (let i = 0; i < 16; i++) {
+    if (!Number.isFinite(model[i])) return false;
+  }
+  return true;
+}
+
 export function transformAabb(
   bounds: { min: [number, number, number]; max: [number, number, number] },
   model: Float32Array | undefined,
 ): { min: [number, number, number]; max: [number, number, number] } {
-  if (!model || model.length !== 16) return bounds;
+  if (!isUsableModelMatrix(model)) return bounds;
   const min: [number, number, number] = [Infinity, Infinity, Infinity];
   const max: [number, number, number] = [-Infinity, -Infinity, -Infinity];
   for (let c = 0; c < 8; c++) {

--- a/packages/renderer/src/pointcloud/point-cloud-uniforms.ts
+++ b/packages/renderer/src/pointcloud/point-cloud-uniforms.ts
@@ -12,6 +12,7 @@
 
 import { POINT_UNIFORM_SIZE } from './point-pipeline.js';
 import type { PointCloudNode } from './point-cloud-node.js';
+import { isUsableModelMatrix } from './point-cloud-node.js';
 
 export type PointColorMode =
   | 'rgb'
@@ -111,7 +112,7 @@ export function writePointCloudUniforms(
   // model — floats 16..31. Per-asset transform (issue #1804: point-cloud
   // ↔ IfcMapConversion alignment); defaults to identity when the node
   // carries none.
-  if (node.model && node.model.length === 16) {
+  if (isUsableModelMatrix(node.model)) {
     u.set(node.model, 16);
   } else {
     u.fill(0, 16, 32);


### PR DESCRIPTION
## Why this exists

PR #1878 was merged at head `d62a74c3` while review fixes were still in flight, so these two fixes never reached main. Both bugs are live on main right now. This restores commit `bb30b48a` verbatim (cherry-picked onto `653a6856`, clean).

They came from the first genuine CodeRabbit review #1878 ever received — its hosted check was green throughout, but every hosted attempt hit the Fair Usage limit, so that green certified a review which never ran. The findings came from a local `coderabbit review --committed --base main --agent`.

## 1. LAS bbox reported in a different frame from the points (`las-source.ts`)

`LasStreamingSource.toInfo()` returned `header.bbox` verbatim, but every point it emits has `originOffset` subtracted in f64 first (`decodeLasPoints`). Bounds and points therefore sat in **different frames**, off by the full offset.

At map magnitudes — LV95 easting ~2.6e6 — that puts scene framing, culling and the height-ramp colour range nowhere near the actual geometry. CodeRabbit rated it *minor*; it is in fact the exact frame-consistency failure that issue #1804 exists to eliminate, left sitting in the PR that fixes it everywhere else.

The bbox is now translated by the same offset on the same x/y/z axes. The new test asserts the invariant directly rather than just the arithmetic: **every emitted point must fall inside the reported box.**

## 2. Two independent model-matrix guards, neither finite-checked

`transformAabb()` (`point-cloud-node.ts`) and `writePointCloudUniforms()` (`point-cloud-uniforms.ts`) each carried their own `length === 16` check. Duplicated guards drift, and a matrix that one accepts while the other rejects puts the reported bounds in a different frame from the rendered points — finding 1 arrived at from the opposite direction.

Both now share `isUsableModelMatrix()`, which additionally requires finite entries, so a single NaN falls back to identity instead of propagating to all eight box corners and to every point on the GPU. The helper is internal — no public API change, api-surface snapshot unchanged.

## Verification

Both fixes are mutation-verified, not assumed:

| mutation | result |
|---|---|
| revert bbox translation | new frame-consistency test fails |
| revert finite check | `falls back to identity ... in BOTH consumers` fails (362 pass / 1 fail) |
| both restored | 363/363 green |

Gates on `36decd89` (against post-merge main): typecheck 33/33 · renderer 363/363 · pointcloud 120 pass / 2 skipped · test-wiring clean · API surface matches snapshot (3957 exports).

Refs #1804.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M76mvdz8Hz7WHEoxwn694V

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected LAS point-cloud bounding boxes when an origin offset is configured, keeping reported bounds aligned with emitted point positions.
  * Prevented invalid point-cloud transformations containing `NaN` or infinite values from producing corrupted bounds or rendering uniforms.
  * Point clouds with unusable transformation matrices now safely fall back to the identity transformation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->