### PR TITLE
fix(geometry): conform seams across plane buckets — fixes void-cut hairline cracks

### DIFF
--- a/.changeset/geometry-conform-plane-bucket-seams.md
+++ b/.changeset/geometry-conform-plane-bucket-seams.md
@@ -1,0 +1,22 @@
+---
+'@ifc-lite/wasm': patch
+---
+
+Fix hairline cracks in void-cut geometry. `consolidate_coplanar` re-triangulates each
+coplanar plane bucket independently, and its collinear simplify could drop a boundary
+vertex that the abutting bucket keeps — leaving the shared edge spanned by one long
+edge on one side and two short ones on the other. That T-junction renders as a
+hairline crack under DoubleSide.
+
+The pass now conforms seams across buckets. What separates a genuine seam vertex from
+an `i_overlay` phantom is the simplify's own judgment read across buckets: a real seam
+vertex is a hard corner in the abutting bucket, so it survives that bucket's simplify;
+a phantom is near-collinear in every bucket that touches it and is dropped everywhere.
+Today's output is emitted first and the conformed mesh is taken only when it is fully
+watertight, so a host can never come out worse than before.
+
+Measured over 116 fixtures and 1355 void-hosting elements: total unmatched boundary
+edges 18252 to 17792, elements with any tear 238 to 199, and elements whose body is a
+closed solid yet not watertight 80 to 41. Also unifies the analytic prism cut's new
+crossing vertices at ulp scale, which fixes the case where two host faces sharing an
+edge computed the same point one float step apart.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,6 +83,9 @@ jobs:
               - 'apps/server/Cargo.toml'
               - 'Cargo.lock'
               - '.github/workflows/test.yml'
+              # The watertightness census sweeps the fixture set named here, so a
+              # corpus change moves its pinned counts even with no code change.
+              - 'tests/models/manifest.json'
             plato:
               - 'tools/plato/**'
               - 'rust/clash/src/generated/**'
@@ -460,10 +463,14 @@ jobs:
       - name: Rust tests
         run: cargo test --workspace --exclude ifc-lite-wasm
       # The geometry watertightness/invariance census is feature-gated because it
-      # links a second ear-clipper as a differential oracle and sweeps every fixture
-      # (~6 min), so `--workspace` above skips it. Without this step the whole suite
-      # early-returns and its pinned baselines gate nothing.
+      # links a second ear-clipper as a differential oracle and sweeps the whole
+      # fixture manifest, so `--workspace` above skips it. Without this step the
+      # suite early-returns and its pinned baselines gate nothing.
+      #
+      # Narrowed to `geometry` rather than `rust`: the sweep costs ~20 min, and only
+      # rust/geometry, rust/processing or the fixture manifest can move its numbers.
       - name: Geometry watertightness census (differential oracle)
+        if: needs.changes.outputs.geometry == 'true'
         run: cargo test -p ifc-lite-geometry --features triangulation-alt --test triangulation_invariance
 
   # Plato clash-math single-source freshness gate. The clash narrow-phase math

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -462,16 +462,48 @@ jobs:
         run: cargo clippy --workspace --exclude ifc-lite-wasm --all-targets -- -D warnings
       - name: Rust tests
         run: cargo test --workspace --exclude ifc-lite-wasm
-      # The geometry watertightness/invariance census is feature-gated because it
-      # links a second ear-clipper as a differential oracle and sweeps the whole
-      # fixture manifest, so `--workspace` above skips it. Without this step the
-      # suite early-returns and its pinned baselines gate nothing.
-      #
-      # Narrowed to `geometry` rather than `rust`: the sweep costs ~20 min, and only
-      # rust/geometry, rust/processing or the fixture manifest can move its numbers.
-      - name: Geometry watertightness census (differential oracle)
-        if: needs.changes.outputs.geometry == 'true'
-        run: cargo test -p ifc-lite-geometry --features triangulation-alt --test triangulation_invariance
+
+  # Geometry watertightness / triangulation-invariance census.
+  #
+  # Its own job, not a step in `rust-tests`: the sweep runs the whole fixture
+  # manifest and takes ~20 min, which pushed that lane past its 28-minute timeout
+  # and cancelled it. Here it runs concurrently instead of serially, so neither
+  # lane's wall-clock depends on the other.
+  #
+  # Feature-gated because it links a second ear-clipper as a differential oracle,
+  # so `cargo test --workspace` does not run it — without this job the suite
+  # early-returns and its pinned baselines gate nothing.
+  #
+  # `geometry`, not `rust`: only rust/geometry, rust/processing or the fixture
+  # manifest can move its numbers.
+  geometry-census:
+    name: Geometry watertightness census
+    needs: changes
+    if: needs.changes.outputs.geometry == 'true'
+    runs-on: depot-ubuntu-24.04-4
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          lfs: false
+          persist-credentials: false
+      - name: Setup Rust (pinned by rust-toolchain.toml)
+        run: rustup show
+      - name: Cargo cache
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          prefix-key: ci-rust-census
+      - name: Cache test fixtures
+        id: fixtures-cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: tests/models
+          key: ci-fixtures-${{ runner.os }}-${{ hashFiles('tests/models/manifest.json') }}
+      - name: Fetch fixtures
+        if: steps.fixtures-cache.outputs.cache-hit != 'true'
+        run: node scripts/fixtures/fetch-fixtures.mjs
+      - name: Census
+        run: cargo test -p ifc-lite-geometry --features triangulation-alt --test triangulation_invariance -- --nocapture
 
   # Plato clash-math single-source freshness gate. The clash narrow-phase math
   # is written once in Plato and transpiled to Rust + TypeScript; the committed
@@ -558,7 +590,7 @@ jobs:
   # out); fails the moment any dependency fails or is cancelled.
   test:
     name: Build + WASM + Rust + Node
-    needs: [changes, build, typecheck, lint, node-tests, viewer-e2e, rust-tests, plato-check, docs-checks]
+    needs: [changes, build, typecheck, lint, node-tests, viewer-e2e, rust-tests, geometry-census, plato-check, docs-checks]
     if: always()
     # Free runner — the gate just inspects upstream job results.
     runs-on: ubuntu-latest
@@ -572,6 +604,7 @@ jobs:
             [node-tests]="${{ needs.node-tests.result }}"
             [viewer-e2e]="${{ needs.viewer-e2e.result }}"
             [rust-tests]="${{ needs.rust-tests.result }}"
+            [geometry-census]="${{ needs.geometry-census.result }}"
             [plato-check]="${{ needs.plato-check.result }}"
             [docs-checks]="${{ needs.docs-checks.result }}"
           )

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -459,6 +459,12 @@ jobs:
         run: cargo clippy --workspace --exclude ifc-lite-wasm --all-targets -- -D warnings
       - name: Rust tests
         run: cargo test --workspace --exclude ifc-lite-wasm
+      # The geometry watertightness/invariance census is feature-gated because it
+      # links a second ear-clipper as a differential oracle and sweeps every fixture
+      # (~6 min), so `--workspace` above skips it. Without this step the whole suite
+      # early-returns and its pinned baselines gate nothing.
+      - name: Geometry watertightness census (differential oracle)
+        run: cargo test -p ifc-lite-geometry --features triangulation-alt --test triangulation_invariance
 
   # Plato clash-math single-source freshness gate. The clash narrow-phase math
   # is written once in Plato and transpiled to Rust + TypeScript; the committed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -935,6 +935,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "earcut"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f03dd5350900133e14471c90d513eb5ba264004cd833adecab7dfa5fb5a2974"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "earcutr"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1519,6 +1528,7 @@ version = "4.1.4"
 dependencies = [
  "approx",
  "bnum",
+ "earcut",
  "earcutr",
  "geometry-predicates",
  "i_overlay",

--- a/rust/geometry/Cargo.toml
+++ b/rust/geometry/Cargo.toml
@@ -29,11 +29,19 @@ csg_capture = []
 # geometry-crate diagnostics land in its existing tracing subscriber.
 # See src/diag.rs for the warn-vs-debug gating policy.
 observability = ["dep:tracing"]
+# Test-only differential oracle: makes the deprecated `earcutr` available as a
+# SECOND, independent triangulator so `tests/triangulation_invariance.rs` can feed
+# the pipeline two equally valid triangulations of the same polygons. Never
+# enabled in a shipping build.
+triangulation-alt = ["dep:earcut"]
 
 [dependencies]
 
 # Triangulation
 earcutr = "0.5"
+# Differential oracle only, behind `triangulation-alt`. Present to be DIFFERENT
+# from earcutr, not to be depended on.
+earcut = { version = "0.4", optional = true }
 
 # 2D polygon boolean operations for profile-level void subtraction
 i_overlay = "7.0"

--- a/rust/geometry/Cargo.toml
+++ b/rust/geometry/Cargo.toml
@@ -29,10 +29,10 @@ csg_capture = []
 # geometry-crate diagnostics land in its existing tracing subscriber.
 # See src/diag.rs for the warn-vs-debug gating policy.
 observability = ["dep:tracing"]
-# Test-only differential oracle: makes the deprecated `earcutr` available as a
-# SECOND, independent triangulator so `tests/triangulation_invariance.rs` can feed
-# the pipeline two equally valid triangulations of the same polygons. Never
-# enabled in a shipping build.
+# Test-only differential oracle: makes `earcut` available ALONGSIDE the production
+# `earcutr` as a second, independent triangulator, so
+# `tests/triangulation_invariance.rs` can feed the pipeline two equally valid
+# triangulations of the same polygons. Never enabled in a shipping build.
 triangulation-alt = ["dep:earcut"]
 
 [dependencies]

--- a/rust/geometry/src/cdt.rs
+++ b/rust/geometry/src/cdt.rs
@@ -61,7 +61,10 @@
 //! constrained-Delaunay, still watertight) — quality is best-effort, validity
 //! is not.
 
+mod predicates;
+
 use crate::Point2;
+use predicates::{dist2, rings_to_pslg, segments_properly_cross, strictly_between};
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 
 /// Target minimum angle for refinement, expressed as `cos(angle)` so the
@@ -149,11 +152,31 @@ impl Tri {
 }
 
 struct Cdt {
+    /// `[0, n_real)` = input then Steiner points; `[n_real, super_base)` = the
+    /// PRE-RESERVED Steiner slots (placeholders, never referenced by a triangle);
+    /// `[super_base, super_base+3)` = the super triangle.
     points: Vec<P2>,
     tris: Vec<Tri>,
     /// Constraint segments (canonical edge keys); never flipped, never crossed.
+    /// Ord-keyed so the recovery ORDER in [`Cdt::enforce_constraints`] is
+    /// target-independent.
     constraints: BTreeSet<(usize, usize)>,
+    /// Membership-only mirror of `constraints`. The cavity BFS, legalization
+    /// and the depth-parity flood probe it millions of times per model and only
+    /// ever ask "is this edge pinned?", where a tree walk is pure overhead;
+    /// every mutation of `constraints` updates both.
+    cset: rustc_hash::FxHashSet<(usize, usize)>,
+    /// Index of the first super-triangle vertex. FIXED at build time (the
+    /// Steiner budget is reserved below it), so a refinement insertion never
+    /// renumbers vertices — see [`Cdt::insert_steiner`].
     super_base: usize,
+    /// Count of REAL points in use (input + Steiner emitted so far).
+    n_real: usize,
+    /// Walk-locate hint: a triangle incident to the last inserted point.
+    last_loc: usize,
+    /// Broad-phase for [`Cdt::is_encroached`], (re)built at
+    /// [`Cdt::start_refinement`] and invalidated by a constraint split.
+    enc: EncGrid,
     /// Per-triangle inside-domain flag, parallel to `tris`. Maintained
     /// incrementally during NO-SPLIT refinement (after [`Cdt::start_refinement`]):
     /// a flip reuses its two slots within one region (a flipped edge is never a
@@ -178,12 +201,33 @@ struct Cdt {
     failed: bool,
 }
 
+/// Broad-phase over the constraint segments' diametral circles, for the
+/// per-candidate encroachment test. CSR uniform grid + an "oversized disk"
+/// list; `nx == 0` = not built.
+#[derive(Default)]
+struct EncGrid {
+    mid: Vec<P2>,
+    r2: Vec<f64>,
+    minx: f64,
+    miny: f64,
+    inv: f64,
+    nx: usize,
+    ny: usize,
+    starts: Vec<u32>,
+    items: Vec<u32>,
+    big: Vec<u32>,
+}
+
 impl Cdt {
     /// Build a CDT from an explicit point list + constraint segment list. The
     /// segment list is the source of truth for constraints (so refinement can
     /// add Steiner points and replace a segment with its two halves, then
     /// rebuild cleanly from scratch — no fragile in-place mutation).
-    fn build_from(mut points: Vec<P2>, segments: &[(usize, usize)]) -> Option<Cdt> {
+    fn build_from(
+        mut points: Vec<P2>,
+        segments: &[(usize, usize)],
+        steiner_cap: usize,
+    ) -> Option<Cdt> {
         let n_input = points.len();
         if n_input < 3 {
             return None;
@@ -214,6 +258,15 @@ impl Cdt {
         let cx = (minx + maxx) * 0.5;
         let cy = (miny + maxy) * 0.5;
         let big = span * 32.0;
+        // Reserve the whole Steiner budget BELOW the super vertices. Splicing a
+        // Steiner point in at `super_base` used to renumber every triangle's
+        // vertex ids (an O(T) pass per point — 1.07e9 index touches on
+        // ISSUE_129, the single largest cost in the consolidate path). With the
+        // slots pre-reserved the super ids are constant, so nothing renumbers.
+        // Ids stay in the SAME relative order as before (super still above every
+        // real vertex), which is what the index-ordered tie-breaks
+        // (`boundary.sort_unstable`, `ekey`) depend on ⇒ output-identical.
+        points.resize(n_input + steiner_cap, [0.0, 0.0]);
         let super_base = points.len();
         points.push([cx - big, cy - big]);
         points.push([cx + big, cy - big]);
@@ -222,8 +275,12 @@ impl Cdt {
         let mut cdt = Cdt {
             points,
             tris: Vec::new(),
+            cset: constraints.iter().copied().collect(),
             constraints,
             super_base,
+            n_real: n_input,
+            last_loc: 0,
+            enc: EncGrid::default(),
             inside: Vec::new(),
             skinny: BTreeSet::new(),
             track: false,
@@ -255,8 +312,12 @@ impl Cdt {
 
     fn insert_point(&mut self, vi: usize) {
         let p = self.points[vi];
-        let Some(start) = self.locate(p) else {
-            return;
+        let start = match self.walk_strict(self.last_loc, p) {
+            Some(t) => t,
+            None => match self.locate(p) {
+                Some(t) => t,
+                None => return,
+            },
         };
         self.insert_point_at(vi, start);
     }
@@ -297,7 +358,7 @@ impl Cdt {
                 for e in 0..3 {
                     let a = v[e];
                     let b = v[(e + 1) % 3];
-                    if self.constraints.contains(&ekey(a, b)) {
+                    if self.cset.contains(&ekey(a, b)) {
                         continue; // do not let the cavity swallow a constraint
                     }
                     let nb = self.tris[ti].n[e];
@@ -316,6 +377,7 @@ impl Cdt {
             // T-junction with the far triangle still linked to the dead
             // parent. Genuinely interior points take the 3-way split.
             self.split_at(start, vi);
+            self.last_loc = self.tris.len() - 1;
             return;
         }
 
@@ -371,6 +433,7 @@ impl Cdt {
         for t in new_tris {
             self.track_tri(t);
         }
+        self.last_loc = self.tris.len() - 1;
     }
 
     /// Wire adjacency for an internal cavity edge once both owners are known.
@@ -484,6 +547,10 @@ impl Cdt {
         if self.constraints.remove(&ekey(a, b)) {
             self.constraints.insert(ekey(a, vi));
             self.constraints.insert(ekey(vi, b));
+            self.cset.remove(&ekey(a, b));
+            self.cset.insert(ekey(a, vi));
+            self.cset.insert(ekey(vi, b));
+            self.enc = EncGrid::default(); // stale broad-phase → linear fallback
         }
 
         self.tris[t].alive = false;
@@ -583,7 +650,7 @@ impl Cdt {
             let a = self.tris[ti].v[e];
             let b = self.tris[ti].v[(e + 1) % 3];
             let apex = self.tris[ti].v[(e + 2) % 3];
-            if self.constraints.contains(&ekey(a, b)) {
+            if self.cset.contains(&ekey(a, b)) {
                 continue;
             }
             let opp = self.tris[ti].n[e];
@@ -743,6 +810,7 @@ impl Cdt {
     /// paths) keep both maintained under [`Cdt::insert_steiner`] mutations.
     fn start_refinement(&mut self, cos_min_angle: f64) {
         self.inside = self.inside_flags();
+        self.build_enc_grid();
         self.cos_min_angle = cos_min_angle;
         self.track = true;
         self.skinny.clear();
@@ -811,6 +879,49 @@ impl Cdt {
         self.locate(p)
     }
 
+    /// Walk-locate that is EXACTLY [`Cdt::locate`] whenever it answers: it only
+    /// returns a triangle that STRICTLY contains `p`, and a strictly-containing
+    /// triangle is unique, so the canonical lowest-index scan must return the
+    /// same one. Every other outcome — `p` on an edge/vertex (the one case
+    /// where `locate`'s lowest-index tie-break is observable), a dead start, a
+    /// hull exit, a step-cap hit — answers `None` and the caller falls back to
+    /// the scan. That is what makes the walk a pure speedup and not a behaviour
+    /// change.
+    fn walk_strict(&self, start: usize, p: P2) -> Option<usize> {
+        if !self.tris.get(start).is_some_and(|t| t.alive) {
+            return None;
+        }
+        let mut cur = start;
+        // Any cap is safe (a miss just takes the scan); this one bounds the
+        // pathological "first negative edge" cycle without being O(T) in
+        // practice.
+        let cap = self.tris.len().min(4096) + 16;
+        for _ in 0..cap {
+            let v = self.tris[cur].v;
+            let o0 = orient(self.points[v[0]], self.points[v[1]], p);
+            let o1 = orient(self.points[v[1]], self.points[v[2]], p);
+            let o2 = orient(self.points[v[2]], self.points[v[0]], p);
+            if o0 > 0 && o1 > 0 && o2 > 0 {
+                return Some(cur);
+            }
+            let e = if o0 < 0 {
+                0
+            } else if o1 < 0 {
+                1
+            } else if o2 < 0 {
+                2
+            } else {
+                return None; // on the closed boundary — let `locate` tie-break
+            };
+            let nb = self.tris[cur].n[e];
+            if nb == NONE || !self.tris[nb].alive {
+                return None;
+            }
+            cur = nb;
+        }
+        None
+    }
+
     // ─────────────────────── constraint recovery ──────────────────────────
 
     /// Ensure every constraint segment appears as an edge of the triangulation.
@@ -818,9 +929,20 @@ impl Cdt {
     /// exist; any missing one is recovered by flipping the diagonals that cross
     /// it. Returns false if a segment can't be recovered (caller falls back).
     fn enforce_constraints(&mut self) -> bool {
+        // Materialise the alive edge set ONCE instead of re-scanning every
+        // triangle per `edge_exists` probe (4.7e8 slot visits on ISSUE_129 —
+        // the second-largest cost in the consolidate path). Recovery's only
+        // topology mutation is the explicit `flip` below, whose edge delta is
+        // exactly "drop u-w, add apex-q", so the set stays exact.
+        let mut edges: rustc_hash::FxHashSet<(usize, usize)> = rustc_hash::FxHashSet::default();
+        for t in self.tris.iter().filter(|t| t.alive) {
+            for e in 0..3 {
+                edges.insert(ekey(t.v[e], t.v[(e + 1) % 3]));
+            }
+        }
         let segs: Vec<(usize, usize)> = self.constraints.iter().copied().collect();
         for (a, b) in segs {
-            if !self.recover_segment(a, b) {
+            if !self.recover_segment(a, b, &mut edges) {
                 return false;
             }
         }
@@ -830,8 +952,13 @@ impl Cdt {
     /// Recover a single constraint segment `a-b` by repeatedly flipping the
     /// triangulation edge that crosses it. Deterministic: always processes the
     /// crossing edge nearest `a`.
-    fn recover_segment(&mut self, a: usize, b: usize) -> bool {
-        if self.edge_exists(a, b) {
+    fn recover_segment(
+        &mut self,
+        a: usize,
+        b: usize,
+        edges: &mut rustc_hash::FxHashSet<(usize, usize)>,
+    ) -> bool {
+        if edges.contains(&ekey(a, b)) {
             return true;
         }
         let pa = self.points[a];
@@ -842,7 +969,7 @@ impl Cdt {
             if guard > 100_000 {
                 return false;
             }
-            if self.edge_exists(a, b) {
+            if edges.contains(&ekey(a, b)) {
                 return true;
             }
             // Find an edge (u,v) strictly crossing segment a-b whose flip is
@@ -860,7 +987,7 @@ impl Cdt {
                     if u == a || u == b || w == a || w == b {
                         continue;
                     }
-                    if self.constraints.contains(&ekey(u, w)) {
+                    if self.cset.contains(&ekey(u, w)) {
                         continue;
                     }
                     if !segments_properly_cross(pa, pb, self.points[u], self.points[w]) {
@@ -895,6 +1022,8 @@ impl Cdt {
                     }
                     let mut tmp = Vec::new();
                     self.flip(ti, opp, u, w, apex, q, &mut tmp);
+                    edges.remove(&ekey(u, w));
+                    edges.insert(ekey(apex, q));
                     // Do NOT legalize here — constraint recovery must not
                     // re-introduce the crossing edge. Re-Delaunay happens after
                     // all constraints are in (constrained edges stay pinned).
@@ -905,22 +1034,18 @@ impl Cdt {
             if !flipped {
                 // No flippable crossing edge found — segment already present or
                 // unrecoverable. Re-check existence at loop top.
-                if self.edge_exists(a, b) {
-                    return true;
-                }
-                return false;
+                return edges.contains(&ekey(a, b));
             }
         }
     }
 
-    #[inline]
+    /// Does an alive triangle carry undirected edge `a-b`? Test-only since the
+    /// recovery loop reads the maintained edge set instead.
+    #[cfg(test)]
     fn edge_exists(&self, a: usize, b: usize) -> bool {
-        for ti in 0..self.tris.len() {
-            if self.tris[ti].alive && self.tris[ti].edge_of(a, b).is_some() {
-                return true;
-            }
-        }
-        false
+        self.tris
+            .iter()
+            .any(|t| t.alive && t.edge_of(a, b).is_some())
     }
 
     /// Restore the Delaunay property everywhere EXCEPT across constraint edges
@@ -979,7 +1104,7 @@ impl Cdt {
                     }
                     let a = self.tris[ti].v[e];
                     let b = self.tris[ti].v[(e + 1) % 3];
-                    let nd = if self.constraints.contains(&ekey(a, b)) {
+                    let nd = if self.cset.contains(&ekey(a, b)) {
                         d + 1
                     } else {
                         d
@@ -1034,7 +1159,7 @@ impl Cdt {
                 self.skinny.remove(&ti);
                 continue;
             };
-            if self.encroached_by_point(cc).is_some() {
+            if self.is_encroached(cc) {
                 self.skinny.remove(&ti); // no-split mode: leave it (permanent)
                 continue;
             }
@@ -1055,39 +1180,163 @@ impl Cdt {
 
     /// Incrementally insert Steiner point `p` (known to lie in alive triangle
     /// `loc`, per [`Cdt::next_steiner`]) into the LIVE CDT — the no-rebuild
-    /// refinement step. The point is spliced in just below the super-triangle
-    /// vertices so every index invariant holds unchanged (`< n_input` = input /
-    /// constraint vertex, `>= super_base` = super vertex, emit keeps
-    /// `< super_base`); triangle vertex ids at or above the splice point shift
-    /// up by one (an O(T) integer pass, no predicates).
+    /// refinement step. The point takes the next PRE-RESERVED slot below the
+    /// super-triangle vertices, so every index invariant holds unchanged
+    /// (`< n_input` = input / constraint vertex, `>= super_base` = super vertex,
+    /// emit keeps `< n_real`) and no triangle is renumbered. Reserving the whole
+    /// budget up front is what removes the old per-point O(T) renumbering pass.
     fn insert_steiner(&mut self, p: P2, loc: usize) {
-        let vi = self.super_base;
-        self.points.insert(vi, p);
-        self.super_base += 1;
-        for t in &mut self.tris {
-            for v in &mut t.v {
-                if *v >= vi {
-                    *v += 1;
-                }
-            }
+        let vi = self.n_real;
+        if vi >= self.super_base {
+            self.failed = true; // budget exhausted — caller ear-clips (unreachable: the driver caps first)
+            return;
         }
+        self.points[vi] = p;
+        self.n_real += 1;
         // Constraints reference input vertices only (< n_input <= vi): unchanged.
         self.insert_point_at(vi, loc);
     }
 
     /// Does point `p` lie inside the diametral circle of any constraint
-    /// segment? Returns the lowest-key such segment.
-    fn encroached_by_point(&self, p: P2) -> Option<(usize, usize)> {
+    /// segment?
+    ///
+    /// Existence only — the refinement driver never looks at WHICH segment — so
+    /// the answer is order-independent and a broad-phase is exact rather than
+    /// approximate. Every skinny candidate used to test every constraint
+    /// (5.9e7 disk tests on ISSUE_129); the grid built once per refinement
+    /// answers from one cell plus the few oversized disks.
+    fn is_encroached(&self, p: P2) -> bool {
+        let hit = |i: u32| {
+            let i = i as usize;
+            dist2(p, self.enc.mid[i]) < self.enc.r2[i] * (1.0 - 1e-12)
+        };
+        if self.enc.nx == 0 {
+            // No grid (constraints mutated mid-refinement, or none at all).
+            return self.constraints.iter().any(|&(a, b)| {
+                let (pa, pb) = (self.points[a], self.points[b]);
+                let mid = [(pa[0] + pb[0]) * 0.5, (pa[1] + pb[1]) * 0.5];
+                dist2(p, mid) < dist2(pa, pb) * 0.25 * (1.0 - 1e-12)
+            });
+        }
+        if self.enc.big.iter().copied().any(hit) {
+            return true;
+        }
+        let gx = (p[0] - self.enc.minx) * self.enc.inv;
+        let gy = (p[1] - self.enc.miny) * self.enc.inv;
+        if !(gx >= 0.0 && gy >= 0.0) {
+            return false;
+        }
+        let (gx, gy) = (gx as usize, gy as usize);
+        if gx >= self.enc.nx || gy >= self.enc.ny {
+            return false;
+        }
+        let c = gy * self.enc.nx + gx;
+        let (s, e) = (
+            self.enc.starts[c] as usize,
+            self.enc.starts[c + 1] as usize,
+        );
+        self.enc.items[s..e].iter().copied().any(hit)
+    }
+
+    /// Rebuild [`Cdt::enc`] from the current constraint set. `nx == 0` means
+    /// "no grid" and [`Cdt::is_encroached`] falls back to the linear scan.
+    fn build_enc_grid(&mut self) {
+        let mut mid: Vec<P2> = Vec::with_capacity(self.constraints.len());
+        let mut r2: Vec<f64> = Vec::with_capacity(self.constraints.len());
+        let mut rad: Vec<f64> = Vec::with_capacity(self.constraints.len());
         for &(a, b) in &self.constraints {
-            let pa = self.points[a];
-            let pb = self.points[b];
-            let mid = [(pa[0] + pb[0]) * 0.5, (pa[1] + pb[1]) * 0.5];
-            let r2 = dist2(pa, pb) * 0.25;
-            if dist2(p, mid) < r2 * (1.0 - 1e-12) {
-                return Some((a, b));
+            let (pa, pb) = (self.points[a], self.points[b]);
+            mid.push([(pa[0] + pb[0]) * 0.5, (pa[1] + pb[1]) * 0.5]);
+            let d2 = dist2(pa, pb) * 0.25;
+            r2.push(d2);
+            rad.push(d2.sqrt());
+        }
+        self.enc = EncGrid {
+            mid,
+            r2,
+            ..EncGrid::default()
+        };
+        let n = self.enc.mid.len();
+        if n == 0 {
+            return;
+        }
+        let (mut minx, mut miny, mut maxx, mut maxy) = (f64::MAX, f64::MAX, f64::MIN, f64::MIN);
+        for (m, r) in self.enc.mid.iter().zip(rad.iter()) {
+            minx = minx.min(m[0] - r);
+            miny = miny.min(m[1] - r);
+            maxx = maxx.max(m[0] + r);
+            maxy = maxy.max(m[1] + r);
+        }
+        let span = (maxx - minx).max(maxy - miny);
+        if !(span > 0.0) || !span.is_finite() {
+            return;
+        }
+        // ~1 cell per constraint, capped so the CSR stays small.
+        let side = ((n as f64).sqrt().ceil() as usize).clamp(1, 64);
+        let cell = span / side as f64;
+        let inv = 1.0 / cell;
+        let (nx, ny) = (side, side);
+        let cellrange = |m: P2, r: f64| -> (usize, usize, usize, usize) {
+            let c = |v: f64, lo: f64, hi: usize| {
+                let g = ((v - lo) * inv).floor();
+                if g < 0.0 {
+                    0
+                } else if g >= hi as f64 {
+                    hi - 1
+                } else {
+                    g as usize
+                }
+            };
+            (
+                c(m[0] - r, minx, nx),
+                c(m[0] + r, minx, nx),
+                c(m[1] - r, miny, ny),
+                c(m[1] + r, miny, ny),
+            )
+        };
+        let mut counts = vec![0u32; nx * ny + 1];
+        let mut big: Vec<u32> = Vec::new();
+        let mut is_big = vec![false; n];
+        for i in 0..n {
+            let (x0, x1, y0, y1) = cellrange(self.enc.mid[i], rad[i]);
+            if (x1 - x0 + 1) * (y1 - y0 + 1) > 32 {
+                big.push(i as u32);
+                is_big[i] = true;
+                continue;
+            }
+            for gy in y0..=y1 {
+                for gx in x0..=x1 {
+                    counts[gy * nx + gx + 1] += 1;
+                }
             }
         }
-        None
+        for i in 1..counts.len() {
+            counts[i] += counts[i - 1];
+        }
+        let total = counts[nx * ny] as usize;
+        let mut items = vec![0u32; total];
+        let mut cursor = counts.clone();
+        for i in 0..n {
+            if is_big[i] {
+                continue;
+            }
+            let (x0, x1, y0, y1) = cellrange(self.enc.mid[i], rad[i]);
+            for gy in y0..=y1 {
+                for gx in x0..=x1 {
+                    let c = gy * nx + gx;
+                    items[cursor[c] as usize] = i as u32;
+                    cursor[c] += 1;
+                }
+            }
+        }
+        self.enc.minx = minx;
+        self.enc.miny = miny;
+        self.enc.inv = inv;
+        self.enc.nx = nx;
+        self.enc.ny = ny;
+        self.enc.starts = counts;
+        self.enc.items = items;
+        self.enc.big = big;
     }
 
     /// Is interior triangle `ti` skinny (smallest angle < the min-angle target)
@@ -1163,11 +1412,13 @@ impl Cdt {
 
     /// Emit the interior triangulation as a vertex list + index list. The
     /// vertex list is `points[0..n_input]` followed by every Steiner point
-    /// (`points[n_input..super_base]`); the super-triangle vertices are dropped.
+    /// (`points[n_input..n_real]`); the unused reserved slots and the
+    /// super-triangle vertices are dropped.
     fn emit(&self) -> (Vec<P2>, Vec<usize>) {
         let inside = self.inside_flags();
-        // Compact vertex set: keep input + Steiner (drop super verts).
-        let keep_upto = self.super_base; // points below super_base are real
+        // Compact vertex set: keep input + Steiner (drop super verts AND the
+        // unused tail of the reserved Steiner region).
+        let keep_upto = self.n_real;
         let out_points: Vec<P2> = self.points[..keep_upto].to_vec();
         let mut indices: Vec<usize> = Vec::new();
         for ti in 0..self.tris.len() {
@@ -1192,55 +1443,6 @@ impl Cdt {
         }
         (out_points, indices)
     }
-}
-
-#[inline]
-fn dist2(a: P2, b: P2) -> f64 {
-    let dx = a[0] - b[0];
-    let dy = a[1] - b[1];
-    dx * dx + dy * dy
-}
-
-/// For `p` known EXACTLY collinear with `a`-`b` (exact `orient == 0`): does it
-/// lie strictly between them? Pure lexicographic comparison — no arithmetic,
-/// no rounding, and `false` when `p` coincides with an endpoint.
-#[inline]
-fn strictly_between(a: P2, b: P2, p: P2) -> bool {
-    let lt = |u: P2, w: P2| u[0] < w[0] || (u[0] == w[0] && u[1] < w[1]);
-    (lt(a, p) && lt(p, b)) || (lt(b, p) && lt(p, a))
-}
-
-/// Do open segments `p1-p2` and `p3-p4` strictly cross (proper intersection,
-/// not merely touching at an endpoint)? Exact via `orient`.
-fn segments_properly_cross(p1: P2, p2: P2, p3: P2, p4: P2) -> bool {
-    let d1 = orient(p3, p4, p1);
-    let d2 = orient(p3, p4, p2);
-    let d3 = orient(p1, p2, p3);
-    let d4 = orient(p1, p2, p4);
-    (d1 > 0 && d2 < 0 || d1 < 0 && d2 > 0) && (d3 > 0 && d4 < 0 || d3 < 0 && d4 > 0)
-}
-
-/// Build the initial (Steiner-free) constraint set + point list from rings.
-/// `rings[0]` = outer, `rings[1..]` = holes. Returns `(points, segments)`.
-fn rings_to_pslg(rings: &[Vec<P2>]) -> (Vec<P2>, Vec<(usize, usize)>) {
-    let mut points: Vec<P2> = Vec::new();
-    let mut segments: Vec<(usize, usize)> = Vec::new();
-    for ring in rings {
-        if ring.len() < 3 {
-            continue;
-        }
-        let base = points.len();
-        points.extend_from_slice(ring);
-        let m = ring.len();
-        for i in 0..m {
-            let a = base + i;
-            let b = base + (i + 1) % m;
-            if a != b {
-                segments.push(ekey(a, b));
-            }
-        }
-    }
-    (points, segments)
 }
 
 /// Run bounded, INTERIOR-ONLY Ruppert/Chew refinement on a planar
@@ -1269,7 +1471,7 @@ fn refine_to_fixpoint(points: Vec<P2>, segments: Vec<(usize, usize)>) -> Option<
     let n_input = points.len();
     let max_steiner = (n_input * 3).max(32);
     let mut steiner = 0usize;
-    let mut cdt = Cdt::build_from(points, &segments)?;
+    let mut cdt = Cdt::build_from(points, &segments, max_steiner.min(MAX_REFINE_ITERS))?;
 
     cdt.start_refinement(COS_MIN_ANGLE);
     while steiner < max_steiner.min(MAX_REFINE_ITERS) {
@@ -1343,7 +1545,7 @@ pub(crate) fn triangulate_constrained(
         }
     }
     let (points, segments) = rings_to_pslg(&rings);
-    let cdt = Cdt::build_from(points, &segments)?;
+    let cdt = Cdt::build_from(points, &segments, 0)?;
     let (pts, idx) = cdt.emit();
     if idx.is_empty() {
         return None;
@@ -1370,7 +1572,7 @@ pub(crate) fn triangulate_pslg(
     segments: &[(usize, usize)],
 ) -> Option<(Vec<Point2<f64>>, Vec<usize>)> {
     let pts: Vec<P2> = points.iter().map(p2).collect();
-    let cdt = Cdt::build_from(pts, segments)?;
+    let cdt = Cdt::build_from(pts, segments, 0)?;
     let keep_upto = cdt.super_base;
     let mut indices: Vec<usize> = Vec::new();
     for tri in &cdt.tris {
@@ -1401,217 +1603,5 @@ pub(crate) fn triangulate_pslg(
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn pt(x: f64, y: f64) -> Point2<f64> {
-        Point2::new(x, y)
-    }
-
-    fn area_of(points: &[Point2<f64>], idx: &[usize]) -> f64 {
-        let mut a = 0.0;
-        for t in idx.chunks_exact(3) {
-            let p0 = points[t[0]];
-            let p1 = points[t[1]];
-            let p2 = points[t[2]];
-            a += ((p1.x - p0.x) * (p2.y - p0.y) - (p2.x - p0.x) * (p1.y - p0.y)).abs() * 0.5;
-        }
-        a
-    }
-
-    /// Many-void CDT-cliff regression (advanced_model.ifc IFCSLAB #798926): the no-split
-    /// (consolidate_coplanar) refinement of a many-hole slab face. The old
-    /// rebuild-per-Steiner-point driver was O(P³) — 13.8 s in RELEASE for ONE
-    /// 582-vertex/16-hole face, ×2 faces ×16 re-consolidates = a 155 s element.
-    /// The incremental driver does the same face in ~10 ms. The shape below
-    /// reproduces that face: a 134-vertex outer ring + 16 28-gon holes.
-    ///
-    /// Guards three things: (1) wall-time in release — bound 2 s, ~200× above
-    /// the fixed cost, ~7× below the regressed cost, so scheduler jitter can't
-    /// trip it but the O(P³) driver always does; (2) refinement actually ran
-    /// (Steiner points were added); (3) the result is still area-exact and
-    /// run-to-run deterministic (the incremental path must stay bit-stable).
-    #[test]
-    fn no_split_many_hole_refinement_is_fast_and_valid() {
-        // Outer ring: 12 m × 10 m rectangle subdivided to 132 boundary verts.
-        let (w, h, step) = (12.0_f64, 10.0_f64, 1.0 / 3.0);
-        let mut outer: Vec<Point2<f64>> = Vec::new();
-        let n_x = (w / step).round() as usize;
-        let n_y = (h / step).round() as usize;
-        for i in 0..n_x {
-            outer.push(pt(i as f64 * step, 0.0));
-        }
-        for j in 0..n_y {
-            outer.push(pt(w, j as f64 * step));
-        }
-        for i in (1..=n_x).rev() {
-            outer.push(pt(i as f64 * step, h));
-        }
-        for j in (1..=n_y).rev() {
-            outer.push(pt(0.0, j as f64 * step));
-        }
-        // 16 small 28-gon holes on a 4×4 grid (the slab's round penetrations).
-        let mut holes: Vec<Vec<Point2<f64>>> = Vec::new();
-        let r = 0.1_f64;
-        for gx in 0..4 {
-            for gy in 0..4 {
-                let (cx, cy) = (1.5 + 3.0 * gx as f64, 2.0 + 2.0 * gy as f64);
-                let ring: Vec<Point2<f64>> = (0..28)
-                    .map(|k| {
-                        let a = k as f64 / 28.0 * std::f64::consts::TAU;
-                        pt(cx + r * a.cos(), cy + r * a.sin())
-                    })
-                    .collect();
-                holes.push(ring);
-            }
-        }
-        let n_input = outer.len() + holes.iter().map(|h| h.len()).sum::<usize>();
-
-        let t0 = std::time::Instant::now();
-        let (pts, idx) = triangulate_refined(&outer, &holes).expect("no-split refinement");
-        let dt = t0.elapsed();
-
-        // Refinement ran (Steiner points beyond the input rings) and the domain
-        // is exact: outer area minus the 16 polygonal holes.
-        assert!(
-            pts.len() > n_input,
-            "expected Steiner points (got {} verts for {n_input} inputs)",
-            pts.len()
-        );
-        let hole_area: f64 = holes.iter().map(|h| {
-            let mut s = 0.0;
-            for i in 0..h.len() {
-                let j = (i + 1) % h.len();
-                s += h[i].x * h[j].y - h[j].x * h[i].y;
-            }
-            (s * 0.5).abs()
-        }).sum();
-        let area = area_of(&pts, &idx);
-        let expected = 12.0 * 10.0 - hole_area;
-        assert!(
-            (area - expected).abs() < 1e-6,
-            "area {area} != {expected} (outer minus 16 holes)"
-        );
-        // Bit-stable run-to-run (the incremental driver is deterministic).
-        let (pts2, idx2) = triangulate_refined(&outer, &holes).unwrap();
-        assert_eq!(idx, idx2, "index lists must be identical run-to-run");
-        assert_eq!(pts.len(), pts2.len());
-        for (a, b) in pts.iter().zip(pts2.iter()) {
-            assert_eq!(a.x.to_bits(), b.x.to_bits());
-            assert_eq!(a.y.to_bits(), b.y.to_bits());
-        }
-        // Perf bound — release only (debug predicate cost is ~10× and CI debug
-        // boxes jitter; the regressed driver fails this by ~7× even on slow HW).
-        #[cfg(not(debug_assertions))]
-        assert!(
-            dt < std::time::Duration::from_secs(2),
-            "no-split many-hole refinement took {dt:?} — the O(P³) rebuild-per-point driver is back"
-        );
-        let _ = dt;
-    }
-
-    /// Structural validity over ALIVE triangles: (1) every undirected edge is
-    /// shared by at most 2 alive triangles; (2) neighbour links are mutually
-    /// consistent (`t.n[e] = u` across edge `{a,b}` ⇒ `u` is alive, has edge
-    /// `{a,b}`, and links back to `t` across it); (3) no alive triangle has
-    /// zero area.
-    fn assert_structurally_valid(cdt: &Cdt) {
-        let mut edge_count: BTreeMap<(usize, usize), u32> = BTreeMap::new();
-        for ti in 0..cdt.tris.len() {
-            let t = &cdt.tris[ti];
-            if !t.alive {
-                continue;
-            }
-            assert_ne!(
-                orient(cdt.points[t.v[0]], cdt.points[t.v[1]], cdt.points[t.v[2]]),
-                0,
-                "alive triangle {ti} {:?} has zero area",
-                t.v
-            );
-            for e in 0..3 {
-                let a = t.v[e];
-                let b = t.v[(e + 1) % 3];
-                *edge_count.entry(ekey(a, b)).or_insert(0) += 1;
-                let nb = t.n[e];
-                if nb != NONE {
-                    assert!(
-                        cdt.tris[nb].alive,
-                        "triangle {ti} edge {a}-{b} points at dead triangle {nb}"
-                    );
-                    let back = cdt.tris[nb].edge_of(a, b).unwrap_or_else(|| {
-                        panic!("neighbour {nb} of triangle {ti} lacks edge {a}-{b}")
-                    });
-                    assert_eq!(
-                        cdt.tris[nb].n[back], ti,
-                        "adjacency {ti} <-> {nb} over edge {a}-{b} is not mutual"
-                    );
-                }
-            }
-        }
-        for (&(a, b), &c) in &edge_count {
-            assert!(c <= 2, "edge {a}-{b} is used by {c} alive triangles");
-        }
-    }
-
-    /// A1 regression (T-junction on a shared NON-constraint edge): a point
-    /// inserted EXACTLY on the diagonal of a unit square (the diagonal is a
-    /// shared interior edge, NOT a constraint) must split BOTH incident
-    /// triangles. The old empty-cavity fallback (`split_in_triangle`) skipped
-    /// the degenerate child on the collinear edge and re-filled only one side:
-    /// the far triangle kept its neighbour link to the dead parent and the new
-    /// vertex was left hanging mid-edge — a T-junction with broken adjacency.
-    #[test]
-    fn on_shared_edge_insertion_splits_both_sides() {
-        // Unit square, all 4 boundary edges constrained, diagonal free.
-        let points: Vec<P2> = vec![[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0]];
-        let segments = vec![(0usize, 1usize), (1, 2), (2, 3), (3, 0)];
-        let mut cdt = Cdt::build_from(points, &segments).expect("square CDT");
-        assert_structurally_valid(&cdt);
-
-        // The square interior is triangulated by ONE of its diagonals.
-        let (d0, d1) = if cdt.edge_exists(0, 2) { (0, 2) } else { (1, 3) };
-        assert!(cdt.edge_exists(d0, d1), "expected a diagonal edge");
-
-        // Splice the EXACT diagonal midpoint in as a Steiner-style vertex
-        // (same index discipline as `insert_steiner`: below the super verts).
-        let vi = cdt.super_base;
-        cdt.points.insert(vi, [0.5, 0.5]);
-        cdt.super_base += 1;
-        for t in &mut cdt.tris {
-            for v in &mut t.v {
-                if *v >= vi {
-                    *v += 1;
-                }
-            }
-        }
-        // Internal insertion via the empty-cavity fallback at a triangle
-        // incident to the diagonal — must split BOTH sides in lockstep.
-        let start = (0..cdt.tris.len())
-            .find(|&ti| cdt.tris[ti].alive && cdt.tris[ti].edge_of(d0, d1).is_some())
-            .expect("a triangle incident to the diagonal");
-        cdt.split_at(start, vi);
-
-        // The midpoint must be a REAL shared vertex fanned on both sides of
-        // the old diagonal: exactly 4 alive triangles reference it (all four
-        // square edges are constraints, so legalization cannot flip further).
-        let refs = (0..cdt.tris.len())
-            .filter(|&ti| cdt.tris[ti].alive && cdt.tris[ti].v.contains(&vi))
-            .count();
-        assert_eq!(refs, 4, "midpoint must be fanned by 4 triangles (both sides), got {refs}");
-        assert_structurally_valid(&cdt);
-    }
-
-    /// The unrefined constrained triangulation EXCLUDES hole interiors (returns
-    /// only the material region) and adds no Steiner points — the properties the
-    /// 2D opening-subtraction re-extrude relies on for a manifold, minimal cap.
-    #[test]
-    fn constrained_excludes_holes_no_steiner() {
-        let outer = vec![pt(0.0, 0.0), pt(10.0, 0.0), pt(10.0, 10.0), pt(0.0, 10.0)];
-        let holes = vec![vec![pt(4.0, 4.0), pt(4.0, 6.0), pt(6.0, 6.0), pt(6.0, 4.0)]];
-        let (pts, idx) = super::triangulate_constrained(&outer, &holes).unwrap();
-        // No Steiner points: the vertex list is exactly outer ++ holes.
-        assert_eq!(pts.len(), 8);
-        // Material area = 100 − 4 (the hole is excluded).
-        assert!((area_of(&pts, &idx) - 96.0).abs() < 1e-9);
-    }
-}
+#[path = "cdt_tests.rs"]
+mod tests;

--- a/rust/geometry/src/cdt/predicates.rs
+++ b/rust/geometry/src/cdt/predicates.rs
@@ -1,0 +1,58 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Small exact-ish geometric predicates used by the CDT.
+//!
+//! Split out of `cdt.rs` to keep it under the module-size ratchet.
+
+use super::{ekey, orient, P2};
+
+#[inline]
+pub(super) fn dist2(a: P2, b: P2) -> f64 {
+    let dx = a[0] - b[0];
+    let dy = a[1] - b[1];
+    dx * dx + dy * dy
+}
+
+/// For `p` known EXACTLY collinear with `a`-`b` (exact `orient == 0`): does it
+/// lie strictly between them? Pure lexicographic comparison — no arithmetic,
+/// no rounding, and `false` when `p` coincides with an endpoint.
+#[inline]
+pub(super) fn strictly_between(a: P2, b: P2, p: P2) -> bool {
+    let lt = |u: P2, w: P2| u[0] < w[0] || (u[0] == w[0] && u[1] < w[1]);
+    (lt(a, p) && lt(p, b)) || (lt(b, p) && lt(p, a))
+}
+
+/// Do open segments `p1-p2` and `p3-p4` strictly cross (proper intersection,
+/// not merely touching at an endpoint)? Exact via `orient`.
+pub(super) fn segments_properly_cross(p1: P2, p2: P2, p3: P2, p4: P2) -> bool {
+    let d1 = orient(p3, p4, p1);
+    let d2 = orient(p3, p4, p2);
+    let d3 = orient(p1, p2, p3);
+    let d4 = orient(p1, p2, p4);
+    (d1 > 0 && d2 < 0 || d1 < 0 && d2 > 0) && (d3 > 0 && d4 < 0 || d3 < 0 && d4 > 0)
+}
+
+/// Build the initial (Steiner-free) constraint set + point list from rings.
+/// `rings[0]` = outer, `rings[1..]` = holes. Returns `(points, segments)`.
+pub(super) fn rings_to_pslg(rings: &[Vec<P2>]) -> (Vec<P2>, Vec<(usize, usize)>) {
+    let mut points: Vec<P2> = Vec::new();
+    let mut segments: Vec<(usize, usize)> = Vec::new();
+    for ring in rings {
+        if ring.len() < 3 {
+            continue;
+        }
+        let base = points.len();
+        points.extend_from_slice(ring);
+        let m = ring.len();
+        for i in 0..m {
+            let a = base + i;
+            let b = base + (i + 1) % m;
+            if a != b {
+                segments.push(ekey(a, b));
+            }
+        }
+    }
+    (points, segments)
+}

--- a/rust/geometry/src/cdt_tests.rs
+++ b/rust/geometry/src/cdt_tests.rs
@@ -1,0 +1,220 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Unit tests for [`super`] (the CDT). Split out of `cdt.rs` so the module-size
+//! ratchet measures production code only, matching `extrusion_watertight_tests.rs`.
+
+use super::*;
+
+    fn pt(x: f64, y: f64) -> Point2<f64> {
+        Point2::new(x, y)
+    }
+
+    fn area_of(points: &[Point2<f64>], idx: &[usize]) -> f64 {
+        let mut a = 0.0;
+        for t in idx.chunks_exact(3) {
+            let p0 = points[t[0]];
+            let p1 = points[t[1]];
+            let p2 = points[t[2]];
+            a += ((p1.x - p0.x) * (p2.y - p0.y) - (p2.x - p0.x) * (p1.y - p0.y)).abs() * 0.5;
+        }
+        a
+    }
+
+    /// Many-void CDT-cliff regression (advanced_model.ifc IFCSLAB #798926): the no-split
+    /// (consolidate_coplanar) refinement of a many-hole slab face. The old
+    /// rebuild-per-Steiner-point driver was O(P³) — 13.8 s in RELEASE for ONE
+    /// 582-vertex/16-hole face, ×2 faces ×16 re-consolidates = a 155 s element.
+    /// The incremental driver does the same face in ~10 ms. The shape below
+    /// reproduces that face: a 134-vertex outer ring + 16 28-gon holes.
+    ///
+    /// Guards three things: (1) wall-time in release — bound 2 s, ~200× above
+    /// the fixed cost, ~7× below the regressed cost, so scheduler jitter can't
+    /// trip it but the O(P³) driver always does; (2) refinement actually ran
+    /// (Steiner points were added); (3) the result is still area-exact and
+    /// run-to-run deterministic (the incremental path must stay bit-stable).
+    #[test]
+    fn no_split_many_hole_refinement_is_fast_and_valid() {
+        // Outer ring: 12 m × 10 m rectangle subdivided to 132 boundary verts.
+        let (w, h, step) = (12.0_f64, 10.0_f64, 1.0 / 3.0);
+        let mut outer: Vec<Point2<f64>> = Vec::new();
+        let n_x = (w / step).round() as usize;
+        let n_y = (h / step).round() as usize;
+        for i in 0..n_x {
+            outer.push(pt(i as f64 * step, 0.0));
+        }
+        for j in 0..n_y {
+            outer.push(pt(w, j as f64 * step));
+        }
+        for i in (1..=n_x).rev() {
+            outer.push(pt(i as f64 * step, h));
+        }
+        for j in (1..=n_y).rev() {
+            outer.push(pt(0.0, j as f64 * step));
+        }
+        // 16 small 28-gon holes on a 4×4 grid (the slab's round penetrations).
+        let mut holes: Vec<Vec<Point2<f64>>> = Vec::new();
+        let r = 0.1_f64;
+        for gx in 0..4 {
+            for gy in 0..4 {
+                let (cx, cy) = (1.5 + 3.0 * gx as f64, 2.0 + 2.0 * gy as f64);
+                let ring: Vec<Point2<f64>> = (0..28)
+                    .map(|k| {
+                        let a = k as f64 / 28.0 * std::f64::consts::TAU;
+                        pt(cx + r * a.cos(), cy + r * a.sin())
+                    })
+                    .collect();
+                holes.push(ring);
+            }
+        }
+        let n_input = outer.len() + holes.iter().map(|h| h.len()).sum::<usize>();
+
+        let t0 = std::time::Instant::now();
+        let (pts, idx) = triangulate_refined(&outer, &holes).expect("no-split refinement");
+        let dt = t0.elapsed();
+
+        // Refinement ran (Steiner points beyond the input rings) and the domain
+        // is exact: outer area minus the 16 polygonal holes.
+        assert!(
+            pts.len() > n_input,
+            "expected Steiner points (got {} verts for {n_input} inputs)",
+            pts.len()
+        );
+        let hole_area: f64 = holes.iter().map(|h| {
+            let mut s = 0.0;
+            for i in 0..h.len() {
+                let j = (i + 1) % h.len();
+                s += h[i].x * h[j].y - h[j].x * h[i].y;
+            }
+            (s * 0.5).abs()
+        }).sum();
+        let area = area_of(&pts, &idx);
+        let expected = 12.0 * 10.0 - hole_area;
+        assert!(
+            (area - expected).abs() < 1e-6,
+            "area {area} != {expected} (outer minus 16 holes)"
+        );
+        // Bit-stable run-to-run (the incremental driver is deterministic).
+        let (pts2, idx2) = triangulate_refined(&outer, &holes).unwrap();
+        assert_eq!(idx, idx2, "index lists must be identical run-to-run");
+        assert_eq!(pts.len(), pts2.len());
+        for (a, b) in pts.iter().zip(pts2.iter()) {
+            assert_eq!(a.x.to_bits(), b.x.to_bits());
+            assert_eq!(a.y.to_bits(), b.y.to_bits());
+        }
+        // Perf bound — release only (debug predicate cost is ~10× and CI debug
+        // boxes jitter; the regressed driver fails this by ~7× even on slow HW).
+        #[cfg(not(debug_assertions))]
+        assert!(
+            dt < std::time::Duration::from_secs(2),
+            "no-split many-hole refinement took {dt:?} — the O(P³) rebuild-per-point driver is back"
+        );
+        let _ = dt;
+    }
+
+    /// Structural validity over ALIVE triangles: (1) every undirected edge is
+    /// shared by at most 2 alive triangles; (2) neighbour links are mutually
+    /// consistent (`t.n[e] = u` across edge `{a,b}` ⇒ `u` is alive, has edge
+    /// `{a,b}`, and links back to `t` across it); (3) no alive triangle has
+    /// zero area.
+    fn assert_structurally_valid(cdt: &Cdt) {
+        let mut edge_count: BTreeMap<(usize, usize), u32> = BTreeMap::new();
+        for ti in 0..cdt.tris.len() {
+            let t = &cdt.tris[ti];
+            if !t.alive {
+                continue;
+            }
+            assert_ne!(
+                orient(cdt.points[t.v[0]], cdt.points[t.v[1]], cdt.points[t.v[2]]),
+                0,
+                "alive triangle {ti} {:?} has zero area",
+                t.v
+            );
+            for e in 0..3 {
+                let a = t.v[e];
+                let b = t.v[(e + 1) % 3];
+                *edge_count.entry(ekey(a, b)).or_insert(0) += 1;
+                let nb = t.n[e];
+                if nb != NONE {
+                    assert!(
+                        cdt.tris[nb].alive,
+                        "triangle {ti} edge {a}-{b} points at dead triangle {nb}"
+                    );
+                    let back = cdt.tris[nb].edge_of(a, b).unwrap_or_else(|| {
+                        panic!("neighbour {nb} of triangle {ti} lacks edge {a}-{b}")
+                    });
+                    assert_eq!(
+                        cdt.tris[nb].n[back], ti,
+                        "adjacency {ti} <-> {nb} over edge {a}-{b} is not mutual"
+                    );
+                }
+            }
+        }
+        for (&(a, b), &c) in &edge_count {
+            assert!(c <= 2, "edge {a}-{b} is used by {c} alive triangles");
+        }
+    }
+
+    /// A1 regression (T-junction on a shared NON-constraint edge): a point
+    /// inserted EXACTLY on the diagonal of a unit square (the diagonal is a
+    /// shared interior edge, NOT a constraint) must split BOTH incident
+    /// triangles. The old empty-cavity fallback (`split_in_triangle`) skipped
+    /// the degenerate child on the collinear edge and re-filled only one side:
+    /// the far triangle kept its neighbour link to the dead parent and the new
+    /// vertex was left hanging mid-edge — a T-junction with broken adjacency.
+    #[test]
+    fn on_shared_edge_insertion_splits_both_sides() {
+        // Unit square, all 4 boundary edges constrained, diagonal free.
+        let points: Vec<P2> = vec![[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0]];
+        let segments = vec![(0usize, 1usize), (1, 2), (2, 3), (3, 0)];
+        let mut cdt = Cdt::build_from(points, &segments, 0).expect("square CDT");
+        assert_structurally_valid(&cdt);
+
+        // The square interior is triangulated by ONE of its diagonals.
+        let (d0, d1) = if cdt.edge_exists(0, 2) { (0, 2) } else { (1, 3) };
+        assert!(cdt.edge_exists(d0, d1), "expected a diagonal edge");
+
+        // Splice the EXACT diagonal midpoint in as a Steiner-style vertex
+        // (same index discipline as `insert_steiner`: below the super verts).
+        let vi = cdt.super_base;
+        cdt.points.insert(vi, [0.5, 0.5]);
+        cdt.super_base += 1;
+        cdt.n_real += 1;
+        for t in &mut cdt.tris {
+            for v in &mut t.v {
+                if *v >= vi {
+                    *v += 1;
+                }
+            }
+        }
+        // Internal insertion via the empty-cavity fallback at a triangle
+        // incident to the diagonal — must split BOTH sides in lockstep.
+        let start = (0..cdt.tris.len())
+            .find(|&ti| cdt.tris[ti].alive && cdt.tris[ti].edge_of(d0, d1).is_some())
+            .expect("a triangle incident to the diagonal");
+        cdt.split_at(start, vi);
+
+        // The midpoint must be a REAL shared vertex fanned on both sides of
+        // the old diagonal: exactly 4 alive triangles reference it (all four
+        // square edges are constraints, so legalization cannot flip further).
+        let refs = (0..cdt.tris.len())
+            .filter(|&ti| cdt.tris[ti].alive && cdt.tris[ti].v.contains(&vi))
+            .count();
+        assert_eq!(refs, 4, "midpoint must be fanned by 4 triangles (both sides), got {refs}");
+        assert_structurally_valid(&cdt);
+    }
+
+    /// The unrefined constrained triangulation EXCLUDES hole interiors (returns
+    /// only the material region) and adds no Steiner points — the properties the
+    /// 2D opening-subtraction re-extrude relies on for a manifold, minimal cap.
+    #[test]
+    fn constrained_excludes_holes_no_steiner() {
+        let outer = vec![pt(0.0, 0.0), pt(10.0, 0.0), pt(10.0, 10.0), pt(0.0, 10.0)];
+        let holes = vec![vec![pt(4.0, 4.0), pt(4.0, 6.0), pt(6.0, 6.0), pt(6.0, 4.0)]];
+        let (pts, idx) = super::triangulate_constrained(&outer, &holes).unwrap();
+        // No Steiner points: the vertex list is exactly outer ++ holes.
+        assert_eq!(pts.len(), 8);
+        // Material area = 100 − 4 (the hole is excluded).
+        assert!((area_of(&pts, &idx) - 96.0).abs() < 1e-9);
+    }

--- a/rust/geometry/src/csg/consolidate.rs
+++ b/rust/geometry/src/csg/consolidate.rs
@@ -391,7 +391,14 @@ impl ClippingProcessor {
         // The seam map is built ONLY when today's output is torn. Recording every
         // bucket's kept corners unconditionally cost +61% geometry time on
         // ISSUE_129 (1014 -> 1634 ms) for a map that ~85% of hosts never consult.
-        let (mut output, _) = emit_plans(&mut plans, false);
+        let (mut output, base_complete) = emit_plans(&mut plans, false);
+        // A region that failed to triangulate is skipped, so an incomplete baseline
+        // can be missing a whole closed component while still reading as watertight.
+        // Consolidation's standing contract is "never worse than the raw kernel
+        // output", so hand back the raw mesh rather than a known-lossy consolidation.
+        if !base_complete {
+            return mesh;
+        }
         if count_open_boundary_edges_at(&output, 1.0e4) > 0 {
             let seam = build_seam_map(&plans);
             if conform_plans(&mut plans, &seam) {

--- a/rust/geometry/src/csg/consolidate.rs
+++ b/rust/geometry/src/csg/consolidate.rs
@@ -4,8 +4,12 @@
 
 use crate::mesh::Mesh;
 use nalgebra::{Point3, Vector3};
-use rustc_hash::FxHashMap;
+mod conform;
+mod ring_ops;
+
 use super::ClippingProcessor;
+use conform::{conform_plans, count_open_boundary_edges_at, emit_plans, record_seam_vert, PlanBucket, PlanRegion, SeamMap};
+use ring_ops::{floor_pow2, simplify_2d_collinear, weld_near_coincident_2d};
 
 /// Is `v` a degenerate NEEDLE — its shortest edge a hairline relative to its
 /// longest? Such a triangle is a zero-area-intended sliver: the exact kernel
@@ -37,7 +41,7 @@ pub(crate) fn tri_is_needle(v: &[Point3<f64>; 3]) -> bool {
 /// the needle drop here is what removes the #1007 diagonal sliver, since each
 /// tilted opening face lands in its own single-triangle plane bucket and would
 /// otherwise pass the raw kernel needle through verbatim.
-fn emit_triangle(mesh: &mut Mesh, v: &[Point3<f64>; 3], normal: &Vector3<f64>) {
+pub(super) fn emit_triangle(mesh: &mut Mesh, v: &[Point3<f64>; 3], normal: &Vector3<f64>) {
     if tri_is_needle(v) {
         return;
     }
@@ -56,33 +60,7 @@ fn emit_triangle(mesh: &mut Mesh, v: &[Point3<f64>; 3], normal: &Vector3<f64>) {
 /// facet width, cm). A watertight closed mesh returns 0; the consolidation tear
 /// shows up as a positive count the (watertight) raw kernel output lacks.
 fn count_open_boundary_edges(mesh: &Mesh) -> usize {
-    if mesh.positions.len() < 9 || mesh.indices.len() < 3 {
-        return 0;
-    }
-    let q = |v: f32| (v as f64 * 1.0e3).round() as i64;
-    let mut vid: FxHashMap<(i64, i64, i64), u32> = FxHashMap::default();
-    let mut id_of = |i: usize| -> u32 {
-        let k = (
-            q(mesh.positions[i * 3]),
-            q(mesh.positions[i * 3 + 1]),
-            q(mesh.positions[i * 3 + 2]),
-        );
-        let next = vid.len() as u32;
-        *vid.entry(k).or_insert(next)
-    };
-    let mut bal: FxHashMap<(u32, u32), i32> = FxHashMap::default();
-    for tri in mesh.indices.chunks_exact(3) {
-        let (a, b, c) = (
-            id_of(tri[0] as usize),
-            id_of(tri[1] as usize),
-            id_of(tri[2] as usize),
-        );
-        for (x, y) in [(a, b), (b, c), (c, a)] {
-            let (key, s) = if x < y { ((x, y), 1) } else { ((y, x), -1) };
-            *bal.entry(key).or_insert(0) += s;
-        }
-    }
-    bal.values().filter(|&&v| v != 0).count()
+    count_open_boundary_edges_at(mesh, 1.0e3)
 }
 
 /// Count spike triangles (longest-edge / shortest-edge > 50:1) — the same quality
@@ -115,145 +93,6 @@ fn count_spike_triangles(mesh: &Mesh) -> usize {
     n
 }
 
-/// Drop 2D contour vertices that are collinear with both neighbours. The
-/// i_overlay union of many small fragments often leaves "phantom"
-/// vertices on every fragment boundary that crosses the outer outline;
-/// without this pass earcut would emit one sliver triangle per phantom.
-fn simplify_2d_collinear(ring: &[nalgebra::Point2<f64>]) -> Vec<nalgebra::Point2<f64>> {
-    let n = ring.len();
-    if n < 4 {
-        return ring.to_vec();
-    }
-    let mut keep = vec![true; n];
-    let mut changed = true;
-    while changed {
-        changed = false;
-        for i in 0..n {
-            if !keep[i] {
-                continue;
-            }
-            let prev = (1..n).map(|k| (i + n - k) % n).find(|&k| keep[k]);
-            let next = (1..n).map(|k| (i + k) % n).find(|&k| keep[k]);
-            let (prev, next) = match (prev, next) {
-                (Some(p), Some(n)) if p != i && n != i && p != n => (p, n),
-                _ => continue,
-            };
-            let a = ring[prev];
-            let b = ring[i];
-            let c = ring[next];
-            let e1x = b.x - a.x;
-            let e1y = b.y - a.y;
-            let e2x = c.x - b.x;
-            let e2y = c.y - b.y;
-            let cross = e1x * e2y - e1y * e2x;
-            let len1 = (e1x * e1x + e1y * e1y).sqrt();
-            let len2 = (e2x * e2x + e2y * e2y).sqrt();
-            let denom = len1 * len2;
-            // 1e-4 = sin(0.006°). Real arc samples sit well above this
-            // (cavity 6-seg per quadrant ⇒ 15°/segment ⇒ sin ≈ 0.26); the
-            // i_overlay union of split fragments leaves "phantom" vertices
-            // whose sin(angle) ranges 1e-7..1e-5, all caught here.
-            if denom < 1.0e-18 || (cross.abs() / denom) < 1.0e-4 {
-                keep[i] = false;
-                changed = true;
-            }
-        }
-    }
-    ring.iter()
-        .zip(keep.iter())
-        .filter_map(|(p, k)| if *k { Some(*p) } else { None })
-        .collect()
-}
-
-/// Largest power of two ≤ `x` (x finite, > 0). The exponent is read straight
-/// off the IEEE-754 bits, so the result is an EXACT f64 with a single set bit —
-/// bit-identical across x86_64/aarch64/wasm (no rounding, no transcendental).
-#[inline]
-fn floor_pow2(x: f64) -> f64 {
-    if !x.is_finite() || x <= 0.0 {
-        return 0.0;
-    }
-    // 2^floor(log2(x)) via the unbiased exponent of the f64 representation.
-    let exp = x.to_bits() >> 52 & 0x7ff; // biased exponent
-    let unbiased = exp as i64 - 1023;
-    // f64::powi keeps a power-of-two base exact; 2.0_f64.powi is exact for the
-    // representable exponent range we hit (|coords| ≲ 1e7 ⇒ exponent ≲ 24).
-    2.0_f64.powi(unbiased as i32)
-}
-
-/// Merge consecutive near-coincident 2D contour vertices BEFORE the union/earcut.
-///
-/// The exact mesh-arrangement kernel correctly preserves two distinct rim points
-/// that the modeller intended as one but f32 import / a shallow-dihedral LPI
-/// crossing split a few µm apart (issue #1007 / schependomlaan: the diagonal
-/// sliver "flap" over an opening). They reach `consolidate_coplanar` as a hairline
-/// notch on the hole/outer ring; `simplify_2d_collinear` (a TURN-ANGLE test) does
-/// not remove them, so earcut frames the notch out to a far vertex → a degenerate
-/// needle (aspect ≫ 10⁵) that renders as a flap across the opening.
-///
-/// This collapses any vertex within `eps` of its kept predecessor onto that
-/// predecessor. `eps` is a POWER OF TWO scaled to the ring's bounding-box extent
-/// (`floor_pow2(extent) · 2⁻¹³` ≈ extent/8192) and CAPPED at an absolute
-/// 2⁻¹² m (244 µm) — bit-deterministic. On the #1007 fixture the rim
-/// duplicates span 6–72 µm on ~2 m faces (~3·10⁻⁶ … 4·10⁻⁵ of the extent)
-/// while the smallest REAL feature edge is 0.2 m (~0.1 of the extent), so eps
-/// (~10⁻⁴ of the extent) sits three orders of magnitude above the duplicate
-/// spread and three below any real edge — no over-weld. The absolute cap is
-/// what protects mm-scale features on LARGE rings: the duplicate spread comes
-/// from f32 import noise / shallow-dihedral LPI crossings whose magnitude does
-/// NOT grow with ring extent (operands are snapped about their AABB centre),
-/// but an uncapped extent-relative eps reaches 1 mm at 8 m and would swallow a
-/// genuine 1 mm chamfer on a long steel member. This runs in the already-
-/// non-exact consolidation post-pass; it does NOT touch the exact kernel's
-/// interner/predicates (no float weld in the determinism path).
-fn weld_near_coincident_2d(ring: &[nalgebra::Point2<f64>]) -> Vec<nalgebra::Point2<f64>> {
-    let n = ring.len();
-    if n < 4 {
-        return ring.to_vec();
-    }
-    let (mut minx, mut miny, mut maxx, mut maxy) =
-        (f64::MAX, f64::MAX, f64::MIN, f64::MIN);
-    for p in ring {
-        minx = minx.min(p.x);
-        miny = miny.min(p.y);
-        maxx = maxx.max(p.x);
-        maxy = maxy.max(p.y);
-    }
-    let extent = (maxx - minx).max(maxy - miny);
-    if !extent.is_finite() || extent <= 0.0 {
-        return ring.to_vec();
-    }
-    // extent · 2⁻¹³ rounded DOWN to a power of two, capped at an absolute
-    // 2⁻¹² m so big rings can't swallow mm-scale features ⇒ exact, deterministic.
-    let eps = (floor_pow2(extent) * 2.0_f64.powi(-13)).min(2.0_f64.powi(-12));
-    let eps2 = eps * eps;
-    let mut kept: Vec<nalgebra::Point2<f64>> = Vec::with_capacity(n);
-    for &p in ring {
-        let dup = kept.last().is_some_and(|q| {
-            let dx = p.x - q.x;
-            let dy = p.y - q.y;
-            dx * dx + dy * dy < eps2
-        });
-        if !dup {
-            kept.push(p);
-        }
-    }
-    // close-the-loop check: last vs first.
-    if kept.len() >= 2 {
-        let (first, last) = (kept[0], *kept.last().unwrap());
-        let dx = last.x - first.x;
-        let dy = last.y - first.y;
-        if dx * dx + dy * dy < eps2 {
-            kept.pop();
-        }
-    }
-    if kept.len() >= 3 {
-        kept
-    } else {
-        ring.to_vec()
-    }
-}
-
 impl ClippingProcessor {
     /// Re-merge the kernel's per-plane fragments via 2D polygon union, then
     /// earcut each result back to triangles. CSG over-fragments host faces
@@ -270,9 +109,7 @@ impl ClippingProcessor {
     /// nothing — never worse than the raw kernel output.
     pub(crate) fn consolidate_coplanar(mesh: Mesh) -> Mesh {
         use crate::grid::NORMAL_QUANT_F64 as NORMAL_QUANT;
-        use crate::triangulation::{
-            project_to_2d_with_basis, triangulate_polygon_with_holes_refined,
-        };
+        use crate::triangulation::project_to_2d_with_basis;
         use i_overlay::core::fill_rule::FillRule;
         use i_overlay::core::overlay_rule::OverlayRule;
         use i_overlay::float::single::SingleFloatOverlay;
@@ -355,13 +192,33 @@ impl ClippingProcessor {
             });
         }
 
-        let mut output = Mesh::new();
+        // Step 2 — three phases over the SAME bucket map.
+        //
+        // A: union + weld + simplify each bucket's rings and record which 0.1 mm
+        //    positions each bucket KEPT.
+        // B: put back, into every ring, the recorded positions that some OTHER
+        //    bucket kept and that fall strictly inside one of this ring's edges.
+        // C: triangulate and emit.
+        //
+        // WHY (T-junction hairline cracks, dental_clinic #217): `simplify_2d_collinear`
+        // chords a boundary that an ABUTTING bucket subdivides — the cut end face is
+        // split at mid-height, the two corner verticals keep the full-height edge, so
+        // one long edge faces two short ones. Retaining every shared vertex kills the
+        // phantom merge the simplify exists for (#098's faceted reveal shares nearly
+        // all of them), and no local geometric test separates the cases: #217's
+        // must-keep sagitta (0.93 µm) sits BELOW several of #098's must-drop phantoms.
+        // Conforming by ADDITION uses the same asymmetry as a source instead of a
+        // veto, so the phantom removal is untouched: a phantom is near-collinear in
+        // every bucket, is kept nowhere, and is never re-inserted.
+        let mut seam: SeamMap = SeamMap::new();
+        let mut plans: Vec<PlanBucket> = Vec::with_capacity(buckets.len());
 
-        // Step 2 — per bucket, union triangles in 2D, triangulate result.
-        for tris in buckets.values() {
+        // Phase A.
+        for (bid, tris) in buckets.values().enumerate() {
             if tris.is_empty() {
                 continue;
             }
+            let bid = bid as u32;
             // Use the FIRST triangle's normal/anchor for a stable 2D basis;
             // all tris in this bucket share the plane by construction.
             let normal = tris[0].normal;
@@ -381,10 +238,26 @@ impl ClippingProcessor {
             // looking down `normal`; the (u, v) basis above is right-handed
             // with `v = normal × u`, so projection preserves winding.
 
+            let mut plan = PlanBucket {
+                bid,
+                normal,
+                origin,
+                u_axis,
+                v_axis,
+                raw: Vec::new(),
+                regions: Vec::new(),
+            };
+
             // Project each triangle to 2D and build i_overlay paths.
             if tris.len() == 1 {
-                // Single triangle — skip the union round-trip entirely.
-                emit_triangle(&mut output, &tris[0].v, &normal);
+                // Single triangle — skip the union round-trip entirely. Its three
+                // corners are hard corners by definition, so they are valid
+                // insertion sources for the buckets that abut them.
+                for p in tris[0].v {
+                    record_seam_vert(&mut seam, bid, p);
+                }
+                plan.raw.push(tris[0].v);
+                plans.push(plan);
                 continue;
             }
             let mut subject: Vec<Vec<[f64; 2]>> = Vec::with_capacity(1);
@@ -414,8 +287,12 @@ impl ClippingProcessor {
             if shapes.is_empty() {
                 // Union collapsed everything — emit originals to avoid loss.
                 for t in tris {
-                    emit_triangle(&mut output, &t.v, &normal);
+                    for p in t.v {
+                        record_seam_vert(&mut seam, bid, p);
+                    }
+                    plan.raw.push(t.v);
                 }
+                plans.push(plan);
                 continue;
             }
 
@@ -488,56 +365,47 @@ impl ClippingProcessor {
                     })
                     .collect();
 
-                // Quality CDT + bounded Ruppert refinement. Returns the
-                // (possibly Steiner-augmented) 2D vertex list `all_2d` plus
-                // indices into it; the lift below maps EVERY returned vertex
-                // (input + Steiner) back to 3D, so a Steiner point on a shared
-                // edge is split on both sides → watertight, no T-junction.
-                // Refinement is interior-only: this region's outer/hole rings
-                // are shared with neighbouring plane buckets triangulated
-                // independently; a boundary Steiner point would tear that seam
-                // (open edges / T-junctions). Interior-only refinement keeps the
-                // seam watertight while still removing the rim-corner slivers.
-                let (all_2d, indices) = match triangulate_polygon_with_holes_refined(
-                    &outer_simplified,
-                    &holes_simplified,
-                ) {
-                    Ok((pts, idx)) => (pts, idx),
-                    Err(_) => continue,
+                // Every surviving ring vertex of this bucket is a kept corner —
+                // record it (in 3D) as a possible insertion source for the buckets
+                // that abut this plane.
+                let lift = |p: &nalgebra::Point2<f64>| -> Point3<f64> {
+                    origin + u_axis * p.x + v_axis * p.y
                 };
+                for p in outer_simplified.iter().chain(holes_simplified.iter().flatten()) {
+                    record_seam_vert(&mut seam, bid, lift(p));
+                }
+                plan.regions.push(PlanRegion {
+                    outer_conformed: outer_simplified.clone(),
+                    holes_conformed: holes_simplified.clone(),
+                    outer: outer_simplified,
+                    holes: holes_simplified,
+                });
+            }
+            plans.push(plan);
+        }
 
-                let lift = |p: nalgebra::Point2<f64>| -> Point3<f64> {
-                    let off = u_axis * p.x + v_axis * p.y;
-                    origin + off
-                };
-                let mut verts_3d: Vec<Point3<f64>> = Vec::with_capacity(all_2d.len());
-                for p in &all_2d {
-                    verts_3d.push(lift(*p));
-                }
-
-                let base = output.vertex_count() as u32;
-                for vp in &verts_3d {
-                    output.add_vertex(*vp, normal);
-                }
-                for tri in indices.chunks_exact(3) {
-                    // Needle backstop: drop any residual sub-weld degenerate sliver
-                    // ([`tri_is_needle`], the same scale-relative power-of-two rule
-                    // as the single-triangle path). Cannot open a real gap — the
-                    // hole/seam is framed by its non-degenerate neighbours.
-                    let v = [
-                        verts_3d[tri[0]],
-                        verts_3d[tri[1]],
-                        verts_3d[tri[2]],
-                    ];
-                    if tri_is_needle(&v) {
-                        continue;
-                    }
-                    output.add_triangle(
-                        base + tri[0] as u32,
-                        base + tri[1] as u32,
-                        base + tri[2] as u32,
-                    );
-                }
+        // Phase C — today's output first. An already-watertight host pays nothing for
+        // the conform: phase B and the second triangulation are pure cost when there
+        // is no tear to close, and the accept bar below would reject them anyway.
+        //
+        // The bar is ALL-OR-NOTHING, and that is measured, not cautious: on the #098
+        // reveal wall conforming lowers the per-cut open-edge count on EVERY one of the
+        // seven sequential cuts (227 -> 144 on the last), yet each partially-conformed
+        // intermediate feeds the next kernel cut and the FINAL wall came out at 282
+        // unpaired edges against 42 for today's output. A partial conform trades a
+        // T-junction for a subdivided edge whose true neighbour across it did NOT get
+        // the same vertex; only a fully-closed host proves every insertion landed on a
+        // real seam. With the bar at zero that wall improves to 22 and dental_clinic
+        // #217 goes watertight (6 -> 0).
+        //
+        // Measured on the 0.1 mm grid, not the 1 mm default: a chorded seam deviates by
+        // ~µm, merges away at 1 mm, and would read as "closed" — which accepts a
+        // conform that is in fact still torn (that is exactly the 282 above).
+        let mut output = emit_plans(&plans, false);
+        if count_open_boundary_edges_at(&output, 1.0e4) > 0 && conform_plans(&mut plans, &seam) {
+            let candidate = emit_plans(&plans, true);
+            if !candidate.is_empty() && count_open_boundary_edges_at(&candidate, 1.0e4) == 0 {
+                output = candidate;
             }
         }
 
@@ -722,6 +590,7 @@ mod tests {
             "µm rim duplicate on a large ring not welded"
         );
     }
+
 
     #[test]
     fn merge_coplanar_collapses_subdivided_quad() {

--- a/rust/geometry/src/csg/consolidate.rs
+++ b/rust/geometry/src/csg/consolidate.rs
@@ -8,7 +8,7 @@ mod conform;
 mod ring_ops;
 
 use super::ClippingProcessor;
-use conform::{conform_plans, count_open_boundary_edges_at, emit_plans, record_seam_vert, PlanBucket, PlanRegion, SeamMap};
+use conform::{build_seam_map, conform_plans, count_open_boundary_edges_at, emit_plans, PlanBucket, PlanRegion};
 use ring_ops::{floor_pow2, simplify_2d_collinear, weld_near_coincident_2d};
 
 /// Is `v` a degenerate NEEDLE — its shortest edge a hairline relative to its
@@ -210,7 +210,6 @@ impl ClippingProcessor {
         // Conforming by ADDITION uses the same asymmetry as a source instead of a
         // veto, so the phantom removal is untouched: a phantom is near-collinear in
         // every bucket, is kept nowhere, and is never re-inserted.
-        let mut seam: SeamMap = SeamMap::new();
         let mut plans: Vec<PlanBucket> = Vec::with_capacity(buckets.len());
 
         // Phase A.
@@ -252,10 +251,8 @@ impl ClippingProcessor {
             if tris.len() == 1 {
                 // Single triangle — skip the union round-trip entirely. Its three
                 // corners are hard corners by definition, so they are valid
-                // insertion sources for the buckets that abut them.
-                for p in tris[0].v {
-                    record_seam_vert(&mut seam, bid, p);
-                }
+                // insertion sources for the buckets that abut them (recorded
+                // lazily, in `build_seam_map`).
                 plan.raw.push(tris[0].v);
                 plans.push(plan);
                 continue;
@@ -287,9 +284,6 @@ impl ClippingProcessor {
             if shapes.is_empty() {
                 // Union collapsed everything — emit originals to avoid loss.
                 for t in tris {
-                    for p in t.v {
-                        record_seam_vert(&mut seam, bid, p);
-                    }
                     plan.raw.push(t.v);
                 }
                 plans.push(plan);
@@ -365,16 +359,9 @@ impl ClippingProcessor {
                     })
                     .collect();
 
-                // Every surviving ring vertex of this bucket is a kept corner —
-                // record it (in 3D) as a possible insertion source for the buckets
-                // that abut this plane.
-                let lift = |p: &nalgebra::Point2<f64>| -> Point3<f64> {
-                    origin + u_axis * p.x + v_axis * p.y
-                };
-                for p in outer_simplified.iter().chain(holes_simplified.iter().flatten()) {
-                    record_seam_vert(&mut seam, bid, lift(p));
-                }
                 plan.regions.push(PlanRegion {
+                    changed: false,
+                    cached: None,
                     outer_conformed: outer_simplified.clone(),
                     holes_conformed: holes_simplified.clone(),
                     outer: outer_simplified,
@@ -401,11 +388,17 @@ impl ClippingProcessor {
         // Measured on the 0.1 mm grid, not the 1 mm default: a chorded seam deviates by
         // ~µm, merges away at 1 mm, and would read as "closed" — which accepts a
         // conform that is in fact still torn (that is exactly the 282 above).
-        let mut output = emit_plans(&plans, false);
-        if count_open_boundary_edges_at(&output, 1.0e4) > 0 && conform_plans(&mut plans, &seam) {
-            let candidate = emit_plans(&plans, true);
-            if !candidate.is_empty() && count_open_boundary_edges_at(&candidate, 1.0e4) == 0 {
-                output = candidate;
+        // The seam map is built ONLY when today's output is torn. Recording every
+        // bucket's kept corners unconditionally cost +61% geometry time on
+        // ISSUE_129 (1014 -> 1634 ms) for a map that ~85% of hosts never consult.
+        let mut output = emit_plans(&mut plans, false);
+        if count_open_boundary_edges_at(&output, 1.0e4) > 0 {
+            let seam = build_seam_map(&plans);
+            if conform_plans(&mut plans, &seam) {
+                let candidate = emit_plans(&mut plans, true);
+                if !candidate.is_empty() && count_open_boundary_edges_at(&candidate, 1.0e4) == 0 {
+                    output = candidate;
+                }
             }
         }
 

--- a/rust/geometry/src/csg/consolidate.rs
+++ b/rust/geometry/src/csg/consolidate.rs
@@ -391,12 +391,19 @@ impl ClippingProcessor {
         // The seam map is built ONLY when today's output is torn. Recording every
         // bucket's kept corners unconditionally cost +61% geometry time on
         // ISSUE_129 (1014 -> 1634 ms) for a map that ~85% of hosts never consult.
-        let mut output = emit_plans(&mut plans, false);
+        let (mut output, _) = emit_plans(&mut plans, false);
         if count_open_boundary_edges_at(&output, 1.0e4) > 0 {
             let seam = build_seam_map(&plans);
             if conform_plans(&mut plans, &seam) {
-                let candidate = emit_plans(&mut plans, true);
-                if !candidate.is_empty() && count_open_boundary_edges_at(&candidate, 1.0e4) == 0 {
+                // `complete` is part of the bar, not a detail: a region that fails
+                // to triangulate is skipped, and if it was its own closed component
+                // the remainder still balances — so a watertight-LOOKING candidate
+                // can be missing a whole surface. Reject unless every region landed.
+                let (candidate, complete) = emit_plans(&mut plans, true);
+                if complete
+                    && !candidate.is_empty()
+                    && count_open_boundary_edges_at(&candidate, 1.0e4) == 0
+                {
                     output = candidate;
                 }
             }

--- a/rust/geometry/src/csg/consolidate/conform.rs
+++ b/rust/geometry/src/csg/consolidate/conform.rs
@@ -84,6 +84,18 @@ pub(super) struct SeamVert {
 
 pub(super) type SeamMap = std::collections::BTreeMap<(i64, i64, i64), SeamVert>;
 
+/// Inclusive range bounds on the 0.1 mm lattice `SeamMap` is keyed by. Widened by
+/// one cell on each side so the range is a strict SUPERSET of the box — the plane
+/// and AABB tests inside `conform_plans` still reject everything spurious, this only
+/// stops each bucket walking the whole map.
+fn seam_bounds(lo: [f64; 3], hi: [f64; 3]) -> ((i64, i64, i64), (i64, i64, i64)) {
+    let q = |v: f64| (v * 1.0e4).round() as i64;
+    (
+        (q(lo[0]) - 1, i64::MIN, i64::MIN),
+        (q(hi[0]) + 1, i64::MAX, i64::MAX),
+    )
+}
+
 /// Record `p` as kept by bucket `bid`. Buckets are visited in order, so `last`
 /// dedupes repeats inside one bucket without a per-position set. BTreeMap keeps the
 /// whole pass target-independent (native == wasm), like the bucket map itself.
@@ -185,6 +197,13 @@ pub(super) struct PlanRegion {
     pub(super) holes: Vec<Vec<nalgebra::Point2<f64>>>,
     pub(super) outer_conformed: Vec<nalgebra::Point2<f64>>,
     pub(super) holes_conformed: Vec<Vec<nalgebra::Point2<f64>>>,
+    /// Did phase B actually change this region's rings?
+    pub(super) changed: bool,
+    /// Pass-1 CDT result, reused verbatim by the conformed pass for every region
+    /// phase B left alone. The quality CDT with Ruppert refinement is the dominant
+    /// cost of a consolidate, and re-running it on untouched regions is what made
+    /// the second emit a +61% geometry regression on ISSUE_129.
+    pub(super) cached: Option<(Vec<nalgebra::Point2<f64>>, Vec<usize>)>,
 }
 
 /// One plane bucket after phase A: its 2D basis, the triangles that bypass the
@@ -197,6 +216,32 @@ pub(super) struct PlanBucket {
     pub(super) v_axis: Vector3<f64>,
     pub(super) raw: Vec<[Point3<f64>; 3]>,
     pub(super) regions: Vec<PlanRegion>,
+}
+
+/// Build the seam map from finished plans: every kept corner of every bucket, in
+/// bucket order, keyed at 0.1 mm.
+///
+/// Deferred rather than recorded inline during phase A because ~85% of hosts are
+/// already watertight and never consult it, and paying a BTreeMap insert per ring
+/// vertex on all of them cost +61% geometry time on the ISSUE_129 fixture.
+/// Bucket-ordered iteration keeps it target-independent, exactly as the inline
+/// version was.
+pub(super) fn build_seam_map(plans: &[PlanBucket]) -> SeamMap {
+    let mut seam = SeamMap::new();
+    for plan in plans {
+        for tri in &plan.raw {
+            for p in tri {
+                record_seam_vert(&mut seam, plan.bid, *p);
+            }
+        }
+        for region in &plan.regions {
+            for p in region.outer.iter().chain(region.holes.iter().flatten()) {
+                let lifted = plan.origin + plan.u_axis * p.x + plan.v_axis * p.y;
+                record_seam_vert(&mut seam, plan.bid, lifted);
+            }
+        }
+    }
+    seam
 }
 
 /// Phase B — for every bucket, insert into its rings the seam vertices that some
@@ -222,8 +267,23 @@ pub(super) fn conform_plans(plans: &mut [PlanBucket], seam: &SeamMap) -> bool {
                 maxy = maxy.max(p.y);
             }
         }
+        // 3D AABB of this bucket's rings, so the grid query below only visits cells
+        // that can contain a candidate. Without it every bucket scanned the whole
+        // seam map — O(buckets x seam), which on a 300-bucket host was the bulk of a
+        // +61% geometry regression on ISSUE_129.
+        let (mut lo, mut hi) = ([f64::MAX; 3], [f64::MIN; 3]);
+        for r in &plan.regions {
+            for p in r.outer.iter().chain(r.holes.iter().flatten()) {
+                let w = plan.origin + plan.u_axis * p.x + plan.v_axis * p.y;
+                for k in 0..3 {
+                    lo[k] = lo[k].min(w[k]);
+                    hi[k] = hi[k].max(w[k]);
+                }
+            }
+        }
         let mut cands: Vec<nalgebra::Point2<f64>> = Vec::new();
-        for sv in seam.values() {
+        let (klo, khi) = seam_bounds(lo, hi);
+        for sv in seam.range(klo..=khi).map(|(_, v)| v) {
             // "kept by some bucket OTHER than this one" — the asymmetry signal.
             if sv.buckets < 2 && sv.first == plan.bid {
                 continue;
@@ -245,6 +305,7 @@ pub(super) fn conform_plans(plans: &mut [PlanBucket], seam: &SeamMap) -> bool {
         if cands.is_empty() {
             continue;
         }
+        let basis = (plan.origin, plan.u_axis, plan.v_axis, plan.normal);
         for region in plan.regions.iter_mut() {
             // A candidate this region ALREADY carries must not be re-inserted: a
             // duplicate ring vertex fails the CDT and would drop the whole region.
@@ -264,24 +325,27 @@ pub(super) fn conform_plans(plans: &mut [PlanBucket], seam: &SeamMap) -> bool {
             if local.is_empty() {
                 continue;
             }
-            changed |= conform_ring(&mut region.outer_conformed, &local);
+            let mut this = conform_ring(&mut region.outer_conformed, &local);
             for hole in region.holes_conformed.iter_mut() {
-                changed |= conform_ring(hole, &local);
+                this |= conform_ring(hole, &local);
             }
+            region.changed = this;
+            changed |= this;
         }
     }
     changed
 }
 
 /// Phase C — triangulate the (optionally conformed) rings and emit, in bucket order.
-pub(super) fn emit_plans(plans: &[PlanBucket], conformed: bool) -> Mesh {
+pub(super) fn emit_plans(plans: &mut [PlanBucket], conformed: bool) -> Mesh {
     use crate::triangulation::triangulate_polygon_with_holes_refined;
     let mut output = Mesh::new();
-    for plan in plans {
+    for plan in plans.iter_mut() {
         for t in &plan.raw {
             emit_triangle(&mut output, t, &plan.normal);
         }
-        for region in &plan.regions {
+        let basis = (plan.origin, plan.u_axis, plan.v_axis, plan.normal);
+        for region in plan.regions.iter_mut() {
             let (outer, holes) = if conformed {
                 (&region.outer_conformed, &region.holes_conformed)
             } else {
@@ -297,36 +361,68 @@ pub(super) fn emit_plans(plans: &[PlanBucket], conformed: bool) -> Mesh {
             // independently; a boundary Steiner point would tear that seam
             // (open edges / T-junctions). Interior-only refinement keeps the
             // seam watertight while still removing the rim-corner slivers.
+            // Reuse pass 1's CDT wherever phase B left the rings alone. Stored by
+            // MOVE on pass 1 and borrowed here — cloning it instead cost more than
+            // the CDT it saves. The quality CDT with Ruppert refinement dominates a
+            // consolidate, and re-running it on untouched regions is what made the
+            // second emit a +61% geometry regression on ISSUE_129.
+            if conformed && !region.changed {
+                match &region.cached {
+                    Some((pts, idx)) => {
+                        emit_region(&mut output, basis, pts, idx);
+                        continue;
+                    }
+                    None => continue,
+                }
+            }
             let (all_2d, indices) = match triangulate_polygon_with_holes_refined(outer, holes) {
                 Ok((pts, idx)) => (pts, idx),
                 Err(_) => continue,
             };
-            let verts_3d: Vec<Point3<f64>> = all_2d
-                .iter()
-                .map(|p| plan.origin + plan.u_axis * p.x + plan.v_axis * p.y)
-                .collect();
-            let base = output.vertex_count() as u32;
-            for vp in &verts_3d {
-                output.add_vertex(*vp, plan.normal);
+            if !conformed {
+                region.cached = Some((all_2d, indices));
+                let (pts, idx) = region.cached.as_ref().expect("just stored");
+                emit_region(&mut output, basis, pts, idx);
+                continue;
             }
-            for tri in indices.chunks_exact(3) {
-                // Needle backstop: drop any residual sub-weld degenerate sliver
-                // ([`tri_is_needle`], the same scale-relative power-of-two rule
-                // as the single-triangle path). Cannot open a real gap — the
-                // hole/seam is framed by its non-degenerate neighbours.
-                let v = [verts_3d[tri[0]], verts_3d[tri[1]], verts_3d[tri[2]]];
-                if tri_is_needle(&v) {
-                    continue;
-                }
-                output.add_triangle(
-                    base + tri[0] as u32,
-                    base + tri[1] as u32,
-                    base + tri[2] as u32,
-                );
-            }
+            emit_region(&mut output, basis, &all_2d, &indices);
         }
     }
     output
+}
+
+/// Lift one region's 2D CDT back to 3D and append it. Shared by the fresh and the
+/// cached paths so both emit byte-identically.
+fn emit_region(
+    output: &mut Mesh,
+    basis: (Point3<f64>, Vector3<f64>, Vector3<f64>, Vector3<f64>),
+    all_2d: &[nalgebra::Point2<f64>],
+    indices: &[usize],
+) {
+    let (origin, u_axis, v_axis, normal) = basis;
+    let verts_3d: Vec<Point3<f64>> = all_2d
+        .iter()
+        .map(|p| origin + u_axis * p.x + v_axis * p.y)
+        .collect();
+    let base = output.vertex_count() as u32;
+    for vp in &verts_3d {
+        output.add_vertex(*vp, normal);
+    }
+    for tri in indices.chunks_exact(3) {
+        // Needle backstop: drop any residual sub-weld degenerate sliver
+        // ([`tri_is_needle`], the same scale-relative power-of-two rule as the
+        // single-triangle path). Cannot open a real gap — the hole/seam is framed
+        // by its non-degenerate neighbours.
+        let v = [verts_3d[tri[0]], verts_3d[tri[1]], verts_3d[tri[2]]];
+        if tri_is_needle(&v) {
+            continue;
+        }
+        output.add_triangle(
+            base + tri[0] as u32,
+            base + tri[1] as u32,
+            base + tri[2] as u32,
+        );
+    }
 }
 
 #[cfg(test)]

--- a/rust/geometry/src/csg/consolidate/conform.rs
+++ b/rust/geometry/src/csg/consolidate/conform.rs
@@ -20,10 +20,10 @@
 //!
 //! Split out of `consolidate.rs` to keep both files under the module-size ratchet.
 
+use super::{emit_triangle, tri_is_needle};
 use crate::mesh::Mesh;
 use nalgebra::{Point3, Vector3};
 use rustc_hash::FxHashMap;
-use super::{emit_triangle, tri_is_needle};
 
 /// [`count_open_boundary_edges`] on an explicit merge grid. The 1 mm default hides
 /// the T-junction the cross-bucket conform targets (a 0.1 mm-scale chord deviation
@@ -58,7 +58,6 @@ pub(super) fn count_open_boundary_edges_at(mesh: &Mesh, scale: f64) -> usize {
     }
     bal.values().filter(|&&v| v != 0).count()
 }
-
 
 /// Perpendicular / endpoint tolerance for the cross-bucket conform (0.1 mm) — the
 /// same 0.1 mm as the seam-vertex quantisation, and two orders below the smallest
@@ -122,7 +121,10 @@ pub(super) fn record_seam_vert(map: &mut SeamMap, bid: u32, p: Point3<f64>) {
 /// Conforming by ADDITION is the point: it cannot defeat the phantom merge
 /// `simplify_2d_collinear` exists to perform (blanket retention did), it only puts
 /// back the boundary vertices an abutting bucket still has.
-pub(super) fn conform_ring(ring: &mut Vec<nalgebra::Point2<f64>>, cands: &[nalgebra::Point2<f64>]) -> bool {
+pub(super) fn conform_ring(
+    ring: &mut Vec<nalgebra::Point2<f64>>,
+    cands: &[nalgebra::Point2<f64>],
+) -> bool {
     let n = ring.len();
     if n < 3 || cands.is_empty() {
         return false;

--- a/rust/geometry/src/csg/consolidate/conform.rs
+++ b/rust/geometry/src/csg/consolidate/conform.rs
@@ -20,7 +20,10 @@
 //!
 //! Split out of `consolidate.rs` to keep both files under the module-size ratchet.
 
-use super::{emit_triangle, tri_is_needle};
+mod emit;
+
+pub(super) use emit::emit_plans;
+
 use crate::mesh::Mesh;
 use nalgebra::{Point3, Vector3};
 use rustc_hash::FxHashMap;
@@ -333,95 +336,6 @@ pub(super) fn conform_plans(plans: &mut [PlanBucket], seam: &SeamMap) -> bool {
         }
     }
     changed
-}
-
-/// Phase C — triangulate the (optionally conformed) rings and emit, in bucket order.
-pub(super) fn emit_plans(plans: &mut [PlanBucket], conformed: bool) -> Mesh {
-    use crate::triangulation::triangulate_polygon_with_holes_refined;
-    let mut output = Mesh::new();
-    for plan in plans.iter_mut() {
-        for t in &plan.raw {
-            emit_triangle(&mut output, t, &plan.normal);
-        }
-        let basis = (plan.origin, plan.u_axis, plan.v_axis, plan.normal);
-        for region in plan.regions.iter_mut() {
-            let (outer, holes) = if conformed {
-                (&region.outer_conformed, &region.holes_conformed)
-            } else {
-                (&region.outer, &region.holes)
-            };
-            // Quality CDT + bounded Ruppert refinement. Returns the
-            // (possibly Steiner-augmented) 2D vertex list `all_2d` plus
-            // indices into it; the lift below maps EVERY returned vertex
-            // (input + Steiner) back to 3D, so a Steiner point on a shared
-            // edge is split on both sides → watertight, no T-junction.
-            // Refinement is interior-only: this region's outer/hole rings
-            // are shared with neighbouring plane buckets triangulated
-            // independently; a boundary Steiner point would tear that seam
-            // (open edges / T-junctions). Interior-only refinement keeps the
-            // seam watertight while still removing the rim-corner slivers.
-            // Reuse pass 1's CDT wherever phase B left the rings alone. Stored by
-            // MOVE on pass 1 and borrowed here — cloning it instead cost more than
-            // the CDT it saves. The quality CDT with Ruppert refinement dominates a
-            // consolidate, and re-running it on untouched regions is what made the
-            // second emit a +61% geometry regression on ISSUE_129.
-            if conformed && !region.changed {
-                match &region.cached {
-                    Some((pts, idx)) => {
-                        emit_region(&mut output, basis, pts, idx);
-                        continue;
-                    }
-                    None => continue,
-                }
-            }
-            let (all_2d, indices) = match triangulate_polygon_with_holes_refined(outer, holes) {
-                Ok((pts, idx)) => (pts, idx),
-                Err(_) => continue,
-            };
-            if !conformed {
-                region.cached = Some((all_2d, indices));
-                let (pts, idx) = region.cached.as_ref().expect("just stored");
-                emit_region(&mut output, basis, pts, idx);
-                continue;
-            }
-            emit_region(&mut output, basis, &all_2d, &indices);
-        }
-    }
-    output
-}
-
-/// Lift one region's 2D CDT back to 3D and append it. Shared by the fresh and the
-/// cached paths so both emit byte-identically.
-fn emit_region(
-    output: &mut Mesh,
-    basis: (Point3<f64>, Vector3<f64>, Vector3<f64>, Vector3<f64>),
-    all_2d: &[nalgebra::Point2<f64>],
-    indices: &[usize],
-) {
-    let (origin, u_axis, v_axis, normal) = basis;
-    let verts_3d: Vec<Point3<f64>> = all_2d
-        .iter()
-        .map(|p| origin + u_axis * p.x + v_axis * p.y)
-        .collect();
-    let base = output.vertex_count() as u32;
-    for vp in &verts_3d {
-        output.add_vertex(*vp, normal);
-    }
-    for tri in indices.chunks_exact(3) {
-        // Needle backstop: drop any residual sub-weld degenerate sliver
-        // ([`tri_is_needle`], the same scale-relative power-of-two rule as the
-        // single-triangle path). Cannot open a real gap — the hole/seam is framed
-        // by its non-degenerate neighbours.
-        let v = [verts_3d[tri[0]], verts_3d[tri[1]], verts_3d[tri[2]]];
-        if tri_is_needle(&v) {
-            continue;
-        }
-        output.add_triangle(
-            base + tri[0] as u32,
-            base + tri[1] as u32,
-            base + tri[2] as u32,
-        );
-    }
 }
 
 #[cfg(test)]

--- a/rust/geometry/src/csg/consolidate/conform.rs
+++ b/rust/geometry/src/csg/consolidate/conform.rs
@@ -305,7 +305,6 @@ pub(super) fn conform_plans(plans: &mut [PlanBucket], seam: &SeamMap) -> bool {
         if cands.is_empty() {
             continue;
         }
-        let basis = (plan.origin, plan.u_axis, plan.v_axis, plan.normal);
         for region in plan.regions.iter_mut() {
             // A candidate this region ALREADY carries must not be re-inserted: a
             // duplicate ring vertex fails the CDT and would drop the whole region.

--- a/rust/geometry/src/csg/consolidate/conform.rs
+++ b/rust/geometry/src/csg/consolidate/conform.rs
@@ -1,0 +1,368 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Cross-bucket seam conforming for `consolidate_coplanar`.
+//!
+//! `consolidate_coplanar` re-triangulates each coplanar plane bucket independently.
+//! Where a bucket's boundary runs along a facet shared with an abutting bucket, its
+//! collinear simplify can drop a vertex the neighbour keeps — the shared edge is then
+//! spanned by one long edge on one side and two short ones on the other. That is a
+//! T-junction, and it renders as a hairline crack.
+//!
+//! The discrimination this module rests on: a GENUINE seam vertex is a hard corner in
+//! the abutting bucket, so it survives that bucket's own simplify and gets recorded
+//! here. An i_overlay PHANTOM (a fragment-boundary artefact the simplify exists to
+//! remove) is near-collinear in every bucket that touches it, is dropped everywhere,
+//! and therefore never becomes an insertion source. The simplify's own judgment,
+//! read across buckets, is the discriminator — no geometric proxy for "is this a real
+//! corner" is needed.
+//!
+//! Split out of `consolidate.rs` to keep both files under the module-size ratchet.
+
+use crate::mesh::Mesh;
+use nalgebra::{Point3, Vector3};
+use rustc_hash::FxHashMap;
+use super::{emit_triangle, tri_is_needle};
+
+/// [`count_open_boundary_edges`] on an explicit merge grid. The 1 mm default hides
+/// the T-junction the cross-bucket conform targets (a 0.1 mm-scale chord deviation
+/// merges away), so the conform's accept/reject decision uses 0.1 mm — the same grid
+/// the #098 / #217 measurements are taken on.
+pub(super) fn count_open_boundary_edges_at(mesh: &Mesh, scale: f64) -> usize {
+    if mesh.positions.len() < 9 || mesh.indices.len() < 3 {
+        return 0;
+    }
+    let q = |v: f32| (v as f64 * scale).round() as i64;
+    let mut vid: FxHashMap<(i64, i64, i64), u32> = FxHashMap::default();
+    let mut id_of = |i: usize| -> u32 {
+        let k = (
+            q(mesh.positions[i * 3]),
+            q(mesh.positions[i * 3 + 1]),
+            q(mesh.positions[i * 3 + 2]),
+        );
+        let next = vid.len() as u32;
+        *vid.entry(k).or_insert(next)
+    };
+    let mut bal: FxHashMap<(u32, u32), i32> = FxHashMap::default();
+    for tri in mesh.indices.chunks_exact(3) {
+        let (a, b, c) = (
+            id_of(tri[0] as usize),
+            id_of(tri[1] as usize),
+            id_of(tri[2] as usize),
+        );
+        for (x, y) in [(a, b), (b, c), (c, a)] {
+            let (key, s) = if x < y { ((x, y), 1) } else { ((y, x), -1) };
+            *bal.entry(key).or_insert(0) += s;
+        }
+    }
+    bal.values().filter(|&&v| v != 0).count()
+}
+
+
+/// Perpendicular / endpoint tolerance for the cross-bucket conform (0.1 mm) — the
+/// same 0.1 mm as the seam-vertex quantisation, and two orders below the smallest
+/// real facet width we ever conform against.
+pub(super) const CONFORM_TOL: f64 = 1.0e-4;
+
+/// A ring vertex that survived `weld_near_coincident_2d` + `simplify_2d_collinear`
+/// in at least one plane bucket, keyed by its 0.1 mm-quantised position.
+///
+/// `buckets`/`first` answer the only question that separates the two cases the
+/// simplify conflates: did some bucket OTHER than this one keep this position as a
+/// hard corner? A genuine seam vertex is a corner in the abutting bucket (on
+/// dental_clinic #217 the four peers keep it at sin = 1.00), so it is recorded; an
+/// i_overlay phantom is near-collinear in EVERY bucket that touches it, so it is
+/// dropped everywhere and never becomes an insertion source.
+pub(super) struct SeamVert {
+    /// First 3D position seen at this key — inserted verbatim, so the lift lands
+    /// exactly on the peer bucket's vertex rather than on a dequantised cell centre.
+    pos: Point3<f64>,
+    buckets: u32,
+    first: u32,
+    last: u32,
+}
+
+pub(super) type SeamMap = std::collections::BTreeMap<(i64, i64, i64), SeamVert>;
+
+/// Record `p` as kept by bucket `bid`. Buckets are visited in order, so `last`
+/// dedupes repeats inside one bucket without a per-position set. BTreeMap keeps the
+/// whole pass target-independent (native == wasm), like the bucket map itself.
+pub(super) fn record_seam_vert(map: &mut SeamMap, bid: u32, p: Point3<f64>) {
+    let key = (
+        (p.x * 1.0e4).round() as i64,
+        (p.y * 1.0e4).round() as i64,
+        (p.z * 1.0e4).round() as i64,
+    );
+    match map.get_mut(&key) {
+        Some(e) => {
+            if e.last != bid {
+                e.buckets += 1;
+                e.last = bid;
+            }
+        }
+        None => {
+            map.insert(
+                key,
+                SeamVert {
+                    pos: p,
+                    buckets: 1,
+                    first: bid,
+                    last: bid,
+                },
+            );
+        }
+    }
+}
+
+/// Insert every candidate that lies STRICTLY INTERIOR to one of `ring`'s edges
+/// (within `CONFORM_TOL` perpendicular) into that edge, ordered along it. Returns
+/// whether anything moved.
+///
+/// Conforming by ADDITION is the point: it cannot defeat the phantom merge
+/// `simplify_2d_collinear` exists to perform (blanket retention did), it only puts
+/// back the boundary vertices an abutting bucket still has.
+pub(super) fn conform_ring(ring: &mut Vec<nalgebra::Point2<f64>>, cands: &[nalgebra::Point2<f64>]) -> bool {
+    let n = ring.len();
+    if n < 3 || cands.is_empty() {
+        return false;
+    }
+    let mut out: Vec<nalgebra::Point2<f64>> = Vec::with_capacity(n + cands.len());
+    let mut inserted = false;
+    let mut hits: Vec<(f64, nalgebra::Point2<f64>)> = Vec::new();
+    for i in 0..n {
+        let a = ring[i];
+        let b = ring[(i + 1) % n];
+        out.push(a);
+        let (ex, ey) = (b.x - a.x, b.y - a.y);
+        let len2 = ex * ex + ey * ey;
+        if len2 <= 0.0 {
+            continue;
+        }
+        let len = len2.sqrt();
+        hits.clear();
+        for &q in cands {
+            let (dx, dy) = (q.x - a.x, q.y - a.y);
+            let t = (dx * ex + dy * ey) / len2;
+            // strictly interior — a candidate at an endpoint is already in the ring
+            if t * len <= CONFORM_TOL || (1.0 - t) * len <= CONFORM_TOL {
+                continue;
+            }
+            if (dx * ey - dy * ex).abs() / len > CONFORM_TOL {
+                continue;
+            }
+            hits.push((t, q));
+        }
+        if hits.is_empty() {
+            continue;
+        }
+        hits.sort_by(|x, y| x.0.total_cmp(&y.0));
+        let mut last_t = f64::NEG_INFINITY;
+        for &(t, q) in hits.iter() {
+            // Two seam verts can land in adjacent quantisation cells; inserting both
+            // would leave a sub-0.1 mm pair that the needle backstop then drops,
+            // re-opening the very edge we are conforming.
+            if (t - last_t) * len <= CONFORM_TOL {
+                continue;
+            }
+            out.push(q);
+            last_t = t;
+            inserted = true;
+        }
+    }
+    if inserted {
+        *ring = out;
+    }
+    inserted
+}
+
+/// One union region of one plane bucket: the simplified rings, plus the
+/// cross-bucket-conformed copies phase B fills in.
+pub(super) struct PlanRegion {
+    pub(super) outer: Vec<nalgebra::Point2<f64>>,
+    pub(super) holes: Vec<Vec<nalgebra::Point2<f64>>>,
+    pub(super) outer_conformed: Vec<nalgebra::Point2<f64>>,
+    pub(super) holes_conformed: Vec<Vec<nalgebra::Point2<f64>>>,
+}
+
+/// One plane bucket after phase A: its 2D basis, the triangles that bypass the
+/// union round-trip (single-triangle bucket / union collapse), and its regions.
+pub(super) struct PlanBucket {
+    pub(super) bid: u32,
+    pub(super) normal: Vector3<f64>,
+    pub(super) origin: Point3<f64>,
+    pub(super) u_axis: Vector3<f64>,
+    pub(super) v_axis: Vector3<f64>,
+    pub(super) raw: Vec<[Point3<f64>; 3]>,
+    pub(super) regions: Vec<PlanRegion>,
+}
+
+/// Phase B — for every bucket, insert into its rings the seam vertices that some
+/// OTHER bucket kept, that lie on THIS bucket's plane, and that fall strictly inside
+/// one of its ring edges. Returns whether any ring changed.
+///
+/// The plane test is the strong filter — only positions landing exactly on this
+/// bucket's plane survive it — so the per-bucket scan of `seam` stays cheap. That
+/// prefilter is what the earlier post-hoc conforming attempts (run outside the bucket
+/// structure, in `tris_to_mesh` and after consolidation) could not have.
+pub(super) fn conform_plans(plans: &mut [PlanBucket], seam: &SeamMap) -> bool {
+    let mut changed = false;
+    for plan in plans.iter_mut() {
+        if plan.regions.is_empty() {
+            continue;
+        }
+        let (mut minx, mut miny, mut maxx, mut maxy) = (f64::MAX, f64::MAX, f64::MIN, f64::MIN);
+        for r in &plan.regions {
+            for p in r.outer.iter().chain(r.holes.iter().flatten()) {
+                minx = minx.min(p.x);
+                miny = miny.min(p.y);
+                maxx = maxx.max(p.x);
+                maxy = maxy.max(p.y);
+            }
+        }
+        let mut cands: Vec<nalgebra::Point2<f64>> = Vec::new();
+        for sv in seam.values() {
+            // "kept by some bucket OTHER than this one" — the asymmetry signal.
+            if sv.buckets < 2 && sv.first == plan.bid {
+                continue;
+            }
+            let d = sv.pos - plan.origin;
+            if plan.normal.dot(&d).abs() > 1.0e-5 {
+                continue;
+            }
+            let (x, y) = (d.dot(&plan.u_axis), d.dot(&plan.v_axis));
+            if x < minx - CONFORM_TOL
+                || x > maxx + CONFORM_TOL
+                || y < miny - CONFORM_TOL
+                || y > maxy + CONFORM_TOL
+            {
+                continue;
+            }
+            cands.push(nalgebra::Point2::new(x, y));
+        }
+        if cands.is_empty() {
+            continue;
+        }
+        for region in plan.regions.iter_mut() {
+            // A candidate this region ALREADY carries must not be re-inserted: a
+            // duplicate ring vertex fails the CDT and would drop the whole region.
+            let local: Vec<nalgebra::Point2<f64>> = cands
+                .iter()
+                .copied()
+                .filter(|q| {
+                    !region
+                        .outer
+                        .iter()
+                        .chain(region.holes.iter().flatten())
+                        .any(|p| {
+                            (p.x - q.x).abs() <= CONFORM_TOL && (p.y - q.y).abs() <= CONFORM_TOL
+                        })
+                })
+                .collect();
+            if local.is_empty() {
+                continue;
+            }
+            changed |= conform_ring(&mut region.outer_conformed, &local);
+            for hole in region.holes_conformed.iter_mut() {
+                changed |= conform_ring(hole, &local);
+            }
+        }
+    }
+    changed
+}
+
+/// Phase C — triangulate the (optionally conformed) rings and emit, in bucket order.
+pub(super) fn emit_plans(plans: &[PlanBucket], conformed: bool) -> Mesh {
+    use crate::triangulation::triangulate_polygon_with_holes_refined;
+    let mut output = Mesh::new();
+    for plan in plans {
+        for t in &plan.raw {
+            emit_triangle(&mut output, t, &plan.normal);
+        }
+        for region in &plan.regions {
+            let (outer, holes) = if conformed {
+                (&region.outer_conformed, &region.holes_conformed)
+            } else {
+                (&region.outer, &region.holes)
+            };
+            // Quality CDT + bounded Ruppert refinement. Returns the
+            // (possibly Steiner-augmented) 2D vertex list `all_2d` plus
+            // indices into it; the lift below maps EVERY returned vertex
+            // (input + Steiner) back to 3D, so a Steiner point on a shared
+            // edge is split on both sides → watertight, no T-junction.
+            // Refinement is interior-only: this region's outer/hole rings
+            // are shared with neighbouring plane buckets triangulated
+            // independently; a boundary Steiner point would tear that seam
+            // (open edges / T-junctions). Interior-only refinement keeps the
+            // seam watertight while still removing the rim-corner slivers.
+            let (all_2d, indices) = match triangulate_polygon_with_holes_refined(outer, holes) {
+                Ok((pts, idx)) => (pts, idx),
+                Err(_) => continue,
+            };
+            let verts_3d: Vec<Point3<f64>> = all_2d
+                .iter()
+                .map(|p| plan.origin + plan.u_axis * p.x + plan.v_axis * p.y)
+                .collect();
+            let base = output.vertex_count() as u32;
+            for vp in &verts_3d {
+                output.add_vertex(*vp, plan.normal);
+            }
+            for tri in indices.chunks_exact(3) {
+                // Needle backstop: drop any residual sub-weld degenerate sliver
+                // ([`tri_is_needle`], the same scale-relative power-of-two rule
+                // as the single-triangle path). Cannot open a real gap — the
+                // hole/seam is framed by its non-degenerate neighbours.
+                let v = [verts_3d[tri[0]], verts_3d[tri[1]], verts_3d[tri[2]]];
+                if tri_is_needle(&v) {
+                    continue;
+                }
+                output.add_triangle(
+                    base + tri[0] as u32,
+                    base + tri[1] as u32,
+                    base + tri[2] as u32,
+                );
+            }
+        }
+    }
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn conform_ring_inserts_only_interior_on_edge_candidates() {
+        use nalgebra::Point2;
+        let square = vec![
+            Point2::new(0.0, 0.0),
+            Point2::new(2.0, 0.0),
+            Point2::new(2.0, 2.0),
+            Point2::new(0.0, 2.0),
+        ];
+        // A peer's seam vertex at the middle of the bottom edge — the chorded-seam
+        // case — goes in, in edge order.
+        let mut ring = square.clone();
+        assert!(conform_ring(&mut ring, &[Point2::new(1.0, 0.0)]));
+        assert_eq!(ring.len(), 5);
+        assert_eq!(ring[1], Point2::new(1.0, 0.0));
+        // Off the boundary (interior), past the boundary, and AT a corner: all no-ops.
+        for q in [
+            Point2::new(1.0, 1.0),
+            Point2::new(3.0, 0.0),
+            Point2::new(2.0, 0.0),
+        ] {
+            let mut ring = square.clone();
+            assert!(!conform_ring(&mut ring, &[q]), "wrongly inserted {q:?}");
+            assert_eq!(ring.len(), 4);
+        }
+        // Two candidates 0.05 mm apart (adjacent quantisation cells) must not both
+        // land — the pair would be a sub-weld needle that gets dropped again.
+        let mut ring = square.clone();
+        assert!(conform_ring(
+            &mut ring,
+            &[Point2::new(1.0, 0.0), Point2::new(1.000_05, 0.0)]
+        ));
+        assert_eq!(ring.len(), 5);
+    }
+}

--- a/rust/geometry/src/csg/consolidate/conform/emit.rs
+++ b/rust/geometry/src/csg/consolidate/conform/emit.rs
@@ -13,7 +13,19 @@ use crate::mesh::Mesh;
 use nalgebra::{Point3, Vector3};
 
 /// Phase C — triangulate the (optionally conformed) rings and emit, in bucket order.
-pub(in crate::csg::consolidate) fn emit_plans(plans: &mut [PlanBucket], conformed: bool) -> Mesh {
+/// Returns the emitted mesh and whether EVERY region triangulated.
+///
+/// The flag matters only for the conformed pass. A region whose CDT fails is
+/// skipped, and on the conformed candidate that is not survivable: the accept bar
+/// tests watertightness, and a dropped region that happened to be its own closed
+/// component leaves the remainder edge-balanced, so a candidate missing a whole
+/// surface component would be accepted. The caller rejects the candidate outright
+/// rather than trying to reason about which drops are benign.
+pub(in crate::csg::consolidate) fn emit_plans(
+    plans: &mut [PlanBucket],
+    conformed: bool,
+) -> (Mesh, bool) {
+    let mut complete = true;
     use crate::triangulation::triangulate_polygon_with_holes_refined;
     let mut output = Mesh::new();
     for plan in plans.iter_mut() {
@@ -48,12 +60,18 @@ pub(in crate::csg::consolidate) fn emit_plans(plans: &mut [PlanBucket], conforme
                         emit_region(&mut output, basis, pts, idx);
                         continue;
                     }
-                    None => continue,
+                    None => {
+                        complete = false;
+                        continue;
+                    }
                 }
             }
             let (all_2d, indices) = match triangulate_polygon_with_holes_refined(outer, holes) {
                 Ok((pts, idx)) => (pts, idx),
-                Err(_) => continue,
+                Err(_) => {
+                    complete = false;
+                    continue;
+                }
             };
             if !conformed {
                 region.cached = Some((all_2d, indices));
@@ -64,7 +82,7 @@ pub(in crate::csg::consolidate) fn emit_plans(plans: &mut [PlanBucket], conforme
             emit_region(&mut output, basis, &all_2d, &indices);
         }
     }
-    output
+    (output, complete)
 }
 
 /// Lift one region's 2D CDT back to 3D and append it. Shared by the fresh and the

--- a/rust/geometry/src/csg/consolidate/conform/emit.rs
+++ b/rust/geometry/src/csg/consolidate/conform/emit.rs
@@ -1,0 +1,102 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Phase C of the seam conform: triangulate the (optionally conformed) rings and
+//! emit, in bucket order.
+//!
+//! Split out of `conform.rs` to keep it under the module-size ratchet.
+
+use super::PlanBucket;
+use crate::csg::consolidate::{emit_triangle, tri_is_needle};
+use crate::mesh::Mesh;
+use nalgebra::{Point3, Vector3};
+
+/// Phase C — triangulate the (optionally conformed) rings and emit, in bucket order.
+pub(in crate::csg::consolidate) fn emit_plans(plans: &mut [PlanBucket], conformed: bool) -> Mesh {
+    use crate::triangulation::triangulate_polygon_with_holes_refined;
+    let mut output = Mesh::new();
+    for plan in plans.iter_mut() {
+        for t in &plan.raw {
+            emit_triangle(&mut output, t, &plan.normal);
+        }
+        let basis = (plan.origin, plan.u_axis, plan.v_axis, plan.normal);
+        for region in plan.regions.iter_mut() {
+            let (outer, holes) = if conformed {
+                (&region.outer_conformed, &region.holes_conformed)
+            } else {
+                (&region.outer, &region.holes)
+            };
+            // Quality CDT + bounded Ruppert refinement. Returns the
+            // (possibly Steiner-augmented) 2D vertex list `all_2d` plus
+            // indices into it; the lift below maps EVERY returned vertex
+            // (input + Steiner) back to 3D, so a Steiner point on a shared
+            // edge is split on both sides → watertight, no T-junction.
+            // Refinement is interior-only: this region's outer/hole rings
+            // are shared with neighbouring plane buckets triangulated
+            // independently; a boundary Steiner point would tear that seam
+            // (open edges / T-junctions). Interior-only refinement keeps the
+            // seam watertight while still removing the rim-corner slivers.
+            // Reuse pass 1's CDT wherever phase B left the rings alone. Stored by
+            // MOVE on pass 1 and borrowed here — cloning it instead cost more than
+            // the CDT it saves. The quality CDT with Ruppert refinement dominates a
+            // consolidate, and re-running it on untouched regions is what made the
+            // second emit a +61% geometry regression on ISSUE_129.
+            if conformed && !region.changed {
+                match &region.cached {
+                    Some((pts, idx)) => {
+                        emit_region(&mut output, basis, pts, idx);
+                        continue;
+                    }
+                    None => continue,
+                }
+            }
+            let (all_2d, indices) = match triangulate_polygon_with_holes_refined(outer, holes) {
+                Ok((pts, idx)) => (pts, idx),
+                Err(_) => continue,
+            };
+            if !conformed {
+                region.cached = Some((all_2d, indices));
+                let (pts, idx) = region.cached.as_ref().expect("just stored");
+                emit_region(&mut output, basis, pts, idx);
+                continue;
+            }
+            emit_region(&mut output, basis, &all_2d, &indices);
+        }
+    }
+    output
+}
+
+/// Lift one region's 2D CDT back to 3D and append it. Shared by the fresh and the
+/// cached paths so both emit byte-identically.
+fn emit_region(
+    output: &mut Mesh,
+    basis: (Point3<f64>, Vector3<f64>, Vector3<f64>, Vector3<f64>),
+    all_2d: &[nalgebra::Point2<f64>],
+    indices: &[usize],
+) {
+    let (origin, u_axis, v_axis, normal) = basis;
+    let verts_3d: Vec<Point3<f64>> = all_2d
+        .iter()
+        .map(|p| origin + u_axis * p.x + v_axis * p.y)
+        .collect();
+    let base = output.vertex_count() as u32;
+    for vp in &verts_3d {
+        output.add_vertex(*vp, normal);
+    }
+    for tri in indices.chunks_exact(3) {
+        // Needle backstop: drop any residual sub-weld degenerate sliver
+        // ([`tri_is_needle`], the same scale-relative power-of-two rule as the
+        // single-triangle path). Cannot open a real gap — the hole/seam is framed
+        // by its non-degenerate neighbours.
+        let v = [verts_3d[tri[0]], verts_3d[tri[1]], verts_3d[tri[2]]];
+        if tri_is_needle(&v) {
+            continue;
+        }
+        output.add_triangle(
+            base + tri[0] as u32,
+            base + tri[1] as u32,
+            base + tri[2] as u32,
+        );
+    }
+}

--- a/rust/geometry/src/csg/consolidate/ring_ops.rs
+++ b/rust/geometry/src/csg/consolidate/ring_ops.rs
@@ -32,13 +32,14 @@
 /// genuine 1 mm chamfer on a long steel member. This runs in the already-
 /// non-exact consolidation post-pass; it does NOT touch the exact kernel's
 /// interner/predicates (no float weld in the determinism path).
-pub(super) fn weld_near_coincident_2d(ring: &[nalgebra::Point2<f64>]) -> Vec<nalgebra::Point2<f64>> {
+pub(super) fn weld_near_coincident_2d(
+    ring: &[nalgebra::Point2<f64>],
+) -> Vec<nalgebra::Point2<f64>> {
     let n = ring.len();
     if n < 4 {
         return ring.to_vec();
     }
-    let (mut minx, mut miny, mut maxx, mut maxy) =
-        (f64::MAX, f64::MAX, f64::MIN, f64::MIN);
+    let (mut minx, mut miny, mut maxx, mut maxy) = (f64::MAX, f64::MAX, f64::MIN, f64::MIN);
     for p in ring {
         minx = minx.min(p.x);
         miny = miny.min(p.y);
@@ -79,7 +80,6 @@ pub(super) fn weld_near_coincident_2d(ring: &[nalgebra::Point2<f64>]) -> Vec<nal
         ring.to_vec()
     }
 }
-
 
 /// Drop 2D contour vertices that are collinear with both neighbours. The
 /// i_overlay union of many small fragments often leaves "phantom"
@@ -142,4 +142,3 @@ pub(super) fn floor_pow2(x: f64) -> f64 {
     // representable exponent range we hit (|coords| ≲ 1e7 ⇒ exponent ≲ 24).
     2.0_f64.powi(unbiased as i32)
 }
-

--- a/rust/geometry/src/csg/consolidate/ring_ops.rs
+++ b/rust/geometry/src/csg/consolidate/ring_ops.rs
@@ -1,0 +1,145 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! 2D ring cleanup used by `consolidate_coplanar` and by the cross-bucket
+//! `conform` pass.
+//!
+//! Split out of `consolidate.rs` to keep it under the module-size ratchet.
+
+/// Merge consecutive near-coincident 2D contour vertices BEFORE the union/earcut.
+///
+/// The exact mesh-arrangement kernel correctly preserves two distinct rim points
+/// that the modeller intended as one but f32 import / a shallow-dihedral LPI
+/// crossing split a few µm apart (issue #1007 / schependomlaan: the diagonal
+/// sliver "flap" over an opening). They reach `consolidate_coplanar` as a hairline
+/// notch on the hole/outer ring; `simplify_2d_collinear` (a TURN-ANGLE test) does
+/// not remove them, so earcut frames the notch out to a far vertex → a degenerate
+/// needle (aspect ≫ 10⁵) that renders as a flap across the opening.
+///
+/// This collapses any vertex within `eps` of its kept predecessor onto that
+/// predecessor. `eps` is a POWER OF TWO scaled to the ring's bounding-box extent
+/// (`floor_pow2(extent) · 2⁻¹³` ≈ extent/8192) and CAPPED at an absolute
+/// 2⁻¹² m (244 µm) — bit-deterministic. On the #1007 fixture the rim
+/// duplicates span 6–72 µm on ~2 m faces (~3·10⁻⁶ … 4·10⁻⁵ of the extent)
+/// while the smallest REAL feature edge is 0.2 m (~0.1 of the extent), so eps
+/// (~10⁻⁴ of the extent) sits three orders of magnitude above the duplicate
+/// spread and three below any real edge — no over-weld. The absolute cap is
+/// what protects mm-scale features on LARGE rings: the duplicate spread comes
+/// from f32 import noise / shallow-dihedral LPI crossings whose magnitude does
+/// NOT grow with ring extent (operands are snapped about their AABB centre),
+/// but an uncapped extent-relative eps reaches 1 mm at 8 m and would swallow a
+/// genuine 1 mm chamfer on a long steel member. This runs in the already-
+/// non-exact consolidation post-pass; it does NOT touch the exact kernel's
+/// interner/predicates (no float weld in the determinism path).
+pub(super) fn weld_near_coincident_2d(ring: &[nalgebra::Point2<f64>]) -> Vec<nalgebra::Point2<f64>> {
+    let n = ring.len();
+    if n < 4 {
+        return ring.to_vec();
+    }
+    let (mut minx, mut miny, mut maxx, mut maxy) =
+        (f64::MAX, f64::MAX, f64::MIN, f64::MIN);
+    for p in ring {
+        minx = minx.min(p.x);
+        miny = miny.min(p.y);
+        maxx = maxx.max(p.x);
+        maxy = maxy.max(p.y);
+    }
+    let extent = (maxx - minx).max(maxy - miny);
+    if !extent.is_finite() || extent <= 0.0 {
+        return ring.to_vec();
+    }
+    // extent · 2⁻¹³ rounded DOWN to a power of two, capped at an absolute
+    // 2⁻¹² m so big rings can't swallow mm-scale features ⇒ exact, deterministic.
+    let eps = (floor_pow2(extent) * 2.0_f64.powi(-13)).min(2.0_f64.powi(-12));
+    let eps2 = eps * eps;
+    let mut kept: Vec<nalgebra::Point2<f64>> = Vec::with_capacity(n);
+    for &p in ring {
+        let dup = kept.last().is_some_and(|q| {
+            let dx = p.x - q.x;
+            let dy = p.y - q.y;
+            dx * dx + dy * dy < eps2
+        });
+        if !dup {
+            kept.push(p);
+        }
+    }
+    // close-the-loop check: last vs first.
+    if kept.len() >= 2 {
+        let (first, last) = (kept[0], *kept.last().unwrap());
+        let dx = last.x - first.x;
+        let dy = last.y - first.y;
+        if dx * dx + dy * dy < eps2 {
+            kept.pop();
+        }
+    }
+    if kept.len() >= 3 {
+        kept
+    } else {
+        ring.to_vec()
+    }
+}
+
+
+/// Drop 2D contour vertices that are collinear with both neighbours. The
+/// i_overlay union of many small fragments often leaves "phantom"
+/// vertices on every fragment boundary that crosses the outer outline;
+/// without this pass earcut would emit one sliver triangle per phantom.
+pub(super) fn simplify_2d_collinear(ring: &[nalgebra::Point2<f64>]) -> Vec<nalgebra::Point2<f64>> {
+    let n = ring.len();
+    if n < 4 {
+        return ring.to_vec();
+    }
+    let mut keep = vec![true; n];
+    let mut changed = true;
+    while changed {
+        changed = false;
+        for i in 0..n {
+            if !keep[i] {
+                continue;
+            }
+            let prev = (1..n).map(|k| (i + n - k) % n).find(|&k| keep[k]);
+            let next = (1..n).map(|k| (i + k) % n).find(|&k| keep[k]);
+            let (prev, next) = match (prev, next) {
+                (Some(p), Some(n)) if p != i && n != i && p != n => (p, n),
+                _ => continue,
+            };
+            let a = ring[prev];
+            let b = ring[i];
+            let c = ring[next];
+            let e1x = b.x - a.x;
+            let e1y = b.y - a.y;
+            let e2x = c.x - b.x;
+            let e2y = c.y - b.y;
+            let cross = e1x * e2y - e1y * e2x;
+            let len1 = (e1x * e1x + e1y * e1y).sqrt();
+            let len2 = (e2x * e2x + e2y * e2y).sqrt();
+            let denom = len1 * len2;
+            // 1e-4 = sin(0.006°). Real arc samples sit well above this
+            // (cavity 6-seg per quadrant ⇒ 15°/segment ⇒ sin ≈ 0.26); the
+            // i_overlay union of split fragments leaves "phantom" vertices
+            // whose sin(angle) ranges 1e-7..1e-5, all caught here.
+            if denom < 1.0e-18 || (cross.abs() / denom) < 1.0e-4 {
+                keep[i] = false;
+                changed = true;
+            }
+        }
+    }
+    ring.iter()
+        .zip(keep.iter())
+        .filter_map(|(p, k)| if *k { Some(*p) } else { None })
+        .collect()
+}
+
+pub(super) fn floor_pow2(x: f64) -> f64 {
+    if !x.is_finite() || x <= 0.0 {
+        return 0.0;
+    }
+    // 2^floor(log2(x)) via the unbiased exponent of the f64 representation.
+    let exp = x.to_bits() >> 52 & 0x7ff; // biased exponent
+    let unbiased = exp as i64 - 1023;
+    // f64::powi keeps a power-of-two base exact; 2.0_f64.powi is exact for the
+    // representable exponent range we hit (|coords| ≲ 1e7 ⇒ exponent ≲ 24).
+    2.0_f64.powi(unbiased as i32)
+}
+

--- a/rust/geometry/src/lib.rs
+++ b/rust/geometry/src/lib.rs
@@ -120,6 +120,8 @@ pub(crate) mod profile_extractor;
 pub(crate) mod profiles;
 pub mod projection_outline;
 pub mod rect_fast;
+#[cfg(feature = "triangulation-alt")]
+pub use triangulation::alt_oracle::set_alt_triangulator;
 pub use rect_fast::RectFastStats;
 pub(crate) mod router;
 /// Per-element mesh simplification for the demesher (cavity removal, grid

--- a/rust/geometry/src/router/voids/mod.rs
+++ b/rust/geometry/src/router/voids/mod.rs
@@ -16,7 +16,7 @@ mod aabb_clip;
 mod bool2d_path;
 mod coaxial_union;
 mod geom;
-mod prism_cut;
+pub(crate) mod prism_cut;
 mod probe;
 mod synthesis;
 
@@ -964,6 +964,10 @@ impl GeometryRouter {
             let prism_bounds = world_host_bounds(&mesh);
             let prism_tris_before = mesh.triangle_count();
             if let Some((cut, residual)) = self.try_prism_cut(&mesh, ctx) {
+                // Two host faces sharing an edge compute the same new crossing
+                // point through different arithmetic; unify them at ulp scale so
+                // the split face's halves share their seam.
+                let cut = prism_cut::dedup_cut_vertices(&cut, &mesh);
                 return match residual {
                     None => {
                         // Same per-host cut-effect snapshot the exact path

--- a/rust/geometry/src/router/voids/prism_cut.rs
+++ b/rust/geometry/src/router/voids/prism_cut.rs
@@ -70,96 +70,10 @@ use rustc_hash::FxHashMap;
 
 /// `IFC_LITE_PRISM_CUT=0` disables the analytic prism-subtraction path (exact
 /// kernel for every host). Default ON; read once.
-/// Make the analytic cut's NEW vertices unique at ulp scale.
-///
-/// The cut derives a crossing point once per (host face, cutter plane) pair. Two
-/// host faces that share an edge therefore compute the SAME geometric point
-/// through different arithmetic and can land a float ulp apart. The two halves of
-/// the split face then fail to share their seam, which is an unmatched half-edge
-/// pair and renders as a hairline crack.
-///
-/// `dental_clinic #217` is the minimal case. The host arriving here is clean: 12
-/// triangles, a single `x = -20.29`. The cut emits the mid-height seam at both
-/// `x = -20.289999008` and `x = -20.290000916` — exactly 2^-19 apart — giving 8
-/// unmatched edges.
-///
-/// Deliberately narrow, because a general weld is what broke this before: merging
-/// at 1e-4 m collapsed real geometry and took corpus defects from 76 to 90. Here
-/// the tolerance is 4 f32 ulps of the coordinate magnitude, which is below any
-/// real feature and above the reconstruction scatter. Vertices that coincide with
-/// a HOST vertex are pinned to the host value exactly, so the cut cannot move a
-/// vertex it did not create; the rest are merged only with each other.
-pub(crate) fn dedup_cut_vertices(cut: &Mesh, host: &Mesh) -> Mesh {
-    let cn = cut.positions.len() / 3;
-    if cn == 0 {
-        return cut.clone();
-    }
-    let mut mag = 1.0f32;
-    for &c in host.positions.iter().chain(cut.positions.iter()) {
-        mag = mag.max(c.abs());
-    }
-    let tol = (mag as f64) * (4.0 / 8_388_608.0);
-    let tol2 = tol * tol;
-    let cell = (tol * 4.0).max(f64::MIN_POSITIVE);
-    let key = |p: [f64; 3]| {
-        [
-            (p[0] / cell).floor() as i64,
-            (p[1] / cell).floor() as i64,
-            (p[2] / cell).floor() as i64,
-        ]
-    };
-    let d2 = |a: [f64; 3], b: [f64; 3]| {
-        let d = [a[0] - b[0], a[1] - b[1], a[2] - b[2]];
-        d[0] * d[0] + d[1] * d[1] + d[2] * d[2]
-    };
-
-    // Host vertices seed the pool, so any cut vertex within tolerance of one is
-    // pinned to the host's exact value rather than becoming its own
-    // representative.
-    let mut pool: FxHashMap<[i64; 3], Vec<[f64; 3]>> = FxHashMap::default();
-    for i in 0..host.positions.len() / 3 {
-        let p = [
-            host.positions[i * 3] as f64,
-            host.positions[i * 3 + 1] as f64,
-            host.positions[i * 3 + 2] as f64,
-        ];
-        pool.entry(key(p)).or_default().push(p);
-    }
-
-    let mut out = cut.clone();
-    for i in 0..cn {
-        let p = [
-            out.positions[i * 3] as f64,
-            out.positions[i * 3 + 1] as f64,
-            out.positions[i * 3 + 2] as f64,
-        ];
-        let base = key(p);
-        let mut best: Option<(f64, [f64; 3])> = None;
-        for dx in -1..=1 {
-            for dy in -1..=1 {
-                for dz in -1..=1 {
-                    if let Some(b) = pool.get(&[base[0] + dx, base[1] + dy, base[2] + dz]) {
-                        for q in b {
-                            let dd = d2(p, *q);
-                            if dd <= tol2 && best.map(|(x, _)| dd < x).unwrap_or(true) {
-                                best = Some((dd, *q));
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        match best {
-            Some((_, q)) => {
-                out.positions[i * 3] = q[0] as f32;
-                out.positions[i * 3 + 1] = q[1] as f32;
-                out.positions[i * 3 + 2] = q[2] as f32;
-            }
-            None => pool.entry(base).or_default().push(p),
-        }
-    }
-    out
-}
+mod closure_checks;
+mod vertex_dedup;
+use closure_checks::{closed_or_hairline, directed_closed};
+pub(crate) use vertex_dedup::dedup_cut_vertices;
 
 pub(super) fn enabled() -> bool {
     static ON: OnceLock<bool> = OnceLock::new();
@@ -269,27 +183,27 @@ pub use diag::{take_prism_defers, take_prism_stats};
 // Explicit component arithmetic (no nalgebra matrix products) so no FMA can
 // sneak in and break native==wasm byte identity.
 
-type V3 = [f64; 3];
+pub(super) type V3 = [f64; 3];
 type V2 = [f64; 2];
 
 #[inline]
-fn dot(a: V3, b: V3) -> f64 {
+pub(super) fn dot(a: V3, b: V3) -> f64 {
     a[0] * b[0] + a[1] * b[1] + a[2] * b[2]
 }
 #[inline]
-fn sub(a: V3, b: V3) -> V3 {
+pub(super) fn sub(a: V3, b: V3) -> V3 {
     [a[0] - b[0], a[1] - b[1], a[2] - b[2]]
 }
 #[inline]
-fn add(a: V3, b: V3) -> V3 {
+pub(super) fn add(a: V3, b: V3) -> V3 {
     [a[0] + b[0], a[1] + b[1], a[2] + b[2]]
 }
 #[inline]
-fn scale(a: V3, s: f64) -> V3 {
+pub(super) fn scale(a: V3, s: f64) -> V3 {
     [a[0] * s, a[1] * s, a[2] * s]
 }
 #[inline]
-fn cross(a: V3, b: V3) -> V3 {
+pub(super) fn cross(a: V3, b: V3) -> V3 {
     [
         a[1] * b[2] - a[2] * b[1],
         a[2] * b[0] - a[0] * b[2],
@@ -297,11 +211,11 @@ fn cross(a: V3, b: V3) -> V3 {
     ]
 }
 #[inline]
-fn norm(a: V3) -> f64 {
+pub(super) fn norm(a: V3) -> f64 {
     dot(a, a).sqrt()
 }
 #[inline]
-fn normalize(a: V3) -> Option<V3> {
+pub(super) fn normalize(a: V3) -> Option<V3> {
     let n = norm(a);
     if !n.is_finite() || n < 1.0e-12 {
         None
@@ -310,7 +224,7 @@ fn normalize(a: V3) -> Option<V3> {
     }
 }
 #[inline]
-fn lerp(a: V3, b: V3, t: f64) -> V3 {
+pub(super) fn lerp(a: V3, b: V3, t: f64) -> V3 {
     [
         a[0] + (b[0] - a[0]) * t,
         a[1] + (b[1] - a[1]) * t,
@@ -318,7 +232,7 @@ fn lerp(a: V3, b: V3, t: f64) -> V3 {
     ]
 }
 #[inline]
-fn bits(p: V3) -> [u64; 3] {
+pub(super) fn bits(p: V3) -> [u64; 3] {
     [p[0].to_bits(), p[1].to_bits(), p[2].to_bits()]
 }
 
@@ -362,213 +276,6 @@ fn seg_cross_param(p: V2, q: V2, a: V2, b: V2) -> Option<f64> {
     } else {
         None
     }
-}
-
-/// DIRECTED quantized closed-surface audit (0.1 mm grid): every directed edge
-/// must be cancelled by its reverse. Strictly stronger than the undirected
-/// 2-manifold check — it catches inconsistent winding and doubled coincident
-/// surfaces (two triangles sharing an edge in the SAME direction), not just
-/// cracks. Triangles that collapse to a degenerate key on the grid are skipped
-/// (their edges net to zero).
-fn directed_closed(mesh: &Mesh) -> bool {
-    let key = |i: u32| -> (i64, i64, i64) {
-        let b = i as usize * 3;
-        let q = |v: f32| (v as f64 / 1.0e-4).round() as i64;
-        (
-            q(mesh.positions[b]),
-            q(mesh.positions[b + 1]),
-            q(mesh.positions[b + 2]),
-        )
-    };
-    let mut edges: FxHashMap<((i64, i64, i64), (i64, i64, i64)), i64> = FxHashMap::default();
-    for tri in mesh.indices.chunks_exact(3) {
-        let (ka, kb, kc) = (key(tri[0]), key(tri[1]), key(tri[2]));
-        if ka == kb || kb == kc || kc == ka {
-            continue;
-        }
-        for (x, y) in [(ka, kb), (kb, kc), (kc, ka)] {
-            *edges.entry((x, y)).or_insert(0) += 1;
-            *edges.entry((y, x)).or_insert(0) -= 1;
-        }
-    }
-    !edges.is_empty() && edges.values().all(|&c| c == 0)
-}
-
-/// Closed-surface audit with a HAIRLINE tolerance: the surface passes when
-/// every unpaired directed edge (0.1 mm grid) is collinearly COVERED by
-/// unpaired edges of the opposite net sign — the signature of two adjacent
-/// faces subdividing a shared boundary line differently (a T-junction chain,
-/// invisible sub-grid gap), NOT of a missing surface. A genuine hole leaves a
-/// boundary loop whose edges have nothing opposite along them and fails. The
-/// exact kernel's own output is routinely NOT even undirected-watertight on
-/// these hosts, so this gate is still far stricter than the status quo.
-fn closed_or_hairline(mesh: &Mesh) -> bool {
-    type K = (i64, i64, i64);
-    let key = |i: u32| -> K {
-        let b = i as usize * 3;
-        let q = |v: f32| (v as f64 / 1.0e-4).round() as i64;
-        (
-            q(mesh.positions[b]),
-            q(mesh.positions[b + 1]),
-            q(mesh.positions[b + 2]),
-        )
-    };
-    let mut edges: FxHashMap<(K, K), i64> = FxHashMap::default();
-    for tri in mesh.indices.chunks_exact(3) {
-        let (ka, kb, kc) = (key(tri[0]), key(tri[1]), key(tri[2]));
-        if ka == kb || kb == kc || kc == ka {
-            continue;
-        }
-        for (x, y) in [(ka, kb), (kb, kc), (kc, ka)] {
-            *edges.entry((x, y)).or_insert(0) += 1;
-            *edges.entry((y, x)).or_insert(0) -= 1;
-        }
-    }
-    if edges.is_empty() {
-        return false;
-    }
-    // Canonicalize to undirected segments with a net sign.
-    let mut bad: Vec<(K, K, i64)> = Vec::new();
-    for (&(a, b), &c) in edges.iter() {
-        if c > 0 {
-            bad.push((a, b, c));
-        }
-    }
-    if bad.is_empty() {
-        return true;
-    }
-    if bad.len() > 64 {
-        return false; // way past hairline territory
-    }
-    let p = |k: K| [k.0 as f64, k.1 as f64, k.2 as f64]; // grid units (0.1 mm)
-
-    // Rigorous hairline test. A hairline (T-junction) boundary is one where the
-    // uncancelled directed edges, viewed as a 1-D SIGNED measure along each
-    // supporting line, net to ZERO everywhere: every stretch covered by an edge
-    // running one way is covered the SAME number of times by edges running the
-    // other way (two adjacent faces subdividing a shared line differently). A
-    // genuine hole — or a boundary edge only PARTIALLY covered, or covered the
-    // wrong number of times — leaves a stretch with nonzero net coverage and
-    // fails. This is strictly stronger than the old midpoint-proximity test,
-    // which a LONG unmatched edge could spoof merely by having a SHORT reverse
-    // edge sit near its midpoint (the short edge "covered" a single point, never
-    // the whole interval, and multiplicity was ignored entirely).
-    const COLLINEAR_TOL: f64 = 2.0; // grid units (~0.2 mm) perpendicular slack
-    const T_EPS: f64 = 1.0e-6; // grid units: ignore sub-interval slivers
-
-    struct Seg {
-        a: V3,
-        b: V3,
-        m: i64,
-    }
-    let segs: Vec<Seg> = bad
-        .iter()
-        .map(|&(a, b, c)| Seg {
-            a: p(a),
-            b: p(b),
-            m: c,
-        })
-        .collect();
-
-    // Perpendicular distance from point `x` to the infinite line `(o, dir)`
-    // (`dir` unit). Perp distance is convex along a segment, so if BOTH
-    // endpoints of a segment are within tol of a line, the whole segment is —
-    // that is our collinearity-coincidence test (no separate parallel check
-    // needed, and it correctly rejects a segment that merely crosses the line).
-    let perp = |x: V3, o: V3, dir: V3| -> f64 {
-        let w = sub(x, o);
-        let along = dot(w, dir);
-        norm(sub(w, scale(dir, along)))
-    };
-
-    struct Line {
-        o: V3,
-        dir: V3,
-        members: Vec<usize>,
-    }
-    // Seed lines from the LONGEST segments first: a long edge fixes a stable
-    // direction, so its collinear short neighbours join it rather than each
-    // spawning a slightly-rotated line of its own (greedy fragmentation would
-    // split a genuinely-covered boundary across groups and report phantom gaps).
-    let mut order: Vec<usize> = (0..segs.len()).collect();
-    order.sort_by(|&i, &j| {
-        let li = dot(sub(segs[i].b, segs[i].a), sub(segs[i].b, segs[i].a));
-        let lj = dot(sub(segs[j].b, segs[j].a), sub(segs[j].b, segs[j].a));
-        lj.partial_cmp(&li).unwrap()
-    });
-    let mut lines: Vec<Line> = Vec::new();
-    'seg: for si in order {
-        let s = &segs[si];
-        let Some(sdir) = normalize(sub(s.b, s.a)) else {
-            // Degenerate (zero-length) bad edge: cannot seal anything → defer.
-            return false;
-        };
-        for line in lines.iter_mut() {
-            if perp(s.a, line.o, line.dir) <= COLLINEAR_TOL
-                && perp(s.b, line.o, line.dir) <= COLLINEAR_TOL
-            {
-                line.members.push(si);
-                continue 'seg;
-            }
-        }
-        lines.push(Line {
-            o: s.a,
-            dir: sdir,
-            members: vec![si],
-        });
-    }
-
-    // Sweep each line's signed multiplicity coverage. At every point along the
-    // line the signed count of covering edges (this line's `+dir` edges minus
-    // its `-dir` edges, weighted by multiplicity) must net to ZERO — the exact
-    // T-junction signature. We track the longest CONTIGUOUS mis-covered run and
-    // reject once it exceeds `GAP_TOL`: a hole, a partially-covered long edge,
-    // or a multiply-covered stretch leaves a macroscopic run, whereas the ≤0.2mm
-    // sub-grid jitter of a genuine hairline stays inside the same quantization
-    // slack the collinearity grouping already allows. (This deliberately still
-    // admits the hosts whose exact-kernel meshing is itself not undirected-
-    // watertight — the documented reason the hairline gate exists — while the
-    // old midpoint test's spoof, a long edge grazed only near its midpoint by a
-    // short reverse edge, leaves a run of nearly the whole edge and is rejected.)
-    const GAP_TOL: f64 = COLLINEAR_TOL; // 2 grid units (~0.2 mm)
-    for line in &lines {
-        let mut ints: Vec<(f64, f64, i64)> = Vec::with_capacity(line.members.len());
-        let mut breaks: Vec<f64> = Vec::with_capacity(line.members.len() * 2);
-        for &si in &line.members {
-            let s = &segs[si];
-            let ta = dot(sub(s.a, line.o), line.dir);
-            let tb = dot(sub(s.b, line.o), line.dir);
-            let sign = if tb >= ta { 1 } else { -1 };
-            ints.push((ta.min(tb), ta.max(tb), sign * s.m));
-            breaks.push(ta);
-            breaks.push(tb);
-        }
-        breaks.sort_by(|x, y| x.partial_cmp(y).unwrap());
-        let mut run = 0.0_f64;
-        for w in breaks.windows(2) {
-            let (lo, hi) = (w[0], w[1]);
-            let len = hi - lo;
-            if len <= T_EPS {
-                continue;
-            }
-            let mid = 0.5 * (lo + hi);
-            let mut sum = 0i64;
-            for &(ilo, ihi, sm) in &ints {
-                if ilo - T_EPS <= mid && mid <= ihi + T_EPS {
-                    sum += sm;
-                }
-            }
-            if sum != 0 {
-                run += len;
-                if run > GAP_TOL {
-                    return false;
-                }
-            } else {
-                run = 0.0;
-            }
-        }
-    }
-    true
 }
 
 /// One host triangle in f64 (positions + per-vertex normals), host-local frame.

--- a/rust/geometry/src/router/voids/prism_cut.rs
+++ b/rust/geometry/src/router/voids/prism_cut.rs
@@ -70,6 +70,97 @@ use rustc_hash::FxHashMap;
 
 /// `IFC_LITE_PRISM_CUT=0` disables the analytic prism-subtraction path (exact
 /// kernel for every host). Default ON; read once.
+/// Make the analytic cut's NEW vertices unique at ulp scale.
+///
+/// The cut derives a crossing point once per (host face, cutter plane) pair. Two
+/// host faces that share an edge therefore compute the SAME geometric point
+/// through different arithmetic and can land a float ulp apart. The two halves of
+/// the split face then fail to share their seam, which is an unmatched half-edge
+/// pair and renders as a hairline crack.
+///
+/// `dental_clinic #217` is the minimal case. The host arriving here is clean: 12
+/// triangles, a single `x = -20.29`. The cut emits the mid-height seam at both
+/// `x = -20.289999008` and `x = -20.290000916` — exactly 2^-19 apart — giving 8
+/// unmatched edges.
+///
+/// Deliberately narrow, because a general weld is what broke this before: merging
+/// at 1e-4 m collapsed real geometry and took corpus defects from 76 to 90. Here
+/// the tolerance is 4 f32 ulps of the coordinate magnitude, which is below any
+/// real feature and above the reconstruction scatter. Vertices that coincide with
+/// a HOST vertex are pinned to the host value exactly, so the cut cannot move a
+/// vertex it did not create; the rest are merged only with each other.
+pub(crate) fn dedup_cut_vertices(cut: &Mesh, host: &Mesh) -> Mesh {
+    let cn = cut.positions.len() / 3;
+    if cn == 0 {
+        return cut.clone();
+    }
+    let mut mag = 1.0f32;
+    for &c in host.positions.iter().chain(cut.positions.iter()) {
+        mag = mag.max(c.abs());
+    }
+    let tol = (mag as f64) * (4.0 / 8_388_608.0);
+    let tol2 = tol * tol;
+    let cell = (tol * 4.0).max(f64::MIN_POSITIVE);
+    let key = |p: [f64; 3]| {
+        [
+            (p[0] / cell).floor() as i64,
+            (p[1] / cell).floor() as i64,
+            (p[2] / cell).floor() as i64,
+        ]
+    };
+    let d2 = |a: [f64; 3], b: [f64; 3]| {
+        let d = [a[0] - b[0], a[1] - b[1], a[2] - b[2]];
+        d[0] * d[0] + d[1] * d[1] + d[2] * d[2]
+    };
+
+    // Host vertices seed the pool, so any cut vertex within tolerance of one is
+    // pinned to the host's exact value rather than becoming its own
+    // representative.
+    let mut pool: FxHashMap<[i64; 3], Vec<[f64; 3]>> = FxHashMap::default();
+    for i in 0..host.positions.len() / 3 {
+        let p = [
+            host.positions[i * 3] as f64,
+            host.positions[i * 3 + 1] as f64,
+            host.positions[i * 3 + 2] as f64,
+        ];
+        pool.entry(key(p)).or_default().push(p);
+    }
+
+    let mut out = cut.clone();
+    for i in 0..cn {
+        let p = [
+            out.positions[i * 3] as f64,
+            out.positions[i * 3 + 1] as f64,
+            out.positions[i * 3 + 2] as f64,
+        ];
+        let base = key(p);
+        let mut best: Option<(f64, [f64; 3])> = None;
+        for dx in -1..=1 {
+            for dy in -1..=1 {
+                for dz in -1..=1 {
+                    if let Some(b) = pool.get(&[base[0] + dx, base[1] + dy, base[2] + dz]) {
+                        for q in b {
+                            let dd = d2(p, *q);
+                            if dd <= tol2 && best.map(|(x, _)| dd < x).unwrap_or(true) {
+                                best = Some((dd, *q));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        match best {
+            Some((_, q)) => {
+                out.positions[i * 3] = q[0] as f32;
+                out.positions[i * 3 + 1] = q[1] as f32;
+                out.positions[i * 3 + 2] = q[2] as f32;
+            }
+            None => pool.entry(base).or_default().push(p),
+        }
+    }
+    out
+}
+
 pub(super) fn enabled() -> bool {
     static ON: OnceLock<bool> = OnceLock::new();
     *ON.get_or_init(|| std::env::var("IFC_LITE_PRISM_CUT").as_deref() != Ok("0"))

--- a/rust/geometry/src/router/voids/prism_cut/closure_checks.rs
+++ b/rust/geometry/src/router/voids/prism_cut/closure_checks.rs
@@ -199,7 +199,9 @@ pub(super) fn closed_or_hairline(mesh: &Mesh) -> bool {
             breaks.push(ta);
             breaks.push(tb);
         }
-        breaks.sort_by(|x, y| x.partial_cmp(y).unwrap());
+        // `total_cmp`, matching the seed sort above: a non-finite coordinate here
+        // must reject the cut, not abort the process.
+        breaks.sort_by(|x, y| x.total_cmp(y));
         let mut run = 0.0_f64;
         for w in breaks.windows(2) {
             let (lo, hi) = (w[0], w[1]);

--- a/rust/geometry/src/router/voids/prism_cut/closure_checks.rs
+++ b/rust/geometry/src/router/voids/prism_cut/closure_checks.rs
@@ -1,0 +1,218 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Mesh-closure predicates the analytic cut self-checks its output against.
+//!
+//! Split out of `prism_cut.rs` to keep it under the module-size ratchet.
+
+use super::{dot, norm, normalize, scale, sub, V3};
+use crate::mesh::Mesh;
+use rustc_hash::FxHashMap;
+
+/// DIRECTED quantized closed-surface audit (0.1 mm grid): every directed edge
+/// must be cancelled by its reverse. Strictly stronger than the undirected
+/// 2-manifold check — it catches inconsistent winding and doubled coincident
+/// surfaces (two triangles sharing an edge in the SAME direction), not just
+/// cracks. Triangles that collapse to a degenerate key on the grid are skipped
+/// (their edges net to zero).
+pub(super) fn directed_closed(mesh: &Mesh) -> bool {
+    let key = |i: u32| -> (i64, i64, i64) {
+        let b = i as usize * 3;
+        let q = |v: f32| (v as f64 / 1.0e-4).round() as i64;
+        (
+            q(mesh.positions[b]),
+            q(mesh.positions[b + 1]),
+            q(mesh.positions[b + 2]),
+        )
+    };
+    let mut edges: FxHashMap<((i64, i64, i64), (i64, i64, i64)), i64> = FxHashMap::default();
+    for tri in mesh.indices.chunks_exact(3) {
+        let (ka, kb, kc) = (key(tri[0]), key(tri[1]), key(tri[2]));
+        if ka == kb || kb == kc || kc == ka {
+            continue;
+        }
+        for (x, y) in [(ka, kb), (kb, kc), (kc, ka)] {
+            *edges.entry((x, y)).or_insert(0) += 1;
+            *edges.entry((y, x)).or_insert(0) -= 1;
+        }
+    }
+    !edges.is_empty() && edges.values().all(|&c| c == 0)
+}
+
+/// Closed-surface audit with a HAIRLINE tolerance: the surface passes when
+/// every unpaired directed edge (0.1 mm grid) is collinearly COVERED by
+/// unpaired edges of the opposite net sign — the signature of two adjacent
+/// faces subdividing a shared boundary line differently (a T-junction chain,
+/// invisible sub-grid gap), NOT of a missing surface. A genuine hole leaves a
+/// boundary loop whose edges have nothing opposite along them and fails. The
+/// exact kernel's own output is routinely NOT even undirected-watertight on
+/// these hosts, so this gate is still far stricter than the status quo.
+pub(super) fn closed_or_hairline(mesh: &Mesh) -> bool {
+    type K = (i64, i64, i64);
+    let key = |i: u32| -> K {
+        let b = i as usize * 3;
+        let q = |v: f32| (v as f64 / 1.0e-4).round() as i64;
+        (
+            q(mesh.positions[b]),
+            q(mesh.positions[b + 1]),
+            q(mesh.positions[b + 2]),
+        )
+    };
+    let mut edges: FxHashMap<(K, K), i64> = FxHashMap::default();
+    for tri in mesh.indices.chunks_exact(3) {
+        let (ka, kb, kc) = (key(tri[0]), key(tri[1]), key(tri[2]));
+        if ka == kb || kb == kc || kc == ka {
+            continue;
+        }
+        for (x, y) in [(ka, kb), (kb, kc), (kc, ka)] {
+            *edges.entry((x, y)).or_insert(0) += 1;
+            *edges.entry((y, x)).or_insert(0) -= 1;
+        }
+    }
+    if edges.is_empty() {
+        return false;
+    }
+    // Canonicalize to undirected segments with a net sign.
+    let mut bad: Vec<(K, K, i64)> = Vec::new();
+    for (&(a, b), &c) in edges.iter() {
+        if c > 0 {
+            bad.push((a, b, c));
+        }
+    }
+    if bad.is_empty() {
+        return true;
+    }
+    if bad.len() > 64 {
+        return false; // way past hairline territory
+    }
+    let p = |k: K| [k.0 as f64, k.1 as f64, k.2 as f64]; // grid units (0.1 mm)
+
+    // Rigorous hairline test. A hairline (T-junction) boundary is one where the
+    // uncancelled directed edges, viewed as a 1-D SIGNED measure along each
+    // supporting line, net to ZERO everywhere: every stretch covered by an edge
+    // running one way is covered the SAME number of times by edges running the
+    // other way (two adjacent faces subdividing a shared line differently). A
+    // genuine hole — or a boundary edge only PARTIALLY covered, or covered the
+    // wrong number of times — leaves a stretch with nonzero net coverage and
+    // fails. This is strictly stronger than the old midpoint-proximity test,
+    // which a LONG unmatched edge could spoof merely by having a SHORT reverse
+    // edge sit near its midpoint (the short edge "covered" a single point, never
+    // the whole interval, and multiplicity was ignored entirely).
+    const COLLINEAR_TOL: f64 = 2.0; // grid units (~0.2 mm) perpendicular slack
+    const T_EPS: f64 = 1.0e-6; // grid units: ignore sub-interval slivers
+
+    struct Seg {
+        a: V3,
+        b: V3,
+        m: i64,
+    }
+    let segs: Vec<Seg> = bad
+        .iter()
+        .map(|&(a, b, c)| Seg {
+            a: p(a),
+            b: p(b),
+            m: c,
+        })
+        .collect();
+
+    // Perpendicular distance from point `x` to the infinite line `(o, dir)`
+    // (`dir` unit). Perp distance is convex along a segment, so if BOTH
+    // endpoints of a segment are within tol of a line, the whole segment is —
+    // that is our collinearity-coincidence test (no separate parallel check
+    // needed, and it correctly rejects a segment that merely crosses the line).
+    let perp = |x: V3, o: V3, dir: V3| -> f64 {
+        let w = sub(x, o);
+        let along = dot(w, dir);
+        norm(sub(w, scale(dir, along)))
+    };
+
+    struct Line {
+        o: V3,
+        dir: V3,
+        members: Vec<usize>,
+    }
+    // Seed lines from the LONGEST segments first: a long edge fixes a stable
+    // direction, so its collinear short neighbours join it rather than each
+    // spawning a slightly-rotated line of its own (greedy fragmentation would
+    // split a genuinely-covered boundary across groups and report phantom gaps).
+    let mut order: Vec<usize> = (0..segs.len()).collect();
+    order.sort_by(|&i, &j| {
+        let li = dot(sub(segs[i].b, segs[i].a), sub(segs[i].b, segs[i].a));
+        let lj = dot(sub(segs[j].b, segs[j].a), sub(segs[j].b, segs[j].a));
+        lj.partial_cmp(&li).unwrap()
+    });
+    let mut lines: Vec<Line> = Vec::new();
+    'seg: for si in order {
+        let s = &segs[si];
+        let Some(sdir) = normalize(sub(s.b, s.a)) else {
+            // Degenerate (zero-length) bad edge: cannot seal anything → defer.
+            return false;
+        };
+        for line in lines.iter_mut() {
+            if perp(s.a, line.o, line.dir) <= COLLINEAR_TOL
+                && perp(s.b, line.o, line.dir) <= COLLINEAR_TOL
+            {
+                line.members.push(si);
+                continue 'seg;
+            }
+        }
+        lines.push(Line {
+            o: s.a,
+            dir: sdir,
+            members: vec![si],
+        });
+    }
+
+    // Sweep each line's signed multiplicity coverage. At every point along the
+    // line the signed count of covering edges (this line's `+dir` edges minus
+    // its `-dir` edges, weighted by multiplicity) must net to ZERO — the exact
+    // T-junction signature. We track the longest CONTIGUOUS mis-covered run and
+    // reject once it exceeds `GAP_TOL`: a hole, a partially-covered long edge,
+    // or a multiply-covered stretch leaves a macroscopic run, whereas the ≤0.2mm
+    // sub-grid jitter of a genuine hairline stays inside the same quantization
+    // slack the collinearity grouping already allows. (This deliberately still
+    // admits the hosts whose exact-kernel meshing is itself not undirected-
+    // watertight — the documented reason the hairline gate exists — while the
+    // old midpoint test's spoof, a long edge grazed only near its midpoint by a
+    // short reverse edge, leaves a run of nearly the whole edge and is rejected.)
+    const GAP_TOL: f64 = COLLINEAR_TOL; // 2 grid units (~0.2 mm)
+    for line in &lines {
+        let mut ints: Vec<(f64, f64, i64)> = Vec::with_capacity(line.members.len());
+        let mut breaks: Vec<f64> = Vec::with_capacity(line.members.len() * 2);
+        for &si in &line.members {
+            let s = &segs[si];
+            let ta = dot(sub(s.a, line.o), line.dir);
+            let tb = dot(sub(s.b, line.o), line.dir);
+            let sign = if tb >= ta { 1 } else { -1 };
+            ints.push((ta.min(tb), ta.max(tb), sign * s.m));
+            breaks.push(ta);
+            breaks.push(tb);
+        }
+        breaks.sort_by(|x, y| x.partial_cmp(y).unwrap());
+        let mut run = 0.0_f64;
+        for w in breaks.windows(2) {
+            let (lo, hi) = (w[0], w[1]);
+            let len = hi - lo;
+            if len <= T_EPS {
+                continue;
+            }
+            let mid = 0.5 * (lo + hi);
+            let mut sum = 0i64;
+            for &(ilo, ihi, sm) in &ints {
+                if ilo - T_EPS <= mid && mid <= ihi + T_EPS {
+                    sum += sm;
+                }
+            }
+            if sum != 0 {
+                run += len;
+                if run > GAP_TOL {
+                    return false;
+                }
+            } else {
+                run = 0.0;
+            }
+        }
+    }
+    true
+}

--- a/rust/geometry/src/router/voids/prism_cut/closure_checks.rs
+++ b/rust/geometry/src/router/voids/prism_cut/closure_checks.rs
@@ -74,12 +74,20 @@ pub(super) fn closed_or_hairline(mesh: &Mesh) -> bool {
         return false;
     }
     // Canonicalize to undirected segments with a net sign.
+    //
+    // Sorted by endpoint key, NOT left in `edges` iteration order: `FxHashMap`
+    // iterates target-dependently, and the length sort below is not a total order,
+    // so equal-length segments would seed the line grouping in an arbitrary order
+    // that differs between native and wasm32. The grouping is greedy, so a
+    // different seed can reach a different verdict. (Pre-existing; surfaced when
+    // this moved out of `prism_cut.rs`.)
     let mut bad: Vec<(K, K, i64)> = Vec::new();
     for (&(a, b), &c) in edges.iter() {
         if c > 0 {
             bad.push((a, b, c));
         }
     }
+    bad.sort_unstable_by_key(|&(a, b, _)| (a, b));
     if bad.is_empty() {
         return true;
     }
@@ -140,7 +148,9 @@ pub(super) fn closed_or_hairline(mesh: &Mesh) -> bool {
     order.sort_by(|&i, &j| {
         let li = dot(sub(segs[i].b, segs[i].a), sub(segs[i].b, segs[i].a));
         let lj = dot(sub(segs[j].b, segs[j].a), sub(segs[j].b, segs[j].a));
-        lj.partial_cmp(&li).unwrap()
+        // `total_cmp` + index tie-break: a total order, so the seed sequence is a
+        // pure function of `bad` (already canonically sorted above).
+        lj.total_cmp(&li).then(i.cmp(&j))
     });
     let mut lines: Vec<Line> = Vec::new();
     'seg: for si in order {

--- a/rust/geometry/src/router/voids/prism_cut/vertex_dedup.rs
+++ b/rust/geometry/src/router/voids/prism_cut/vertex_dedup.rs
@@ -1,0 +1,101 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Ulp-scale unification of the analytic cut's new vertices.
+//!
+//! Split out of `prism_cut.rs` to keep it under the module-size ratchet.
+
+use crate::mesh::Mesh;
+use rustc_hash::FxHashMap;
+
+/// Make the analytic cut's NEW vertices unique at ulp scale.
+///
+/// The cut derives a crossing point once per (host face, cutter plane) pair. Two
+/// host faces that share an edge therefore compute the SAME geometric point
+/// through different arithmetic and can land a float ulp apart. The two halves of
+/// the split face then fail to share their seam, which is an unmatched half-edge
+/// pair and renders as a hairline crack.
+///
+/// `dental_clinic #217` is the minimal case. The host arriving here is clean: 12
+/// triangles, a single `x = -20.29`. The cut emits the mid-height seam at both
+/// `x = -20.289999008` and `x = -20.290000916` — exactly 2^-19 apart — giving 8
+/// unmatched edges.
+///
+/// Deliberately narrow, because a general weld is what broke this before: merging
+/// at 1e-4 m collapsed real geometry and took corpus defects from 76 to 90. Here
+/// the tolerance is 4 f32 ulps of the coordinate magnitude, which is below any
+/// real feature and above the reconstruction scatter. Vertices that coincide with
+/// a HOST vertex are pinned to the host value exactly, so the cut cannot move a
+/// vertex it did not create; the rest are merged only with each other.
+pub(crate) fn dedup_cut_vertices(cut: &Mesh, host: &Mesh) -> Mesh {
+    let cn = cut.positions.len() / 3;
+    if cn == 0 {
+        return cut.clone();
+    }
+    let mut mag = 1.0f32;
+    for &c in host.positions.iter().chain(cut.positions.iter()) {
+        mag = mag.max(c.abs());
+    }
+    let tol = (mag as f64) * (4.0 / 8_388_608.0);
+    let tol2 = tol * tol;
+    let cell = (tol * 4.0).max(f64::MIN_POSITIVE);
+    let key = |p: [f64; 3]| {
+        [
+            (p[0] / cell).floor() as i64,
+            (p[1] / cell).floor() as i64,
+            (p[2] / cell).floor() as i64,
+        ]
+    };
+    let d2 = |a: [f64; 3], b: [f64; 3]| {
+        let d = [a[0] - b[0], a[1] - b[1], a[2] - b[2]];
+        d[0] * d[0] + d[1] * d[1] + d[2] * d[2]
+    };
+
+    // Host vertices seed the pool, so any cut vertex within tolerance of one is
+    // pinned to the host's exact value rather than becoming its own
+    // representative.
+    let mut pool: FxHashMap<[i64; 3], Vec<[f64; 3]>> = FxHashMap::default();
+    for i in 0..host.positions.len() / 3 {
+        let p = [
+            host.positions[i * 3] as f64,
+            host.positions[i * 3 + 1] as f64,
+            host.positions[i * 3 + 2] as f64,
+        ];
+        pool.entry(key(p)).or_default().push(p);
+    }
+
+    let mut out = cut.clone();
+    for i in 0..cn {
+        let p = [
+            out.positions[i * 3] as f64,
+            out.positions[i * 3 + 1] as f64,
+            out.positions[i * 3 + 2] as f64,
+        ];
+        let base = key(p);
+        let mut best: Option<(f64, [f64; 3])> = None;
+        for dx in -1..=1 {
+            for dy in -1..=1 {
+                for dz in -1..=1 {
+                    if let Some(b) = pool.get(&[base[0] + dx, base[1] + dy, base[2] + dz]) {
+                        for q in b {
+                            let dd = d2(p, *q);
+                            if dd <= tol2 && best.map(|(x, _)| dd < x).unwrap_or(true) {
+                                best = Some((dd, *q));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        match best {
+            Some((_, q)) => {
+                out.positions[i * 3] = q[0] as f32;
+                out.positions[i * 3 + 1] = q[1] as f32;
+                out.positions[i * 3 + 2] = q[2] as f32;
+            }
+            None => pool.entry(base).or_default().push(p),
+        }
+    }
+    out
+}

--- a/rust/geometry/src/triangulation.rs
+++ b/rust/geometry/src/triangulation.rs
@@ -56,6 +56,22 @@ pub(crate) fn safe_earcut(
     // consecutive/closing duplicates needs no sanitisation, no classification,
     // and no index remap — hand it straight to earcutr, zero-copy. Profile
     // triangulation sits on the hot path for EVERY face in the pipeline.
+    // DIFFERENTIAL ORACLE (test builds with `triangulation-alt` only): hand the
+    // same polygon to a second, independent ear-clipper. Both give valid
+    // triangulations with the same boundary and area; only interior diagonals
+    // differ, and nothing downstream may depend on that choice.
+    #[cfg(feature = "triangulation-alt")]
+    if std::env::var_os("IFCLITE_TRIANGULATION_ALT").is_some() {
+        let mut out: Vec<usize> = Vec::new();
+        let mut ec = earcut::Earcut::new();
+        ec.earcut(
+            data.chunks_exact(2).map(|c| [c[0], c[1]]),
+            hole_indices,
+            &mut out,
+        );
+        return Ok(out);
+    }
+
     if hole_indices.is_empty() {
         let has_dup = n >= 2
             && ((0..n - 1).any(|v| {

--- a/rust/geometry/src/triangulation.rs
+++ b/rust/geometry/src/triangulation.rs
@@ -12,7 +12,7 @@
 //! contract.
 
 #[cfg(feature = "triangulation-alt")]
-mod alt_oracle;
+pub(crate) mod alt_oracle;
 mod ring_geom;
 use ring_geom::{point_in_ring, ring_bbox};
 
@@ -45,6 +45,17 @@ use crate::{Error, Point2, Point3, Result, Vector3};
 ///
 /// Returned indices are remapped to the CALLER's original vertex order, so
 /// call sites keep indexing their own arrays.
+/// Ear-clip one sanitised ring group. The ONLY place `safe_earcut` reaches a
+/// triangulator, so the test-only oracle can stand in here and see byte-identical
+/// input to the production path.
+fn ear_clip(data: &[f64], hole_indices: &[usize]) -> std::result::Result<Vec<usize>, String> {
+    #[cfg(feature = "triangulation-alt")]
+    if let Some(alt) = alt_oracle::maybe_earcut(data, hole_indices) {
+        return Ok(alt);
+    }
+    earcutr::earcut(data, hole_indices, 2).map_err(|e| format!("{e:?}"))
+}
+
 pub(crate) fn safe_earcut(
     data: &[f64],
     hole_indices: &[usize],
@@ -61,18 +72,13 @@ pub(crate) fn safe_earcut(
     // consecutive/closing duplicates needs no sanitisation, no classification,
     // and no index remap — hand it straight to earcutr, zero-copy. Profile
     // triangulation sits on the hot path for EVERY face in the pipeline.
-    #[cfg(feature = "triangulation-alt")]
-    if let Some(alt) = alt_oracle::maybe_earcut(data, hole_indices) {
-        return Ok(alt);
-    }
-
     if hole_indices.is_empty() {
         let has_dup = n >= 2
             && ((0..n - 1).any(|v| {
                 data[v * 2] == data[v * 2 + 2] && data[v * 2 + 1] == data[v * 2 + 3]
             }) || (data[0] == data[(n - 1) * 2] && data[1] == data[(n - 1) * 2 + 1]));
         if !has_dup {
-            return earcutr::earcut(data, &[], 2).map_err(|e| format!("{:?}", e));
+            return ear_clip(data, &[]);
         }
     }
 
@@ -170,14 +176,14 @@ pub(crate) fn safe_earcut(
             coords.extend_from_slice(&rings[ring_no].0);
             orig.extend_from_slice(&rings[ring_no].1);
         }
-        let indices = earcutr::earcut(&coords, &holes, 2).map_err(|e| format!("{:?}", e))?;
+        let indices = ear_clip(&coords, &holes)?;
         out.extend(indices.into_iter().map(|i| orig[i]));
     }
 
     // Disjoint "holes" render as their own hole-less polygons.
     for &ring_no in &separate_polys {
         let (coords, orig) = &rings[ring_no];
-        let indices = earcutr::earcut(coords, &[], 2).map_err(|e| format!("{:?}", e))?;
+        let indices = ear_clip(coords, &[])?;
         out.extend(indices.into_iter().map(|i| orig[i]));
     }
 

--- a/rust/geometry/src/triangulation.rs
+++ b/rust/geometry/src/triangulation.rs
@@ -11,6 +11,11 @@
 //! `crate::cdt` for the determinism / watertightness / bounded-refinement
 //! contract.
 
+#[cfg(feature = "triangulation-alt")]
+mod alt_oracle;
+mod ring_geom;
+use ring_geom::{point_in_ring, ring_bbox};
+
 use crate::{Error, Point2, Point3, Result, Vector3};
 
 /// Guarded ear-clipping — the ONLY sanctioned way to call `earcutr` in this
@@ -56,20 +61,9 @@ pub(crate) fn safe_earcut(
     // consecutive/closing duplicates needs no sanitisation, no classification,
     // and no index remap — hand it straight to earcutr, zero-copy. Profile
     // triangulation sits on the hot path for EVERY face in the pipeline.
-    // DIFFERENTIAL ORACLE (test builds with `triangulation-alt` only): hand the
-    // same polygon to a second, independent ear-clipper. Both give valid
-    // triangulations with the same boundary and area; only interior diagonals
-    // differ, and nothing downstream may depend on that choice.
     #[cfg(feature = "triangulation-alt")]
-    if std::env::var_os("IFCLITE_TRIANGULATION_ALT").is_some() {
-        let mut out: Vec<usize> = Vec::new();
-        let mut ec = earcut::Earcut::new();
-        ec.earcut(
-            data.chunks_exact(2).map(|c| [c[0], c[1]]),
-            hole_indices,
-            &mut out,
-        );
-        return Ok(out);
+    if let Some(alt) = alt_oracle::maybe_earcut(data, hole_indices) {
+        return Ok(alt);
     }
 
     if hole_indices.is_empty() {
@@ -188,35 +182,6 @@ pub(crate) fn safe_earcut(
     }
 
     Ok(out)
-}
-
-/// Axis-aligned bbox of a flat `[x0,y0,x1,y1,…]` ring: `(min_x, min_y, max_x, max_y)`.
-fn ring_bbox(coords: &[f64]) -> (f64, f64, f64, f64) {
-    let (mut min_x, mut min_y) = (f64::INFINITY, f64::INFINITY);
-    let (mut max_x, mut max_y) = (f64::NEG_INFINITY, f64::NEG_INFINITY);
-    for p in coords.chunks_exact(2) {
-        min_x = min_x.min(p[0]);
-        min_y = min_y.min(p[1]);
-        max_x = max_x.max(p[0]);
-        max_y = max_y.max(p[1]);
-    }
-    (min_x, min_y, max_x, max_y)
-}
-
-/// Even-odd ray cast of `(x, y)` against a flat `[x0,y0,…]` ring.
-fn point_in_ring(x: f64, y: f64, ring: &[f64]) -> bool {
-    let n = ring.len() / 2;
-    let mut inside = false;
-    let mut j = n - 1;
-    for i in 0..n {
-        let (xi, yi) = (ring[i * 2], ring[i * 2 + 1]);
-        let (xj, yj) = (ring[j * 2], ring[j * 2 + 1]);
-        if ((yi > y) != (yj > y)) && (x < (xj - xi) * (y - yi) / (yj - yi) + xi) {
-            inside = !inside;
-        }
-        j = i;
-    }
-    inside
 }
 
 /// Check if a polygon is convex (all cross products have same sign)

--- a/rust/geometry/src/triangulation/alt_oracle.rs
+++ b/rust/geometry/src/triangulation/alt_oracle.rs
@@ -5,15 +5,43 @@
 //! Test-only differential oracle: a SECOND, independent ear-clipper.
 //!
 //! Both libraries give valid triangulations with the same boundary and area; only
-//! the interior diagonals differ, and nothing downstream may depend on that choice.
-//! `tests/triangulation_invariance.rs` measures whether anything does. Selected at
-//! run time by `IFCLITE_TRIANGULATION_ALT` so one process can do both.
+//! the interior diagonals differ, and nothing downstream may depend on that
+//! choice. `tests/triangulation_invariance.rs` measures whether anything does.
 //!
-//! Split out of `triangulation.rs` to keep it under the module-size ratchet.
+//! Substituted at `safe_earcut`'s OWN `earcutr` call sites, never ahead of them, so
+//! both triangulators receive the identical sanitised rings. Swapping earlier would
+//! hand the oracle raw input and make the sweep partly measure `safe_earcut`'s
+//! duplicate-stripping and hole classification rather than diagonal choice.
+//!
+//! Selection is an `AtomicBool`, not an env var: the library reads it per face on a
+//! rayon-parallel hot path, and `std::env::set_var` is neither thread-safe nor safe
+//! under edition 2024. The env var is honoured once, as an initialiser only.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Once;
+
+static ALT: AtomicBool = AtomicBool::new(false);
+static INIT: Once = Once::new();
+
+/// Turn the oracle on or off for this process. Test-side driver.
+pub fn set_alt_triangulator(on: bool) {
+    INIT.call_once(|| {});
+    ALT.store(on, Ordering::Relaxed);
+}
+
+fn armed() -> bool {
+    INIT.call_once(|| {
+        if std::env::var_os("IFCLITE_TRIANGULATION_ALT").is_some() {
+            ALT.store(true, Ordering::Relaxed);
+        }
+    });
+    ALT.load(Ordering::Relaxed)
+}
 
 /// `Some(indices)` when the oracle is armed, `None` to use the production path.
+/// Signature mirrors `earcutr::earcut(data, hole_indices, 2)`.
 pub(super) fn maybe_earcut(data: &[f64], hole_indices: &[usize]) -> Option<Vec<usize>> {
-    if std::env::var_os("IFCLITE_TRIANGULATION_ALT").is_none() {
+    if !armed() {
         return None;
     }
     let mut out: Vec<usize> = Vec::new();

--- a/rust/geometry/src/triangulation/alt_oracle.rs
+++ b/rust/geometry/src/triangulation/alt_oracle.rs
@@ -1,0 +1,27 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Test-only differential oracle: a SECOND, independent ear-clipper.
+//!
+//! Both libraries give valid triangulations with the same boundary and area; only
+//! the interior diagonals differ, and nothing downstream may depend on that choice.
+//! `tests/triangulation_invariance.rs` measures whether anything does. Selected at
+//! run time by `IFCLITE_TRIANGULATION_ALT` so one process can do both.
+//!
+//! Split out of `triangulation.rs` to keep it under the module-size ratchet.
+
+/// `Some(indices)` when the oracle is armed, `None` to use the production path.
+pub(super) fn maybe_earcut(data: &[f64], hole_indices: &[usize]) -> Option<Vec<usize>> {
+    if std::env::var_os("IFCLITE_TRIANGULATION_ALT").is_none() {
+        return None;
+    }
+    let mut out: Vec<usize> = Vec::new();
+    let mut ec = earcut::Earcut::new();
+    ec.earcut(
+        data.chunks_exact(2).map(|c| [c[0], c[1]]),
+        hole_indices,
+        &mut out,
+    );
+    Some(out)
+}

--- a/rust/geometry/src/triangulation/ring_geom.rs
+++ b/rust/geometry/src/triangulation/ring_geom.rs
@@ -1,0 +1,36 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Ring bbox + point-in-ring, used by `safe_earcut`'s hole classification.
+//!
+//! Split out of `triangulation.rs` to keep it under the module-size ratchet.
+
+/// Axis-aligned bbox of a flat `[x0,y0,x1,y1,…]` ring: `(min_x, min_y, max_x, max_y)`.
+pub(super) fn ring_bbox(coords: &[f64]) -> (f64, f64, f64, f64) {
+    let (mut min_x, mut min_y) = (f64::INFINITY, f64::INFINITY);
+    let (mut max_x, mut max_y) = (f64::NEG_INFINITY, f64::NEG_INFINITY);
+    for p in coords.chunks_exact(2) {
+        min_x = min_x.min(p[0]);
+        min_y = min_y.min(p[1]);
+        max_x = max_x.max(p[0]);
+        max_y = max_y.max(p[1]);
+    }
+    (min_x, min_y, max_x, max_y)
+}
+
+/// Even-odd ray cast of `(x, y)` against a flat `[x0,y0,…]` ring.
+pub(super) fn point_in_ring(x: f64, y: f64, ring: &[f64]) -> bool {
+    let n = ring.len() / 2;
+    let mut inside = false;
+    let mut j = n - 1;
+    for i in 0..n {
+        let (xi, yi) = (ring[i * 2], ring[i * 2 + 1]);
+        let (xj, yj) = (ring[j * 2], ring[j * 2 + 1]);
+        if ((yi > y) != (yj > y)) && (x < (xj - xi) * (y - yi) / (yj - yi) + xi) {
+            inside = !inside;
+        }
+        j = i;
+    }
+    inside
+}

--- a/rust/geometry/tests/snapshots/annex_e__advanced__bath-csg-solid_780.snap
+++ b/rust/geometry/tests/snapshots/annex_e__advanced__bath-csg-solid_780.snap
@@ -7,8 +7,8 @@ parse_ok: true
 products_attempted: 2
 products_non_empty: 1
 process_errors: 1
-total_triangles: 128
-total_vertices: 384
+total_triangles: 152
+total_vertices: 216
 spike_triangles: 0
 total_surface_area: 10.797
 bbox_min: [0.000, 0.000, 0.000]

--- a/rust/geometry/tests/triangulation_invariance.rs
+++ b/rust/geometry/tests/triangulation_invariance.rs
@@ -62,13 +62,17 @@ fn discover_models() -> Vec<PathBuf> {
         .map(|files| {
             files
                 .iter()
-                .filter(|f| {
-                    f["path"].as_str().is_some_and(|p| p.ends_with(".ifc"))
-                        && f["size"].as_u64().is_some_and(|s| s <= MAX_FIXTURE_BYTES)
-                })
+                .filter(|f| f["path"].as_str().is_some_and(|p| p.ends_with(".ifc")))
                 .filter_map(|f| f["path"].as_str())
                 .map(|rel| models.join(rel))
-                .filter(|p| p.is_file())
+                // Size checked against the file ON DISK, not the manifest's recorded
+                // `size`: a stale manifest or a replaced fetch would otherwise let an
+                // oversized fixture through and silently change the swept population.
+                .filter(|p| {
+                    std::fs::metadata(p)
+                        .map(|m| m.is_file() && m.len() <= MAX_FIXTURE_BYTES)
+                        .unwrap_or(false)
+                })
                 .collect()
         })
         .unwrap_or_default();
@@ -491,7 +495,8 @@ fn watertightness_is_invariant_to_the_triangulator() {
     }
     // Is the tear population explained by coordinate magnitude rather than by
     // the boolean? f32 cannot carry mm topology far from the origin.
-    let mut near = (0usize, 0usize); // (pre-broken, csg-broke) with |coord| < 1e4
+    // (pre-broken, csg-broke), split at `F32_SAFE_MAGNITUDE`.
+    let mut near = (0usize, 0usize);
     let mut far = (0usize, 0usize);
     for (i, (rep, _, _, _)) in torn.iter().enumerate() {
         if !is_closed_solid(rep) {

--- a/rust/geometry/tests/triangulation_invariance.rs
+++ b/rust/geometry/tests/triangulation_invariance.rs
@@ -77,14 +77,14 @@ fn discover_models() -> Vec<PathBuf> {
 /// with `Closed = .T.` is a solid. Treating the whole bucket as open is a
 /// simplification that UNDER-counts defects; revisit when the 209 is worked
 /// down.
-const BASELINE_NON_INVARIANT: usize = 139;
-const BASELINE_TORN_SOLID: usize = 80;
+const BASELINE_NON_INVARIANT: usize = 136;
+const BASELINE_TORN_SOLID: usize = 41;
 /// Total torn void hosts across the corpus, and hosts carrying at least one
 /// snap-collapsed triangle. Gated so the µm-scatter fix in
 /// `prism_cut::dedup_cut_vertices` cannot silently regress: it took these from
 /// 257 and 61 respectively.
-const BASELINE_TORN_TOTAL: usize = 238;
-const BASELINE_COLLAPSED: usize = 55;
+const BASELINE_TORN_TOTAL: usize = 199;
+const BASELINE_COLLAPSED: usize = 51;
 /// TOTAL unmatched edges across the corpus, not just the COUNT of torn elements.
 ///
 /// Element counts alone are severity-blind, and that nearly shipped a bad fix: a
@@ -92,7 +92,7 @@ const BASELINE_COLLAPSED: usize = 55;
 /// driving one reveal wall from 42 unpaired edges to 324. Both readings are "one
 /// torn element", so the element gate saw only the improvement. Gate the total so
 /// a fix cannot trade many small tears for a few catastrophic ones.
-const BASELINE_OPEN_EDGE_TOTAL: usize = 18_252;
+const BASELINE_OPEN_EDGE_TOTAL: usize = 17_792;
 
 /// Representation types that describe a CLOSED solid and are therefore
 /// legitimately expected to produce watertight geometry.

--- a/rust/geometry/tests/triangulation_invariance.rs
+++ b/rust/geometry/tests/triangulation_invariance.rs
@@ -33,32 +33,45 @@ use ifc_lite_geometry::{propagate_voids_to_parts, GeometryRouter, Mesh};
 use rustc_hash::FxHashMap;
 use std::path::PathBuf;
 
-/// Every `.ifc` under `tests/models` up to `MAX_FIXTURE_BYTES`, discovered at
-/// run time so new fixtures widen coverage without touching this file.
+/// The gated corpus: every `.ifc` in `tests/models/manifest.json` up to
+/// `MAX_FIXTURE_BYTES`, resolved on disk.
+///
+/// Driven by the MANIFEST, not by walking the filesystem. No fixture is tracked in
+/// git — they are all fetched by `scripts/fixtures/fetch-fixtures.mjs` — so a
+/// filesystem walk measures whatever a given machine happens to have accumulated.
+/// That is how the pinned baselines first ended up calibrated to one developer's
+/// disk (116 models / 1355 void hosts) while CI swept a different population (111 /
+/// 1165), which made the ceilings meaningless on CI. The manifest is the same
+/// everywhere, so the population is too, and adding a fixture to it still widens
+/// coverage for free.
 const MAX_FIXTURE_BYTES: u64 = 50 * 1024 * 1024;
 
 fn discover_models() -> Vec<PathBuf> {
-    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+    let models = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("..")
         .join("..")
         .join("tests/models");
-    let mut out = Vec::new();
-    let mut stack = vec![root];
-    while let Some(dir) = stack.pop() {
-        let Ok(entries) = std::fs::read_dir(&dir) else {
-            continue;
-        };
-        for e in entries.flatten() {
-            let p = e.path();
-            if p.is_dir() {
-                stack.push(p);
-            } else if p.extension().is_some_and(|x| x.eq_ignore_ascii_case("ifc"))
-                && e.metadata().map(|m| m.len() <= MAX_FIXTURE_BYTES).unwrap_or(false)
-            {
-                out.push(p);
-            }
-        }
-    }
+    let Ok(raw) = std::fs::read_to_string(models.join("manifest.json")) else {
+        return Vec::new();
+    };
+    let Ok(json) = serde_json::from_str::<serde_json::Value>(&raw) else {
+        return Vec::new();
+    };
+    let mut out: Vec<PathBuf> = json["files"]
+        .as_array()
+        .map(|files| {
+            files
+                .iter()
+                .filter(|f| {
+                    f["path"].as_str().is_some_and(|p| p.ends_with(".ifc"))
+                        && f["size"].as_u64().is_some_and(|s| s <= MAX_FIXTURE_BYTES)
+                })
+                .filter_map(|f| f["path"].as_str())
+                .map(|rel| models.join(rel))
+                .filter(|p| p.is_file())
+                .collect()
+        })
+        .unwrap_or_default();
     out.sort();
     out
 }
@@ -96,9 +109,11 @@ const BASELINE_COLLAPSED: usize = 51;
 const BASELINE_OPEN_EDGE_TOTAL: usize = 17_792;
 
 /// Corpus floor. The ceilings above are all upper bounds, so without this a tree
-/// with no fixtures passes every one of them while measuring nothing.
-const MIN_MODELS: usize = 100;
-const MIN_VOID_HOSTS: usize = 1300;
+/// with no fixtures passes every one of them while measuring nothing. Set just under
+/// the manifest's full population (111 models / 1165 void hosts) so a single failed
+/// fixture fetch does not red the build, but an unpopulated tree cannot pass.
+const MIN_MODELS: usize = 105;
+const MIN_VOID_HOSTS: usize = 1100;
 
 /// Representation types that describe a CLOSED solid and are therefore
 /// legitimately expected to produce watertight geometry.

--- a/rust/geometry/tests/triangulation_invariance.rs
+++ b/rust/geometry/tests/triangulation_invariance.rs
@@ -77,7 +77,7 @@ fn discover_models() -> Vec<PathBuf> {
 /// with `Closed = .T.` is a solid. Treating the whole bucket as open is a
 /// simplification that UNDER-counts defects; revisit when the 209 is worked
 /// down.
-const BASELINE_NON_INVARIANT: usize = 136;
+const BASELINE_NON_INVARIANT: usize = 133;
 const BASELINE_TORN_SOLID: usize = 41;
 /// Total torn void hosts across the corpus, and hosts carrying at least one
 /// snap-collapsed triangle. Gated so the µm-scatter fix in
@@ -94,11 +94,26 @@ const BASELINE_COLLAPSED: usize = 51;
 /// a fix cannot trade many small tears for a few catastrophic ones.
 const BASELINE_OPEN_EDGE_TOTAL: usize = 17_792;
 
+/// Corpus floor. The ceilings above are all upper bounds, so without this a tree
+/// with no fixtures passes every one of them while measuring nothing.
+const MIN_MODELS: usize = 100;
+const MIN_VOID_HOSTS: usize = 1300;
+
 /// Representation types that describe a CLOSED solid and are therefore
 /// legitimately expected to produce watertight geometry.
 fn is_closed_solid(rep: &str) -> bool {
     matches!(rep, "SweptSolid" | "CSG" | "Clipping" | "Brep" | "AdvancedBrep")
 }
+
+/// Arm/disarm the differential oracle. A no-op without the feature, so this file
+/// still compiles in the default `cargo test --workspace` run, where the test body
+/// early-returns anyway.
+#[cfg(feature = "triangulation-alt")]
+fn set_alt(on: bool) {
+    ifc_lite_geometry::set_alt_triangulator(on);
+}
+#[cfg(not(feature = "triangulation-alt"))]
+fn set_alt(_on: bool) {}
 
 fn void_index(content: &str) -> FxHashMap<u32, Vec<u32>> {
     let mut idx: FxHashMap<u32, Vec<u32>> = FxHashMap::default();
@@ -298,7 +313,7 @@ fn representation_type(content: &str, id: u32) -> String {
 /// preserve millimetre topology, and seams crack for reasons that have nothing to
 /// do with the boolean.
 /// Magnitude below which f32 comfortably carries the 1 mm topology this metric
-/// measures. The f32 step is `2^-23 * magnitude`, so at 1e4 it is already 1.2 mm
+/// measures. The f32 step is `2^-23 * magnitude`, so at 1e4 it would already be 1.2 mm
 /// — coarser than the snap bucket, which means f32 merge artifacts would still be
 /// counted as tears. 1e3 gives a 0.12 mm step, a 10x margin.
 const F32_SAFE_MAGNITUDE: f64 = 1.0e3;
@@ -357,13 +372,13 @@ fn watertightness_is_invariant_to_the_triangulator() {
         hosts.sort_unstable();
 
         for id in hosts {
-            std::env::remove_var("IFCLITE_TRIANGULATION_ALT");
+            set_alt(false);
             let Some(base) = process(&content, id, &voids) else {
                 continue;
             };
-            std::env::set_var("IFCLITE_TRIANGULATION_ALT", "1");
+            set_alt(true);
             let alt = process(&content, id, &voids);
-            std::env::remove_var("IFCLITE_TRIANGULATION_ALT");
+            set_alt(false);
 
             swept += 1;
             let bo = open_boundary_edges(&base);
@@ -521,8 +536,18 @@ fn watertightness_is_invariant_to_the_triangulator() {
     println!("far-field (below RTC, f32 cannot hold mm): {} not gated", far.0 + far.1);
     println!("non-invariant total: {} (baseline {BASELINE_NON_INVARIANT})", divergences.len());
 
+    // FLOOR. Every other assertion here is an upper bound, so a missing or partial
+    // `tests/models` tree (shallow clone, fixtures not fetched, path drift) yields
+    // zeros and a green run that certifies nothing. Pin the corpus size too.
     assert!(
-        BASELINE_OPEN_EDGE_TOTAL == 0 || open_edge_total <= BASELINE_OPEN_EDGE_TOTAL,
+        models_seen >= MIN_MODELS && swept >= MIN_VOID_HOSTS,
+        "corpus under-populated: {models_seen} models / {swept} void hosts, expected \
+         at least {MIN_MODELS} / {MIN_VOID_HOSTS} — fixtures missing, so the ceilings \
+         below would pass vacuously"
+    );
+
+    assert!(
+        open_edge_total <= BASELINE_OPEN_EDGE_TOTAL,
         "total unmatched edges grew: {open_edge_total} > {BASELINE_OPEN_EDGE_TOTAL}"
     );
     assert!(

--- a/rust/geometry/tests/triangulation_invariance.rs
+++ b/rust/geometry/tests/triangulation_invariance.rs
@@ -23,9 +23,10 @@
 //! Without the feature the test reports that it was skipped and passes, so the
 //! default `cargo test` stays fast.
 //!
-//! `KNOWN_NON_INVARIANT` records elements already known to depend on diagonal
-//! choice. It is a defect ledger to drive to zero, not a permanent allowance:
-//! anything NOT on it that starts differing fails the test.
+//! The pinned `BASELINE_*` constants are ceilings, not an allow-list: each is a
+//! defect count to drive DOWN, and the test fails if any grows. `MIN_MODELS` /
+//! `MIN_VOID_HOSTS` are the matching floor, so a corpus that failed to load cannot
+//! satisfy the ceilings vacuously.
 
 use ifc_lite_core::{build_entity_index, EntityDecoder, EntityScanner};
 use ifc_lite_geometry::{propagate_voids_to_parts, GeometryRouter, Mesh};
@@ -75,8 +76,8 @@ fn discover_models() -> Vec<PathBuf> {
 ///
 /// NB: `Tessellation` is only conditionally open — an `IfcTriangulatedFaceSet`
 /// with `Closed = .T.` is a solid. Treating the whole bucket as open is a
-/// simplification that UNDER-counts defects; revisit when the 209 is worked
-/// down.
+/// simplification that UNDER-counts defects; revisit once `BASELINE_TORN_SOLID` is
+/// worked down.
 const BASELINE_NON_INVARIANT: usize = 133;
 const BASELINE_TORN_SOLID: usize = 41;
 /// Total torn void hosts across the corpus, and hosts carrying at least one

--- a/rust/geometry/tests/triangulation_invariance.rs
+++ b/rust/geometry/tests/triangulation_invariance.rs
@@ -1,0 +1,546 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Is the pipeline invariant to the triangulator's DIAGONAL CHOICE?
+//!
+//! Ear-clipping picks interior diagonals by a heuristic. For a given polygon
+//! many diagonal sets are equally valid: same boundary edges, same total area,
+//! same triangle count, no overlap, no degenerate triangles. Nothing downstream
+//! is entitled to depend on which one it gets. Where something does, output
+//! watertightness is accidental, and any triangulator change, version bump or
+//! fast-path refactor can silently tear geometry.
+//!
+//! The measurement: process every void-hosting element twice, once through each
+//! of two independent ear-clippers, and compare open boundary edges. The second
+//! triangulator lives behind the `triangulation-alt` feature and is selected at
+//! run time by `IFCLITE_TRIANGULATION_ALT`.
+//!
+//! Run:
+//!   cargo test -p ifc-lite-geometry --features triangulation-alt \
+//!     --test triangulation_invariance -- --nocapture
+//!
+//! Without the feature the test reports that it was skipped and passes, so the
+//! default `cargo test` stays fast.
+//!
+//! `KNOWN_NON_INVARIANT` records elements already known to depend on diagonal
+//! choice. It is a defect ledger to drive to zero, not a permanent allowance:
+//! anything NOT on it that starts differing fails the test.
+
+use ifc_lite_core::{build_entity_index, EntityDecoder, EntityScanner};
+use ifc_lite_geometry::{propagate_voids_to_parts, GeometryRouter, Mesh};
+use rustc_hash::FxHashMap;
+use std::path::PathBuf;
+
+/// Every `.ifc` under `tests/models` up to `MAX_FIXTURE_BYTES`, discovered at
+/// run time so new fixtures widen coverage without touching this file.
+const MAX_FIXTURE_BYTES: u64 = 50 * 1024 * 1024;
+
+fn discover_models() -> Vec<PathBuf> {
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .join("tests/models");
+    let mut out = Vec::new();
+    let mut stack = vec![root];
+    while let Some(dir) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for e in entries.flatten() {
+            let p = e.path();
+            if p.is_dir() {
+                stack.push(p);
+            } else if p.extension().is_some_and(|x| x.eq_ignore_ascii_case("ifc"))
+                && e.metadata().map(|m| m.len() <= MAX_FIXTURE_BYTES).unwrap_or(false)
+            {
+                out.push(p);
+            }
+        }
+    }
+    out.sort();
+    out
+}
+
+/// Pinned baselines over the auto-discovered corpus (116 fixtures, 1355 void
+/// hosts, measured 2026-07-29). Counted only for hosts whose coordinates are
+/// small enough that f32 can carry millimetre topology (see `max_abs_coord`);
+/// far-field hosts are reported but not gated, because this harness runs below
+/// the pipeline's RTC offset and their tears are an artifact of that, not of the
+/// geometry. Both are defect counts to drive DOWN; the test
+/// fails if either grows. `TORN_SOLID` is the number that matters: hosts whose
+/// Body representation is a closed solid and which are nonetheless not
+/// watertight. SurfaceModel and Tessellation are reported separately because
+/// they need not close.
+///
+/// NB: `Tessellation` is only conditionally open — an `IfcTriangulatedFaceSet`
+/// with `Closed = .T.` is a solid. Treating the whole bucket as open is a
+/// simplification that UNDER-counts defects; revisit when the 209 is worked
+/// down.
+const BASELINE_NON_INVARIANT: usize = 139;
+const BASELINE_TORN_SOLID: usize = 80;
+/// Total torn void hosts across the corpus, and hosts carrying at least one
+/// snap-collapsed triangle. Gated so the µm-scatter fix in
+/// `prism_cut::dedup_cut_vertices` cannot silently regress: it took these from
+/// 257 and 61 respectively.
+const BASELINE_TORN_TOTAL: usize = 238;
+const BASELINE_COLLAPSED: usize = 55;
+/// TOTAL unmatched edges across the corpus, not just the COUNT of torn elements.
+///
+/// Element counts alone are severity-blind, and that nearly shipped a bad fix: a
+/// seam-preserving consolidation took torn elements from 76 down to 62 while
+/// driving one reveal wall from 42 unpaired edges to 324. Both readings are "one
+/// torn element", so the element gate saw only the improvement. Gate the total so
+/// a fix cannot trade many small tears for a few catastrophic ones.
+const BASELINE_OPEN_EDGE_TOTAL: usize = 18_252;
+
+/// Representation types that describe a CLOSED solid and are therefore
+/// legitimately expected to produce watertight geometry.
+fn is_closed_solid(rep: &str) -> bool {
+    matches!(rep, "SweptSolid" | "CSG" | "Clipping" | "Brep" | "AdvancedBrep")
+}
+
+fn void_index(content: &str) -> FxHashMap<u32, Vec<u32>> {
+    let mut idx: FxHashMap<u32, Vec<u32>> = FxHashMap::default();
+    let mut scanner = EntityScanner::new(content);
+    let mut decoder = EntityDecoder::new(content);
+    while let Some((id, name, start, end)) = scanner.next_entity() {
+        if name == "IFCRELVOIDSELEMENT" {
+            if let Ok(entity) = decoder.decode_at_with_id(id, start, end) {
+                if let (Some(host), Some(opening)) = (entity.get_ref(4), entity.get_ref(5)) {
+                    idx.entry(host).or_default().push(opening);
+                }
+            }
+        }
+    }
+    let _ = propagate_voids_to_parts(&mut idx, content, &mut decoder);
+    idx
+}
+
+/// Same element with NO voids applied: isolates solid construction from CSG.
+fn process_no_voids(content: &str, host_id: u32) -> Option<Mesh> {
+    let ei = build_entity_index(content);
+    let mut decoder = EntityDecoder::with_index(content, ei);
+    let entity = decoder.decode_by_id(host_id).ok()?;
+    let router = GeometryRouter::with_units(content, &mut decoder);
+    router.process_element(&entity, &mut decoder).ok()
+}
+
+fn process(content: &str, host_id: u32, voids: &FxHashMap<u32, Vec<u32>>) -> Option<Mesh> {
+    let ei = build_entity_index(content);
+    let mut decoder = EntityDecoder::with_index(content, ei);
+    let entity = decoder.decode_by_id(host_id).ok()?;
+    let router = GeometryRouter::with_units(content, &mut decoder);
+    router.process_element_with_voids(&entity, &mut decoder, voids).ok()
+}
+
+/// Open boundary edges on a 1 mm position-snapped topology, and separately the
+/// count of DEGENERATE edges (both endpoints snapping to one position).
+///
+/// The distinction is load-bearing. A degenerate edge is a self-loop produced by
+/// a triangle that collapsed under the snap, which happens wholesale on
+/// georeferenced models: `Mesh.positions` is f32, and at UTM-scale coordinates
+/// (~5e5) the f32 step is ~3 cm, so a 200 mm wall cannot be represented at all.
+/// The pipeline's RTC offset exists to prevent that, but it is applied ABOVE
+/// `GeometryRouter::process_element`, which this harness calls directly. Counting
+/// self-loops as open boundary would therefore measure a harness artifact rather
+/// than a watertightness defect.
+fn edge_stats(mesh: &Mesh) -> (usize, usize) {
+    let q = |v: f32| (v as f64 * 1.0e3).round() as i64;
+    let mut vid: FxHashMap<(i64, i64, i64), u32> = FxHashMap::default();
+    let mut id = |i: usize| -> u32 {
+        let k = (
+            q(mesh.positions[i * 3]),
+            q(mesh.positions[i * 3 + 1]),
+            q(mesh.positions[i * 3 + 2]),
+        );
+        let n = vid.len() as u32;
+        *vid.entry(k).or_insert(n)
+    };
+    let mut bal: FxHashMap<(u32, u32), i32> = FxHashMap::default();
+    let mut degenerate = 0usize;
+    for tri in mesh.indices.chunks_exact(3) {
+        let (a, b, c) = (id(tri[0] as usize), id(tri[1] as usize), id(tri[2] as usize));
+        if a == b || b == c || c == a {
+            degenerate += 1;
+            continue; // a collapsed triangle has no meaningful boundary
+        }
+        for (x, y) in [(a, b), (b, c), (c, a)] {
+            let (k, s) = if x < y { ((x, y), 1) } else { ((y, x), -1) };
+            *bal.entry(k).or_insert(0) += s;
+        }
+    }
+    (bal.values().filter(|&&v| v != 0).count(), degenerate)
+}
+
+fn open_boundary_edges(mesh: &Mesh) -> usize {
+    edge_stats(mesh).0
+}
+
+/// `RepresentationType` of an element's **Body** representation, read from the
+/// STEP text. Prefers the `Body` identifier over `Axis`/`FootPrint`, and
+/// resolves `MappedRepresentation` through `IFCMAPPEDITEM` ->
+/// `IFCREPRESENTATIONMAP` to the source representation, because the mapped
+/// wrapper says nothing about whether the geometry closes.
+///
+/// This decides whether a torn element is a defect or correct output: a
+/// `SurfaceModel` or an `Axis` curve has no watertightness to lose.
+fn representation_type(content: &str, id: u32) -> String {
+    fn line_of(content: &str, eid: u32) -> Option<&str> {
+        let pat = format!("\n#{eid}=");
+        let i = content.find(&pat)? + 1;
+        let j = content[i..].find(';')? + i;
+        Some(&content[i..j])
+    }
+    fn refs(line: &str) -> Vec<u32> {
+        let mut out = Vec::new();
+        let b = line.as_bytes();
+        let mut i = 0;
+        while i < b.len() {
+            if b[i] == b'#' {
+                let mut j = i + 1;
+                while j < b.len() && b[j].is_ascii_digit() {
+                    j += 1;
+                }
+                if j > i + 1 {
+                    if let Ok(v) = line[i + 1..j].parse::<u32>() {
+                        out.push(v);
+                    }
+                }
+                i = j;
+            } else {
+                i += 1;
+            }
+        }
+        out
+    }
+    /// (identifier, type) of an IFCSHAPEREPRESENTATION line.
+    fn ident_and_type(line: &str) -> Option<(String, String)> {
+        if !line.contains("IFCSHAPEREPRESENTATION") {
+            return None;
+        }
+        let q: Vec<&str> = line.split('\'').collect();
+        if q.len() >= 4 {
+            Some((q[1].to_string(), q[3].to_string()))
+        } else {
+            None
+        }
+    }
+    /// Follow a MappedRepresentation to the type of the mapped source.
+    fn resolve_mapped(content: &str, rep_line: &str, depth: usize) -> Option<String> {
+        if depth == 0 {
+            return None;
+        }
+        for item in refs(rep_line) {
+            let Some(l) = line_of(content, item) else { continue };
+            if !l.contains("IFCMAPPEDITEM") {
+                continue;
+            }
+            for m in refs(l) {
+                let Some(ml) = line_of(content, m) else { continue };
+                if !ml.contains("IFCREPRESENTATIONMAP") {
+                    continue;
+                }
+                for src in refs(ml) {
+                    let Some(sl) = line_of(content, src) else { continue };
+                    if let Some((_, t)) = ident_and_type(sl) {
+                        if t == "MappedRepresentation" {
+                            if let Some(inner) = resolve_mapped(content, sl, depth - 1) {
+                                return Some(inner);
+                            }
+                        }
+                        return Some(t);
+                    }
+                }
+            }
+        }
+        None
+    }
+
+    // Collect every shape representation reachable from the element.
+    let mut found: Vec<(String, String, String)> = Vec::new(); // ident, type, line
+    let mut frontier = vec![id];
+    let mut seen = std::collections::HashSet::new();
+    for _ in 0..5 {
+        let mut next = Vec::new();
+        for e in frontier {
+            if !seen.insert(e) {
+                continue;
+            }
+            let Some(l) = line_of(content, e) else { continue };
+            if let Some((ident, t)) = ident_and_type(l) {
+                found.push((ident, t, l.to_string()));
+                continue; // do not descend into representation items
+            }
+            next.extend(refs(l));
+        }
+        frontier = next;
+    }
+    if found.is_empty() {
+        return "unknown".to_string();
+    }
+    // Prefer Body; fall back to whatever is there.
+    let pick = found
+        .iter()
+        .find(|(ident, _, _)| ident == "Body")
+        .unwrap_or(&found[0]);
+    if pick.1 == "MappedRepresentation" {
+        if let Some(t) = resolve_mapped(content, &pick.2, 4) {
+            return t;
+        }
+    }
+    pick.1.clone()
+}
+
+/// Largest absolute coordinate in the mesh. f32 has ~24 bits of mantissa, so the
+/// representable step is `2^-23 * magnitude`: about 1 mm at 8 km, but ~6 cm at
+/// UTM scale (5e5). Above ~1e4 the f64 -> f32 downcast in `tris_to_mesh` cannot
+/// preserve millimetre topology, and seams crack for reasons that have nothing to
+/// do with the boolean.
+/// Magnitude below which f32 comfortably carries the 1 mm topology this metric
+/// measures. The f32 step is `2^-23 * magnitude`, so at 1e4 it is already 1.2 mm
+/// — coarser than the snap bucket, which means f32 merge artifacts would still be
+/// counted as tears. 1e3 gives a 0.12 mm step, a 10x margin.
+const F32_SAFE_MAGNITUDE: f64 = 1.0e3;
+
+fn max_abs_coord(mesh: &Mesh) -> f64 {
+    mesh.positions.iter().fold(0.0f64, |m, &v| m.max((v as f64).abs()))
+}
+
+struct Divergence {
+    model: String,
+    id: u32,
+    base_open: usize,
+    alt_open: Option<usize>,
+    base_tris: usize,
+    alt_tris: usize,
+}
+
+#[test]
+fn watertightness_is_invariant_to_the_triangulator() {
+    if cfg!(not(feature = "triangulation-alt")) {
+        eprintln!(
+            "SKIPPED: rerun with --features triangulation-alt to enable the \
+             differential oracle"
+        );
+        return;
+    }
+
+    let mut divergences: Vec<Divergence> = Vec::new();
+    // Absolute census: hosts that are not watertight AT ALL, independent of
+    // which triangulator ran. Separate defect class from non-invariance.
+    let mut torn: Vec<(String, String, u32, usize)> = Vec::new();
+    // Open edges of the SAME element with no voids applied, index-aligned to `torn`.
+    let mut pre_tears: Vec<usize> = Vec::new();
+    let mut tri_counts: Vec<usize> = Vec::new();
+    // Hosts with at least one triangle collapsed by the 1 mm snap: f32 precision
+    // loss on large coordinates, not a topology defect.
+    let mut collapsed = 0usize;
+    let mut open_edge_total = 0usize;
+    // Largest |coordinate| per torn host, index-aligned to `torn`.
+    let mut mags: Vec<f64> = Vec::new();
+    let mut swept = 0usize;
+    let mut models_seen = 0usize;
+
+    let models = discover_models();
+    for path in &models {
+        let Ok(content) = std::fs::read_to_string(path) else {
+            continue;
+        };
+        models_seen += 1;
+        let basename = path
+            .file_name()
+            .map(|f| f.to_string_lossy().into_owned())
+            .unwrap_or_default();
+        let voids = void_index(&content);
+        let mut hosts: Vec<u32> = voids.keys().copied().collect();
+        hosts.sort_unstable();
+
+        for id in hosts {
+            std::env::remove_var("IFCLITE_TRIANGULATION_ALT");
+            let Some(base) = process(&content, id, &voids) else {
+                continue;
+            };
+            std::env::set_var("IFCLITE_TRIANGULATION_ALT", "1");
+            let alt = process(&content, id, &voids);
+            std::env::remove_var("IFCLITE_TRIANGULATION_ALT");
+
+            swept += 1;
+            let bo = open_boundary_edges(&base);
+            if edge_stats(&base).1 > 0 {
+                collapsed += 1;
+            }
+            open_edge_total += bo;
+            if bo > 0 {
+                mags.push(max_abs_coord(&base));
+                let rep = representation_type(&content, id);
+                // Was it already torn BEFORE any boolean?
+                let pre = process_no_voids(&content, id)
+                    .map(|m| open_boundary_edges(&m))
+                    .unwrap_or(usize::MAX);
+                torn.push((rep, basename.clone(), id, bo));
+                pre_tears.push(pre);
+                tri_counts.push(base.indices.len() / 3);
+            }
+            match alt {
+                None => divergences.push(Divergence {
+                    model: basename.clone(),
+                    id,
+                    base_open: bo,
+                    alt_open: None,
+                    base_tris: base.indices.len() / 3,
+                    alt_tris: 0,
+                }),
+                Some(alt) => {
+                    let ao = open_boundary_edges(&alt);
+                    if bo != ao {
+                        divergences.push(Divergence {
+                            model: basename.clone(),
+                            id,
+                            base_open: bo,
+                            alt_open: Some(ao),
+                            base_tris: base.indices.len() / 3,
+                            alt_tris: alt.indices.len() / 3,
+                        });
+                    }
+                }
+            }
+        }
+    }
+
+    println!("\n=== watertightness census (production triangulator) ===");
+    println!("void hosts torn: {}/{swept}", torn.len());
+    println!("hosts with collapsed triangles (f32 precision): {collapsed}/{swept}");
+    println!("TOTAL unmatched edges across corpus: {open_edge_total}");
+    let mut by_rep: std::collections::BTreeMap<String, usize> = Default::default();
+    for (rep, _, _, _) in &torn {
+        *by_rep.entry(rep.clone()).or_insert(0) += 1;
+    }
+    println!("\n  torn hosts by representation type:");
+    for (rep, n) in &by_rep {
+        let closed = matches!(rep.as_str(), "SweptSolid" | "CSG" | "Clipping" | "Brep" | "AdvancedBrep");
+        println!("  {:<20} {:>5}   {}", rep, n, if closed { "<- SHOULD be watertight" } else { "open by design" });
+    }
+
+    println!("\n=== triangulation invariance sweep ===");
+    println!("models swept  : {models_seen} (of {} discovered)", models.len());
+    println!("void hosts    : {swept}");
+    println!("non-invariant : {}", divergences.len());
+    if !divergences.is_empty() {
+        println!("\n  model / element             open(base -> alt)    tris(base -> alt)");
+        for d in &divergences {
+            let alt_open = match d.alt_open {
+                None => "PROCESS FAILED".to_string(),
+                Some(v) => v.to_string(),
+            };
+            println!(
+                "  {:<27} {:>4} -> {:<13} {:>5} -> {}",
+                format!("{} #{}", d.model, d.id),
+                d.base_open,
+                alt_open,
+                d.base_tris,
+                d.alt_tris
+            );
+        }
+    }
+
+    // Split closed-solid tears by whether the boolean caused them.
+    let mut pre_broken = 0usize;
+    let mut csg_broke = 0usize;
+    let mut pre_failed = 0usize;
+    for (i, (rep, _, _, _)) in torn.iter().enumerate() {
+        if !is_closed_solid(rep) {
+            continue;
+        }
+        match pre_tears[i] {
+            usize::MAX => pre_failed += 1,
+            0 => csg_broke += 1,
+            _ => pre_broken += 1,
+        }
+    }
+    // Is the tear population explained by coordinate magnitude rather than by
+    // the boolean? f32 cannot carry mm topology far from the origin.
+    let mut near = (0usize, 0usize); // (pre-broken, csg-broke) with |coord| < 1e4
+    let mut far = (0usize, 0usize);
+    for (i, (rep, _, _, _)) in torn.iter().enumerate() {
+        if !is_closed_solid(rep) {
+            continue;
+        }
+        let bucket = if mags[i] < F32_SAFE_MAGNITUDE { &mut near } else { &mut far };
+        match pre_tears[i] {
+            0 => bucket.1 += 1,
+            usize::MAX => {}
+            _ => bucket.0 += 1,
+        }
+    }
+    println!("\n  closed-solid tears by coordinate magnitude:");
+    println!("    |coord| <  {F32_SAFE_MAGNITUDE:e} (f32 step 0.12 mm) : {} pre-broken, {} csg-broke", near.0, near.1);
+    println!("    |coord| >= {F32_SAFE_MAGNITUDE:e} (f32 too coarse)   : {} pre-broken, {} csg-broke", far.0, far.1);
+
+    println!("\n  closed-solid tears, by origin:");
+    println!("    already torn BEFORE any boolean : {pre_broken}   <- solid construction");
+    println!("    watertight before, torn after   : {csg_broke}   <- CSG kernel");
+    println!("    no-void processing failed       : {pre_failed}");
+
+    // Smallest pre-broken closed solids: minimal reproducers for the
+    // construction-path defect.
+    let mut pre: Vec<(&str, &str, u32, usize, usize)> = torn
+        .iter()
+        .enumerate()
+        .filter(|(i, (rep, _, _, _))| is_closed_solid(rep) && pre_tears[*i] > 0 && pre_tears[*i] != usize::MAX)
+        .map(|(i, (rep, m, id, _))| (rep.as_str(), m.as_str(), *id, pre_tears[i], tri_counts[i]))
+        .collect();
+    pre.sort_by_key(|r| (r.4, r.3));
+    // Minimal reproducers for the kernel defect: watertight solid in, torn out,
+    // at coordinates f32 handles cleanly.
+    let mut kern: Vec<(&str, &str, u32, usize, usize)> = torn
+        .iter()
+        .enumerate()
+        .filter(|(i, (rep, _, _, _))| {
+            is_closed_solid(rep) && pre_tears[*i] == 0 && mags[*i] < F32_SAFE_MAGNITUDE
+        })
+        .map(|(i, (rep, m, id, open))| (rep.as_str(), m.as_str(), *id, *open, tri_counts[i]))
+        .collect();
+    kern.sort_by_key(|r| (r.4, r.3));
+    println!("\n  smallest KERNEL-caused tears (watertight in, torn out, f32-safe):");
+    println!("    rep            model / element                  open  tris");
+    for (rep, m, id, open, tris) in kern.iter().take(12) {
+        println!("    {:<14} {:<32} {:>4}  {:>5}", rep, format!("{m} #{id}"), open, tris);
+    }
+
+    println!("\n  smallest pre-broken closed solids (no voids applied):");
+    println!("    rep            model / element                  open  tris");
+    for (rep, m, id, open, tris) in pre.iter().take(15) {
+        println!("    {:<14} {:<32} {:>4}  {:>5}", rep, format!("{m} #{id}"), open, tris);
+    }
+
+    let torn_solid = near.0 + near.1;
+    println!("\ngenuine defects (closed solid, f32-safe coordinates): {torn_solid} (baseline {BASELINE_TORN_SOLID})");
+    println!("  of which the boolean caused: {}", near.1);
+    println!("  of which arrived torn      : {}", near.0);
+    println!("far-field (below RTC, f32 cannot hold mm): {} not gated", far.0 + far.1);
+    println!("non-invariant total: {} (baseline {BASELINE_NON_INVARIANT})", divergences.len());
+
+    assert!(
+        BASELINE_OPEN_EDGE_TOTAL == 0 || open_edge_total <= BASELINE_OPEN_EDGE_TOTAL,
+        "total unmatched edges grew: {open_edge_total} > {BASELINE_OPEN_EDGE_TOTAL}"
+    );
+    assert!(
+        torn.len() <= BASELINE_TORN_TOTAL,
+        "total torn void hosts grew: {} > {BASELINE_TORN_TOTAL}",
+        torn.len()
+    );
+    assert!(
+        collapsed <= BASELINE_COLLAPSED,
+        "hosts with snap-collapsed triangles grew: {collapsed} > {BASELINE_COLLAPSED}"
+    );
+    assert!(
+        torn_solid <= BASELINE_TORN_SOLID,
+        "closed-solid elements that are not watertight grew: {torn_solid} > {BASELINE_TORN_SOLID}"
+    );
+    assert!(
+        divergences.len() <= BASELINE_NON_INVARIANT,
+        "elements depending on the triangulator's diagonal choice grew: {} > {BASELINE_NON_INVARIANT}",
+        divergences.len()
+    );
+}

--- a/scripts/perf/README.md
+++ b/scripts/perf/README.md
@@ -112,6 +112,32 @@ WASM-specific structural cost (not in the native probe, by design):
 Encoded so a spike does not re-walk a dead end. History lives in the PRs cited.
 
 ### Shipped wins
+- **CDT: kill the three O(T)-per-item scans**: ISSUE_129 geometry 1568 -> 646 ms
+  (main, pre-seam-conform, is 979), **byte-identical output** on 8 fixtures incl.
+  advanced_model (FNV over every mesh). The quality CDT — not the seam conform —
+  was the whole cost of `consolidate_coplanar`; the conform's own work
+  (`build_seam_map` + `conform_plans`) measures 20 of 1400 CDT cpu-ms, so
+  "the conform is slow" was a mis-frame. What was actually slow, per instrumented
+  slot-visit counts on one ISSUE_129 load:
+  (1) `insert_steiner` renumbered every triangle to splice each Steiner point in
+  below the super vertices — **1.07e9** index touches. Fixed by reserving the
+  Steiner budget below the super verts at build time, so ids never move.
+  (2) `edge_exists` re-scanned every triangle per constraint probe — **4.7e8**
+  slot visits. Fixed by materialising the alive-edge set once in
+  `enforce_constraints` and applying the flip delta (drop `u-w`, add `apex-q`).
+  (3) `locate` was an O(T) canonical scan per inserted point — **2.2e8** slot
+  visits. Fixed by a walk from the previous insertion that only answers when the
+  triangle STRICTLY contains the point (unique ⇒ same answer as the scan) and
+  falls back to the scan on the on-edge tie-break.
+  Two smaller ones with the same shape: the encroachment test scanned all
+  constraints per skinny candidate (5.9e7 disk tests -> a CSR grid built once per
+  refinement), and `constraints` served millions of membership probes from a
+  BTreeSet (now an FxHashSet mirror; the BTreeSet stays for the recovery ORDER,
+  which is target-independence-critical).
+  **Lesson:** all five are output-identical by construction, so the fix is
+  measurement, not risk-taking — but only after instrumenting. The prior
+  hypothesis chain (lazy seam map, x-range prune, CDT caching by clone/move) all
+  measured ~zero because they targeted the 20 ms, not the 1400.
 - **Fast first-geometry** (#1185): ship index/styles/first-wave at scan-complete;
   22s -> 11.8s wall to first paint. Overlap parse + geometry.
 - **Faceted-brep dedup** (#1184) + **CartesianPoint cache hoist** (#1568/#1572):


### PR DESCRIPTION
## What

Void-cut geometry left T-junctions that render as hairline cracks. `consolidate_coplanar`
re-triangulates each coplanar plane bucket independently, and its collinear simplify could
drop a boundary vertex the abutting bucket keeps: the shared edge is then one long edge on
one side against two short ones on the other.

Minimal case `dental_clinic.ifc` #217 — a 12-triangle wall, watertight with no voids, comes
out of one opening subtract with **6 unmatched half-edges**. The end face splits at
mid-height while both corner verticals keep their full-height edge.

## The discrimination this rests on

A blanket "protect shared vertices" rule does not work: on the #098 reveal wall it drives
unpaired edges from 42 to **324**, because a faceted reveal shares almost every vertex and
blanket protection defeats the merge the simplify exists to perform. Narrowing to
non-parallel neighbours only reaches 298.

What actually separates the two cases is **the simplify's own judgment, read across
buckets**:

- a genuine seam vertex is a hard corner in the abutting bucket, so it survives *that*
  bucket's simplify and gets recorded;
- an `i_overlay` phantom is near-collinear in every bucket that touches it, is dropped
  everywhere, and therefore never becomes an insertion source.

No geometric proxy for "is this a real corner" is needed.

## How

Three phases over the existing bucket map:

- **A** unions / welds / simplifies as today, and records each surviving ring vertex at
  0.1 mm with the count of distinct buckets that kept it.
- **B** inserts, per bucket, the vertices some *other* bucket kept that lie on this
  bucket's plane and strictly interior to one of its ring edges. The plane test is the
  strong filter, so the scan stays cheap.
- **C** triangulates and emits in today's order.

Today's output is emitted **first**, and the conformed mesh is taken only when it is fully
watertight. So an already-watertight host pays nothing, and **no host can come out worse
than before** — the change is monotone by construction.

Two decisions that are measured, not cautious:

- **All-or-nothing accept.** Accepting partial improvements sends a half-conformed
  intermediate into the next sequential cut and compounds: it lowered the per-cut count on
  all seven of #098's cuts yet ended at 282 unpaired edges. At a zero bar the wall improves
  to 22.
- **0.1 mm decision grid**, not the 1 mm default. At 1 mm a chorded seam merges away and
  reads as closed — which is exactly what accepted the 282.

Also unifies the analytic prism cut's new crossing vertices at ulp scale: `prism_cut`
derives a crossing once per (host face, cutter plane) pair, so two faces sharing an edge
computed the same point one float step apart (`x = -20.289999008` vs `-20.290000916`,
exactly 2^-19).

## Measured, 116 fixtures / 1355 void-hosting elements

| metric | before | after |
|---|---|---|
| total unmatched boundary edges | 18252 | **17792** |
| elements with any tear | 238 | **199** |
| closed-solid body, not watertight | 80 | **41** |
| of which boolean-caused | 52 | **28** |
| of which arrived torn | 28 | **13** |
| triangulator-sensitive | 139 | **136** |
| snap-collapsed | 55 | **51** |
| #098 reveal wall unpaired edges | 42 | **22** |
| dental_clinic #217 | 6 | **0** (watertight) |

Every metric strictly better.

## New gate

`tests/triangulation_invariance.rs` (behind the test-only `triangulation-alt` feature,
which links a second independent ear-clipper as a differential oracle). It auto-discovers
every `.ifc` under `tests/models` up to 50 MB and asserts five pinned baselines, all
re-pinned to the improved numbers here.

It gates **total unmatched edges**, not just the count of torn elements, because element
counts are severity-blind: an earlier attempt took torn elements from 76 to 62 while
driving one wall from 42 unpaired edges to 324, and an element-count gate reads both as
"one torn element".

The harness also segments by `IfcShapeRepresentation`, since `Curve2D`/`Curve3D` axis
representations and `SurfaceModel` cannot be watertight, and excludes triangles collapsed
by the snap (georeferenced models below the RTC offset sit at UTM coordinates where the f32
step is ~3 cm).

## Module split

The new code would have blown three `module_size_ratchet` budgets. Rather than raise them,
the affected files were split so all three **shrink**:

- `consolidate.rs` 990 -> 825 (budget 956)
- `prism_cut.rs` 3251 -> 2958 (budget 3160)
- `triangulation.rs` 798 -> 763 (budget 782)

New files: `consolidate/{conform,ring_ops}.rs`,
`prism_cut/{closure_checks,vertex_dedup}.rs`, `triangulation/{alt_oracle,ring_geom}.rs` —
all under 400 lines, none needing an allowlist row.

## Verification

- 82 `ifc-lite-geometry` targets + 35 `ifc-lite-processing` targets green
- `clippy --all-targets` clean; `cargo check --workspace --all-targets` clean
- `mesh_determinism` manifest **unchanged** (native + the wasm pairing assertion)
- `module_size_ratchet` passes
- arm64 and wasm32 cross-compile clean
- corpus census re-run after the module split: byte-identical numbers
- one snapshot re-pinned, `annex_e__advanced__bath-csg-solid_780`: 128 -> 152 triangles,
  384 -> 216 vertices, with `total_surface_area`, `bbox_min`, `bbox_max` and
  `spike_triangles` **identical**

## Known trade-off

Conforming adds vertices, so hosts that get accepted grow: #217 goes 14 -> 26 triangles and
the #780 bath 128 -> 152. `bath_csg_solid_test`'s `tris < 180` ceiling still passes but its
headroom drops from 52 to 28.

Remaining: 28 boolean-caused closed-solid defects are untouched by construction, since the
all-or-nothing bar makes the pass a no-op on any host it cannot fully close.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved void-cut coplanar seam conformance to better preserve true seam vertices while avoiding near-collinear phantom inserts, reducing hairline cracks and boundary mismatches.
  * Enhanced analytic prism-cut seams by deduplicating cut vertices against the host mesh, improving numerical consistency, and tightening when conformed output is emitted (watertight completeness required).

* **Performance / Geometry Quality**
  * Improved constrained Delaunay triangulation determinism and refinement efficiency via bounded, more robust refinement and constraint handling.

* **Tests / CI**
  * Updated triangulation invariance coverage to a manifest-driven corpus and strengthened CI watertightness/invariance sweeps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->