### PR TITLE
fix(renderer,viewer): snap and section-select aligned point clouds at their rendered positions

### DIFF
--- a/.changeset/pointcloud-align-snap-reconcile.md
+++ b/.changeset/pointcloud-align-snap-reconcile.md
@@ -1,0 +1,13 @@
+---
+'@ifc-lite/renderer': patch
+---
+
+Fold each point cloud's render transform into ray snap queries.
+
+The spatial index behind measure-tool point snapping stores raw decoder
+positions, while an aligned (georeferenced) asset is drawn through its
+per-asset model matrix. Snapping therefore returned pre-alignment
+coordinates: a measurement landed where the point used to be, not where it
+is drawn. The query now rewrites the ray into each node's local frame and
+converts distances and hit positions back to world space, so snapping
+agrees with the rendering. Unaligned clouds take an unchanged fast path.

--- a/apps/viewer/src/hooks/ingest/pointCloudAlignment.test.ts
+++ b/apps/viewer/src/hooks/ingest/pointCloudAlignment.test.ts
@@ -360,7 +360,9 @@ describe('getPointCloudAlignmentMatrix', () => {
   });
 
   it('returns the UNALIGNED matrix when the toggle is off — not undefined', () => {
-    // Regression guard for a review suggestion that would have broken this.
+    // Regression guard for a CodeRabbit suggestion on PR #1889 (issue
+    // #1804 follow-up) that would have broken this: it proposed returning
+    // undefined here so callers could take the no-matrix fast path.
     // `unalignedMatrix` is NOT identity: it restores the f64 decode-time
     // origin subtraction, a translation of map magnitude (~2.6e6). Handing
     // callers `undefined` here would leave them on raw decode coordinates

--- a/apps/viewer/src/hooks/ingest/pointCloudAlignment.test.ts
+++ b/apps/viewer/src/hooks/ingest/pointCloudAlignment.test.ts
@@ -8,7 +8,10 @@ import assert from 'node:assert';
 import {
   applyMapConversion,
   computePointCloudAlignment,
+  getPointCloudAlignmentMatrix,
   invertMapConversion,
+  registerPointCloudAlignment,
+  unregisterPointCloudAlignment,
   type MapConversionParams,
 } from './pointCloudAlignment.js';
 import type { ModelGeoref } from './federationAlign.js';
@@ -334,5 +337,50 @@ describe('computePointCloudAlignment (issue #1804)', () => {
   it('returns null when the effective scale is ~zero', () => {
     const georef = makeGeoref({ mapConversion: { scale: 0 } });
     assert.strictEqual(computePointCloudAlignment(georef), null);
+  });
+});
+
+/**
+ * `getPointCloudAlignmentMatrix` feeds CPU consumers (the 2D scan overlay)
+ * the matrix the GPU is currently drawing through, so they place raw
+ * cached points where the user actually sees them.
+ */
+describe('getPointCloudAlignmentMatrix', () => {
+  const georef: ModelGeoref = {
+    mapConversion: {
+      eastings: 2_600_000, northings: 1_200_000, orthogonalHeight: 450,
+      xAxisAbscissa: 1, xAxisOrdinate: 0, scale: 1,
+    } as MapConversion,
+    projectedCRS: {} as ProjectedCRS,
+    coordinateInfo: undefined,
+  } as unknown as ModelGeoref;
+
+  it('returns undefined for a handle with no alignment registered', () => {
+    assert.strictEqual(getPointCloudAlignmentMatrix(4242, true), undefined);
+  });
+
+  it('returns the UNALIGNED matrix when the toggle is off — not undefined', () => {
+    // Regression guard for a review suggestion that would have broken this.
+    // `unalignedMatrix` is NOT identity: it restores the f64 decode-time
+    // origin subtraction, a translation of map magnitude (~2.6e6). Handing
+    // callers `undefined` here would leave them on raw decode coordinates
+    // while the GPU renders with that offset restored — reintroducing, for
+    // the toggle-off case, exactly the frame mismatch this API exists to
+    // remove.
+    const transform = computePointCloudAlignment(georef);
+    assert.ok(transform, 'fixture must produce an alignment');
+    registerPointCloudAlignment({ id: 91 }, transform!);
+    try {
+      const off = getPointCloudAlignmentMatrix(91, false);
+      assert.ok(off, 'a registered asset must still report a matrix when unaligned');
+      assert.strictEqual(off, transform!.unalignedMatrix);
+      const isIdentity = off![12] === 0 && off![13] === 0 && off![14] === 0;
+      assert.ok(!isIdentity, 'unalignedMatrix carries the decode offset; it is not a no-op');
+
+      const on = getPointCloudAlignmentMatrix(91, true);
+      assert.strictEqual(on, transform!.alignedMatrix);
+    } finally {
+      unregisterPointCloudAlignment(91);
+    }
   });
 });

--- a/apps/viewer/src/hooks/ingest/pointCloudAlignment.test.ts
+++ b/apps/viewer/src/hooks/ingest/pointCloudAlignment.test.ts
@@ -373,12 +373,19 @@ describe('getPointCloudAlignmentMatrix', () => {
     try {
       const off = getPointCloudAlignmentMatrix(91, false);
       assert.ok(off, 'a registered asset must still report a matrix when unaligned');
-      assert.strictEqual(off, transform!.unalignedMatrix);
-      const isIdentity = off![12] === 0 && off![13] === 0 && off![14] === 0;
+      assert.strictEqual(off!.matrix, transform!.unalignedMatrix);
+      const isIdentity = off!.matrix[12] === 0 && off!.matrix[13] === 0 && off!.matrix[14] === 0;
       assert.ok(!isIdentity, 'unalignedMatrix carries the decode offset; it is not a no-op');
+      // It restores ABSOLUTE native coordinates, so the caller must still
+      // apply the world -> render-frame shift.
+      assert.strictEqual(off!.outputsRenderFrame, false);
 
       const on = getPointCloudAlignmentMatrix(91, true);
-      assert.strictEqual(on, transform!.alignedMatrix);
+      assert.strictEqual(on!.matrix, transform!.alignedMatrix);
+      // The aligned matrix folds the whole viewer shift into its decode
+      // offset (zero translation column), so it is ALREADY render-frame —
+      // shifting it again would displace the overlay by the full offset.
+      assert.strictEqual(on!.outputsRenderFrame, true);
     } finally {
       unregisterPointCloudAlignment(91);
     }

--- a/apps/viewer/src/hooks/ingest/pointCloudAlignment.ts
+++ b/apps/viewer/src/hooks/ingest/pointCloudAlignment.ts
@@ -305,26 +305,47 @@ export function hasRegisteredPointCloudAlignment(): boolean {
 }
 
 /**
- * The matrix currently being applied to `handleId` on the GPU, or
- * undefined when that asset has no alignment registered.
+ * The transform currently applied to `handleId` on the GPU, or undefined
+ * when that asset has no alignment registered.
  *
- * `enabled` must be the live `pointCloudAlignmentEnabled` store flag —
- * the registry deliberately does not cache it, since
+ * `enabled` must be the live `pointCloudAlignmentEnabled` store flag — the
+ * registry deliberately does not cache it, since
  * `applyPointCloudAlignmentToggle` is the single writer that pushes the
  * choice to the renderer.
  *
  * Exists so CPU-side consumers of raw cached scan points (the 2D section
  * scan layer, #1805) can place them where the GPU actually draws them.
  * Without it those consumers read pre-alignment coordinates while the 3D
- * view shows aligned ones — the same class of gap the snap query had.
+ * view shows aligned ones.
+ *
+ * **`outputsRenderFrame` is the part callers get wrong.** The two matrices
+ * do not land in the same space:
+ *
+ * - `alignedMatrix` consumes decode-shifted residuals and, because the
+ *   whole viewer shift was folded into `decodeOriginOffset` (zero
+ *   translation column), lands DIRECTLY in the viewer render frame. A
+ *   caller that then also applies the render-frame shift subtracts it
+ *   twice and displaces the result by the model's full RTC/origin offset.
+ * - `unalignedMatrix` restores the raw native placement instead, so its
+ *   output is absolute and still needs the usual world -> render-frame
+ *   shift.
  */
+export interface AppliedPointCloudTransform {
+  matrix: Float32Array;
+  /** True when `matrix` already lands in the viewer render frame, so no
+   *  further render-frame shift may be applied. */
+  outputsRenderFrame: boolean;
+}
+
 export function getPointCloudAlignmentMatrix(
   handleId: number,
   enabled: boolean,
-): Float32Array | undefined {
+): AppliedPointCloudTransform | undefined {
   const entry = registry.get(handleId);
   if (!entry) return undefined;
-  return enabled ? entry.transform.alignedMatrix : entry.transform.unalignedMatrix;
+  return enabled
+    ? { matrix: entry.transform.alignedMatrix, outputsRenderFrame: true }
+    : { matrix: entry.transform.unalignedMatrix, outputsRenderFrame: false };
 }
 
 /** Renderer surface this module needs — matches `@ifc-lite/renderer`'s

--- a/apps/viewer/src/hooks/ingest/pointCloudAlignment.ts
+++ b/apps/viewer/src/hooks/ingest/pointCloudAlignment.ts
@@ -304,6 +304,29 @@ export function hasRegisteredPointCloudAlignment(): boolean {
   return registry.size > 0;
 }
 
+/**
+ * The matrix currently being applied to `handleId` on the GPU, or
+ * undefined when that asset has no alignment registered.
+ *
+ * `enabled` must be the live `pointCloudAlignmentEnabled` store flag —
+ * the registry deliberately does not cache it, since
+ * `applyPointCloudAlignmentToggle` is the single writer that pushes the
+ * choice to the renderer.
+ *
+ * Exists so CPU-side consumers of raw cached scan points (the 2D section
+ * scan layer, #1805) can place them where the GPU actually draws them.
+ * Without it those consumers read pre-alignment coordinates while the 3D
+ * view shows aligned ones — the same class of gap the snap query had.
+ */
+export function getPointCloudAlignmentMatrix(
+  handleId: number,
+  enabled: boolean,
+): Float32Array | undefined {
+  const entry = registry.get(handleId);
+  if (!entry) return undefined;
+  return enabled ? entry.transform.alignedMatrix : entry.transform.unalignedMatrix;
+}
+
 /** Renderer surface this module needs — matches `@ifc-lite/renderer`'s
  *  `Renderer.setPointCloudTransform`. Typed narrowly here so this module
  *  doesn't need to import the whole `Renderer` class. */

--- a/apps/viewer/src/hooks/scanSectionMath.test.ts
+++ b/apps/viewer/src/hooks/scanSectionMath.test.ts
@@ -387,3 +387,69 @@ describe('mergeScanBandSelections', () => {
     assert.strictEqual(merged.points.length, 6);
   });
 });
+
+/**
+ * Aligned-scan reconciliation for the 2D overlay (#1804 x #1805).
+ *
+ * The scan cache holds RAW decoder points; an aligned asset is drawn
+ * through its GPU matrix. Without folding that matrix in here, the 2D
+ * section overlay selects a band around pre-alignment coordinates while
+ * the 3D view shows the scan aligned to the building — the two views
+ * disagree about where the same scan is.
+ */
+describe('selectScanBand with an aligned point cloud', () => {
+  /** Column-major 4x4: identity rotation/scale, translation only. */
+  function translation(x: number, y: number, z: number): Float32Array {
+    return new Float32Array([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, x, y, z, 1]);
+  }
+
+  const plane: ScanSectionPlane = { axis: 'y', position: 5, flipped: false };
+
+  it('selects the band around the RENDERED position, not the raw one', () => {
+    // Raw point at y=0. The asset is drawn +5 in y, so it renders at y=5
+    // and must fall inside a band centred on y=5.
+    const sample: ScanPointSample = { positions: new Float32Array([0, 0, 0]), count: 1 };
+    const aligned = selectScanBand({
+      sample, coordinateInfo: undefined, plane, thickness: 0.2, model: translation(0, 5, 0),
+    });
+    assert.strictEqual(aligned.totalInBand, 1, 'aligned point must be in band at its rendered height');
+  });
+
+  it('does not select the stale raw position once aligned', () => {
+    // Same asset, but the band sits at the RAW height (y=0). Nothing is
+    // rendered there any more, so nothing should be selected.
+    const sample: ScanPointSample = { positions: new Float32Array([0, 0, 0]), count: 1 };
+    const atRaw = selectScanBand({
+      sample,
+      coordinateInfo: undefined,
+      plane: { axis: 'y', position: 0, flipped: false },
+      thickness: 0.2,
+      model: translation(0, 5, 0),
+    });
+    assert.strictEqual(atRaw.totalInBand, 0, 'pre-alignment position must no longer be selected');
+  });
+
+  it('is unchanged when no matrix is supplied (unaligned fast path)', () => {
+    const sample: ScanPointSample = { positions: new Float32Array([0, 5, 0]), count: 1 };
+    const bare = selectScanBand({ sample, coordinateInfo: undefined, plane, thickness: 0.2 });
+    const identity = selectScanBand({
+      sample, coordinateInfo: undefined, plane, thickness: 0.2, model: translation(0, 0, 0),
+    });
+    assert.strictEqual(bare.totalInBand, 1);
+    assert.strictEqual(identity.totalInBand, 1);
+    assert.deepStrictEqual(identity.points[0].point, bare.points[0].point);
+  });
+
+  it('emits the transformed point, so the count pass and the collect pass agree', () => {
+    // Both passes must read the point through the same transform; if only
+    // the band test were transformed, totalInBand and points.length would
+    // disagree (or the drawn dot would be at the untransformed spot).
+    const sample: ScanPointSample = { positions: new Float32Array([3, 0, 0]), count: 1 };
+    const out = selectScanBand({
+      sample, coordinateInfo: undefined, plane, thickness: 0.2, model: translation(0, 5, 0),
+    });
+    assert.strictEqual(out.totalInBand, 1);
+    assert.strictEqual(out.points.length, 1);
+    close(out.points[0].point.x, 3);
+  });
+});

--- a/apps/viewer/src/hooks/scanSectionMath.test.ts
+++ b/apps/viewer/src/hooks/scanSectionMath.test.ts
@@ -453,3 +453,74 @@ describe('selectScanBand with an aligned point cloud', () => {
     close(out.points[0].point.x, 3);
   });
 });
+
+/**
+ * Double-shift regression (#1889 review, Codex P1).
+ *
+ * `computePointCloudAlignment` folds the ENTIRE viewer shift into
+ * `decodeOriginOffset`, so `alignedMatrix` lands directly in the render
+ * frame with a zero translation column. Applying the render-frame shift on
+ * top of it subtracts that shift twice and displaces the overlay by the
+ * model's full RTC/origin offset — which, at map magnitudes, means the
+ * section selects nothing at all.
+ *
+ * The original tests for the aligned path all passed
+ * `coordinateInfo: undefined`, making the shift zero and the double
+ * subtraction invisible. These use a NON-ZERO shift on purpose.
+ */
+describe('selectScanBand — aligned matrices must not be shifted twice', () => {
+  const coordinateInfo = {
+    wasmRtcOffset: { x: 1000, y: 2000, z: 5 },
+    originShift: { x: 3, y: 9, z: -7 },
+  } as never;
+
+  function translation(x: number, y: number, z: number): Float32Array {
+    return new Float32Array([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, x, y, z, 1]);
+  }
+
+  it('an aligned matrix output is used as-is (already render-frame)', () => {
+    // The matrix puts the point at render-frame y=5, so a band at y=5
+    // must select it — with the shift applied again it would land at
+    // y = 5 - shift.y and be missed entirely.
+    const sample: ScanPointSample = { positions: new Float32Array([0, 0, 0]), count: 1 };
+    const out = selectScanBand({
+      sample,
+      coordinateInfo,
+      plane: { axis: 'y', position: 5, flipped: false },
+      thickness: 0.2,
+      model: translation(0, 5, 0),
+      modelOutputsRenderFrame: true,
+    });
+    assert.strictEqual(out.totalInBand, 1, 'aligned output must not be shifted a second time');
+    close(out.points[0].point.x, 0);
+  });
+
+  it('an UNALIGNED matrix output still gets the render-frame shift', () => {
+    // `unalignedMatrix` restores absolute native coordinates, so the
+    // world -> render-frame shift still applies. Point lands at
+    // render-frame y = 5 - shift.y, where shift.y = rtc.z + originShift.y.
+    const shift = pointCloudRenderFrameShift(coordinateInfo);
+    const sample: ScanPointSample = { positions: new Float32Array([0, 0, 0]), count: 1 };
+    const out = selectScanBand({
+      sample,
+      coordinateInfo,
+      plane: { axis: 'y', position: 5 - shift.y, flipped: false },
+      thickness: 0.2,
+      model: translation(0, 5, 0),
+      modelOutputsRenderFrame: false,
+    });
+    assert.strictEqual(out.totalInBand, 1, 'unaligned output must still be shifted into the render frame');
+  });
+
+  it('no matrix at all is unaffected by the flag', () => {
+    const shift = pointCloudRenderFrameShift(coordinateInfo);
+    const sample: ScanPointSample = { positions: new Float32Array([0, 5, 0]), count: 1 };
+    const out = selectScanBand({
+      sample,
+      coordinateInfo,
+      plane: { axis: 'y', position: 5 - shift.y, flipped: false },
+      thickness: 0.2,
+    });
+    assert.strictEqual(out.totalInBand, 1, 'raw cached points still take the render-frame shift');
+  });
+});

--- a/apps/viewer/src/hooks/scanSectionMath.ts
+++ b/apps/viewer/src/hooks/scanSectionMath.ts
@@ -129,6 +129,14 @@ export interface SelectScanBandParams {
   thickness: number;
   /** 8-word LAS class-visibility mask (see `pointCloudSlice.ts`). Omitted = all visible. */
   classMask?: readonly number[];
+  /**
+   * The asset's current GPU transform (#1804), from
+   * `getPointCloudAlignmentMatrix`. Cached scan points are raw decoder
+   * output, so without this an ALIGNED scan's 2D overlay lands at
+   * pre-alignment coordinates while the 3D view draws it aligned. Omit for
+   * an unaligned asset.
+   */
+  model?: Float32Array;
   /** Cap on rendered (post-decimation) point count. */
   maxRendered?: number;
 }
@@ -265,19 +273,39 @@ function readColor(
  * (debounced on section-plane changes), not per frame.
  */
 export function selectScanBand(params: SelectScanBandParams): ScanBandSelection {
-  const { sample, coordinateInfo, plane, thickness, classMask, maxRendered = DEFAULT_SCAN_RENDER_CAP } = params;
+  const { sample, coordinateInfo, plane, thickness, classMask, model, maxRendered = DEFAULT_SCAN_RENDER_CAP } = params;
   const { positions, colors, classifications, count } = sample;
   const shift = pointCloudRenderFrameShift(coordinateInfo);
   const halfThickness = Math.max(thickness, 0) / 2;
+  // Cached scan points are RAW decoder output; an aligned asset (#1804) is
+  // drawn through `model` on the GPU. Fold it in here or the 2D overlay
+  // sits at pre-alignment coordinates while the 3D view shows the scan
+  // aligned to the building. Skipped entirely when absent (the common
+  // unaligned case) so nothing pays matrix cost for nothing.
+  const useModel = model !== undefined && model.length === 16;
 
   const passesClassMask = (i: number): boolean => {
     if (!classMask || !classifications) return true;
     return isPointCloudClassVisible(classMask, classifications[i]);
   };
+  // Single reader for both passes below — the band test and the collect
+  // loop MUST agree on where a point is, so there is deliberately only one
+  // place that turns an index into a render-frame position.
+  const readPoint = (i: number): Vec3 => {
+    const x = positions[i * 3];
+    const y = positions[i * 3 + 1];
+    const z = positions[i * 3 + 2];
+    const p: Vec3 = useModel
+      ? {
+        x: model[0] * x + model[4] * y + model[8] * z + model[12],
+        y: model[1] * x + model[5] * y + model[9] * z + model[13],
+        z: model[2] * x + model[6] * y + model[10] * z + model[14],
+      }
+      : { x, y, z };
+    return toRenderFrame(p, shift);
+  };
   const inBand = (i: number): boolean => {
-    const p: Vec3 = { x: positions[i * 3], y: positions[i * 3 + 1], z: positions[i * 3 + 2] };
-    const rp = toRenderFrame(p, shift);
-    return Math.abs(signedBandDistance(rp, plane)) <= halfThickness;
+    return Math.abs(signedBandDistance(readPoint(i), plane)) <= halfThickness;
   };
 
   let totalInBand = 0;
@@ -294,8 +322,7 @@ export function selectScanBand(params: SelectScanBandParams): ScanBandSelection 
   let matchIndex = -1;
   for (let i = 0; i < count; i++) {
     if (!passesClassMask(i)) continue;
-    const p: Vec3 = { x: positions[i * 3], y: positions[i * 3 + 1], z: positions[i * 3 + 2] };
-    const rp = toRenderFrame(p, shift);
+    const rp = readPoint(i);
     if (Math.abs(signedBandDistance(rp, plane)) > halfThickness) continue;
     matchIndex++;
     if (matchIndex % stride !== 0) continue;

--- a/apps/viewer/src/hooks/scanSectionMath.ts
+++ b/apps/viewer/src/hooks/scanSectionMath.ts
@@ -137,6 +137,15 @@ export interface SelectScanBandParams {
    * an unaligned asset.
    */
   model?: Float32Array;
+  /**
+   * Whether `model` already lands in the viewer render frame. The aligned
+   * matrix does (the whole viewer shift is folded into its decode offset,
+   * leaving a zero translation column), so applying the render-frame shift
+   * on top of it would subtract that shift TWICE and displace the overlay
+   * by the model's full RTC/origin offset. The unaligned matrix restores
+   * absolute native coordinates and still needs the shift.
+   */
+  modelOutputsRenderFrame?: boolean;
   /** Cap on rendered (post-decimation) point count. */
   maxRendered?: number;
 }
@@ -273,7 +282,10 @@ function readColor(
  * (debounced on section-plane changes), not per frame.
  */
 export function selectScanBand(params: SelectScanBandParams): ScanBandSelection {
-  const { sample, coordinateInfo, plane, thickness, classMask, model, maxRendered = DEFAULT_SCAN_RENDER_CAP } = params;
+  const {
+    sample, coordinateInfo, plane, thickness, classMask, model,
+    modelOutputsRenderFrame = false, maxRendered = DEFAULT_SCAN_RENDER_CAP,
+  } = params;
   const { positions, colors, classifications, count } = sample;
   const shift = pointCloudRenderFrameShift(coordinateInfo);
   const halfThickness = Math.max(thickness, 0) / 2;
@@ -283,6 +295,9 @@ export function selectScanBand(params: SelectScanBandParams): ScanBandSelection 
   // aligned to the building. Skipped entirely when absent (the common
   // unaligned case) so nothing pays matrix cost for nothing.
   const useModel = model !== undefined && model.length === 16;
+  // Skip the render-frame shift when the matrix already produced
+  // render-frame coordinates — otherwise it is subtracted twice.
+  const shiftAfterModel = !(useModel && modelOutputsRenderFrame);
 
   const passesClassMask = (i: number): boolean => {
     if (!classMask || !classifications) return true;
@@ -302,7 +317,7 @@ export function selectScanBand(params: SelectScanBandParams): ScanBandSelection 
         z: model[2] * x + model[6] * y + model[10] * z + model[14],
       }
       : { x, y, z };
-    return toRenderFrame(p, shift);
+    return shiftAfterModel ? toRenderFrame(p, shift) : p;
   };
   const inBand = (i: number): boolean => {
     return Math.abs(signedBandDistance(readPoint(i), plane)) <= halfThickness;

--- a/apps/viewer/src/hooks/useScanSectionLayer.ts
+++ b/apps/viewer/src/hooks/useScanSectionLayer.ts
@@ -83,7 +83,7 @@ const EMPTY_SELECTION: ScanBandSelection = {
  * (non-streamed) assets have no renderer handle and therefore no
  * alignment registration, so they carry no matrix.
  */
-type ScanSource = ScanPointSample & { model?: Float32Array };
+type ScanSource = ScanPointSample & { model?: Float32Array; modelOutputsRenderFrame?: boolean };
 
 function collectScanSources(
   models: ReadonlyMap<string, FederatedModel>,
@@ -114,7 +114,10 @@ function collectScanSources(
             colors: cached.colors ?? undefined,
             classifications: cached.classifications ?? undefined,
             count: cached.count,
-            model: getPointCloudAlignmentMatrix(model.pointCloudHandleId, alignmentEnabled),
+            ...(() => {
+              const t = getPointCloudAlignmentMatrix(model.pointCloudHandleId, alignmentEnabled);
+              return t ? { model: t.matrix, modelOutputsRenderFrame: t.outputsRenderFrame } : {};
+            })(),
           });
         }
       }
@@ -213,6 +216,7 @@ export function useScanSectionLayer(params: UseScanSectionLayerParams): UseScanS
       const selections = sources.map((sample) => selectScanBand({
         sample, coordinateInfo, plane, thickness, classMask, maxRendered,
         model: sample.model,
+        modelOutputsRenderFrame: sample.modelOutputsRenderFrame,
       }));
       // Re-apply the render cap to the MERGED result: each asset caps its
       // own selection, but several dense scans would otherwise concatenate

--- a/apps/viewer/src/hooks/useScanSectionLayer.ts
+++ b/apps/viewer/src/hooks/useScanSectionLayer.ts
@@ -24,8 +24,9 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import type { GeometryResult, PointCloudAsset } from '@ifc-lite/geometry';
 import type { FederatedModel, SectionPlane } from '@/store/types';
-import { customPlaneCenter } from '@/store';
+import { customPlaneCenter, useViewerStore } from '@/store';
 import { getPointCloudScanSample } from './ingest/pointCloudScanCache.js';
+import { getPointCloudAlignmentMatrix } from './ingest/pointCloudAlignment.js';
 import {
   selectScanBand,
   mergeScanBandSelections,
@@ -75,12 +76,21 @@ const EMPTY_SELECTION: ScanBandSelection = {
   stride: 1,
 };
 
-/** Gather every currently-loaded point cloud as a flat `ScanPointSample[]`. */
+/**
+ * Gather every currently-loaded point cloud, each paired with the GPU
+ * transform it is currently drawn through (#1804) so the 2D overlay can
+ * place raw cached points where the 3D view actually shows them. Inline
+ * (non-streamed) assets have no renderer handle and therefore no
+ * alignment registration, so they carry no matrix.
+ */
+type ScanSource = ScanPointSample & { model?: Float32Array };
+
 function collectScanSources(
   models: ReadonlyMap<string, FederatedModel>,
   legacyPointClouds: readonly PointCloudAsset[] | undefined,
-): ScanPointSample[] {
-  const sources: ScanPointSample[] = [];
+  alignmentEnabled: boolean,
+): ScanSource[] {
+  const sources: ScanSource[] = [];
 
   const pushInlineAsset = (asset: PointCloudAsset) => {
     if (asset.chunk.pointCount > 0 && asset.chunk.positions.length > 0) {
@@ -104,6 +114,7 @@ function collectScanSources(
             colors: cached.colors ?? undefined,
             classifications: cached.classifications ?? undefined,
             count: cached.count,
+            model: getPointCloudAlignmentMatrix(model.pointCloudHandleId, alignmentEnabled),
           });
         }
       }
@@ -156,6 +167,10 @@ export function useScanSectionLayer(params: UseScanSectionLayerParams): UseScanS
 
   const [selection, setSelection] = useState<ScanBandSelection>(EMPTY_SELECTION);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Which matrix each streamed asset is currently drawn through (#1804).
+  // Flipping the toggle must move the 2D overlay with the 3D view, so this
+  // is a real dependency of the recompute below, not a one-shot read.
+  const alignmentEnabled = useViewerStore((st) => st.pointCloudAlignmentEnabled);
 
   // Fold every dependency the computation reads into one key so the
   // debounce timer restarts exactly when something relevant changed —
@@ -174,10 +189,10 @@ export function useScanSectionLayer(params: UseScanSectionLayerParams): UseScanS
   // Cheap presence check (map lookups, no O(n) point scan) — independent of
   // `enabled` so the UI can report "a scan is loaded, just hidden".
   const hasPointCloud = useMemo(
-    () => collectScanSources(models, legacyPointClouds).length > 0,
+    () => collectScanSources(models, legacyPointClouds, alignmentEnabled).length > 0,
     // Keyed on `modelsKey` (a stable string), not `models` identity, since
     // the Map reference can change without any visible-content change.
-    [modelsKey, legacyPointClouds],
+    [modelsKey, legacyPointClouds, alignmentEnabled],
   );
 
   useEffect(() => {
@@ -189,7 +204,7 @@ export function useScanSectionLayer(params: UseScanSectionLayerParams): UseScanS
     }
 
     timerRef.current = setTimeout(() => {
-      const sources = collectScanSources(models, legacyPointClouds);
+      const sources = collectScanSources(models, legacyPointClouds, alignmentEnabled);
       if (sources.length === 0) {
         setSelection(EMPTY_SELECTION);
         return;
@@ -197,6 +212,7 @@ export function useScanSectionLayer(params: UseScanSectionLayerParams): UseScanS
       const plane = toScanSectionPlane(sectionPlane, coordinateInfo);
       const selections = sources.map((sample) => selectScanBand({
         sample, coordinateInfo, plane, thickness, classMask, maxRendered,
+        model: sample.model,
       }));
       // Re-apply the render cap to the MERGED result: each asset caps its
       // own selection, but several dense scans would otherwise concatenate
@@ -219,6 +235,7 @@ export function useScanSectionLayer(params: UseScanSectionLayerParams): UseScanS
     modelsKey,
     legacyPointClouds,
     maxRendered,
+    alignmentEnabled,
   ]);
 
   // Stable result identity: consumers put this object in dependency arrays

--- a/packages/renderer/src/pointcloud/point-cloud-ray-transform.ts
+++ b/packages/renderer/src/pointcloud/point-cloud-ray-transform.ts
@@ -55,6 +55,25 @@
  * so a single scalar `s` is exact. `matrixUniformScale` falls back to the
  * mean column length for anything else, which keeps a non-uniform matrix
  * approximately right rather than wildly wrong.
+ *
+ * ## Known limit: long-range reach under a sub-unit scale
+ *
+ * `PointCloudSpatialIndex` caps its per-step dilation at
+ * `MAX_DILATION_RADIUS_CELLS * cellSize` = 2 LOCAL units, a deliberate
+ * bound on march cost. Because the tolerance is converted into local
+ * units, a matrix with `s < 1` tightens that cap in world terms: a
+ * foot-based CRS (`s = 0.3048`) caps the effective snap radius at
+ * `2 * 0.3048 = 0.61 m` rather than 2 m, so at long range a point inside
+ * the nominal ~8px tolerance can sit outside the searched cells and be
+ * missed.
+ *
+ * This is a reach limit, not a wrong answer: whatever the query returns is
+ * correctly placed, and near-to-mid range (where measuring actually
+ * happens) is unaffected. Restoring the full world-space reach means
+ * scaling the cap to `MAX_DILATION_RADIUS_CELLS / s` (~14 cells at
+ * s = 0.3048), which re-inflates the per-step probe cost that the
+ * leading-slab bound exists to contain — a perf trade that should be made
+ * deliberately, with a benchmark, rather than folded into this fix.
  */
 
 import { MathUtils } from '../math.js';

--- a/packages/renderer/src/pointcloud/point-cloud-ray-transform.ts
+++ b/packages/renderer/src/pointcloud/point-cloud-ray-transform.ts
@@ -1,0 +1,193 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Ray <-> point-cloud local-frame conversion for snap queries.
+ *
+ * ## Why this exists
+ *
+ * Two features landed independently and left a gap between them:
+ *
+ * - #1804 gives each point-cloud node a per-asset model matrix
+ *   (`PointCloudNode.model`) applied at RENDER time — the shader places
+ *   points through it, and `transformAabb` folds it into reported bounds.
+ * - #1860 built the snap/measure spatial index, which stores RAW,
+ *   untransformed chunk positions straight off the decoder.
+ *
+ * So for a georeferenced (aligned) scan the renderer draws points at
+ * aligned positions while the snap query walks an index of pre-alignment
+ * positions: a measurement snapped to where the point USED to be, not
+ * where the user can see it. Both features are individually correct; the
+ * defect only exists in their composition, which is why neither PR's tests
+ * caught it.
+ *
+ * ## Why the ray moves, not the points
+ *
+ * We inverse-transform the ray into the node's local frame rather than
+ * transforming candidate points into world space:
+ *
+ * - The index's cell keys are packed RELATIVE to the first indexed point
+ *   and are only meaningful in local space — transforming points would
+ *   invalidate the whole acceleration structure.
+ * - It is O(1) per node instead of O(points-examined).
+ *
+ * ## Distances stay in world units
+ *
+ * `queryRay` treats `t` as a distance along a UNIT direction and compares
+ * `toleranceAt(t)` as a perpendicular radius, both in the index's own
+ * space. Under a matrix with scale `s`, a world distance `d` is a local
+ * distance `d / s`. Every distance-valued quantity therefore has to be
+ * converted on the way in and back on the way out:
+ *
+ *   maxDistance_local = maxDistance_world / s
+ *   toleranceAt_local(t_local) = toleranceAt_world(t_local * s) / s
+ *   distance_world = distance_local * s
+ *
+ * Get this wrong and the ~8px screen-space snap tolerance silently means
+ * something different on any scan whose CRS is not in metres (a foot-based
+ * CRS carries s = 0.3048), which would read as "snapping feels wrong on
+ * US survey-foot projects" — the sort of bug that is very hard to trace
+ * back to a matrix.
+ *
+ * The alignment matrices this handles are similarity transforms (uniform
+ * scale * rotation about Y, zero translation — see `pointCloudAlignment`),
+ * so a single scalar `s` is exact. `matrixUniformScale` falls back to the
+ * mean column length for anything else, which keeps a non-uniform matrix
+ * approximately right rather than wildly wrong.
+ */
+
+import { MathUtils } from '../math.js';
+import type { Vec3 } from '../raycaster.js';
+import { isUsableModelMatrix } from './point-cloud-node.js';
+
+/** The subset of a `PointCloudNode` the snap-source snapshot reads. */
+export interface RayQueryNodeLike {
+  meta: { expressId: number; modelIndex?: number };
+  spatialIndex: { pointCount: number };
+  model?: Float32Array;
+}
+
+/** One entry of the snapshot handed to `queryPointClouds`. */
+export interface RayQuerySource<TNode extends RayQueryNodeLike> {
+  expressId: number;
+  modelIndex?: number;
+  index: TNode['spatialIndex'];
+  classMask: Uint32Array;
+  model?: Float32Array;
+}
+
+/**
+ * Build the snap-query snapshot from live nodes.
+ *
+ * Pure and node-shaped rather than inlined in `PointCloudRenderer` so it is
+ * testable without a `GPUDevice`. That matters here specifically: the
+ * renderer-to-query wiring is exactly where the aligned-scan gap lived, and
+ * it went unnoticed because nothing could exercise it without a GPU. Empty
+ * nodes are skipped, mirroring `getPickNodes`.
+ */
+export function buildRayQuerySources<TNode extends RayQueryNodeLike>(
+  nodes: Iterable<TNode>,
+  classMask: Uint32Array,
+): Array<RayQuerySource<TNode>> {
+  const out: Array<RayQuerySource<TNode>> = [];
+  for (const node of nodes) {
+    if (node.spatialIndex.pointCount === 0) continue;
+    out.push({
+      expressId: node.meta.expressId,
+      modelIndex: node.meta.modelIndex,
+      index: node.spatialIndex,
+      // The index stores RAW decoder positions while the shader draws
+      // through `model` (#1804) — the query needs the matrix to reconcile
+      // the two, or an aligned scan snaps to pre-alignment coordinates.
+      model: node.model,
+      classMask,
+    });
+  }
+  return out;
+}
+
+/** A ray rewritten into a point cloud's local frame, plus the conversions
+ *  needed to move distances and hit positions back out to world space. */
+export interface LocalFrameRay {
+  origin: Vec3;
+  /** Unit-length in local space, so `queryRay`'s `t` stays a true distance. */
+  direction: Vec3;
+  /** World distance = local distance * this. 1 for an identity transform. */
+  distanceScale: number;
+  /** Map a local-space hit position back to world space. */
+  toWorld(p: Vec3): Vec3;
+}
+
+/**
+ * Uniform scale factor of a column-major 4x4's linear part.
+ *
+ * Exact for a similarity transform (every column has the same length);
+ * for a non-uniform matrix it returns the mean, which keeps snap
+ * tolerances in the right ballpark rather than exact. Returns 1 for a
+ * degenerate (~zero) matrix so callers never divide by zero.
+ */
+export function matrixUniformScale(m: Float32Array): number {
+  const cx = Math.hypot(m[0], m[1], m[2]);
+  const cy = Math.hypot(m[4], m[5], m[6]);
+  const cz = Math.hypot(m[8], m[9], m[10]);
+  const mean = (cx + cy + cz) / 3;
+  return mean > 1e-12 ? mean : 1;
+}
+
+/**
+ * True when `m` is close enough to the identity that transforming through
+ * it is pure overhead. The overwhelmingly common case is an unaligned
+ * scan, and this keeps that path allocation-free.
+ */
+export function isIdentityMatrix(m: Float32Array): boolean {
+  const EPS = 1e-6;
+  for (let i = 0; i < 16; i++) {
+    const expected = i % 5 === 0 ? 1 : 0;
+    if (Math.abs(m[i] - expected) > EPS) return false;
+  }
+  return true;
+}
+
+/**
+ * Rewrite a world-space ray into `model`'s local frame.
+ *
+ * Returns `null` when no transform is needed (absent, malformed, identity)
+ * or when the matrix is singular — callers should then query with the
+ * original world ray, which is the correct behaviour for an unaligned
+ * cloud and a safe fallback for a degenerate matrix.
+ */
+export function toLocalFrameRay(
+  origin: Vec3,
+  direction: Vec3,
+  model: Float32Array | undefined,
+): LocalFrameRay | null {
+  if (!isUsableModelMatrix(model) || isIdentityMatrix(model)) return null;
+
+  const inv = MathUtils.invert({ m: model });
+  if (!inv) return null;
+  const i = inv.m;
+
+  const ox = i[0] * origin.x + i[4] * origin.y + i[8] * origin.z + i[12];
+  const oy = i[1] * origin.x + i[5] * origin.y + i[9] * origin.z + i[13];
+  const oz = i[2] * origin.x + i[6] * origin.y + i[10] * origin.z + i[14];
+
+  // Direction is a vector: no translation column.
+  const dx = i[0] * direction.x + i[4] * direction.y + i[8] * direction.z;
+  const dy = i[1] * direction.x + i[5] * direction.y + i[9] * direction.z;
+  const dz = i[2] * direction.x + i[6] * direction.y + i[10] * direction.z;
+  const len = Math.hypot(dx, dy, dz);
+  if (!(len > 1e-12)) return null;
+
+  const m = model;
+  return {
+    origin: { x: ox, y: oy, z: oz },
+    direction: { x: dx / len, y: dy / len, z: dz / len },
+    distanceScale: matrixUniformScale(m),
+    toWorld: (p: Vec3): Vec3 => ({
+      x: m[0] * p.x + m[4] * p.y + m[8] * p.z + m[12],
+      y: m[1] * p.x + m[5] * p.y + m[9] * p.z + m[13],
+      z: m[2] * p.x + m[6] * p.y + m[10] * p.z + m[14],
+    }),
+  };
+}

--- a/packages/renderer/src/pointcloud/point-cloud-renderer.ts
+++ b/packages/renderer/src/pointcloud/point-cloud-renderer.ts
@@ -28,6 +28,7 @@ import {
   type PointCloudNodeMeta,
 } from './point-cloud-node.js';
 import type { PointCloudSpatialIndex } from './point-cloud-spatial-index.js';
+import { buildRayQuerySources } from './point-cloud-ray-transform.js';
 import {
   normalizeClassMask,
   writePointCloudUniforms,
@@ -467,19 +468,10 @@ export class PointCloudRenderer {
     modelIndex?: number;
     index: PointCloudSpatialIndex;
     classMask: Uint32Array;
+    model?: Float32Array;
   }> {
-    const out: Array<{ expressId: number; modelIndex?: number; index: PointCloudSpatialIndex; classMask: Uint32Array }> = [];
-    for (const node of this.nodes.values()) {
-      if (node.spatialIndex.pointCount === 0) continue;
-      out.push({
-        expressId: node.meta.expressId,
-        modelIndex: node.meta.modelIndex,
-        index: node.spatialIndex,
-        // Live reference — read synchronously within one query, and
-        // `setOptions` replaces (never mutates in place) the array.
-        classMask: this.options.classMask,
-      });
-    }
-    return out;
+    // `classMask` is a live reference — read synchronously within one
+    // query, and `setOptions` replaces (never mutates in place) the array.
+    return buildRayQuerySources(this.nodes.values(), this.options.classMask);
   }
 }

--- a/packages/renderer/src/raycast-point-cloud-query.test.ts
+++ b/packages/renderer/src/raycast-point-cloud-query.test.ts
@@ -26,6 +26,7 @@ import {
   type PointCloudSnapCamera,
 } from './raycast-point-cloud-query.js';
 import { PointCloudSpatialIndex } from './pointcloud/point-cloud-spatial-index.js';
+import { buildRayQuerySources } from './pointcloud/point-cloud-ray-transform.js';
 import { SnapType, type SnapTarget } from './snap-detector.js';
 
 /** A representative measure-tool camera: ~60deg vertical FOV, 800px-tall canvas. */
@@ -263,5 +264,161 @@ describe('pointCloudSnapEnabled — snap toggle gating', () => {
       pointCloudSnapEnabled({ snapToVertices: false, snapToEdges: false, snapToFaces: false, snapToPointClouds: true }),
       true,
     );
+  });
+});
+
+/**
+ * Aligned-scan reconciliation (#1804 x #1860).
+ *
+ * The spatial index stores RAW decoder positions while the shader draws
+ * points through the node's `model` matrix. Without folding that matrix
+ * into the query, a measurement on a georeferenced scan snaps to where the
+ * point sat BEFORE alignment — visibly off from the dot the user clicked.
+ * Neither feature's own tests could catch this; it only exists in their
+ * composition.
+ */
+describe('queryPointClouds with an aligned point cloud', () => {
+  /** Index holding a single raw point, cell size 0.5m. */
+  function indexWithPointAt(x: number, y: number, z: number): PointCloudSpatialIndex {
+    const index = new PointCloudSpatialIndex(0.5);
+    index.insertRange(new Float32Array([x, y, z]), 1);
+    return index;
+  }
+
+  /** Column-major 4x4: uniform scale `k`, rotation `deg` about Y, translation `t`. */
+  function makeModel(k: number, deg: number, t: [number, number, number]): Float32Array {
+    const r = (deg * Math.PI) / 180;
+    const a = Math.cos(r);
+    const b = Math.sin(r);
+    return new Float32Array([
+      k * a, 0, k * b, 0,
+      0, k, 0, 0,
+      -k * b, 0, k * a, 0,
+      t[0], t[1], t[2], 1,
+    ]);
+  }
+
+  function sourceWith(index: PointCloudSpatialIndex, model?: Float32Array): PointCloudRaySource[] {
+    return [{ expressId: 7, index, model }];
+  }
+
+  /** Ray straight down -Z from the origin, which is how these fixtures are aimed. */
+  function rayToward(x: number, y: number) {
+    return { origin: { x, y, z: 0 }, direction: { x: 0, y: 0, z: -1 } };
+  }
+
+  it('snaps to the RENDERED position, not the raw indexed one (pure translation)', () => {
+    // Raw point at (0,0,-10); model shifts it +3 in x. The user sees a dot
+    // at x=3, so a ray down x=3 must find it and report x=3.
+    const index = indexWithPointAt(0, 0, -10);
+    const model = makeModel(1, 0, [3, 0, 0]);
+    const hit = queryPointClouds(() => sourceWith(index, model), rayToward(3, 0), CAMERA, 100);
+    assert.ok(hit, 'ray aimed at the rendered position must hit');
+    assert.ok(Math.abs(hit!.position.x - 3) < 1e-3, `expected world x=3, got ${hit!.position.x}`);
+    assert.ok(Math.abs(hit!.distance - 10) < 1e-3, `expected world distance 10, got ${hit!.distance}`);
+  });
+
+  it('does not snap at the raw position once the cloud is aligned', () => {
+    // The mirror of the above: a ray down the RAW x=0 must now MISS,
+    // because nothing is rendered there any more.
+    const index = indexWithPointAt(0, 0, -10);
+    const model = makeModel(1, 0, [3, 0, 0]);
+    const hit = queryPointClouds(() => sourceWith(index, model), rayToward(0, 0), CAMERA, 100);
+    assert.strictEqual(hit, null, 'stale raw position must not be snappable');
+  });
+
+  it('handles rotation + translation', () => {
+    // 90deg about Y: the matrix maps pz onto column 2 = (-1, 0, 0), so raw
+    // (0,0,-10) contributes -10 * (-1,0,0) = (10,0,0), plus the [5,0,0]
+    // translation => rendered at (15,0,0).
+    const index = indexWithPointAt(0, 0, -10);
+    const model = makeModel(1, 90, [5, 0, 0]);
+    const hit = queryPointClouds(
+      () => sourceWith(index, model),
+      { origin: { x: 15, y: 0, z: 5 }, direction: { x: 0, y: 0, z: -1 } },
+      CAMERA,
+      100,
+    );
+    assert.ok(hit, 'rotated+translated point must be found at its rendered position');
+    assert.ok(Math.abs(hit!.position.x - 15) < 1e-2, `expected world x=15, got ${hit!.position.x}`);
+    assert.ok(Math.abs(hit!.position.z - 0) < 1e-2, `expected world z=0, got ${hit!.position.z}`);
+  });
+
+  it('reports distance in WORLD units under a scaled matrix', () => {
+    // k=2 doubles every distance: a raw point 10 local units away renders
+    // 20 world units away, and `distance` feeds the measure tool directly.
+    const index = indexWithPointAt(0, 0, -10);
+    const model = makeModel(2, 0, [0, 0, 0]);
+    const hit = queryPointClouds(() => sourceWith(index, model), rayToward(0, 0), CAMERA, 100);
+    assert.ok(hit, 'scaled point must be found');
+    assert.ok(Math.abs(hit!.position.z - -20) < 1e-2, `expected world z=-20, got ${hit!.position.z}`);
+    assert.ok(Math.abs(hit!.distance - 20) < 1e-2, `expected world distance 20, got ${hit!.distance}`);
+  });
+
+  it('stays exact at georeferenced magnitudes (LV95)', () => {
+    // The f32 precision case #1804 exists for: a Swiss-scale translation
+    // must not smear the snapped position.
+    const index = indexWithPointAt(0, 0, -10);
+    const model = makeModel(1, 0, [2_600_000, 1_200_000, 450]);
+    const hit = queryPointClouds(
+      () => sourceWith(index, model),
+      { origin: { x: 2_600_000, y: 1_200_000, z: 450 }, direction: { x: 0, y: 0, z: -1 } },
+      CAMERA,
+      100,
+    );
+    assert.ok(hit, 'point must still be found at LV95 magnitude');
+    assert.ok(Math.abs(hit!.position.x - 2_600_000) < 0.5, `x drifted: ${hit!.position.x}`);
+    assert.ok(Math.abs(hit!.distance - 10) < 0.5, `distance drifted: ${hit!.distance}`);
+  });
+
+  it('is unchanged for an absent or identity matrix', () => {
+    const index = indexWithPointAt(0, 0, -10);
+    const bare = queryPointClouds(() => sourceWith(index, undefined), rayToward(0, 0), CAMERA, 100);
+    const identity = queryPointClouds(
+      () => sourceWith(index, makeModel(1, 0, [0, 0, 0])),
+      rayToward(0, 0),
+      CAMERA,
+      100,
+    );
+    assert.ok(bare, 'unaligned cloud must still snap');
+    assert.ok(identity, 'identity matrix must behave like no matrix');
+    assert.deepStrictEqual(identity!.position, bare!.position);
+    assert.strictEqual(identity!.distance, bare!.distance);
+  });
+});
+
+/**
+ * Renderer -> query wiring (#1804 x #1860).
+ *
+ * The reconciliation is only real if the renderer actually HANDS the
+ * matrix to the query. The original gap survived precisely because nothing
+ * exercised this seam — `getRayQuerySources` needs a GPUDevice, so the
+ * source-building is extracted as a pure function to make it testable.
+ */
+describe('buildRayQuerySources', () => {
+  const MASK = new Uint32Array(8).fill(0xffffffff);
+  const model = new Float32Array([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 7, 8, 9, 1]);
+
+  function node(expressId: number, pointCount: number, m?: Float32Array) {
+    return { meta: { expressId, modelIndex: 3 }, spatialIndex: { pointCount }, model: m };
+  }
+
+  it('forwards each node\'s model matrix to the query', () => {
+    const [src] = buildRayQuerySources([node(1, 5, model)], MASK);
+    assert.strictEqual(src.model, model, 'the alignment matrix must reach the snap query');
+    assert.strictEqual(src.expressId, 1);
+    assert.strictEqual(src.modelIndex, 3);
+    assert.strictEqual(src.classMask, MASK);
+  });
+
+  it('leaves model undefined for an unaligned node', () => {
+    const [src] = buildRayQuerySources([node(2, 5, undefined)], MASK);
+    assert.strictEqual(src.model, undefined);
+  });
+
+  it('skips empty nodes', () => {
+    const out = buildRayQuerySources([node(1, 0, model), node(2, 4, model)], MASK);
+    assert.strictEqual(out.length, 1);
+    assert.strictEqual(out[0].expressId, 2);
   });
 });

--- a/packages/renderer/src/raycast-point-cloud-query.ts
+++ b/packages/renderer/src/raycast-point-cloud-query.ts
@@ -14,6 +14,7 @@ import type { MagneticSnapResult, SnapOptions, SnapTarget } from './snap-detecto
 import { screenToWorldRadius } from './snap-geometry-utils.js';
 import type { PickOptions } from './types.js';
 import type { PointCloudSpatialIndex } from './pointcloud/point-cloud-spatial-index.js';
+import { toLocalFrameRay } from './pointcloud/point-cloud-ray-transform.js';
 
 /** Source the RaycastEngine queries for point-cloud ray snapping (#1860). */
 export interface PointCloudRaySource {
@@ -23,6 +24,14 @@ export interface PointCloudRaySource {
   /** Current LAS class visibility bitmask (#1783); hidden-class points
    *  are not snappable. Omit for "everything visible". */
   classMask?: Uint32Array | null;
+  /**
+   * The node's per-asset render transform (#1804), or undefined when the
+   * asset is unaligned. The index holds RAW decoder positions, so without
+   * this the query would snap to where a georeferenced point sat BEFORE
+   * alignment while the shader draws it somewhere else — see
+   * `point-cloud-ray-transform.ts`.
+   */
+  model?: Float32Array;
 }
 
 /** Supplied by the renderer once point clouds are loaded; empty/null disables point snapping. */
@@ -129,9 +138,40 @@ export function queryPointClouds(
     // Never search past the current best (or the caller's bound) — keeps
     // the "nearest across assets" search itself O(assets).
     const bound = best ? Math.min(maxDistance, best.distance) : maxDistance;
-    const hit = src.index.queryRay(ray.origin, ray.direction, bound, toleranceAt, src.classMask);
-    if (hit && (!best || hit.distance < best.distance)) {
-      best = { position: hit.position, expressId: src.expressId, modelIndex: src.modelIndex, distance: hit.distance };
+
+    // An aligned asset (#1804) renders through `model` while its index
+    // holds raw decoder positions, so the ray has to be rewritten into the
+    // node's local frame — and every distance-valued quantity converted
+    // with it, or the screen-space tolerance quietly changes meaning under
+    // a non-metre CRS. `null` means "no transform needed", which is both
+    // the unaligned fast path and the safe fallback for a singular matrix.
+    const local = toLocalFrameRay(ray.origin, ray.direction, src.model);
+    if (!local) {
+      const hit = src.index.queryRay(ray.origin, ray.direction, bound, toleranceAt, src.classMask);
+      if (hit && (!best || hit.distance < best.distance)) {
+        best = { position: hit.position, expressId: src.expressId, modelIndex: src.modelIndex, distance: hit.distance };
+      }
+      continue;
+    }
+
+    const s = local.distanceScale;
+    const hit = src.index.queryRay(
+      local.origin,
+      local.direction,
+      bound / s,
+      (tLocal: number) => toleranceAt(tLocal * s) / s,
+      src.classMask,
+    );
+    if (hit) {
+      const worldDistance = hit.distance * s;
+      if (!best || worldDistance < best.distance) {
+        best = {
+          position: local.toWorld(hit.position),
+          expressId: src.expressId,
+          modelIndex: src.modelIndex,
+          distance: worldDistance,
+        };
+      }
     }
   }
   return best;


### PR DESCRIPTION
## The gap

Five PRs landed today. Three of them compose into a defect that none of their own test suites could catch:

- **#1878** (issue #1804) gives each point-cloud node a per-asset model matrix, applied at **render** time — the shader places points through it and `transformAabb` folds it into reported bounds.
- **#1875** (issue #1860) built the measure tool's snap spatial index, which stores **raw** decoder positions.
- **#1874** (issue #1805) caches **raw** scan points for the 2D section overlay.

So on a georeferenced scan the renderer draws points in one place while both CPU consumers read another.

**User-visible symptom:** a measurement on an aligned scan snaps to where the point sat *before* alignment — visibly off from the dot that was clicked — and the 2D section overlay selects a band around pre-alignment coordinates while the 3D view shows the scan aligned to the building.

This was deliberately deferred rather than folded into #1878, so each PR stayed independently reviewable. This is that follow-up.

## Renderer: move the ray, not the points

`getRayQuerySources()` now emits `node.model`, and `queryPointClouds` rewrites the ray into each node's local frame rather than transforming candidates:

- the index's cell keys are packed **relative to its first indexed point** and are only meaningful in local space — transforming points would invalidate the acceleration structure;
- it is O(1) per node instead of O(points-examined).

### Distances must convert with it

`queryRay` treats `t` as a distance along a unit direction and compares `toleranceAt(t)` as a world-space perpendicular radius. Under a matrix with scale `s`, **every** distance-valued quantity converts:

```
maxDistance_local        = maxDistance_world / s
toleranceAt_local(t)     = toleranceAt_world(t * s) / s
distance_world           = distance_local * s
```

Get this wrong and the ~8px screen-space snap tolerance silently means something different on any non-metre CRS — a foot-based CRS carries `s = 0.3048`. That would surface as "snapping feels wrong on US survey-foot projects", which is very hard to trace back to a matrix. The alignment matrices here are similarity transforms (uniform scale × rotation about Y), so a single scalar is exact; `matrixUniformScale` falls back to the mean column length for anything else.

Everything #1875 established is preserved: screen-space nearest selection, the coincident-surface guard, LAS class-mask filtering, the march bound, and "never snaps behind the visible surface". Absent/identity matrices take an allocation-free fast path.

## Viewer: the same gap in the 2D overlay

`addPointsToScanCache` caches raw Y-up points while `setPointCloudTransform` applies alignment on the GPU, so the 2D layer had the identical mismatch. `selectScanBand` now accepts the matrix and applies it through a **single `readPoint` reader shared by the count and collect passes** — deliberately one reader, since those two loops disagreeing is the drift pattern that produced three separate bugs in this batch. `getPointCloudAlignmentMatrix` exposes the currently-applied matrix, and the layer tracks the live toggle so flipping alignment moves the 2D overlay with the 3D view.

## The test that would have caught this

The renderer→query seam was **untested**, which is why the gap survived: `getRayQuerySources` needs a `GPUDevice`. Source-building is extracted as pure `buildRayQuerySources` so that seam is now testable.

My first mutation check passed when it should have failed — the tests constructed `PointCloudRaySource` directly and never exercised the wiring. Worth stating plainly, because a mutation check that doesn't mutate looks exactly like one that passes.

| mutation | result |
|---|---|
| query ignores the matrix | 5 renderer tests fail |
| source snapshot drops the matrix | wiring test fails |
| 2D layer ignores the matrix | 3 viewer tests fail |
| all restored | 372 renderer / 2026 viewer, 0 fail |

Coverage: identity/absent (unchanged), pure translation, rotation+translation, scaled matrix (world-unit distances), and LV95 magnitude (~2.6e6) for f32 drift.

## Review

Hosted CodeRabbit has been a false pass all day (Fair Usage rate limiting), so coverage came from a local `coderabbit review --committed --base main --agent`: **1 finding, rejected with a regression guard.**

It suggested `getPointCloudAlignmentMatrix` return `undefined` when the toggle is off, to let callers take the fast path. `unalignedMatrix` is **not** identity — it restores the f64 decode-time origin subtraction, a translation of map magnitude. Returning `undefined` would leave CPU consumers on raw decode coordinates while the GPU renders with that offset restored, reintroducing this exact bug for the toggle-off case. Pinned by a test in `01c53c47`.

## Gates

typecheck 33/33 · renderer 372/372 · viewer 2026 pass / 0 fail / 2 skipped · test-wiring clean · API surface matches snapshot (3958 exports) · changeset added (`@ifc-lite/renderer` patch)

Refs #1804 #1860 #1805

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M76mvdz8Hz7WHEoxwn694V

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Point-cloud snapping and measurement now match the rendered positions of aligned point clouds, including translated, rotated, scaled, and georeferenced data.
  * Scan section overlays now correctly account for point-cloud alignment and avoid applying render-frame shifts twice.
  * Unaligned point clouds retain the existing fast-path behavior.

* **Tests**
  * Added coverage for aligned snapping, scan-band selection, transformation handling, and alignment state changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->