### PR TITLE
fix(sandbox): own every QuickJS handle across throws so dispose cannot abort the module (#1905)

### DIFF
--- a/.changeset/sandbox-dispose-handle-leak.md
+++ b/.changeset/sandbox-dispose-handle-leak.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/sandbox": patch
+---
+
+Fix `sandbox.dispose()` aborting the whole QuickJS WASM module when a `bim.*` result could not be marshalled. Handles created through a QuickJS context are unmanaged lifetimes — `context.dispose()` does not free them — so a container handle orphaned by a mid-marshal exception (a throwing getter, a revoked `Proxy`, any host error raised while a result was being converted) kept a JSObject on the runtime's GC list and made `JS_FreeRuntime` assert `list_empty(&rt->gc_obj_list)`. Emscripten then `abort()`ed, leaving the sandbox unusable until a page reload. The bridge now owns every handle it creates across throws (`marshalValue`, namespace registration, the `bim` and `console` globals), and the disposable result of `executePendingJobs()` is freed instead of dropped. Script errors surface unchanged; only the abort is gone.

--- a/packages/sandbox/src/bridge-schema.ts
+++ b/packages/sandbox/src/bridge-schema.ts
@@ -218,32 +218,41 @@ function buildNamespace(
   schema: NamespaceSchema,
   context: BridgeCallContext,
 ): void {
+  // try/finally, not a bare sequence: a throw anywhere in the registration
+  // loop would otherwise orphan `nsHandle` (and the in-flight `fn`), and an
+  // orphaned handle makes the runtime's own dispose() abort the WASM module
+  // — see disposeOrphan() below for the full mechanism (#1905).
   const nsHandle = vm.newObject();
-
-  for (const method of schema.methods) {
-    const fn = vm.newFunction(method.name, (...handles: QuickJSHandle[]) => {
-      // Host-side errors (capability denials, SDK exceptions, type
-      // errors) MUST be re-thrown as a plain `Error` with a string
-      // message. Throwing a custom Error subclass — or any non-plain
-      // object — across the QuickJS native-callback boundary leaves
-      // the realm in a corrupt state: a subsequent handle access
-      // throws "Lifetime not alive". Normalising to a plain Error
-      // here keeps the failure a clean, catchable script exception.
+  try {
+    for (const method of schema.methods) {
+      const fn = vm.newFunction(method.name, (...handles: QuickJSHandle[]) => {
+        // Host-side errors (capability denials, SDK exceptions, type
+        // errors) MUST be re-thrown as a plain `Error` with a string
+        // message. Throwing a custom Error subclass — or any non-plain
+        // object — across the QuickJS native-callback boundary leaves
+        // the realm in a corrupt state: a subsequent handle access
+        // throws "Lifetime not alive". Normalising to a plain Error
+        // here keeps the failure a clean, catchable script exception.
+        try {
+          const nativeArgs = unmarshalArgs(vm, handles, method.args);
+          const result = method.call(sdk, nativeArgs, context);
+          return marshalReturn(vm, result, method.returns);
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          throw new Error(`bim.${schema.name}.${method.name}: ${msg}`);
+        }
+      });
       try {
-        const nativeArgs = unmarshalArgs(vm, handles, method.args);
-        const result = method.call(sdk, nativeArgs, context);
-        return marshalReturn(vm, result, method.returns);
-      } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err);
-        throw new Error(`bim.${schema.name}.${method.name}: ${msg}`);
+        vm.setProp(nsHandle, method.name, fn);
+      } finally {
+        fn.dispose();
       }
-    });
-    vm.setProp(nsHandle, method.name, fn);
-    fn.dispose();
-  }
+    }
 
-  vm.setProp(bimHandle, schema.name, nsHandle);
-  nsHandle.dispose();
+    vm.setProp(bimHandle, schema.name, nsHandle);
+  } finally {
+    nsHandle.dispose();
+  }
 }
 
 export function disposeSchemaNamespaceSession(context: BridgeCallContext): void {
@@ -310,6 +319,25 @@ function marshalReturn(vm: QuickJSContext, value: unknown, type: ReturnType): Qu
  */
 const MARSHAL_MAX_DEPTH = 64;
 
+/**
+ * Free a container handle that is being abandoned because marshalling threw.
+ *
+ * A handle created through the context is an *unmanaged* Lifetime —
+ * `QuickJSContext.dispose()` does NOT free it. An orphaned handle therefore
+ * keeps its JSObject on the runtime's `gc_obj_list`, and `JS_FreeRuntime`
+ * asserts `list_empty(&rt->gc_obj_list)` — an emscripten `abort()` that kills
+ * the WASM module for the rest of the document lifetime (#1905).
+ *
+ * The caller re-throws the original error afterwards: a failing `.dispose()`
+ * here only means the handle is already dead, which is the outcome we wanted,
+ * and it must not mask the real cause.
+ */
+function disposeOrphan(handle: QuickJSHandle): void {
+  try {
+    handle.dispose();
+  } catch { /* handle already dead — nothing to free */ }
+}
+
 /** Recursively convert a native JS value to a QuickJS handle */
 export function marshalValue(vm: QuickJSContext, value: unknown): QuickJSHandle {
   return marshalValueWithGuard(vm, value, 0, new WeakSet());
@@ -339,19 +367,37 @@ function marshalValueWithGuard(
   try {
     if (Array.isArray(value)) {
       const arr = vm.newArray();
-      for (let i = 0; i < value.length; i++) {
-        const item = marshalValueWithGuard(vm, value[i], depth + 1, stack);
-        vm.setProp(arr, i, item);
-        item.dispose();
+      try {
+        for (let i = 0; i < value.length; i++) {
+          const item = marshalValueWithGuard(vm, value[i], depth + 1, stack);
+          try {
+            vm.setProp(arr, i, item);
+          } finally {
+            item.dispose();
+          }
+        }
+      } catch (err) {
+        disposeOrphan(arr);
+        throw err;
       }
       return arr;
     }
 
     const out = vm.newObject();
-    for (const [k, v] of Object.entries(obj)) {
-      const handle = marshalValueWithGuard(vm, v, depth + 1, stack);
-      vm.setProp(out, k, handle);
-      handle.dispose();
+    try {
+      // Object.entries invokes getters, and a value in the graph may be a
+      // revoked Proxy — both throw from host code we do not control.
+      for (const [k, v] of Object.entries(obj)) {
+        const handle = marshalValueWithGuard(vm, v, depth + 1, stack);
+        try {
+          vm.setProp(out, k, handle);
+        } finally {
+          handle.dispose();
+        }
+      }
+    } catch (err) {
+      disposeOrphan(out);
+      throw err;
     }
     return out;
   } finally {

--- a/packages/sandbox/src/bridge-schema.ts
+++ b/packages/sandbox/src/bridge-schema.ts
@@ -335,7 +335,12 @@ const MARSHAL_MAX_DEPTH = 64;
 function disposeOrphan(handle: QuickJSHandle): void {
   try {
     handle.dispose();
-  } catch { /* handle already dead — nothing to free */ }
+  } catch (err) {
+    // Already-dead handle: the outcome we wanted. Surfaced rather than
+    // swallowed, because a burst of these is the signature of the very
+    // ownership bug this function exists to prevent.
+    console.warn('[ifc-lite/sandbox] abandoned QuickJS handle could not be disposed', err);
+  }
 }
 
 /** Recursively convert a native JS value to a QuickJS handle */

--- a/packages/sandbox/src/bridge.ts
+++ b/packages/sandbox/src/bridge.ts
@@ -38,13 +38,18 @@ export function buildBridge(
   buildConsole(vm, logs);
 
   // ── bim global ─────────────────────────────────────────────
+  // The handle is freed in a `finally`: if namespace construction throws,
+  // an orphaned handle would keep a JSObject alive past context teardown and
+  // make the runtime's own dispose() abort the WASM module (#1905).
   const bimHandle = vm.newObject();
+  try {
+    // All namespaces are schema-driven (model, query, viewer, mutate, lens, export)
+    buildSchemaNamespaces(vm, bimHandle, sdk, perms, context);
 
-  // All namespaces are schema-driven (model, query, viewer, mutate, lens, export)
-  buildSchemaNamespaces(vm, bimHandle, sdk, perms, context);
-
-  vm.setProp(vm.global, 'bim', bimHandle);
-  bimHandle.dispose();
+    vm.setProp(vm.global, 'bim', bimHandle);
+  } finally {
+    bimHandle.dispose();
+  }
 
   return {
     logs,
@@ -68,30 +73,36 @@ function buildConsole(vm: QuickJSContext, logs: LogEntry[]): void {
   let totalBytes = 0;
   let truncated = false;
 
-  for (const level of ['log', 'warn', 'error', 'info'] as const) {
-    const fn = vm.newFunction(level, (...args: QuickJSHandle[]) => {
-      if (truncated) return;
-      if (logs.length >= MAX_LOG_ENTRIES || totalBytes >= MAX_TOTAL_BYTES) {
-        truncated = true;
-        logs.push({ level: 'warn', args: ['[log output truncated: limit reached]'], timestamp: Date.now() });
-        return;
-      }
-      const nativeArgs = args.map(a => vm.dump(a));
-      // Approximate host cost of retaining this entry; treat unserializable
-      // args (e.g. cyclic) as zero-cost rather than failing the log call.
-      let entryBytes = 0;
+  try {
+    for (const level of ['log', 'warn', 'error', 'info'] as const) {
+      const fn = vm.newFunction(level, (...args: QuickJSHandle[]) => {
+        if (truncated) return;
+        if (logs.length >= MAX_LOG_ENTRIES || totalBytes >= MAX_TOTAL_BYTES) {
+          truncated = true;
+          logs.push({ level: 'warn', args: ['[log output truncated: limit reached]'], timestamp: Date.now() });
+          return;
+        }
+        const nativeArgs = args.map(a => vm.dump(a));
+        // Approximate host cost of retaining this entry; treat unserializable
+        // args (e.g. cyclic) as zero-cost rather than failing the log call.
+        let entryBytes = 0;
+        try {
+          entryBytes = JSON.stringify(nativeArgs)?.length ?? 0;
+        } catch {
+          entryBytes = 0; /* unserializable args — skip cost accounting */
+        }
+        totalBytes += entryBytes;
+        logs.push({ level, args: nativeArgs, timestamp: Date.now() });
+      });
       try {
-        entryBytes = JSON.stringify(nativeArgs)?.length ?? 0;
-      } catch {
-        entryBytes = 0; /* unserializable args — skip cost accounting */
+        vm.setProp(consoleHandle, level, fn);
+      } finally {
+        fn.dispose();
       }
-      totalBytes += entryBytes;
-      logs.push({ level, args: nativeArgs, timestamp: Date.now() });
-    });
-    vm.setProp(consoleHandle, level, fn);
-    fn.dispose();
-  }
+    }
 
-  vm.setProp(vm.global, 'console', consoleHandle);
-  consoleHandle.dispose();
+    vm.setProp(vm.global, 'console', consoleHandle);
+  } finally {
+    consoleHandle.dispose();
+  }
 }

--- a/packages/sandbox/src/dispose-leak.test.ts
+++ b/packages/sandbox/src/dispose-leak.test.ts
@@ -1,0 +1,156 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Regression tests for the `JS_FreeRuntime` abort (#1905):
+ *
+ *   Aborted(Assertion failed: list_empty(&rt->gc_obj_list),
+ *           at: ../../vendor/quickjs/quickjs.c,2036, JS_FreeRuntime)
+ *
+ * A handle created through a QuickJSContext is an *unmanaged* Lifetime —
+ * `context.dispose()` does not free it. So any handle the bridge creates and
+ * fails to dispose keeps a JSObject on the runtime's GC list, and
+ * `runtime.dispose()` trips that assertion: an emscripten `abort()` that kills
+ * the WASM module for the rest of the document lifetime.
+ *
+ * The assertion is therefore the leak oracle these tests use — "dispose() does
+ * not throw" is precisely "no live handles remain". Each case drives the real
+ * `createSandbox` -> real bridge -> real `dispose()` path.
+ *
+ * This file is kept separate so vitest gives it its own worker: an abort
+ * poisons the shared WASM module for every later test in the same process.
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { BimContext } from '@ifc-lite/sdk';
+import { createSandbox } from './sandbox.js';
+
+const CREATE_ONLY_PERMISSIONS = {
+  query: false,
+  mutate: false,
+  viewer: false,
+  export: true,
+  model: false,
+  lens: false,
+  files: false,
+} as const;
+
+/**
+ * Minimal SDK stub whose `bim.model.list()` hands the bridge `value`.
+ * `model.list` is a `returns: 'value'` method, so the value goes straight
+ * through `marshalValue` — the recursive marshaller under test.
+ */
+function sdkReturning(value: () => unknown): BimContext {
+  return { model: { list: value } } as unknown as BimContext;
+}
+
+/**
+ * Run `script`, expect it to fail (the marshaller throws host-side), then
+ * assert teardown is clean. The abort surfaces from `dispose()`, not `eval()`.
+ */
+async function evalThenDispose(sdk: BimContext, script: string): Promise<void> {
+  const sandbox = await createSandbox(sdk);
+  try {
+    await expect(sandbox.eval(script, { typescript: false })).rejects.toThrow();
+  } finally {
+    expect(() => sandbox.dispose()).not.toThrow();
+  }
+}
+
+describe('sandbox dispose after a failed marshal (#1905)', () => {
+  it('frees the half-built object when an own getter throws mid-marshal', async () => {
+    const sdk = sdkReturning(() => [
+      { id: 'a' },
+      {
+        id: 'b',
+        get name(): string {
+          throw new Error('property read exploded');
+        },
+      },
+    ]);
+
+    await evalThenDispose(sdk, 'bim.model.list()');
+  });
+
+  it('frees the half-built array when an element cannot be inspected', async () => {
+    const { proxy, revoke } = Proxy.revocable({ id: 'a' }, {});
+    revoke(); // every operation on `proxy` — including Array.isArray — now throws
+    const sdk = sdkReturning(() => [{ id: 'ok' }, proxy]);
+
+    await evalThenDispose(sdk, 'bim.model.list()');
+  });
+
+  it('frees every container in the recursion, not just the innermost', async () => {
+    const sdk = sdkReturning(() => [
+      {
+        id: 'a',
+        rows: [
+          { ok: true },
+          {
+            get value(): number {
+              throw new Error('nested read exploded');
+            },
+          },
+        ],
+      },
+    ]);
+
+    await evalThenDispose(sdk, 'bim.model.list()');
+  });
+
+  it('still reports the host error to the script', async () => {
+    const sdk = sdkReturning(() => [
+      {
+        get name(): string {
+          throw new Error('property read exploded');
+        },
+      },
+    ]);
+
+    const sandbox = await createSandbox(sdk);
+    try {
+      await expect(sandbox.eval('bim.model.list()', { typescript: false })).rejects.toThrow(
+        'bim.model.list: property read exploded',
+      );
+    } finally {
+      expect(() => sandbox.dispose()).not.toThrow();
+    }
+  });
+
+  it.each([
+    ['a script that throws', 'throw new Error("script blew up")'],
+    ['an async body drained from the job queue', '(async () => { return 41 + 1; })(), 42'],
+    ['a promise left pending at exit', 'new Promise(() => {}), "done"'],
+  ])('disposes cleanly after %s', async (_label, script) => {
+    // Guards the eval() result-handle ownership: whichever exit eval() takes,
+    // the handle from evalCode() must be freed before teardown.
+    const sandbox = await createSandbox({} as BimContext);
+    try {
+      await sandbox.eval(script, { typescript: false }).catch(() => undefined);
+    } finally {
+      expect(() => sandbox.dispose()).not.toThrow();
+    }
+  });
+
+  it('disposes cleanly after a successful create run (no over-disposal)', async () => {
+    const sandbox = await createSandbox({} as BimContext, {
+      permissions: CREATE_ONLY_PERMISSIONS,
+    });
+
+    try {
+      const result = await sandbox.eval(
+        `const h = bim.create.project({ Name: "Leak Check" });
+         const storey = bim.create.addIfcBuildingStorey(h, { Name: "GF", Elevation: 0 });
+         bim.create.addIfcWall(h, storey, {
+           Name: "Wall", Start: [0, 0, 0], End: [5, 0, 0], Thickness: 0.2, Height: 3,
+         });
+         bim.create.toIfc(h).content.length;`,
+        { typescript: false },
+      );
+      expect(result.value).toBeGreaterThan(0);
+    } finally {
+      expect(() => sandbox.dispose()).not.toThrow();
+    }
+  });
+});

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -118,26 +118,6 @@ export class Sandbox {
       jsCode = await transpileTypeScript(code);
     }
 
-    this.evalStartTime = Date.now();
-
-    const result = this.vm.evalCode(jsCode, options?.filename ?? 'script.js');
-
-    // Drain the QuickJS job queue. Promise callbacks and `async`
-    // function bodies are scheduled as jobs — without this, an entry
-    // wrapped as `async function run()` returns a pending promise and
-    // its body never executes (the tool "succeeds" in 1ms doing
-    // nothing). executePendingJobs runs them to completion.
-    if (this.runtime) {
-      try {
-        this.runtime.executePendingJobs();
-      } catch {
-        // A job that throws must not abort the eval result handling.
-      }
-    }
-
-    const durationMs = Date.now() - this.evalStartTime;
-    this.evalStartTime = 0;
-
     // Disposing an eval-result handle must never crash the run. If the
     // realm became invalid mid-eval, `.dispose()` throws "Lifetime not
     // alive" — swallow that so the real error (or value) still gets
@@ -147,41 +127,71 @@ export class Sandbox {
       try { h.dispose(); } catch { /* handle already dead — nothing to free */ }
     };
 
-    if (result.error) {
-      let errorData: unknown;
-      try {
-        errorData = this.vm.dump(result.error);
-      } catch (dumpErr) {
-        errorData = { message: dumpErr instanceof Error ? dumpErr.message : String(dumpErr) };
-      }
-      safeDispose(result.error);
-      throw new ScriptError(
-        typeof errorData === 'object' && errorData !== null && 'message' in errorData
-          ? String((errorData as { message: unknown }).message)
-          : String(errorData),
-        this.logs,
-        durationMs,
-      );
-    }
+    this.evalStartTime = Date.now();
 
-    let value: unknown;
+    const result = this.vm.evalCode(jsCode, options?.filename ?? 'script.js');
+
+    // The eval-result handle is freed in a `finally` covering every exit —
+    // including an unexpected throw from job draining. A handle created
+    // through the context is an unmanaged lifetime that `vm.dispose()` does
+    // NOT free, so leaking one keeps a JSObject on the runtime's GC list and
+    // makes `runtime.dispose()` abort the whole WASM module (#1905).
+    const resultHandle = result.error ?? result.value;
     try {
-      value = this.vm.dump(result.value);
-    } catch (dumpErr) {
-      safeDispose(result.value);
-      throw new ScriptError(
-        `Sandbox realm became invalid during execution: ${dumpErr instanceof Error ? dumpErr.message : String(dumpErr)}`,
-        this.logs,
-        durationMs,
-      );
-    }
-    safeDispose(result.value);
+      // Drain the QuickJS job queue. Promise callbacks and `async`
+      // function bodies are scheduled as jobs — without this, an entry
+      // wrapped as `async function run()` returns a pending promise and
+      // its body never executes (the tool "succeeds" in 1ms doing
+      // nothing). executePendingJobs runs them to completion.
+      //
+      // Its result is disposable and must be freed: the failure branch owns a
+      // live error handle. A job that throws is reported through that result
+      // rather than as a host exception, so draining still cannot abort the
+      // eval result handling below.
+      if (this.runtime) {
+        this.runtime.executePendingJobs().dispose();
+      }
 
-    return {
-      value,
-      logs: [...this.logs],
-      durationMs,
-    };
+      const durationMs = Date.now() - this.evalStartTime;
+      // Stand the CPU interrupt down before dumping results — vm.dump can run
+      // VM code (toJSON / getters) and must not be cut short by the timeout.
+      this.evalStartTime = 0;
+
+      if (result.error) {
+        let errorData: unknown;
+        try {
+          errorData = this.vm.dump(result.error);
+        } catch (dumpErr) {
+          errorData = { message: dumpErr instanceof Error ? dumpErr.message : String(dumpErr) };
+        }
+        throw new ScriptError(
+          typeof errorData === 'object' && errorData !== null && 'message' in errorData
+            ? String((errorData as { message: unknown }).message)
+            : String(errorData),
+          this.logs,
+          durationMs,
+        );
+      }
+
+      let value: unknown;
+      try {
+        value = this.vm.dump(result.value);
+      } catch (dumpErr) {
+        throw new ScriptError(
+          `Sandbox realm became invalid during execution: ${dumpErr instanceof Error ? dumpErr.message : String(dumpErr)}`,
+          this.logs,
+          durationMs,
+        );
+      }
+
+      return {
+        value,
+        logs: [...this.logs],
+        durationMs,
+      };
+    } finally {
+      safeDispose(resultHandle);
+    }
   }
 
   /** Dispose the sandbox and free WASM memory */

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -124,7 +124,11 @@ export class Sandbox {
     // through instead of being masked by a teardown failure.
     const safeDispose = (h: { dispose(): void } | undefined): void => {
       if (!h) return;
-      try { h.dispose(); } catch { /* handle already dead — nothing to free */ }
+      try {
+        h.dispose();
+      } catch (err) {
+        console.warn('[ifc-lite/sandbox] eval-result handle could not be disposed', err);
+      }
     };
 
     this.evalStartTime = Date.now();

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -190,6 +190,11 @@ export class Sandbox {
         durationMs,
       };
     } finally {
+      // Belt-and-braces: the success path already zeroed this before the dumps,
+      // but an unexpected throw from job draining would otherwise leave the CPU
+      // interrupt armed against a stale start time, so the next VM code to run
+      // in this realm (including teardown) would be cut short as a timeout.
+      this.evalStartTime = 0;
       safeDispose(resultHandle);
     }
   }


### PR DESCRIPTION
Refs #1905. **Deliberately does not close the issue** — see "Why this stays open" below.

## Root cause (one of two)

A handle created through a `QuickJSContext` is an **unmanaged** Lifetime: `QuickJSContext.dispose()` does not free it (verified — `ContextMemory.heapValueHandle` returns a bare `new Lifetime(...)`, unlike the scope-managed `staticHeapValueHandle`). Every container handle the bridge built was held in a bare local and freed on the success path only, so any throw between `newObject()`/`newArray()` and the matching `.dispose()` orphaned a JSObject. The orphan survives `JS_FreeContext`, and `JS_FreeRuntime` then trips `assert(list_empty(&rt->gc_obj_list))` — aborting the whole emscripten module, which is why the sandbox is unusable until a page reload.

The reachable trigger is a host-side exception raised while a `bim.*` result is being marshalled: a throwing own getter, a revoked `Proxy`, anything that makes `Object.entries` or the recursion fail partway through a structure.

## The fix

All in `packages/sandbox/src` — take ownership of every handle across throws:

- `bridge-schema.ts` `marshalValueWithGuard`: each container is disposed if the loop throws, each child in a `finally` so a throwing `setProp` cannot leak it either. Every level of the recursion is freed, not just the innermost.
- `bridge-schema.ts` `buildNamespace`: `nsHandle` and the in-flight `fn` move to `finally`.
- `bridge.ts` `buildBridge` / `buildConsole`: same for `bimHandle`, `consoleHandle`, each `fn`.
- `sandbox.ts` `eval`: the `executePendingJobs()` result was dropped entirely and its failure branch owns a live error handle — now disposed; the eval-result handle moves into a `finally`.
- `sandbox.ts` (review follow-up, 8b0cb59d): the `evalStartTime = 0` reset that stands the CPU interrupt down sat inside the `try`, so a throw from job draining left the interrupt armed against a stale start time and the next VM code in that realm — including teardown — would be cut short as a timeout. A copy now lives in the `finally`.

Regression test `dispose-leak.test.ts` drives the real `createSandbox` -> real bridge -> real `dispose()`. The shipped wasm's assertion is itself the "no live handles remain" oracle. On unfixed source 4 of its 8 cases fail with the exact production message; with the fix all 8 pass. Verified independently by the reviewer.

## Why this stays open

Adversarial review **demonstrated a second, independent trigger of the identical assertion that is still live with this fix applied**: heap exhaustion inside a queued QuickJS job.

Reproduced end-to-end through the real `createSandbox` at production defaults (64 MB / 30 s — exactly what `useSandbox.ts:167-170` configures), on this branch:

```js
async function run() { await 0; const a = []; for (;;) { a.push({ k: "v" }); } } run(); "started"
```

`eval()` resolves with `"started"`, then `sandbox.dispose()` throws the verbatim production message. It reaches OOM in ~1 s, well inside the timeout. This is squarely in plausible-production territory — `sandbox.ts`'s own comment notes that entry points are commonly wrapped as `async function run()`, whose post-await body runs as a job.

It is an **upstream defect, not a handle we own.** A minimal fresh-process repro with no ifc-lite code at all (only `getQuickJS` + `evalCode` + `executePendingJobs`, every handle disposed) aborts at every memory limit tested, 256 KB through 64 MB. Bisected: OOM inside a *drained job* aborts; OOM in the main eval body is clean; a job that merely throws is clean; the same script without draining is clean. It aborts whether the rejection is unhandled, `.catch()`ed, or `try`/`catch`ed inside the job.

No in-repo mitigation exists: quickjs-emscripten 0.32.0 exposes no GC trigger. The only remaining lever would be to deliberately skip `runtime.dispose()` on a heuristic OOM signal — trading a document-wide module death for an unbounded WASM runtime leak. That was **not** shipped; it is a maintainer call and wants an upstream issue against quickjs-emscripten first.

**Also honest about attribution:** the script text is not in telemetry, and both triggers fit the production event equally well (marshal-throw makes `eval()` reject then abort in the `finally`; OOM makes `eval()` resolve then abort in the `finally` — both surface as `mechanism.handled = false` from the same `dispose()` frame). So the claim that this commit fixes *the reported occurrence* is unproven either way. It removes a real root cause; it does not let us assert the issue is done.

## Other gaps

- `buildNamespace` / `buildBridge` / `buildConsole` exception-safety is correct by construction but has no test — neither agent could construct a realistic throw during registration through the public surface.
- `pnpm check:api-surface` was not run (needs a full workspace build). Verified by substitute: the diff contains no changed export lines and `disposeOrphan` is module-private, so both `scripts/api-surface.json` entries are unchanged. `patch` changeset is correct.
- The published export `marshalValue` changes behaviour on the throw path (no longer leaves an orphan). No callers outside `bridge-schema.ts` in-repo, but it is a >=1.0 surface.
