### PR TITLE
docs(vision),ci: moonshot finishing plan (Phase 4-6) + the standing-evidence lane (B4.1)

### DIFF
--- a/.github/workflows/moonshot.yml
+++ b/.github/workflows/moonshot.yml
@@ -26,6 +26,8 @@
 #   E6  tamper batteries             v1 (5 cases) + v2 (18 cases)
 #   E7  gradient battery             analytic-vs-finite-difference, 1000 points
 #   E8  world-gym determinism        20/20 seeds byte-identical
+#   E9  prose vs artifact            every numeral in every REPORT/DESIGN and in
+#                                    docs/vision must be backed or marked
 #
 # E3 is the densest signal in the program. `scripts/moonshot/b35-demo/run.mjs`
 # writes a report whose entire `deterministic` subtree is a pure function of
@@ -94,6 +96,9 @@ on:
       - 'tools/world-gym/**'
       # The exams themselves.
       - 'scripts/moonshot/**'
+      # The gate record. E9's numeral gate reads these, and a wrong figure has
+      # already reached this tree once through a docs-only commit.
+      - 'docs/vision/**'
       - '.github/workflows/moonshot.yml'
   pull_request:
     branches: [main]
@@ -108,6 +113,7 @@ on:
       - 'packages/wasm/**'
       - 'tools/world-gym/**'
       - 'scripts/moonshot/**'
+      - 'docs/vision/**'
       - '.github/workflows/moonshot.yml'
 
 concurrency:
@@ -319,6 +325,17 @@ jobs:
       # which is the failure the exam is really about: an assertion that cannot
       # fail is not evidence.
       #
+      # SCOPE, stated because the G4 re-review caught the earlier framing
+      # overclaiming: the perturbed constant is JAVASCRIPT. This step proves the
+      # golden is wired to act 5 and can fail; it does NOT prove a wasm kernel
+      # measurement still reaches it (disconnect the kernel and this still
+      # passes, because kernelCarbonKg is a product with the perturbed
+      # constant). The kernel half is evidenced out-of-lane by
+      # `assert-b35-golden.mjs --kernel`, which edits rust/geometry and rebuilds
+      # the bundle -- minutes and a rust toolchain, i.e. two more wasm builds on
+      # top of the one this job already pays for. Its committed output is
+      # scripts/moonshot/ci/kernel-perturbation-evidence.txt.
+      #
       # Cost is ~12 s (two extra demo runs). It rewrites and restores three
       # files under try/finally plus SIGINT/SIGTERM handlers and verifies with
       # `git status` that it put them back, so a cancelled run cannot leave a
@@ -402,6 +419,31 @@ jobs:
         run: |
           node tools/world-gym/determinism-check.mjs
           echo '- **E8 world-gym determinism** -- 20/20 seeds byte-identical' >> "$GITHUB_STEP_SUMMARY"
+
+      # --- E9: the claim NOBODY else in this lane checks --------------------
+      # Every other step re-runs code and asserts the result. This one reads the
+      # PROSE and asserts that each numeral in it either matches an artifact or
+      # carries an inline `<!-- numeral-ok: <token> :: <reason> -->` saying why it
+      # cannot. The G4 review's section 6 is the reason: five of the seven things
+      # its audit found un-catchable were the same thing -- "prose that no
+      # artifact backs", including all three of its hard catches. Re-running a
+      # battery cannot find a sentence that disagrees with the JSON it came from.
+      #
+      # Scope is deliberately wider than the bets: it covers `docs/vision/**` as
+      # well, because the earlier report-only version was rooted at
+      # scripts/moonshot and therefore could not see the plans and reviews at all
+      # -- which is how a wrong B4.5 figure reached the finishing plan's
+      # amendment list in the commit that was fixing wrong figures.
+      #
+      # A STALE marker (one whose numeral has since become backed, or has left
+      # the document) fails this step too. That is intentional: when another
+      # bet's branch merges and its figures become checkable, the gate says so
+      # rather than leaving a permanent hole. The fix is to delete two lines.
+      - name: E9 prose vs artifact numerals (bets + docs/vision, gated)
+        shell: bash
+        run: |
+          node scripts/moonshot/ci/check-report-numerals.mjs --gate
+          echo '- **E9 prose vs artifact** -- every numeral backed by an artifact or marked with a reason' >> "$GITHUB_STEP_SUMMARY"
 
       # Runs even when something above failed, so the summary always records
       # which trigger this was and whether the Holter-gated exams were part of

--- a/.github/workflows/moonshot.yml
+++ b/.github/workflows/moonshot.yml
@@ -1,0 +1,404 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+# Moonshot standing evidence (bet B4.1).
+#
+# Every headline number in docs/vision/ came out of a script under
+# scripts/moonshot/ or tools/world-gym/ that, until this workflow existed, ran
+# exactly once, on one laptop, with nothing watching it. Thirteen other CI
+# workflows and not one of them touched that tree: the only automated
+# protection was @ifc-lite/provenance's own vitest suite. A kernel change
+# could silently invalidate eight months of published claims and CI would stay
+# green.
+#
+# This lane re-runs the exams and asserts them. Every step is named after the
+# claim it defends, so a failure notification alone says which act broke
+# without opening the log -- the same diagnostic style as
+# .github/workflows/wide-arithmetic.yml.
+#
+#   E1  provenance unit suite        node-hash-v0 + certificates + merge battery
+#   E2  the four gate demos          G0 / G1 / G2-footprint / G2-merge
+#   E3  B3.5 five-act demo           asserted BYTE-FOR-BYTE against a seeded golden
+#   E4  certified optimization       short run -> v1 + v2 certificate chains
+#   E5  chain verification           --mode full AND --mode spot
+#   E6  tamper batteries             v1 (5 cases) + v2 (18 cases)
+#   E7  gradient battery             analytic-vs-finite-difference, 1000 points
+#   E8  world-gym determinism        20/20 seeds byte-identical
+#
+# E3 is the densest signal in the program. `scripts/moonshot/b35-demo/run.mjs`
+# writes a report whose entire `deterministic` subtree is a pure function of
+# master seed 20260724 (wall clocks and the timestamp live ONLY under
+# `volatile`), so one number moving anywhere across world-gym,
+# @ifc-lite/create, @ifc-lite/provenance, the benchmark scorer or the geometry
+# kernel surfaces as a named path diff. See scripts/moonshot/ci/assert-b35-golden.mjs.
+#
+# COST. This is deliberately a cheap, non-blocking lane and MUST NOT become a
+# required check:
+#   - weekly `schedule` + on-demand `workflow_dispatch`, same profile as
+#     determinism.yml / wide-arithmetic.yml;
+#   - `push`/`pull_request` ONLY on the paths that can actually invalidate the
+#     results (the geometry/processing kernel, the packages the demos import,
+#     the wasm bundle, world-gym, and the moonshot scripts themselves). A
+#     docs-only or viewer-only PR never sees this job at all.
+#   - free `ubuntu-latest` runners (public repo), never Depot.
+# The measurable work is ~30 s; everything else is toolchain. Nearly all the
+# wall clock is the wasm32 build, which the shared Swatinem cargo cache makes
+# cheap once warm.
+#
+# FIXTURE GATE. G0's exam and G1's data-plane scale run both hard-code the
+# 169 MB Holter Tower fixture (tests/models/ara3d/ISSUE_053_20181220Holter_Tower_10.ifc).
+# Runtime is not the problem (G0 ~7 s, G1 ~6 s once the file is on disk) -- the
+# 177 MB pull plus its entry in the repo's shared 10 GB Actions cache is. So
+# the scheduled/dispatched runs fetch it and run both; `push`/`pull_request`
+# runs fetch only duplex.ifc (2.4 MB) and SKIP those two steps with an
+# explicit "skipped: fixture-gated" line in the log AND the step summary --
+# never a silent pass. Kernel coverage on the push path is not lost: E2c, E3
+# (act 5), E5 and E6 all re-measure through the wasm geometry kernel.
+
+name: Moonshot standing evidence
+
+on:
+  schedule:
+    # Weekly, Sunday 06:41 UTC. Deliberately a different day and minute from
+    # determinism.yml (Mon 03:17) and wide-arithmetic.yml (Wed 04:29) so the
+    # three weekly lanes never share a scheduler slot.
+    - cron: '41 6 * * 0'
+  workflow_dispatch:
+    inputs:
+      holter:
+        description: 'Fetch the 169 MB Holter fixture and run the G0 / G1 scale exams'
+        type: boolean
+        default: true
+  # NOTE: the two path lists below are duplicated verbatim. GitHub Actions does
+  # not support YAML anchors/aliases in workflow files, so they cannot be
+  # shared -- keep them in lockstep by hand.
+  push:
+    branches: [main]
+    paths:
+      # The exact-CSG kernel and the meshing pipeline: E2c, E3 act 5, E5 and
+      # E6 all re-measure real geometry through the wasm bundle, so a kernel
+      # change is exactly what must re-run these.
+      - 'rust/geometry/**'
+      - 'rust/processing/**'
+      # Authoring path used by the diff-spike's seeded IFC builds (raw-hash
+      # commitments in the endpoint certificates depend on it byte-for-byte).
+      - 'packages/create/**'
+      # node-hash-v0, certificates, the merge battery: E1 through E3 rest on it.
+      - 'packages/provenance/**'
+      # The wasm bundle every kernel re-measurement goes through.
+      - 'packages/wasm/**'
+      # Seeded world generation, labeling, reward channels and the benchmark
+      # scorer: E3 acts 1/3/4 and E8.
+      - 'tools/world-gym/**'
+      # The exams themselves.
+      - 'scripts/moonshot/**'
+      - '.github/workflows/moonshot.yml'
+  pull_request:
+    branches: [main]
+    # Same list as `push` above. NOTE: path-filtered, non-blocking, and NOT to
+    # be added to branch protection -- this lane exists to be looked at, not to
+    # gate merges.
+    paths:
+      - 'rust/geometry/**'
+      - 'rust/processing/**'
+      - 'packages/create/**'
+      - 'packages/provenance/**'
+      - 'packages/wasm/**'
+      - 'tools/world-gym/**'
+      - 'scripts/moonshot/**'
+      - '.github/workflows/moonshot.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # Cancel superseded PR pushes; never cancel a scheduled evidence run.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+env:
+  # Same early opt-in as the other workflows: GitHub deprecated Node 20 for
+  # JavaScript actions, and some pinned actions here have no Node-24 release.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  # Short certified-optimization budget shared by E4/E5/E6. `--segment 96`
+  # over the 480 recorded steps yields 5 segments, which is what keeps the v2
+  # tamper battery at its full 18 cases: with the default 256-step segments the
+  # same run collapses to 2 segments, where `v2-forge-endroot` becomes vacuous
+  # (the middle segment IS the last one, so its endRoot already equals the
+  # final state root -> reported SKIPPED) and `v2-spot-sampling-miss` cannot
+  # run at all (it needs segments > spotK = min(4, segments)). Shrinking the
+  # segment size rather than growing --rounds/--max-iter buys that coverage for
+  # free: the optimizer budget, and therefore the runtime, is unchanged.
+  CERT_ARGS: '--rounds 4 --max-iter 120 --segment 96 --emit-v1'
+  # Gradient battery point count. The published M3 gate protocol is 1000
+  # points and the whole battery costs ~1.2 s, so there is nothing to save by
+  # reducing it -- running the real protocol keeps this step's PASS/FAIL
+  # identical to the number quoted in docs/vision/.
+  BATTERY_POINTS: '1000'
+
+jobs:
+  standing-evidence:
+    name: Moonshot exams (provenance, gates, B3.5 golden, certificates, determinism)
+    # Free GitHub-hosted runner -- this lane is weekly + non-blocking, so a cold
+    # cargo build is acceptable and costs nothing but wall clock.
+    runs-on: ubuntu-latest
+    # The exams themselves take ~30 s. The budget is the wasm32 build: ~3-5 min
+    # with a warm Swatinem cache, up to ~15 min cold. 30 gives cold builds room
+    # without letting a hang sit forever.
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # Fixtures live in a GitHub Release (tests/models/manifest.json,
+          # AGENTS.md section 9); the repo does not use Git LFS.
+          lfs: false
+          persist-credentials: false
+
+      - name: Setup pnpm
+        # v6 reads the version from package.json's `packageManager` field;
+        # passing `with.version` here would error with ERR_PNPM_BAD_PM_VERSION.
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          # PINNED to an exact patch, not the 22.x line. The B3.5 golden is a
+          # byte-comparison of an optimizer's output: act 5 runs projected
+          # gradient descent, and while IEEE arithmetic and JSON.stringify are
+          # spec-fixed, V8's Math.exp/log/pow are NOT - a V8 update inside the
+          # same Node major could shift a last-ulp result and turn this lane red
+          # for a reason that is not a kernel regression. The golden was blessed
+          # on v22.14.0; re-blessing is a deliberate act (assert-b35-golden.mjs
+          # --update), so the runtime that produces it is pinned too.
+          node-version: 22.14.0
+          cache: pnpm
+
+      # Rust nightly (pinned by rust-toolchain.toml) + wasm-pack + cargo cache,
+      # single-sourced with test.yml / release.yml / sdk-canary.yml /
+      # benchmark.yml so the toolchain never drifts between lanes.
+      - name: Setup WASM build toolchain
+        uses: ./.github/actions/setup-wasm-build
+        with:
+          cache-prefix: ci-moonshot
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # Built from source on purpose -- no prebuilt fast path here. A published
+      # bundle would defeat the entire lane: the point is to catch a kernel
+      # change that invalidates a published number, and that change is in the
+      # Rust source by definition.
+      - name: Build WASM bindings from source
+        run: bash scripts/build-wasm.sh
+
+      # The demos import sibling packages' built `dist/` by relative path
+      # (@ifc-lite/cli, clash, create, data, encoding, geometry, provenance,
+      # query and their transitive deps). Filtered rather than a bare
+      # `pnpm build` so the viewer/landing/embed bundles -- which nothing here
+      # imports -- are never built: 28 turbo tasks instead of 40.
+      - name: Build workspace packages the exams import
+        run: |
+          pnpm turbo build \
+            --filter=@ifc-lite/cli \
+            --filter=@ifc-lite/clash \
+            --filter=@ifc-lite/create \
+            --filter=@ifc-lite/query \
+            --filter=@ifc-lite/provenance
+
+      # --- Fixtures ------------------------------------------------------
+      - name: Decide fixture scope
+        id: fixtures
+        shell: bash
+        run: |
+          scope=minimal
+          case "${{ github.event_name }}" in
+            schedule) scope=full ;;
+            workflow_dispatch) [ "${{ inputs.holter }}" = "false" ] || scope=full ;;
+          esac
+          echo "scope=${scope}" >> "$GITHUB_OUTPUT"
+          if [ "$scope" = full ]; then
+            echo "fixture scope: FULL (duplex.ifc + the 169 MB Holter Tower) -- G0 and G1 will run."
+          else
+            echo "fixture scope: MINIMAL (duplex.ifc only) -- G0 and G1 are fixture-gated on this trigger."
+          fi
+
+      - name: Cache moonshot fixtures
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: tests/models
+          # Namespaced away from test.yml's `ci-fixtures-...` key, which holds
+          # the FULL ~994 MiB tree. This lane needs two files; restoring the
+          # whole tree would cost more than re-downloading them. The scope is
+          # part of the key so a minimal cache is never mistaken for a full one.
+          key: ci-moonshot-fixtures-${{ runner.os }}-${{ steps.fixtures.outputs.scope }}-${{ hashFiles('tests/models/manifest.json') }}
+
+      # Run unconditionally, cache hit or not: fetch-fixtures.mjs hashes what is
+      # already on disk and downloads only what is missing or wrong, so this is
+      # simultaneously the fetch and the integrity check, and a corrupt cache
+      # entry can never be used silently. FIXTURE_TIMEOUT_MS is raised from its
+      # 60 s default because that is a per-attempt budget covering the whole
+      # body: 177 MB on a slow link genuinely exceeds it and burns the retry
+      # budget on one stalled object (observed locally).
+      - name: Fetch fixtures (selective)
+        shell: bash
+        env:
+          FIXTURE_TIMEOUT_MS: '600000'
+        run: |
+          files=(ara3d/duplex.ifc)
+          if [ "${{ steps.fixtures.outputs.scope }}" = full ]; then
+            files+=(ara3d/ISSUE_053_20181220Holter_Tower_10.ifc)
+          fi
+          echo "fetching: ${files[*]}"
+          node scripts/fixtures/fetch-fixtures.mjs "${files[@]}"
+
+      # --- E1: the one thing that already had automated protection ---------
+      - name: E1 provenance unit suite (node-hash-v0, certificates, merge battery)
+        run: pnpm --filter @ifc-lite/provenance test
+
+      # --- E2: the four gate demos, each asserted on exit code -------------
+      # G0 and G1 are the Holter-gated pair; see the FIXTURE GATE note above.
+      - name: E2a gate G0 certificate demo (169 MB model, verify < 500 ms)
+        shell: bash
+        run: |
+          if [ "${{ steps.fixtures.outputs.scope }}" != full ]; then
+            echo "::notice title=E2a G0::skipped: fixture-gated (needs the 169 MB Holter Tower; fetched on schedule/workflow_dispatch only)"
+            echo '- **E2a gate G0** -- skipped: fixture-gated (Holter 169 MB)' >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          node scripts/moonshot/g0-certificate-demo.mjs
+          echo '- **E2a gate G0** -- PASS' >> "$GITHUB_STEP_SUMMARY"
+
+      - name: E2b gate G1 memoized recompute (mesh run + 100k-node scale run)
+        shell: bash
+        run: |
+          if [ "${{ steps.fixtures.outputs.scope }}" != full ]; then
+            echo "::notice title=E2b G1::skipped: fixture-gated (its data-plane scale run hard-codes the 169 MB Holter Tower; the mesh-bearing run alone cannot be selected)"
+            echo '- **E2b gate G1** -- skipped: fixture-gated (Holter 169 MB)' >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          node scripts/moonshot/g1-memoized-recompute.mjs
+          echo '- **E2b gate G1** -- PASS' >> "$GITHUB_STEP_SUMMARY"
+
+      # Meshes duplex.ifc through the wasm kernel, so this one runs on every
+      # trigger and is the push path's primary geometry tripwire alongside E3/E5.
+      - name: E2c gate G2 footprint tightness (kernel-meshed conflict predicate)
+        shell: bash
+        run: |
+          node scripts/moonshot/g2-footprint-tightness.mjs
+          echo '- **E2c gate G2 footprint tightness** -- PASS' >> "$GITHUB_STEP_SUMMARY"
+
+      - name: E2d gate G2 merge soundness (1000-schedule property battery)
+        shell: bash
+        run: |
+          node scripts/moonshot/g2-merge-soundness.mjs
+          echo '- **E2d gate G2 merge soundness** -- PASS' >> "$GITHUB_STEP_SUMMARY"
+
+      # --- E3: the five-act demo, byte-for-byte against its seeded golden ---
+      # Split in two on purpose: a red "run" step means an act threw; a red
+      # "golden" step means every act completed but a measured number moved.
+      # Those are different investigations and must not share a step name.
+      - name: E3a B3.5 five-act demo (run, master seed 20260724)
+        run: node scripts/moonshot/b35-demo/run.mjs
+
+      - name: E3b B3.5 deterministic subtree vs committed golden
+        shell: bash
+        run: |
+          node scripts/moonshot/ci/assert-b35-golden.mjs
+          echo '- **E3 B3.5 five-act demo** -- deterministic subtree matches golden' >> "$GITHUB_STEP_SUMMARY"
+
+      # --- E4/E5/E6: proof-carrying optimization ---------------------------
+      # Scope, honestly: E4 builds the chain and E5/E6 verify it IN THE SAME
+      # RUN, so the endpoint certificate binds a kernel measurement taken by
+      # the same binary that E5's re-measurement uses. That makes these steps a
+      # forgery test (can a tampered chain pass?), not a drift test (did the
+      # kernel change?) -- verified: a 1e-6 extrusion-depth perturbation in
+      # rust/geometry leaves all of E4/E5/E6 green because the chain and the
+      # verifier move together. The standing regression signal against kernel
+      # drift is E3b, whose golden is committed and therefore does NOT move.
+      - name: E4 certified optimization run (short budget, v1 + v2 chains)
+        shell: bash
+        run: |
+          # CERT_ARGS is a flag list, not one word -- split it into an array
+          # rather than relying on unquoted expansion.
+          read -r -a cert_args <<< "$CERT_ARGS"
+          node scripts/moonshot/diff-spike/optimize-certified.mjs \
+            "${cert_args[@]}" --out "$RUNNER_TEMP/certified"
+
+      - name: E5a chain verification --mode full (every segment replayed)
+        run: node scripts/moonshot/diff-spike/verify-trajectory.mjs "$RUNNER_TEMP/certified/trajectory-chain-v2.json" --mode full
+
+      - name: E5b chain verification --mode spot (sampled segments)
+        run: node scripts/moonshot/diff-spike/verify-trajectory.mjs "$RUNNER_TEMP/certified/trajectory-chain-v2.json" --mode spot
+
+      - name: E6a tamper battery v1 (per-step chain, 5 forgeries)
+        shell: bash
+        run: |
+          node scripts/moonshot/diff-spike/tamper-test.mjs "$RUNNER_TEMP/certified/trajectory-chain.json" | tee "$RUNNER_TEMP/tamper-v1.log"
+          grep -q 'tamper test PASS: control verified, 5 tampers detected' "$RUNNER_TEMP/tamper-v1.log" || {
+            echo "::error title=E6a::v1 battery exited 0 but did not report the expected 5 detected forgeries."
+            exit 1
+          }
+
+      # The count assertion is the point: a v2 case that silently turns vacuous
+      # still exits 0 (it reports SKIPPED, not FAIL), so a green exit code alone
+      # would quietly hide lost coverage. 18 = 12 forgeries + 4 spot-k guards +
+      # the sampling hit/miss pair, which is what `--segment 96` buys.
+      - name: E6b tamper battery v2 (checkpointed chain + sidecar, 18 cases)
+        shell: bash
+        run: |
+          node scripts/moonshot/diff-spike/tamper-test.mjs "$RUNNER_TEMP/certified/trajectory-chain-v2.json" | tee "$RUNNER_TEMP/tamper-v2.log"
+          grep -q 'tamper test PASS (v2): controls verified, 18 tamper cases behaved as specified' "$RUNNER_TEMP/tamper-v2.log" || {
+            echo "::error title=E6b::v2 battery did not report the full 18-case coverage."
+            echo "A case reported SKIPPED (vacuous on this chain) or the case count changed."
+            grep -n 'SKIPPED' "$RUNNER_TEMP/tamper-v2.log" || true
+            echo "Coverage depends on the chain having > 4 segments AND a middle segment that is not the"
+            echo "last one; CERT_ARGS in this workflow pins --segment 96 over 480 steps to guarantee both."
+            exit 1
+          }
+          if grep -q 'SKIPPED' "$RUNNER_TEMP/tamper-v2.log"; then
+            echo "::error title=E6b::a v2 tamper case reported SKIPPED -- coverage silently dropped."
+            grep -n 'SKIPPED' "$RUNNER_TEMP/tamper-v2.log"
+            exit 1
+          fi
+          echo '- **E4/E5/E6 proof-carrying optimization** -- chain verified (full + spot), 5 v1 + 18 v2 forgeries detected' >> "$GITHUB_STEP_SUMMARY"
+
+      # --- E7: the differentiability claim ---------------------------------
+      - name: E7 gradient battery (analytic vs central finite differences)
+        shell: bash
+        run: |
+          node scripts/moonshot/diff-spike/battery.mjs "$BATTERY_POINTS"
+          echo "- **E7 gradient battery** -- PASS at ${BATTERY_POINTS} points" >> "$GITHUB_STEP_SUMMARY"
+
+      # --- E8: the seeded-world determinism claim --------------------------
+      - name: E8 world-gym determinism (20/20 seeds byte-identical)
+        shell: bash
+        run: |
+          node tools/world-gym/determinism-check.mjs
+          echo '- **E8 world-gym determinism** -- 20/20 seeds byte-identical' >> "$GITHUB_STEP_SUMMARY"
+
+      # Runs even when something above failed, so the summary always records
+      # which trigger this was and whether the Holter-gated exams were part of
+      # the evidence. `if: always()` deliberately, but with no `continue-on-error`
+      # anywhere above -- any red step still fails the job.
+      - name: Evidence summary
+        if: always()
+        shell: bash
+        env:
+          SCOPE: ${{ steps.fixtures.outputs.scope }}
+        run: |
+          {
+            echo "### Moonshot standing evidence"
+            echo ""
+            echo "trigger: \`${{ github.event_name }}\` | fixture scope: \`${SCOPE:-not-reached}\` | commit: \`${{ github.sha }}\`"
+            echo ""
+            if [ -z "$SCOPE" ]; then
+              echo "> The job failed before the fixture scope was decided -- the failure is in setup"
+              echo "> (checkout / toolchain / wasm build / package build), not in an exam."
+              echo ""
+            elif [ "$SCOPE" != full ]; then
+              echo "> G0 and G1 were **fixture-gated** on this trigger (the 169 MB Holter Tower is fetched"
+              echo "> on \`schedule\` / \`workflow_dispatch\` only). Run this workflow manually to include them."
+              echo ""
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/moonshot.yml
+++ b/.github/workflows/moonshot.yml
@@ -20,6 +20,7 @@
 #   E1  provenance unit suite        node-hash-v0 + certificates + merge battery
 #   E2  the four gate demos          G0 / G1 / G2-footprint / G2-merge
 #   E3  B3.5 five-act demo           asserted BYTE-FOR-BYTE against a seeded golden
+#   E3c the tripwire's own exam      E3b must go RED on a seeded perturbation
 #   E4  certified optimization       short run -> v1 + v2 certificate chains
 #   E5  chain verification           --mode full AND --mode spot
 #   E6  tamper batteries             v1 (5 cases) + v2 (18 cases)
@@ -306,6 +307,31 @@ jobs:
         run: |
           node scripts/moonshot/ci/assert-b35-golden.mjs
           echo '- **E3 B3.5 five-act demo** -- deterministic subtree matches golden' >> "$GITHUB_STEP_SUMMARY"
+
+      # E3c is the only step in this lane that tests the LANE rather than the
+      # program. Every other step asserts that something is still true; this one
+      # asserts that E3b -- the single genuine drift tripwire in the whole
+      # workflow, per the G4 review's audit of all 17 assertion steps -- would
+      # actually notice if it were not. It perturbs a carbon factor by 1e-6
+      # relative, re-runs the demo, requires E3b to go red naming act 5 and
+      # `kernelValidation/kernelCarbonKg`, then restores the tree and requires
+      # E3b to go green again. It exits NON-ZERO if the tripwire stays green,
+      # which is the failure the exam is really about: an assertion that cannot
+      # fail is not evidence.
+      #
+      # Cost is ~12 s (two extra demo runs). It rewrites and restores three
+      # files under try/finally plus SIGINT/SIGTERM handlers and verifies with
+      # `git status` that it put them back, so a cancelled run cannot leave a
+      # perturbed checkout behind. It tolerates E3a's fresh `volatile`
+      # timestamps in demo-report.{json,md} -- what it requires is that the
+      # status is IDENTICAL afterwards, not that it was pristine before.
+      #
+      # The committed output of this step is scripts/moonshot/ci/self-test-evidence.txt.
+      - name: E3c B3.5 tripwire self-test (the golden must be able to fail)
+        shell: bash
+        run: |
+          node scripts/moonshot/ci/assert-b35-golden.mjs --self-test
+          echo '- **E3c B3.5 tripwire self-test** -- the golden goes red on a 1e-6 perturbation and green on restore' >> "$GITHUB_STEP_SUMMARY"
 
       # --- E4/E5/E6: proof-carrying optimization ---------------------------
       # Scope, honestly: E4 builds the chain and E5/E6 verify it IN THE SAME

--- a/docs/vision/moonshots-execution-plan.md
+++ b/docs/vision/moonshots-execution-plan.md
@@ -186,7 +186,21 @@ an agent team) plus named human time, because that is the actual currency here.
    scan input in Phase 3.
 8. **Exams.** Midterm: 100% of emitted programs compile by construction (invalid ops
    unreachable at decode time), quality scored on the M2 benchmark, beats unconstrained
-   baseline of the same base model by a wide, stated margin. Final: one real scanned room to
+   baseline of the same base model by a wide, stated margin.
+   **AMENDED 2026-07-26 (betting table, amendment 1 of moonshots-finishing-plan.md
+   section 9).** The "wide, stated margin" clause is replaced by: correctly handles
+   infeasible briefs at a rate exceeding budget-matched baselines, and recovers from
+   held-out-rule violations, both with pre-registered paired CIs, with feasible-brief
+   quality reported as a null result. Rationale: two tiers and one fresh-sample
+   replication support the amended quantity and not the original. Tier-1 was
+   instrument-limited (saturated rubric, validator rules serialized into the prompt).
+   Tier-2 held five rules out of prompts, proved rubric headroom (mediocre proposer at
+   mean 0.847), and ran three budget-matched arms: the feasible-quality margin was
+   +0.008 [0.000, 0.025] vs validator-filtered best-of-3 and 0.000 vs unfiltered; the
+   replication put both at +0.05 [0, 0.15]. Every CI touches or straddles zero. What
+   replicated exactly: infeasibility handling 3/3 vs 1/3 for both baselines, zero
+   constraint laundering. Compile-by-construction (100%) is unamended and met.
+   Final: one real scanned room to
    parametric IFC with headline quantities within 5% of a manually modeled reference, plus one
    world-model scene imported with a bill of quantities.
 
@@ -218,6 +232,18 @@ an agent team) plus named human time, because that is the actual currency here.
    agreement vs CPU on 10^8 random + adversarial near-degenerate inputs, >= 10x throughput.
    Final: one kernel stage (candidate: pairwise triangle intersection classification) running
    GPU-side with end-to-end manifest parity and >= 5x stage speedup on real models.
+   **RESOLVED 2026-07-25, met literally and lost economically (amendment 2).** On real
+   workloads extracted from the production CSG pipeline (194/194 fidelity-gated jobs
+   byte-identical), sign-for-sign manifest parity is EXACT and the speedup clause is met
+   against the equivalent exact CPU evaluation: 5.8x to 25.1x with model-wide batching.
+   Against the path that actually ships (native Shewchuk adaptive filtering) the GPU
+   LOSES on every model, 0.05x to 0.20x realized and ~0.2x asymptotic (~80 ns/tuple GPU
+   vs ~15 ns native; the degenerate-only subset cannot win either at ~65 ns, since
+   identifying it requires running the filter anyway). Per-op dispatch, the batch shape
+   the current kernel structure produces, sinks to 0.8x-1.1x on three of five models.
+   Remaining M6c exam is retargeted to publication (B6.3), not a speedup. Consequence:
+   M3's per-step projection budget re-plans around CPU threading only, which puts M6b on
+   the critical path. See scripts/moonshot/b34-kernel-stage/REPORT.md.
 
 ## 3. Phased roadmap with gates
 
@@ -226,7 +252,7 @@ Each phase ends at a betting table that doubles as the gate review. Gate criteri
 exams above; they are pre-committed and only the betting table can amend them, in writing, in
 this file.
 
-### Phase 0, one cycle (target: through early Sep 2026). "Foundations and first proof."
+### Phase 0, one cycle (target: through early Sep 2026; ACTUAL: executed 2026-07-24). "Foundations and first proof."
 
 Bets:
 - **B0.1 Hash spec + certificate v0 (M1).** Unify mesh manifests, blob hashes, and diff
@@ -242,7 +268,7 @@ Gate G0: B0.1 demo passes the M1 midterm timing on a real 100 MB fixture; B0.3 s
 without manifest changes; B0.4 runs an agent loop end to end. Fail on B0.1 = the program's
 core premise (cheap subtree replay) is wrong; stop and rethink before spending more.
 
-### Phase 1, two cycles (target: Sep-Dec 2026). "The root and the factory."
+### Phase 1, two cycles (target: Sep-Dec 2026; ACTUAL: executed 2026-07-24). "The root and the factory."
 
 Bets:
 - **B1.1 Merkle DAG + memoized recompute (M1).** Dependency-tracked recomputation through the
@@ -257,7 +283,7 @@ Bets:
 Gate G1: M1 midterm + M2 midterm + M6c spike gate, each as specified in section 2. M6c fail =
 kill M6c (ledger entry), M3's step-time budget re-planned around CPU threading only.
 
-### Phase 2, two cycles (target: Dec 2026-Mar 2027). "Theorems and training."
+### Phase 2, two cycles (target: Dec 2026-Mar 2027; ACTUAL: executed 2026-07-24/25). "Theorems and training."
 
 Bets:
 - **B2.1 Merge soundness contract (M4):** commutation certificates + conflict predicates +
@@ -273,7 +299,14 @@ Bets:
 Gate G2: M4 midterm, M5 midterm, M3 spike gate. M3 fail = downgrade M3 to derivative-free
 optimizer over the same objectives (still demo-able, no longer a moonshot claim), ledger entry.
 
-### Phase 3, two cycles (target: Mar-Jun 2027). "The compounding demo."
+### Phase 3, two cycles (target: Mar-Jun 2027; ACTUAL: executed 2026-07-24/25). "The compounding demo."
+
+**STATUS 2026-07-26 (amendment 3): three of five bets delivered.** B3.3, B3.4 and B3.5
+landed. **B3.1 (encrypted provable multiplayer) and B3.2 (scan-to-parametric) were never
+built** and are carried into Phase 5 as B5.4 and B5.5 rather than silently absorbed.
+Both skipped bets are the two that required contact with something outside the
+parametric sandbox; see the "building on the safe side of the risk" pre-mortem entry in
+moonshots-finishing-plan.md section 8.
 
 Bets:
 - **B3.1 Encrypted provable multiplayer (M4 final).**
@@ -355,3 +388,55 @@ Serial human calendar (the real schedule):
 2. Bet B0.2: add the wide-arithmetic CI lane next to determinism.yml.
 3. Bet B0.4: prototype `ifc-lite gym` as a thin CLI subcommand over existing checks.
 4. Schedule the Phase 0 betting table.
+
+---
+
+## 8. Negative-results ledger (backfilled 2026-07-26, amendment 4)
+
+Section 1 mandates a ledger entry for every killed or downgraded item so they are
+not accidentally re-spiked in a year. Until now it held effectively nothing. Backfill,
+newest first. Each entry states what was believed, what was measured, and what the
+belief costs to revive.
+
+**N1. M6c: exact predicates on GPU lose to adaptive filtering at the classification
+stage (2026-07-25).** Believed: a sign-exact GPU predicate library would accelerate the
+kernel's hot classification stage. Measured: parity exact and >= 5x versus exact CPU
+evaluation, but 0.05x-0.20x versus the production adaptive-Shewchuk path, asymptotically
+included. The adaptive filter resolves almost every predicate in floating point and never
+pays the exact-arithmetic cost the GPU is optimizing. Reviving requires either a stage
+whose realized arithmetic is genuinely exact-dominated (the escalated LPI/TPI tiers are
+the named candidate, ~5000x per call) or a consumer with no adaptive filter. Do not
+re-spike the classification stage.
+
+**N2. M2 benchmark v1.0 integrity is broken by construction (2026-07-25).** Believed:
+forbidding access to the label fields was sufficient to protect the answer key. Measured:
+`benchmark/attacks/clean-twin-diff.mjs` regenerates each seed's clean twin
+(`corruptRate: 0`, corruption lives on an independent RNG stream), diffs the bytes, and
+scores an exact 1.000 aggregate through the real scorer, above the kernel oracle (0.931)
+and the text heuristic (0.993), reading only `model.content`. Adding geometric or organic
+defect families does NOT fix this: any defect on an independent stream is isolated by the
+same diff. Reviving a public launch requires denying the adversary the clean twin
+(hosted bytes, secret per-split salt, or a real-model substrate), not a longer defect
+list. The attack stays committed as a regression.
+
+**N3. M5 feasible-brief quality margin is null (2026-07-25, replicated).** Believed:
+per-op kernel feedback would produce better programs than the same model generating
+freely. Measured across two tiers and one fresh-sample replication: no detectable
+feasible-quality margin against a budget-matched informed baseline (+0.008 [0.000, 0.025]
+and +0.05 [0, 0.15]; both CIs touch zero). The value that does replicate is at the
+infeasibility boundary (3/3 vs 1/3) and in recovery from rules held out of the prompt.
+Reviving the margin claim requires a weaker proposer or briefs whose constraint
+interactions defeat three informed samples; at Haiku strength on these tiers it is not
+there. See amendment 1.
+
+**N4. Threaded WASM as a whole-pipeline lever, re-refuted (2026-07-23, pre-dates the
+moonshot program but bears on M6b).** Measured 0.87x on the full pipeline (atomics tax).
+M6b's 2.9x-4.2x is a CSG-stage figure and must not be restated as an end-to-end one.
+
+**Calendar note (amendment 5).** Phases 0 through 3 were executed 2026-07-24/25, roughly
+eight months ahead of the targets recorded above, because the agent-build track ran far
+faster than the plan assumed while the human-calendar items (spec freeze, integrity
+decision, external recruitment) did not move. The targets are left in place as written
+rather than rewritten, since the gap between them and the actuals is itself the finding:
+agent-cycles were never the scarce resource. Phase 4 to 6 targets live in
+moonshots-finishing-plan.md.

--- a/docs/vision/moonshots-execution-plan.md
+++ b/docs/vision/moonshots-execution-plan.md
@@ -279,7 +279,7 @@ Gate G0: B0.1 demo passes the M1 midterm timing on a real 100 MB fixture; B0.3 s
 without manifest changes; B0.4 runs an agent loop end to end. Fail on B0.1 = the program's
 core premise (cheap subtree replay) is wrong; stop and rethink before spending more.
 
-### Phase 1, two cycles (target: Sep-Dec 2026; ACTUAL: executed 2026-07-24). "The root and the factory."
+### Phase 1, two cycles (target: Sep-Dec 2026; ACTUAL: executed and gated 2026-07-24, M6c verdict 2026-07-25). "The root and the factory."
 
 Bets:
 - **B1.1 Merkle DAG + memoized recompute (M1).** Dependency-tracked recomputation through the
@@ -362,9 +362,20 @@ Pre-committed kill conditions (ledger entry mandatory, resurrection requires new
   section 2, M3, risk 6). Its own oracle then showed the extrusion volume is a
   smooth closed form, so that exam could not have failed. **B4.4's PASS therefore
   neither passes nor fails this criterion.** M3's status is
-  **UNADJUDICATED pending the CSG-adjoint bet in Phase 5**; the obstruction is
-  scoped at two cycles in `scripts/moonshot/b44-kernel-adjoint/DESIGN.md`
-  section 6.1.
+  **UNADJUDICATED**, and it stays that way until a CSG-adjoint bet is run.
+  **That bet is NOT scheduled.** Phase 5 contains B5.1 to B5.5 and nothing else;
+  the CSG-adjoint work has no number, no exam, no kill clause, no statement of
+  which of B5.1 to B5.5 it would displace against the five-bet cap, and no
+  cycle-budget line. Entering a bet is a betting-table act, not a sentence in an
+  amendment, so nothing here schedules it and no reader should infer that it is
+  queued, next, or first in Phase 5. What exists is an input to that decision:
+  `scripts/moonshot/b44-kernel-adjoint/DESIGN.md` section 6.1 scopes the
+  obstruction at two cycles and names it (the exact-predicate tier is a
+  fixed-width integer type with no derivative slot).
+  Note also what the PROVISIONAL marker above does and does not mean: merging
+  #1897 makes this amendment *signed by the gate holder*, i.e. part of the
+  record. It is not approval of a CSG-adjoint bet, and it is certainly not
+  completion of one.
 - **M4:** if footprint tightening cannot get false-conflict rate below 20% on real traces,
   provable merging is technically true but practically annoying; keep the theorem, drop the
   auto-merge product claim.

--- a/docs/vision/moonshots-execution-plan.md
+++ b/docs/vision/moonshots-execution-plan.md
@@ -354,8 +354,10 @@ Pre-committed kill conditions (ledger entry mandatory, resurrection requires new
   re-gate once.
 - **M3:** spike gate is binary. No adjoint battery pass, no differentiable moonshot.
   **AMENDED 2026-07-29 (betting table, amendment 6 of moonshots-finishing-plan.md
-  section 9; signed off by Louis Truempler as gate-holder, not by the bet's
-  author).** The Phase 4 spike (B4.4) was run against the **extrusion mesher**,
+  section 9). PROVISIONAL: this amendment carries gate-holder sign-off when
+  docs PR #1897 is merged by the repo-owner account, which is what sign-off
+  means in this program - see that file's section 9.1. Until then it is the
+  proposed record, and the claim is checkable with `gh pr view 1897`.** The Phase 4 spike (B4.4) was run against the **extrusion mesher**,
   not the CSG/void path this criterion was written about (see the kill risk at
   section 2, M3, risk 6). Its own oracle then showed the extrusion volume is a
   smooth closed form, so that exam could not have failed. **B4.4's PASS therefore

--- a/docs/vision/moonshots-execution-plan.md
+++ b/docs/vision/moonshots-execution-plan.md
@@ -342,6 +342,16 @@ Pre-committed kill conditions (ledger entry mandatory, resurrection requires new
   held-out tasks by G2, the realism gap is structural; pivot corpus to augmented-real and
   re-gate once.
 - **M3:** spike gate is binary. No adjoint battery pass, no differentiable moonshot.
+  **AMENDED 2026-07-29 (betting table, amendment 6 of moonshots-finishing-plan.md
+  section 9; signed off by Louis Truempler as gate-holder, not by the bet's
+  author).** The Phase 4 spike (B4.4) was run against the **extrusion mesher**,
+  not the CSG/void path this criterion was written about (see the kill risk at
+  section 2, M3, risk 6). Its own oracle then showed the extrusion volume is a
+  smooth closed form, so that exam could not have failed. **B4.4's PASS therefore
+  neither passes nor fails this criterion.** M3's status is
+  **UNADJUDICATED pending the CSG-adjoint bet in Phase 5**; the obstruction is
+  scoped at two cycles in `scripts/moonshot/b44-kernel-adjoint/DESIGN.md`
+  section 6.1.
 - **M4:** if footprint tightening cannot get false-conflict rate below 20% on real traces,
   provable merging is technically true but practically annoying; keep the theorem, drop the
   auto-merge product claim.

--- a/docs/vision/moonshots-execution-plan.md
+++ b/docs/vision/moonshots-execution-plan.md
@@ -66,6 +66,10 @@ research that consume everything before them.
 | M6b threaded CSG | validated, not wired | 5 | docs/architecture/csg-threading-design.md: 2.9-4.2x CSG-step |
 | M6c exact predicates on GPU | untested principle | 1 | predicate cascade well-factored in kernel/predicates.rs; nothing on GPU |
 
+<!-- numeral-ok: 1.71x :: the wasm wide-arithmetic end-to-end speedup, measured by
+     docs/architecture/wasm-wide-arithmetic.md and its benchmark, not by any
+     scripts/moonshot artifact. Cited here, produced elsewhere. -->
+
 ## 2. Heilmeier catechism per moonshot
 
 Format: the eight answers, compressed. Costs are in agent-cycles (one focused Shape Up bet by
@@ -242,6 +246,13 @@ an agent team) plus named human time, because that is the actual currency here.
    identifying it requires running the filter anyway). Per-op dispatch, the batch shape
    the current kernel structure produces, sinks to 0.8x-1.1x on three of five models.
    Remaining M6c exam is retargeted to publication (B6.3), not a speedup. Consequence:
+
+<!-- numeral-ok: 0.20x, 194 :: 0.20x is the endpoint of a RANGE measured against the
+     production adaptive-Shewchuk path; report.b25.throughput.json emits speedups against
+     the exact BigInt CPU baseline (4.4x / 19.5x / 102x) and holds no production-path
+     comparison, so the ratio is computed outside the artifact. 194 is the size of the
+     fidelity-gated job corpus extracted from the production CSG benchmark, which lives
+     under benchmark/, not under scripts/moonshot. -->
    M3's per-step projection budget re-plans around CPU threading only, which puts M6b on
    the critical path. See scripts/moonshot/b34-kernel-stage/REPORT.md.
 
@@ -418,6 +429,9 @@ whose realized arithmetic is genuinely exact-dominated (the escalated LPI/TPI ti
 the named candidate, ~5000x per call) or a consumer with no adaptive filter. Do not
 re-spike the classification stage.
 
+<!-- numeral-ok: 5000x :: order-of-magnitude cost of an escalated LPI/TPI exact tier per
+     call, from the kernel's own predicate profiling, not from a b25 report. -->
+
 **N2. M2 benchmark v1.0 integrity is broken by construction (2026-07-25).** Believed:
 forbidding access to the label fields was sufficient to protect the answer key. Measured:
 `benchmark/attacks/clean-twin-diff.mjs` regenerates each seed's clean twin
@@ -428,6 +442,10 @@ defect families does NOT fix this: any defect on an independent stream is isolat
 same diff. Reviving a public launch requires denying the adversary the clean twin
 (hosted bytes, secret per-split salt, or a real-model substrate), not a longer defect
 list. The attack stays committed as a regression.
+
+<!-- numeral-ok: 0.931, 0.993 :: aggregate scores of the kernel oracle and the text
+     heuristic through the real benchmark scorer. Emitted by the benchmark harness under
+     benchmark/, not by any scripts/moonshot artifact. -->
 
 **N3. M5 feasible-brief quality margin is null (2026-07-25, replicated).** Believed:
 per-op kernel feedback would produce better programs than the same model generating

--- a/docs/vision/moonshots-finishing-plan.md
+++ b/docs/vision/moonshots-finishing-plan.md
@@ -1,0 +1,550 @@
+# Moonshots finishing plan: Phase 4 to 6
+
+Written 2026-07-26. Third document in the set, after
+[moonshots-tech.md](./moonshots-tech.md) (what and why) and
+[moonshots-execution-plan.md](./moonshots-execution-plan.md) (how, in what order).
+That second document's calendar is now fiction: it dated Phase 3 to Mar-Jun 2027
+and three of its five Phase 3 bets landed in July 2026. This document does three
+things the other two cannot:
+
+1. Corrects the record on what Phase 0 to 3 actually delivered, including two
+   bets that were never built and one exam that was met literally while being
+   lost economically.
+2. Defines what "finished" means, because the program has been chasing one of
+   three possible finish lines and treating it as all three.
+3. Plans Phases 4 to 6 to the end, with pre-committed gates, in the same
+   framework, plus the instruments the program's own red team showed were
+   missing.
+
+Nothing here is a retreat from the thesis. The thesis (neural systems propose,
+the kernel disposes) survived Phase 2 and 3 intact. What did not survive is the
+assumption that self-authored harnesses grading self-generated distributions can
+finish the job.
+
+---
+
+## 1. Correcting the record
+
+### 1.1 Phase 3 delivered three of five bets
+
+| Bet | Status | Evidence |
+|---|---|---|
+| B3.1 encrypted provable multiplayer (M4 final) | **NOT BUILT** | no artifact anywhere in `scripts/`, `tools/`, or `packages/collab` |
+| B3.2 scan-to-parametric + world-model import (M5 final) | **NOT BUILT** | same |
+| B3.3 proof-carrying optimization chain (M3 final, partial) | delivered | `scripts/moonshot/diff-spike/`, chain format v2 merged as #1888 |
+| B3.4 kernel stage on GPU with manifest parity (M6c final) | delivered, split verdict | `scripts/moonshot/b34-kernel-stage/REPORT.md` |
+| B3.5 the integrated jaw-drop | delivered | `scripts/moonshot/b35-demo/`, five acts, seeded, 7.5 s |
+
+So the two hardest final exams in the program, both requiring contact with
+something outside the parametric sandbox (encryption across three real clients;
+a real scanned room), were skipped in favour of the three that could be built
+from existing parts. That is a survivorship pattern, not a schedule accident,
+and it is the single most important fact in this document.
+
+### 1.2 The G2 red-team scorecard
+
+The adversarial review (`reviews/g2-red-team-2026-07-24.md`) raised four
+findings plus one structural criticism. Status as of today:
+
+| Finding | Status | Detail |
+|---|---|---|
+| B2.3 (M5): exam cannot measure its claim | **CLOSED** | tier-2 exam 2026-07-25 implements all five required changes (rubric headroom proven at mean 0.847 spread 0 to 1; five validator rules held out of prompts; three budget-matched arms at k=3; 23 briefs including 3 infeasible; anti-laundering intent-fidelity multiplier), then replicated on fresh samples |
+| B2.2 (M2): answer key is publicly computable | **CONFIRMED, UNFIXED** | `benchmark/attacks/clean-twin-diff.mjs` scores an exact **1.000 aggregate on dev** through the real scorer, above both anchors; spec still `1.0.0`, integrity model unchanged (correctly parked as a maintainer decision) |
+| B2.1 (M4): spatial predicate unfalsifiable | **OPEN** | `merge-model.ts` still applies ops purely per-node; spatial-structure edits explicitly outside the v0 vocabulary; no real-trace replay |
+| B2.4 (M3): gradients never touch the kernel | **OPEN and widened** | B3.3 built more certificate infrastructure on the parametric path instead of attacking adjoints through CSG |
+| Section 3: nothing verifies against the external world | **OPEN** | every result in the program is still measured on distributions the program authored |
+
+The M5 outcome deserves its honest headline, because it is the template for how
+this program should behave: the tier-2 verdict is **less** flattering than
+tier-1's, not more. The midterm's "wide margin" clause is **not met** for
+feasible generation under either run: run 1 (23 briefs) put the paired margin at
++0.008 [0.000, 0.025] against validator-filtered best-of-3 and exactly 0.000
+against unfiltered; the fresh-sample replication put both at +0.05 [0, 0.15],
+a CI that still straddles zero. What did replicate, exactly, on independent
+samples: infeasibility handling at 3/3 versus 1/3 for both baselines, and zero
+laundering. Run 1 also showed 6/6 recovery when held-out rules bite; the
+replication surfaced one repair-cap exhaustion (T2-10), so the recovery claim is
+"6/6 in one run, with a known cap-sensitivity" rather than unconditional.
+T2-F3, infeasible only under a rule that appears in no prompt, is a clean
+structural demonstration that the kernel carries unpromptable information. That
+is a real result and a narrower one than the exam asked for.
+
+### 1.3 M6c: met literally, lost economically
+
+B3.4's own report is unambiguous and needs to be read into the program record
+rather than left inside a bet directory:
+
+- Versus the equivalent exact CPU evaluation of the same stage, on real
+  extracted workloads with model-wide batching: **5.8x to 25.1x. Exam clause
+  met.** Sign-for-sign manifest parity exact.
+- Versus the actual production CPU path (native Shewchuk adaptive, the code
+  that really runs): **0.05x to 0.20x. The GPU loses on every model,
+  including asymptotically.** Per-tuple asymptote is roughly 80 ns on GPU
+  against 15 ns native, and shipping only the degenerate subset cannot win
+  (65 ns versus 80 ns) because you cannot identify the subset without running
+  the filter anyway.
+- Per-op dispatch, which is the batch shape today's kernel structure naturally
+  produces, sinks to 0.8x to 1.1x on three of five models.
+
+The honest reading: the B2.5 library beats every exact-tier CPU evaluation it is
+put against, and does not beat a well-engineered adaptive filter at this stage's
+realized arithmetic. This is a **publishable negative result of the kind the
+execution plan explicitly pre-authorised** ("Below that, publish the negative
+result; it is still a contribution"), and it has a consequence the plan also
+anticipated: M3's per-step projection budget must be re-planned around CPU
+threading only. M6b (threaded CSG, 2.9x to 4.2x, still documented as "validated
+by measurement, not yet wired into production") therefore stops being a nice
+lever and becomes the critical path for M3's interactivity claim.
+
+### 1.4 Standing evidence: zero
+
+Thirteen CI workflows exist. None runs anything under `scripts/moonshot/`
+(verified 2026-07-27: the sole grep hit in `release.yml` is a comment about SLSA
+provenance, not this program's package). The only moonshot code with automated
+protection is `@ifc-lite/provenance`'s own vitest suite. Every headline number in
+Phases 1 to 3 is therefore a measurement taken once, on one machine, on one day,
+with no tripwire if a kernel change invalidates it. The b35 demo is seeded such
+that every number outside one marked block is a pure function of seed 20260724,
+which makes it an ideal golden-output regression test that nobody is running.
+
+### 1.5 Honest TRL, revised
+
+| Moonshot | Plan's TRL (2026-07-24) | Actual today | Why the change |
+|---|---|---|---|
+| M1 proof-carrying buildings | 3 | **4** | spec + library + memoized engine + verified demos, but zero callers outside `scripts/moonshot/`; package is `private`, `0.0.1` |
+| M2 world gym | 2-3 | **5** | 100k corpus, five reward channels, `ifc-lite gym` shipped in the CLI; benchmark integrity broken by its own attack |
+| M3 differentiable buildings | 1-2 | **3** | closed-form gradients validated and certified end to end; kernel adjoints and the projection operator untouched |
+| M4 provable merges | 3 | **3** | strong battery, but the spatial half of the predicate has never produced a true conflict, so the contract is partly unfalsified |
+| M5 grounding compiler | 2 | **4** | two-tier exam with held-out rules and replication; no real input modality, no scan, no world-model import |
+| M6a wasm wide-arithmetic | 6 | **6** | CI lane exists (`wide-arithmetic.yml`); still waiting on the browser flag |
+| M6b threaded CSG | 5 | **5** | unchanged, and now on the critical path |
+| M6c exact predicates on GPU | 1 | **4, with a negative economic verdict** | real stage, real parity, loses to the production filter |
+
+TRL 4 to 5 across the board, with one shipped surface. That is a genuinely
+strong six-month position and it is not TRL 7 anywhere, which is what "finished"
+would require.
+
+---
+
+## 2. Framework: four instruments, plus three
+
+The original four stay: **Heilmeier catechism** as the planning unit, **DARPA
+phases with TRL and go/no-go gates**, **Shape Up 6-week cycles with a betting
+table**, **X-style pre-committed kill criteria**. They worked. Phases 0 to 3
+produced falsifiable exams and the program failed several of them out loud,
+which is the whole point.
+
+Three instruments are added, each answering a failure mode the last three phases
+demonstrated rather than predicted:
+
+**5. Standing evidence (answers: results decay silently).** No result counts as
+held unless a scheduled job re-derives it. A number measured once is a claim
+about the past. This is the cheapest instrument in the program and its absence
+is currently the largest single risk to everything already achieved.
+
+**6. External validity as a gate clause, not a caveat (answers: the program
+grades its own distributions).** Every remaining exam gets a paired clause
+measured on data the program did not author: real IFC from other tools, real
+edit traces, briefs written by someone else. A result that has not survived
+contact with foreign data is reported at half strength.
+
+**7. Standing adversarial review (answers: survivorship bias).** The G2 review
+was the highest-yield artifact the program produced per hour spent, and it was
+commissioned once. Every gate from G4 onward carries a mandatory adversarial
+review bet, run by a reviewer with no authorship stake in the phase, with the
+right to declare a gate failed. Its findings enter the record before the gate
+closes, not after.
+
+---
+
+## 3. Three finish lines
+
+The program has been chasing the first of these and speaking as though it had
+crossed all three.
+
+**Finish line A, research.** The exams in section 2 of the execution plan, met on
+their stated terms. Status: 4 midterms met (one on softened terms), 3 finals
+delivered of 5, 2 finals never attempted.
+
+**Finish line B, evidence.** Every held result is (a) re-derived on a schedule,
+(b) measured at least once against data the program did not author, and (c) has
+survived one adversarial review it did not commission. Status: not started.
+
+**Finish line C, product.** At least one moonshot capability reachable by a user
+who has never read `docs/vision/`. Status: exactly one item crossed
+(`ifc-lite gym`). `@ifc-lite/provenance`, declared the trust root of six
+moonshots, is a private prototype at version 0.0.1 with zero callers outside
+demo scripts.
+
+**Definition of done for this program: A, B and C, in that order of difficulty,
+with C scoped to one deliberate landing rather than six.**
+
+---
+
+## 4. Heilmeier catechism for the finish
+
+Only the answers that changed since 2026-07-24 are restated. Where an answer is
+unchanged, the original stands.
+
+### M1 proof-carrying buildings
+
+- **What is new (revised):** the library, the node-hash spec, the memoized DAG
+  engine and cheap third-party verification are all built and demonstrated. What
+  is new from here is nothing technical. It is integration: the first product
+  surface where a change ships with a certificate a stranger can check.
+- **Risks (revised):** the dominant risk is no longer hash instability, it is
+  **orphaning**. A trust root with no callers is a research artifact that will
+  drift out of sync with the product it claims to secure. Second risk: the M1
+  midterm has never been run in its stated form (the mesh-bearing run used
+  duplex, the 100 MB scale run skipped mesh leaves; the two halves have never
+  been done at once).
+- **Exams (added, Phase 4):** midterm as literally worded, single run: a wall
+  edit on the 169 MB Holter Tower fixture **with real geometry-mesh leaves
+  present**, certificate verified in a second process in under 500 ms while
+  resolving under 5% of DAG nodes.
+
+### M2 world gym
+
+- **How is it done today (revised):** by us, and broken by us. The benchmark's
+  answer key is publicly computable and the attack that proves it is committed
+  in the repo scoring a perfect 1.000.
+- **Risks (revised):** launching v1.0 publicly would be a reputational
+  liability, because the first serious adversary reproduces `clean-twin-diff` in
+  an afternoon. The integrity choice is a fork in the design premise, not a
+  patch: "regenerable by anyone" and "unbreakable answer key" cannot both hold.
+- **Exams (revised):** the M2 final's "one external group post-trains and
+  improves on a held-out split" clause is retained, and gated behind an
+  integrity model that survives `clean-twin-diff` on the split being reported.
+
+### M3 differentiable buildings
+
+- **Risks (revised):** the spike gate passed on closed-form volume formulas,
+  which the red team correctly notes were never in doubt. The kill risk named in
+  the original plan (adjoints through the CSG path may be intractable) is
+  **still entirely unmeasured**, and B3.3 spent Phase 3 building certificate
+  infrastructure on the safe side of it. Additionally, M6c's economic loss
+  removes the GPU from the projection-speed story, so the interactivity claim
+  now depends on M6b shipping.
+- **Exams (added, Phase 4, binary):** adjoints through the real mesher on the
+  rectangular-extrusion family, differentiating divergence-theorem volumes with
+  respect to design parameters, matching central finite differences to 1e-6
+  relative on 95% of a 200-point seeded battery. Pass means M3 is a moonshot.
+  Fail means invoke the pre-committed downgrade.
+
+### M4 provable merges
+
+- **Risks (revised):** the theorem is stated over an op model that cannot
+  represent the hazard the spatial rule exists for. In 1,000 schedules the
+  spatial rule produced 35 false conflicts and **zero** true ones, so both the
+  headline ("zero unsound auto-merges") and the kill metric are measured on a
+  distribution that cannot adjudicate them.
+- **Exams (revised):** the midterm's false-conflict figure must be reported
+  **restricted to schedules where the spatial rule fired**, under spatially
+  coupled apply semantics, against the plan's existing < 20% bar. The final
+  (B3.1, encrypted, three clients) is unchanged and unbuilt.
+
+### M5 grounding compiler
+
+- **Exams (amended, see section 9):** the midterm's "wide margin" clause is not
+  supported after two tiers and one replication, and should be formally amended
+  to the quantity the evidence does support: correct behaviour at the
+  infeasibility boundary and guaranteed recovery under held-out rules, both
+  with pre-registered paired CIs.
+- **Risks (revised):** at Haiku strength the proposer does not make intent-level
+  errors often enough for decode-time feedback to show a quality margin. A wide
+  margin needs either a weaker proposer or briefs whose constraint interactions
+  defeat three informed samples. Both are available; neither has been tried.
+
+### M6 geometry at silicon speed
+
+- **What is new (revised):** M6c's contribution is now a negative result with a
+  precise boundary (exact-tier evaluation versus adaptive filtering), which is
+  more publishable than a marginal win and less useful to the other moonshots.
+- **Risks (revised):** M6b is now load-bearing for M3's interactivity and is
+  still not wired into production.
+- **Exams (unchanged for M6a/M6b; M6c retargeted):** M6c's remaining exam is a
+  paper, not a speedup.
+
+---
+
+## 5. Phased roadmap, Phase 4 to 6
+
+Cadence unchanged: Shape Up 6-week cycles, phases end at a betting table that
+doubles as the gate review, gate criteria pre-committed and amendable only in
+writing in this file. Maximum five bets per phase, per the original pre-mortem.
+
+### Phase 4, one cycle. "Standing evidence and the two open findings."
+
+The shortest phase and the highest leverage. Nothing new is claimed; what is
+already claimed is made durable and the two open red-team findings are closed.
+
+**B4.1 The standing-evidence lane (instrument 5).**
+A scheduled `moonshot.yml` running: provenance vitest, g0/g1/g2 demos, the b35
+five-act demo asserted against its seeded report hashes, both tamper batteries,
+the diff-spike gradient battery at reduced point count, a short certified run
+verified in both FULL and SPOT mode, and world-gym `determinism-check`. Weekly,
+plus on any change to `rust/geometry`, `packages/create`, `packages/provenance`
+or `packages/wasm`.
+*Exam:* green in under 20 minutes; a deliberate one-bit kernel perturbation
+turns it red and names which act broke.
+
+**B4.2 Spatially coupled merge semantics (closes the B2.1 finding).**
+Give the op model semantics that can fail: hosted openings must remain inside
+their host wall, `geometry-replace` triggers a re-cut, ops can be rejected on
+spatial grounds. Re-run the 1,000-schedule battery.
+*Exam:* false-conflict rate restricted to schedules where the spatial rule
+fired, reported against the < 20% bar, with the count of spatial-only **true**
+conflicts stated explicitly.
+*Binary consequence:* if the spatial rule still yields zero true conflicts under
+coupled semantics, delete the rule and say so in the ledger. A predicate that
+never fires truthfully is not a contribution.
+
+**B4.3 Benchmark integrity v1.1 (closes the B2.2 finding; human decision).**
+Choose one of the three documented options and implement it. Recommendation, for
+the record and subject to the betting table: **hosted episode bytes for test,
+dev left open and explicitly labelled attackable-by-design, with
+`clean-twin-diff` cited in the spec as the reason.** This preserves local
+iteration, stops the spec claiming an integrity property it does not have, and
+defers the salt decision until a hosted scorer exists.
+*Exam:* `clean-twin-diff` scores at or below the always-clean anchor on the
+reporting split; spec version bumped; the attack stays committed as a
+regression.
+
+**B4.4 The M3 kernel-adjoint spike (binary).**
+A dual-number scalar type through the mesher for the rectangular-extrusion
+family, differentiating divergence-theorem volumes.
+*Exam:* as section 4. Two cycles' worth of risk compressed into one; if it needs
+more than one cycle to reach a verdict, that is itself the answer.
+
+**B4.5 The M1 midterm as worded.**
+Mesh-bearing DAG at 169 MB scale, both halves in one run.
+*Exam:* under 500 ms verification, under 5% of nodes resolved, over 90% cache
+hits on single-wall recompute, with real mesh leaves present throughout.
+
+**Gate G4.** All five exams above, plus the first standing adversarial review
+(instrument 7) commissioned against Phase 4's own results. Fail on B4.1 is not
+permitted to roll over: without the lane, later gates cannot know whether
+earlier results still hold.
+
+### Phase 5, two cycles. "Contact with the world."
+
+The phase the program has been avoiding. Every bet here is measured on data
+authored elsewhere.
+
+**B5.1 Real merge traces.** Replay the merge battery against captured
+multi-user collab sessions (the audit logs already exist).
+*Exam:* false-conflict rate on real traces against the < 20% kill bar. This is
+the metric the original plan named and the program has never measured.
+
+**B5.2 Foreign IFC.** Run the benchmark's three tasks, and the defect detector,
+against real third-party files (`tests/models`, the IfcOpenShell parity corpus,
+and at least one file exported from Revit or Tekla that nobody in this program
+has seen).
+*Exam:* report the score delta versus the synthetic corpus. Any delta is the
+finding; a large one is the most valuable result of the phase.
+
+**B5.3 Foreign briefs.** 30 or more M5 briefs written by people who are not the
+program, three samples each, pre-registered paired CIs, tier-2 rubric.
+*Exam:* infeasibility handling and repair recovery replicate on foreign briefs;
+feasible-quality margin reported with its CI whatever it says.
+
+**B5.4 B3.1 encrypted provable multiplayer (the unbuilt M4 final).**
+Three clients, randomized schedules, byte-identical convergence verified by
+hash exchange, server provably never holding plaintext.
+
+**B5.5 B3.2 scan-to-parametric (the unbuilt M5 final).**
+One real scanned room to parametric IFC, headline quantities within 5% of a
+manually modelled reference, plus one world-model scene imported with a bill of
+quantities. This is the highest-variance bet in the program and the one whose
+success would be least deniable.
+
+**Gate G5.** M4 final, M5 final, plus the external-validity clauses of B5.1 to
+B5.3. Second standing adversarial review, mandatory.
+
+### Phase 6, two cycles. "Landing and publication."
+
+**B6.1 The one deliberate landing (finish line C).**
+Certificates into the collab layer's layer publish and review flow. That surface
+already has provenance records, named AI peers, per-principal rate limits and
+audit logs, so the certificate is the missing artifact rather than a new
+concept, and it turns M1 into the governance layer the agentic-BIM press keeps
+describing. Ship `ifc-lite verify` alongside as the headless entry point.
+*Exam:* `@ifc-lite/provenance` is no longer `private`, has at least one non-demo
+caller, and an agent edit made under a region-scoped permission is verified by a
+third party who never downloads the full model. That last clause is the M1 final
+exam, and it only makes sense once there is a product surface to make the edit
+on.
+
+**B6.2 Hosted benchmark and one external lab.**
+The M2 final. Gated on B4.3.
+
+**B6.3 The M6c paper.** Exact predicates on WebGPU: the technique, the
+sign-exactness proof, the parity manifests, and the negative economic verdict
+against adaptive filtering. The negative result is the interesting half and
+nobody else is positioned to publish it. Note the shelf life: WGSL i64 or a
+WebGPU f64 extension would erode the novelty, so this is time-sensitive in a way
+no other bet is.
+
+**B6.4 The M4 convergence writeup.** Gated on B4.2 and B5.1, because the
+theorem is only worth publishing with a real-trace conflict rate attached.
+
+**B6.5 B3.5 v2: the demo, in a browser, on foreign data.**
+The current integrated demo is Node, seeded, and synthetic end to end. The
+version worth putting on a stage runs in browser tabs, starts from a file the
+audience brought, and streams certificates. Same five acts, no synthetic
+substrate.
+
+**Gate G6 = the final exams**, all six moonshots, with the external-validity
+clause attached to each. Third standing adversarial review, with the explicit
+brief of attacking the program's summary of itself.
+
+---
+
+## 6. The stretch tier
+
+Reaching for the stars, stated so it can be checked rather than admired. If all
+of the above lands, the defensible claim in mid-2027 is:
+
+**A building, from any origin, whose every change carries a machine-checkable
+receipt; a public benchmark that grades machines on it; a compiler that turns
+neural output into it; and a merge theorem that survives three encrypted
+strangers editing at once, all running in a browser tab, all re-verified every
+week by a robot that will tell you the moment it stops being true.**
+
+Every clause in that sentence maps to a numbered exam above. Three of them are
+close, two are unbuilt, one (M3's kernel adjoints) is a genuine coin flip, and
+one (M6c) has already resolved into a negative result worth publishing. That
+distribution is what an honest moonshot portfolio looks like at TRL 4 to 5.
+
+The version that would be indefensible, and which the program is currently one
+enthusiastic slide away from claiming, is the same sentence with the words
+"verified", "public" and "real" doing work the evidence does not support.
+
+---
+
+## 7. What this costs
+
+| Phase | Agent-cycles | Human days (Louis) | Cash |
+|---|---|---|---|
+| 4 | 4-5 (parallel) | 2 (gate) + 0.5 (B4.3 decision) | none |
+| 5 | 6-8 | 3 (gate) + 1 (brief recruitment) + 1 (scan capture) | model budget for B5.3; scanner access or one purchased scan |
+| 6 | 5-6 | 5 (gate) + paper writing + external lab outreach + open-sourcing decision on provenance | hosting for the benchmark scorer |
+
+Roughly 15 to 19 agent-cycles over about 8 months. As before, agent-cycles are
+not the scarce resource. The scarce resources are your gate time, three items
+that only you can sign (benchmark integrity model, provenance package going
+public, paper submissions), and one new item: **someone outside the program**,
+needed three times (foreign briefs, foreign IFC, adversarial review). Budget
+that as a real dependency rather than a favour, because Phase 5 cannot start
+without it.
+
+---
+
+## 8. Kill criteria, updated
+
+Pre-committed; ledger entry mandatory; resurrection requires new evidence.
+
+- **M1:** if B6.1 has no non-demo caller by G6, M1 is a research artifact.
+  Publish the spec and library as such, and stop describing it as the trust root
+  of the other moonshots.
+- **M2:** unchanged on realism transfer, plus: if B4.3's integrity model still
+  falls to a clean-twin-class attack at G5, retire the word "benchmark" and call
+  it an internal eval harness.
+- **M3:** B4.4 is binary. Fail means the pre-committed downgrade to
+  derivative-free optimization over the same objectives, with the B3.3
+  certificate machinery retained (it is genuinely good and format-independent)
+  and the "differentiable buildings" claim withdrawn.
+- **M4:** if the real-trace false-conflict rate (B5.1) exceeds 20%, keep the
+  theorem and drop the auto-merge product claim, exactly as originally written.
+  New clause: if B4.2 shows the spatial rule produces no true conflicts under
+  coupled semantics, delete the rule.
+- **M5:** the "wide margin" clause is amended rather than killed (section 9). If
+  B5.3's foreign briefs also show no feasible-quality margin, that is the
+  finding, and the honest product claim narrows permanently to constraint
+  discovery and infeasibility handling.
+- **M6c:** already resolved. Retarget to publication. Do not spend another cycle
+  chasing a speedup that the asymptote says is not there.
+- **M6b:** if it is not wired into production by G5, M3's interactivity claim
+  is withdrawn regardless of B4.4's outcome.
+
+**Pre-mortem, updated.** The original three (diffusion of effort, human calendar
+slips, maintenance starves the program) stand. Two new ones, both observed
+rather than predicted:
+
+4. **Building on the safe side of the risk.** Phase 3 skipped its two hardest
+   bets and polished a third. Antidote: B4.4 and B5.5 are scheduled first within
+   their phases, and a phase that delivers only its easy bets is recorded as a
+   failed phase even if every delivered exam passed.
+5. **Self-grading drift.** Every instrument in the program was authored by the
+   program. Antidote: instruments 6 and 7, and the rule that a result which has
+   not met foreign data is reported at half strength.
+
+---
+
+## 9. Amendments to the record, required in writing
+
+Per the execution plan's own rule that only the betting table may amend gate
+criteria, and only in writing in that file:
+
+1. **M5 midterm, "beats an unconstrained baseline by a wide, stated margin":**
+   amend to "correctly handles infeasible briefs at a rate exceeding
+   budget-matched baselines, and recovers from held-out-rule violations, both
+   with pre-registered paired CIs, with feasible-brief quality reported as a
+   null result." Two tiers and one replication support this and not the original.
+2. **M6c final, ">= 5x stage speedup on real models":** record as met literally
+   and lost economically, with the 0.05x to 0.20x production-path comparison in
+   the citation. Retarget the remaining exam to publication.
+3. **Phase 3 status:** record as three of five bets delivered, with B3.1 and
+   B3.2 carried into Phase 5 rather than silently absorbed.
+4. **Negative-results ledger:** the plan mandates entries for killed or
+   downgraded items and there are effectively none. Backfill: M6c's economic
+   verdict, the benchmark integrity break, and the M5 feasible-quality null.
+5. **Calendar:** replace the Phase 3 dates with actuals and this document's
+   Phase 4 to 6 targets.
+
+---
+
+## 10. Agent-buildable versus human-only, updated
+
+**Parallel track (agents, no permission blocking):** the CI lane, coupled merge
+semantics, the adjoint spike, the M1 midterm run, encrypted multiplayer
+plumbing, scan-to-parametric pipeline, foreign-IFC scoring runs, browser demo,
+paper drafts, all documentation.
+
+**Serial human calendar (the real schedule), with the new items marked:**
+
+- Benchmark integrity model decision (B4.3). **Blocking Phase 6.**
+- **NEW: making `@ifc-lite/provenance` public and non-prototype.** Blocking
+  finish line C. Note that the spec-freeze PR (#1886), which stamps
+  `node-hash-v0` at 1.0.0 and bumps the package to 0.1.0, is itself still open
+  and is a prerequisite: freezing the wire format is what makes a public
+  package's compatibility promise meaningful.
+- **NEW: recruiting the outside.** Foreign brief authors, a foreign IFC source,
+  and an adversarial reviewer with no authorship stake. Blocking Phase 5.
+- **NEW: one real scan.** Access to a scanner or a purchased scan plus a
+  manually modelled reference. Blocking B5.5.
+- Trust-root and signing-key custody (unchanged, now actually needed by B5.4).
+- Paper submissions: M6c (time-sensitive), M4 (gated on real traces).
+- External lab recruitment for the M2 final.
+- V8 advocacy for wide-arithmetic (unchanged, still cheap, still only you).
+- Every merge to main.
+
+---
+
+## 11. First moves
+
+In order, this week:
+
+1. **B4.1.** Write `moonshot.yml`. Half a day of work protecting eight months
+   of results. Right now a single kernel change could silently falsify every
+   headline in the program and nothing would say so.
+2. **Amendments 1 to 5** into `moonshots-execution-plan.md`. Ten minutes each,
+   and they stop the record hardening around claims the evidence has already
+   outrun.
+3. **B4.3 decision.** One paragraph from you unblocks Phase 6.
+4. **Schedule the Phase 4 betting table** and name the adversarial reviewer for
+   G4 at the same time, so the review is commissioned before the work it will
+   attack is finished.
+
+The order matters. Item 1 makes everything already achieved durable, item 2
+makes it honest, and items 3 and 4 are the two things nobody else can do.

--- a/docs/vision/moonshots-finishing-plan.md
+++ b/docs/vision/moonshots-finishing-plan.md
@@ -288,6 +288,33 @@ or `packages/wasm`.
 *Exam:* green in under 20 minutes; a deliberate one-bit kernel perturbation
 turns it red and names which act broke.
 
+*Result and a correction to this bet's own premise (2026-07-27).* The lane is
+built and both halves of the exam are met: 33-36 s of assertions, ~1m45s
+end to end locally, and a real kernel perturbation (`depth * 1.000001` inside
+`extrude_profile`, wasm rebuilt) turns it red naming act 5 and the three
+kernel-validation fields that moved. Two things learned by building it that
+this plan had wrong:
+
+1. **The tamper batteries are a forgery test, not a drift test.** The lane
+   builds a certified chain and verifies it *in the same run*, so the endpoint
+   certificate binds a measurement taken by the same binary the verifier uses:
+   chain and verifier move together and a kernel change cannot make them
+   disagree. Confirmed empirically - under the kernel perturbation above, every
+   chain and tamper step stayed green. **The only standing regression signal
+   against kernel drift is the committed B3.5 golden**, because it is the one
+   assertion whose reference does not move. A green tamper battery is evidence
+   about forgery resistance and says nothing about stability.
+2. **The tripwire's floor is the report's rounding, not machine epsilon.** A
+   one-ULP carbon-factor perturbation stays green (the demo report rounds carbon
+   to 3 decimals, parameters to 6); 3e-9 relative is caught. "One-bit
+   perturbation" in this exam should be read as "a perturbation that survives
+   rounding", which is the honest bar.
+
+Consequence for instrument 5: the certificate and tamper results are held by
+the lane in the *forgery* sense only. Holding them against drift would need a
+committed golden chain verified by a current binary, which is a bet, not a
+line in this one.
+
 **B4.2 Spatially coupled merge semantics (closes the B2.1 finding).**
 Give the op model semantics that can fail: hosted openings must remain inside
 their host wall, `geometry-replace` triggers a re-cut, ops can be rejected on

--- a/docs/vision/moonshots-finishing-plan.md
+++ b/docs/vision/moonshots-finishing-plan.md
@@ -674,10 +674,20 @@ amendable only in writing in this file - and the re-scope below was not.
    binary gate as originally stated.** M3's status is amended to: *adjoints
    reach the real mesher on a smooth family, verified byte-identical to
    production on the native build; adjoints through CSG remain entirely
-   unmeasured.* The CSG-adjoint bet is scheduled first in Phase 5, ahead of
-   B5.5, per the review's required item 2; `scripts/moonshot/b44-kernel-adjoint/DESIGN.md`
-   section 6.1 already scopes it at two cycles and names the obstruction (the
-   exact-predicate tier is a fixed-width integer type with no derivative slot).
+   unmeasured.*
+
+   **The CSG-adjoint bet is NOT yet scheduled** (corrected 2026-07-29 by the G4
+   re-attestation, which caught this sentence asserting the opposite while the
+   commit that wrote it declared option (b)). This amendment takes the
+   re-review's **option (b)**: the scheduling claim is withdrawn and M3's status
+   is recorded as UNADJUDICATED pending Phase 5, dated. Entering the bet is a
+   betting-table act, not a sentence in an amendment: it needs a number, an
+   exam, a kill clause, a statement of which of B5.1-B5.5 it displaces against
+   the five-bet cap, and a cycle-budget update. None of those exist yet.
+   `scripts/moonshot/b44-kernel-adjoint/DESIGN.md` section 6.1 scopes the work
+   at two cycles and names the obstruction (the exact-predicate tier is a
+   fixed-width integer type with no derivative slot), which is the input to
+   that decision, not the decision.
 7. **B4.4's grading metric amends the exam's finite-difference wording.** The
    exam reads "matching central finite differences to 1e-6 relative on 95% of a
    200-point seeded battery". The delivered result matches central finite

--- a/docs/vision/moonshots-finishing-plan.md
+++ b/docs/vision/moonshots-finishing-plan.md
@@ -54,6 +54,11 @@ findings plus one structural criticism. Status as of today:
 | B2.4 (M3): gradients never touch the kernel | **OPEN and widened** | B3.3 built more certificate infrastructure on the parametric path instead of attacking adjoints through CSG |
 | Section 3: nothing verifies against the external world | **OPEN** | every result in the program is still measured on distributions the program authored |
 
+<!-- numeral-src: 0.847 :: m5-constrained-decoding/results-tier2.json#headroom.meanQuality -->
+<!-- numeral-src: 1.000 :: none - the clean-twin-diff aggregate, produced by
+     benchmark/attacks/clean-twin-diff.mjs against the live scorer. No committed
+     artifact stores it. -->
+
 The M5 outcome deserves its honest headline, because it is the template for how
 this program should behave: the tier-2 verdict is **less** flattering than
 tier-1's, not more. The midterm's "wide margin" clause is **not met** for
@@ -84,12 +89,22 @@ rather than left inside a bet directory:
   (65 ns versus 80 ns) because you cannot identify the subset without running
   the filter anyway.
 
-  <!-- numeral-ok: 0.20x :: endpoint of a RANGE measured against the production
-       adaptive-Shewchuk path. report.b25.throughput.json emits speedups against
-       the exact BigInt CPU baseline only, so this ratio is computed outside the
-       artifact. -->
+  <!-- numeral-src: 5.8x :: b34-kernel-stage/report.b34.json#models[0].speedups.gpuWholeVsCpuBigInt -->
+  <!-- numeral-src: 25.1x :: b34-kernel-stage/report.b34.json#models[4].speedups.gpuWholeVsCpuBigInt -->
+  <!-- numeral-src: 0.05x :: b34-kernel-stage/report.b34.json#models[2].speedups.gpuWholeVsNativeShewchuk -->
+  <!-- numeral-src: 0.8x :: b34-kernel-stage/report.b34.json#models[1].speedups.gpuPerOpVsCpuBigInt -->
+  <!-- numeral-src: 1.1x :: b34-kernel-stage/report.b34.json#models[0].speedups.gpuPerOpVsCpuBigInt -->
+  <!-- numeral-src: 0.20x :: none - endpoint of a RANGE against the production
+       adaptive-Shewchuk path. The per-model maximum this file emits is
+       models[4].speedups.gpuWholeVsNativeShewchuk, and it is not 0.20x; the
+       range endpoint was computed outside the artifact and stays unbacked
+       until B3.4 emits it. -->
 - Per-op dispatch, which is the batch shape today's kernel structure naturally
   produces, sinks to 0.8x to 1.1x on three of five models.
+
+<!-- numeral-src: 2.9x, 4.2x :: none - M6b's threaded-CSG speedup range, quoted
+     from moonshots-tech.md. It was measured before this program committed any
+     artifact for it, and nothing in scripts/moonshot/ emits it. -->
 
 The honest reading: the B2.5 library beats every exact-tier CPU evaluation it is
 put against, and does not beat a well-engineered adaptive filter at this stage's
@@ -111,6 +126,8 @@ Phases 1 to 3 is therefore a measurement taken once, on one machine, on one day,
 with no tripwire if a kernel change invalidates it. The b35 demo is seeded such
 that every number outside one marked block is a pure function of seed 20260724,
 which makes it an ideal golden-output regression test that nobody is running.
+
+<!-- numeral-src: 20260724 :: b35-demo/demo-report.json#deterministic.masterSeed -->
 
 ### 1.5 Honest TRL, revised
 
@@ -239,10 +256,12 @@ unchanged, the original stands.
   respect to design parameters, matching central finite differences to 1e-6
   relative on 95% of a 200-point seeded battery. Pass means M3 is a moonshot.
   Fail means invoke the pre-committed downgrade.
-  **RETRACTED 2026-07-29 (amendment 6, signed off by Louis Truempler).** This
-  exam was run and passed, but against the extrusion mesher rather than the CSG
-  path M3's kill risk names, so "pass means M3 is a moonshot" does not hold.
-  M3 is UNADJUDICATED pending the Phase 5 CSG-adjoint bet.
+  **RETRACTED 2026-07-29 (amendment 6; PROVISIONAL until the docs PR #1897 is
+  merged by the repo owner, which is what gate-holder sign-off means - see
+  section 9.1).** This exam was run and passed, but against the extrusion mesher
+  rather than the CSG path M3's kill risk names, so "pass means M3 is a
+  moonshot" does not hold. M3 is UNADJUDICATED pending the Phase 5 CSG-adjoint
+  bet.
 
 ### M4 provable merges
 
@@ -372,6 +391,49 @@ halves are evidenced, and the two artifacts are deliberately not the same thing:
   tripwire-can-fire check; the kernel artifact is the end-to-end proof; and this
   plan now says which is which rather than letting one stand in for the other.
 
+*Step E9, the numeral gate: what a green run does and does not mean (added
+2026-07-30).* The lane's last assertion step runs
+`scripts/moonshot/ci/check-report-numerals.mjs --gate` over every bet directory
+and over `docs/vision/**`. **It is a contradiction gate, not a truth gate**, and
+its own calibration is quoted here so a green E9 can never be read as
+verification. The checker perturbs each numeral in a document by a seeded three
+to thirty percent - far outside any rounding or unit story, i.e. definitely
+wrong - and re-runs the matcher. On the `docs/vision` prose, whose haystack is
+the union of every moonshot artifact in the tree, **57.5% to 91.7% of those
+deliberately-wrong decoys came back "backed" by coincidence**, and 69.0% on this
+document, measured when the gate first went green (commit `0d5a68a2`). Two
+further limits, both measured rather than feared: about 23% of the numerals in
+the checked corpus are excused by self-certified inline `numeral-ok` markers,
+and re-introducing a known-wrong figure together with a marker makes the finding
+vanish. What a green E9 does establish is narrow and still worth having: no
+sentence in the checked corpus contradicts a committed artifact it names, and no
+excuse has outlived its reason.
+
+*The fix is per-claim binding, not a bigger haystack.* A second marker form
+names the artifact and JSON path a figure came from -
+`<!-- numeral-src: 899 :: b45-m1-midterm/scorecard.json#sensitivityElementGranularityClaim.verifyMs -->` -
+so that figure's haystack is one value and its decoy pass rate is zero. A
+binding that resolves and disagrees is a hard gate failure, and it is the only
+check in the program that can say *this sentence contradicts the field it claims
+to quote*. A binding into a bet directory not yet in this tree is PENDING: not
+counted as backed, its decoys never cleared, and enforced the day the branch
+lands. This document's load-bearing figures were bound on 2026-07-30, and this
+document's own decoy rate fell to 43.8% as a result. Over the bound subset alone
+it is 0.8% of 123 decoys, which is the number that shows the mechanism working;
+the rest of the fall is arithmetic, since every figure moved out of the union
+stops being a coin flip. The remainder is what "backed" is still worth for the
+figures that are not bound, and it is not much.
+
+<!-- numeral-src: 57.5%, 91.7%, 69.0%, 23%, 43.8%, 0.8%, 123 :: none - this checker's own decoy
+     calibration over docs/vision, printed by
+     scripts/moonshot/ci/check-report-numerals.mjs and deliberately NOT emitted
+     into any artifact: an artifact under scripts/moonshot/ joins the union
+     index this figure is a measurement OF, so emitting it would let the number
+     back itself. Reproduce with `node
+     scripts/moonshot/ci/check-report-numerals.mjs`: the 57.5-to-91.7% range and
+     69.0% are the state at commit 0d5a68a2, before per-claim binding; 43.8% and
+     the 0.8%-of-123 bound subset are this document's state after it. -->
+
 Consequence for instrument 5: the certificate and tamper results are held by
 the lane in the *forgery* sense only. Holding them against drift would need a
 committed golden chain verified by a current binary, which is a bet, not a
@@ -387,6 +449,71 @@ conflicts stated explicitly.
 *Binary consequence:* if the spatial rule still yields zero true conflicts under
 coupled semantics, delete the rule and say so in the ledger. A predicate that
 never fires truthfully is not a contribution.
+
+*G4 result note (added 2026-07-30). B4.1, B4.4 and B4.5 each received an inline
+result note and this bet - the only one that FAILED its bar - did not. That gap
+is closed here.*
+
+**The exam FAILS.** The restricted false-conflict rate is **40.82%** (20 of 49
+schedules where the spatial rule fired) against the plan's < 20% bar, and it
+fails on its own terms: the Wilson 95% interval [28.22%, 54.75%] excludes 20%.
+**Its denominator is not the bar's**, and the record must not be read as though
+it were. Three ratios, named with their denominators:
+
+| ratio | value | denominator |
+|---|---|---|
+| the bar's own quantity (false positives over commuting schedules) | 8.78% | ground-truth-commuting schedules - **passes** |
+| like-for-like comparator (precision-complement over all flagged) | 66.14% | flagged schedules |
+| the reported restricted rate | **40.82%** | flagged schedules where the spatial rule fired - **fails** |
+
+Against its like-for-like comparator the spatial rule over-approximates *less*
+than the predicate as a whole. Both facts are true and the record carries both.
+
+**The verdict was KEEP, and the threshold that produced it was
+delete-iff-zero.** The binary consequence above reads "if the spatial rule still
+yields zero true conflicts, delete the rule", so a single true conflict in 1,000
+schedules would have kept it. A pre-committed bar that one event clears is not a
+test of the rule; it is a test of whether the op model can produce the event at
+all.
+
+**Derived-cut sensitivity, measured rather than argued** (schedule stream pinned
+to the baseline, so every cell attributes the same events):
+
+| cut semantics (rows) against containment (columns) | enforced | off |
+|---|---|---|
+| **lazy** (this bet's default) | **9** | 9 |
+| **derived** (IFC, and this repo) | 3 | **0** schedule-matched; 1 when the stream is regenerated under that variant's own semantics |
+
+**The audit's finding, plainly: the delete-clause was evaluated on the one cell
+manufactured so that the rule can fire** - the default cell, top-left. The
+stored lazy cut is the dominant mechanism and sustains the whole count on its
+own, which is why turning containment off alone changes nothing; containment
+becomes load-bearing only once cuts are derived. IFC does not store cuts, and neither
+does this codebase - `rust/geometry/src/void_index.rs` builds host-to-openings
+from `IfcRelVoidsElement` and `router/voids/` subtracts at load time from the
+uncut Body, and the kernel is built for overhanging cutters
+(`drop_faces_outside_host`), so IFC imposes no containment either. Under the
+semantics IFC and this repo's own kernel implement, the rule's true catches fall
+to **zero or one**. The residual case is a referential-integrity hazard - an
+opening added into an element another client removes, i.e. `IfcRelVoidsElement`
+integrity - which a read-set check over relationship targets would catch without
+any geometry at all. KEEP therefore stands on replay-cost avoidance, not on
+soundness: `createCommutationCertificate` replays both orders regardless of the
+predicate, so zero unsound certificates are emitted with or without the rule.
+
+B5.1 on real traces remains the only test that adjudicates this, which is what
+the bet's own PR says.
+
+<!-- numeral-src: 40.82%, 8.78%, 66.14%, 28.22%, 54.75%, 49 :: none - B4.2 is
+     the one Phase 4 bet that commits no scorecard JSON. Its grid and its three
+     ratios are emitted to stdout by scripts/moonshot/g2-merge-soundness.mjs and
+     pinned by tests in packages/provenance on branch feat/b42-spatial-merge, so
+     no artifact in any tree backs them and no coincidental hit in the union
+     index may be allowed to look like one. Closing this gap - emitting a
+     scorecard from that script - is the cheapest remaining item in the
+     instrument-5 backlog. The grid's own small integers cannot be bound the
+     same way: a file-scoped marker on a bare digit would also block the honest
+     matches that digit has elsewhere in this document. -->
 
 **B4.3 Benchmark integrity v1.1 (closes the B2.2 finding; human decision).**
 Choose one of the three documented options and implement it. Recommendation, for
@@ -436,35 +563,40 @@ two axes in a table that varies one), not an invented one, and the underlying
 defect in both directions is the same: a figure whose run was never committed.
 It is committed now. Recorded here rather than by editing the dated review.
 
-<!-- numeral-ok: 21,777, 12.62%, 12.6224, 465.4ms :: B4.5's g0/g1-shape
-     element-granularity figures. 21,777 and 12.6224 are
-     sensitivityElementGranularityClaim.nodesResolved / .nodesResolvedPct in
-     scorecard-no-aggregates.json on branch feat/b45-m1-midterm and become
-     backed once that shares this tree; 12.62% is the same value written to two
-     decimals; 465.4 ms is the uncommitted run's timing, quoted here only to
-     show it does NOT match the committed 453.5 ms, and must stay unbacked. -->
+<!-- numeral-src: 21,777 :: b45-m1-midterm/scorecard-no-aggregates.json#sensitivityElementGranularityClaim.nodesResolved -->
+<!-- numeral-src: 12.6224, 12.62% :: b45-m1-midterm/scorecard-no-aggregates.json#sensitivityElementGranularityClaim.nodesResolvedPct -->
+<!-- numeral-src: 465.4ms :: none - the uncommitted run's timing, quoted here
+     only to show it does NOT match the committed 453.5 ms. It must never read
+     as backed; if it does, the sentence around it has become false. -->
 
-<!-- numeral-ok: 25,058, 24.27% :: B4.5's figures. 25,058 is a bound the G4
-     reviewer derived from the scorecard's clause-3 headroom, not a measurement;
-     24.27% is scorecard.sensitivityElementGranularityClaim.nodesResolvedPct =
-     24.2655, and it will read as backed here once
-     scripts/moonshot/b45-m1-midterm/ is in the same tree as this document -
-     today it lives on branch feat/b45-m1-midterm. -->
+<!-- numeral-ok: 25,058 :: a bound the G4 reviewer derived from the
+     scorecard's clause-3 headroom, not a measurement. -->
+<!-- numeral-src: 24.27% :: b45-m1-midterm/scorecard.json#sensitivityElementGranularityClaim.nodesResolvedPct -->
 
 *(Corrected 2026-07-29: this sentence read "907 ms" against a committed
 `scripts/moonshot/b45-m1-midterm/scorecard.json` whose
 `sensitivityElementGranularityClaim.verifyMs` is 899. The wrong figure was
 introduced by the commit remediating the previous round of wrong figures, in a
 document the numeral checker could not then see - which is why its search root
-now covers `docs/vision/**`.)*
+now covers `docs/vision/**`. What that gate is and is not worth is quoted with
+the lane's step E9 above; the figure below is bound per-claim to the field it
+comes from rather than left to the union index.)*
 
-<!-- numeral-ok: 899ms, 899, 907ms :: 899 is
-     scorecard.sensitivityElementGranularityClaim.verifyMs and reads as backed
-     once scripts/moonshot/b45-m1-midterm/ shares this tree (branch
-     feat/b45-m1-midterm today). 907 ms is quoted only in order to retract it -
-     it is the figure this correction removes, and it must stay unbacked. -->
+<!-- numeral-src: 899ms, 899 :: b45-m1-midterm/scorecard.json#sensitivityElementGranularityClaim.verifyMs -->
+<!-- numeral-src: 907ms :: none - quoted only in order to retract it. It is the
+     figure this correction removes, and a coincidental hit in the union index
+     must not be allowed to vindicate it. -->
+
 *Exam:* under 500 ms verification, under 5% of nodes resolved, over 90% cache
 hits on single-wall recompute, with real mesh leaves present throughout.
+
+<!-- numeral-src: 500ms, 5%, 90%, 95%, 20%, 1e-6 :: none - the exam BARS
+     of this phase. A bar is a decision this plan made, not a measurement any
+     bet emits, so it must never read as backed: before these were bound, every
+     one of them was being cleared against an unrelated field of
+     b34-kernel-stage/report.b34.json, which is the union-haystack pathology in
+     its purest form. -->
+<!-- numeral-src: 200 :: b44-kernel-adjoint/battery.json#[0].npoints -->
 
 **Gate G4.** All five exams above, plus the first standing adversarial review
 (instrument 7) commissioned against Phase 4's own results. Fail on B4.1 is not
@@ -651,10 +783,38 @@ criteria, and only in writing in that file:
 5. **Calendar:** replace the Phase 3 dates with actuals and this document's
    Phase 4 to 6 targets.
 
+### 9.1 What gate-holder sign-off is
+
+*Added 2026-07-30, because the sign-off recorded on amendments 6 to 8 was a
+sentence one agent wrote about another.* Everything in this repository is
+authored and committed by the same unsigned identity, so a prose line reading
+"signed off by the gate holder" is indistinguishable in the git record from the
+thing it disclaims. There is exactly **one real human signature act** available
+here, and the plan now names it:
+
+> **Gate-holder sign-off IS the merge of the gate's docs PR by the repo-owner
+> account**, or equivalently a GPG-signed tag on the docs branch head. Nothing
+> else counts. A merge is performed by an authenticated account that is not the
+> agent's, it is recorded by the forge rather than asserted in the diff, and it
+> is checkable after the fact by anyone with `gh pr view`.
+
+Consequences, stated so they can be checked rather than trusted:
+
+- **Amendments 6, 7 and 8 are PROVISIONAL until #1897 merges.** They are the
+  proposed record, entered in writing per the plan's own rule and open to
+  revision; they become the signed record at merge and not before.
+- Nothing in Phase 4 has passed sign-off as of this writing: #1886, #1897,
+  #1899, #1900 and #1902 are all open. A gate cannot close on unmerged branches,
+  which is a second, independent reason G4 stays failed.
+- Any future sentence claiming sign-off must name the PR or tag that carries it,
+  so a reader can verify the claim without trusting the writer.
+
 **Added 2026-07-29 after the G4 adversarial review failed the gate**
-(`reviews/g4-red-team-2026-07-29.md`). These three are the review's required
-item 1, entered here because the plan's own rule is that gate criteria are
-amendable only in writing in this file - and the re-scope below was not.
+(`reviews/g4-red-team-2026-07-29.md`), and re-attested the same day
+(`reviews/g4-re-attestation-2026-07-29.md`). These three are the review's
+required item 1, entered here because the plan's own rule is that gate criteria
+are amendable only in writing in this file - and the re-scope below was not.
+**All three are provisional per section 9.1 until #1897 merges.**
 
 6. **M3's Phase 4 exam was re-scoped, and the re-scope is recorded here rather
    than assumed.** `moonshots-execution-plan.md` names M3's kill risk as the
@@ -666,9 +826,8 @@ amendable only in writing in this file - and the re-scope below was not.
    family B, which has a distinct oracle and a battery-wide worst deviation of
    1.358479e-12). The conclusion is unchanged and the smoothness holds for both
    families - a functional containing no piecewise-differentiability risk.
-   <!-- numeral-ok: 2.19e-13, 1.358479e-12 :: B4.4's oracle-versus-forward-value
-        worst deviations, emitted by that bet's battery.json on branch
-        wip/b44-kernel-adjoints; not yet in this tree. -->
+   <!-- numeral-src: 2.19e-13 :: b44-kernel-adjoint/battery.json#[0].maxOracleRelDev -->
+   <!-- numeral-src: 1.358479e-12 :: b44-kernel-adjoint/battery.json#[5].maxOracleRelDev -->
    **B4.4's PASS
    therefore does NOT retire M3's kill risk and does not trigger or clear the
    binary gate as originally stated.** M3's status is amended to: *adjoints
@@ -698,13 +857,49 @@ amendable only in writing in this file - and the re-scope below was not.
    misclassified - but it is an amendment and is recorded as one. Note also
    that the accompanying "0/200 on the old metric" figure is partly a property
    of the U(-30, 30) m placement box, not of the metric alone.
-8. **Phase 4 is recorded as a FAILED phase under pre-mortem entry 4**, on the
-   review's decisive ground: the antidote ("B4.4 and B5.5 are scheduled first
-   within their phases") was applied to the schedule and not to the content.
-   Scheduling a bet first de-risks nothing if its exam has been moved to the
-   safe side beforehand. Three of four delivered bets nonetheless volunteered
-   the case against themselves, which is instruments 5 and 7 working; the
-   review found errors of framing rather than errors of fact.
+8. **Phase 4 is recorded as a FAILED phase under pre-mortem entry 4.**
+
+   *Re-grounded 2026-07-30, after an audit of this amendment itself.* This entry
+   originally grounded the failure as a phase that "delivers only its easy
+   bets", which is pre-mortem 4's clause applied verbatim. That description is
+   wrong in both directions: B4.2 and B4.4 were not easy - one required new
+   merge semantics and published a failing number against its own bar, the other
+   required a generic mesher refactor with a byte-identity proof over thousands
+   of cases - and calling them easy hides what actually went wrong. The correct
+   description is that **Phase 4 adjudicates only its safe questions**, on three
+   grounds:
+
+   (a) **B4.4's binary exam was written on a functional its own oracle proves
+   smooth**, so it could not fail - and its PASS was then used to declare M3's
+   kill criterion untriggered. Amendment 6 retracts that use.
+   (b) **The M4 delete-clause was evaluated only under the op model that
+   manufactures the rule's catches** - the stored lazy cut, which is the only
+   cut semantics under which the rule's true catches survive at all. Under the
+   derived cuts that IFC and this repo's own kernel implement they fall to zero
+   or one. See B4.2's entry in section 5 for the measured grid.
+   (c) **B4.3 was never delivered**, so gate G4's "all five exams above" clause
+   could not close regardless of how the other four scored.
+
+   **The antidote named in pre-mortem 4 is a null instrument, and this plan
+   should stop citing scheduling order as one.** "B4.4 and B5.5 are scheduled
+   first within their phases" presumes a serial schedule. Every delivered
+   Phase 4 bet ran on the same morning in its own worktree; there was no
+   "first", so the antidote never had an opportunity to apply. It would not have
+   helped if it had: an exam moved to the safe side is safe whenever it runs.
+   What would have caught all three grounds above is a different instrument -
+   **the difficulty of an exam is adjudicated before the bet runs, by someone
+   with no stake in it**, i.e. instrument 7 applied at commissioning time rather
+   than at gate time. Pre-mortem 4's antidote is replaced by that.
+
+   **The FAIL attaches to this phase's ADJUDICATIONS, not to its measurements.**
+   All four delivered bets reproduce to the digit, and three of them volunteered
+   the case against themselves before any reviewer arrived: B4.4's
+   winding-orientation trap in `create_side_walls`, B4.2's failing restricted
+   rate, and B4.5's granularity qualifier together with the geometry-traversal
+   defect it found in g0/g1. That is instruments 5 and 7 working. Both reviews
+   of this gate - the standing review and the re-attestation
+   (`reviews/g4-re-attestation-2026-07-29.md`) - found errors of framing, scope
+   and record-keeping, and neither found an error of fact.
 
 ---
 
@@ -731,6 +926,11 @@ paper drafts, all documentation.
 - Paper submissions: M6c (time-sensitive), M4 (gated on real traces).
 - External lab recruitment for the M2 final.
 - V8 advocacy for wide-arithmetic (unchanged, still cheap, still only you).
+- **NEW: gate-holder sign-off itself.** Section 9.1 defines it as the merge of
+  the gate's docs PR by the repo-owner account. That makes merging #1897 not
+  administrative tidying but the act that converts amendments 6 to 8 from
+  proposed to signed, and it is the only signature act in this program that an
+  agent structurally cannot perform or fake.
 - Every merge to main.
 
 ---

--- a/docs/vision/moonshots-finishing-plan.md
+++ b/docs/vision/moonshots-finishing-plan.md
@@ -310,6 +310,21 @@ this plan had wrong:
    perturbation" in this exam should be read as "a perturbation that survives
    rounding", which is the honest bar.
 
+*G4 review note (2026-07-29): both halves of this exam are attested rather than
+evidenced and the bet does NOT yet pass.* The only observed run is 5m27s but was
+a `pull_request` event, i.e. the configuration in which the two Holter-gated
+steps skip - so "green in under 20 minutes" has not been demonstrated in the
+configuration the exam describes. The perturbation half has **no committed
+artifact**: it exists as prose in a commit message. The plan states B4.1 may not
+roll over, so this must be closed with a committed red-run log or a `--self-test`
+mode plus one `workflow_dispatch` run with the Holter fixture. The review also
+audited all 17 assertion steps and found **1 genuine drift tripwire, 8
+self-consistent, 8 that never touch the kernel** - the blind spot is broader
+than the tamper batteries alone, and the smallest detectable regression is
+~3e-9 relative on a volume-derived scalar over one 74-element synthetic model
+(a winding or orientation regression whose volume integral is unchanged passes
+green).
+
 Consequence for instrument 5: the certificate and tamper results are held by
 the lane in the *forgery* sense only. Holding them against drift would need a
 committed golden chain verified by a current binary, which is a bet, not a
@@ -345,6 +360,14 @@ more than one cycle to reach a verdict, that is itself the answer.
 
 **B4.5 The M1 midterm as worded.**
 Mesh-bearing DAG at 169 MB scale, both halves in one run.
+*G4 review note:* delivered and reproduced, but **only clause 1 (<500 ms) had a
+real failure mode**. Clause 2 resolves O(storeys) nodes regardless of model
+size, so a bigger model makes it easier; clause 3 would need one wall edit to
+recompute >25,058 nodes to fail. Do not quote "PASS on all three clauses" as
+three independent results. The pass also holds only for a **storey-granularity**
+claim: at element granularity, which is the shape the M1 *final* exam's
+region-scoped permission actually needs, both clauses FAIL (24.27%, 907 ms).
+That row belongs in B6.1's risk register.
 *Exam:* under 500 ms verification, under 5% of nodes resolved, over 90% cache
 hits on single-wall recompute, with real mesh leaves present throughout.
 
@@ -528,6 +551,44 @@ criteria, and only in writing in that file:
    verdict, the benchmark integrity break, and the M5 feasible-quality null.
 5. **Calendar:** replace the Phase 3 dates with actuals and this document's
    Phase 4 to 6 targets.
+
+**Added 2026-07-29 after the G4 adversarial review failed the gate**
+(`reviews/g4-red-team-2026-07-29.md`). These three are the review's required
+item 1, entered here because the plan's own rule is that gate criteria are
+amendable only in writing in this file - and the re-scope below was not.
+
+6. **M3's Phase 4 exam was re-scoped, and the re-scope is recorded here rather
+   than assumed.** `moonshots-execution-plan.md` names M3's kill risk as the
+   **CSG/void path** being only piecewise-differentiable. B4.4's exam, written
+   in section 5 of this document, targets the **extrusion mesher**. The bet's
+   own oracle then proved that path's emitted volume is exactly
+   `det*xdim*ydim*depth` to 2.19e-13 at every one of 1,200 sampled points - a
+   functional containing no piecewise-differentiability risk. **B4.4's PASS
+   therefore does NOT retire M3's kill risk and does not trigger or clear the
+   binary gate as originally stated.** M3's status is amended to: *adjoints
+   reach the real mesher on a smooth family, verified byte-identical to
+   production on the native build; adjoints through CSG remain entirely
+   unmeasured.* The CSG-adjoint bet is scheduled first in Phase 5, ahead of
+   B5.5, per the review's required item 2; `scripts/moonshot/b44-kernel-adjoint/DESIGN.md`
+   section 6.1 already scopes it at two cycles and names the obstruction (the
+   exact-predicate tier is a fixed-width integer type with no derivative slot).
+7. **B4.4's grading metric amends the exam's finite-difference wording.** The
+   exam reads "matching central finite differences to 1e-6 relative on 95% of a
+   200-point seeded battery". The delivered result matches central finite
+   differences on **60% of components**; the other 40% (rigid motions, void
+   translation) are graded against a theoretical zero, because a relative
+   metric cannot adjudicate a zero derivative at any tolerance. The partition
+   is mathematically sound and the review confirmed no parameter is
+   misclassified - but it is an amendment and is recorded as one. Note also
+   that the accompanying "0/200 on the old metric" figure is partly a property
+   of the U(-30, 30) m placement box, not of the metric alone.
+8. **Phase 4 is recorded as a FAILED phase under pre-mortem entry 4**, on the
+   review's decisive ground: the antidote ("B4.4 and B5.5 are scheduled first
+   within their phases") was applied to the schedule and not to the content.
+   Scheduling a bet first de-risks nothing if its exam has been moved to the
+   safe side beforehand. Three of four delivered bets nonetheless volunteered
+   the case against themselves, which is instruments 5 and 7 working; the
+   review found errors of framing rather than errors of fact.
 
 ---
 

--- a/docs/vision/moonshots-finishing-plan.md
+++ b/docs/vision/moonshots-finishing-plan.md
@@ -230,6 +230,10 @@ unchanged, the original stands.
   respect to design parameters, matching central finite differences to 1e-6
   relative on 95% of a 200-point seeded battery. Pass means M3 is a moonshot.
   Fail means invoke the pre-committed downgrade.
+  **RETRACTED 2026-07-29 (amendment 6, signed off by Louis Truempler).** This
+  exam was run and passed, but against the extrusion mesher rather than the CSG
+  path M3's kill risk names, so "pass means M3 is a moonshot" does not hold.
+  M3 is UNADJUDICATED pending the Phase 5 CSG-adjoint bet.
 
 ### M4 provable merges
 
@@ -357,6 +361,14 @@ A dual-number scalar type through the mesher for the rectangular-extrusion
 family, differentiating divergence-theorem volumes.
 *Exam:* as section 4. Two cycles' worth of risk compressed into one; if it needs
 more than one cycle to reach a verdict, that is itself the answer.
+*G4 review note (2026-07-29), the note this entry should have carried from the
+start:* delivered and reproduced at 200/200, with production behaviour proved
+byte-identical over 4,000 cases on the native build - but **against the
+extrusion mesher, not the CSG/void path M3's kill risk names.** The bet's own
+oracle shows that path's volume is a smooth closed form, so the exam could not
+have failed. This entry does **not** adjudicate M3's binary gate; see amendment
+6. The 40% of components graded against a theoretical zero rather than against
+finite differences are covered by amendment 7.
 
 **B4.5 The M1 midterm as worded.**
 Mesh-bearing DAG at 169 MB scale, both halves in one run.
@@ -500,7 +512,11 @@ Pre-committed; ledger entry mandatory; resurrection requires new evidence.
 - **M2:** unchanged on realism transfer, plus: if B4.3's integrity model still
   falls to a clean-twin-class attack at G5, retire the word "benchmark" and call
   it an internal eval harness.
-- **M3:** B4.4 is binary. Fail means the pre-committed downgrade to
+- **M3:** B4.4 is binary. **Superseded 2026-07-29 by amendment 6:** B4.4 was
+  re-scoped to the extrusion mesher, so it does not trigger or clear this
+  criterion; M3 is unadjudicated pending the Phase 5 CSG-adjoint bet. The
+  downgrade clause below stands, unfired, and applies to that bet's outcome.
+  Fail means the pre-committed downgrade to
   derivative-free optimization over the same objectives, with the B3.3
   certificate machinery retained (it is genuinely good and format-independent)
   and the "differentiable buildings" claim withdrawn.
@@ -562,8 +578,11 @@ amendable only in writing in this file - and the re-scope below was not.
    **CSG/void path** being only piecewise-differentiable. B4.4's exam, written
    in section 5 of this document, targets the **extrusion mesher**. The bet's
    own oracle then proved that path's emitted volume is exactly
-   `det*xdim*ydim*depth` to 2.19e-13 at every one of 1,200 sampled points - a
-   functional containing no piecewise-differentiability risk. **B4.4's PASS
+   `det*xdim*ydim*depth` to 2.19e-13 across the **600 family-A points** that
+   closed form covers (corrected 2026-07-29: the battery's other 600 points are
+   family B, which has a distinct oracle and a battery-wide worst deviation of
+   1.358479e-12). The conclusion is unchanged and the smoothness holds for both
+   families - a functional containing no piecewise-differentiability risk. **B4.4's PASS
    therefore does NOT retire M3's kill risk and does not trigger or clear the
    binary gate as originally stated.** M3's status is amended to: *adjoints
    reach the real mesher on a smooth family, verified byte-identical to

--- a/docs/vision/moonshots-finishing-plan.md
+++ b/docs/vision/moonshots-finishing-plan.md
@@ -83,6 +83,11 @@ rather than left inside a bet directory:
   against 15 ns native, and shipping only the degenerate subset cannot win
   (65 ns versus 80 ns) because you cannot identify the subset without running
   the filter anyway.
+
+  <!-- numeral-ok: 0.20x :: endpoint of a RANGE measured against the production
+       adaptive-Shewchuk path. report.b25.throughput.json emits speedups against
+       the exact BigInt CPU baseline only, so this ratio is computed outside the
+       artifact. -->
 - Per-op dispatch, which is the batch shape today's kernel structure naturally
   produces, sinks to 0.8x to 1.1x on three of five models.
 
@@ -203,6 +208,10 @@ unchanged, the original stands.
   present**, certificate verified in a second process in under 500 ms while
   resolving under 5% of DAG nodes.
 
+<!-- numeral-ok: 169MB :: the on-disk size of the Holter Tower fixture
+     (tests/models/ara3d/ISSUE_053_20181220Holter_Tower_10.ifc). A fact about a
+     file, recorded in tests/models/manifest.json; no bet artifact emits it. -->
+
 ### M2 world gym
 
 - **How is it done today (revised):** by us, and broken by us. The benchmark's
@@ -290,7 +299,10 @@ verified in both FULL and SPOT mode, and world-gym `determinism-check`. Weekly,
 plus on any change to `rust/geometry`, `packages/create`, `packages/provenance`
 or `packages/wasm`.
 *Exam:* green in under 20 minutes; a deliberate one-bit kernel perturbation
-turns it red and names which act broke.
+turns it red and names which act broke. *Read "one-bit" as "the smallest change
+the artifact can represent": the committed report rounds carbon to 3 decimals,
+so a literal one-ULP nudge is below its serialization floor. The attested
+perturbation is 1e-6 relative, ~300x above the measured ~3e-9 floor.*
 
 *Result and a correction to this bet's own premise (2026-07-27).* The lane is
 built and both halves of the exam are met: 33-36 s of assertions, ~1m45s
@@ -314,6 +326,12 @@ this plan had wrong:
    perturbation" in this exam should be read as "a perturbation that survives
    rounding", which is the honest bar.
 
+<!-- numeral-ok: 3e-9 :: the measured sensitivity FLOOR of the B3.5 golden, i.e. a
+     property of the tripwire established by injection and transcribed in
+     scripts/moonshot/ci/self-test-evidence.txt. It is not a value any report
+     emits, and it must not be: the golden pins measurements, not its own
+     resolution. -->
+
 *G4 review note (2026-07-29): both halves of this exam are attested rather than
 evidenced and the bet does NOT yet pass.* The only observed run is 5m27s but was
 a `pull_request` event, i.e. the configuration in which the two Holter-gated
@@ -328,6 +346,31 @@ than the tamper batteries alone, and the smallest detectable regression is
 ~3e-9 relative on a volume-derived scalar over one 74-element synthetic model
 (a winding or orientation regression whose volume integral is unchanged passes
 green).
+
+*Closed 2026-07-29, and the record now says which perturbation was used.* Both
+halves are evidenced, and the two artifacts are deliberately not the same thing:
+
+- **Timing.** One `workflow_dispatch` run with the Holter fixture,
+  run 30441941453: **10m 01s** whole job with both Holter-gated exams running,
+  against a 20-minute bar. Transcribed in
+  `scripts/moonshot/ci/self-test-evidence.txt`.
+- **Kernel perturbation, the real one.**
+  `scripts/moonshot/ci/kernel-perturbation-evidence.txt` is the verbatim red run
+  of a **one-line change to `extrude_profile` in `rust/geometry/src/extrusion.rs`**
+  (`let depth = depth * 1.000001;`, +1e-6 relative on every extruded depth),
+  **with the wasm bundle rebuilt from source**. The golden goes red naming act 5
+  and exactly three paths, all under `acts/act5/data/kernelValidation/`; reverting
+  and rebuilding returns it to green. Reproduce with
+  `node scripts/moonshot/ci/assert-b35-golden.mjs --kernel`.
+- **What runs in the lane is NOT that.** Step E3c
+  (`assert-b35-golden.mjs --self-test`, ~12 s) perturbs a **JavaScript** carbon
+  constant, because two wasm rebuilds cannot sit in a lane whose whole budget is
+  20 minutes. The G4 re-review showed the two are not interchangeable: the JS
+  self-test still passes if the wasm kernel is disconnected from act 5 entirely,
+  since its only kernel-flavoured assertion is that `kernelCarbonKg` moved and
+  that field is a product with the perturbed constant. So E3c is the in-lane
+  tripwire-can-fire check; the kernel artifact is the end-to-end proof; and this
+  plan now says which is which rather than letting one stand in for the other.
 
 Consequence for instrument 5: the certificate and tamper results are held by
 the lane in the *forgery* sense only. Holding them against drift would need a
@@ -378,8 +421,48 @@ size, so a bigger model makes it easier; clause 3 would need one wall edit to
 recompute >25,058 nodes to fail. Do not quote "PASS on all three clauses" as
 three independent results. The pass also holds only for a **storey-granularity**
 claim: at element granularity, which is the shape the M1 *final* exam's
-region-scoped permission actually needs, both clauses FAIL (24.27%, 907 ms).
+region-scoped permission actually needs, both clauses FAIL (24.27%, 899 ms).
 That row belongs in B6.1's risk register.
+
+*Addendum 2026-07-29, and it cuts against the review.* The review's other B4.5
+catch - a table row "21,777 nodes / 12.62% / 465.4 ms / FAIL" that **no artifact
+produces** - was half right. Committing the bet's `--no-aggregates` run as
+`scripts/moonshot/b45-m1-midterm/scorecard-no-aggregates.json` shows the row is
+the element-granularity claim measured on the **g0/g1 DAG shape**: that
+artifact's `sensitivityElementGranularityClaim` reads `nodesResolved` 21,777 and
+`nodesResolvedPct` 12.6224, matching the row to the digit. Only the timing was a
+different run's. So the row was a real measurement in the wrong table (it varied
+two axes in a table that varies one), not an invented one, and the underlying
+defect in both directions is the same: a figure whose run was never committed.
+It is committed now. Recorded here rather than by editing the dated review.
+
+<!-- numeral-ok: 21,777, 12.62%, 12.6224, 465.4ms :: B4.5's g0/g1-shape
+     element-granularity figures. 21,777 and 12.6224 are
+     sensitivityElementGranularityClaim.nodesResolved / .nodesResolvedPct in
+     scorecard-no-aggregates.json on branch feat/b45-m1-midterm and become
+     backed once that shares this tree; 12.62% is the same value written to two
+     decimals; 465.4 ms is the uncommitted run's timing, quoted here only to
+     show it does NOT match the committed 453.5 ms, and must stay unbacked. -->
+
+<!-- numeral-ok: 25,058, 24.27% :: B4.5's figures. 25,058 is a bound the G4
+     reviewer derived from the scorecard's clause-3 headroom, not a measurement;
+     24.27% is scorecard.sensitivityElementGranularityClaim.nodesResolvedPct =
+     24.2655, and it will read as backed here once
+     scripts/moonshot/b45-m1-midterm/ is in the same tree as this document -
+     today it lives on branch feat/b45-m1-midterm. -->
+
+*(Corrected 2026-07-29: this sentence read "907 ms" against a committed
+`scripts/moonshot/b45-m1-midterm/scorecard.json` whose
+`sensitivityElementGranularityClaim.verifyMs` is 899. The wrong figure was
+introduced by the commit remediating the previous round of wrong figures, in a
+document the numeral checker could not then see - which is why its search root
+now covers `docs/vision/**`.)*
+
+<!-- numeral-ok: 899ms, 899, 907ms :: 899 is
+     scorecard.sensitivityElementGranularityClaim.verifyMs and reads as backed
+     once scripts/moonshot/b45-m1-midterm/ shares this tree (branch
+     feat/b45-m1-midterm today). 907 ms is quoted only in order to retract it -
+     it is the figure this correction removes, and it must stay unbacked. -->
 *Exam:* under 500 ms verification, under 5% of nodes resolved, over 90% cache
 hits on single-wall recompute, with real mesh leaves present throughout.
 
@@ -582,7 +665,11 @@ amendable only in writing in this file - and the re-scope below was not.
    closed form covers (corrected 2026-07-29: the battery's other 600 points are
    family B, which has a distinct oracle and a battery-wide worst deviation of
    1.358479e-12). The conclusion is unchanged and the smoothness holds for both
-   families - a functional containing no piecewise-differentiability risk. **B4.4's PASS
+   families - a functional containing no piecewise-differentiability risk.
+   <!-- numeral-ok: 2.19e-13, 1.358479e-12 :: B4.4's oracle-versus-forward-value
+        worst deviations, emitted by that bet's battery.json on branch
+        wip/b44-kernel-adjoints; not yet in this tree. -->
+   **B4.4's PASS
    therefore does NOT retire M3's kill risk and does not trigger or clear the
    binary gate as originally stated.** M3's status is amended to: *adjoints
    reach the real mesher on a smooth family, verified byte-identical to

--- a/docs/vision/moonshots-finishing-plan.md
+++ b/docs/vision/moonshots-finishing-plan.md
@@ -142,9 +142,10 @@ which makes it an ideal golden-output regression test that nobody is running.
 | M6b threaded CSG | 5 | **5** | unchanged, and now on the critical path |
 | M6c exact predicates on GPU | 1 | **4, with a negative economic verdict** | real stage, real parity, loses to the production filter |
 
-TRL 4 to 5 across the board, with one shipped surface. That is a genuinely
-strong six-month position and it is not TRL 7 anywhere, which is what "finished"
-would require.
+The column spans **TRL 3 to 6**, not a flat band: M6a is already 6, M3 and M4
+are still 3, and the modal value is 4. Five of the eight moved up and none moved
+down. That is a genuinely strong six-month position, with one shipped surface,
+and it is not TRL 7 anywhere - which is what "finished" would require.
 
 ---
 
@@ -279,9 +280,16 @@ unchanged, the original stands.
 
 - **Exams (amended, see section 9):** the midterm's "wide margin" clause is not
   supported after two tiers and one replication, and should be formally amended
-  to the quantity the evidence does support: correct behaviour at the
-  infeasibility boundary and guaranteed recovery under held-out rules, both
-  with pre-registered paired CIs.
+  to the quantity the evidence does support. The amendment as landed in
+  `moonshots-execution-plan.md` reads: correctly handles infeasible briefs at a
+  rate exceeding budget-matched baselines, and **recovers from held-out-rule
+  violations**, both with pre-registered paired CIs, with feasible-brief quality
+  reported as a null result. Recovery is not guaranteed and the amendment must
+  not be read as saying so: it is bounded by the tier-2 arm's repair cap of 2
+  (at most three calls per task), and the executed exam showed run 1 at 6/6
+  recovery with the replication exhausting that cap on T2-10, which then scored
+  0. The defensible claim is "6/6 in one run, with a known cap-sensitivity",
+  which is what section 1.2 already records.
 - **Risks (revised):** at Haiku strength the proposer does not make intent-level
   errors often enough for decode-time feedback to show a quality margin. A wide
   margin needs either a weaker proposer or briefs whose constraint interactions
@@ -399,15 +407,19 @@ its own calibration is quoted here so a green E9 can never be read as
 verification. The checker perturbs each numeral in a document by a seeded three
 to thirty percent - far outside any rounding or unit story, i.e. definitely
 wrong - and re-runs the matcher. On the `docs/vision` prose, whose haystack is
-the union of every moonshot artifact in the tree, **57.5% to 91.7% of those
-deliberately-wrong decoys came back "backed" by coincidence**, and 69.0% on this
-document, measured when the gate first went green (commit `0d5a68a2`). Two
-further limits, both measured rather than feared: about 23% of the numerals in
-the checked corpus are excused by self-certified inline `numeral-ok` markers,
-and re-introducing a known-wrong figure together with a marker makes the finding
-vanish. What a green E9 does establish is narrow and still worth having: no
-sentence in the checked corpus contradicts a committed artifact it names, and no
-excuse has outlived its reason.
+the union of every moonshot artifact in the tree, **between roughly 40% and
+91.7% of those deliberately-wrong decoys came back "backed" by coincidence**,
+depending on the document, with this one at the bottom of the range. The exact
+span is printed by the checker at the end of every run, computed from that run
+rather than transcribed, because a figure this document quotes about itself is
+a figure editing this document changes. Two further limits, both measured rather
+than feared: about a fifth of the numerals in the checked corpus are excused by
+self-certified inline `numeral-ok` markers, a quarter once
+`numeral-src: ... :: none` assertions are counted too, and re-introducing a
+known-wrong figure together with a marker makes the finding vanish. What a green
+E9 does establish is narrow and still worth having: no sentence in the checked
+corpus contradicts a committed artifact it names, and no excuse has outlived its
+reason.
 
 *The fix is per-claim binding, not a bigger haystack.* A second marker form
 names the artifact and JSON path a figure came from -
@@ -418,28 +430,45 @@ check in the program that can say *this sentence contradicts the field it claims
 to quote*. A binding into a bet directory not yet in this tree is PENDING: not
 counted as backed, its decoys never cleared, and enforced the day the branch
 lands. This document's load-bearing figures were bound on 2026-07-30, and this
-document's own decoy rate fell to 43.8% as a result. Over the bound subset alone
-it is 0.8% of 123 decoys, which is the number that shows the mechanism working;
-the rest of the fall is arithmetic, since every figure moved out of the union
-stops being a coin flip. The remainder is what "backed" is still worth for the
-figures that are not bound, and it is not much.
+document's own decoy rate fell as a result. **Over its bound subset alone the
+decoys clear at 0.7%, against roughly three quarters for the figures still left
+to the union index** - that gap, not the headline, is the number that shows the
+mechanism working. The rest of the fall is arithmetic, since every figure moved
+out of the union stops being a coin flip. The union-index remainder is what
+"backed" is still worth for the figures that are not bound, and it is not much.
 
-<!-- numeral-src: 57.5%, 91.7%, 69.0%, 23%, 43.8%, 0.8%, 123 :: none - this checker's own decoy
+*Why these calibration figures moved.* An earlier revision of this section
+quoted 57.5% to 91.7%, 69.0% and 43.8%. Those were real measurements of a
+checker whose decoy generator was broken for exponent-form numerals: it read the
+decimal count off the whole string, so a decoy for `2.19e-13` was written
+`toFixed(6)` and became `0.000000`, a value most artifacts hold somewhere. Every
+exponent-form figure in the program was therefore calibrated against a decoy of
+zero. Fixed in PR #1897, which is why the rates fell; nothing about the corpus
+changed.
+
+<!-- numeral-src: 40%, 57.5%, 91.7%, 69.0%, 43.8%, 0.7% :: none - this checker's own decoy
      calibration over docs/vision, printed by
      scripts/moonshot/ci/check-report-numerals.mjs and deliberately NOT emitted
      into any artifact: an artifact under scripts/moonshot/ joins the union
      index this figure is a measurement OF, so emitting it would let the number
      back itself. Reproduce with `node
-     scripts/moonshot/ci/check-report-numerals.mjs`: the 57.5-to-91.7% range and
-     69.0% are the state at commit 0d5a68a2, before per-claim binding; 43.8% and
-     the 0.8%-of-123 bound subset are this document's state after it. -->
+     scripts/moonshot/ci/check-report-numerals.mjs`, which prints the exact
+     span. The prose above is deliberately coarse at the low end and exact only
+     at 91.7% (node-hash-v0.md, the one document in the corpus this section
+     cannot perturb): this section is self-referential, so a low endpoint stated
+     to one decimal is a number that moves every time the paragraph quoting it
+     is edited. Its own bound-subset rate, 0.7%, survives that because it is
+     stable to one decimal against small edits; the unbound rate is given in
+     words for the same reason. The superseded 57.5%, 69.0% and 43.8% are quoted
+     only to retract them, in the paragraph that does so. -->
 
 Consequence for instrument 5: the certificate and tamper results are held by
 the lane in the *forgery* sense only. Holding them against drift would need a
 committed golden chain verified by a current binary, which is a bet, not a
 line in this one.
 
-**B4.2 Spatially coupled merge semantics (closes the B2.1 finding).**
+**B4.2 Spatially coupled merge semantics (bet AGAINST the B2.1 finding; B2.1
+stays OPEN - see "what B4.2 closed" at the end of this entry).**
 Give the op model semantics that can fail: hosted openings must remain inside
 their host wall, `geometry-replace` triggers a re-cut, ops can be rejected on
 spatial grounds. Re-run the 1,000-schedule battery.
@@ -501,10 +530,34 @@ any geometry at all. KEEP therefore stands on replay-cost avoidance, not on
 soundness: `createCommutationCertificate` replays both orders regardless of the
 predicate, so zero unsound certificates are emitted with or without the rule.
 
+**What B4.2 closed, and what it did not.** Three claims with three different
+denominators, separated because this record has run them together before:
+
+1. *The plan's M4 kill criterion is met, and B4.2 did not need to close it.*
+   That criterion reads "false-conflict rate below 20%" and is measured over
+   ground-truth-commuting schedules: **8.78%** (84 of 957), `killCriterionPass:
+   true` in the battery's own output.
+2. *B4.2's own restricted exam is not met.* 40.82% (20 of 49),
+   `spatialKillCriterionPass: false`. This is a precision-complement over
+   flagged-and-spatial-fired schedules; the battery's `ratios.note` says in as
+   many words that its like-for-like comparator is the 66.14% flagged rate and
+   **not** the plan's < 20% bar. Both numbers are true at once because they are
+   not the same quantity.
+3. *The B2.1 finding itself is NOT closed.* B2.1 said the spatial predicate was
+   unfalsifiable: it had never produced a true conflict, so neither the headline
+   nor the kill metric could be adjudicated on it. Coupled semantics did make it
+   fire truthfully - 29 true conflicts among the 49 schedules where the spatial
+   rule fired, 9 of them spatial-only, against zero before the bet. But the
+   derived-cut grid above shows that count is a property of the lazy-cut cell,
+   and under the cut semantics IFC and this codebase actually implement it falls
+   to zero or one. A rule that fires truthfully only under semantics nothing in
+   the stack implements is unfalsified in the sense B2.1 meant, which is why
+   section 1.2 still carries B2.1 as OPEN.
+
 B5.1 on real traces remains the only test that adjudicates this, which is what
 the bet's own PR says.
 
-<!-- numeral-src: 40.82%, 8.78%, 66.14%, 28.22%, 54.75%, 49 :: none - B4.2 is
+<!-- numeral-src: 40.82%, 8.78%, 66.14%, 28.22%, 54.75%, 49, 957 :: none - B4.2 is
      the one Phase 4 bet that commits no scorecard JSON. Its grid and its three
      ratios are emitted to stdout by scripts/moonshot/g2-merge-soundness.mjs and
      pinned by tests in packages/provenance on branch feat/b42-spatial-merge, so
@@ -515,7 +568,8 @@ the bet's own PR says.
      same way: a file-scoped marker on a bare digit would also block the honest
      matches that digit has elsewhere in this document. -->
 
-**B4.3 Benchmark integrity v1.1 (closes the B2.2 finding; human decision).**
+**B4.3 Benchmark integrity v1.1 (aimed at the B2.2 finding; human decision).
+STATUS: PENDING. Nothing about it is closed.**
 Choose one of the three documented options and implement it. Recommendation, for
 the record and subject to the betting table: **hosted episode bytes for test,
 dev left open and explicitly labelled attackable-by-design, with
@@ -525,6 +579,20 @@ defers the salt decision until a hosted scorer exists.
 *Exam:* `clean-twin-diff` scores at or below the always-clean anchor on the
 reporting split; spec version bumped; the attack stays committed as a
 regression.
+*Why it is PENDING, spelled out so no reader has to infer it.* Three things must
+happen and none of them has:
+
+1. **The integrity-model decision.** Secret per-split salt versus hosted episode
+   bytes is Louis's call and has not been made. The recommendation above is a
+   recommendation, not the decision.
+2. **The implementation of whichever option is chosen**, including the spec
+   version bump.
+3. **The clean-twin check re-run against it**, i.e. `clean-twin-diff` scoring at
+   or below the always-clean anchor on the reporting split rather than the 1.000
+   aggregate it scores today.
+
+Until all three are done, B2.2 stays **CONFIRMED, UNFIXED** in section 1.2 and
+this bet is not a Phase 4 delivery.
 
 **B4.4 The M3 kernel-adjoint spike (binary).**
 A dual-number scalar type through the mesher for the rectangular-extrusion
@@ -857,6 +925,41 @@ are amendable only in writing in this file - and the re-scope below was not.
    misclassified - but it is an amendment and is recorded as one. Note also
    that the accompanying "0/200 on the old metric" figure is partly a property
    of the U(-30, 30) m placement box, not of the metric alone.
+
+   *The amended pass condition, written out so it can be re-graded without
+   reading the harness.* **Denominator: points, not components.** Each battery
+   is 200 seeded points, a point passes iff **every** component at that point
+   passes, and the bar is the exam's own **95% of 200**. Components are
+   partitioned once, by parameter, before any measurement:
+   - **Active components** are graded strictly: relative agreement with central
+     finite differences within **1e-6**, unchanged from the exam's wording.
+     Family A is 10 parameters per point of which 6 are active (1,200 of 2,000
+     components); family B is 14 of which 8 are active (1,600 of 2,800). The
+     "60% of components" figure above is family A's split; family B's is 8 in
+     14.
+   - **Invariant components** are the parameters whose analytic derivative is
+     zero by construction (rigid motions, void translation). They are graded
+     against that theoretical zero, as `|ad| / ||ad||_inf` at the same point,
+     and pass only if that ratio is at machine-noise level. They are **not**
+     compared to finite differences at all, and this is the whole amendment:
+     FD noise on those components measures up to 7.451817e-8 absolute against a
+     true value of 0, so any relative FD criterion fails them at every
+     tolerance.
+   The delivered result under this rule: **200/200 on five of the six
+   (family, seed) batteries and 199/200 on the sixth**, all six PASS against the
+   95% bar; worst active relative error 1.262e-6 at the single failing point,
+   worst invariant ratio 2.8e-14 across all six. The retired metric - the strict
+   relative criterion applied to *all* components - scores 0/200 on every
+   battery, which is the "0/200" figure above and is a statement about zero
+   derivatives, not about the gradient.
+
+   <!-- numeral-src: 199 :: b44-kernel-adjoint/battery.json#[5].passed -->
+   <!-- numeral-src: 1.262e-6 :: b44-kernel-adjoint/battery.json#[5].maxRelErrActive -->
+   <!-- numeral-src: 2.8e-14 :: b44-kernel-adjoint/battery.json#[1].maxInvariantAdRatio -->
+   <!-- numeral-src: 7.451817e-8 :: b44-kernel-adjoint/battery.json#[5].maxInvariantFdNoise -->
+   <!-- numeral-ok: -30 :: a bound of the harness's U(-30, 30) m placement box,
+        a sampling-design constant declared in b44-kernel-adjoint/run.mjs and
+        emitted by no report. -->
 8. **Phase 4 is recorded as a FAILED phase under pre-mortem entry 4.**
 
    *Re-grounded 2026-07-30, after an audit of this amendment itself.* This entry
@@ -937,18 +1040,39 @@ paper drafts, all documentation.
 
 ## 11. First moves
 
-In order, this week:
+This list is the outstanding blockers as of 2026-07-30, not the list this
+section shipped with. The original four - write `moonshot.yml` (B4.1),
+land amendments 1 to 5, take the B4.3 decision, schedule the Phase 4 betting
+table and commission the G4 reviewer - are done except B4.3, which survives
+below. B4.1's lane exists and both halves of its exam now have committed
+artifacts; amendments 1 to 5 are in `moonshots-execution-plan.md`; the G4 review
+was commissioned, ran, and failed the gate, and its re-attestation kept it
+failed. Rewriting the list rather than ticking it is deliberate: a stale
+"do this first" list is the same defect class as a stale figure.
 
-1. **B4.1.** Write `moonshot.yml`. Half a day of work protecting eight months
-   of results. Right now a single kernel change could silently falsify every
-   headline in the program and nothing would say so.
-2. **Amendments 1 to 5** into `moonshots-execution-plan.md`. Ten minutes each,
-   and they stop the record hardening around claims the evidence has already
-   outrun.
-3. **B4.3 decision.** One paragraph from you unblocks Phase 6.
-4. **Schedule the Phase 4 betting table** and name the adversarial reviewer for
-   G4 at the same time, so the review is commissioned before the work it will
-   attack is finished.
+In order:
 
-The order matters. Item 1 makes everything already achieved durable, item 2
-makes it honest, and items 3 and 4 are the two things nobody else can do.
+1. **Merge #1897.** Section 9.1 defines gate-holder sign-off as the merge of
+   the gate's docs PR by the repo-owner account, so this merge is what converts
+   amendments 6 to 8 from proposed to signed. Nothing downstream of them is
+   settled until it happens, and no agent can perform or fake it.
+2. **B4.3 decision.** Secret per-split salt versus hosted episode bytes. One
+   paragraph from you, then the implementation and the clean-twin re-check.
+   Blocking Phase 6, and B2.2 stays CONFIRMED, UNFIXED until all three are done.
+3. **Phase 5's external-data prerequisites**, which are lead-time items and not
+   agent work: a foreign IFC source and real collaboration traces (B5.1),
+   foreign brief authors (B5.2), and one real scan plus a manually modelled
+   reference (B5.5). Phase 5 cannot start against internally authored
+   distributions without repeating the finding that section 3 of the G2 review
+   already made.
+4. **The Phase 5 betting table**, which has to settle whether the CSG-adjoint
+   bet enters at all. Amendment 6 leaves M3 UNADJUDICATED pending it, and
+   entering it needs a number, an exam, a kill clause, a statement of which of
+   B5.1 to B5.5 it displaces against the five-bet cap, and a cycle-budget
+   update. None of those exist, and writing them is a betting-table act.
+5. **Name the G5 adversarial reviewer before Phase 5's work finishes**, on the
+   same logic that made G4 worth commissioning: a reviewer named afterwards
+   reviews a record that has already hardened.
+
+Item 1 is the only one that unblocks the rest of the stack; items 2 and 3 are
+the two nobody else can do; item 4 is the decision the whole M3 line waits on.

--- a/docs/vision/moonshots-tech.md
+++ b/docs/vision/moonshots-tech.md
@@ -47,9 +47,17 @@ in CI, and together they form something no other codebase in AEC has:
    (1.9-3.1x on predicates, 1.71x end-to-end CSG, blocked only on browser flags) and threaded
    CSG via wasm-bindgen-rayon (2.9-4.2x on the CSG step, architecture validated).
 
-<!-- numeral-ok: 1.71x, 3.1x :: wasm wide-arithmetic speedups, measured by
-     docs/architecture/wasm-wide-arithmetic.md and its benchmark. Cited here,
-     produced elsewhere; no scripts/moonshot artifact emits them. -->
+<!-- numeral-src: 1.9, 1.71x, 3.1x :: none - wasm wide-arithmetic speedups: BOTH
+     endpoints of the predicate range (1.9x to 3.1x) plus the 1.71x end-to-end
+     CSG figure. Measured by docs/architecture/wasm-wide-arithmetic.md and its
+     benchmark; cited here, produced elsewhere, and no scripts/moonshot artifact
+     emits any of them. Bound to `none` rather than left to the union index so
+     that a coincidental hit on a bare 1.9 or 2.9 cannot read as provenance. -->
+<!-- numeral-src: 2.9, 4.2x :: none - BOTH endpoints of M6b's threaded-CSG range
+     (2.9x to 4.2x), a CSG-STAGE figure and not an end-to-end one; see the
+     negative-results ledger entry N4 in moonshots-execution-plan.md. Measured
+     before this program committed any artifact for it; nothing in
+     scripts/moonshot/ emits it. -->
 
 Compressed to one sentence: **this is the only geometry system in the built-world domain that
 is simultaneously exact, deterministic to the byte, content-addressable, browser-native,

--- a/docs/vision/moonshots-tech.md
+++ b/docs/vision/moonshots-tech.md
@@ -7,6 +7,9 @@ including the jaws of people who fund frontier infrastructure?
 
 ## 1. What six months actually built
 
+<!-- numeral-ok: 1,376 :: repository commit count on the day this section was
+     written, from `git rev-list --count`. A fact about the repo, not a bet
+     measurement; no artifact emits it and none should. -->
 The repo is 1,376 commits old (first commit 2026-01-12). The commit rate tripled from ~120/month
 in Jan-Apr to 368 in June. Underneath the viewer, the following assets now exist and are verified
 in CI, and together they form something no other codebase in AEC has:
@@ -43,6 +46,10 @@ in CI, and together they form something no other codebase in AEC has:
 8. **Two de-risked engine levers already measured and documented:** wasm wide-arithmetic
    (1.9-3.1x on predicates, 1.71x end-to-end CSG, blocked only on browser flags) and threaded
    CSG via wasm-bindgen-rayon (2.9-4.2x on the CSG step, architecture validated).
+
+<!-- numeral-ok: 1.71x, 3.1x :: wasm wide-arithmetic speedups, measured by
+     docs/architecture/wasm-wide-arithmetic.md and its benchmark. Cited here,
+     produced elsewhere; no scripts/moonshot artifact emits them. -->
 
 Compressed to one sentence: **this is the only geometry system in the built-world domain that
 is simultaneously exact, deterministic to the byte, content-addressable, browser-native,

--- a/docs/vision/reviews/g2-red-team-2026-07-24.md
+++ b/docs/vision/reviews/g2-red-team-2026-07-24.md
@@ -123,6 +123,9 @@ is asserted, never demonstrated: both baselines score an identical 0.977655
 because both only read surviving embedded values; no baseline exercises the
 geometry-recovery route the spec claims as deliberate headroom.
 
+<!-- numeral-ok: 0.977655 :: a quantity-estimation score produced by the M2
+     benchmark scorer under benchmark/, outside this checker's artifact set. -->
+
 **Where the original narrative is right:** the dangling-ref finding is a
 genuine product gap (oracle F1=0 on 94 planted instances, honestly scored);
 catching saturation before public launch is real.
@@ -153,6 +156,9 @@ error they structurally cannot catch:
 
 The B2.4 caveat is the narrative's most defensible item: with
 `relErr = |ad-fd|/max(|ad|,|fd|,1e-6)` and TOL 1e-6, an exact ad=0 fails
+<!-- numeral-ok: 1e-12 :: the absolute FD-noise threshold implied by the metric's
+     own 1e-6 denominator floor and 1e-6 tolerance. Arithmetic on two bars stated
+     in the same sentence, not a measurement any artifact emits. -->
 whenever FD noise exceeds 1e-12 absolute - guaranteed at f ~ 1e5 - so the 2.3%
 is a metric artifact and the translation-invariance argument for the true zero
 is sound. The real B2.4 issue is scope (admitted in its DESIGN): gradients
@@ -207,6 +213,8 @@ distribution engineered (3 m grid spacing) to keep conflicts rare.
   is the publicly computable answer key (open seed-keyed generator + clean
   twin) and generator fingerprints, not defect modality. Decisive experiment:
   implement the clean-twin-diff submission and score it on dev. Threshold: if
+<!-- numeral-ok: 0.9313 :: the oracle-kernel anchor's aggregate through the M2
+     benchmark scorer, emitted under benchmark/, outside this artifact set. -->
   it exceeds oracle-kernel's 0.9313 aggregate (prediction ~1.0 including
   quantities), v1.1 must change the integrity model, decouple triage from
   detection, and demonstrate (not assert) quantity headroom.

--- a/docs/vision/reviews/g4-re-attestation-2026-07-29.md
+++ b/docs/vision/reviews/g4-re-attestation-2026-07-29.md
@@ -1,0 +1,220 @@
+# G4 re-attestation - the second adversarial cycle
+
+Date: 2026-07-29, the same day as
+[`g4-red-team-2026-07-29.md`](./g4-red-team-2026-07-29.md) and after it. This is
+a **separate review with a separate mandate**: the first one attacked Phase 4's
+work, this one attacked Phase 4's *remediation of that review*. It is the reason
+the amendments in `moonshots-finishing-plan.md` say what they say.
+
+## Why this file is being written after the fact
+
+**The cycle it records left no committed document.** Its ruling and its seven
+exit criteria existed only inside agent messages and in the commit subjects that
+cite them by number, so the audit trail of this gate cycle was not
+reconstructible from origin - a program whose thesis is standing evidence closed
+its own gate cycle on an artifact nobody committed. Recorded here, late and
+labelled, rather than left as a hole.
+
+**What is verbatim and what is reconstructed.** Every sentence in quotation
+marks below is copied from a commit body on origin, with the commit named. The
+exit criteria themselves are **reconstructed**: the wording is lost and only the
+numbering and the closing act survive, so each one is stated as the thing the
+record proves was demanded, not as the sentence the reviewer wrote. One of the
+seven (A1) left no anchor at all and is marked as such. Reconstruction is worth
+less than the original; that is the cost of not committing it, and it is stated
+here rather than smoothed over.
+
+## Method
+
+Five attackers, a skeptic, and a judge. Each attacker took one remediation claim
+and checked it **against origin** rather than against the claim - re-reading the
+committed file, the committed artifact, and the PR body a reader actually sees,
+in the state a stranger would fetch them. The skeptic then attacked each
+attestation in turn, on the standing assumption that an attestation is a claim
+like any other. The judge ruled on what survived.
+
+The design point is narrow and worth keeping: the first review found that the
+orchestrator's verification could re-run every battery and still miss prose that
+no artifact backs. Re-attestation does not re-run anything. It reads what
+origin holds and asks whether the sentence and the artifact say the same thing.
+
+## RULING: GATE G4 STAYS FAILED
+
+The remediation closed real work - the perturbation artifact is real, the
+ablation is real, the numeral checker gates - and it did not close the gate. The
+decisive reason is in the defects below: **the round-one remediation
+re-committed the same defect class it was written to fix, three times.** A
+remediation that reproduces the failure mode under review is not a remediation
+yet.
+
+## The seven exit criteria
+
+Cited in commit subjects as "G4 item N". They are **not** the G4 review's six
+required items; see the numbering note at the end.
+
+**A1 - unrecovered.** No commit subject or body anchors an item 1, and the
+wording is lost. The one remediation thread in this cycle that carries no
+numbered anchor is the correction of PR #1900's body (defect 3 below), which is
+the most likely occupant of this slot; it is recorded here with that uncertainty
+stated rather than silently numbered.
+
+**A2 - resolve M3's adjudication status, by scheduling the CSG-adjoint bet
+properly or by withdrawing the claim that it is scheduled.** Closed as option
+(b): commit `1d5c5b97` says "M3's status is recorded as UNADJUDICATED pending
+the Phase 5 CSG-adjoint bet, rather than left as a binary that can neither pass
+nor fail. This is option (b) of the re-review's exit criterion 2." The
+withdrawal itself landed later, in `0d5a68a2`, because the amendment text had
+not actually followed the option the commit declared - defect 1.
+
+**A3 - the retraction must reach every document a reader can see, and it must be
+signed by the gate holder rather than by the party it excuses.** Two halves.
+Governance half, commit `1d5c5b97`: "Closes the governance half of the G4
+re-review's exit criterion 3: the amendments were written by the party whose
+work they excuse, in the wrong file, without the betting-table marker amendments
+1-5 all carry." Artifact half, commit `a90030c0`: B4.4's own conclusion section
+"said 'differentiable buildings survives the exam it was given' - true, and
+misleading in the one file a reader on this branch can see, because the
+retraction lives in `docs/vision` on a different branch."
+
+**A4 - correct the misstated tolerance and point count, everywhere it was
+copied.** Closed in the plan by `1d5c5b97` and in the artifacts by `98d9a6d5`.
+Defect 2.
+
+**A5 - produce a real KERNEL perturbation artifact; the shipped self-test is not
+one.** Commit `7b2cf114`: "The plan's B4.1 exam says 'a deliberate one-bit
+KERNEL perturbation turns it red'. The shipped `--self-test` perturbed a
+JavaScript carbon constant, and the adversarial re-review proved that is not
+equivalent: the wasm kernel can be disconnected from act 5 entirely and the
+self-test still passes."
+
+**A6 - the numeral checker must GATE, and it must cover `docs/vision`.** Same
+commit: the checker "now gates (`--gate`, step E9) over every bet directory AND
+`docs/vision/**`, which the review identified as the blind spot that let a
+fourth bad figure into amendment 6." Its artifact-side half is `37a08f8e`, which
+found that B4.5's own reproduction command "wrote `scorecard.json` in place, so
+the reproduction command documented in its own REPORT.md destroyed the artifact
+every later claim is checked against - that is how eleven prose/artifact
+contradictions were created here in the first place."
+
+**A7 - measure B4.2's derived-cut sensitivity instead of arguing about it, and
+restate what the spatial rule actually buys.** Commit `f2a2705d` implemented the
+semantics as a switch and "measured the full 2x2 rather than argued about it",
+returning the finding that the first review's mechanism split was wrong. Defect
+4 came out of the same work.
+
+## The four defects
+
+### 1. An amendment that contradicted its own commit message
+
+Amendment 6 asserted that the CSG-adjoint bet **is scheduled first in Phase 5,
+ahead of B5.5**, while the commit that wrote it declared it was taking option
+(b) - "the route that exists precisely to DROP that claim" (`0d5a68a2`). Phase 5
+contained B5.1 to B5.5 and nothing else: no number, no exam, no kill clause, no
+displacement against the five-bet cap, and an unchanged cycle budget.
+
+The commit that caught it states the shape of the thing plainly: "a live false
+statement of record was sitting inside the amendment written to fix the record."
+Withdrawn, and the plan now says that entering a bet is a betting-table act
+rather than a sentence in an amendment.
+
+### 2. The tolerance figure, wrong for the third time
+
+The tolerance 2.19e-13 began as a correct measurement used with a wrong scope:
+the first review wrote it as holding "at every one of 1,200 sampled points". The
+amendment written to eliminate that class of error imported the same phrase
+unchecked. Round one of the remediation corrected the plan; the artifacts it
+cited were not corrected, so B4.4's DESIGN.md still said the forward value
+matched the closed form "to 2e-13 relative across all 1,200 family-A points" -
+"wrong twice", per `98d9a6d5`, because the battery's points are half family A
+and half family B, and family B has a **different** oracle,
+`det*depth*(A_outer + A_hole/3)`. A Rust doc comment claimed family B was
+"Verified below to 1e-13", false by about 13.6x and asserted nowhere in the
+file.
+
+Corrected values: family A's worst oracle-versus-forward deviation is
+2.188857e-13 over the family-A half; the battery-wide worst, on family B, is
+1.358479e-12. The smoothness conclusion is unchanged - only the scope was
+wrong, three times, in three documents, each time inside a correction.
+
+That is also why the numeral gate now covers `docs/vision`. It still does not
+cover Rust doc comments.
+
+### 3. PR #1900's unbacked pooling row
+
+The first review had already found that B4.2's PR body carried a row reading
+`42 further seeds / 36,000 schedules pooling to ~31%` - the strongest evidence
+in its table - and that the study "exists nowhere in the repository". The row is
+quoted here as a string rather than as a figure, because it is withdrawn text
+and there is nothing for it to be checked against. Round one fixed the
+module and the ledger; **nobody fixed the PR body**, which is the document a
+reader on GitHub actually sees and the only one a reviewer of that bet reads
+end to end. The re-attestation checked origin rather than the branch and found
+the pre-restatement story still standing there.
+
+The body was rewritten in `7ddb4de7`, which records the reason in the PR itself:
+"Body rewritten after the G4 re-attestation found it still carrying the
+pre-restatement story, including a `42-seed/36,000-schedule` pooling row that
+exists in no committed artifact."
+
+The general lesson is the one this cycle keeps producing: **the record is
+whatever a stranger can fetch**, and a PR body is part of it.
+
+### 4. The false "only one of the 9" claim
+
+The sensitivity work of A7 introduced its own false claim in its own docstring:
+schedule 937 was described as "the only one of the 9 that survives every
+correction". False - the schedule-matched derived/off cell is **zero**, so none
+of the original nine survives both corrections; 937 comes from a stream
+regenerated under derived/off semantics, a schedule the baseline never drew.
+
+Commit `7ddb4de7` names the pattern rather than just the instance: "A false
+claim inside the correction written to fix false claims, which is the pattern
+this whole gate cycle keeps finding." The substantive point survives in correct
+form: 937 is the only conflict anywhere in the grid with an IFC basis, namely
+`IfcRelVoidsElement` referential integrity - an opening added into an element
+another client removes.
+
+## What the re-attestation did not dispute
+
+- Every measurement in Phase 4 still reproduces. This cycle, like the first,
+  found errors of framing, scope and record-keeping, and none of fact.
+- The ablation and the sensitivity grid are genuine new work that made the
+  program's own claim weaker and more precise, volunteered by the bet.
+- The kernel-perturbation artifact is the real thing and is sharper than the
+  self-test it replaced.
+
+## Numbering convention, so this cannot recur
+
+The collision is demonstrable in the log. Commits `9039d402` and `1d5c5b97` both
+say "G4 items 3 and 4" and implement entirely different item sets - the first
+against the G4 review's required list, the second against this cycle's exit
+criteria. Commits `841aabdc` and `7b2cf114` both say "G4 items 5 and 6", again
+against different lists. Commit `f2a2705d` says "G4 item 7", and the G4 review
+has six required items, so that citation resolves to nothing.
+
+From here:
+
+1. **A numbered list that a commit may cite must exist in a committed document
+   before the commit that cites it.** This is the rule that would have prevented
+   all of the above, and the only one that matters. An uncommitted list is not a
+   numbering scheme, it is a private one.
+2. **Cite items with a qualified tag, never a bare "item N".** `G4-R1` to
+   `G4-R6` are the G4 standing review's required items; `G4-A1` to `G4-A7` are
+   this re-attestation's exit criteria. In general `G<n>-R<k>` for a gate's
+   standing review and `G<n>-A<k>` for its re-attestation.
+3. **A cycle that produces exit criteria commits them before any commit closes
+   one.** Cheap, and it is what this file is retrofitting.
+
+<!-- numeral-ok: 937 :: a schedule index from B4.2's regenerated derived/off
+     stream on branch feat/b42-spatial-merge, which commits no scorecard JSON -
+     that bet's grid is emitted to stdout by
+     scripts/moonshot/g2-merge-soundness.mjs and pinned by provenance tests, so
+     no artifact in any tree backs it. It is the one Phase 4 headline with no
+     machine-readable source, and until one exists this marker is the whole
+     guarantee. -->
+<!-- numeral-ok: 13.6x, 1e-13, 2e-13 :: 13.6x is the ratio between the claimed
+     1e-13 and the measured 1.358479e-12, arithmetic done in the sentence;
+     1e-13 and 2e-13 are the two WRONG tolerances being retracted here and must
+     stay unbacked. -->
+<!-- numeral-src: 2.19e-13, 2.188857e-13 :: b44-kernel-adjoint/battery.json#[0].maxOracleRelDev -->
+<!-- numeral-src: 1.358479e-12 :: b44-kernel-adjoint/battery.json#[5].maxOracleRelDev -->

--- a/docs/vision/reviews/g4-red-team-2026-07-29.md
+++ b/docs/vision/reviews/g4-red-team-2026-07-29.md
@@ -18,7 +18,19 @@ review follows.
    path. The Phase 4 exam was written against the extrusion mesher, whose
    emitted volume the bet's own oracle proves is exactly
    `det*xdim*ydim*depth` to 2.19e-13 at every one of 1,200 sampled points - a
-   functional with no piecewise-differentiability risk in it. The re-scope is
+   functional with no piecewise-differentiability risk in it.
+   **Scope correction, do not quote the sentence above without it.** 2.19e-13 is
+   not a battery-wide figure. The 1,200 points are two families of 600, checked
+   against two *different* closed forms: the 600 family-A points match
+   `det*xdim*ydim*depth` to a worst 2.188857e-13, and the 600 family-B points
+   are checked against `det*depth*(A_outer + A_hole/3)`, whose worst deviation
+   is 1.358479e-12. The battery-wide maximum is therefore 1.358479e-12, on
+   family B. Full account in
+   [g4-re-attestation-2026-07-29.md, "The tolerance figure, wrong for the third
+   time"](g4-re-attestation-2026-07-29.md#2-the-tolerance-figure-wrong-for-the-third-time).
+   The smoothness conclusion this finding rests on is unaffected: both oracles
+   are closed forms, and the argument turns on a closed form EXISTING, not on
+   which tolerance it is matched to. The re-scope is
    absent from the amendment list, and the resulting PASS was used to declare
    M3's kill criterion untriggered. Pre-mortem entry 4 pre-commits the
    consequence: a phase that delivers only its easy bets is a failed phase even
@@ -102,6 +114,11 @@ adjoint claim does not.
      reviewer computed from the battery. Those artifacts live on branch
      wip/b44-kernel-adjoints and are not in this tree, so they read as unbacked
      here and will read as backed once the branches share a tree. -->
+<!-- numeral-src: 2.188857e-13 :: b44-kernel-adjoint/battery.json#[0].maxOracleRelDev -->
+<!-- numeral-src: 1.358479e-12 :: b44-kernel-adjoint/battery.json#[5].maxOracleRelDev -->
+<!-- numeral-ok: -30, -1 :: bounds of the harness's placement boxes, U(-30, 30) m
+     as run and U(-1, 1) m as the counterfactual. Sampling-design constants
+     declared in b44-kernel-adjoint/run.mjs, emitted by no report. -->
 <!-- numeral-ok: 1e-12 :: not a measurement. It is the absolute FD-noise
      threshold implied by the old metric's own 1e-6 denominator floor and 1e-6
      tolerance -- arithmetic on two bars, done in the sentence. -->

--- a/docs/vision/reviews/g4-red-team-2026-07-29.md
+++ b/docs/vision/reviews/g4-red-team-2026-07-29.md
@@ -92,6 +92,20 @@ battery** (ratios cap at 30, rectangles have 4 vertices, no duplicate vertices
 are sampled). The 4,000-case byte-identity battery does cover them; the
 adjoint claim does not.
 
+<!-- Provenance addendum, added 2026-07-29 by the gate holder for the numeral
+     gate. No sentence of this review is altered; these comments record where
+     each unbacked figure comes from. -->
+<!-- numeral-ok: 2.19e-13, 1e-15, 2.4e-8, 2.9e-8 :: B4.4's figures. 2.19e-13 and
+     1e-15 are worst oracle-versus-forward deviations from that bet's
+     battery.json / kernel-cross-check.json; 2.4e-8 is the wasm-versus-native
+     codegen gap from the same cross-check; 2.9e-8 is the measured FD noise the
+     reviewer computed from the battery. Those artifacts live on branch
+     wip/b44-kernel-adjoints and are not in this tree, so they read as unbacked
+     here and will read as backed once the branches share a tree. -->
+<!-- numeral-ok: 1e-12 :: not a measurement. It is the absolute FD-noise
+     threshold implied by the old metric's own 1e-6 denominator floor and 1e-6
+     tolerance -- arithmetic on two bars, done in the sentence. -->
+
 ## 2. B4.2 coupled merge semantics
 
 **The 9 true conflicts are real, and they are real because of two invented
@@ -131,6 +145,12 @@ better result. It does not exist.
 improvement.** The base model changed (a hosted opening in every second grid
 element; 35% of adds create openings). Flagged conflicts went *down* while a
 coupling that creates conflicts was added, which is itself the tell.
+
+<!-- numeral-ok: 40.82%, 8.78%, 49 :: B4.2's figures, emitted by that bet's
+     battery/scorecard JSON on branch feat/b42-spatial-merge, not in this tree. -->
+<!-- numeral-ok: 28.2%, 54.7% :: the reviewer's own Wilson 95% interval on 20/49,
+     computed in this document. Deliberately not backed by any artifact: it is an
+     analysis OF the bet's numbers, not one of them. -->
 
 **The golden re-bless is clean.** 48 changed lines, all inside
 `acts/act4/data/battery`; acts 1/2/3/5 byte-identical including every hash.
@@ -175,6 +195,33 @@ falsified, but **any statement of the form "the DAG covers the model" is wrong
 by ~36% of geometry on aggregated buildings**, and the g0/g1 node censuses are
 undercounts. Fix the traversal before Phase 6 re-quotes them.
 
+<!-- numeral-ok: 24.27%, 25,058, 172,526, 0.0348%, 56.1ms, 40,028, 110,632 ::
+     B4.5's figures. They are emitted by
+     scripts/moonshot/b45-m1-midterm/scorecard.json (and, for the g0/g1 DAG
+     shape, scorecard-no-aggregates.json) on branch feat/b45-m1-midterm, so they
+     read as unbacked from this tree only. 25,058 is a bound this review derived
+     from the clause-3 headroom rather than a measured value. -->
+<!-- numeral-ok: 907ms :: a faithful quotation of what B4.5's REPORT.md said on
+     the day this review was written. The committed scorecard's
+     sensitivityElementGranularityClaim.verifyMs is 899, and the report was
+     corrected to 899.0 the same day. This review is a DATED record and is not
+     rewritten to match a later artifact; the correction is carried in
+     moonshots-finishing-plan.md, which is the live document. -->
+<!-- numeral-ok: 21,777, 12.62%, 465.4ms :: the row this review reports as
+     produced by no artifact. SUPERSEDED IN PART, 2026-07-29: committing B4.5's
+     `--no-aggregates` run (scorecard-no-aggregates.json) showed the row was an
+     element-granularity claim measured on the g0/g1 DAG SHAPE -- the artifact's
+     sensitivityElementGranularityClaim reads nodesResolved 21,777 and
+     nodesResolvedPct 12.6224, matching this row to the digit; only 465.4 ms is
+     a different run's timing (committed: 453.5 ms). The review's finding stands
+     as to the committed artifacts and as to the row being in the wrong table;
+     it overstated in saying the numbers exist nowhere. The review text is left
+     as written, being dated; the correction lives in
+     moonshots-finishing-plan.md and in B4.5's REPORT.md. Expect the first two
+     tokens to go STALE here once feat/b45-m1-midterm shares this tree -- that
+     is the anti-rot check working, and the fix is to delete them from this
+     line. -->
+
 ## 4. B4.1 what the lane actually protects
 
 Applying "would this notice a silent kernel change?" to all 17 assertion steps:
@@ -201,6 +248,11 @@ discovered live in `create_side_walls` is invisible to it.
 and only for quantities feeding a volume integral, on the elements present in
 one synthetic model. "One-bit perturbation" in the exam should be read as
 "a >= 3e-9 relative change in the volume of one of 74 synthetic walls".
+
+<!-- numeral-ok: 3e-9 :: the measured sensitivity FLOOR of the B3.5 golden, i.e.
+     a property of the tripwire established by injection and transcribed in
+     scripts/moonshot/ci/self-test-evidence.txt. No report emits it, and none
+     should: the golden pins measurements, not its own resolution. -->
 
 **Four structural gaps.** (a) The paths filter omits `rust/core/**` (parser,
 units), `rust/wasm-bindings/**` (the crate actually compiled),

--- a/docs/vision/reviews/g4-red-team-2026-07-29.md
+++ b/docs/vision/reviews/g4-red-team-2026-07-29.md
@@ -1,0 +1,304 @@
+# G4 Standing Adversarial Review - Phase 4
+
+Date: 2026-07-29. Reviewer: standing adversarial reviewer commissioned under
+instrument 7 of the finishing plan, with no authorship stake in any Phase 4 bet
+and the pre-committed authority to fail the gate. Read-only throughout; every
+headline re-run from the bet's own worktree, every prose claim checked against
+the artifact that is supposed to back it.
+
+## VERDICT: GATE G4 FAILS
+
+Not because the work is bad - three of four delivered bets are high quality and
+two published their own bad news unprompted - but because the gate's own
+pre-committed terms are not met. Three grounds, summarized here; the full
+review follows.
+
+1. **The binary risk was not attacked, it was re-scoped, and the re-scope was
+   not recorded.** The execution plan names M3's kill risk as the CSG/void
+   path. The Phase 4 exam was written against the extrusion mesher, whose
+   emitted volume the bet's own oracle proves is exactly
+   `det*xdim*ydim*depth` to 2.19e-13 at every one of 1,200 sampled points - a
+   functional with no piecewise-differentiability risk in it. The re-scope is
+   absent from the amendment list, and the resulting PASS was used to declare
+   M3's kill criterion untriggered. Pre-mortem entry 4 pre-commits the
+   consequence: a phase that delivers only its easy bets is a failed phase even
+   if every delivered exam passed.
+2. **B4.1's exam is unverifiable, and the plan says B4.1 may not roll over.**
+   "Green in under 20 minutes" has been demonstrated only in the configuration
+   that skips its two heaviest steps; the "a deliberate perturbation turns it
+   red" half has no committed artifact of any kind.
+3. **Three numbers in the Phase 4 record contradict their own artifacts** (all
+   three independently confirmed by the orchestrator before this review was
+   filed). A phase whose thesis is standing evidence cannot close a gate with
+   unbacked figures in its own reports.
+
+## Reproduction status: all four bets reproduce
+
+No number in any of the four bets is fabricated. Every headline re-ran to the
+digit from the bet's own worktree. The problems are in framing, in exam design,
+and in prose that no artifact emits.
+
+## 1. B4.4 kernel adjoints
+
+**The parameter partition is mathematically sound. It is not neutral.** No
+parameter in the invariant set is wrongly classified: rigid-motion invariance
+of the divergence functional requires a closed mesh, the aspect-ratio veto that
+could open it needs a 10000:1 ratio while the sampling box caps at 30, and the
+family-B flipped hole tube still sums area-vectors to zero. The assigned attack
+does not land, and that should be said plainly.
+
+The cost is elsewhere. **800 of 2000 components in family A (40%) are never
+compared to a finite difference at all**; they are graded against a theoretical
+zero with a bar set by the largest gradient component, and pass by eight orders
+of magnitude. The pre-committed exam reads "matching central finite differences
+to 1e-6 relative on 95% of a 200-point battery"; the delivered result matches
+central finite differences on 60% of components. That is defensible on
+numerical-analysis grounds - a relative metric cannot adjudicate a zero
+derivative, as the G2 reviewer himself conceded - but **it is an amendment, and
+the plan's rule is that gate criteria are amendable only in writing in the
+plan.** It was amended in the bet's own DESIGN.md instead.
+
+**"0/200 on the old metric for a provably correct gradient" is partly a
+property of the sampling box.** The old metric's 1e-6 denominator floor means
+an invariant component fails iff FD noise exceeds 1e-12 absolute; measured
+noise is 2.9e-8, driven by cubic conditioning at placements drawn from
+U(-30, 30) m. Shrink the box to U(-1, 1) and the noise lands near the pass/fail
+boundary. The honest framing is "the old metric fails at world-scale
+placement", not the unqualified form.
+
+**The exam contained no piecewise-differentiability risk, and the artifact
+proves it.** Forward value matches the closed form `det(shear)*xdim*ydim*depth`
+to 2.19e-13 at every one of 1,200 family-A points. Across the whole box - both
+sides of the axis-alignment branch, both winding signs, every earcut output -
+no branch ever changed the answer. The differentiated functional is analytically
+smooth. What is genuinely new is the *mechanism* (derivatives flowing through
+the shipping mesher's bytes, with a byte-identity guard this reviewer verified
+by diffing the "verbatim copies" token-for-token against the pre-refactor
+commit - they hold). What is not new is the risk retired.
+
+**One prose claim is contradicted by its own artifact.** DESIGN.md line 129
+says "bit-identical volume at 8 of 24 points". From
+`kernel-cross-check.json`: exactly **1** point is bit-identical; 8 agree to
+<= 1e-15. Independently confirmed. This matters beyond its size because
+"bit-identical" is the word carrying the byte-identity claim through the bet.
+Relatedly, the 2.4e-8 gap is **wasm-vs-native codegen, not correct-vs-
+incorrect**: both sides run the same Rust. The consequence is scoping -
+"production behaviour is byte-identical over 4,000 cases" is established for
+the **native** build; the artifact users actually run is wasm.
+
+**Coverage note:** the aspect-ratio veto, the circular-profile test and the
+degenerate-edge skip are all instrumented but **never reached by the gradient
+battery** (ratios cap at 30, rectangles have 4 vertices, no duplicate vertices
+are sampled). The 4,000-case byte-identity battery does cover them; the
+adjoint claim does not.
+
+## 2. B4.2 coupled merge semantics
+
+**The 9 true conflicts are real, and they are real because of two invented
+rules.** Three are apply-failures from an invented invariant (a hosted opening
+must stay inside its host AABB) that **IFC does not impose** -
+`IfcRelVoidsElement` requires no containment and oversized openings are ordinary
+practice. Six are divergences from the lazy-cut record, which stores a stale cut
+in the canonical hashed state. **In IFC, and in this very codebase, the cut is
+derived, never stored:** the wall's Body is the uncut solid and the subtraction
+happens at load time. Make the cut eager or derived, as production does, and
+both orders agree - and the spatial rule returns to zero true conflicts.
+
+So the G2 finding is closed in the weakest available sense: the rule is
+falsifiable **under an op model designed so that it can be**, not under the
+model the product implements. B5.1 on real traces remains the only test that
+matters, which the bet's own PR says.
+
+**The 40.82% and the <20% bar are not the same quantity.** The headline rate is
+`falseConflicts / groundTruthConvergent` (a false-positive rate over commuting
+schedules); the restricted rate is `spatialFiredFalse / spatialFiredFlagged` (a
+precision-complement over flagged schedules). Under the headline's own
+convention the analogous unrestricted number is 66%, not 8.78%. The comparison
+is not like-for-like in either direction. The FAIL nonetheless survives on its
+own terms: Wilson 95% CI on 20/49 is [28.2%, 54.7%], excluding 20%.
+
+**The KEEP verdict is not motivated reasoning, but its threshold is trivial:**
+the pre-committed rule is "delete iff zero", so 1 true conflict in 1,000
+schedules would have kept the rule, under semantics the same bet authored.
+
+**The decisive experiment was not run.** The soundness argument now *depends*
+on the spatial rule, so disabling it under coupled semantics should produce
+unsound auto-merges. That one-line ablation would convert "the rule catches 9
+things" into "without the rule the certificate is unsound" - a categorically
+better result. It does not exist.
+
+**The headline improvement 10.63% -> 8.78% is a distribution change, not an
+improvement.** The base model changed (a hosted opening in every second grid
+element; 35% of adds create openings). Flagged conflicts went *down* while a
+coupling that creates conflicts was added, which is itself the tell.
+
+**The golden re-bless is clean.** 48 changed lines, all inside
+`acts/act4/data/battery`; acts 1/2/3/5 byte-identical including every hash.
+Credit where due.
+
+**Unbacked figure:** the PR's "42 further seeds / 36,000 schedules pooling to
+~31%" - the strongest evidence in its table - **exists nowhere in the
+repository**. Independently confirmed.
+
+## 3. B4.5 M1 midterm
+
+**Storey is the natural Merkle shape and the wrong governance shape.** The
+claim is a textbook sibling proof and was not gerrymandered. But the M1 *final*
+exam is about a **region-scoped** agent edit, and on a 50-storey tower a
+storey-granularity certificate is a claim about 2% of the building. The shape
+that predicts B6.1 is the element/region one - the row that reads **907 ms /
+24.27% / FAIL** from a 36.5 MB bundle. That belongs in B6.1's forward risk
+register, not the caveat list.
+
+**Two of three clauses have no failure mode at this scale.** Clause 2 resolves
+O(storeys) nodes regardless of model size - the bigger the model, the easier
+the clause, as the bet's own code comments note. Clause 3 would need a single
+wall edit to recompute >25,058 nodes to fail. **Clause 1 is the only clause
+that was a test**, and it passed at 8.9x margin. "PASS on all three clauses"
+should not be quoted as three independent results.
+
+**A row in the record that no artifact produces.** REPORT.md line 103 gives the
+g0/g1 narrower shape as 21,777 nodes / 12.62% / 465.4 ms / FAIL. No script
+implements a third granularity; the scorecard contains no such figures; and the
+row **contradicts the same document's caveat-3 table**, which gives that shape
+as 172,526 nodes / 0.0348% / 56.1 ms / PASS. Independently confirmed: the
+figures appear in no artifact. (Provenance note: this row was transcribed by
+the orchestrator from the building agent's summary message, which contained
+both sets of numbers; neither the transcription nor the verification caught the
+contradiction.)
+
+**The 36% geometry finding is real and its blast radius is small.** g0/g1
+traverse only `IfcRelContainedInSpatialStructure`, missing ~40,028 of 110,632
+MeshData entries on this fixture. g0 ran data-plane only, g1 ran on a fixture
+with no curtain wall, and b35 uses a synthetic model - so no headline is
+falsified, but **any statement of the form "the DAG covers the model" is wrong
+by ~36% of geometry on aggregated buildings**, and the g0/g1 node censuses are
+undercounts. Fix the traversal before Phase 6 re-quotes them.
+
+## 4. B4.1 what the lane actually protects
+
+Applying "would this notice a silent kernel change?" to all 17 assertion steps:
+
+| Class | Count |
+|---|---|
+| A - genuine drift tripwire (committed reference that does not move) | **1** (the B3.5 golden assert) |
+| B - self-consistent (both sides computed in-run by the same binary) | 8 |
+| C - never touches the kernel | 8 |
+
+**One step in seventeen is a drift tripwire.** The workflow says so about
+itself, in-file, which is rare and creditable - but the finishing plan frames
+the blind spot as being about the tamper batteries specifically, and it is
+broader: the g1, footprint and demo-run steps are also self-consistent.
+
+**What the one tripwire measures:** ~120 pinned leaves, of which five are
+direct kernel measurements, all **scalar volume/carbon integrals over one
+74-element synthetic model**. A regression in winding orientation, normal
+direction, index ordering or triangulation quality whose volume integral is
+unchanged **passes green**. Concretely, the hole-wall mis-orientation B4.4
+discovered live in `create_side_walls` is invisible to it.
+
+**Smallest detectable regression: ~3e-9 relative on a volume-derived scalar**,
+and only for quantities feeding a volume integral, on the elements present in
+one synthetic model. "One-bit perturbation" in the exam should be read as
+"a >= 3e-9 relative change in the volume of one of 74 synthetic walls".
+
+**Four structural gaps.** (a) The paths filter omits `rust/core/**` (parser,
+units), `rust/wasm-bindings/**` (the crate actually compiled),
+`packages/geometry/**`, `packages/clash/**`, `scripts/build-wasm.sh` and
+`rust-toolchain.toml` - the implementation matches the plan's list; the plan's
+list is incomplete. (b) The two Holter-gated steps exit 0 on every push and PR,
+so the M1 headline numbers are not re-derived on the push path at all. (c) The
+footprint step computes a kill criterion, prints it, and never gates on it,
+while the workflow calls that step the push path's primary geometry tripwire.
+(d) `build-wasm.sh` exits 0 on a stale on-disk bundle when `wasm-pack` is
+missing - a silent-pass route into a lane whose premise is building from source.
+
+**Both halves of the exam are attested rather than evidenced.** The single
+observed run is 5m27s but was a pull_request event, i.e. the configuration
+where the two heaviest steps skip; no scheduled/full run exists. The
+perturbation half has no committed artifact.
+
+## 5. Does Phase 4 repeat Phase 3's pattern?
+
+**Yes, in a better-tailored costume.** Phase 3's pattern was skipping the two
+bets requiring contact outside the sandbox. Phase 4's is keeping the hard bet
+on the schedule and writing its exam where it cannot fail. The sequence is
+documented in the program's own files one day apart: the execution plan names
+the CSG/void path as the kill risk; the finishing plan correctly diagnoses that
+Phase 3 built on the safe side of it; and then, in the next paragraph, sets the
+binary exam on the extrusion mesher. **The pre-mortem antidote was applied to
+the schedule and not to the content.** Scheduling a bet first de-risks nothing
+if its exam has been moved to the safe side beforehand.
+
+Partial credit on the other charge: B4.1 is half a day by the plan's own
+estimate and B4.5 is a run of existing machinery, but B4.2 required real new
+semantics and published a failing number unsoftened, and B4.4 required
+substantial engineering with a byte-identity proof that holds. Effort, however,
+is not risk.
+
+**What Phase 4 did that Phase 3 did not:** three of four bets volunteered the
+case against themselves - the forgery-vs-drift correction, the 40.82% FAIL, the
+granularity qualifier and the 36% finding. That is instruments 5 and 7 working
+before the reviewer arrived, and it is why this review found errors of framing
+rather than errors of fact.
+
+## 6. What the orchestrator's verification structurally cannot catch
+
+Re-running a battery on the same machine with the same fixtures tests
+reproducibility, and **reproducibility was never the failure mode**. It cannot
+catch: an exam whose bar cannot be missed; a partition that is valid but
+non-neutral; a denominator switch; a distribution change presented as an
+improvement; **prose that no artifact backs** (all three hard catches in this
+review are in this class - the code was re-run, but nobody diffed the prose
+against the JSON); a scope re-write upstream of the work; and anything hidden
+by one machine, one Node, one wasm build, one fixture set, one author's mental
+model.
+
+Cheap structural fix, since five of seven are prose-versus-artifact: **make
+every number quoted in a REPORT or DESIGN emit from the scorecard JSON, and add
+a check that every numeral in the prose appears in the artifact.** That is not
+a research problem.
+
+## 7. What turns this FAIL into a PASS
+
+Required, in order of importance:
+
+1. **Amend the record in writing** in the finishing plan's amendment section:
+   (a) M3's Phase 4 exam was re-scoped from the CSG/void path to the extrusion
+   mesher; (b) B4.4's PASS therefore does **not** retire the kill risk;
+   (c) the active/invariant partition amends the exam's finite-difference
+   wording for 40% of components. Restate M3's status as "adjoints reach the
+   real mesher on a smooth family", not "the binary gate passed".
+2. **Schedule the CSG-adjoint bet first in Phase 5**, ahead of B5.5. The bet's
+   own DESIGN section 6.1 already scopes it correctly at two cycles.
+3. **Produce the B4.1 perturbation artifact** (a committed red-run log or a
+   `--self-test` mode), and run the lane once on workflow_dispatch with the
+   Holter fixture so the under-20-minutes clause is met in the configuration
+   the exam describes.
+4. **Fix the three prose/artifact contradictions** and add the numeral check.
+5. **Restate B4.2's two comparisons** - either report the restricted rate under
+   the headline's denominator or say explicitly that they are different ratios
+   - and mark 10.63% -> 8.78% as measured on different base models.
+6. **Add B4.2's ablation:** coupled semantics with the spatial rule disabled,
+   counting unsound auto-merges. If non-zero, KEEP is justified by soundness
+   rather than by 9 conflicts out of 1,000.
+
+Recommended, not required: close the paths filter over the six omitted
+locations; make the footprint kill criterion set an exit code or stop calling
+it a tripwire; add one non-volume kernel field (a mesh hash or index digest) to
+the golden so a winding regression cannot pass green; widen g0/g1 to follow
+`IfcRelAggregates`; carry B4.5's element-granularity row into B6.1's risk
+register.
+
+## 8. Where the program is right
+
+- B4.4's byte-identity guard is genuine; the "verbatim copies" diff clean
+  against the pre-refactor commit.
+- B4.4's CSG obstruction analysis is the most valuable page in the phase and
+  should be lifted into the plan verbatim.
+- B4.2 published a failing number against its own bar without softening it, and
+  declined to make the predicate host-aware to fix the rate.
+- B4.2's golden re-bless is auditably scoped; acts 1/2/3/5 are byte-identical.
+- B4.5's "the invariant worth quoting is the count, 60 nodes" is the correct
+  reading of its own result, volunteered.
+- B4.1's workflow documents its own blind spot in-file. Very few CI lanes do.

--- a/scripts/moonshot/b34-kernel-stage/REPORT.md
+++ b/scripts/moonshot/b34-kernel-stage/REPORT.md
@@ -89,6 +89,19 @@ cargo run --release --manifest-path extractor/Cargo.toml -- \
 node harness-b34.mjs --dir=<scratch> --models=duplex,advanced,holter,c20,i129
 ```
 
+<!-- Numeral provenance, added 2026-07-29 for the numeral gate
+     (scripts/moonshot/ci/check-report-numerals.mjs). No figure in this report is
+     changed; these comments record which numbers report.b34.json emits and which
+     it does not. -->
+<!-- numeral-ok: 640, 96, 96B :: format constants of the path-C encoding, not
+     measurements: a 640-bit exact integer accumulator over 96-byte tuples. Fixed
+     by the kernel's design and stated in the WGSL, not emitted by any report. -->
+<!-- numeral-ok: 194 :: the fidelity-gated job corpus size, summed over the
+     per-model `meta.jobs` fields of report.b34.json. The artifact stores the
+     addends, not the total. -->
+<!-- numeral-ok: 82% :: the void-CSG share of load time, from the repo's separate
+     CSG performance investigation, not from this bet. -->
+
 ## 2. What the real workload actually looks like
 
 First honest finding: on typical models the mesh-kernel void stage is far
@@ -123,6 +136,14 @@ grazing contacts), nothing like random inputs; per-tuple those cost the CPU
 adaptive path ~6x more (~65 ns vs ~10 ns native), and up to 68% of the
 stage's CPU time (duplex).
 
+<!-- numeral-ok: 20.8%, 35.8%, 18.1%, 25.8%, 4.4%, 6.4%, 8.3% :: shares computed
+     in the table row from two counts printed in that same row, both of which come
+     from report.b34.json (`meta.totalPairs`, `meta.nearCoplanarPairs`,
+     `meta.tuples`, `meta.signCounts.zero`). Arithmetic the reader can check on
+     the line; the artifact stores the operands, not the ratio. -->
+<!-- numeral-ok: 108k :: rounded tuple count of the single largest i129 element,
+     a per-element figure the model-level report does not break out. -->
+
 ## 3. Manifest parity (the exam's correctness bar): EXACT - PASS
 
 Every extracted tuple was evaluated three independent ways: (a) Rust
@@ -139,6 +160,14 @@ in-page BigInt exact oracle.
 - The x8-tiled i129 run (2,194,032 tuples) is also 0-mismatch.
 
 Sign-for-sign, the stage's GPU result is byte-identical to the CPU path.
+
+<!-- numeral-ok: 302,490 :: the exact sum of report.b34.json's five per-model
+     `meta.tuples` values (4,116 + 4,656 + 5,448 + 14,016 + 274,254). The artifact
+     stores the addends, not the total. -->
+<!-- numeral-ok: 2,194,032 :: tuple count of the x8-tiled i129 SYNTHETIC run,
+     which was produced by amplifying the corpus at run time
+     (report.b34.json's `amplify` is null for the committed run) and whose own
+     report was not committed. -->
 
 ## 4. Stage speedup vs the >=5x exam bar: split verdict
 
@@ -192,6 +221,11 @@ before any of the GPU's batching constraints. The B2.5 library beats every
 *exact-tier* CPU evaluation it is put against; it does not beat a
 well-engineered adaptive filter at this stage's realized arithmetic.
 
+<!-- numeral-ok: 0.6ms, 34.8ms, 175.8ms, 0.20x :: 0.1-0.6 ms is the observed
+     per-dispatch floor range, an envelope rather than a stored field; the
+     34.8/175.8 ms row is the x8-tiled i129 SYNTHETIC run described above, whose
+     report was not committed, and 0.20x is that row's ratio. -->
+
 ## 5. Integration plan for the real Rust/wasm path - and whether the win survives
 
 **Where the seam is.** `arrangement::arrange` (and `arrange_many`): step 1
@@ -230,6 +264,11 @@ lever for the arrangement's explicit-predicate stage is refuted by the
 measured workload, and honestly so: the predicates are not the bottleneck the
 moonshot framing assumed at this stage; the adaptive filter already deleted
 the cost the GPU was supposed to delete.
+
+<!-- numeral-ok: 5000x, 135x :: 5000x is the escalated interval/exact tier cost
+     per call from the kernel's own budget.rs profiling (the #1109 stall family);
+     135x is the best exact-CPU-tier speedup quoted from B2.5's DESIGN.md, a
+     different bet's run. Neither is emitted by report.b34.json. -->
 
 ## 6. Files
 

--- a/scripts/moonshot/b34-kernel-stage/REPORT.md
+++ b/scripts/moonshot/b34-kernel-stage/REPORT.md
@@ -96,9 +96,14 @@ node harness-b34.mjs --dir=<scratch> --models=duplex,advanced,holter,c20,i129
 <!-- numeral-ok: 640, 96, 96B :: format constants of the path-C encoding, not
      measurements: a 640-bit exact integer accumulator over 96-byte tuples. Fixed
      by the kernel's design and stated in the WGSL, not emitted by any report. -->
-<!-- numeral-ok: 194 :: the fidelity-gated job corpus size, summed over the
-     per-model `meta.jobs` fields of report.b34.json. The artifact stores the
-     addends, not the total. -->
+<!-- numeral-ok: 194 :: the number of jobs that PASSED the byte-identity fidelity
+     gate, summed over report.b34.json's five per-model `meta.fidelityChecked`
+     fields: models[0..4].meta.fidelityChecked = 10 (duplex) + 13 (advanced) + 2
+     (holter) + 68 (c20) + 101 (i129) = 194. It is NOT the sum of `meta.jobs`,
+     which is 208: i129 declares 115 jobs but only 101 were fidelity-checked,
+     the 14 batched i129 jobs being excluded. numeral-src cannot express this
+     because no single field holds the total; the five addends are individually
+     bindable and are named above so the sum is checkable by hand. -->
 <!-- numeral-ok: 82% :: the void-CSG share of load time, from the repo's separate
      CSG performance investigation, not from this bet. -->
 
@@ -136,11 +141,21 @@ grazing contacts), nothing like random inputs; per-tuple those cost the CPU
 adaptive path ~6x more (~65 ns vs ~10 ns native), and up to 68% of the
 stage's CPU time (duplex).
 
-<!-- numeral-ok: 20.8%, 35.8%, 18.1%, 25.8%, 4.4%, 6.4%, 8.3% :: shares computed
-     in the table row from two counts printed in that same row, both of which come
-     from report.b34.json (`meta.totalPairs`, `meta.nearCoplanarPairs`,
-     `meta.tuples`, `meta.signCounts.zero`). Arithmetic the reader can check on
-     the line; the artifact stores the operands, not the ratio. -->
+<!-- numeral-ok: 20.8%, 35.8%, 18.1%, 6.4% :: shares computed in the table row
+     from two counts PRINTED IN THAT SAME ROW, so the arithmetic is checkable on
+     the line. 20.8%, 18.1% and 6.4% are `meta.nearCoplanarPairs` over
+     `meta.totalPairs`; 35.8% is `meta.signCounts.zero` over `meta.tuples`. All
+     four operand fields are in report.b34.json, which stores the operands and
+     not the ratio. -->
+<!-- numeral-ok: 25.8%, 4.4%, 8.3% :: also `meta.signCounts.zero` over
+     `meta.tuples`, but written BARE in the "exact-Zero signs" column with no
+     count beside them, so unlike 35.8% their numerator is not on the line and
+     has to be read out of report.b34.json: advanced 1203/4656, holter 238/5448,
+     i129 22861/274254. -->
+<!-- numeral-src: 1.2% :: none - the fourth bare zero-sign share, c20's
+     162/14016 = 1.156%, rounded to 1.2%. Bound to `none` because a bare 1.2
+     resolves against unrelated fields in the union index, and this ratio is
+     stored by no artifact any more than the three above it. -->
 <!-- numeral-ok: 108k :: rounded tuple count of the single largest i129 element,
      a per-element figure the model-level report does not break out. -->
 
@@ -266,9 +281,13 @@ moonshot framing assumed at this stage; the adaptive filter already deleted
 the cost the GPU was supposed to delete.
 
 <!-- numeral-ok: 5000x, 135x :: 5000x is the escalated interval/exact tier cost
-     per call from the kernel's own budget.rs profiling (the #1109 stall family);
-     135x is the best exact-CPU-tier speedup quoted from B2.5's DESIGN.md, a
-     different bet's run. Neither is emitted by report.b34.json. -->
+     per call from the kernel's own budget.rs profiling (the #1109 stall family).
+     The range "25-135x" quotes BOTH endpoints of B2.5's exact-CPU-tier result
+     table in scripts/moonshot/gpu-predicates/DESIGN.md: the low endpoint is the
+     1e6-tuple row's 24.6x, rounded UP to 25; the high endpoint is the 1e7-tuple
+     row's 135.1x, rounded DOWN to 135. That table is markdown, not JSON, so
+     neither endpoint can be bound with numeral-src to a field, and neither is
+     emitted by report.b34.json - it is a different bet's run. -->
 
 ## 6. Files
 

--- a/scripts/moonshot/ci/assert-b35-golden.mjs
+++ b/scripts/moonshot/ci/assert-b35-golden.mjs
@@ -38,13 +38,26 @@
  * The floor is the report's own rounding, and act 5's kernel-validation
  * block is the most sensitive part of it.
  *
+ * SELF-TEST. `--self-test` tests the test: it injects a known perturbation,
+ * proves this script goes red and names act 5 and the moved paths, restores
+ * the tree and proves it goes green again. See selfTest() below for the
+ * mechanics and for why the perturbation has the magnitude it has. It exists
+ * because the G4 review (docs/vision/reviews/g4-red-team-2026-07-29.md
+ * section 4) found that the perturbation half of B4.1's exam was attested in
+ * prose and had no committed artifact: a tripwire nobody ever fires is
+ * indistinguishable from a tripwire that cannot fire.
+ *
  * Usage:
- *   node scripts/moonshot/ci/assert-b35-golden.mjs            # assert
- *   node scripts/moonshot/ci/assert-b35-golden.mjs --update   # re-bless
+ *   node scripts/moonshot/ci/assert-b35-golden.mjs             # assert
+ *   node scripts/moonshot/ci/assert-b35-golden.mjs --update    # re-bless
+ *   node scripts/moonshot/ci/assert-b35-golden.mjs --self-test # prove it fires
  *
  * Exit codes: 0 match, 1 drift, 2 usage/IO problem.
+ * Under --self-test: 0 the tripwire fired and recovered, 1 it did not (or the
+ * tree was not restored), 2 usage/IO problem.
  */
 
+import { spawnSync } from 'node:child_process';
 import { readFileSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -55,6 +68,13 @@ const REPORT_PATH = path.join(REPO_ROOT, 'scripts/moonshot/b35-demo/demo-report.
 const GOLDEN_PATH = path.join(HERE, 'b35-golden.json');
 
 const UPDATE = process.argv.includes('--update');
+const SELF_TEST = process.argv.includes('--self-test');
+
+if (UPDATE && SELF_TEST) {
+  console.error('::error::--update and --self-test are mutually exclusive.');
+  console.error('--self-test asserts the CURRENT golden is the right reference; --update replaces it.');
+  process.exit(2);
+}
 
 /** Serialize exactly the way run.mjs serializes demo-report.json. */
 function serialize(value) {
@@ -101,6 +121,320 @@ function diffPaths(a, b, prefix = '', out = []) {
   }
   return out;
 }
+
+// ---------------------------------------------------------------------------
+// --self-test: fire the tripwire on purpose, then put everything back.
+// ---------------------------------------------------------------------------
+
+const DEMO_RUN = path.join(REPO_ROOT, 'scripts/moonshot/b35-demo/run.mjs');
+const REPORT_MD_PATH = path.join(REPO_ROOT, 'scripts/moonshot/b35-demo/demo-report.md');
+const CARBON_MODEL_PATH = path.join(REPO_ROOT, 'scripts/moonshot/diff-spike/carbon-model.mjs');
+
+/**
+ * The injection site and its magnitude.
+ *
+ * WHERE. `CARBON_FACTORS.Concrete` in scripts/moonshot/diff-spike/carbon-model.mjs.
+ * It reaches the golden's kernel-validation block by a path that is provable
+ * by reading two lines rather than by trusting a measurement:
+ * scripts/moonshot/b35-demo/act5-descent.mjs imports CARBON_FACTORS and
+ * accumulates `kernelCarbon += row.kernelVolume * factor` over the volumes the
+ * wasm geometry kernel re-measured, then emits it as
+ * `acts/act5/data/kernelValidation/kernelCarbonKg` (and, via
+ * `|kernelCarbon - n.carbon| / n.carbon`, as `carbonRelDev`). So a change to
+ * this constant MUST move the kernel-validation fields unless the pipeline
+ * from the kernel to the golden is broken -- which is exactly the failure the
+ * self-test is here to detect. It is also the same constant the bet's own
+ * prose claims was perturbed, so this script now evidences that claim rather
+ * than restating it.
+ *
+ * WHY 1e-6 RELATIVE (315 -> 315.000315). The tripwire's floor is the report's
+ * own rounding, not machine epsilon. `kernelCarbonKg` is rounded to 3 decimals
+ * on a ~73,459 kg total, so the smallest change that can survive serialization
+ * is ~7e-9 relative on that total; a one-ULP nudge (315.00000000000006)
+ * provably does NOT move the golden and would make this a self-test that
+ * fails for the wrong reason. The documented, measured floor is ~3e-9 relative
+ * on this constant. 1e-6 sits ~300x above that floor and ~140x above the
+ * rounding limit, which buys the assertion a margin no plausible re-blessing
+ * of the golden can eat, while staying far too small to be mistaken for a
+ * deliberate model change by anyone reading the diff. The magnitude is chosen
+ * for reliability of the tripwire test; it is NOT a claim about sensitivity.
+ * The sensitivity claim remains the measured ~3e-9 stated in the header.
+ */
+const PERTURB_FIND = '  Concrete: 315,';
+const PERTURB_REPLACE = '  Concrete: 315.000315,';
+const PERTURB_DESC =
+  'CARBON_FACTORS.Concrete 315 -> 315.000315 (+1e-6 relative) in scripts/moonshot/diff-spike/carbon-model.mjs';
+
+/** Files --self-test rewrites. Every one of them is restored byte-for-byte. */
+const TOUCHED = [
+  'scripts/moonshot/diff-spike/carbon-model.mjs',
+  'scripts/moonshot/b35-demo/demo-report.json',
+  'scripts/moonshot/b35-demo/demo-report.md',
+];
+
+function git(args) {
+  const r = spawnSync('git', args, { cwd: REPO_ROOT, encoding: 'utf-8' });
+  return { code: r.status, out: (r.stdout ?? '').trim(), err: (r.stderr ?? '').trim() };
+}
+
+/** `git status --porcelain` restricted to the files this mode rewrites. */
+function touchedStatus() {
+  const r = git(['status', '--porcelain', '--', ...TOUCHED]);
+  if (r.code !== 0) return null; // not a git checkout (e.g. a tarball) -- handled by the caller
+  return r.out;
+}
+
+function runNode(scriptPath, args = []) {
+  const started = Date.now();
+  const r = spawnSync(process.execPath, [scriptPath, ...args], {
+    cwd: REPO_ROOT,
+    encoding: 'utf-8',
+    // The demo prints a lot; 64 MB is far more than either child produces.
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  return {
+    code: r.status,
+    stdout: r.stdout ?? '',
+    stderr: r.stderr ?? '',
+    ms: Date.now() - started,
+  };
+}
+
+/**
+ * The `  <path>` lines from the assert's differing-paths block, and only from
+ * there: collection starts at the "N differing path(s)" header and stops at
+ * the blank line that closes the block, so the trailing legend and the
+ * re-bless instructions can never be mistaken for JSON paths.
+ */
+function parseDiffPaths(stderr) {
+  const out = [];
+  let inBlock = false;
+  for (const line of stderr.split('\n')) {
+    if (!inBlock) {
+      if (/^\d+\+? differing path\(s\)/.test(line)) inBlock = true;
+      continue;
+    }
+    if (line.trim() === '') break;
+    const m = /^ {2}(\S+)$/.exec(line);
+    if (m) out.push(m[1]);
+  }
+  return out;
+}
+
+function selfTest() {
+  const log = [];
+  const say = (s = '') => {
+    log.push(s);
+    console.log(s);
+  };
+  const fail = (s) => {
+    log.push(s);
+    console.error(s);
+  };
+
+  say('B3.5 golden tripwire --self-test');
+  say(`  perturbation: ${PERTURB_DESC}`);
+  say(`  assert under test: ${path.relative(REPO_ROOT, fileURLToPath(import.meta.url))}`);
+  say('');
+
+  // Baseline for the restore proof. NOT required to be empty: in the CI lane
+  // this step runs after E3a, which legitimately rewrites demo-report.{json,md}
+  // with fresh `volatile` wall clocks, so demanding a pristine tree would make
+  // the step unusable exactly where it matters. What IS required is that the
+  // status is byte-identical afterwards -- the snapshot/restore is over file
+  // CONTENT, so restoring a pre-modified file reproduces its modification too.
+  // A pre-existing modification is reported rather than swallowed, because
+  // evidence taken from a modified tree is weaker evidence.
+  const before = touchedStatus();
+  if (before === null) {
+    console.error('::error::--self-test needs a git checkout: it verifies the tree is restored with `git status`.');
+    process.exit(2);
+  }
+  if (before !== '') {
+    say('NOTE: these files were already modified before the self-test started;');
+    say('      they are snapshotted and put back exactly as found:');
+    for (const line of before.split('\n')) say(`      ${line}`);
+    say('');
+  }
+
+  // Snapshot as bytes rather than trusting `git checkout --` to undo things:
+  // the restore must work even if the perturbation crashed something that
+  // left git in a state we did not anticipate.
+  const snapshot = new Map();
+  for (const rel of TOUCHED) {
+    const abs = path.join(REPO_ROOT, rel);
+    try {
+      snapshot.set(abs, readFileSync(abs));
+    } catch (err) {
+      console.error(`::error::cannot snapshot ${rel}: ${err.message}`);
+      process.exit(2);
+    }
+  }
+  // Deliberately NOT latched: it must be safe (and effective) to call more
+  // than once. Stage B re-runs the demo AFTER restoring, and that run rewrites
+  // demo-report.{json,md} with fresh `volatile` wall clocks -- so the final
+  // restore in the `finally` is the one that actually leaves the tree clean.
+  const restore = () => {
+    for (const [abs, bytes] of snapshot) writeFileSync(abs, bytes);
+  };
+  // try/finally covers throws; these cover Ctrl-C and a CI cancellation.
+  const onSignal = (sig) => {
+    restore();
+    process.exit(sig === 'SIGINT' ? 130 : 143);
+  };
+  process.on('SIGINT', onSignal);
+  process.on('SIGTERM', onSignal);
+
+  const problems = [];
+  let stageA = null;
+  let stageB = null;
+  let capturedFailure = '';
+
+  try {
+    // --- Stage A: perturb, re-run the demo, expect the tripwire to fire ----
+    const original = readFileSync(CARBON_MODEL_PATH, 'utf-8');
+    const hits = original.split(PERTURB_FIND).length - 1;
+    if (hits !== 1) {
+      fail(`::error::injection anchor ${JSON.stringify(PERTURB_FIND)} occurs ${hits} time(s) in`);
+      fail(`  ${path.relative(REPO_ROOT, CARBON_MODEL_PATH)} -- expected exactly 1.`);
+      fail('  The carbon model moved; re-point PERTURB_FIND rather than weakening the match.');
+      restore();
+      process.exit(2);
+    }
+    writeFileSync(CARBON_MODEL_PATH, original.replace(PERTURB_FIND, PERTURB_REPLACE), 'utf-8');
+    say('stage A -- perturbation injected, re-running the five-act demo');
+
+    const demoA = runNode(DEMO_RUN);
+    if (demoA.code !== 0) {
+      // A perturbation that makes the demo throw proves nothing about the
+      // golden: it never got as far as writing a report to compare.
+      fail(`::error::stage A: the demo exited ${demoA.code} under the perturbation instead of completing.`);
+      fail('The self-test needs the demo to RUN and produce a different number, not to crash.');
+      fail(demoA.stderr.split('\n').slice(-25).join('\n'));
+      problems.push('stage A: demo did not complete under the perturbation');
+    } else {
+      say(`  demo completed in ${(demoA.ms / 1000).toFixed(1)}s`);
+      const assertA = runNode(fileURLToPath(import.meta.url));
+      stageA = assertA;
+      capturedFailure = assertA.stderr;
+      say(`  golden check exited ${assertA.code} in ${(assertA.ms / 1000).toFixed(1)}s (expected 1 = drift)`);
+
+      if (assertA.code === 0) {
+        problems.push(
+          'THE TRIPWIRE DID NOT FIRE: the golden check passed with a perturbed carbon factor. ' +
+            'A >=1e-6 relative change reached no pinned field -- the golden no longer covers ' +
+            "act 5's kernel-validation block, or the demo is not reading the perturbed source.",
+        );
+      } else if (assertA.code !== 1) {
+        problems.push(
+          `the golden check exited ${assertA.code} (usage/IO), not 1 (drift) -- it failed for the wrong reason`,
+        );
+      }
+      if (!assertA.stderr.includes('B3.5 DETERMINISTIC DRIFT')) {
+        problems.push('the failure output does not carry the "B3.5 DETERMINISTIC DRIFT" banner');
+      }
+
+      const paths = parseDiffPaths(assertA.stderr);
+      const act5 = paths.filter((p) => p.startsWith('acts/act5/'));
+      const other = paths.filter((p) => !p.startsWith('acts/act5/'));
+      const kernel = paths.filter((p) => p.startsWith('acts/act5/data/kernelValidation/'));
+      say(`  differing paths named: ${paths.length} (act 5: ${act5.length}, kernel-validation: ${kernel.length})`);
+
+      if (act5.length === 0) {
+        problems.push('the failure names no acts/act5/* path -- "names which act broke" is not met');
+      }
+      if (!kernel.includes('acts/act5/data/kernelValidation/kernelCarbonKg')) {
+        problems.push(
+          'acts/act5/data/kernelValidation/kernelCarbonKg did not move, although the perturbed ' +
+            'constant is multiplied into it by act5-descent.mjs -- the kernel measurement is no ' +
+            'longer reaching the golden',
+        );
+      }
+      if (other.length > 0) {
+        // Deterministic, so this cannot go flaky: the perturbed constant is
+        // imported only by act 5. Anything else moving is a real finding.
+        problems.push(
+          `${other.length} path(s) outside act 5 moved under an act-5-only perturbation: ${other.join(', ')}`,
+        );
+      }
+    }
+
+    // --- Stage B: restore, re-run, expect green again ---------------------
+    say('');
+    say('stage B -- original state restored, re-running to prove recovery');
+    restore();
+    const demoB = runNode(DEMO_RUN);
+    if (demoB.code !== 0) {
+      fail(`::error::stage B: the demo exited ${demoB.code} after restore.`);
+      fail(demoB.stderr.split('\n').slice(-25).join('\n'));
+      problems.push('stage B: demo did not complete after restore');
+    } else {
+      say(`  demo completed in ${(demoB.ms / 1000).toFixed(1)}s`);
+      const assertB = runNode(fileURLToPath(import.meta.url));
+      stageB = assertB;
+      say(`  golden check exited ${assertB.code} in ${(assertB.ms / 1000).toFixed(1)}s (expected 0 = match)`);
+      if (assertB.code !== 0) {
+        problems.push(
+          'the golden check is still red after the perturbation was reverted. Either the restore ' +
+            'is incomplete, or the tree was ALREADY drifting before this self-test ran -- in which ' +
+            "case stage A's red proves nothing.",
+        );
+        fail(assertB.stderr.split('\n').slice(0, 30).join('\n'));
+      }
+    }
+  } finally {
+    restore();
+    process.off('SIGINT', onSignal);
+    process.off('SIGTERM', onSignal);
+  }
+
+  // --- The restore has to be provable, not asserted ------------------------
+  const after = touchedStatus();
+  say('');
+  if (after === null) {
+    problems.push('could not run `git status` to verify the tree was restored');
+  } else if (after !== before) {
+    problems.push(
+      `the tree was NOT restored to its starting state.\n` +
+        `  before: ${JSON.stringify(before)}\n` +
+        `  after:  ${JSON.stringify(after)}`,
+    );
+  } else if (after === '') {
+    say(`tree restored: \`git status --porcelain\` clean over all ${TOUCHED.length} touched files.`);
+  } else {
+    say(`tree restored: \`git status --porcelain\` identical to the pre-run baseline over all ${TOUCHED.length} touched files.`);
+  }
+
+  say('');
+  if (problems.length > 0) {
+    console.error('::error::B3.5 GOLDEN SELF-TEST FAILED -- the tripwire cannot be trusted.');
+    for (const p of problems) console.error(`  - ${p}`);
+    process.exit(1);
+  }
+
+  say('SELF-TEST PASS: the B3.5 golden tripwire fires on a 1e-6 relative carbon-factor');
+  say('perturbation, names act 5 and its kernel-validation fields, and returns to green');
+  say('when the perturbation is reverted.');
+  say('');
+  say('--- captured failure output (stage A) ---');
+  const captured = capturedFailure.trimEnd();
+  console.log(captured);
+  log.push(captured);
+
+  // A machine-readable tail so a future evidence refresh can diff two runs.
+  const summary = {
+    perturbation: PERTURB_DESC,
+    stageAExit: stageA?.code ?? null,
+    stageBExit: stageB?.code ?? null,
+    node: process.version,
+    platform: `${process.platform}-${process.arch}`,
+  };
+  say('');
+  say(`summary: ${JSON.stringify(summary)}`);
+  process.exit(0);
+}
+
+if (SELF_TEST) selfTest();
 
 const report = readJson(REPORT_PATH, 'B3.5 demo report').value;
 if (!report || typeof report !== 'object' || typeof report.deterministic !== 'object' || report.deterministic === null) {

--- a/scripts/moonshot/ci/assert-b35-golden.mjs
+++ b/scripts/moonshot/ci/assert-b35-golden.mjs
@@ -133,24 +133,48 @@ function readJson(file, what) {
   }
 }
 
-/** Every leaf path where `a` and `b` disagree, as `a/b/c` strings. */
-function diffPaths(a, b, prefix = '', out = []) {
-  if (out.length >= 40) return out;
-  const bothObjects =
-    a !== null && b !== null && typeof a === 'object' && typeof b === 'object' &&
-    Array.isArray(a) === Array.isArray(b);
-  if (!bothObjects) {
-    if (JSON.stringify(a) !== JSON.stringify(b)) {
-      out.push({ path: prefix || '(root)', golden: a, actual: b });
+/**
+ * How many differing leaves the walk collects before it stops. A cap keeps a
+ * shape change from printing thousands of lines, but a SILENT cap reads as
+ * "and that is all of them", which is the one thing a drift report must never
+ * imply. The constant is shared with the printer and with `--self-test` so the
+ * truncated case is announced everywhere it can occur.
+ */
+const MAX_DIFF_PATHS = 40;
+
+/**
+ * Every leaf path where `a` and `b` disagree, as `a/b/c` strings, up to
+ * `MAX_DIFF_PATHS`. `truncated` is true when the walk stopped early, i.e. the
+ * list is a prefix of the differences and not the whole set.
+ */
+function diffPaths(a, b) {
+  const out = [];
+  let truncated = false;
+  const walk = (x, y, prefix) => {
+    if (out.length >= MAX_DIFF_PATHS) {
+      truncated = true;
+      return;
     }
-    return out;
-  }
-  const keys = [...new Set([...Object.keys(a), ...Object.keys(b)])];
-  for (const k of keys) {
-    diffPaths(a[k], b[k], prefix ? `${prefix}/${k}` : k, out);
-    if (out.length >= 40) break;
-  }
-  return out;
+    const bothObjects =
+      x !== null && y !== null && typeof x === 'object' && typeof y === 'object' &&
+      Array.isArray(x) === Array.isArray(y);
+    if (!bothObjects) {
+      if (JSON.stringify(x) !== JSON.stringify(y)) {
+        out.push({ path: prefix || '(root)', golden: x, actual: y });
+      }
+      return;
+    }
+    const keys = [...new Set([...Object.keys(x), ...Object.keys(y)])];
+    for (const k of keys) {
+      walk(x[k], y[k], prefix ? `${prefix}/${k}` : k);
+      if (out.length >= MAX_DIFF_PATHS) {
+        truncated = true;
+        break;
+      }
+    }
+  };
+  walk(a, b, '');
+  return { diffs: out, truncated };
 }
 
 // ---------------------------------------------------------------------------
@@ -247,6 +271,7 @@ function runNode(scriptPath, args = []) {
  */
 function parseDiffPaths(stderr) {
   const out = [];
+  let truncated = false;
   let inBlock = false;
   for (const line of stderr.split('\n')) {
     if (!inBlock) {
@@ -254,10 +279,14 @@ function parseDiffPaths(stderr) {
       continue;
     }
     if (line.trim() === '') break;
+    if (line.includes(`LIST TRUNCATED at the ${MAX_DIFF_PATHS}-entry cap`)) {
+      truncated = true;
+      continue;
+    }
     const m = /^ {2}(\S+)$/.exec(line);
     if (m) out.push(m[1]);
   }
-  return out;
+  return { paths: out, truncated };
 }
 
 function selfTest() {
@@ -376,11 +405,26 @@ function selfTest() {
         problems.push('the failure output does not carry the "B3.5 DETERMINISTIC DRIFT" banner');
       }
 
-      const paths = parseDiffPaths(assertA.stderr);
+      const { paths, truncated } = parseDiffPaths(assertA.stderr);
       const act5 = paths.filter((p) => p.startsWith('acts/act5/'));
       const other = paths.filter((p) => !p.startsWith('acts/act5/'));
       const kernel = paths.filter((p) => p.startsWith('acts/act5/data/kernelValidation/'));
-      say(`  differing paths named: ${paths.length} (act 5: ${act5.length}, kernel-validation: ${kernel.length})`);
+      say(
+        `  differing paths named: ${paths.length}${truncated ? ` (TRUNCATED at the ${MAX_DIFF_PATHS}-entry cap)` : ''}` +
+          ` (act 5: ${act5.length}, kernel-validation: ${kernel.length})`,
+      );
+
+      // Reported BEFORE the path assertions below, because a truncated list
+      // makes every one of them unsound: a required path can be absent because
+      // it never moved, or merely because the cap cut the list before it. Those
+      // are different defects and must not print the same message.
+      if (truncated) {
+        problems.push(
+          `the differing-path list hit the ${MAX_DIFF_PATHS}-entry cap, so the assertions below are ` +
+            'evaluated on a PREFIX of the differences -- a missing required path here may be a cap ' +
+            'artifact rather than a real absence. Raise MAX_DIFF_PATHS or narrow the perturbation.',
+        );
+      }
 
       if (act5.length === 0) {
         problems.push('the failure names no acts/act5/* path -- "names which act broke" is not met');
@@ -666,11 +710,22 @@ function kernelTest() {
         if (!assertA.stderr.includes('B3.5 DETERMINISTIC DRIFT')) {
           problems.push('the failure output does not carry the "B3.5 DETERMINISTIC DRIFT" banner');
         }
-        const paths = parseDiffPaths(assertA.stderr);
+        const { paths, truncated } = parseDiffPaths(assertA.stderr);
         const kernel = paths.filter((p) => p.startsWith('acts/act5/data/kernelValidation/'));
         const other = paths.filter((p) => !p.startsWith('acts/act5/data/kernelValidation/'));
-        say(`  differing paths named: ${paths.length} (kernel-validation: ${kernel.length})`);
+        say(
+          `  differing paths named: ${paths.length}${truncated ? ` (TRUNCATED at the ${MAX_DIFF_PATHS}-entry cap)` : ''}` +
+            ` (kernel-validation: ${kernel.length})`,
+        );
         for (const p of paths) say(`    ${p}`);
+        if (truncated) {
+          // Same reason as the model-constant mode: a capped list turns "the
+          // required path is absent" into an ambiguous statement.
+          problems.push(
+            `the differing-path list hit the ${MAX_DIFF_PATHS}-entry cap, so the kernel-validation ` +
+              'assertions below are evaluated on a PREFIX of the differences',
+          );
+        }
         if (!kernel.includes('acts/act5/data/kernelValidation/kernelCarbonKg')) {
           problems.push(
             'acts/act5/data/kernelValidation/kernelCarbonKg did not move under a kernel ' +
@@ -794,7 +849,7 @@ if (golden.text === actualText) {
   process.exit(0);
 }
 
-const diffs = diffPaths(golden.value, report.deterministic);
+const { diffs, truncated } = diffPaths(golden.value, report.deterministic);
 console.error(
   '::error::B3.5 DETERMINISTIC DRIFT -- the five-act demo no longer reproduces its seeded golden.',
 );
@@ -806,7 +861,13 @@ if (diffs.length === 0) {
   console.error('No value-level difference found -- the two serialize differently only in key order or');
   console.error('formatting, i.e. the report SHAPE changed rather than any measured number.');
 } else {
-  console.error(`${diffs.length}${diffs.length >= 40 ? '+' : ''} differing path(s), golden -> actual:`);
+  console.error(`${diffs.length}${truncated ? '+' : ''} differing path(s), golden -> actual:`);
+  if (truncated) {
+    console.error(
+      `  LIST TRUNCATED at the ${MAX_DIFF_PATHS}-entry cap -- these are the first ${MAX_DIFF_PATHS} of` +
+        ' AT LEAST that many. Fix these, re-run, and the next batch appears.',
+    );
+  }
   for (const d of diffs) {
     console.error(`  ${d.path}`);
     console.error(`      golden: ${JSON.stringify(d.golden)}`);

--- a/scripts/moonshot/ci/assert-b35-golden.mjs
+++ b/scripts/moonshot/ci/assert-b35-golden.mjs
@@ -1,0 +1,165 @@
+#!/usr/bin/env node
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Standing-evidence tripwire for the B3.5 five-act demo
+ * (.github/workflows/moonshot.yml, bet B4.1).
+ *
+ * `scripts/moonshot/b35-demo/run.mjs` writes `demo-report.json` whose entire
+ * `deterministic` subtree is a pure function of the master seed (default
+ * 20260724) -- act statuses, entity counts, reward channels, node/read
+ * counts, merge-battery tallies, carbon numbers, hashes. Wall clocks and the
+ * timestamp live ONLY under `volatile`. That makes the deterministic subtree
+ * the single densest regression signal in the moonshot program: one number
+ * moving anywhere across world-gym, @ifc-lite/create, @ifc-lite/provenance,
+ * the benchmark scorer or the geometry kernel shows up here.
+ *
+ * This script asserts that subtree BYTE-FOR-BYTE against the committed
+ * golden at `scripts/moonshot/ci/b35-golden.json`, and on a mismatch names
+ * the JSON paths that moved so a red run is diagnosable from the step log
+ * alone.
+ *
+ * Note the demo REWRITES `scripts/moonshot/b35-demo/demo-report.json` in
+ * place on every run, so that file cannot be its own baseline -- hence a
+ * separate, explicitly-named golden.
+ *
+ * Sensitivity, measured rather than assumed. The report rounds (carbon to 3
+ * decimals, parameters to 6), so this is not an ULP-level tripwire: a
+ * one-ULP nudge of a carbon factor (315 -> 315.00000000000006) does NOT
+ * move it. What does, verified by injection:
+ *   - a 3e-9 relative change to a carbon factor (315 -> 315.000001) ->
+ *     names acts/act5/data/params/* and the carbon fields;
+ *   - a 1e-6 relative change to extrusion depth in rust/geometry ->
+ *     names acts/act5/data/kernelValidation/* (kernelCarbonKg,
+ *     worstElementRelDev, carbonRelDev), i.e. it catches a wasm geometry
+ *     kernel change through the act-5 re-measurement.
+ * The floor is the report's own rounding, and act 5's kernel-validation
+ * block is the most sensitive part of it.
+ *
+ * Usage:
+ *   node scripts/moonshot/ci/assert-b35-golden.mjs            # assert
+ *   node scripts/moonshot/ci/assert-b35-golden.mjs --update   # re-bless
+ *
+ * Exit codes: 0 match, 1 drift, 2 usage/IO problem.
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(HERE, '../../..');
+const REPORT_PATH = path.join(REPO_ROOT, 'scripts/moonshot/b35-demo/demo-report.json');
+const GOLDEN_PATH = path.join(HERE, 'b35-golden.json');
+
+const UPDATE = process.argv.includes('--update');
+
+/** Serialize exactly the way run.mjs serializes demo-report.json. */
+function serialize(value) {
+  return `${JSON.stringify(value, null, 2)}\n`;
+}
+
+function readJson(file, what) {
+  let text;
+  try {
+    text = readFileSync(file, 'utf-8');
+  } catch (err) {
+    console.error(`::error::${what} not found at ${path.relative(REPO_ROOT, file)}: ${err.message}`);
+    if (file === REPORT_PATH) {
+      console.error('Run `node scripts/moonshot/b35-demo/run.mjs` first -- it writes the report this script checks.');
+    } else {
+      console.error('Re-bless with `node scripts/moonshot/ci/assert-b35-golden.mjs --update`.');
+    }
+    process.exit(2);
+  }
+  try {
+    return { text, value: JSON.parse(text) };
+  } catch (err) {
+    console.error(`::error::${what} at ${path.relative(REPO_ROOT, file)} is not valid JSON: ${err.message}`);
+    process.exit(2);
+  }
+}
+
+/** Every leaf path where `a` and `b` disagree, as `a/b/c` strings. */
+function diffPaths(a, b, prefix = '', out = []) {
+  if (out.length >= 40) return out;
+  const bothObjects =
+    a !== null && b !== null && typeof a === 'object' && typeof b === 'object' &&
+    Array.isArray(a) === Array.isArray(b);
+  if (!bothObjects) {
+    if (JSON.stringify(a) !== JSON.stringify(b)) {
+      out.push({ path: prefix || '(root)', golden: a, actual: b });
+    }
+    return out;
+  }
+  const keys = [...new Set([...Object.keys(a), ...Object.keys(b)])];
+  for (const k of keys) {
+    diffPaths(a[k], b[k], prefix ? `${prefix}/${k}` : k, out);
+    if (out.length >= 40) break;
+  }
+  return out;
+}
+
+const report = readJson(REPORT_PATH, 'B3.5 demo report').value;
+if (!report || typeof report !== 'object' || typeof report.deterministic !== 'object' || report.deterministic === null) {
+  console.error(`::error::${path.relative(REPO_ROOT, REPORT_PATH)} has no \`deterministic\` object -- the report shape changed.`);
+  process.exit(2);
+}
+const actualText = serialize(report.deterministic);
+
+if (UPDATE) {
+  writeFileSync(GOLDEN_PATH, actualText, 'utf-8');
+  console.log(`golden updated: ${path.relative(REPO_ROOT, GOLDEN_PATH)} (${actualText.length} bytes)`);
+  console.log(`source report:  ${path.relative(REPO_ROOT, REPORT_PATH)} (masterSeed ${report.deterministic.masterSeed})`);
+  process.exit(0);
+}
+
+const golden = readJson(GOLDEN_PATH, 'B3.5 golden');
+
+if (golden.text === actualText) {
+  const acts = Object.entries(report.deterministic.acts ?? {})
+    .map(([k, v]) => `${k}=${v.status}`)
+    .join(' ');
+  console.log(
+    `B3.5 deterministic subtree matches the golden byte-for-byte ` +
+      `(${actualText.length} bytes, masterSeed ${report.deterministic.masterSeed}, config ` +
+      `${JSON.stringify(report.deterministic.config)}).`,
+  );
+  console.log(`acts: ${acts}`);
+  process.exit(0);
+}
+
+const diffs = diffPaths(golden.value, report.deterministic);
+console.error(
+  '::error::B3.5 DETERMINISTIC DRIFT -- the five-act demo no longer reproduces its seeded golden.',
+);
+console.error('');
+console.error(`golden: ${path.relative(REPO_ROOT, GOLDEN_PATH)} (${golden.text.length} bytes)`);
+console.error(`actual: ${path.relative(REPO_ROOT, REPORT_PATH)} -> deterministic (${actualText.length} bytes)`);
+console.error('');
+if (diffs.length === 0) {
+  console.error('No value-level difference found -- the two serialize differently only in key order or');
+  console.error('formatting, i.e. the report SHAPE changed rather than any measured number.');
+} else {
+  console.error(`${diffs.length}${diffs.length >= 40 ? '+' : ''} differing path(s), golden -> actual:`);
+  for (const d of diffs) {
+    console.error(`  ${d.path}`);
+    console.error(`      golden: ${JSON.stringify(d.golden)}`);
+    console.error(`      actual: ${JSON.stringify(d.actual)}`);
+  }
+}
+console.error('');
+console.error('The leading path segment names the act that broke:');
+console.error('  acts/act1 = BIRTH       world-gym generator/labeler/reward channels');
+console.error('  acts/act2 = PROOF       node-hash-v0 DAG + certificate verify/tamper (@ifc-lite/provenance)');
+console.error('  acts/act3 = SABOTAGE    benchmark splits/ground-truth/scorer');
+console.error('  acts/act4 = CONVERGENCE merge battery + commutation certificates');
+console.error('  acts/act5 = DESCENT     differentiable carbon model + GEOMETRY KERNEL re-measurement');
+console.error('');
+console.error('If the change is intended, re-run the demo and re-bless with:');
+console.error('  node scripts/moonshot/b35-demo/run.mjs');
+console.error('  node scripts/moonshot/ci/assert-b35-golden.mjs --update');
+console.error('and commit both the golden and scripts/moonshot/b35-demo/demo-report.{json,md}.');
+process.exit(1);

--- a/scripts/moonshot/ci/assert-b35-golden.mjs
+++ b/scripts/moonshot/ci/assert-b35-golden.mjs
@@ -38,25 +38,50 @@
  * The floor is the report's own rounding, and act 5's kernel-validation
  * block is the most sensitive part of it.
  *
- * SELF-TEST. `--self-test` tests the test: it injects a known perturbation,
- * proves this script goes red and names act 5 and the moved paths, restores
- * the tree and proves it goes green again. See selfTest() below for the
- * mechanics and for why the perturbation has the magnitude it has. It exists
- * because the G4 review (docs/vision/reviews/g4-red-team-2026-07-29.md
- * section 4) found that the perturbation half of B4.1's exam was attested in
- * prose and had no committed artifact: a tripwire nobody ever fires is
- * indistinguishable from a tripwire that cannot fire.
+ * TWO SELF-TESTS, AND THEY PROVE DIFFERENT THINGS. Both exist because the G4
+ * review (docs/vision/reviews/g4-red-team-2026-07-29.md section 4) found that
+ * the perturbation half of B4.1's exam was attested in prose with no committed
+ * artifact: a tripwire nobody ever fires is indistinguishable from a tripwire
+ * that cannot fire. Do not read either one as the other.
+ *
+ *   --self-test  MODEL-CONSTANT self-test. Perturbs a JavaScript constant
+ *                (`CARBON_FACTORS.Concrete` in the diff-spike's carbon model),
+ *                re-runs the demo, requires this script to go red naming act 5,
+ *                restores and requires green. ~12 s, no toolchain, runs in the
+ *                CI lane on every execution.
+ *                IT IS NOT A KERNEL PERTURBATION. The G4 re-review proved the
+ *                distinction is not pedantic: you can disconnect the wasm
+ *                geometry kernel from act 5 entirely and this mode still
+ *                passes, because its only kernel-flavoured assertion is that
+ *                `kernelValidation/kernelCarbonKg` moved -- and that field is a
+ *                product with the perturbed JS constant, so it moves either
+ *                way. What a green run establishes is: the golden is wired to
+ *                act 5's data and can distinguish a >=1e-6 relative change in
+ *                it from no change. What it does NOT establish is that any
+ *                kernel measurement is still reaching that data.
+ *
+ *   --kernel     KERNEL perturbation. Applies `depth *= 1.000001` to
+ *                `extrude_profile` in rust/geometry, REBUILDS THE WASM BUNDLE
+ *                FROM SOURCE, re-runs the demo, requires this script to go red
+ *                naming ONLY `acts/act5/data/kernelValidation/*`, then reverts,
+ *                rebuilds and requires green. Minutes, and needs a rust
+ *                toolchain plus wasm-pack, so it is opt-in and out-of-lane.
+ *                This is the mode that proves rust/geometry -> wasm -> act 5 ->
+ *                golden is intact end to end. Its committed output is
+ *                scripts/moonshot/ci/kernel-perturbation-evidence.txt.
  *
  * Usage:
  *   node scripts/moonshot/ci/assert-b35-golden.mjs             # assert
  *   node scripts/moonshot/ci/assert-b35-golden.mjs --update    # re-bless
- *   node scripts/moonshot/ci/assert-b35-golden.mjs --self-test # prove it fires
+ *   node scripts/moonshot/ci/assert-b35-golden.mjs --self-test # JS-constant tripwire test
+ *   node scripts/moonshot/ci/assert-b35-golden.mjs --kernel    # real kernel perturbation
  *
  * Exit codes: 0 match, 1 drift, 2 usage/IO problem.
- * Under --self-test: 0 the tripwire fired and recovered, 1 it did not (or the
- * tree was not restored), 2 usage/IO problem.
+ * Under --self-test / --kernel: 0 the tripwire fired and recovered, 1 it did
+ * not (or the tree was not restored), 2 usage/IO problem.
  */
 
+import { createHash } from 'node:crypto';
 import { spawnSync } from 'node:child_process';
 import { readFileSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
@@ -69,10 +94,16 @@ const GOLDEN_PATH = path.join(HERE, 'b35-golden.json');
 
 const UPDATE = process.argv.includes('--update');
 const SELF_TEST = process.argv.includes('--self-test');
+const KERNEL_TEST = process.argv.includes('--kernel');
 
-if (UPDATE && SELF_TEST) {
-  console.error('::error::--update and --self-test are mutually exclusive.');
-  console.error('--self-test asserts the CURRENT golden is the right reference; --update replaces it.');
+if (UPDATE && (SELF_TEST || KERNEL_TEST)) {
+  console.error('::error::--update and the self-test modes are mutually exclusive.');
+  console.error('The self-tests assert the CURRENT golden is the right reference; --update replaces it.');
+  process.exit(2);
+}
+if (SELF_TEST && KERNEL_TEST) {
+  console.error('::error::--self-test and --kernel are separate modes; run them one at a time.');
+  console.error('--self-test perturbs a JS model constant; --kernel perturbs rust/geometry and rebuilds wasm.');
   process.exit(2);
 }
 
@@ -134,18 +165,26 @@ const CARBON_MODEL_PATH = path.join(REPO_ROOT, 'scripts/moonshot/diff-spike/carb
  * The injection site and its magnitude.
  *
  * WHERE. `CARBON_FACTORS.Concrete` in scripts/moonshot/diff-spike/carbon-model.mjs.
- * It reaches the golden's kernel-validation block by a path that is provable
- * by reading two lines rather than by trusting a measurement:
- * scripts/moonshot/b35-demo/act5-descent.mjs imports CARBON_FACTORS and
- * accumulates `kernelCarbon += row.kernelVolume * factor` over the volumes the
- * wasm geometry kernel re-measured, then emits it as
+ * scripts/moonshot/b35-demo/act5-descent.mjs imports CARBON_FACTORS, uses it as
+ * the objective the optimizer descends, and also accumulates
+ * `kernelCarbon += row.kernelVolume * factor` over the volumes the wasm
+ * geometry kernel re-measured, emitting that sum as
  * `acts/act5/data/kernelValidation/kernelCarbonKg` (and, via
- * `|kernelCarbon - n.carbon| / n.carbon`, as `carbonRelDev`). So a change to
- * this constant MUST move the kernel-validation fields unless the pipeline
- * from the kernel to the golden is broken -- which is exactly the failure the
- * self-test is here to detect. It is also the same constant the bet's own
- * prose claims was perturbed, so this script now evidences that claim rather
- * than restating it.
+ * `|kernelCarbon - n.carbon| / n.carbon`, as `carbonRelDev`).
+ *
+ * WHAT A GREEN STAGE A DOES AND DOES NOT ESTABLISH. It establishes that a
+ * >=1e-6 relative change to act 5's inputs reaches pinned leaves of the golden
+ * and is named there -- i.e. the golden is wired to act 5's data and this
+ * script can tell a perturbed run from an unperturbed one. It does NOT
+ * establish that a kernel measurement is still reaching the golden. The G4
+ * re-review demonstrated the gap concretely: disconnect the wasm geometry
+ * kernel from act 5 entirely and this mode still passes, because
+ * `kernelCarbonKg` is a PRODUCT with the perturbed constant and moves whether
+ * or not `row.kernelVolume` came from the kernel. So the assertion below that
+ * `kernelCarbonKg` moved is a wiring check on act 5, not a kernel check. The
+ * kernel check is `--kernel`, which perturbs rust/geometry and rebuilds the
+ * wasm bundle; its committed output is
+ * scripts/moonshot/ci/kernel-perturbation-evidence.txt.
  *
  * WHY 1e-6 RELATIVE (315 -> 315.000315). The tripwire's floor is the report's
  * own rounding, not machine epsilon. `kernelCarbonKg` is rounded to 3 decimals
@@ -232,7 +271,10 @@ function selfTest() {
     console.error(s);
   };
 
-  say('B3.5 golden tripwire --self-test');
+  say('B3.5 golden tripwire --self-test (JS MODEL CONSTANT, not a kernel perturbation)');
+  say('  scope: proves the golden is wired to act 5 and can fail. For the kernel');
+  say('         path (rust/geometry -> wasm -> act 5) run --kernel; its committed');
+  say('         output is scripts/moonshot/ci/kernel-perturbation-evidence.txt.');
   say(`  perturbation: ${PERTURB_DESC}`);
   say(`  assert under test: ${path.relative(REPO_ROOT, fileURLToPath(import.meta.url))}`);
   say('');
@@ -322,8 +364,8 @@ function selfTest() {
       if (assertA.code === 0) {
         problems.push(
           'THE TRIPWIRE DID NOT FIRE: the golden check passed with a perturbed carbon factor. ' +
-            'A >=1e-6 relative change reached no pinned field -- the golden no longer covers ' +
-            "act 5's kernel-validation block, or the demo is not reading the perturbed source.",
+            'A >=1e-6 relative change to act 5 reached no pinned field -- the golden no longer ' +
+            'covers act 5, or the demo is not reading the perturbed source.',
         );
       } else if (assertA.code !== 1) {
         problems.push(
@@ -344,10 +386,15 @@ function selfTest() {
         problems.push('the failure names no acts/act5/* path -- "names which act broke" is not met');
       }
       if (!kernel.includes('acts/act5/data/kernelValidation/kernelCarbonKg')) {
+        // A WIRING check on act 5, deliberately not described as a kernel
+        // check: the perturbed constant is multiplied into kernelCarbonKg by
+        // act5-descent.mjs, so this fires if the kernel-validation block has
+        // stopped being emitted or stopped being pinned -- not if the kernel
+        // has stopped feeding it. See --kernel for the latter.
         problems.push(
           'acts/act5/data/kernelValidation/kernelCarbonKg did not move, although the perturbed ' +
-            'constant is multiplied into it by act5-descent.mjs -- the kernel measurement is no ' +
-            'longer reaching the golden',
+            'constant is multiplied into it by act5-descent.mjs -- the kernel-validation block is ' +
+            'no longer emitted, or no longer pinned by the golden',
         );
       }
       if (other.length > 0) {
@@ -415,6 +462,9 @@ function selfTest() {
   say('SELF-TEST PASS: the B3.5 golden tripwire fires on a 1e-6 relative carbon-factor');
   say('perturbation, names act 5 and its kernel-validation fields, and returns to green');
   say('when the perturbation is reverted.');
+  say('SCOPE: this is a JS model constant. It proves the golden is wired to act 5 and');
+  say('can fail; it does NOT prove a kernel measurement still reaches it. That is');
+  say('--kernel / kernel-perturbation-evidence.txt.');
   say('');
   say('--- captured failure output (stage A) ---');
   const captured = capturedFailure.trimEnd();
@@ -434,7 +484,286 @@ function selfTest() {
   process.exit(0);
 }
 
+// ---------------------------------------------------------------------------
+// --kernel: the real thing. Perturb rust/geometry, rebuild wasm, prove red.
+// ---------------------------------------------------------------------------
+
+const EXTRUSION_PATH = path.join(REPO_ROOT, 'rust/geometry/src/extrusion.rs');
+const WASM_PATH = path.join(REPO_ROOT, 'packages/wasm/pkg/ifc-lite_bg.wasm');
+const BUILD_WASM = path.join(REPO_ROOT, 'scripts/build-wasm.sh');
+
+/**
+ * The kernel injection site.
+ *
+ * `extrude_profile` is the swept-solid path the b35 demo's walls, slabs and
+ * columns go through, so scaling its depth changes every emitted volume in the
+ * model by the same relative amount. The anchor is the whole signature plus the
+ * opening brace, which is unique in the file and cannot silently drift onto
+ * `extrude_profile_watertight` (the bool2d path, which this demo does not use).
+ *
+ * 1e-6 relative rather than one ULP for the same reason the model-constant mode
+ * uses 1e-6: demo-report.json rounds carbon to 3 decimals on a ~73,459 kg
+ * total, so ~7e-9 relative is the smallest change that can survive being
+ * serialized at all. See kernel-perturbation-evidence.txt.
+ */
+const KERNEL_ANCHOR = `pub fn extrude_profile(
+    profile: &Profile2D,
+    depth: f64,
+    transform: Option<Matrix4<f64>>,
+) -> Result<Mesh> {
+`;
+const KERNEL_INJECT = '    let depth = depth * 1.000001;\n';
+const KERNEL_DESC =
+  'extrude_profile depth *= 1.000001 (+1e-6 relative) in rust/geometry/src/extrusion.rs';
+
+/** Files --kernel rewrites. Every one of them is restored byte-for-byte. */
+const KERNEL_TOUCHED = [
+  'rust/geometry/src/extrusion.rs',
+  'scripts/moonshot/b35-demo/demo-report.json',
+  'scripts/moonshot/b35-demo/demo-report.md',
+];
+
+function sha256File(file) {
+  try {
+    return createHash('sha256').update(readFileSync(file)).digest('hex');
+  } catch {
+    return null;
+  }
+}
+
+function buildWasm(label) {
+  const started = Date.now();
+  const r = spawnSync('bash', [BUILD_WASM], {
+    cwd: REPO_ROOT,
+    encoding: 'utf-8',
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  const ms = Date.now() - started;
+  console.log(`  ${label}: bash scripts/build-wasm.sh exited ${r.status} in ${(ms / 1000).toFixed(0)}s`);
+  return { code: r.status, stdout: r.stdout ?? '', stderr: r.stderr ?? '', ms };
+}
+
+function kernelTest() {
+  const say = (s = '') => console.log(s);
+  const fail = (s) => console.error(s);
+
+  say('B3.5 golden tripwire --kernel (REAL kernel perturbation, rebuilds wasm from source)');
+  say(`  perturbation: ${KERNEL_DESC}`);
+  say('  cost: two full wasm rebuilds. Minutes, not seconds -- this is why it is opt-in');
+  say('        and why the CI lane runs --self-test instead. Needs rust + wasm-pack.');
+  say('');
+
+  const before = git(['status', '--porcelain', '--', ...KERNEL_TOUCHED]);
+  if (before.code !== 0) {
+    console.error('::error::--kernel needs a git checkout: it verifies the tree is restored with `git status`.');
+    process.exit(2);
+  }
+  if (before.out !== '') {
+    say('NOTE: these files were already modified before this run started; they are');
+    say('      snapshotted and put back exactly as found:');
+    for (const line of before.out.split('\n')) say(`      ${line}`);
+    say('');
+  }
+
+  const snapshot = new Map();
+  for (const rel of KERNEL_TOUCHED) {
+    const abs = path.join(REPO_ROOT, rel);
+    try {
+      snapshot.set(abs, readFileSync(abs));
+    } catch (err) {
+      console.error(`::error::cannot snapshot ${rel}: ${err.message}`);
+      process.exit(2);
+    }
+  }
+  const restore = () => {
+    for (const [abs, bytes] of snapshot) writeFileSync(abs, bytes);
+  };
+  const onSignal = (sig) => {
+    restore();
+    console.error('');
+    console.error('INTERRUPTED. rust/geometry/src/extrusion.rs was restored, but the wasm bundle in');
+    console.error('packages/wasm/pkg/ is whatever the last completed build produced. Re-run');
+    console.error('`bash scripts/build-wasm.sh` before trusting any local geometry measurement.');
+    process.exit(sig === 'SIGINT' ? 130 : 143);
+  };
+  process.on('SIGINT', onSignal);
+  process.on('SIGTERM', onSignal);
+
+  const problems = [];
+  let capturedFailure = '';
+  const wasmBefore = sha256File(WASM_PATH);
+
+  try {
+    // --- Stage 0: the baseline has to be green, or stage A proves nothing ---
+    say('stage 0 -- baseline (the golden must already match before we perturb anything)');
+    const demo0 = runNode(DEMO_RUN);
+    if (demo0.code !== 0) {
+      fail(`::error::stage 0: the demo exited ${demo0.code} on an unperturbed tree.`);
+      fail(demo0.stderr.split('\n').slice(-25).join('\n'));
+      restore();
+      process.exit(2);
+    }
+    const assert0 = runNode(fileURLToPath(import.meta.url));
+    say(`  golden check exited ${assert0.code} (expected 0 = match)`);
+    if (assert0.code !== 0) {
+      fail('::error::stage 0: the golden is ALREADY red before the perturbation.');
+      fail('A red stage A would then prove nothing. Fix the drift first, or re-bless.');
+      fail(assert0.stderr.split('\n').slice(0, 30).join('\n'));
+      restore();
+      process.exit(2);
+    }
+
+    // --- Stage A: perturb the kernel, rebuild, expect red -------------------
+    const original = readFileSync(EXTRUSION_PATH, 'utf-8');
+    const hits = original.split(KERNEL_ANCHOR).length - 1;
+    if (hits !== 1) {
+      fail(`::error::the extrude_profile signature anchor occurs ${hits} time(s) in`);
+      fail(`  ${path.relative(REPO_ROOT, EXTRUSION_PATH)} -- expected exactly 1.`);
+      fail('  The kernel moved; re-point KERNEL_ANCHOR rather than weakening the match.');
+      restore();
+      process.exit(2);
+    }
+    writeFileSync(EXTRUSION_PATH, original.replace(KERNEL_ANCHOR, KERNEL_ANCHOR + KERNEL_INJECT), 'utf-8');
+    say('');
+    say('stage A -- kernel perturbed, rebuilding the wasm bundle from source');
+    const buildA = buildWasm('stage A');
+    if (buildA.code !== 0) {
+      fail('::error::stage A: the wasm build failed under the perturbation.');
+      fail(buildA.stderr.split('\n').slice(-30).join('\n'));
+      problems.push('stage A: wasm build failed');
+    } else {
+      const wasmAfter = sha256File(WASM_PATH);
+      say(`  bundle sha256 ${String(wasmBefore).slice(0, 16)} -> ${String(wasmAfter).slice(0, 16)}`);
+      if (wasmAfter !== null && wasmAfter === wasmBefore) {
+        // scripts/build-wasm.sh exits 0 on a stale on-disk bundle when
+        // wasm-pack is missing -- the G4 review's structural gap (d). Catch it
+        // here rather than reporting "the tripwire did not fire".
+        problems.push(
+          'the wasm bundle did NOT change after a kernel edit + rebuild. The build did not ' +
+            'actually rebuild (is wasm-pack installed? scripts/build-wasm.sh can exit 0 on a ' +
+            'stale on-disk bundle) -- nothing below this line is evidence about the kernel.',
+        );
+      }
+      const demoA = runNode(DEMO_RUN);
+      if (demoA.code !== 0) {
+        fail(`::error::stage A: the demo exited ${demoA.code} under the perturbation instead of completing.`);
+        fail(demoA.stderr.split('\n').slice(-25).join('\n'));
+        problems.push('stage A: demo did not complete under the perturbation');
+      } else {
+        const assertA = runNode(fileURLToPath(import.meta.url));
+        capturedFailure = assertA.stderr;
+        say(`  golden check exited ${assertA.code} (expected 1 = drift)`);
+        if (assertA.code === 0) {
+          problems.push(
+            'THE TRIPWIRE DID NOT FIRE: the golden check passed with a perturbed geometry ' +
+              'kernel. A 1e-6 relative change to every extruded depth reached no pinned field, ' +
+              'so no kernel measurement is reaching the golden -- which is exactly the failure ' +
+              'the model-constant --self-test cannot see.',
+          );
+        } else if (assertA.code !== 1) {
+          problems.push(`the golden check exited ${assertA.code} (usage/IO), not 1 (drift)`);
+        }
+        if (!assertA.stderr.includes('B3.5 DETERMINISTIC DRIFT')) {
+          problems.push('the failure output does not carry the "B3.5 DETERMINISTIC DRIFT" banner');
+        }
+        const paths = parseDiffPaths(assertA.stderr);
+        const kernel = paths.filter((p) => p.startsWith('acts/act5/data/kernelValidation/'));
+        const other = paths.filter((p) => !p.startsWith('acts/act5/data/kernelValidation/'));
+        say(`  differing paths named: ${paths.length} (kernel-validation: ${kernel.length})`);
+        for (const p of paths) say(`    ${p}`);
+        if (!kernel.includes('acts/act5/data/kernelValidation/kernelCarbonKg')) {
+          problems.push(
+            'acts/act5/data/kernelValidation/kernelCarbonKg did not move under a kernel ' +
+              'perturbation -- the wasm re-measurement is not reaching the golden',
+          );
+        }
+        if (other.length > 0) {
+          // Expected to be empty and worth asserting: the JS model is untouched,
+          // so the optimizer's own parameters must NOT move. If they do, act 5
+          // is reading geometry somewhere it should not be, or the demo is not
+          // deterministic under a rebuild.
+          problems.push(
+            `${other.length} path(s) outside acts/act5/data/kernelValidation moved under a ` +
+              `kernel-only perturbation: ${other.join(', ')}`,
+          );
+        }
+      }
+    }
+
+    // --- Stage B: revert, rebuild, expect green again -----------------------
+    say('');
+    say('stage B -- kernel reverted, rebuilding the wasm bundle again to prove recovery');
+    restore();
+    const buildB = buildWasm('stage B');
+    if (buildB.code !== 0) {
+      fail('::error::stage B: the wasm build failed after the revert. The bundle on disk is now');
+      fail('whatever stage A produced -- re-run `bash scripts/build-wasm.sh` before trusting it.');
+      fail(buildB.stderr.split('\n').slice(-30).join('\n'));
+      problems.push('stage B: wasm build failed after revert');
+    } else {
+      const demoB = runNode(DEMO_RUN);
+      if (demoB.code !== 0) {
+        fail(`::error::stage B: the demo exited ${demoB.code} after restore.`);
+        problems.push('stage B: demo did not complete after restore');
+      } else {
+        const assertB = runNode(fileURLToPath(import.meta.url));
+        say(`  golden check exited ${assertB.code} (expected 0 = match)`);
+        if (assertB.code !== 0) {
+          problems.push(
+            'the golden check is still red after the kernel perturbation was reverted -- the ' +
+              'revert or the rebuild is incomplete',
+          );
+          fail(assertB.stderr.split('\n').slice(0, 30).join('\n'));
+        }
+      }
+    }
+  } finally {
+    restore();
+    process.off('SIGINT', onSignal);
+    process.off('SIGTERM', onSignal);
+  }
+
+  const after = git(['status', '--porcelain', '--', ...KERNEL_TOUCHED]);
+  say('');
+  if (after.code !== 0) {
+    problems.push('could not run `git status` to verify the tree was restored');
+  } else if (after.out !== before.out) {
+    problems.push(
+      `the tree was NOT restored to its starting state.\n  before: ${JSON.stringify(before.out)}\n  after:  ${JSON.stringify(after.out)}`,
+    );
+  } else {
+    say(`tree restored: \`git status --porcelain\` identical to the pre-run baseline over all ${KERNEL_TOUCHED.length} touched files.`);
+    say('(packages/wasm/pkg/ifc-lite_bg.wasm is gitignored; stage B rebuilt it from the');
+    say(' restored source, so it measures the same as it did before this run.)');
+  }
+
+  say('');
+  if (problems.length > 0) {
+    console.error('::error::B3.5 GOLDEN --kernel TEST FAILED.');
+    for (const p of problems) console.error(`  - ${p}`);
+    process.exit(1);
+  }
+
+  say('KERNEL TEST PASS: a 1e-6 relative change to extrude_profile in rust/geometry,');
+  say('compiled into the wasm bundle, turns the B3.5 golden red naming act 5 and ONLY');
+  say('its kernel-validation fields, and it returns to green when reverted and rebuilt.');
+  say('The path rust/geometry -> wasm -> act 5 -> golden is intact end to end.');
+  say('');
+  say('--- captured failure output (stage A) ---');
+  console.log(capturedFailure.trimEnd());
+  say('');
+  say(
+    `summary: ${JSON.stringify({
+      perturbation: KERNEL_DESC,
+      node: process.version,
+      platform: `${process.platform}-${process.arch}`,
+    })}`,
+  );
+  process.exit(0);
+}
+
 if (SELF_TEST) selfTest();
+if (KERNEL_TEST) kernelTest();
 
 const report = readJson(REPORT_PATH, 'B3.5 demo report').value;
 if (!report || typeof report !== 'object' || typeof report.deterministic !== 'object' || report.deterministic === null) {

--- a/scripts/moonshot/ci/b35-golden.json
+++ b/scripts/moonshot/ci/b35-golden.json
@@ -1,0 +1,357 @@
+{
+  "masterSeed": 20260724,
+  "config": {
+    "devSliceSize": 40,
+    "batterySchedules": 1000
+  },
+  "acts": {
+    "act1": {
+      "status": "ok",
+      "data": {
+        "seed": 20260724,
+        "family": "office",
+        "entityCount": 548,
+        "fileSize": 28004,
+        "storeyCount": 1,
+        "sha256": "80b58870ce12bc4f40bbd4da5ba7b5ce63dfdf7aa944bcc5774ce238898ab912",
+        "groundTruthTotals": {
+          "slabCount": 1,
+          "slabGrossArea": 214.212816,
+          "slabGrossVolume": 62.550142,
+          "wallCount": 4,
+          "wallGrossSideArea": 427.1124,
+          "wallGrossVolume": 68.594251,
+          "partitionWallCount": 6,
+          "roomCount": 16,
+          "roomNetFloorArea": 214.212816,
+          "roomNetVolume": 617.361336
+        },
+        "schema": {
+          "valid": true,
+          "errors": 0,
+          "warnings": 0
+        },
+        "clashTotal": 0,
+        "rewardChannels": {
+          "schemaValidity": 1,
+          "clashScore": 1,
+          "determinismHashMatch": 1,
+          "quantityAccuracy": 1,
+          "defectDetection": 1
+        },
+        "allChannelsPerfect": true
+      }
+    },
+    "act2": {
+      "status": "ok",
+      "data": {
+        "totalNodes": 56,
+        "elements": 27,
+        "psetLeaves": 27,
+        "storeys": 1,
+        "rootHashBefore": "sha256:771cb465932d61e5607a251de8af33a35e721a4eac442787f9974ede79105f0d",
+        "rootHashAfter": "sha256:aa00d60d3f10503c221f09d61b141577fdfac1b8cf012de9ecc7df7f4b170012",
+        "edit": {
+          "expressId": 58,
+          "ifcType": "IfcWall",
+          "property": "GrossVolume",
+          "before": 8.136439344000001,
+          "after": 9.136439344000001
+        },
+        "certificateWrites": 4,
+        "certificateReads": 0,
+        "claimGranularity": "sibling-element-subtrees",
+        "untouchedClaimRefs": 26,
+        "secondProcessVerifyOk": true,
+        "nodesResolved": 30,
+        "nodesResolvedPct": 53.5714,
+        "tamper": {
+          "expressId": 41,
+          "ifcType": "IfcSlab",
+          "caught": true,
+          "reason": "hash-mismatch"
+        }
+      }
+    },
+    "act3": {
+      "status": "ok",
+      "data": {
+        "spotlight": {
+          "seed": 20260725,
+          "family": "office",
+          "sha256": "5d3a433fa4ade71ae882d19a3d9185a33c29e098b0601ed6e059497a4da0d2b4",
+          "plantedDefects": [
+            {
+              "type": "duplicate-globalid",
+              "guid": "1jaVXacz_tNbsfXb48C$nJ"
+            }
+          ],
+          "plantedTypes": [
+            "duplicate-globalid"
+          ],
+          "detectedTypes": [
+            "duplicate-globalid"
+          ],
+          "caughtCount": 1,
+          "plantedCount": 1
+        },
+        "oracleSlice": {
+          "split": "dev",
+          "seeds": [
+            8,
+            18,
+            28,
+            38,
+            48,
+            58,
+            68,
+            78,
+            88,
+            98,
+            108,
+            118,
+            128,
+            138,
+            148,
+            158,
+            168,
+            178,
+            188,
+            198,
+            208,
+            218,
+            228,
+            238,
+            248,
+            258,
+            268,
+            278,
+            288,
+            298,
+            308,
+            318,
+            328,
+            338,
+            348,
+            358,
+            368,
+            378,
+            388,
+            398
+          ],
+          "corruptedCount": 17,
+          "defectMacroF1": 0.857143,
+          "defectPerType": {
+            "clash-pair": {
+              "tp": 4,
+              "fp": 0,
+              "fn": 0,
+              "f1": 1
+            },
+            "degenerate-geometry": {
+              "tp": 3,
+              "fp": 0,
+              "fn": 0,
+              "f1": 1
+            },
+            "duplicate-globalid": {
+              "tp": 2,
+              "fp": 0,
+              "fn": 0,
+              "f1": 1
+            },
+            "missing-site": {
+              "tp": 4,
+              "fp": 0,
+              "fn": 0,
+              "f1": 1
+            },
+            "multiple-project": {
+              "tp": 5,
+              "fp": 0,
+              "fn": 0,
+              "f1": 1
+            },
+            "dangling-ref": {
+              "tp": 0,
+              "fp": 0,
+              "fn": 8,
+              "f1": 0
+            },
+            "missing-quantities": {
+              "tp": 7,
+              "fp": 0,
+              "fn": 0,
+              "f1": 1
+            }
+          },
+          "quantityScore": 0.94697,
+          "triageScore": 0.873166,
+          "triagePairs": 477
+        }
+      }
+    },
+    "act4": {
+      "status": "ok",
+      "data": {
+        "baseEntities": 27,
+        "baseRootHash": "sha256:1d335793b20bc580ce16ba7eafbb3a0a9c48b0786a9e0444cff42eba58c52ebc",
+        "mergedRootHash": "sha256:bff4e3213591febc02e084fdbaf4cc84fadd4ae5382748535d685247bb9cf4ed",
+        "certificateBaseRootHash": "sha256:1d335793b20bc580ce16ba7eafbb3a0a9c48b0786a9e0444cff42eba58c52ebc",
+        "autoMerge": {
+          "clients": [
+            "alice",
+            "bob"
+          ],
+          "aWrites": 2,
+          "bWrites": 2,
+          "verifiedIndependently": true
+        },
+        "blockedConflict": {
+          "blocked": true,
+          "conflicts": [
+            {
+              "a": "alice-2",
+              "b": "bob-2",
+              "structural": true,
+              "spatial": false
+            }
+          ]
+        },
+        "battery": {
+          "schedules": 1000,
+          "seed": 20260724,
+          "epsilonMm": 50,
+          "autoMerged": 849,
+          "unsoundAutoMerges": 0,
+          "unsoundScheduleIndices": [],
+          "flaggedConflicts": 151,
+          "trueConflicts": 50,
+          "falseConflicts": 101,
+          "groundTruthConvergent": 950,
+          "conflictRate": 0.151,
+          "falseConflictRate": 0.10631578947368421,
+          "certificatesIssued": 849,
+          "certificatesVerified": 33,
+          "certificateFailures": 0,
+          "examPass": true,
+          "killCriterionPass": true
+        }
+      }
+    },
+    "act5": {
+      "status": "ok",
+      "data": {
+        "params": {
+          "Lx": 14.927229,
+          "Ly": 13.740763,
+          "h1": 3,
+          "h2": 3,
+          "h3": 3,
+          "tw": 0.18,
+          "ts": 0.18,
+          "tr": 0.18,
+          "wwL": 1.948896,
+          "wh": 1.337394,
+          "sill": 0.57,
+          "dw": 1.429887,
+          "dh": 2.306698,
+          "cw": 0.280305,
+          "cd": 0.290873,
+          "bw": 0.15,
+          "bh": 0.38163,
+          "tp": 0.08,
+          "wwS": 2.049852,
+          "gt": 0.02,
+          "fw": 0.6,
+          "fd": 0.6,
+          "fh": 0.5,
+          "dt": 0.04
+        },
+        "startCarbonKg": 177100.875,
+        "optimumCarbonKg": 73459.098,
+        "reductionPct": 58.521,
+        "penaltyRounds": [
+          {
+            "round": 0,
+            "mu": 10,
+            "carbon": 67833.465,
+            "maxViol": 0.51179282,
+            "iters": 400
+          },
+          {
+            "round": 1,
+            "mu": 40,
+            "carbon": 71744.224,
+            "maxViol": 0.127153118,
+            "iters": 400
+          },
+          {
+            "round": 2,
+            "mu": 160,
+            "carbon": 72789.725,
+            "maxViol": 0.033694104,
+            "iters": 400
+          },
+          {
+            "round": 3,
+            "mu": 640,
+            "carbon": 73304.362,
+            "maxViol": 0.008108661,
+            "iters": 400
+          },
+          {
+            "round": 4,
+            "mu": 2560,
+            "carbon": 73426.599,
+            "maxViol": 0.0021569,
+            "iters": 400
+          },
+          {
+            "round": 5,
+            "mu": 10240,
+            "carbon": 73459.098,
+            "maxViol": 0.00051128,
+            "iters": 400
+          }
+        ],
+        "residualScaledViolation": 0.00051128,
+        "residualConstraints": [
+          {
+            "name": "floor-area",
+            "g": 0.048957657
+          },
+          {
+            "name": "daylight-s0",
+            "g": 0.000004166
+          },
+          {
+            "name": "column-section",
+            "g": 0.00051128
+          },
+          {
+            "name": "beam-depth",
+            "g": 0.000057799
+          }
+        ],
+        "optimumIfc": {
+          "bytes": 111197,
+          "mappedElements": 74,
+          "sha256": "48fc69e72d33c45002832dec38d53fc6d0c563bab997e8fafcdc537181078c4e"
+        },
+        "kernelValidation": {
+          "worstElementRelDev": 0.000001675,
+          "worstElementKey": "wall-south-s0",
+          "missingMeshes": 0,
+          "kernelCarbonKg": 73459.109,
+          "carbonRelDev": 1.54e-7
+        },
+        "schema": {
+          "valid": true,
+          "errors": 0,
+          "warnings": 1
+        }
+      }
+    }
+  }
+}

--- a/scripts/moonshot/ci/check-report-numerals.mjs
+++ b/scripts/moonshot/ci/check-report-numerals.mjs
@@ -113,6 +113,33 @@
  * than a marker, and it is what was done for B4.5's g0/g1 DAG shape rather than
  * leaving three figures excused.
  *
+ * THIS IS NOT A TRUTH GATE, AND THE SCRIPT SAYS SO IN ITS OWN OUTPUT. The
+ * decoy calibration below measures the only thing that matters about a green
+ * run: how often a deliberately-wrong number is cleared as "backed" by
+ * coincidence. Against a single curated scorecard that rate is near zero.
+ * Against `docs/vision`, whose haystack is the UNION of every moonshot
+ * artifact in the tree (~8,900 numbers), it measured 57.5% to 91.7% per
+ * document on 2026-07-29 -- 69.0% on the finishing plan itself. A "backed"
+ * verdict there means "some field somewhere in the program holds this value",
+ * which is close to no information at all. The gate catches a figure that
+ * contradicts a named artifact; it does not certify one that agrees with the
+ * pile.
+ *
+ * THE FIX FOR THAT IS POSITIVE BINDING, NOT A BIGGER HAYSTACK. A second marker
+ * form names the artifact and the JSON path a figure comes from:
+ *
+ *   <!-- numeral-src: 899 :: b45-m1-midterm/scorecard.json#sensitivityElementGranularityClaim.verifyMs -->
+ *
+ * A bound numeral is checked against that ONE value, so its haystack is 1 and
+ * its decoy pass rate is ~0 (a 3-30% perturbation cannot land inside the
+ * half-ULP of a single named field). A binding that resolves and disagrees is a
+ * hard finding -- the strongest check in this script, because it is the only
+ * one that can say "this sentence contradicts the field it claims to quote".
+ * A binding into a bet directory that is not in this tree yet is PENDING: it is
+ * not counted as backed, its decoys are never cleared, and it becomes a real
+ * check the moment the branch lands. A binding into a directory that DOES exist
+ * but whose file or path does not is a broken binding and fails the gate.
+ *
  * Usage:
  *   node scripts/moonshot/ci/check-report-numerals.mjs
  *   node scripts/moonshot/ci/check-report-numerals.mjs <dir-or-repo-root> ...
@@ -327,8 +354,32 @@ function indexArtifacts(files) {
  */
 const MARKER_RE = /<!--\s*numeral-ok:\s*([\s\S]*?)\s*-->/g;
 
+/**
+ * POSITIVE BINDING -- the marker that makes a "backed" verdict mean something.
+ *
+ *   <!-- numeral-src: 899 :: b45-m1-midterm/scorecard.json#sensitivityElementGranularityClaim.verifyMs -->
+ *
+ * `numeral-ok` says "this number is legitimately absent from the artifacts, and
+ * here is why" -- it EXCUSES. `numeral-src` says "this number is field X of
+ * artifact Y" -- it BINDS, and the checker then verifies exactly that. The two
+ * are not interchangeable and a token may carry only one of them.
+ *
+ * The path is relative to `scripts/moonshot/` (a repo-relative path starting
+ * `scripts/` also works). After `#` comes a dotted JSON path in the same
+ * notation this report already prints for artifact values: `a.b[0].c`.
+ *
+ * WHY THIS FORM. `docs/vision` is checked against the union of every artifact
+ * in the tree, so the question "does the program hold this number anywhere" is
+ * nearly always yes -- see the decoy calibration in the header. Naming the
+ * field collapses the haystack to one value, which is the difference between
+ * "not contradicted" and "quoted from here". It also survives a re-bless: when
+ * the artifact's field moves, the gate says which sentence quoted it.
+ */
+const MARKER_SRC_RE = /<!--\s*numeral-src:\s*([\s\S]*?)\s*-->/g;
+
 function parseMarkers(rawText) {
   const out = new Map(); // token -> reason
+  const bindings = new Map(); // token -> artifact reference string
   const bad = [];
   // Blank code first, so a document that DOCUMENTS the marker syntax inside a
   // code span (`<!-- numeral-ok: <token> :: <reason> -->`) does not register
@@ -362,7 +413,108 @@ function parseMarkers(rawText) {
     }
     for (const t of tokens) out.set(t, reason);
   }
-  return { markers: out, bad };
+  for (const m of text.matchAll(MARKER_SRC_RE)) {
+    const body = m[1];
+    const split = body.indexOf('::');
+    if (split === -1) {
+      bad.push(`numeral-src marker without a " :: <artifact>#<json.path>": ${JSON.stringify(body.slice(0, 80))}`);
+      continue;
+    }
+    const tokens = body.slice(0, split).split(/,\s+/).map((t) => t.trim()).filter(Boolean);
+    const rest = body.slice(split + 2).trim();
+    // `:: none - <why>` is the NEGATIVE binding: an assertion that no artifact
+    // emits this figure. It is not the same as `numeral-ok`, which only excuses
+    // a numeral the union index failed to match. A negative binding also BLOCKS
+    // the union match, which is the point: a retracted figure, or a measurement
+    // of the checker itself, must not be silently vindicated by a coincidental
+    // hit somewhere in ~8,900 numbers. Its decoys are never cleared either, so
+    // it costs the calibration nothing.
+    const ref = /^none\b/i.test(rest) ? `none${rest.slice(4)}` : rest.replace(/\s+/g, '');
+    if (tokens.length === 0) {
+      bad.push(`numeral-src marker lists no numerals: ${JSON.stringify(body.slice(0, 80))}`);
+      continue;
+    }
+    if (!/^none\b/i.test(ref) && !ref.includes('#')) {
+      bad.push(`numeral-src marker needs <artifact>#<json.path>, got ${JSON.stringify(ref.slice(0, 80))}`);
+      continue;
+    }
+    for (const t of tokens) {
+      if (out.has(t)) {
+        bad.push(`${t} carries both a numeral-ok excuse and a numeral-src binding; a token may have only one`);
+        continue;
+      }
+      bindings.set(t, ref);
+    }
+  }
+  return { markers: out, bindings, bad };
+}
+
+// ---------------------------------------------------------------------------
+// Binding resolution
+// ---------------------------------------------------------------------------
+
+const artifactCache = new Map();
+
+function loadArtifact(abs) {
+  if (!artifactCache.has(abs)) {
+    let doc = null;
+    try {
+      doc = JSON.parse(readFileSync(abs, 'utf-8'));
+    } catch {
+      doc = null;
+    }
+    artifactCache.set(abs, doc);
+  }
+  return artifactCache.get(abs);
+}
+
+/** `models[0].speedups.x` -> the number at that path, or undefined. */
+function readJsonPath(doc, jsonPath) {
+  let node = doc;
+  for (const seg of jsonPath.match(/[^.[\]]+/g) ?? []) {
+    if (node === null || node === undefined) return undefined;
+    node = Array.isArray(node) && /^\d+$/.test(seg) ? node[Number(seg)] : node[seg];
+  }
+  if (typeof node === 'number') return Number.isFinite(node) ? node : undefined;
+  if (typeof node === 'string' && /^-?\d+(\.\d+)?([eE][+-]?\d+)?$/.test(node.trim())) {
+    const v = Number(node.trim());
+    return Number.isFinite(v) ? v : undefined;
+  }
+  return undefined;
+}
+
+/**
+ * A binding resolves to one of four states. PENDING is the interesting one: a
+ * bet directory that is simply not in this tree yet (its branch is unmerged) is
+ * a promise the checker will start enforcing the day it lands, and until then
+ * the numeral is NOT counted as backed. A directory that exists with a missing
+ * file or path is a typo, and typos must not hide inside PENDING.
+ */
+function resolveBinding(ref) {
+  if (/^none\b/i.test(ref)) {
+    return { status: 'none', reason: ref.slice(4).replace(/^\s*[-:]\s*/, '').trim() };
+  }
+  const [relRaw, jsonPath] = ref.split('#');
+  const rel = relRaw.startsWith('scripts/') || relRaw.startsWith('docs/')
+    ? relRaw
+    : path.join('scripts/moonshot', relRaw);
+  const abs = path.join(REPO_ROOT, rel);
+  const betDir = path.dirname(abs);
+  if (!statSafe(abs)) {
+    if (!statSafe(betDir)) return { status: 'pending', rel, jsonPath };
+    return { status: 'missing-file', rel, jsonPath };
+  }
+  const doc = loadArtifact(abs);
+  if (doc === null) return { status: 'missing-file', rel, jsonPath };
+  const value = readJsonPath(doc, jsonPath);
+  if (value === undefined) return { status: 'missing-path', rel, jsonPath };
+  return { status: 'ok', rel, jsonPath, value, src: `${path.basename(rel)}:${jsonPath}` };
+}
+
+/** Does the bound value back this numeral, under the prose's own unit scales? */
+function bindingBacks(p, tol, unit, value) {
+  for (const [s] of scalesFor(unit)) if (Math.abs(value * s - p) <= tol) return true;
+  return false;
 }
 
 const SPACES = (n) => ' '.repeat(n);
@@ -610,9 +762,19 @@ function matchDerived(p, tol, unit, index) {
  * reader is entitled to know that before trusting a clean report.
  *
  * Seeded (mulberry32) so the printed rate is reproducible run to run.
+ *
+ * A numeral carrying a `numeral-src` binding is calibrated against ITS OWN
+ * haystack -- the single named field, or nothing at all when the binding is
+ * still pending -- because that is the evidence the reader is being offered.
+ * That is the whole mechanism: every figure moved from the union to a binding
+ * moves three decoys from a coin flip to a certainty, and the rate falls with
+ * it. `bound` / `unbound` are reported separately so the headline rate can
+ * never be improved by quietly binding the easy numbers.
  */
-function calibrate(groups, index) {
-  if (groups.length === 0) return { decoys: 0, cleared: 0, rate: 0 };
+function calibrate(groups, index, bindingIndexFor) {
+  if (groups.length === 0) {
+    return { decoys: 0, cleared: 0, rate: 0, bound: { decoys: 0, cleared: 0 }, unbound: { decoys: 0, cleared: 0 } };
+  }
   let s = 0x9e3779b9;
   const rnd = () => {
     s = (s + 0x6d2b79f5) | 0;
@@ -622,7 +784,12 @@ function calibrate(groups, index) {
   };
   let cleared = 0;
   let decoys = 0;
+  const bound = { decoys: 0, cleared: 0 };
+  const unbound = { decoys: 0, cleared: 0 };
   for (const g of groups) {
+    const own = bindingIndexFor ? bindingIndexFor(g) : null;
+    const haystack = own === null ? index : own;
+    const isBound = own !== null;
     for (let k = 0; k < 3; k += 1) {
       const factor = 1 + (rnd() < 0.5 ? -1 : 1) * (0.03 + rnd() * 0.27);
       const v = g.value * factor;
@@ -636,10 +803,15 @@ function calibrate(groups, index) {
       })();
       const rawDecoy = v.toFixed(Math.min(decimals, 12));
       decoys += 1;
-      if (matchDirect(Number(rawDecoy), writtenTolerance(rawDecoy), g.unit, index).kind) cleared += 1;
+      const tally = isBound ? bound : unbound;
+      tally.decoys += 1;
+      if (matchDirect(Number(rawDecoy), writtenTolerance(rawDecoy), g.unit, haystack).kind) {
+        cleared += 1;
+        tally.cleared += 1;
+      }
     }
   }
-  return { decoys, cleared, rate: decoys === 0 ? 0 : cleared / decoys };
+  return { decoys, cleared, rate: decoys === 0 ? 0 : cleared / decoys, bound, unbound };
 }
 
 // ---------------------------------------------------------------------------
@@ -670,14 +842,19 @@ for (const bet of bets) {
 
   for (const doc of bet.prose) {
     const rawText = readFileSync(doc, 'utf-8');
-    const { markers, bad: badMarkers } = parseMarkers(rawText);
+    const { markers, bindings, bad: badMarkers } = parseMarkers(rawText);
     const usedMarkers = new Set();
+    const usedBindings = new Set();
     const nums = extractNumerals(rawText);
     const backed = [];
     const nearMiss = [];
     const noTrace = [];
     const derived = [];
     const excused = [];
+    const bound = [];
+    const pending = [];
+    const assertedUnbacked = [];
+    const brokenBindings = [];
 
     // Group identical (value, unit) pairs so a number quoted five times is one
     // finding with five line numbers, not five findings.
@@ -688,8 +865,53 @@ for (const bet of bets) {
       groups.get(key).lines.push(n.line);
     }
 
+    // Bindings first: a numeral that names its source is checked against that
+    // source and nothing else, whatever the union index happens to contain.
+    const boundHaystack = new Map(); // token -> 1-element index, or [] when pending
     for (const g of groups.values()) {
       const token = `${g.raw}${g.unit}`;
+      const ref = bindings.get(token);
+      if (!ref) continue;
+      usedBindings.add(token);
+      const tol = writtenTolerance(g.raw);
+      const r = resolveBinding(ref);
+      if (r.status === 'none') {
+        boundHaystack.set(token, []);
+        assertedUnbacked.push({ ...g, reason: r.reason || '(no reason given)' });
+        continue;
+      }
+      if (r.status === 'pending') {
+        boundHaystack.set(token, []);
+        pending.push({ ...g, ref, rel: r.rel, jsonPath: r.jsonPath });
+        continue;
+      }
+      if (r.status === 'missing-file' || r.status === 'missing-path') {
+        boundHaystack.set(token, []);
+        brokenBindings.push({
+          ...g,
+          ref,
+          why: r.status === 'missing-file'
+            ? `the bet directory exists but ${r.rel} does not parse or does not exist`
+            : `${r.rel} has no numeric value at ${r.jsonPath}`,
+        });
+        continue;
+      }
+      if (!bindingBacks(g.value, tol, g.unit, r.value)) {
+        boundHaystack.set(token, []);
+        brokenBindings.push({
+          ...g,
+          ref,
+          why: `the prose says ${token} and ${r.rel}#${r.jsonPath} holds ${r.value} -- outside the half-ULP of the written digit`,
+        });
+        continue;
+      }
+      boundHaystack.set(token, [{ v: r.value, src: r.src }]);
+      bound.push({ ...g, ref, src: r.src, artifactValue: r.value });
+    }
+
+    for (const g of groups.values()) {
+      const token = `${g.raw}${g.unit}`;
+      if (bindings.has(token)) continue; // adjudicated above
       const tol = writtenTolerance(g.raw);
       const direct = matchDirect(g.value, tol, g.unit, index);
       if (direct.kind) {
@@ -725,23 +947,47 @@ for (const bet of bets) {
           : 'no unbacked numeral in this document matches this token -- the prose moved, delete the marker',
       });
     }
+    // A binding whose numeral has left the document is the same defect: an
+    // assertion about a sentence nobody can read any more.
+    for (const [token, ref] of bindings) {
+      if (usedBindings.has(token)) continue;
+      staleMarkers.push({
+        token,
+        reason: ref,
+        why: 'no numeral in this document matches this numeral-src binding -- the prose moved, update or delete the binding',
+      });
+    }
 
     nearMiss.sort((a, b) => a.near.rel - b.near.rel);
     noTrace.sort((a, b) => a.lines[0] - b.lines[0]);
     derived.sort((a, b) => a.lines[0] - b.lines[0]);
     excused.sort((a, b) => a.lines[0] - b.lines[0]);
 
+    bound.sort((a, b) => a.lines[0] - b.lines[0]);
+    pending.sort((a, b) => a.lines[0] - b.lines[0]);
+    assertedUnbacked.sort((a, b) => a.lines[0] - b.lines[0]);
+    brokenBindings.sort((a, b) => a.lines[0] - b.lines[0]);
+
     betOut.docs.push({
       doc: path.relative(REPO_ROOT, doc) || path.basename(doc),
       total: groups.size,
       backed: backed.length,
+      backedSources: backed.map((b) => ({ token: `${b.raw}${b.unit}`, lines: b.lines, src: b.src, via: b.via })),
+      bound,
+      pending,
+      assertedUnbacked,
+      brokenBindings,
       nearMiss,
       noTrace,
       derived,
       excused,
       staleMarkers,
       badMarkers,
-      decoy: calibrate([...groups.values()], index),
+      decoy: calibrate(
+        [...groups.values()],
+        index,
+        (g) => boundHaystack.get(`${g.raw}${g.unit}`) ?? null,
+      ),
     });
   }
   results.push(betOut);
@@ -772,15 +1018,25 @@ for (const bet of results) {
     // land by coincidence (this bet's 8.9x "explains" as a percent change
     // between two unrelated verify medians), so letting them pass --gate silently
     // would be the one place the checker clears a number it has not checked.
-    findings += unbacked + d.derived.length + d.staleMarkers.length + d.badMarkers.length;
+    findings += unbacked + d.derived.length + d.staleMarkers.length + d.badMarkers.length + d.brokenBindings.length;
     console.log(
-      `   ${d.doc}: ${d.total} numerals -- ${d.backed} backed, ${d.excused.length} marked, ` +
+      `   ${d.doc}: ${d.total} numerals -- ${d.backed} backed, ${d.bound.length} BOUND, ` +
+        `${d.pending.length} binding pending, ${d.assertedUnbacked.length} asserted-unbacked, ` +
+        `${d.excused.length} marked, ` +
         `${d.derived.length} derived-only, ${unbacked} UNBACKED`,
     );
     console.log(
       `   calibration: ${(d.decoy.rate * 100).toFixed(1)}% of ${d.decoy.decoys} ` +
         `deliberately-wrong decoys were also "backed"`,
     );
+    if (d.decoy.bound.decoys > 0) {
+      const bp = (d.decoy.bound.cleared / d.decoy.bound.decoys) * 100;
+      const up = d.decoy.unbound.decoys === 0 ? 0 : (d.decoy.unbound.cleared / d.decoy.unbound.decoys) * 100;
+      console.log(
+        `                per-claim bound: ${bp.toFixed(1)}% of ${d.decoy.bound.decoys}; ` +
+          `against the union index: ${up.toFixed(1)}% of ${d.decoy.unbound.decoys}`,
+      );
+    }
     if (d.decoy.rate > 0.25) {
       console.log(
         `   >> the BACKED count carries little information for this bet: its artifacts hold raw`,
@@ -794,6 +1050,14 @@ for (const bet of results) {
       console.log(
         `   >> against a curated scorecard, not against a data dump.`,
       );
+    }
+    if (d.brokenBindings.length > 0) {
+      console.log('');
+      console.log(`   BROKEN numeral-src BINDINGS (a named source that does not say what the prose says):`);
+      for (const n of d.brokenBindings) {
+        console.log(`     ${fmtLines(n.lines).padEnd(14)} ${(n.raw + n.unit).padEnd(14)} ${n.ref}`);
+        console.log(`     ${''.padEnd(14)} ${n.why}`);
+      }
     }
     if (d.nearMiss.length > 0) {
       console.log('');
@@ -836,6 +1100,27 @@ for (const bet of results) {
         console.log(`     ${''.padEnd(14)} reason on file: ${s.reason}`);
       }
     }
+    if (d.bound.length > 0) {
+      console.log('');
+      console.log(`   BOUND to a named field (\`<!-- numeral-src: ... :: file#json.path -->\`, haystack of 1):`);
+      for (const n of d.bound) {
+        console.log(`     ${fmtLines(n.lines).padEnd(14)} ${(n.raw + n.unit).padEnd(14)} ${n.artifactValue} <- ${n.ref}`);
+      }
+    }
+    if (d.pending.length > 0) {
+      console.log('');
+      console.log(`   BINDING PENDING (bet directory not in this tree; NOT counted as backed, checked when it lands):`);
+      for (const n of d.pending) {
+        console.log(`     ${fmtLines(n.lines).padEnd(14)} ${(n.raw + n.unit).padEnd(14)} ${n.ref}`);
+      }
+    }
+    if (d.assertedUnbacked.length > 0) {
+      console.log('');
+      console.log(`   ASSERTED UNBACKED (\`numeral-src: ... :: none\`; the union match is BLOCKED for these):`);
+      for (const n of d.assertedUnbacked) {
+        console.log(`     ${fmtLines(n.lines).padEnd(14)} ${(n.raw + n.unit).padEnd(14)} ${n.reason}`);
+      }
+    }
     if (d.excused.length > 0) {
       console.log('');
       console.log(`   MARKED as legitimately unbacked (\`<!-- numeral-ok: ... :: reason -->\`):`);
@@ -858,6 +1143,13 @@ console.log('the artifact -- that is the catch this exists for. The near-miss li
 console.log('(c) lives: a number sitting 1% from the committed value is almost always prose');
 console.log('left behind by a re-run. STALE/MALFORMED markers count as findings too: an');
 console.log('excuse that no longer applies is the same defect one level up.');
+console.log('');
+console.log('And read the calibration before the BACKED count. Against a union haystack a');
+console.log('"backed" verdict means only that SOME field in the program holds that value --');
+console.log('on docs/vision that cleared 57.5% to 91.7% of deliberately-wrong decoys. This is');
+console.log('a contradiction gate, not a truth gate. The way to make a figure actually');
+console.log('checkable is `<!-- numeral-src: <token> :: <file>#<json.path> -->`, which binds it');
+console.log('to one field and drops its decoy rate to ~0.');
 
 if (GATE && findings > 0) {
   console.error(`::error::${findings} finding(s) and --gate was requested.`);

--- a/scripts/moonshot/ci/check-report-numerals.mjs
+++ b/scripts/moonshot/ci/check-report-numerals.mjs
@@ -16,17 +16,29 @@
  * or DESIGN emit from the scorecard JSON, and add a check that every numeral
  * in the prose appears in the artifact."
  *
- * REPORT, NOT GATE -- and that is a deliberate choice, not a shortcut.
- * Prose legitimately contains numbers no artifact emits: bars from the plan,
- * figures re-quoted from another bet's run, arithmetic done in the sentence
- * ("43.7% of the DAG"), and counts from a variant run whose output was never
- * committed. A checker strict enough to catch a stale transcription is
- * therefore also loud enough to flag a dozen honest lines per document, and a
- * red gate that is wrong a dozen times per document gets `|| true`-d within a
- * week. So the default is exit 0 with a RANKED list, ordered by how much it
- * looks like a transcription error rather than by how loudly it fails to
- * match. `--gate` turns it into exit 1 for a directory that has been curated
- * to zero findings and wants to stay there.
+ * IT GATES, AND HERE IS WHAT THAT COST. The first revision of this script was
+ * report-only, on the argument that prose legitimately contains numbers no
+ * artifact emits -- bars from the plan, figures re-quoted from another bet's
+ * run, arithmetic done in the sentence ("43.7% of the DAG"), counts from a
+ * variant run whose output was never committed -- so a strict checker would
+ * flag a dozen honest lines per document and get `|| true`-d within a week.
+ * That argument was right about the noise and wrong about the conclusion: a
+ * report nobody is obliged to act on is how the fourth bad figure reached the
+ * finishing plan. The fix was to make each of those honest lines say WHY, once,
+ * next to itself (see MARKER_RE below), and then gate on the remainder. The
+ * whole tree is curated to zero, `--gate` is wired into
+ * .github/workflows/moonshot.yml as step E9, and the default run is still a
+ * ranked report so a human can look without failing anything.
+ *
+ * WHAT IT SEES. Two kinds of prose set: every bet directory under
+ * scripts/moonshot/ against its own artifacts, and every .md under
+ * docs/vision/ -- the plans, the reviews and the spec, i.e. the gate record
+ * itself -- against the union of every moonshot artifact in the tree. The
+ * second kind exists because the first revision hard-coded its root to
+ * scripts/moonshot and therefore structurally could not see the documents where
+ * the gate record lives, which is how a wrong B4.5 figure (907 ms against a
+ * committed 899) got into amendment 6 of the finishing plan in the very commit
+ * that was remediating wrong figures.
  *
  * WHAT COUNTS AS BACKED. For a numeral written as `N` in the prose, the
  * tolerance is the half-ULP of its own last written digit -- 56.5 admits
@@ -54,7 +66,10 @@
  *   - a numeral whose immediately preceding word is structural: section, act,
  *     clause, phase, gate, bet, step, line, item, instrument, table, figure,
  *     version, round, tier, note, page, appendix, cycle, chapter, milestone,
- *     entry, footnote, or a leading `#`.
+ *     entry, footnote, run, commit, see, a month name, or a leading `#` / `§`;
+ *     and the far end of such a range (`lines 148-171`, `line 241-243`).
+ *   - a numeral hyphen-joined to a preceding word and carrying no unit, the
+ *     mirror of the trailing-identifier rule: IEEE-754, mid-2027.
  * Everything else is checked. The suppressions are deliberately about SHAPE
  * (this token is not a measurement) and never about VALUE, so no rule here
  * can hide a wrong number.
@@ -70,26 +85,39 @@
  *
  * DIMENSIONLESS numerals that are only explicable as a ratio over two artifact
  * values (a/b, a/b*100, percent change) get their own lower tier. It is always
- * printed, never folded into "backed": over a 50-number scorecard those
- * pairings match by coincidence often enough that a hit is a hint, not a
- * clearance. Read that tier as "a reader could plausibly have computed this in
- * the sentence", not as "this is correct".
+ * printed, never folded into "backed", and it FAILS --gate: over a scorecard
+ * with a hundred numbers those pairings land by coincidence often enough to be
+ * worthless as a clearance (B4.5's genuine `8.9x` margin "explains" as the
+ * percent change between two unrelated verify medians). Read that tier as "a
+ * reader could plausibly have computed this in the sentence, and the checker
+ * cannot tell whether they did", which is a reason to mark it, not to clear
+ * it.
  *
- * KNOWN FALSE-POSITIVE CLASSES, so nobody has to rediscover them:
+ * KNOWN LEGITIMATE-BUT-UNBACKED CLASSES, i.e. what a `numeral-ok` marker is
+ * for. None can be suppressed by a rule without also suppressing a real catch,
+ * which is why each one is annotated by hand instead:
  *   - a number the prose itself is quoting in order to RETRACT it (B4.5's
- *     correction paragraph quotes the removed row's figures verbatim);
+ *     correction paragraph quotes the removed row's figures verbatim, and if
+ *     they ever became backed that paragraph would be wrong);
  *   - prose that truncates rather than rounds a unit conversion (`36 MB` from
- *     36,536,090 B is 36.5, outside the half-ULP of "36");
- *   - a bar, budget or target from the plan (`< 500 ms`, `< 5%`, `> 90%`);
- *   - a figure re-quoted from a DIFFERENT bet's run, whose artifact is not in
- *     this directory.
- * All four are cheap for a human to dismiss and none can be removed without
- * also removing a real catch, which is the whole reason this is a report.
+ *     36,536,090 B is 36.5, outside the half-ULP of "36") -- prefer fixing the
+ *     prose;
+ *   - a bar, budget, target or tolerance (`< 500 ms`, `< 5%`, `1e-6`);
+ *   - a figure re-quoted from a DIFFERENT bet's run, or from a bet whose branch
+ *     is not yet in this tree -- these self-heal, because the marker goes STALE
+ *     when the artifact arrives;
+ *   - a format constant or a derivation done in the document (`96 B/tuple`, the
+ *     512-bit width budget);
+ *   - session bookkeeping (model calls, timeouts) that no results file stores.
+ * Where a number could instead be EMITTED, emit it: that is strictly better
+ * than a marker, and it is what was done for B4.5's g0/g1 DAG shape rather than
+ * leaving three figures excused.
  *
  * Usage:
  *   node scripts/moonshot/ci/check-report-numerals.mjs
  *   node scripts/moonshot/ci/check-report-numerals.mjs <dir-or-repo-root> ...
  *   node scripts/moonshot/ci/check-report-numerals.mjs --gate      # exit 1 on findings
+ *                                                                 (CI: step E9)
  *   node scripts/moonshot/ci/check-report-numerals.mjs --json
  *
  * Exit codes: 0 report produced (default, whatever it found), 1 findings with
@@ -114,6 +142,8 @@ const PROSE_NAMES = new Set(['REPORT.md', 'DESIGN.md']);
 const JSON_IGNORE = /^(package(-lock)?|tsconfig.*|jsconfig|\.eslintrc)\.json$/;
 /** Beyond this many artifact numbers the O(n^2) derived pass is skipped. */
 const DERIVED_LIMIT = 600;
+/** The gate record itself. Every .md here is prose this checker must see. */
+const VISION_DIR = 'docs/vision';
 
 // ---------------------------------------------------------------------------
 // Discovery
@@ -140,30 +170,65 @@ function walk(dir, depth = 2, out = []) {
   return out;
 }
 
+const isArtifact = (f) => f.endsWith('.json') && !JSON_IGNORE.test(path.basename(f));
+
 /**
- * A "bet directory" is any directory holding at least one prose doc AND at
- * least one non-config .json. Deliberately broader than the review's literal
- * list (`scorecard.json`, `battery.json`, `results*.json`, `report*.json`):
- * B4.4's contradicted figure lives in `kernel-cross-check.json`, which none of
- * those globs match, and a checker that cannot see the artifact holding the
- * error is not worth running.
+ * A "prose set" is a group of documents plus the artifact index they are
+ * checked against. There are two kinds, and the second one only exists because
+ * the G4 re-review found the first one structurally blind.
+ *
+ * BET SETS. Any directory under `scripts/moonshot/` holding at least one prose
+ * doc AND at least one non-config .json, checked against its OWN artifacts.
+ * Deliberately broader than the review's literal list (`scorecard.json`,
+ * `battery.json`, `results*.json`, `report*.json`): B4.4's contradicted figure
+ * lives in `kernel-cross-check.json`, which none of those globs match, and a
+ * checker that cannot see the artifact holding the error is not worth running.
+ *
+ * THE GATE RECORD. `docs/vision/**` -- the finishing plan, the execution plan,
+ * the tech doc, the reviews and the spec. The first revision of this script
+ * hard-coded its root to `scripts/moonshot` and therefore could not see a
+ * single one of them, which is exactly how a wrong B4.5 figure (907 ms against
+ * a committed 899.0 ms) reached amendment 6 of the finishing plan *in the
+ * commit that was supposed to remediate wrong figures*. These documents quote
+ * numbers from every bet in the program, so the artifact index they are checked
+ * against is the UNION of every moonshot artifact in the tree, not any one
+ * bet's. That union is large enough that the DERIVED pass is skipped and the
+ * decoy calibration is poor -- both are printed, and neither weakens the only
+ * thing this set is for: catching a figure that contradicts the artifact it
+ * claims to come from.
  */
-function findBetDirs(root) {
+function findProseSets(root) {
   const base = path.join(root, 'scripts/moonshot');
-  const roots = [];
-  if (statSafe(base)?.isDirectory()) {
-    for (const e of listDir(base)) if (e.isDirectory()) roots.push(path.join(base, e.name));
-  } else if (statSafe(root)?.isDirectory()) {
-    roots.push(root);
-  }
   const found = [];
-  for (const dir of roots) {
-    const files = walk(dir);
-    const prose = files.filter((f) => PROSE_NAMES.has(path.basename(f)));
-    const artifacts = files.filter(
-      (f) => f.endsWith('.json') && !JSON_IGNORE.test(path.basename(f)),
-    );
-    if (prose.length > 0 && artifacts.length > 0) found.push({ dir, prose, artifacts });
+  const unionArtifacts = [];
+
+  if (statSafe(base)?.isDirectory()) {
+    for (const e of listDir(base)) {
+      if (!e.isDirectory()) continue;
+      const dir = path.join(base, e.name);
+      const files = walk(dir);
+      const prose = files.filter((f) => PROSE_NAMES.has(path.basename(f)));
+      const artifacts = files.filter(isArtifact);
+      unionArtifacts.push(...artifacts);
+      if (prose.length > 0 && artifacts.length > 0) found.push({ dir, prose, artifacts });
+    }
+  }
+
+  const vision = path.join(root, VISION_DIR);
+  if (statSafe(vision)?.isDirectory()) {
+    const prose = walk(vision, 3).filter((f) => f.endsWith('.md'));
+    if (prose.length > 0 && unionArtifacts.length > 0) {
+      found.push({ dir: vision, prose, artifacts: unionArtifacts, union: true });
+    }
+  }
+
+  // An explicit directory target that is neither of the above (e.g. a single
+  // bet directory passed on the command line) is checked against itself.
+  if (found.length === 0 && statSafe(root)?.isDirectory()) {
+    const files = walk(root);
+    const prose = files.filter((f) => PROSE_NAMES.has(path.basename(f)) || f.endsWith('.md'));
+    const artifacts = files.filter(isArtifact);
+    if (prose.length > 0 && artifacts.length > 0) found.push({ dir: root, prose, artifacts });
   }
   return found;
 }
@@ -232,6 +297,74 @@ function indexArtifacts(files) {
 // Prose extraction
 // ---------------------------------------------------------------------------
 
+/**
+ * INLINE MARKERS -- how a legitimately-unbacked numeral is cleared.
+ *
+ *   <!-- numeral-ok: 500ms, 16GB :: a bar from the plan; a machine spec -->
+ *
+ * The token list is written exactly as this report prints a finding
+ * (`raw + unit`, thousands separators included: `1,376`, `24.27%`, `2.19e-13`,
+ * `907ms`). A marker is FILE-SCOPED: it clears those tokens anywhere in the
+ * document it appears in, which matches this checker's own unit of finding --
+ * numerals are grouped by (raw, unit) across the file, not by line.
+ *
+ * WHY IN THE FILE AND NOT IN AN ALLOWLIST FILE. The defect this whole script
+ * exists to catch is prose drifting away from the thing that justifies it. An
+ * allowlist in a sibling directory is that defect wearing a different hat: it
+ * is edited in a different commit from the sentence it excuses, it is keyed on
+ * something (a line, a path) that moves, and nobody reading the claim ever sees
+ * it. A marker three lines from the number appears in the same diff hunk as the
+ * number, so a reviewer changing the sentence is shown the reason it was
+ * excused. Markers live inside HTML comments, which maskProse() already blanks,
+ * so they cannot themselves smuggle a numeral into the document.
+ *
+ * ANTI-ROT. An excuse must not outlive its reason, so markers are checked in
+ * both directions. A marker naming a token that is now BACKED, or that no
+ * longer appears in the document at all, is reported as STALE and fails
+ * --gate. That is deliberate friction: when another bet's artifact lands in the
+ * tree and its figures become checkable, the gate says so instead of leaving a
+ * permanent hole where the check used to be.
+ */
+const MARKER_RE = /<!--\s*numeral-ok:\s*([\s\S]*?)\s*-->/g;
+
+function parseMarkers(rawText) {
+  const out = new Map(); // token -> reason
+  const bad = [];
+  // Blank code first, so a document that DOCUMENTS the marker syntax inside a
+  // code span (`<!-- numeral-ok: <token> :: <reason> -->`) does not register
+  // `<token>` as a real marker. Found by this checker reporting exactly that
+  // stale marker against B4.5's own explanation of the mechanism.
+  const text = rawText
+    .replace(/```[\s\S]*?```/g, (m2) => m2.replace(/[^\n]/g, ' '))
+    .replace(/~~~[\s\S]*?~~~/g, (m2) => m2.replace(/[^\n]/g, ' '))
+    .replace(/`[^`\n]*`/g, (m2) => m2.replace(/[^\n]/g, ' '));
+  for (const m of text.matchAll(MARKER_RE)) {
+    const body = m[1];
+    // `::` rather than `--` as the separator: a literal `--` inside an HTML
+    // comment is invalid per the HTML spec and some markdown pipelines choke
+    // on it, which is a silly way to break a documentation build.
+    const split = body.indexOf('::');
+    if (split === -1) {
+      bad.push(`numeral-ok marker without a " :: <reason>": ${JSON.stringify(body.slice(0, 80))}`);
+      continue;
+    }
+    // Split on ", " and not on ",": `25,058` is one token, and a thousands
+    // separator is never followed by a space.
+    const tokens = body.slice(0, split).split(/,\s+/).map((t) => t.trim()).filter(Boolean);
+    const reason = body.slice(split + 2).trim();
+    if (tokens.length === 0) {
+      bad.push(`numeral-ok marker lists no numerals: ${JSON.stringify(body.slice(0, 80))}`);
+      continue;
+    }
+    if (reason === '') {
+      bad.push(`numeral-ok marker has an empty reason: ${JSON.stringify(body.slice(0, 80))}`);
+      continue;
+    }
+    for (const t of tokens) out.set(t, reason);
+  }
+  return { markers: out, bad };
+}
+
 const SPACES = (n) => ' '.repeat(n);
 
 /** Blank out a region while preserving length AND newlines, so offsets hold. */
@@ -269,14 +402,23 @@ const UNIT_SUFFIX = new Set([
   'b', 'kb', 'mb', 'gb', 'tb', 'kib', 'mib', 'gib', 'k', 'M',
 ]);
 
-/** Words that make the following number a reference, not a measurement. */
+/**
+ * Words that make the following number a reference, not a measurement.
+ * The month names are here for the same reason as the rest: `Mar 2027` and
+ * `Dec 2026` are calendar references, and the finishing plan's schedule
+ * section is full of them.
+ */
 const STRUCTURAL_WORD = new Set([
   'section', 'sections', 'act', 'acts', 'clause', 'clauses', 'phase', 'phases',
   'gate', 'gates', 'bet', 'bets', 'step', 'steps', 'line', 'lines', 'item',
   'items', 'instrument', 'instruments', 'table', 'figure', 'appendix', 'page',
   'version', 'round', 'rounds', 'tier', 'note', 'notes', 'cycle', 'cycles',
   'chapter', 'milestone', 'entry', 'footnote', 'v', 'no', 'nr', 'issue', 'pr',
-  'case', 'cases', 'point', 'points',
+  'case', 'cases', 'point', 'points', 'run', 'runs', 'workflow', 'commit',
+  'see', 'per',
+  'jan', 'january', 'feb', 'february', 'mar', 'march', 'apr', 'april', 'may',
+  'jun', 'june', 'jul', 'july', 'aug', 'august', 'sep', 'sept', 'september',
+  'oct', 'october', 'nov', 'november', 'dec', 'december',
 ]);
 
 const NUM_RE = /(?<![\w.$])(\d{1,3}(?:,\d{3})+|\d+)(\.\d+)?([eE][+-]?\d+)?/g;
@@ -319,9 +461,23 @@ function extractNumerals(rawText) {
 
     // Preceding word: structural references are not measurements.
     const beforeText = masked.slice(Math.max(0, start - 24), start);
-    if (/#\s?$/.test(beforeText)) continue;
+    // A leading `#` or `§` makes it a cross-reference, not a quantity.
+    if (/[#§]\s?$/.test(beforeText)) continue;
     const pw = /([A-Za-z]+)[\s]+$/.exec(beforeText);
     if (pw && STRUCTURAL_WORD.has(pw[1].toLowerCase())) continue;
+
+    // The FAR end of a structural range: "lines 148-171", "line 241-243".
+    // The rule above only reaches the near end, which left the node-hash-v0
+    // spec reporting its own source-line citations as unbacked measurements.
+    const rangeTail = /([A-Za-z]+)\s+\d[\d,.]*\s*[-–]\s*$/.exec(beforeText);
+    if (rangeTail && STRUCTURAL_WORD.has(rangeTail[1].toLowerCase())) continue;
+
+    // A numeral hyphen-joined to a preceding WORD is part of a compound name,
+    // the mirror of the trailing-identifier rule: IEEE-754, mid-2027, IFC4X3.
+    // Gated on the numeral carrying no unit, so a genuine bar written as
+    // "sub-500 ms" stays checkable -- the suppression is about token shape and
+    // never about value.
+    if (unit === '' && /[A-Za-z]-$/.test(beforeText)) continue;
 
     const value = Number(raw.replace(/,/g, ''));
     if (!Number.isFinite(value)) continue;
@@ -492,10 +648,10 @@ function calibrate(groups, index) {
 
 const roots = targets.length > 0 ? targets.map((t) => path.resolve(t)) : [REPO_ROOT];
 const bets = [];
-for (const r of roots) bets.push(...findBetDirs(r));
+for (const r of roots) bets.push(...findProseSets(r));
 
 if (bets.length === 0) {
-  console.error(`::error::no bet directory found under ${roots.join(', ')}`);
+  console.error(`::error::no prose set found under ${roots.join(', ')}`);
   console.error('A bet directory needs at least one of REPORT.md / DESIGN.md and one non-config .json.');
   process.exit(2);
 }
@@ -513,11 +669,15 @@ for (const bet of bets) {
   };
 
   for (const doc of bet.prose) {
-    const nums = extractNumerals(readFileSync(doc, 'utf-8'));
+    const rawText = readFileSync(doc, 'utf-8');
+    const { markers, bad: badMarkers } = parseMarkers(rawText);
+    const usedMarkers = new Set();
+    const nums = extractNumerals(rawText);
     const backed = [];
     const nearMiss = [];
     const noTrace = [];
     const derived = [];
+    const excused = [];
 
     // Group identical (value, unit) pairs so a number quoted five times is one
     // finding with five line numbers, not five findings.
@@ -529,10 +689,19 @@ for (const bet of bets) {
     }
 
     for (const g of groups.values()) {
+      const token = `${g.raw}${g.unit}`;
       const tol = writtenTolerance(g.raw);
       const direct = matchDirect(g.value, tol, g.unit, index);
       if (direct.kind) {
+        // A marker on a numeral the artifact now backs is an excuse that has
+        // outlived its reason: record it so the STALE list can report it.
+        if (markers.has(token)) usedMarkers.add(`${token} backed`);
         backed.push({ ...g, via: direct.kind, scale: direct.scale, src: direct.entry.src });
+        continue;
+      }
+      if (markers.has(token)) {
+        usedMarkers.add(token);
+        excused.push({ ...g, reason: markers.get(token) });
         continue;
       }
       const der = matchDerived(g.value, tol, g.unit, index);
@@ -544,17 +713,34 @@ for (const bet of bets) {
       else noTrace.push({ ...g, crowding: direct.crowding });
     }
 
+    // Anti-rot: every marker must still be doing work.
+    const staleMarkers = [];
+    for (const [token, reason] of markers) {
+      if (usedMarkers.has(token)) continue;
+      staleMarkers.push({
+        token,
+        reason,
+        why: usedMarkers.has(`${token} backed`)
+          ? 'the artifact now BACKS this numeral -- delete the marker, the check covers it'
+          : 'no unbacked numeral in this document matches this token -- the prose moved, delete the marker',
+      });
+    }
+
     nearMiss.sort((a, b) => a.near.rel - b.near.rel);
     noTrace.sort((a, b) => a.lines[0] - b.lines[0]);
     derived.sort((a, b) => a.lines[0] - b.lines[0]);
+    excused.sort((a, b) => a.lines[0] - b.lines[0]);
 
     betOut.docs.push({
-      doc: path.basename(doc),
+      doc: path.relative(REPO_ROOT, doc) || path.basename(doc),
       total: groups.size,
       backed: backed.length,
       nearMiss,
       noTrace,
       derived,
+      excused,
+      staleMarkers,
+      badMarkers,
       decoy: calibrate([...groups.values()], index),
     });
   }
@@ -581,10 +767,15 @@ for (const bet of results) {
   );
   for (const d of bet.docs) {
     const unbacked = d.nearMiss.length + d.noTrace.length;
-    findings += unbacked;
+    // Derived-only counts as a finding. The DERIVED tier is explicitly "a hint,
+    // not a clearance" -- over a scorecard with a hundred numbers those pairings
+    // land by coincidence (this bet's 8.9x "explains" as a percent change
+    // between two unrelated verify medians), so letting them pass --gate silently
+    // would be the one place the checker clears a number it has not checked.
+    findings += unbacked + d.derived.length + d.staleMarkers.length + d.badMarkers.length;
     console.log(
-      `   ${d.doc}: ${d.total} numerals -- ${d.backed} backed, ${d.derived.length} derived-only, ` +
-        `${unbacked} UNBACKED`,
+      `   ${d.doc}: ${d.total} numerals -- ${d.backed} backed, ${d.excused.length} marked, ` +
+        `${d.derived.length} derived-only, ${unbacked} UNBACKED`,
     );
     console.log(
       `   calibration: ${(d.decoy.rate * 100).toFixed(1)}% of ${d.decoy.decoys} ` +
@@ -632,22 +823,44 @@ for (const bet of results) {
         );
       }
     }
+    if (d.badMarkers.length > 0) {
+      console.log('');
+      console.log(`   MALFORMED numeral-ok MARKERS:`);
+      for (const b of d.badMarkers) console.log(`     ${b}`);
+    }
+    if (d.staleMarkers.length > 0) {
+      console.log('');
+      console.log(`   STALE numeral-ok MARKERS (an excuse must not outlive its reason):`);
+      for (const s of d.staleMarkers) {
+        console.log(`     ${s.token.padEnd(14)} ${s.why}`);
+        console.log(`     ${''.padEnd(14)} reason on file: ${s.reason}`);
+      }
+    }
+    if (d.excused.length > 0) {
+      console.log('');
+      console.log(`   MARKED as legitimately unbacked (\`<!-- numeral-ok: ... :: reason -->\`):`);
+      for (const n of d.excused) {
+        console.log(`     ${fmtLines(n.lines).padEnd(14)} ${(n.raw + n.unit).padEnd(14)} ${n.reason}`);
+      }
+    }
     console.log('');
   }
 }
 
 console.log('------------------------------------');
-console.log(`${findings} unbacked numeral(s) across ${results.length} bet director(ies).`);
+console.log(`${findings} finding(s) across ${results.length} prose set(s).`);
 console.log('');
 console.log('Reading this: an UNBACKED numeral is a QUESTION, not a defect. The three');
-console.log('legitimate answers are (a) it is a bar or a figure from elsewhere -- fine;');
-console.log('(b) it is arithmetic the reader can do -- consider emitting it; (c) it does');
-console.log('not match the artifact -- that is the catch this exists for. The near-miss');
-console.log('list is where (c) lives: a number sitting 1% from the committed value is');
-console.log('almost always prose left behind by a re-run.');
+console.log('legitimate answers are (a) it is a bar or a figure from elsewhere -- mark it');
+console.log('with `<!-- numeral-ok: <token> :: <reason> -->`; (b) it is arithmetic the');
+console.log('reader can do -- prefer emitting it into the artifact; (c) it does not match');
+console.log('the artifact -- that is the catch this exists for. The near-miss list is where');
+console.log('(c) lives: a number sitting 1% from the committed value is almost always prose');
+console.log('left behind by a re-run. STALE/MALFORMED markers count as findings too: an');
+console.log('excuse that no longer applies is the same defect one level up.');
 
 if (GATE && findings > 0) {
-  console.error(`::error::${findings} unbacked numeral(s) and --gate was requested.`);
+  console.error(`::error::${findings} finding(s) and --gate was requested.`);
   process.exit(1);
 }
 process.exit(0);

--- a/scripts/moonshot/ci/check-report-numerals.mjs
+++ b/scripts/moonshot/ci/check-report-numerals.mjs
@@ -1,0 +1,653 @@
+#!/usr/bin/env node
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Prose-versus-artifact numeral report for the moonshot bets.
+ *
+ * WHY THIS EXISTS. The G4 standing adversarial review
+ * (docs/vision/reviews/g4-red-team-2026-07-29.md, section 6) found that five
+ * of the seven things the orchestrator's verification structurally cannot
+ * catch are the same thing: prose that no artifact backs. All three hard
+ * catches in that review were of this class -- the code was re-run and
+ * reproduced to the digit, but nobody diffed the sentences against the JSON.
+ * Its named cheap fix is this script: "make every number quoted in a REPORT
+ * or DESIGN emit from the scorecard JSON, and add a check that every numeral
+ * in the prose appears in the artifact."
+ *
+ * REPORT, NOT GATE -- and that is a deliberate choice, not a shortcut.
+ * Prose legitimately contains numbers no artifact emits: bars from the plan,
+ * figures re-quoted from another bet's run, arithmetic done in the sentence
+ * ("43.7% of the DAG"), and counts from a variant run whose output was never
+ * committed. A checker strict enough to catch a stale transcription is
+ * therefore also loud enough to flag a dozen honest lines per document, and a
+ * red gate that is wrong a dozen times per document gets `|| true`-d within a
+ * week. So the default is exit 0 with a RANKED list, ordered by how much it
+ * looks like a transcription error rather than by how loudly it fails to
+ * match. `--gate` turns it into exit 1 for a directory that has been curated
+ * to zero findings and wants to stay there.
+ *
+ * WHAT COUNTS AS BACKED. For a numeral written as `N` in the prose, the
+ * tolerance is the half-ULP of its own last written digit -- 56.5 admits
+ * [56.45, 56.55), so the artifact's 56.494 backs it; 2.19e-13 admits
+ * +/- 0.5e-15. That is the rule a careful writer already follows, so it
+ * neither invents slack nor punishes rounding. On top of that the value is
+ * compared under scale factors chosen BY THE UNIT the prose wrote: x100 for a
+ * percent against a stored fraction, /1e3 for seconds against milliseconds,
+ * and /1e3, /1e6, /1e9 plus the three 1024 powers for byte units. So `0.0239%`
+ * matches an artifact `0.023944` and `2.80 s` matches `2796`. Scales are NOT
+ * applied blindly across units -- see scalesFor() for what that cost.
+ * Thousands separators are stripped before parsing, so `250,582` and `250582`
+ * are the same number.
+ *
+ * WHAT IS IGNORED, AND WHY (the false-positive controls):
+ *   - fenced code blocks and inline code spans. Reproduction commands, flags,
+ *     file names and type names (`f32`, `--segment 96`) are the single largest
+ *     source of noise and none of them are claims.
+ *   - link targets, bare URLs, HTML comments.
+ *   - ISO dates (2026-07-29) and semver-shaped triples (0.8.5, 22.14.0).
+ *   - ordered-list markers and numbered headings at the start of a line.
+ *   - any numeral glued to a letter or underscore on either side, unless the
+ *     trailing run is a known unit: B4.5, IFC4X3, ISSUE_053, node-hash-v0 and
+ *     sha256 are identifiers, while 8.9x and 500ms are quantities.
+ *   - a numeral whose immediately preceding word is structural: section, act,
+ *     clause, phase, gate, bet, step, line, item, instrument, table, figure,
+ *     version, round, tier, note, page, appendix, cycle, chapter, milestone,
+ *     entry, footnote, or a leading `#`.
+ * Everything else is checked. The suppressions are deliberately about SHAPE
+ * (this token is not a measurement) and never about VALUE, so no rule here
+ * can hide a wrong number.
+ *
+ * RANKING. Unbacked numerals are ordered by whether the artifact contains
+ * something *close but not equal*. A prose 56.5 sitting 0.9% away from an
+ * artifact 55.971 is far more likely to be a stale transcription than a prose
+ * 40,028 with nothing within 10% of it anywhere in the JSON -- the latter is
+ * usually a real quantity from a run that was never committed, which is worth
+ * knowing but is a different problem. Near-misses are printed first, closest
+ * first, and are suppressed when the neighbourhood is crowded (see
+ * matchDirect) so the report never points at an unrelated field.
+ *
+ * DIMENSIONLESS numerals that are only explicable as a ratio over two artifact
+ * values (a/b, a/b*100, percent change) get their own lower tier. It is always
+ * printed, never folded into "backed": over a 50-number scorecard those
+ * pairings match by coincidence often enough that a hit is a hint, not a
+ * clearance. Read that tier as "a reader could plausibly have computed this in
+ * the sentence", not as "this is correct".
+ *
+ * KNOWN FALSE-POSITIVE CLASSES, so nobody has to rediscover them:
+ *   - a number the prose itself is quoting in order to RETRACT it (B4.5's
+ *     correction paragraph quotes the removed row's figures verbatim);
+ *   - prose that truncates rather than rounds a unit conversion (`36 MB` from
+ *     36,536,090 B is 36.5, outside the half-ULP of "36");
+ *   - a bar, budget or target from the plan (`< 500 ms`, `< 5%`, `> 90%`);
+ *   - a figure re-quoted from a DIFFERENT bet's run, whose artifact is not in
+ *     this directory.
+ * All four are cheap for a human to dismiss and none can be removed without
+ * also removing a real catch, which is the whole reason this is a report.
+ *
+ * Usage:
+ *   node scripts/moonshot/ci/check-report-numerals.mjs
+ *   node scripts/moonshot/ci/check-report-numerals.mjs <dir-or-repo-root> ...
+ *   node scripts/moonshot/ci/check-report-numerals.mjs --gate      # exit 1 on findings
+ *   node scripts/moonshot/ci/check-report-numerals.mjs --json
+ *
+ * Exit codes: 0 report produced (default, whatever it found), 1 findings with
+ * --gate, 2 usage/IO problem.
+ */
+
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(HERE, '../../..');
+
+const argv = process.argv.slice(2);
+const GATE = argv.includes('--gate');
+const AS_JSON = argv.includes('--json');
+const targets = argv.filter((a) => !a.startsWith('--'));
+
+/** Prose documents a bet is expected to keep in sync with its artifacts. */
+const PROSE_NAMES = new Set(['REPORT.md', 'DESIGN.md']);
+/** Not artifacts: build/config JSON that happens to sit in a bet directory. */
+const JSON_IGNORE = /^(package(-lock)?|tsconfig.*|jsconfig|\.eslintrc)\.json$/;
+/** Beyond this many artifact numbers the O(n^2) derived pass is skipped. */
+const DERIVED_LIMIT = 600;
+
+// ---------------------------------------------------------------------------
+// Discovery
+// ---------------------------------------------------------------------------
+
+function listDir(dir) {
+  try {
+    return readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+}
+
+/** Every file under `dir` down to `depth` levels. */
+function walk(dir, depth = 2, out = []) {
+  for (const e of listDir(dir)) {
+    const abs = path.join(dir, e.name);
+    if (e.isDirectory()) {
+      if (depth > 0 && e.name !== 'node_modules' && !e.name.startsWith('.')) walk(abs, depth - 1, out);
+    } else if (e.isFile()) {
+      out.push(abs);
+    }
+  }
+  return out;
+}
+
+/**
+ * A "bet directory" is any directory holding at least one prose doc AND at
+ * least one non-config .json. Deliberately broader than the review's literal
+ * list (`scorecard.json`, `battery.json`, `results*.json`, `report*.json`):
+ * B4.4's contradicted figure lives in `kernel-cross-check.json`, which none of
+ * those globs match, and a checker that cannot see the artifact holding the
+ * error is not worth running.
+ */
+function findBetDirs(root) {
+  const base = path.join(root, 'scripts/moonshot');
+  const roots = [];
+  if (statSafe(base)?.isDirectory()) {
+    for (const e of listDir(base)) if (e.isDirectory()) roots.push(path.join(base, e.name));
+  } else if (statSafe(root)?.isDirectory()) {
+    roots.push(root);
+  }
+  const found = [];
+  for (const dir of roots) {
+    const files = walk(dir);
+    const prose = files.filter((f) => PROSE_NAMES.has(path.basename(f)));
+    const artifacts = files.filter(
+      (f) => f.endsWith('.json') && !JSON_IGNORE.test(path.basename(f)),
+    );
+    if (prose.length > 0 && artifacts.length > 0) found.push({ dir, prose, artifacts });
+  }
+  return found;
+}
+
+function statSafe(p) {
+  try {
+    return statSync(p);
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Artifact index
+// ---------------------------------------------------------------------------
+
+/** Every finite numeric leaf in the artifacts, with the path that produced it. */
+function indexArtifacts(files) {
+  const entries = [];
+  for (const file of files) {
+    let doc;
+    try {
+      doc = JSON.parse(readFileSync(file, 'utf-8'));
+    } catch {
+      continue; // a malformed artifact is a different problem than a wrong numeral
+    }
+    const rel = path.basename(file);
+    const visit = (node, keyPath) => {
+      if (typeof node === 'number') {
+        if (Number.isFinite(node)) entries.push({ v: node, src: `${rel}:${keyPath || '(root)'}` });
+        return;
+      }
+      if (typeof node === 'string') {
+        // Numbers stored as strings still count as emitted by the artifact,
+        // and so do numbers EMBEDDED in a label. B4.4's battery.json records
+        // its seed as `"family": "A/seed-20260727"` rather than as a numeric
+        // field, and a checker that cannot see it reports the prose's seed as
+        // unbacked -- a false positive created purely by where the artifact
+        // chose to put the digits.
+        const t = node.trim();
+        if (/^-?\d+(\.\d+)?([eE][+-]?\d+)?$/.test(t)) {
+          const v = Number(t);
+          if (Number.isFinite(v)) entries.push({ v, src: `${rel}:${keyPath || '(root)'}` });
+          return;
+        }
+        for (const m of t.matchAll(/\d+(?:\.\d+)?/g)) {
+          const v = Number(m[0]);
+          if (Number.isFinite(v)) entries.push({ v, src: `${rel}:${keyPath || '(root)'} (in string)` });
+        }
+        return;
+      }
+      if (Array.isArray(node)) {
+        node.forEach((c, i) => visit(c, `${keyPath}[${i}]`));
+        return;
+      }
+      if (node && typeof node === 'object') {
+        for (const [k, c] of Object.entries(node)) visit(c, keyPath ? `${keyPath}.${k}` : k);
+      }
+    };
+    visit(doc, '');
+  }
+  return entries;
+}
+
+// ---------------------------------------------------------------------------
+// Prose extraction
+// ---------------------------------------------------------------------------
+
+const SPACES = (n) => ' '.repeat(n);
+
+/** Blank out a region while preserving length AND newlines, so offsets hold. */
+function blank(text, re) {
+  return text.replace(re, (m) => m.replace(/[^\n]/g, ' '));
+}
+
+function maskProse(text) {
+  let t = text;
+  t = blank(t, /```[\s\S]*?```/g); // fenced code
+  t = blank(t, /~~~[\s\S]*?~~~/g);
+  t = blank(t, /<!--[\s\S]*?-->/g); // html comments
+  t = blank(t, /`[^`\n]*`/g); // inline code
+  t = blank(t, /\]\([^)\n]*\)/g); // link + image targets
+  t = blank(t, /\bhttps?:\/\/\S+/g); // bare urls
+  t = blank(t, /\b\d{4}-\d{2}-\d{2}\b/g); // ISO dates
+  t = blank(t, /(?<![\w.])\d+\.\d+\.\d+(?![\w.])/g); // semver-shaped triples
+  // Ordered-list markers and numbered headings, at line start only.
+  t = t
+    .split('\n')
+    .map((line) => {
+      const m = /^(\s*(?:[-*+]\s+)?)(\d+[.)])(\s)/.exec(line);
+      if (m) return m[1] + SPACES(m[2].length) + line.slice(m[1].length + m[2].length);
+      const h = /^(#{1,6}\s+)(\d+[.)]?)(\s)/.exec(line);
+      if (h) return h[1] + SPACES(h[2].length) + line.slice(h[1].length + h[2].length);
+      return line;
+    })
+    .join('\n');
+  return t;
+}
+
+/** Trailing letter runs that are units rather than the rest of an identifier. */
+const UNIT_SUFFIX = new Set([
+  'x', 'ms', 's', 'm', 'mm', 'cm', 'km', 'kg', 'g', 'h', 'ns', 'us',
+  'b', 'kb', 'mb', 'gb', 'tb', 'kib', 'mib', 'gib', 'k', 'M',
+]);
+
+/** Words that make the following number a reference, not a measurement. */
+const STRUCTURAL_WORD = new Set([
+  'section', 'sections', 'act', 'acts', 'clause', 'clauses', 'phase', 'phases',
+  'gate', 'gates', 'bet', 'bets', 'step', 'steps', 'line', 'lines', 'item',
+  'items', 'instrument', 'instruments', 'table', 'figure', 'appendix', 'page',
+  'version', 'round', 'rounds', 'tier', 'note', 'notes', 'cycle', 'cycles',
+  'chapter', 'milestone', 'entry', 'footnote', 'v', 'no', 'nr', 'issue', 'pr',
+  'case', 'cases', 'point', 'points',
+]);
+
+const NUM_RE = /(?<![\w.$])(\d{1,3}(?:,\d{3})+|\d+)(\.\d+)?([eE][+-]?\d+)?/g;
+
+function extractNumerals(rawText) {
+  const masked = maskProse(rawText);
+  // Line starts, for offset -> line number.
+  const lineStarts = [0];
+  for (let i = 0; i < masked.length; i += 1) if (masked[i] === '\n') lineStarts.push(i + 1);
+  const lineOf = (off) => {
+    let lo = 0;
+    let hi = lineStarts.length - 1;
+    while (lo < hi) {
+      const mid = (lo + hi + 1) >> 1;
+      if (lineStarts[mid] <= off) lo = mid;
+      else hi = mid - 1;
+    }
+    return lo + 1;
+  };
+
+  const out = [];
+  for (const m of masked.matchAll(NUM_RE)) {
+    const start = m.index;
+    const raw = m[0];
+    const end = start + raw.length;
+
+    // Trailing context: an identifier tail disqualifies, a unit does not.
+    const tail = /^[A-Za-z_]+/.exec(masked.slice(end, end + 8));
+    let unit = '';
+    if (tail) {
+      const word = tail[0];
+      if (!UNIT_SUFFIX.has(word.toLowerCase())) continue;
+      unit = word;
+    } else if (masked[end] === '%') {
+      unit = '%';
+    } else {
+      const after = /^\s?([%x]|ms|s\b|kg|MB|GB|KB|GiB|MiB|B\b)/.exec(masked.slice(end, end + 5));
+      if (after) unit = after[1];
+    }
+
+    // Preceding word: structural references are not measurements.
+    const beforeText = masked.slice(Math.max(0, start - 24), start);
+    if (/#\s?$/.test(beforeText)) continue;
+    const pw = /([A-Za-z]+)[\s]+$/.exec(beforeText);
+    if (pw && STRUCTURAL_WORD.has(pw[1].toLowerCase())) continue;
+
+    const value = Number(raw.replace(/,/g, ''));
+    if (!Number.isFinite(value)) continue;
+    out.push({ raw, value, unit, line: lineOf(start) });
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Matching
+// ---------------------------------------------------------------------------
+
+/** Half the place value of the last digit actually written. */
+function writtenTolerance(raw) {
+  const s = raw.replace(/,/g, '');
+  const em = /[eE]([+-]?\d+)$/.exec(s);
+  const exp = em ? Number(em[1]) : 0;
+  const mantissa = em ? s.slice(0, em.index) : s;
+  const dot = mantissa.indexOf('.');
+  const decimals = dot === -1 ? 0 : mantissa.length - dot - 1;
+  const tol = 0.5 * 10 ** (exp - decimals);
+  return Math.max(tol, Math.abs(Number(s)) * 1e-12);
+}
+
+const BYTE_UNITS = new Set(['b', 'kb', 'mb', 'gb', 'tb', 'kib', 'mib', 'gib']);
+
+/**
+ * Scale factors are chosen by the UNIT the prose wrote, not applied blindly.
+ * An earlier revision tried all fifteen against every numeral and, on a bet
+ * whose artifacts hold ~3,900 numbers, that cleared almost anything: fifteen
+ * scales x 3,900 values is ~58,000 chances to land inside a half-ULP window.
+ * Unit-gating cuts the search to at most seven and makes a "backed" verdict
+ * mean something. The decoy calibration printed with each document measures
+ * what is left.
+ */
+function scalesFor(unit) {
+  const u = unit.toLowerCase();
+  const out = [[1, '']];
+  if (u === '%') out.push([100, 'x100 (artifact stores the fraction)']);
+  else if (u === '') out.push([100, 'x100'], [0.01, '/100 (artifact stores the percent)']);
+  else if (u === 's') out.push([0.001, '/1e3 (artifact in ms)']);
+  else if (u === 'ms') out.push([1000, 'x1e3 (artifact in s)']);
+  else if (BYTE_UNITS.has(u)) {
+    out.push(
+      [1e-3, '/1e3'],
+      [1e-6, '/1e6 (artifact in bytes)'],
+      [1e-9, '/1e9 (artifact in bytes)'],
+      [1 / 1024, '/1KiB'],
+      [1 / 1048576, '/1MiB'],
+      [1 / 1073741824, '/1GiB'],
+    );
+  }
+  return out;
+}
+
+function matchDirect(p, tol, unit, index) {
+  const scales = scalesFor(unit);
+  let best = null;
+  let crowding = 0; // artifact values within 10% at scale 1 -- see below
+  for (const e of index) {
+    for (const [s, label] of scales) {
+      const d = Math.abs(e.v * s - p);
+      if (d <= tol) return { kind: s === 1 && e.v === p ? 'exact' : 'rounded', scale: label, entry: e };
+    }
+    const rel = p === 0 ? (e.v === 0 ? 0 : Infinity) : Math.abs((e.v - p) / p);
+    if (rel < 0.1) {
+      crowding += 1;
+      if (best === null || rel < best.rel) best = { rel, entry: e };
+    }
+  }
+  // `crowding` is what makes the near-miss list readable. "The artifact holds
+  // 55.971 and the prose says 56.5" is a strong hint IF 55.971 is the only
+  // number in that neighbourhood. In an artifact with hundreds of timings
+  // something sits within 1% of anything, and the nearest neighbour is then
+  // an accident of density, not evidence. Above the threshold the numeral is
+  // still reported -- it is still unbacked -- but without a misleading
+  // "closest value" pointing at an unrelated field.
+  const informative = best !== null && best.rel <= 0.05 && crowding <= 3;
+  return { kind: null, near: informative ? best : null, crowding };
+}
+
+/** Derived explanations are offered only for DIMENSIONLESS numerals. */
+const DERIVABLE_UNIT = new Set(['%', 'x', '']);
+
+/**
+ * Only ratios, and only for dimensionless quantities. Both restrictions were
+ * forced by measurement rather than taste.
+ *
+ * Sums and differences were in the first revision and had to go: over a
+ * 50-number scorecard they generate ~12,000 candidate values, enough to
+ * "explain" almost any numeral within its written tolerance. They swallowed
+ * B4.5's headline `56.5 ms` -- a number that genuinely does not match its
+ * artifact -- which is precisely the catch this script exists to make. A rule
+ * that explains the one real finding is worse than no rule.
+ *
+ * The dimension restriction is the same argument from the other side: `43.7%
+ * of the DAG` and `8.9x margin` are arithmetic a reader does in their head, so
+ * a ratio is a fair explanation. `56.5 ms` is a measurement; if it is not in
+ * the artifact, no amount of dividing other people's numbers makes it so.
+ */
+function matchDerived(p, tol, unit, index) {
+  if (!DERIVABLE_UNIT.has(unit.toLowerCase())) return null;
+  if (index.length > DERIVED_LIMIT) return null;
+  for (let i = 0; i < index.length; i += 1) {
+    const a = index[i].v;
+    for (let j = 0; j < index.length; j += 1) {
+      if (i === j) continue;
+      const b = index[j].v;
+      if (b === 0) continue;
+      if (Math.abs(a / b - p) <= tol) return { how: 'a/b', a: index[i], b: index[j] };
+      if (Math.abs((a / b) * 100 - p) <= tol) return { how: 'a/b*100', a: index[i], b: index[j] };
+      if (Math.abs(((a - b) / b) * 100 - p) <= tol) return { how: '(a-b)/b*100', a: index[i], b: index[j] };
+    }
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Calibration: how often does this checker CLEAR a number that is wrong?
+// ---------------------------------------------------------------------------
+
+/**
+ * The honest way to read a "107 of 117 backed" line is to know what "backed"
+ * is worth against that particular artifact set. So: take the document's own
+ * numerals, perturb each by a seeded 3-30% -- far outside any rounding or unit
+ * story, i.e. definitely wrong -- and re-run the matcher. Whatever fraction
+ * comes back "backed" is the rate at which a genuinely wrong number would be
+ * silently cleared by this checker on this bet. On a small scorecard it is
+ * near zero; on an artifact set with thousands of numbers it is not, and the
+ * reader is entitled to know that before trusting a clean report.
+ *
+ * Seeded (mulberry32) so the printed rate is reproducible run to run.
+ */
+function calibrate(groups, index) {
+  if (groups.length === 0) return { decoys: 0, cleared: 0, rate: 0 };
+  let s = 0x9e3779b9;
+  const rnd = () => {
+    s = (s + 0x6d2b79f5) | 0;
+    let t = Math.imul(s ^ (s >>> 15), 1 | s);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+  let cleared = 0;
+  let decoys = 0;
+  for (const g of groups) {
+    for (let k = 0; k < 3; k += 1) {
+      const factor = 1 + (rnd() < 0.5 ? -1 : 1) * (0.03 + rnd() * 0.27);
+      const v = g.value * factor;
+      if (v === 0) continue;
+      // Write the decoy at the same precision the prose used, so the tolerance
+      // is the same tolerance the real numeral got.
+      const decimals = (() => {
+        const raw = g.raw.replace(/,/g, '');
+        const dot = raw.indexOf('.');
+        return dot === -1 ? 0 : raw.length - dot - 1;
+      })();
+      const rawDecoy = v.toFixed(Math.min(decimals, 12));
+      decoys += 1;
+      if (matchDirect(Number(rawDecoy), writtenTolerance(rawDecoy), g.unit, index).kind) cleared += 1;
+    }
+  }
+  return { decoys, cleared, rate: decoys === 0 ? 0 : cleared / decoys };
+}
+
+// ---------------------------------------------------------------------------
+// Run
+// ---------------------------------------------------------------------------
+
+const roots = targets.length > 0 ? targets.map((t) => path.resolve(t)) : [REPO_ROOT];
+const bets = [];
+for (const r of roots) bets.push(...findBetDirs(r));
+
+if (bets.length === 0) {
+  console.error(`::error::no bet directory found under ${roots.join(', ')}`);
+  console.error('A bet directory needs at least one of REPORT.md / DESIGN.md and one non-config .json.');
+  process.exit(2);
+}
+
+const results = [];
+
+for (const bet of bets) {
+  const index = indexArtifacts(bet.artifacts);
+  const betOut = {
+    dir: path.relative(REPO_ROOT, bet.dir) || bet.dir,
+    artifacts: bet.artifacts.map((f) => path.basename(f)),
+    artifactNumbers: index.length,
+    derivedPassRun: index.length <= DERIVED_LIMIT,
+    docs: [],
+  };
+
+  for (const doc of bet.prose) {
+    const nums = extractNumerals(readFileSync(doc, 'utf-8'));
+    const backed = [];
+    const nearMiss = [];
+    const noTrace = [];
+    const derived = [];
+
+    // Group identical (value, unit) pairs so a number quoted five times is one
+    // finding with five line numbers, not five findings.
+    const groups = new Map();
+    for (const n of nums) {
+      const key = `${n.raw}|${n.unit}`;
+      if (!groups.has(key)) groups.set(key, { ...n, lines: [] });
+      groups.get(key).lines.push(n.line);
+    }
+
+    for (const g of groups.values()) {
+      const tol = writtenTolerance(g.raw);
+      const direct = matchDirect(g.value, tol, g.unit, index);
+      if (direct.kind) {
+        backed.push({ ...g, via: direct.kind, scale: direct.scale, src: direct.entry.src });
+        continue;
+      }
+      const der = matchDerived(g.value, tol, g.unit, index);
+      if (der) {
+        derived.push({ ...g, how: der.how, a: der.a, b: der.b });
+        continue;
+      }
+      if (direct.near) nearMiss.push({ ...g, near: direct.near });
+      else noTrace.push({ ...g, crowding: direct.crowding });
+    }
+
+    nearMiss.sort((a, b) => a.near.rel - b.near.rel);
+    noTrace.sort((a, b) => a.lines[0] - b.lines[0]);
+    derived.sort((a, b) => a.lines[0] - b.lines[0]);
+
+    betOut.docs.push({
+      doc: path.basename(doc),
+      total: groups.size,
+      backed: backed.length,
+      nearMiss,
+      noTrace,
+      derived,
+      decoy: calibrate([...groups.values()], index),
+    });
+  }
+  results.push(betOut);
+}
+
+if (AS_JSON) {
+  console.log(JSON.stringify(results, null, 2));
+  process.exit(0);
+}
+
+let findings = 0;
+const fmtLines = (lines) => (lines.length > 4 ? `L${lines.slice(0, 4).join(',')}+${lines.length - 4}` : `L${lines.join(',')}`);
+
+console.log('Prose-versus-artifact numeral report');
+console.log('====================================');
+console.log('');
+
+for (const bet of results) {
+  console.log(`## ${bet.dir}`);
+  console.log(
+    `   artifacts: ${bet.artifacts.join(', ')} (${bet.artifactNumbers} numbers` +
+      `${bet.derivedPassRun ? '' : '; DERIVED pass skipped, index too large'})`,
+  );
+  for (const d of bet.docs) {
+    const unbacked = d.nearMiss.length + d.noTrace.length;
+    findings += unbacked;
+    console.log(
+      `   ${d.doc}: ${d.total} numerals -- ${d.backed} backed, ${d.derived.length} derived-only, ` +
+        `${unbacked} UNBACKED`,
+    );
+    console.log(
+      `   calibration: ${(d.decoy.rate * 100).toFixed(1)}% of ${d.decoy.decoys} ` +
+        `deliberately-wrong decoys were also "backed"`,
+    );
+    if (d.decoy.rate > 0.25) {
+      console.log(
+        `   >> the BACKED count carries little information for this bet: its artifacts hold raw`,
+      );
+      console.log(
+        `   >> sample data (dense continua of floats), so a wrong number lands next to a real one`,
+      );
+      console.log(
+        `   >> by chance. Only the UNBACKED list is signal here. This checker earns its keep`,
+      );
+      console.log(
+        `   >> against a curated scorecard, not against a data dump.`,
+      );
+    }
+    if (d.nearMiss.length > 0) {
+      console.log('');
+      console.log(`   UNBACKED, but the artifact holds something close (ranked, closest first):`);
+      for (const n of d.nearMiss) {
+        console.log(
+          `     ${fmtLines(n.lines).padEnd(14)} ${(n.raw + n.unit).padEnd(14)} ` +
+            `closest ${n.near.entry.v} (${(n.near.rel * 100).toFixed(2)}% off) <- ${n.near.entry.src}`,
+        );
+      }
+    }
+    if (d.noTrace.length > 0) {
+      console.log('');
+      console.log(`   UNBACKED, no informative nearest artifact value:`);
+      for (const n of d.noTrace) {
+        const why = n.crowding > 3 ? ` (${n.crowding} artifact values within 10%: neighbourhood too crowded to name one)` : '';
+        console.log(`     ${fmtLines(n.lines).padEnd(14)} ${n.raw + n.unit}${why}`);
+      }
+    }
+    if (d.derived.length > 0) {
+      console.log('');
+      console.log(`   DERIVED-ONLY (arithmetic over two artifact values; a hit here is a hint, not a clearance):`);
+      for (const n of d.derived) {
+        console.log(
+          `     ${fmtLines(n.lines).padEnd(14)} ${(n.raw + n.unit).padEnd(14)} ` +
+            `${n.how} with a=${n.a.v} (${n.a.src}), b=${n.b.v} (${n.b.src})`,
+        );
+      }
+    }
+    console.log('');
+  }
+}
+
+console.log('------------------------------------');
+console.log(`${findings} unbacked numeral(s) across ${results.length} bet director(ies).`);
+console.log('');
+console.log('Reading this: an UNBACKED numeral is a QUESTION, not a defect. The three');
+console.log('legitimate answers are (a) it is a bar or a figure from elsewhere -- fine;');
+console.log('(b) it is arithmetic the reader can do -- consider emitting it; (c) it does');
+console.log('not match the artifact -- that is the catch this exists for. The near-miss');
+console.log('list is where (c) lives: a number sitting 1% from the committed value is');
+console.log('almost always prose left behind by a re-run.');
+
+if (GATE && findings > 0) {
+  console.error(`::error::${findings} unbacked numeral(s) and --gate was requested.`);
+  process.exit(1);
+}
+process.exit(0);

--- a/scripts/moonshot/ci/check-report-numerals.mjs
+++ b/scripts/moonshot/ci/check-report-numerals.mjs
@@ -118,8 +118,13 @@
  * run: how often a deliberately-wrong number is cleared as "backed" by
  * coincidence. Against a single curated scorecard that rate is near zero.
  * Against `docs/vision`, whose haystack is the UNION of every moonshot
- * artifact in the tree (~8,900 numbers), it measured 57.5% to 91.7% per
- * document on 2026-07-29 -- 69.0% on the finishing plan itself. A "backed"
+ * artifact in the tree (~8,900 numbers), it is high: tens of percent, and over
+ * 90% on one document. No figure is transcribed here on purpose -- the run
+ * epilogue COMPUTES the docs/vision span from the run it just did, because a
+ * checker that hunts stale numerals must not carry one in its own header. (The
+ * 57.5%-to-91.7% figures quoted here before 2026-08-01 were measured with a
+ * decoy generator that rendered every exponent-form numeral through toFixed()
+ * and so tested a decoy of 0.000000.) A "backed"
  * verdict there means "some field somewhere in the program holds this value",
  * which is close to no information at all. The gate catches a figure that
  * contradicts a named artifact; it does not certify one that agrees with the
@@ -575,6 +580,19 @@ const STRUCTURAL_WORD = new Set([
 
 const NUM_RE = /(?<![\w.$])(\d{1,3}(?:,\d{3})+|\d+)(\.\d+)?([eE][+-]?\d+)?/g;
 
+/**
+ * Characters that can open a SIGNED numeral. `NUM_RE` deliberately matches the
+ * magnitude only, because folding `[+-]?` into the pattern would swallow the
+ * separator of every range and date -- `lines 148-171`, `2026-07-24`,
+ * `IEEE-754` -- and the range/compound suppressions below all look for that
+ * separator in the text BEFORE the match. So the sign is recovered afterwards
+ * and only when it is adjacent to the digits AND opened by a delimiter, which
+ * is exactly the shape a written negative has and a range never does. Without
+ * this, `-1.669700836e-2` was read as `+1.669700836e-2` and mismatched an
+ * artifact holding the real, negative value.
+ */
+const SIGN_OPENER = /[\s([{,;:=<>]/;
+
 function extractNumerals(rawText) {
   const masked = maskProse(rawText);
   // Line starts, for offset -> line number.
@@ -631,9 +649,18 @@ function extractNumerals(rawText) {
     // never about value.
     if (unit === '' && /[A-Za-z]-$/.test(beforeText)) continue;
 
-    const value = Number(raw.replace(/,/g, ''));
+    // Sign recovery, after every suppression above has had the unsigned text
+    // it expects. See SIGN_OPENER.
+    const signChar = start > 0 ? masked[start - 1] : '';
+    const signed =
+      (signChar === '-' || signChar === '+') &&
+      (start === 1 || SIGN_OPENER.test(masked[start - 2]))
+        ? signChar + raw
+        : raw;
+
+    const value = Number(signed.replace(/,/g, ''));
     if (!Number.isFinite(value)) continue;
-    out.push({ raw, value, unit, line: lineOf(start) });
+    out.push({ raw: signed, value, unit, line: lineOf(start) });
   }
   return out;
 }
@@ -796,12 +823,19 @@ function calibrate(groups, index, bindingIndexFor) {
       if (v === 0) continue;
       // Write the decoy at the same precision the prose used, so the tolerance
       // is the same tolerance the real numeral got.
-      const decimals = (() => {
-        const raw = g.raw.replace(/,/g, '');
-        const dot = raw.indexOf('.');
-        return dot === -1 ? 0 : raw.length - dot - 1;
-      })();
-      const rawDecoy = v.toFixed(Math.min(decimals, 12));
+      // Precision comes from the MANTISSA, and an exponent-form numeral stays
+      // in exponent form. Reading decimals off the whole string counted the
+      // exponent digits ("2.19e-13" -> 6) and then toFixed(6) collapsed the
+      // decoy to "0.000000", which tests nothing: every exponent-form figure
+      // in the program was being calibrated against a decoy of zero.
+      const plain = g.raw.replace(/,/g, '');
+      const em = /[eE][+-]?\d+$/.exec(plain);
+      const mantissa = em ? plain.slice(0, em.index) : plain;
+      const dot = mantissa.indexOf('.');
+      const decimals = dot === -1 ? 0 : mantissa.length - dot - 1;
+      const rawDecoy = em
+        ? v.toExponential(Math.min(decimals, 12))
+        : v.toFixed(Math.min(decimals, 12));
       decoys += 1;
       const tally = isBound ? bound : unbound;
       tally.decoys += 1;
@@ -1144,9 +1178,20 @@ console.log('(c) lives: a number sitting 1% from the committed value is almost a
 console.log('left behind by a re-run. STALE/MALFORMED markers count as findings too: an');
 console.log('excuse that no longer applies is the same defect one level up.');
 console.log('');
+// Computed from THIS run rather than transcribed, so the one number the
+// checker publishes about itself cannot go stale the way the figures it hunts
+// do. Falls back to a generic sentence when no docs/vision set was scanned.
+const visionRates = results
+  .flatMap((b) => b.docs)
+  .filter((d) => d.doc.startsWith('docs/vision') && d.decoy.decoys > 0)
+  .map((d) => d.decoy.rate * 100);
+const visionSpan = visionRates.length
+  ? `on docs/vision this run that cleared ${Math.min(...visionRates).toFixed(1)}% to ` +
+    `${Math.max(...visionRates).toFixed(1)}% of deliberately-wrong decoys. This is`
+  : 'and the calibration lines above say how often that happened by chance. This is';
 console.log('And read the calibration before the BACKED count. Against a union haystack a');
 console.log('"backed" verdict means only that SOME field in the program holds that value --');
-console.log('on docs/vision that cleared 57.5% to 91.7% of deliberately-wrong decoys. This is');
+console.log(visionSpan);
 console.log('a contradiction gate, not a truth gate. The way to make a figure actually');
 console.log('checkable is `<!-- numeral-src: <token> :: <file>#<json.path> -->`, which binds it');
 console.log('to one field and drops its decoy rate to ~0.');

--- a/scripts/moonshot/ci/kernel-perturbation-evidence.txt
+++ b/scripts/moonshot/ci/kernel-perturbation-evidence.txt
@@ -1,0 +1,184 @@
+B4.1 standing-evidence lane -- committed proof that the B3.5 golden tripwire
+fires on a REAL one-line change to the Rust geometry kernel.
+
+WHY THIS FILE EXISTS, AND WHY self-test-evidence.txt WAS NOT ENOUGH
+The finishing plan's B4.1 exam reads "a deliberate one-bit KERNEL perturbation
+turns it red and names which act broke". The first attempt at that evidence
+(scripts/moonshot/ci/self-test-evidence.txt) perturbs a JavaScript carbon
+constant, `CARBON_FACTORS.Concrete` in scripts/moonshot/diff-spike/carbon-model.mjs.
+The G4 adversarial re-review showed the two are not equivalent, and the
+demonstration is worth restating because it is the whole reason this file
+exists:
+
+  You can disconnect the wasm geometry kernel from act 5 entirely and the
+  JS self-test still passes.
+
+Its only kernel-flavoured assertion is that `kernelValidation/kernelCarbonKg`
+moved -- and that field is a product with the perturbed JS constant, so it
+moves whether or not any kernel measurement is still feeding it. The JS
+self-test proves the golden is wired to act 5. It does not prove the golden is
+wired to the kernel. This file closes that gap by perturbing the kernel itself
+and rebuilding the wasm bundle from source.
+
+Read the two artifacts as a pair:
+  self-test-evidence.txt          in-lane, ~12 s, runs on every CI execution.
+                                  Proves E3b can fail at all and names act 5.
+  kernel-perturbation-evidence.txt (this file) out-of-lane, needs a rust
+                                  toolchain and two wasm rebuilds. Proves the
+                                  path rust/geometry -> wasm -> act 5 -> golden
+                                  is intact end to end.
+Re-attest this one locally with:
+
+    node scripts/moonshot/ci/assert-b35-golden.mjs --kernel
+
+which automates exactly the procedure transcribed below.
+
+WHEN AND WHERE
+  date              2026-07-29
+  machine           Apple M4, 16 GB, macOS 26.5.2, arm64 (LOCAL, not CI)
+  node              v22.14.0 (the version moonshot.yml pins for the golden)
+  rustc             1.93.0-nightly (b6d7ff3aa 2025-11-14)
+  wasm-pack         0.14.0
+  repo commit       1d5c5b97bbc0145015e0bc1d5a38771353187988
+                    (branch docs/moonshot-finishing-plan, tree otherwise clean)
+  golden            scripts/moonshot/ci/b35-golden.json, 8931 bytes, unmodified
+                    throughout -- the reference never moved, only the kernel did
+
+THE EXACT PERTURBATION
+  file    rust/geometry/src/extrusion.rs
+  applied by `git apply` of:
+
+    diff --git a/rust/geometry/src/extrusion.rs b/rust/geometry/src/extrusion.rs
+    index d14458bf..e3626041 100644
+    --- a/rust/geometry/src/extrusion.rs
+    +++ b/rust/geometry/src/extrusion.rs
+    @@ -16,6 +16,7 @@ pub fn extrude_profile(
+         depth: f64,
+         transform: Option<Matrix4<f64>>,
+     ) -> Result<Mesh> {
+    +    let depth = depth * 1.000001;
+         if depth <= 0.0 {
+             return Err(Error::InvalidExtrusion(
+                 "Depth must be positive".to_string(),
+
+  magnitude  +1e-6 relative on every extruded depth in the shipping mesher.
+  scope      `extrude_profile` is the swept-solid path the b35 demo's walls,
+             slabs and columns go through. Nothing else in the tree is touched:
+             no JavaScript, no golden, no report, no demo script.
+
+  Why not literally one bit: a one-ULP nudge of a depth (1.0 ->
+  1.0000000000000002) is provably below the report's own serialization floor.
+  demo-report.json rounds carbon to 3 decimals on a ~73,459 kg total, so ~7e-9
+  relative is the smallest change that can survive being written down at all,
+  and the measured floor for a volume-derived scalar is ~3e-9. 1e-6 is ~300x
+  above that floor -- large enough that the tripwire firing is not luck, small
+  enough that no reviewer would mistake it for an intended model change.
+  "One-bit" in the exam should therefore be read as "the smallest change the
+  artifact can represent", which is what B4.1's own sensitivity note already
+  says.
+
+PROCEDURE, AND WHAT EACH STEP COST
+  1. baseline           node scripts/moonshot/b35-demo/run.mjs           6.1 s
+                        node scripts/moonshot/ci/assert-b35-golden.mjs   exit 0
+                        wasm md5 16bc012171281ec39cf421fa83ecd461
+  2. apply the diff above to rust/geometry/src/extrusion.rs
+  3. rebuild            bash scripts/build-wasm.sh
+                        wasm md5 8e428de5863c68bdad1e96a0226f1ddf  (CHANGED)
+  4. re-run + assert    node scripts/moonshot/b35-demo/run.mjs           exit 0
+                        node scripts/moonshot/ci/assert-b35-golden.mjs   exit 1
+                        <- the red run, transcribed verbatim below
+  5. revert             git checkout -- rust/geometry/src/extrusion.rs
+  6. rebuild            bash scripts/build-wasm.sh
+                        wasm md5 7a4b382be34e8aece81a33a63a0a447d
+  7. re-run + assert    node scripts/moonshot/ci/assert-b35-golden.mjs   exit 0
+                        "B3.5 deterministic subtree matches the golden
+                         byte-for-byte (8931 bytes, masterSeed 20260724,
+                         config {"devSliceSize":40,"batterySchedules":1000})
+                         acts: act1=ok act2=ok act3=ok act4=ok act5=ok"
+
+  RE-ATTESTED THE SAME DAY THROUGH THE AUTOMATED MODE. `assert-b35-golden.mjs
+  --kernel` was then run on the same tree and reproduced this red run exactly:
+  stage 0 green, stage A red with the same three paths and the same six values,
+  stage B green, tree restored. Its two rebuilds took 31 s and 30 s and it also
+  asserts that the bundle's sha256 CHANGED across the perturbed rebuild
+  (74bd06aa... -> 43bdc99a...), which is the guard against
+  `scripts/build-wasm.sh` exiting 0 on a stale on-disk bundle when wasm-pack is
+  missing -- the G4 review's structural gap (d). So the transcription below is
+  not the only copy of this evidence; the procedure is executable.
+
+  An incremental rebuild after touching one file in rust/geometry measured
+  27 s wall on this machine with a warm cargo cache (step 6 re-measured with
+  `touch rust/geometry/src/extrusion.rs`). That is the best case and it is why
+  this is not an in-lane step: the same build is 1m39s warm and up to ~15 min
+  cold on the CI runner (moonshot.yml's own timeout note), the self-test needs
+  TWO of them, and the lane's whole budget is 20 minutes against an observed
+  10m01s. Doubling the dominant cost to re-prove something that does not change
+  between commits is a bad trade; re-attesting on demand is the right shape.
+
+A REBUILD IS NOT BYTE-REPRODUCIBLE; THE MEASUREMENT IS
+Three builds of this same source tree produced three different bundles --
+16bc0121... (step 1, built 2026-07-27), 7a4b382b... (step 6) and f6cdcf53...
+(the timing re-measurement) -- and all three reproduce the committed golden
+byte-for-byte. So the golden is pinned to the kernel's ANSWERS, not to the
+bundle's bytes, and it does not go red merely because someone rebuilt. That is
+the property that makes it usable as a standing tripwire, and it is worth
+knowing that it was checked rather than assumed.
+
+WHAT THE RED RUN PROVES, AND WHAT IT DOES NOT
+Compare the two failure shapes. The JS carbon-constant perturbation moves 35
+pinned paths, because it perturbs the objective the optimizer descends, so every
+optimizer parameter and every intermediate round moves with it. The kernel
+perturbation moves exactly 3, and all three are in
+`acts/act5/data/kernelValidation/` -- the block act5-descent.mjs fills by
+RE-MEASURING the optimized design through the wasm geometry kernel and comparing
+it to the differentiable model's own answer. The optimizer parameters do not
+move at all, because the JS model is untouched. That is the signature of a
+kernel-only change, and it is a sharper result than the JS self-test produces:
+it isolates the kernel path instead of merely passing through it.
+
+What it does NOT prove is any broadening of B4.1's sensitivity claim. The
+golden still pins ~120 leaves of which five are direct kernel measurements, all
+scalar volume/carbon integrals over one 74-element synthetic model. A winding,
+normal-direction, index-ordering or triangulation-quality regression whose
+volume integral is unchanged still passes green. This artifact closes the
+"attested rather than evidenced" finding; it does not close the "one non-volume
+kernel field would be worth adding" recommendation, which remains open.
+
+VERBATIM RED RUN (step 4)
+The block below is the unedited stderr of
+`node scripts/moonshot/ci/assert-b35-golden.mjs` with the kernel perturbation
+built into packages/wasm/pkg/ifc-lite_bg.wasm.
+
+========================================================================
+::error::B3.5 DETERMINISTIC DRIFT -- the five-act demo no longer reproduces its seeded golden.
+
+golden: scripts/moonshot/ci/b35-golden.json (8931 bytes)
+actual: scripts/moonshot/b35-demo/demo-report.json -> deterministic (8935 bytes)
+
+3 differing path(s), golden -> actual:
+  acts/act5/data/kernelValidation/worstElementRelDev
+      golden: 0.000001675
+      actual: 0.000002947
+  acts/act5/data/kernelValidation/kernelCarbonKg
+      golden: 73459.109
+      actual: 73459.186
+  acts/act5/data/kernelValidation/carbonRelDev
+      golden: 1.54e-7
+      actual: 0.000001207
+
+The leading path segment names the act that broke:
+  acts/act1 = BIRTH       world-gym generator/labeler/reward channels
+  acts/act2 = PROOF       node-hash-v0 DAG + certificate verify/tamper (@ifc-lite/provenance)
+  acts/act3 = SABOTAGE    benchmark splits/ground-truth/scorer
+  acts/act4 = CONVERGENCE merge battery + commutation certificates
+  acts/act5 = DESCENT     differentiable carbon model + GEOMETRY KERNEL re-measurement
+
+If the change is intended, re-run the demo and re-bless with:
+  node scripts/moonshot/b35-demo/run.mjs
+  node scripts/moonshot/ci/assert-b35-golden.mjs --update
+and commit both the golden and scripts/moonshot/b35-demo/demo-report.{json,md}.
+========================================================================
+
+The named act is act5 = DESCENT, and the three named fields are the kernel
+re-measurement block. "Names which act broke" is met, on a kernel perturbation,
+with the reference golden untouched.

--- a/scripts/moonshot/ci/self-test-evidence.txt
+++ b/scripts/moonshot/ci/self-test-evidence.txt
@@ -80,25 +80,36 @@ THE EXACT PERTURBATION
   change in a diff. It is a reliability choice, not a sensitivity claim.
 
 NEGATIVE CONTROL (this file's most important line)
-A self-test that always passes is the same disease it was written to cure. Run
-on 2026-07-29 with PERTURB_REPLACE set to the one-ULP value 315.00000000000006
-and nothing else changed, the mode correctly FAILED, exit 1:
+A self-test that always passes is the same disease it was written to cure. Re-run
+on 2026-08-01 at b893b89c (same branch, same machine as the header above) with
+PERTURB_REPLACE set to the one-ULP value 315.00000000000006 and nothing else
+changed, the mode correctly FAILED, exit 1. Verbatim stderr, the only edit being
+a line wrap of each `  - ` bullet to fit this file:
 
   ::error::B3.5 GOLDEN SELF-TEST FAILED -- the tripwire cannot be trusted.
     - THE TRIPWIRE DID NOT FIRE: the golden check passed with a perturbed carbon
-      factor. A >=1e-6 relative change reached no pinned field -- the golden no
-      longer covers act 5's kernel-validation block, or the demo is not reading
-      the perturbed source.
+      factor. A >=1e-6 relative change to act 5 reached no pinned field -- the
+      golden no longer covers act 5, or the demo is not reading the perturbed
+      source.
     - the failure output does not carry the "B3.5 DETERMINISTIC DRIFT" banner
     - the failure names no acts/act5/* path -- "names which act broke" is not met
     - acts/act5/data/kernelValidation/kernelCarbonKg did not move, although the
-      perturbed constant is multiplied into it by act5-descent.mjs -- the kernel
-      measurement is no longer reaching the golden
+      perturbed constant is multiplied into it by act5-descent.mjs -- the
+      kernel-validation block is no longer emitted, or no longer pinned by the
+      golden
 
   stage A reported: golden check exited 0 (expected 1 = drift), differing paths
-  named: 0. The tree was still restored clean. So the mode distinguishes "the
-  tripwire fired" from "the tripwire was asked something it cannot detect", and
-  exits non-zero for the second -- it tests the test.
+  named: 0 (act 5: 0, kernel-validation: 0). The tree was still restored clean.
+  So the mode distinguishes "the tripwire fired" from "the tripwire was asked
+  something it cannot detect", and exits non-zero for the second -- it tests the
+  test.
+
+  This block was regenerated on 2026-08-01 rather than hand-corrected: the
+  transcript captured on 2026-07-29 had drifted from the messages the script
+  actually emits (the fourth bullet still read "the kernel measurement is no
+  longer reaching the golden", wording the script stopped using when the
+  assertion was correctly re-described as a WIRING check on act 5). A negative
+  control that quotes output the code cannot produce is not evidence.
 
 TIMING: THE "GREEN IN UNDER 20 MINUTES" HALF OF THE EXAM
 Both halves are now measured in the FULL configuration (the two Holter-gated

--- a/scripts/moonshot/ci/self-test-evidence.txt
+++ b/scripts/moonshot/ci/self-test-evidence.txt
@@ -1,12 +1,34 @@
 B4.1 standing-evidence lane -- committed proof that the B3.5 golden tripwire
-can actually fail.
+can actually fail, on a JAVASCRIPT MODEL CONSTANT.
+
+SCOPE. READ THIS BEFORE QUOTING THIS FILE.
+This is NOT the kernel perturbation the B4.1 exam names. The G4 adversarial
+re-review showed the difference is load-bearing: you can disconnect the wasm
+geometry kernel from act 5 entirely and this self-test still passes, because
+its only kernel-flavoured assertion is that `kernelValidation/kernelCarbonKg`
+moved -- and that field is a product with the perturbed JS constant, so it moves
+whether or not a kernel measurement still feeds it.
+
+  What a green run here establishes: the golden is wired to act 5's data and
+  can distinguish a >=1e-6 relative change in it from no change, i.e. E3b is a
+  tripwire and not an assertion that cannot fail.
+  What it does NOT establish: that a kernel measurement is still reaching the
+  golden.
+
+The kernel half of the exam is evidenced separately, by an actual one-line
+change to rust/geometry compiled into the wasm bundle:
+scripts/moonshot/ci/kernel-perturbation-evidence.txt, reproducible with
+`node scripts/moonshot/ci/assert-b35-golden.mjs --kernel`. This file is the
+cheap in-lane tripwire; that one is the end-to-end proof. Neither substitutes
+for the other.
 
 WHY THIS FILE EXISTS
 The G4 standing adversarial review (docs/vision/reviews/g4-red-team-2026-07-29.md,
 section 4) failed gate G4 in part because "both halves of B4.1's exam are
 attested rather than evidenced": the perturbation half existed only as prose in
 a commit message. Section 7 item 3 requires a committed red-run artifact or a
-`--self-test` mode. This is the artifact. It is the verbatim stdout of
+`--self-test` mode. This is the artifact for the in-lane mode. It is the
+verbatim stdout of
 
     node scripts/moonshot/ci/assert-b35-golden.mjs --self-test
 
@@ -16,13 +38,21 @@ Regenerate it with that command; the only line that should move between runs is
 the per-stage wall clock.
 
 WHEN AND WHERE
-  date              2026-07-29
+  date              2026-07-29 (verbatim block below regenerated the same day
+                    after the mode's banner was corrected to state its scope)
   machine           Apple M4, 16 GB, macOS 26.5.2, arm64 (LOCAL, not CI)
   node              v22.14.0 (the version moonshot.yml pins for the golden)
   rustc             1.93.0-nightly (b6d7ff3aa 2025-11-14)
   wasm-pack         0.14.0
-  wasm bundle       packages/wasm/pkg/ifc-lite_bg.wasm, md5 16bc012171281ec39cf421fa83ecd461
-  repo commit       5f8f3549627459511593ae70c049ec57f51fdb9d (docs/moonshot-finishing-plan)
+  wasm bundle       packages/wasm/pkg/ifc-lite_bg.wasm. NOT pinned by md5 here:
+                    the bundle is not byte-reproducible across rebuilds while
+                    the golden it produces is (three builds of one source tree,
+                    three md5s, one identical golden -- see
+                    kernel-perturbation-evidence.txt). The md5 recorded in an
+                    earlier revision of this file, 16bc0121..., was a fact about
+                    one build, not about the evidence.
+  repo commit       1d5c5b97bbc0145015e0bc1d5a38771353187988 (docs/moonshot-finishing-plan)
+                    (first captured at 5f8f3549 on the same branch)
   self-test runtime 13 s wall (two full five-act demo runs plus two golden checks)
 
 THE EXACT PERTURBATION
@@ -129,17 +159,20 @@ produced under the perturbation -- that is the red run the G4 review asked to
 see committed.
 
 ========================================================================
-B3.5 golden tripwire --self-test
+B3.5 golden tripwire --self-test (JS MODEL CONSTANT, not a kernel perturbation)
+  scope: proves the golden is wired to act 5 and can fail. For the kernel
+         path (rust/geometry -> wasm -> act 5) run --kernel; its committed
+         output is scripts/moonshot/ci/kernel-perturbation-evidence.txt.
   perturbation: CARBON_FACTORS.Concrete 315 -> 315.000315 (+1e-6 relative) in scripts/moonshot/diff-spike/carbon-model.mjs
   assert under test: scripts/moonshot/ci/assert-b35-golden.mjs
 
 stage A -- perturbation injected, re-running the five-act demo
-  demo completed in 6.4s
+  demo completed in 7.9s
   golden check exited 1 in 0.0s (expected 1 = drift)
   differing paths named: 35 (act 5: 35, kernel-validation: 3)
 
 stage B -- original state restored, re-running to prove recovery
-  demo completed in 6.0s
+  demo completed in 8.0s
   golden check exited 0 in 0.0s (expected 0 = match)
 
 tree restored: `git status --porcelain` clean over all 3 touched files.
@@ -147,6 +180,9 @@ tree restored: `git status --porcelain` clean over all 3 touched files.
 SELF-TEST PASS: the B3.5 golden tripwire fires on a 1e-6 relative carbon-factor
 perturbation, names act 5 and its kernel-validation fields, and returns to green
 when the perturbation is reverted.
+SCOPE: this is a JS model constant. It proves the golden is wired to act 5 and
+can fail; it does NOT prove a kernel measurement still reaches it. That is
+--kernel / kernel-perturbation-evidence.txt.
 
 --- captured failure output (stage A) ---
 ::error::B3.5 DETERMINISTIC DRIFT -- the five-act demo no longer reproduces its seeded golden.

--- a/scripts/moonshot/ci/self-test-evidence.txt
+++ b/scripts/moonshot/ci/self-test-evidence.txt
@@ -1,0 +1,276 @@
+B4.1 standing-evidence lane -- committed proof that the B3.5 golden tripwire
+can actually fail.
+
+WHY THIS FILE EXISTS
+The G4 standing adversarial review (docs/vision/reviews/g4-red-team-2026-07-29.md,
+section 4) failed gate G4 in part because "both halves of B4.1's exam are
+attested rather than evidenced": the perturbation half existed only as prose in
+a commit message. Section 7 item 3 requires a committed red-run artifact or a
+`--self-test` mode. This is the artifact. It is the verbatim stdout of
+
+    node scripts/moonshot/ci/assert-b35-golden.mjs --self-test
+
+which is also run on every lane execution as workflow step
+"E3c B3.5 tripwire self-test (the golden must be able to fail)".
+Regenerate it with that command; the only line that should move between runs is
+the per-stage wall clock.
+
+WHEN AND WHERE
+  date              2026-07-29
+  machine           Apple M4, 16 GB, macOS 26.5.2, arm64 (LOCAL, not CI)
+  node              v22.14.0 (the version moonshot.yml pins for the golden)
+  rustc             1.93.0-nightly (b6d7ff3aa 2025-11-14)
+  wasm-pack         0.14.0
+  wasm bundle       packages/wasm/pkg/ifc-lite_bg.wasm, md5 16bc012171281ec39cf421fa83ecd461
+  repo commit       5f8f3549627459511593ae70c049ec57f51fdb9d (docs/moonshot-finishing-plan)
+  self-test runtime 13 s wall (two full five-act demo runs plus two golden checks)
+
+THE EXACT PERTURBATION
+  file              scripts/moonshot/diff-spike/carbon-model.mjs
+  edit              CARBON_FACTORS.Concrete: 315  ->  315.000315
+  magnitude         +1e-6 relative
+  applied by        assert-b35-golden.mjs --self-test, in-process, then reverted
+                    from a byte snapshot under try/finally and SIGINT/SIGTERM
+                    handlers; `git status --porcelain` over the three touched
+                    files is asserted to be identical afterwards.
+
+  Why this site: act5-descent.mjs imports CARBON_FACTORS and accumulates
+  `kernelCarbon += row.kernelVolume * factor` over the volumes the wasm geometry
+  kernel re-measured, emitting the sum as
+  acts/act5/data/kernelValidation/kernelCarbonKg. The constant therefore reaches
+  the golden's kernel-validation block by construction, not by luck.
+
+  Why 1e-6 and not one ULP: the tripwire's floor is the report's own rounding.
+  kernelCarbonKg is rounded to 3 decimals on a ~73,459 kg total, so ~7e-9
+  relative is the smallest change that can survive serialization; the measured
+  floor for this constant is ~3e-9. A one-ULP nudge (315.00000000000006) is
+  known NOT to move the golden -- see the NEGATIVE CONTROL below. 1e-6 sits
+  ~300x above the measured floor, which is margin the assertion cannot lose to
+  a re-blessing, while staying far too small to pass for a deliberate model
+  change in a diff. It is a reliability choice, not a sensitivity claim.
+
+NEGATIVE CONTROL (this file's most important line)
+A self-test that always passes is the same disease it was written to cure. Run
+on 2026-07-29 with PERTURB_REPLACE set to the one-ULP value 315.00000000000006
+and nothing else changed, the mode correctly FAILED, exit 1:
+
+  ::error::B3.5 GOLDEN SELF-TEST FAILED -- the tripwire cannot be trusted.
+    - THE TRIPWIRE DID NOT FIRE: the golden check passed with a perturbed carbon
+      factor. A >=1e-6 relative change reached no pinned field -- the golden no
+      longer covers act 5's kernel-validation block, or the demo is not reading
+      the perturbed source.
+    - the failure output does not carry the "B3.5 DETERMINISTIC DRIFT" banner
+    - the failure names no acts/act5/* path -- "names which act broke" is not met
+    - acts/act5/data/kernelValidation/kernelCarbonKg did not move, although the
+      perturbed constant is multiplied into it by act5-descent.mjs -- the kernel
+      measurement is no longer reaching the golden
+
+  stage A reported: golden check exited 0 (expected 1 = drift), differing paths
+  named: 0. The tree was still restored clean. So the mode distinguishes "the
+  tripwire fired" from "the tripwire was asked something it cannot detect", and
+  exits non-zero for the second -- it tests the test.
+
+TIMING: THE "GREEN IN UNDER 20 MINUTES" HALF OF THE EXAM
+Both halves are now measured in the FULL configuration (the two Holter-gated
+steps RUN, not skip). The G4 review's objection was that the only observed run
+was a `pull_request` event, where E2a and E2b exit 0 without doing anything.
+
+  CI, workflow_dispatch, holter=true, ubuntu-latest, run 30441941453
+  (2026-07-29, commit 5f8f3549, branch docs/moonshot-finishing-plan):
+
+    whole job                                        10m 01s   (bar: 20m)
+      setup: checkout/pnpm/node/toolchain/install      4m 02s
+      build wasm from source + workspace packages      1m 39s
+      fixture cache + fetch (duplex + Holter 169 MB)      4s
+      the fifteen assertion steps E1..E8                 80s
+    E2a G0 (Holter)   8s        E2b G1 (Holter)  9s
+    E1 2s  E2c 1s  E2d 3s  E3a 19s  E3b 0s  E4 4s  E5a 2s  E5b 3s
+    E6a 9s  E6b 12s  E7 7s  E8 1s
+    result: SUCCESS, every step green, including both Holter-gated exams.
+
+  LOCAL, same commit, warm toolchain (Apple M4 above), all fifteen assertion
+  steps replayed end to end in the full configuration, E3c included:
+
+    E1  1.4s   E2a 6.4s   E2b 6.4s   E2c 0.5s   E2d 1.7s
+    E3a 6.0s   E3b 0.0s   E3c 12.2s
+    E4  1.5s   E5a 0.9s   E5b 0.9s   E6a 3.1s   E6b 4.3s
+    E7  1.2s   E8  1.3s
+    total 49s, every step exit 0.
+
+  E3c did not exist when run 30441941453 was dispatched, so its cost is measured
+  locally only: +12.2s, i.e. the lane's assertion budget goes from ~80s to ~95s
+  in CI and the 20-minute clause is not remotely at risk.
+
+CAN THE LANE BE DISPATCHED WHILE moonshot.yml IS STILL ON A PR BRANCH? YES.
+This was checked rather than assumed, because the usual rule is that
+workflow_dispatch requires the workflow on the default branch. moonshot.yml does
+NOT exist on main:
+
+    $ git cat-file -e ltplus/main:.github/workflows/moonshot.yml
+    fatal: path '.github/workflows/moonshot.yml' exists on disk, but not in 'ltplus/main'
+
+and yet
+
+    $ gh workflow run 321177537 --ref docs/moonshot-finishing-plan -f holter=true
+    https://github.com/LTplus-AG/ifc-lite/actions/runs/30441941453
+
+dispatched successfully and ran to completion with event=workflow_dispatch and
+fixture scope FULL. The default-branch requirement governs whether GitHub
+REGISTERS a workflow and shows its "Run workflow" button; once the workflow has
+been registered by an earlier run on the branch (two pull_request runs, 30243482383
+and 30440435782), the API accepts a dispatch against that same ref. So the exam's
+"one workflow_dispatch run with the Holter fixture" is satisfied now, before the
+branch merges.
+
+VERBATIM SELF-TEST OUTPUT FOLLOWS
+The block below is stdout of the passing run described in the header. The
+"captured failure output" section inside it is the real stderr the golden check
+produced under the perturbation -- that is the red run the G4 review asked to
+see committed.
+
+========================================================================
+B3.5 golden tripwire --self-test
+  perturbation: CARBON_FACTORS.Concrete 315 -> 315.000315 (+1e-6 relative) in scripts/moonshot/diff-spike/carbon-model.mjs
+  assert under test: scripts/moonshot/ci/assert-b35-golden.mjs
+
+stage A -- perturbation injected, re-running the five-act demo
+  demo completed in 6.4s
+  golden check exited 1 in 0.0s (expected 1 = drift)
+  differing paths named: 35 (act 5: 35, kernel-validation: 3)
+
+stage B -- original state restored, re-running to prove recovery
+  demo completed in 6.0s
+  golden check exited 0 in 0.0s (expected 0 = match)
+
+tree restored: `git status --porcelain` clean over all 3 touched files.
+
+SELF-TEST PASS: the B3.5 golden tripwire fires on a 1e-6 relative carbon-factor
+perturbation, names act 5 and its kernel-validation fields, and returns to green
+when the perturbation is reverted.
+
+--- captured failure output (stage A) ---
+::error::B3.5 DETERMINISTIC DRIFT -- the five-act demo no longer reproduces its seeded golden.
+
+golden: scripts/moonshot/ci/b35-golden.json (8931 bytes)
+actual: scripts/moonshot/b35-demo/demo-report.json -> deterministic (8935 bytes)
+
+35 differing path(s), golden -> actual:
+  acts/act5/data/params/Lx
+      golden: 14.927229
+      actual: 14.934305
+  acts/act5/data/params/Ly
+      golden: 13.740763
+      actual: 13.734242
+  acts/act5/data/params/wwL
+      golden: 1.948896
+      actual: 1.937039
+  acts/act5/data/params/wh
+      golden: 1.337394
+      actual: 1.341871
+  acts/act5/data/params/dw
+      golden: 1.429887
+      actual: 1.452212
+  acts/act5/data/params/dh
+      golden: 2.306698
+      actual: 2.320606
+  acts/act5/data/params/cw
+      golden: 0.280305
+      actual: 0.270803
+  acts/act5/data/params/cd
+      golden: 0.290873
+      actual: 0.300998
+  acts/act5/data/params/bh
+      golden: 0.38163
+      actual: 0.381449
+  acts/act5/data/params/wwS
+      golden: 2.049852
+      actual: 2.049699
+  acts/act5/data/startCarbonKg
+      golden: 177100.875
+      actual: 177100.988
+  acts/act5/data/optimumCarbonKg
+      golden: 73459.098
+      actual: 73453.162
+  acts/act5/data/reductionPct
+      golden: 58.521
+      actual: 58.525
+  acts/act5/data/penaltyRounds/0/carbon
+      golden: 67833.465
+      actual: 67830.331
+  acts/act5/data/penaltyRounds/0/maxViol
+      golden: 0.51179282
+      actual: 0.512128667
+  acts/act5/data/penaltyRounds/1/carbon
+      golden: 71744.224
+      actual: 71811.664
+  acts/act5/data/penaltyRounds/1/maxViol
+      golden: 0.127153118
+      actual: 0.120477996
+  acts/act5/data/penaltyRounds/2/carbon
+      golden: 72789.725
+      actual: 72804.868
+  acts/act5/data/penaltyRounds/2/maxViol
+      golden: 0.033694104
+      actual: 0.032602052
+  acts/act5/data/penaltyRounds/3/carbon
+      golden: 73304.362
+      actual: 73293.928
+  acts/act5/data/penaltyRounds/3/maxViol
+      golden: 0.008108661
+      actual: 0.008238318
+  acts/act5/data/penaltyRounds/4/carbon
+      golden: 73426.599
+      actual: 73422.585
+  acts/act5/data/penaltyRounds/4/maxViol
+      golden: 0.0021569
+      actual: 0.001994865
+  acts/act5/data/penaltyRounds/5/carbon
+      golden: 73459.098
+      actual: 73453.162
+  acts/act5/data/penaltyRounds/5/maxViol
+      golden: 0.00051128
+      actual: 0.000533172
+  acts/act5/data/residualScaledViolation
+      golden: 0.00051128
+      actual: 0.000533172
+  acts/act5/data/residualConstraints/0/g
+      golden: 0.048957657
+      actual: 0.049728291
+  acts/act5/data/residualConstraints/1/g
+      golden: 0.000004166
+      actual: 0.000004057
+  acts/act5/data/residualConstraints/2/g
+      golden: 0.00051128
+      actual: 0.000533172
+  acts/act5/data/residualConstraints/3/g
+      golden: 0.000057799
+      actual: 0.000057842
+  acts/act5/data/optimumIfc/bytes
+      golden: 111197
+      actual: 111257
+  acts/act5/data/optimumIfc/sha256
+      golden: "48fc69e72d33c45002832dec38d53fc6d0c563bab997e8fafcdc537181078c4e"
+      actual: "f14e091f9a457ecff501935cda87fa274f932b3aa24ebf6967c012f06382ab2e"
+  acts/act5/data/kernelValidation/worstElementRelDev
+      golden: 0.000001675
+      actual: 0.0000013
+  acts/act5/data/kernelValidation/kernelCarbonKg
+      golden: 73459.109
+      actual: 73453.165
+  acts/act5/data/kernelValidation/carbonRelDev
+      golden: 1.54e-7
+      actual: 4.8e-8
+
+The leading path segment names the act that broke:
+  acts/act1 = BIRTH       world-gym generator/labeler/reward channels
+  acts/act2 = PROOF       node-hash-v0 DAG + certificate verify/tamper (@ifc-lite/provenance)
+  acts/act3 = SABOTAGE    benchmark splits/ground-truth/scorer
+  acts/act4 = CONVERGENCE merge battery + commutation certificates
+  acts/act5 = DESCENT     differentiable carbon model + GEOMETRY KERNEL re-measurement
+
+If the change is intended, re-run the demo and re-bless with:
+  node scripts/moonshot/b35-demo/run.mjs
+  node scripts/moonshot/ci/assert-b35-golden.mjs --update
+and commit both the golden and scripts/moonshot/b35-demo/demo-report.{json,md}.
+
+summary: {"perturbation":"CARBON_FACTORS.Concrete 315 -> 315.000315 (+1e-6 relative) in scripts/moonshot/diff-spike/carbon-model.mjs","stageAExit":1,"stageBExit":0,"node":"v22.14.0","platform":"darwin-arm64"}

--- a/scripts/moonshot/gpu-predicates/DESIGN.md
+++ b/scripts/moonshot/gpu-predicates/DESIGN.md
@@ -118,6 +118,15 @@ before the expensive exact tier runs.
   the cap fires and routes to fallback rather than silently computing a wrong
   sign.
 
+<!-- Numeral provenance, added 2026-07-29 for the numeral gate
+     (scripts/moonshot/ci/check-report-numerals.mjs). No figure in this document
+     is changed; these comments record which numbers the committed
+     report.b25.*.json artifacts emit and which they do not. -->
+<!-- numeral-ok: 52, 63, 1074 :: IEEE-754 double structure and its consequences
+     (52-bit mantissa, ~2^63 for the largest plausible coordinate, the ~1074-bit
+     spread from DBL_MAX down to the smallest subnormal). Properties of the
+     format, not measurements. -->
+
 ## 5. Width budget (why 512-bit two's-complement-free sign-magnitude is enough)
 
 Let `W = 53 + D_MAX = 153` bits (worst-case magnitude of a single shifted
@@ -154,6 +163,13 @@ narrowest limb count that covers the test's actual `D`, branching per lane or
 per workgroup. This spike deliberately skips that optimization to keep the
 shader small and the correctness argument easy to audit; see §7 for the
 resulting throughput hit.
+
+<!-- numeral-ok: 512, 153, 154, 308, 309, 463, 465, 47, 160, 256 :: the width
+     derivation itself. Every one of these is computed in the table on the line
+     it appears on, from `W` = 153 and the stated rule (W+1, 2(W+1), 2(W+1)+1,
+     463+2), and 512 / 16 limbs / 47 spare bits / 256 partial products follow
+     from that. A register width is a design decision, not a measurement, and no
+     battery report emits one. -->
 
 ## 6. Representation: sign-magnitude, not two's complement
 
@@ -242,6 +258,15 @@ produced by `node harness.mjs --phase=all`. Headline:
   end-to-end for a real caller — that gap is real, disclosed, and left for
   B2.5/B3.4 to close.
 
+<!-- numeral-ok: 1,500,009, 506 :: case counts of the B1.3 spike battery. The
+     committed report.b25.*.json files are from a LATER, differently-scaled
+     invocation (per-label totalCases of 1e6 / 2e5 and so on); the spike run's
+     own JSON was never committed. Stated here so nobody reads these as backed. -->
+<!-- numeral-ok: 15.3x, 29.6x, 31.0x :: throughput ratios from that same
+     uncommitted spike run. -->
+<!-- numeral-ok: 1e-6 :: a coordinate MAGNITUDE in the rotating 1e3/1e9/1e-6
+     generator set, i.e. a generator parameter, not a result. -->
+
 ## 9. B2.5 follow-up: the encode bottleneck is closed, and incircle is in
 
 Everything in this section was measured on the same machine and stack as
@@ -298,6 +323,11 @@ The worker-parallelized-encode candidate was not implemented: with encode
 gone from the pipeline entirely, there is nothing left for workers to
 parallelize on the main path (it would only multiply path B's 5.4x).
 
+<!-- numeral-ok: 1.34x, 290ms, 96B, 288B :: 1.34x and ~290 ms (shader
+     compilation) are from the baseline-reproduction run of §9.1, whose JSON was
+     not committed; 96 B and 288 B are the per-test upload sizes of the two
+     encodings, format constants fixed by the WGSL. -->
+
 ### 9.3 incircle and the unified width budget
 
 `incircleRaw` computes the standard lifted 3x3 determinant (sign of d
@@ -313,6 +343,11 @@ difference 2^154, square 2^308, lift (sum of two squares) 2^309, row term
 (orient3d only needs 465 bits; the length-aware multiply makes the extra
 container limbs nearly free). Truncation to 20 limbs is exact for gated
 inputs, same argument as section 5.
+
+<!-- numeral-ok: 618, 620, 330,016 :: 2^618 and 2^620 are the derived worst-case
+     magnitudes of the two determinants, computed from the width rule in section
+     5; 330,016 is the case count of the encode-equivalence check, whose report
+     (report.b25.encodecheck.json) records the check but not that total. -->
 
 ### 9.4 Correctness results (all zero-mismatch)
 
@@ -339,6 +374,12 @@ inputs, same argument as section 5.
 Total verified this round: ~21.5M orient3d + ~6.5M incircle evaluations,
 zero sign disagreements, zero gate disagreements.
 
+<!-- numeral-ok: 1,500,524, 511, 1,453,523, 21.5M, 6.5M :: battery totals for
+     the B2.5 correctness round. The committed report.b25.battery.json /
+     .incircle.json / .bigrandom.json hold per-label case counts from that
+     round's individual invocations; these are the summed totals across them,
+     which no artifact stores. -->
+
 ### 9.5 End-to-end throughput (the number that was missing)
 
 Measured e2e = everything the caller pays: CPU-side prep (none for path C
@@ -363,6 +404,16 @@ The B1.3 arithmetic-only ratio (31x at 1e7) is now the *end-to-end* ratio:
 the 1.3-1.4x caveat of section 8 is closed. incircle lands higher because
 its CPU BigInt cost per test is ~3.6x orient3d's (degree 4, wider
 intermediates) while its GPU cost is barely higher.
+
+<!-- numeral-ok: 261ms, 64ms, 21ms, 4.1x, 12.3x, 2537ms, 503ms, 24.6x, 24950ms,
+     4962ms, 781ms, 925ms, 18ms, 51.7x, 8296ms, 94.8x, 91088ms, 674ms, 135.1x,
+     3.6x :: the two end-to-end throughput tables. These are the clearest
+     provenance gap in this bet: the committed report.b25.throughput.json holds a
+     single n=1e6 row from a different invocation, so none of the three-scale
+     rows above has a committed artifact. They are transcribed from the run log.
+     Recorded rather than quietly dropped -- re-running them needs a WebGPU host
+     and is out of scope for the G4 gate, but it is a real gap and belongs in
+     B2.5's ledger, not in a silent allowlist. -->
 
 ### 9.6 Remaining gaps
 

--- a/scripts/moonshot/gpu-predicates/DESIGN.md
+++ b/scripts/moonshot/gpu-predicates/DESIGN.md
@@ -109,7 +109,7 @@ before the expensive exact tier runs.
 - `D_MAX = 100` covers a coordinate-magnitude ratio of `2^100 ≈ 1.27e30`
   within one predicate — vastly larger than any realistic single-scene
   dynamic range (even "1 nanometer feature next to a 10,000 km georeferenced
-  coordinate" is only ~2^63). It is chosen generously relative to real
+  coordinate" is only ~2^53). It is chosen generously relative to real
   geometry so the fallback rate on realistic inputs is ~0%, while still being
   a hard, provable, checked limit — not an approximation.
 - Genuinely extreme constructions (subnormals mixed with O(1) magnitudes,
@@ -122,10 +122,17 @@ before the expensive exact tier runs.
      (scripts/moonshot/ci/check-report-numerals.mjs). No figure in this document
      is changed; these comments record which numbers the committed
      report.b25.*.json artifacts emit and which they do not. -->
-<!-- numeral-ok: 52, 63, 1074 :: IEEE-754 double structure and its consequences
-     (52-bit mantissa, ~2^63 for the largest plausible coordinate, the ~1074-bit
-     spread from DBL_MAX down to the smallest subnormal). Properties of the
-     format, not measurements. -->
+<!-- numeral-ok: 52, 1074 :: IEEE-754 binary64 structure. 52 is the width of the
+     FRACTION FIELD (the stored bits; the significand is 53 with the implicit
+     leading 1, which is why section 4 says at most 53 bits for a normal and 52
+     for a subnormal). 1074 is the exponent-range spread from an O(1) magnitude
+     down to the smallest subnormal, 2^-1074 -- NOT from DBL_MAX, which would be
+     ~2098. Properties of the format, not measurements.
+     Not covered here, because it is neither: the "~2^53" in section 4 is a
+     GEOMETRY-DERIVED dynamic-range ratio, 1e7 m over 1e-9 m = 1e16 ~= 2^53, and
+     its near-coincidence with the significand width is arithmetic rather than
+     derivation. An earlier revision of that line read ~2^63, which the
+     arithmetic does not support. -->
 
 ## 5. Width budget (why 512-bit two's-complement-free sign-magnitude is enough)
 
@@ -323,10 +330,21 @@ The worker-parallelized-encode candidate was not implemented: with encode
 gone from the pipeline entirely, there is nothing left for workers to
 parallelize on the main path (it would only multiply path B's 5.4x).
 
-<!-- numeral-ok: 1.34x, 290ms, 96B, 288B :: 1.34x and ~290 ms (shader
-     compilation) are from the baseline-reproduction run of §9.1, whose JSON was
-     not committed; 96 B and 288 B are the per-test upload sizes of the two
-     encodings, format constants fixed by the WGSL. -->
+<!-- numeral-src: 1731ms :: gpu-predicates/report.throughput.json#throughput[1].encodeMs -->
+<!-- numeral-src: 146ms :: gpu-predicates/report.throughput.json#throughput[1].gpuMs -->
+<!-- numeral-src: 2523ms :: gpu-predicates/report.throughput.json#throughput[1].cpuBigIntMs -->
+<!-- numeral-src: 17x :: none - a RATIO of section 9.1 that no artifact stores:
+     cpuBigIntMs / gpuMs = 2523.4 / 146.4 = 17.24, over the three fields bound
+     directly above. Bound to `none` deliberately: left to the union index a
+     bare 17 resolves against an unrelated field in report.b25.bigrandom.json,
+     and a coincidence must not be allowed to read as provenance. -->
+<!-- numeral-ok: 1.34x :: the other section-9.1 ratio, also stored by no
+     artifact: cpuBigIntMs / (encodeMs + gpuMs) = 2523.4 / (1730.9 + 146.4) =
+     1.344, over the same three bound fields. -->
+<!-- numeral-ok: 290ms, 96B, 288B :: ~290 ms is the first-dispatch shader
+     compilation observed in the §9.1 reproduction run, which report.throughput.json
+     does not break out as a field; 96 B and 288 B are the per-test upload sizes
+     of the two encodings, format constants fixed by the WGSL. -->
 
 ### 9.3 incircle and the unified width budget
 

--- a/scripts/moonshot/m5-constrained-decoding/DESIGN.md
+++ b/scripts/moonshot/m5-constrained-decoding/DESIGN.md
@@ -148,6 +148,18 @@ run logs under the session scratchpad (`m5/raw`, `m5/ifc`, `m5/*.log`).
   The kernel-feedback loop demonstrably works end to end; the exam tasks
   simply never needed it.
 
+<!-- Numeral provenance, added 2026-07-29 for the numeral gate
+     (scripts/moonshot/ci/check-report-numerals.mjs). No figure in this document
+     is changed; these comments record which numbers results.json /
+     results-tier2.json emit and which they do not. -->
+<!-- numeral-ok: 66.7 :: compile-rate margin in POINTS (percentage-point
+     difference between two rates the artifact stores as fractions), computed in
+     the sentence. -->
+<!-- numeral-ok: 45, 300s :: operational totals of the tier-1 session, not exam
+     results: 45 model calls including smoke tests, the T01 pilot and 3 calls
+     lost to a killed run, and the 300 s per-call timeout the raw-IFC arm needed.
+     The results JSON records per-task outcomes, not session bookkeeping. -->
+
 ## Honest reading vs the M5 midterm bar
 
 - "100 percent of emitted programs compile by construction": PASS, and by
@@ -293,6 +305,10 @@ coupling (T2-07/16), properties at scale (T2-08/17), capstones
 (T2-10/20). A selftest proves all 20 feasible briefs are satisfiable at
 quality 1.0 via hand-written golden programs before any model call.
 
+<!-- numeral-ok: 23 :: the tier-2 brief count (20 feasible + 3 infeasible), a
+     property of the task set defined in tasks-tier2.mjs. results-tier2.json
+     stores the per-task records, not their count. -->
+
 ## 5. Infeasible briefs and anti-laundering scoring
 
 The tier-1 repair probe "converged" by silently rewriting the stated sill
@@ -333,6 +349,14 @@ selection in (b)/(c) matched the rubric-oracle on every task (oracle mean
 = selected mean). 115 model calls total for tier-2 (107 exam including a
 killed-and-resumed chunk, 8 headroom probe), on top of tier-1's 45.
 
+<!-- numeral-ok: 0.992, 0.906, 0.913, 1.26 :: arm-level MEANS over the tier-2
+     briefs. results-tier2.json stores every per-task quality score and call
+     count; these tables aggregate them, and the aggregate is not a stored
+     field. -->
+<!-- numeral-ok: 115, 107 :: session bookkeeping again -- total model calls for
+     tier-2 including a killed-and-resumed chunk and the headroom probe. Not exam
+     results and not stored. -->
+
 ### Verdict, stated plainly
 
 Does kernel-feedback decoding beat budget-matched informed sampling at
@@ -357,6 +381,9 @@ Attribution within the infeasibility margin, honestly split:
   draw declared infeasibility; the three baseline draws all emitted
   programs. Same model, same prompt - 1 of 4 draws declared.
 - T2-F1 (grossly obvious): all arms declared. No margin.
+
+<!-- numeral-ok: 0.094, 0.087 :: the two paired margins over the full 23-brief
+     set, i.e. differences of the arm means above. Computed here, not stored. -->
 
 ### What tier-2 actually taught
 
@@ -393,6 +420,10 @@ Attribution within the infeasibility margin, honestly split:
    error message exactly - T2-18 initially EXHAUSTED because of it, the
    validator gained a 1e-9 epsilon, and T2-18 was rerun cleanly for all
    three arms (the pre-fix exhaustion is preserved in exam-run.log).
+
+<!-- numeral-ok: 1e-9 :: the epsilon added to the validator's boundary
+     comparison after the T2-18 floating-point rejection. A code constant, not a
+     measurement. -->
 
 ### Implication for M5
 

--- a/scripts/moonshot/m5-constrained-decoding/DESIGN.md
+++ b/scripts/moonshot/m5-constrained-decoding/DESIGN.md
@@ -152,7 +152,7 @@ run logs under the session scratchpad (`m5/raw`, `m5/ifc`, `m5/*.log`).
      (scripts/moonshot/ci/check-report-numerals.mjs). No figure in this document
      is changed; these comments record which numbers results.json /
      results-tier2.json emit and which they do not. -->
-<!-- numeral-ok: 66.7 :: compile-rate margin in POINTS (percentage-point
+<!-- numeral-ok: +66.7 :: compile-rate margin in POINTS (percentage-point
      difference between two rates the artifact stores as fractions), computed in
      the sentence. -->
 <!-- numeral-ok: 45, 300s :: operational totals of the tier-1 session, not exam
@@ -349,10 +349,23 @@ selection in (b)/(c) matched the rubric-oracle on every task (oracle mean
 = selected mean). 115 model calls total for tier-2 (107 exam including a
 killed-and-resumed chunk, 8 headroom probe), on top of tier-1's 45.
 
-<!-- numeral-ok: 0.992, 0.906, 0.913, 1.26 :: arm-level MEANS over the tier-2
-     briefs. results-tier2.json stores every per-task quality score and call
-     count; these tables aggregate them, and the aggregate is not a stored
-     field. -->
+<!-- numeral-src: 1.000 :: none - arm-level MEAN QUALITY, and unbackable rather
+     than merely unbacked: this is the 1.000 that arm (a) scores on the 20
+     feasible briefs, arm (c) scores on the same 20, and arm (a) scores on all
+     23, and no artifact in this tree holds it. Bound to `none` so a coincidental
+     1.000 elsewhere in the union index cannot stand in as provenance. -->
+<!-- numeral-ok: 0.992, 0.906, 0.913 :: the remaining arm-level mean qualities in
+     the two quality rows of the table above. No artifact backs them: this table
+     is RUN 1, and
+     results-tier2.json now holds the replication's records instead (see
+     "Tier-2 replication run" below, which states the overwrite). Run 1's
+     per-task scores survive only as this table. -->
+<!-- numeral-ok: 1.26 :: NOT a quality mean. It is arm (a)'s MEAN CALLS PER TASK
+     in run 1, the last row of the same table, i.e. how often the repair loop
+     fired on top of the one baseline call. Unbacked for the same reason: the
+     comparable field in results-tier2.json is
+     summary.constrained.meanCalls = 1.391, which is the REPLICATION's value and
+     must not be read as this one. -->
 <!-- numeral-ok: 115, 107 :: session bookkeeping again -- total model calls for
      tier-2 including a killed-and-resumed chunk and the headroom probe. Not exam
      results and not stored. -->
@@ -382,7 +395,7 @@ Attribution within the infeasibility margin, honestly split:
   programs. Same model, same prompt - 1 of 4 draws declared.
 - T2-F1 (grossly obvious): all arms declared. No margin.
 
-<!-- numeral-ok: 0.094, 0.087 :: the two paired margins over the full 23-brief
+<!-- numeral-ok: +0.094, +0.087 :: the two paired margins over the full 23-brief
      set, i.e. differences of the arm means above. Computed here, not stored. -->
 
 ### What tier-2 actually taught


### PR DESCRIPTION
Two of the four "first moves" from the finishing plan, executed.

## 1. The plan itself (`docs/vision/moonshots-finishing-plan.md`)

Third vision document. Corrects the Phase 0-3 record, defines three distinct finish lines the program had been conflating, and plans Phases 4-6 with pre-committed gates plus three instruments the G2 red team showed were missing (standing evidence; external validity as a gate clause; standing adversarial review).

Every load-bearing claim was verified before committing: 13 workflows with **zero** touching `scripts/moonshot/` (the `release.yml` grep hit is an SLSA comment), `@ifc-lite/provenance` still `private`/`0.0.1`, and **B3.1 + B3.2 genuinely never built** - Phase 3 delivered 3 of 5, skipping exactly the two bets that required contact outside the parametric sandbox.

## 2. Amendments 1-5 to `moonshots-execution-plan.md`

Per that plan's own rule that gate criteria change only in writing: the M5 "wide margin" clause amended to what two tiers plus a replication actually support; M6c recorded as met literally and lost economically (0.05x-0.20x vs the production adaptive path); Phase 3 corrected to 3-of-5 with B3.1/B3.2 carried into Phase 5; a **negative-results ledger backfilled** with four entries; phases stamped with actuals.

## 3. B4.1, the standing-evidence lane (`.github/workflows/moonshot.yml`)

Weekly + `workflow_dispatch`, plus `push`/`pull_request` only on paths that can invalidate results. Never a required per-PR check. 33-36s of assertions, ~1m45s local end to end, `timeout-minutes: 30`.

**Both halves of the exam met.** Green end to end; a real kernel perturbation (`depth * 1.000001` in `extrude_profile`, wasm rebuilt) turns it red at exactly one step, naming act 5 and the three kernel-validation fields that moved.

### Two findings that change what this lane proves

- **The tamper batteries are a forgery test, not a drift test.** The lane builds a certified chain and verifies it in the same run, so chain and verifier move together and a kernel change cannot make them disagree - confirmed empirically, since every chain/tamper step stayed green under the perturbation. **The committed B3.5 golden is the only standing signal against kernel drift.** Recorded in the plan so nobody reads a green tamper battery as stability evidence.
- **The tripwire floor is the report's rounding, not machine epsilon.** One ULP survives; 3e-9 relative is caught.

### Choices worth a sanity check

- **Node pinned to `22.14.0` exactly.** The golden byte-compares an optimizer's output and V8's `Math.exp/log/pow` are not spec-fixed, so a V8 bump inside the 22.x line could redden the lane for a non-regression.
- **Fixture-gating:** g0 *and* g1 both need the 169MB Holter tower. Scheduled runs fetch it; push/PR runs skip those two steps with a visible `::notice` **and** a step-summary line - never a silent pass. Selective fetch keeps PR cost at 2.4MB.
- **`--segment 96`** on the certified run keeps the full 18-case v2 tamper battery (the default 256 gives 2 segments, where one case goes vacuous and another cannot run). Costs nothing.
- **Gradient battery left at the full 1000 points** rather than reduced: it costs 1.2s, and reducing it would make the step's verdict differ from the number published in `docs/vision/`.

## Open items (disclosed, not fixed)

Nothing asserts the committed `demo-report.json` stays in sync with the golden; running the lane locally dirties that tracked file; `b34`, `gpu-predicates` (needs a GPU) and `m5` are out of scope; the two `paths:` lists are duplicated verbatim because Actions has no YAML anchors. CI wall-clock (~8-20 min) is inference from local timings, not a measured runner figure - the first scheduled run is the real measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added scheduled and on-demand evidence validation with fixture-based scope and summary reporting.
  - Added deterministic golden checks and self-tests for the B3.5 demonstration, including tamper detection and recovery validation.

- **CI / Tests**
  - Added artifact-backed numeral verification with provenance, binding, and gating checks.
  - Expanded checks for optimization, gradients, determinism, kernel changes, and tampering.

- **Documentation**
  - Updated execution and finishing plans with results, limitations, amendments, and roadmap details.
  - Added red-team reviews and provenance annotations for reported measurements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->