### PR TITLE
fix(renderer): stop the pick path aborting on a dead GPU device (#1901)

### DIFF
--- a/.changeset/renderer-pick-guards-dead-device.md
+++ b/.changeset/renderer-pick-guards-dead-device.md
@@ -1,0 +1,27 @@
+---
+'@ifc-lite/renderer': patch
+---
+
+`Renderer.pick()` / `pickRect()` no longer drive a destroyed or lost GPU device.
+
+`render()` and `getGPUDevice()` both early-return once the device is gone; the
+pick path skipped that contract entirely. A pick is a full GPU round trip that
+ends in a `mapAsync` readback, so on a dead device the readback rejects with
+`AbortError: Failed to execute 'mapAsync' on 'GPUBuffer': A valid external
+Instance reference no longer exists.` Nothing on the pick path is in a position
+to handle it — the DOM click/contextmenu listeners that reach it are `async`
+functions whose promise nobody awaits — so it escaped as an unhandled
+rejection. And because the picker stayed dead, this was not a one-shot teardown
+race: it fired again on every subsequent click at a frozen viewport.
+
+`pick()` now resolves `null` and `pickRect()` an empty set once
+`isDeviceLost()` is true or the device is uninitialised, mirroring how
+`render()` degrades to skipping the frame. The GPU call is never issued, so no
+error is being hidden — consumers that want to react to the loss still
+subscribe to `onDeviceLost()`.
+
+Two supporting leaks are closed: `Renderer.destroy()` now also clears the
+picker reference held by the internal picking manager (it previously nulled
+only its own, leaving the manager pointing at a destroyed picker), and `Picker`
+— a public export usable standalone — now honours its own `destroyed` flag in
+`pick()` / `pickRect()` instead of only in `destroy()`.

--- a/.changeset/renderer-pick-guards-dead-device.md
+++ b/.changeset/renderer-pick-guards-dead-device.md
@@ -20,6 +20,14 @@ race: it fired again on every subsequent click at a frozen viewport.
 error is being hidden — consumers that want to react to the loss still
 subscribe to `onDeviceLost()`.
 
+The entry guard cannot close the window between `queue.submit()` and the map
+settling: a pick that was legal when it started is still aborted if the canvas
+unmounts, the model reloads (`Renderer.destroy()` ends in `device.destroy()`)
+or the driver resets while the readback is in flight — same `AbortError`, same
+escaping rejection. `Picker` now treats an `AbortError` from its own readback
+as "the device went away" and degrades to no hit. Only `AbortError` is caught:
+a validation fault rejects with `OperationError` and still propagates.
+
 Two supporting leaks are closed: `Renderer.destroy()` now also clears the
 picker reference held by the internal picking manager (it previously nulled
 only its own, leaving the manager pointing at a destroyed picker), and `Picker`

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -2985,9 +2985,34 @@ export class Renderer {
      *
      * Note: x, y are CSS pixel coordinates relative to the canvas element.
      * These are scaled internally to match the actual canvas pixel dimensions.
+     *
+     * Resolves null once the device is gone — see `pickPathAlive()`.
      */
     async pick(x: number, y: number, options?: PickOptions): Promise<PickResult | null> {
+        if (!this.pickPathAlive()) return null;
         return this.pickingManager.pick(x, y, options, this.activePickClip());
+    }
+
+    /**
+     * Whether the GPU pick path can still run — the same liveness contract
+     * `render()` and `getGPUDevice()` apply, which the pick path used to skip.
+     *
+     * A pick is a full GPU round trip (render pass, `copyTextureToBuffer`,
+     * `mapAsync` readback). Once the device is destroyed or lost, that readback
+     * never completes: Chromium rejects the pending map with an AbortError
+     * ("A valid external Instance reference no longer exists"). Nothing on the
+     * pick path is in a position to handle it — the DOM click/contextmenu
+     * handlers that reach here are `async` listeners whose promise nobody
+     * awaits — so it escapes as an unhandled rejection, once per click, for as
+     * long as the user keeps clicking a frozen viewport (#1901).
+     *
+     * Callers therefore degrade to "no hit" instead of throwing, matching how
+     * `render()` degrades to "skip the frame". This is not a swallow: the GPU
+     * call is never issued, so no error is being hidden. Consumers that want to
+     * react to the loss subscribe to `onDeviceLost()`.
+     */
+    private pickPathAlive(): boolean {
+        return !this.deviceLost && this.device.isInitialized();
     }
 
     /**
@@ -3006,6 +3031,8 @@ export class Renderer {
      *
      * See `PickingManager.pickRect` for the visibility-filter +
      * limitation notes.
+     *
+     * Resolves an empty set once the device is gone — see `pickPathAlive()`.
      */
     async pickRect(
         x0: number,
@@ -3014,6 +3041,7 @@ export class Renderer {
         y1: number,
         options?: PickOptions,
     ): Promise<Set<number>> {
+        if (!this.pickPathAlive()) return new Set();
         return this.pickingManager.pickRect(x0, y0, x1, y1, options, this.activePickClip());
     }
 
@@ -3513,9 +3541,13 @@ export class Renderer {
         this.pipeline?.destroy();
         this.pipeline = null;
 
-        // Picker GPU resources
+        // Picker GPU resources. The manager holds its own reference, so clear
+        // that too — otherwise its `if (!this.picker) return null` guard keeps
+        // pointing at a destroyed picker and a stray click still drives dead
+        // GPU resources (#1901).
         this.picker?.destroy();
         this.picker = null;
+        this.pickingManager.setPicker(null);
 
         // Post-processor uniform buffer
         this.postProcessor?.destroy();

--- a/packages/renderer/src/picker.ts
+++ b/packages/renderer/src/picker.ts
@@ -41,6 +41,49 @@ function unprojectPickSample(
   return MathUtils.transformPoint(inv, { x: ndcX, y: ndcY, z: depth });
 }
 
+/**
+ * Whether a rejected `mapAsync` readback means "the GPU resource went away"
+ * rather than "we asked for something illegal".
+ *
+ * WebGPU only rejects a map with `AbortError` when the thing being mapped
+ * stops existing: the buffer is destroyed or unmapped before the map settles,
+ * or the device/instance behind it is destroyed or lost. The pick path never
+ * touches its readback buffers before the map settles, so for us that reduces
+ * to "the device is gone" — Chromium words it
+ * `AbortError: … A valid external Instance reference no longer exists.` (#1901).
+ *
+ * The entry guards in `pick()` / `pickRect()` (and `Renderer.pickPathAlive()`)
+ * stop a pick that STARTS on a dead device, but they cannot close the window
+ * between `queue.submit()` and the map settling: a pick that was perfectly
+ * legal when it started is still aborted if the canvas unmounts, the model
+ * reloads (`Renderer.destroy()` ends in `device.destroy()`), or the driver
+ * resets while the readback is in flight. Nothing on that path can handle the
+ * rejection — the DOM listeners that reach it are `async` functions nobody
+ * awaits — so it escapes as an unhandled rejection.
+ *
+ * Real faults are NOT covered here: a validation failure (already-mapped
+ * buffer, bad usage flags, out-of-range range) rejects with `OperationError`,
+ * which still propagates.
+ */
+function isReadbackAbort(err: unknown): boolean {
+  return typeof err === 'object' && err !== null && (err as { name?: unknown }).name === 'AbortError';
+}
+
+/**
+ * Free readback buffers on the aborted path. The device may already be gone,
+ * in which case `destroy()` is a no-op — or throws on some backends, which
+ * must not turn a handled teardown back into an escaping error.
+ */
+function releaseReadbacks(...buffers: GPUBuffer[]): void {
+  for (const buffer of buffers) {
+    try {
+      buffer.destroy();
+    } catch {
+      /* device already gone; the buffer died with it */
+    }
+  }
+}
+
 /** Point-pick sizing parameters forwarded to the GPU pipeline. */
 export interface PointPickSizing {
   sizeMode: 0 | 1 | 2; // matches PointCloudRenderer's SIZE_MODE_INDEX
@@ -341,7 +384,9 @@ export class Picker {
    * (already correct for hover/selection plumbing — no remapping needed).
    *
    * Returns null once `destroy()` has run — every texture and buffer below is
-   * already freed, so the `mapAsync` readback could only reject.
+   * already freed, so the `mapAsync` readback could only reject. Also returns
+   * null if the device dies *during* the readback, which no entry guard can
+   * pre-empt (see {@link isReadbackAbort}).
    */
   async pick(
     x: number,
@@ -404,7 +449,14 @@ export class Picker {
 
     this.device.queue.submit([encoder.finish()]);
     // GPUMapMode.READ = 1 (WebGPU spec)
-    await Promise.all([readBuffer.mapAsync(1), depthBuffer.mapAsync(1)]);
+    try {
+      await Promise.all([readBuffer.mapAsync(1), depthBuffer.mapAsync(1)]);
+    } catch (err) {
+      // The device died between submit and readback — see isReadbackAbort.
+      if (!isReadbackAbort(err)) throw err;
+      releaseReadbacks(readBuffer, depthBuffer);
+      return null;
+    }
     const sample = new Uint32Array(readBuffer.getMappedRange())[0];
     const depthBytes = new Uint8Array(depthBuffer.getMappedRange());
     const depthOffset = sampleY * depthBytesPerRow + sampleX * 4;
@@ -483,8 +535,8 @@ export class Picker {
    * rect = 480k pixels = ~2 MB transfer, fine for one-shot but we'd
    * want a GPU-side dedupe for sustained marquee selection.
    *
-   * Returns an empty set once `destroy()` has run, for the same reason
-   * {@link Picker.pick} returns null.
+   * Returns an empty set once `destroy()` has run — or if the device dies
+   * mid-readback — for the same reasons {@link Picker.pick} returns null.
    */
   async pickRect(
     x0: number,
@@ -529,7 +581,14 @@ export class Picker {
       { width: rectW, height: rectH },
     );
     this.device.queue.submit([encoder.finish()]);
-    await readBuffer.mapAsync(1);
+    try {
+      await readBuffer.mapAsync(1);
+    } catch (err) {
+      // The device died between submit and readback — see isReadbackAbort.
+      if (!isReadbackAbort(err)) throw err;
+      releaseReadbacks(readBuffer);
+      return new Set();
+    }
     const view = new Uint32Array(readBuffer.getMappedRange());
     const ids = new Set<number>();
     const stridePx = rowStride / 4;

--- a/packages/renderer/src/picker.ts
+++ b/packages/renderer/src/picker.ts
@@ -62,6 +62,7 @@ export class Picker {
   private expressIdBuffer: GPUBuffer;
   private bindGroup: GPUBindGroup;
   private maxMeshes: number = 100000; // Support up to 100K meshes (was 10K)
+  /** Set by `destroy()`; makes it idempotent and turns `pick`/`pickRect` into no-ops. */
   private destroyed = false;
   private pointPicker: PointPicker | null = null;
   // Reused scratch for the 32-float (128-byte) uniform block: viewProj +
@@ -338,6 +339,9 @@ export class Picker {
    * Returns `PickResult` with `{expressId, modelIndex}` for both kinds.
    * For point hits, expressId is the federated globalId of the asset
    * (already correct for hover/selection plumbing — no remapping needed).
+   *
+   * Returns null once `destroy()` has run — every texture and buffer below is
+   * already freed, so the `mapAsync` readback could only reject.
    */
   async pick(
     x: number,
@@ -351,6 +355,7 @@ export class Picker {
     instancedTemplates?: readonly InstancedTemplateGPU[],
     clip?: PickClipState | null,
   ): Promise<PickResult | null> {
+    if (this.destroyed) return null;
     const encoder = this.renderPickPass(width, height, meshes, viewProj, pointNodes, pointSizing, instancedTemplates, clip);
 
     // Clamp the texel origin to the texture bounds. Math.floor(x/y) can
@@ -477,6 +482,9 @@ export class Picker {
    * sustained use because the readback grows with rect area. A 800×600
    * rect = 480k pixels = ~2 MB transfer, fine for one-shot but we'd
    * want a GPU-side dedupe for sustained marquee selection.
+   *
+   * Returns an empty set once `destroy()` has run, for the same reason
+   * {@link Picker.pick} returns null.
    */
   async pickRect(
     x0: number,
@@ -492,6 +500,7 @@ export class Picker {
     instancedTemplates?: readonly InstancedTemplateGPU[],
     clip?: PickClipState | null,
   ): Promise<Set<number>> {
+    if (this.destroyed) return new Set();
     // Normalise + clip rect to texture bounds.
     const lx = Math.max(0, Math.floor(Math.min(x0, x1)));
     const ly = Math.max(0, Math.floor(Math.min(y0, y1)));

--- a/packages/renderer/src/picker.ts
+++ b/packages/renderer/src/picker.ts
@@ -78,8 +78,11 @@ function releaseReadbacks(...buffers: GPUBuffer[]): void {
   for (const buffer of buffers) {
     try {
       buffer.destroy();
-    } catch {
-      /* device already gone; the buffer died with it */
+    } catch (err) {
+      // Non-fatal: the device is already gone and the buffer died with it.
+      // Surfaced rather than swallowed, per the no-silent-catch house rule —
+      // this firing on a LIVE device would mean a real teardown bug.
+      console.warn('[Picker] failed to release a readback buffer during teardown', err);
     }
   }
 }
@@ -452,9 +455,13 @@ export class Picker {
     try {
       await Promise.all([readBuffer.mapAsync(1), depthBuffer.mapAsync(1)]);
     } catch (err) {
+      // Free BOTH readbacks on every failure path, not just the aborted one.
+      // `Promise.all` rejects the moment one map fails, so the other may have
+      // succeeded and still be holding its mapped GPU allocation — rethrowing
+      // without this leaks it for the life of the device.
+      releaseReadbacks(readBuffer, depthBuffer);
       // The device died between submit and readback — see isReadbackAbort.
       if (!isReadbackAbort(err)) throw err;
-      releaseReadbacks(readBuffer, depthBuffer);
       return null;
     }
     const sample = new Uint32Array(readBuffer.getMappedRange())[0];
@@ -584,9 +591,11 @@ export class Picker {
     try {
       await readBuffer.mapAsync(1);
     } catch (err) {
+      // Released on every failure path, not just the aborted one — a real
+      // fault must not leak the readback's GPU allocation on its way out.
+      releaseReadbacks(readBuffer);
       // The device died between submit and readback — see isReadbackAbort.
       if (!isReadbackAbort(err)) throw err;
-      releaseReadbacks(readBuffer);
       return new Set();
     }
     const view = new Uint32Array(readBuffer.getMappedRange());

--- a/packages/renderer/src/renderer-render-paths.test.ts
+++ b/packages/renderer/src/renderer-render-paths.test.ts
@@ -696,6 +696,12 @@ describe('pick path survives the device dying mid-readback (#1901)', () => {
         for (let i = 0; i < 3; i++) await Promise.resolve();
         const second = h.renderer.pick(20, 20);
         for (let i = 0; i < 3; i++) await Promise.resolve();
+        // Without this the case can pass vacuously: if the picks need more
+        // microtask turns to reach mapAsync than we spun, destroy() lands
+        // before submit and both settle via the ENTRY guard, never exercising
+        // the overlapping-in-flight release this case exists to cover.
+        // Two picks x (colour + depth) = 4 parked readbacks.
+        assert.strictEqual(h.pendingMaps(), 4, 'both picks must be parked on their readbacks');
         h.renderer.destroy();
         const settled = await Promise.allSettled([first, second]);
         assert.deepStrictEqual(settled.map((s) => s.status), ['fulfilled', 'fulfilled']);

--- a/packages/renderer/src/renderer-render-paths.test.ts
+++ b/packages/renderer/src/renderer-render-paths.test.ts
@@ -5,6 +5,7 @@
 import { describe, it, mock } from 'node:test';
 import assert from 'node:assert';
 import { Renderer } from './index.js';
+import { Picker } from './picker.js';
 import type { MeshData, RenderOptions, BatchedMesh } from './types.js';
 
 /**
@@ -12,9 +13,11 @@ import type { MeshData, RenderOptions, BatchedMesh } from './types.js';
  * fixes are exercised end to end without a browser: error-scope push/pop
  * balance on every exit path, destroy() idempotency, content-based
  * visibility epochs reaching the batched draw path, partial-cache
- * drop/rebuild on hide/isolate toggling, and hydrated-mesh disposal across
- * selections and federated models. The stub records buffer creates/destroys
- * and draw calls; everything else (Scene, Camera, batching, caches) is real.
+ * drop/rebuild on hide/isolate toggling, hydrated-mesh disposal across
+ * selections and federated models, and the pick path's device-liveness
+ * guard. The stub records buffer creates/destroys, draw calls and
+ * `mapAsync` readbacks; everything else (Scene, Camera, batching, caches,
+ * Picker, PickingManager) is real.
  */
 
 // WebGPU enum globals used by Scene buffer creation (not defined in node).
@@ -26,10 +29,19 @@ import type { MeshData, RenderOptions, BatchedMesh } from './types.js';
     COPY_SRC: 1, COPY_DST: 2, TEXTURE_BINDING: 4, STORAGE_BINDING: 8, RENDER_ATTACHMENT: 16,
 };
 
+/**
+ * Verbatim Chromium/Dawn wording when a pending (or newly issued) buffer map
+ * is completed by wire-client shutdown — i.e. the GPU device behind it is
+ * destroyed or lost. This is the exact string reported in #1901.
+ */
+const MAP_ASYNC_ABORT =
+    "Failed to execute 'mapAsync' on 'GPUBuffer': A valid external Instance reference no longer exists.";
+
 interface FakeBuffer {
     size: number;
     destroyed: number;
     getMappedRange(): ArrayBuffer;
+    mapAsync(mode: number): Promise<void>;
     unmap(): void;
     destroy(): void;
 }
@@ -42,6 +54,8 @@ interface Harness {
         /** vertex buffer bound at slot 0 when each drawIndexed fired */
         draws: unknown[];
         createdBuffers: FakeBuffer[];
+        /** how many times a readback buffer was actually mapped */
+        mapAsync: number;
     };
     knobs: {
         /** 'texture' = getCurrentTexture succeeds; 'null' = returns null */
@@ -50,6 +64,13 @@ interface Harness {
         encodeThrows: boolean;
         /** make popErrorScope() reject (device lost while scope pending) */
         popRejects: boolean;
+        /**
+         * The GPU device behind the stub is gone (destroyed by us, or lost to a
+         * driver reset / GPU-process crash). Set automatically by
+         * `device.destroy()`; set by hand to model an involuntary loss, where
+         * the device object stays wired up but every map rejects.
+         */
+        gpuDead: boolean;
     };
     render(options?: RenderOptions): void;
     /** flush the popErrorScope() promise chains */
@@ -57,8 +78,10 @@ interface Harness {
 }
 
 function makeHarness(): Harness {
-    const stats: Harness['stats'] = { push: 0, pop: 0, draws: [], createdBuffers: [] };
-    const knobs: Harness['knobs'] = { textureMode: 'texture', encodeThrows: false, popRejects: false };
+    const stats: Harness['stats'] = { push: 0, pop: 0, draws: [], createdBuffers: [], mapAsync: 0 };
+    const knobs: Harness['knobs'] = {
+        textureMode: 'texture', encodeThrows: false, popRejects: false, gpuDead: false,
+    };
 
     const makeBuffer = (desc: { size: number }): FakeBuffer => {
         const buf: FakeBuffer & { _ab: ArrayBuffer } = {
@@ -66,6 +89,14 @@ function makeHarness(): Harness {
             destroyed: 0,
             _ab: new ArrayBuffer(desc.size),
             getMappedRange() { return this._ab; },
+            mapAsync() {
+                stats.mapAsync++;
+                // Same failure mode as the browser: a map issued against a dead
+                // device rejects rather than resolving.
+                return knobs.gpuDead
+                    ? Promise.reject(new DOMException(MAP_ASYNC_ABORT, 'AbortError'))
+                    : Promise.resolve();
+            },
             unmap() { /* no-op */ },
             destroy() { this.destroyed++; },
         };
@@ -119,7 +150,17 @@ function makeHarness(): Harness {
                 case 'createCommandEncoder': return () => encoder;
                 case 'createBuffer': return (desc: { size: number }) => makeBuffer(desc);
                 case 'createBindGroup': return () => ({});
-                case 'createTexture': return () => ({ createView: () => ({}), destroy() { /* no-op */ } });
+                case 'createTexture': return (desc: { size: { width: number; height: number } }) => ({
+                    width: desc.size.width,
+                    height: desc.size.height,
+                    createView: () => ({}),
+                    destroy() { /* no-op */ },
+                });
+                // Picker builds real pipelines in its constructor and binds
+                // through the auto layout, so both arms must return objects.
+                case 'createShaderModule': return () => ({});
+                case 'createRenderPipeline': return () => ({ getBindGroupLayout: () => ({}) });
+                case 'destroy': return () => { knobs.gpuDead = true; };
                 default: return () => undefined;
             }
         },
@@ -446,5 +487,111 @@ describe('hydrated selection meshes across renders', () => {
 
         h.render({});
         assert.strictEqual(scene.getMeshes().filter((m) => m.hydrated).length, 0);
+    });
+});
+
+/**
+ * Regression for #1901: an unhandled `AbortError` from `mapAsync` on every
+ * click after the GPU device went away.
+ *
+ * `render()` has always early-returned on a destroyed/lost device; the pick
+ * path did not. A pick is a full GPU round trip ending in a `mapAsync`
+ * readback, so once the device is gone that readback rejects — and the DOM
+ * click/contextmenu handlers that reach here are `async` listeners whose
+ * promise nobody awaits, so the rejection escapes unhandled. Not a one-shot
+ * teardown race: the picker stays dead, so it fired once per click (three
+ * aborts 0.8 s apart in one production session).
+ *
+ * Every assertion below is on `stats.mapAsync`, not just on the returned
+ * value: the fix must short-circuit BEFORE the GPU call. A try/catch around
+ * the readback would still report a non-zero count and fail these.
+ */
+describe('pick path survives a dead GPU device (#1901)', () => {
+    /** Wire a REAL Picker into the renderer (init() needs a browser). */
+    function installPicker(h: Harness): Picker {
+        const picker = new Picker(h.renderer['device'], 256, 256);
+        (h.renderer as unknown as Record<string, unknown>)['picker'] = picker;
+        h.renderer['pickingManager'].setPicker(picker);
+        return picker;
+    }
+
+    /** Model an involuntary loss (driver reset / GPU-process crash). */
+    function loseDevice(h: Harness): void {
+        h.knobs.gpuDead = true;
+        h.renderer['handleDeviceLost']({ message: 'device lost', reason: 'unknown' });
+    }
+
+    it('positive control: a healthy pick really does reach the mapAsync readback', async () => {
+        const h = makeHarness();
+        installPicker(h);
+        // Resolves null because the stub reads back a zeroed sample (no hit);
+        // the readback COUNT is what proves the pass ran, not the value.
+        assert.strictEqual(await h.renderer.pick(10, 10), null);
+        assert.strictEqual(h.stats.mapAsync, 2, 'pick() maps the colour + depth readbacks');
+
+        h.stats.mapAsync = 0;
+        assert.deepStrictEqual(await h.renderer.pickRect(0, 0, 8, 8), new Set());
+        assert.strictEqual(h.stats.mapAsync, 1, 'pickRect() maps the rect readback');
+    });
+
+    it('pick() after destroy() resolves null instead of rejecting with AbortError', async () => {
+        const h = makeHarness();
+        installPicker(h);
+        h.renderer.destroy();
+
+        h.stats.mapAsync = 0;
+        assert.strictEqual(await h.renderer.pick(10, 10), null);
+        assert.strictEqual(h.stats.mapAsync, 0, 'guard must fire before the GPU readback');
+    });
+
+    it('pick() after an involuntary device loss resolves null instead of rejecting', async () => {
+        const h = makeHarness();
+        installPicker(h);
+        // The production shape: renderer still mounted, canvas frozen, user
+        // keeps clicking. Every click used to mint an unhandled rejection.
+        loseDevice(h);
+
+        h.stats.mapAsync = 0;
+        for (let i = 0; i < 3; i++) {
+            assert.strictEqual(await h.renderer.pick(10, 10), null);
+        }
+        assert.strictEqual(h.stats.mapAsync, 0, 'no click may reach the GPU readback');
+    });
+
+    it('pickRect() resolves an empty set after destroy() and after device loss', async () => {
+        const destroyed = makeHarness();
+        installPicker(destroyed);
+        destroyed.renderer.destroy();
+        destroyed.stats.mapAsync = 0;
+        assert.deepStrictEqual(await destroyed.renderer.pickRect(0, 0, 8, 8), new Set());
+        assert.strictEqual(destroyed.stats.mapAsync, 0);
+
+        const lost = makeHarness();
+        installPicker(lost);
+        loseDevice(lost);
+        lost.stats.mapAsync = 0;
+        assert.deepStrictEqual(await lost.renderer.pickRect(0, 0, 8, 8), new Set());
+        assert.strictEqual(lost.stats.mapAsync, 0);
+    });
+
+    it('Picker itself is inert after destroy() (it is a public export, usable standalone)', async () => {
+        const h = makeHarness();
+        const picker = installPicker(h);
+        const viewProj = new Float32Array(16);
+        picker.destroy();
+        h.knobs.gpuDead = true;
+
+        h.stats.mapAsync = 0;
+        assert.strictEqual(await picker.pick(10, 10, 256, 256, [], viewProj), null);
+        assert.deepStrictEqual(await picker.pickRect(0, 0, 8, 8, 256, 256, [], viewProj), new Set());
+        assert.strictEqual(h.stats.mapAsync, 0);
+    });
+
+    it('destroy() clears the picker the PickingManager holds, not just the renderer\'s', () => {
+        const h = makeHarness();
+        installPicker(h);
+        h.renderer.destroy();
+        assert.strictEqual(h.renderer['pickingManager']['picker'], null,
+            'a dangling manager reference keeps driving destroyed GPU resources');
     });
 });

--- a/packages/renderer/src/renderer-render-paths.test.ts
+++ b/packages/renderer/src/renderer-render-paths.test.ts
@@ -721,4 +721,23 @@ describe('pick path survives the device dying mid-readback (#1901)', () => {
         rect.settlePendingMaps(new DOMException('Buffer is already mapped', 'OperationError'));
         await assert.rejects(rectInflight.inflight, /already mapped/);
     });
+
+    it('a REAL readback fault still frees the readback buffers on its way out', async () => {
+        // #1901: the abort path released the readbacks but the rethrow path did
+        // not, so every real fault leaked its GPU allocation for the life of the
+        // device. Promise.all rejects the moment ONE map fails, so the other
+        // buffer can be mapped and live at that point — both must be freed.
+        const h = makeHarness();
+        installPicker(h);
+        const before = h.stats.createdBuffers.length;
+        const { inflight } = await park(h, () => h.renderer.pick(10, 10));
+        h.settlePendingMaps(new DOMException('Buffer is already mapped', 'OperationError'));
+        await assert.rejects(inflight, /already mapped/);
+
+        const readbacks = h.stats.createdBuffers.slice(before);
+        assert.strictEqual(readbacks.length, 2, 'pick() allocates the colour + depth readbacks');
+        for (const buf of readbacks) {
+            assert.ok(buf.destroyed > 0, 'a readback buffer survived the rethrow — leaked');
+        }
+    });
 });

--- a/packages/renderer/src/renderer-render-paths.test.ts
+++ b/packages/renderer/src/renderer-render-paths.test.ts
@@ -71,17 +71,29 @@ interface Harness {
          * the device object stays wired up but every map rejects.
          */
         gpuDead: boolean;
+        /**
+         * Park every `mapAsync` instead of resolving it, so a test can land a
+         * teardown *while a readback is in flight* — the window no entry guard
+         * can close. `settlePendingMaps()` decides how each parked map ends.
+         */
+        deferMaps: boolean;
     };
     render(options?: RenderOptions): void;
     /** flush the popErrorScope() promise chains */
     settle(): Promise<void>;
+    /** number of `mapAsync` calls currently parked (deferMaps) */
+    pendingMaps(): number;
+    /** complete every parked map: resolve it, or reject it with `reason` */
+    settlePendingMaps(reason?: unknown): void;
 }
 
 function makeHarness(): Harness {
     const stats: Harness['stats'] = { push: 0, pop: 0, draws: [], createdBuffers: [], mapAsync: 0 };
     const knobs: Harness['knobs'] = {
         textureMode: 'texture', encodeThrows: false, popRejects: false, gpuDead: false,
+        deferMaps: false,
     };
+    const parkedMaps: { resolve: () => void; reject: (e: unknown) => void }[] = [];
 
     const makeBuffer = (desc: { size: number }): FakeBuffer => {
         const buf: FakeBuffer & { _ab: ArrayBuffer } = {
@@ -93,9 +105,13 @@ function makeHarness(): Harness {
                 stats.mapAsync++;
                 // Same failure mode as the browser: a map issued against a dead
                 // device rejects rather than resolving.
-                return knobs.gpuDead
-                    ? Promise.reject(new DOMException(MAP_ASYNC_ABORT, 'AbortError'))
-                    : Promise.resolve();
+                if (knobs.gpuDead) {
+                    return Promise.reject(new DOMException(MAP_ASYNC_ABORT, 'AbortError'));
+                }
+                if (knobs.deferMaps) {
+                    return new Promise<void>((resolve, reject) => { parkedMaps.push({ resolve, reject }); });
+                }
+                return Promise.resolve();
             },
             unmap() { /* no-op */ },
             destroy() { this.destroyed++; },
@@ -160,7 +176,14 @@ function makeHarness(): Harness {
                 // through the auto layout, so both arms must return objects.
                 case 'createShaderModule': return () => ({});
                 case 'createRenderPipeline': return () => ({ getBindGroupLayout: () => ({}) });
-                case 'destroy': return () => { knobs.gpuDead = true; };
+                // Destroying a device also completes every map still pending
+                // against it — with an AbortError, exactly as Chromium does.
+                case 'destroy': return () => {
+                    knobs.gpuDead = true;
+                    for (const m of parkedMaps.splice(0)) {
+                        m.reject(new DOMException(MAP_ASYNC_ABORT, 'AbortError'));
+                    }
+                };
                 default: return () => undefined;
             }
         },
@@ -220,6 +243,12 @@ function makeHarness(): Harness {
             await Promise.resolve();
             await Promise.resolve();
             await Promise.resolve();
+        },
+        pendingMaps() { return parkedMaps.length; },
+        settlePendingMaps(reason?: unknown) {
+            for (const m of parkedMaps.splice(0)) {
+                if (reason === undefined) m.resolve(); else m.reject(reason);
+            }
         },
     };
 }
@@ -593,5 +622,97 @@ describe('pick path survives a dead GPU device (#1901)', () => {
         h.renderer.destroy();
         assert.strictEqual(h.renderer['pickingManager']['picker'], null,
             'a dangling manager reference keeps driving destroyed GPU resources');
+    });
+});
+
+/**
+ * Second half of #1901: the window the entry guards CANNOT close.
+ *
+ * A pick that was perfectly legal when it started is still aborted if the
+ * device dies between `queue.submit()` and the `mapAsync` settling — the
+ * canvas unmounts, the model reloads (`Renderer.destroy()` ends in
+ * `device.destroy()`), or the driver resets. Same `AbortError`, same async
+ * stack (the awaiting `pick` frames are preserved), same unhandled rejection,
+ * because the DOM listeners that reach here are `async` functions nobody
+ * awaits.
+ *
+ * These tests deliberately let the readback RUN (`stats.mapAsync > 0`) — that
+ * is the whole point, the guard already fired for everything it can see.
+ */
+describe('pick path survives the device dying mid-readback (#1901)', () => {
+    function installPicker(h: Harness): Picker {
+        const picker = new Picker(h.renderer['device'], 256, 256);
+        (h.renderer as unknown as Record<string, unknown>)['picker'] = picker;
+        h.renderer['pickingManager'].setPicker(picker);
+        return picker;
+    }
+
+    /**
+     * Run the pick up to the point where it is parked on `mapAsync`. Boxed in
+     * an object because `await` unwraps a promise-of-a-promise — returning the
+     * in-flight promise directly would await the very thing we want to keep
+     * parked.
+     */
+    async function park(h: Harness, start: () => Promise<unknown>): Promise<{ inflight: Promise<unknown> }> {
+        h.knobs.deferMaps = true;
+        const inflight = start();
+        for (let i = 0; i < 5; i++) await Promise.resolve();
+        assert.ok(h.pendingMaps() > 0, 'pick should be parked on the mapAsync readback');
+        return { inflight };
+    }
+
+    it('pick() parked on mapAsync when destroy() lands resolves null, not AbortError', async () => {
+        const h = makeHarness();
+        installPicker(h);
+        const { inflight } = await park(h, () => h.renderer.pick(10, 10));
+        h.renderer.destroy();
+        assert.strictEqual(await inflight, null);
+        assert.ok(h.stats.mapAsync > 0, 'the readback really was in flight');
+    });
+
+    it('pickRect() parked on mapAsync when destroy() lands resolves empty, not AbortError', async () => {
+        const h = makeHarness();
+        installPicker(h);
+        const { inflight } = await park(h, () => h.renderer.pickRect(0, 0, 8, 8));
+        h.renderer.destroy();
+        assert.deepStrictEqual(await inflight, new Set());
+    });
+
+    it('an involuntary loss mid-readback degrades the same way', async () => {
+        const h = makeHarness();
+        installPicker(h);
+        const { inflight } = await park(h, () => h.renderer.pick(10, 10));
+        h.knobs.gpuDead = true;
+        h.renderer['handleDeviceLost']({ message: 'device lost', reason: 'unknown' });
+        h.settlePendingMaps(new DOMException(MAP_ASYNC_ABORT, 'AbortError'));
+        assert.strictEqual(await inflight, null);
+    });
+
+    it('overlapping picks are all released, not just the newest', async () => {
+        const h = makeHarness();
+        installPicker(h);
+        h.knobs.deferMaps = true;
+        const first = h.renderer.pick(10, 10);
+        for (let i = 0; i < 3; i++) await Promise.resolve();
+        const second = h.renderer.pick(20, 20);
+        for (let i = 0; i < 3; i++) await Promise.resolve();
+        h.renderer.destroy();
+        const settled = await Promise.allSettled([first, second]);
+        assert.deepStrictEqual(settled.map((s) => s.status), ['fulfilled', 'fulfilled']);
+    });
+
+    it('a REAL readback fault still propagates — the catch is not a blanket swallow', async () => {
+        const h = makeHarness();
+        installPicker(h);
+        const { inflight } = await park(h, () => h.renderer.pick(10, 10));
+        // Validation failures reject with OperationError, never AbortError.
+        h.settlePendingMaps(new DOMException('Buffer is already mapped', 'OperationError'));
+        await assert.rejects(inflight, /already mapped/);
+
+        const rect = makeHarness();
+        installPicker(rect);
+        const rectInflight = await park(rect, () => rect.renderer.pickRect(0, 0, 8, 8));
+        rect.settlePendingMaps(new DOMException('Buffer is already mapped', 'OperationError'));
+        await assert.rejects(rectInflight.inflight, /already mapped/);
     });
 });


### PR DESCRIPTION
Closes #1901.

## Root cause

`Renderer.pick()` / `pickRect()` were the one caller sitting outside the renderer's own device-liveness contract. `render()` and `getGPUDevice()` early-return once `deviceLost` is set or the device is uninitialised, but the pick path drove a full GPU round trip ending in `mapAsync` on a dead device. That readback rejects with `AbortError: … A valid external Instance reference no longer exists.`, and because the DOM listeners that reach it are `async` and nobody awaits them, it escaped as an unhandled rejection — once per click.

That matches the production stack exactly (canvas handler -> `selectionHandlers` -> `store.pick` -> `store.pick` -> `Picker.pick`, `mechanism.handled === false`).

## The fix, in two halves

**Entry guard** (3416b421) — `pick()` returns `null` and `pickRect()` returns an empty `Set` when the device is gone, using the same `!deviceLost && device.isInitialized()` predicate `render()` already uses. Also fixes a real leak found on the way: `Renderer.destroy()` nulled only `this.picker`, never the picker the `PickingManager` holds, so `PickingManager`'s own `if (!this.picker) return null` bail could never fire. `Picker` now also honours its own `destroyed` flag, which was previously write-only.

**In-flight guard** (9a1429af) — added during adversarial review, and this half is the one that matters most in production. An entry guard cannot pre-empt a pick that is *already parked* on `mapAsync` when `device.destroy()` or a driver reset lands. Worse: on an involuntary loss, `deviceLost` is only set when the `device.lost` promise resolves, so **every click between a GPU-process crash and that resolution sailed straight past the entry guard**.

## Adversarial verification

The verifier re-ran the fail-then-pass proof independently rather than trusting it. Reverting just the two source files and re-running `pnpm --filter @ifc-lite/renderer test` gives 5 failures with the verbatim production message; restoring gives 378/378.

It then attacked the entry-guard-only commit with a throwaway probe using a deferrable `mapAsync` so teardown could land mid-readback — **4 of 6 probes still reproduced the exact production string** (mid-flight destroy, mid-flight involuntary loss, `pickRect` mid-flight destroy, and both of two overlapping picks). That is what produced the second commit. Every dead-device assertion is on `stats.mapAsync === 0`, so a try/catch symptom patch could not have made these tests pass.

Also independently refuted: overlapping picks are *not* the cause on their own (`renderPickPass` -> `copyTextureToBuffer` -> `queue.submit` is synchronous, and both readback buffers are per-call locals), and the `picker.ts:359` comment named in the issue is a red herring — it is about coordinate clamping, and the clamp is present.

## Reviewer notes / known gaps

- **Behaviour change worth a look:** `PickingManager.pick()` has a CPU-raycast fallback for large batched models that needs no GPU. Because the guard sits at the `Renderer` level, a pick during device loss now returns `null` instead of taking that pure-CPU path. On a lost device the viewport is frozen anyway and this matches how `render()` degrades, so it was judged correct — but it is a real semantic change.
- **Not reproduced in a real browser.** Both halves are verified against a stub GPU that rejects with a real `DOMException(<verbatim Dawn message>, 'AbortError')`. Device loss cannot be forced locally.
- **This stops the exception storm, not the underlying UX failure.** Nothing in `apps/viewer/src` subscribes to `onDeviceLost` (grep: zero hits), so after a loss the canvas still freezes on its last frame with no user-facing signal. Deserves its own issue.
- **#1904 is NOT fixed by this and is a separate root cause** — confirmed independently by both the implementer and the verifier. `PickingManager.pickRect` reads only `Scene.getMeshes()` (hydrated meshes); batched geometry lives in `batchedMeshes` and never reaches the pick pass, and `pickRect` has neither the CPU-raycast fallback nor the hydration path `pick()` has. Decisive discriminator: `pickRect`'s only call site logs `'[useMouseControls] Rectangle selection failed:'` on a rejection, so an abort would have been *logged*, not silent. Repro #1904 with the console open — a warning means same cause, silence means the missing batched path.
- `packages/drawing-2d/src/gpu-section-cutter.ts:358,380` has the identical unguarded `mapAsync` shape. Left alone to avoid widening scope, but it will produce the same unhandled rejection if a section-cut readback races teardown.
- Separately confirmed: the `ifc-lite:cancelled` fingerprint on these events was **not** a deliberate classification. `analytics-scrub.ts:258-265` runs `classifyLoadError` over every `$exception` and `load-errors.ts:159` matches `/aborterror/i`, so any `AbortError` anywhere in the app is bucketed as a model-load cancellation. These events stop once this ships, but the mis-classification remains for future `AbortError`s.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `pick()` / `pickRect()` behavior when the graphics device is lost, uninitialized, or destroyed—picking now safely degrades (no result / empty set) instead of attempting GPU work.
  * Prevented mid-readback aborts from surfacing as unhandled failures; genuine picking errors still propagate.
  * Enhanced teardown and readback cleanup during destruction and interrupted readbacks to avoid stale picker usage and potential resource leaks.
* **Tests**
  * Added a regression test to ensure readback buffers are freed even when readback fails with a non-abort error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->