### PR TITLE
fix(viewer): degrade the location minimap when WebGL is unavailable (#1914)

### DIFF
--- a/apps/viewer/src/components/viewer/properties/LocationMap.tsx
+++ b/apps/viewer/src/components/viewer/properties/LocationMap.tsx
@@ -25,6 +25,11 @@ import type { CoordinateInfo, GeometryResult, MeshData } from '@ifc-lite/geometr
 import { downloadBlob } from '@/lib/export/download';
 import { reprojectToLatLon, reprojectFromLatLon, queryTerrainElevation, computeFootprintGeoJSON, type LatLon } from '@/lib/geo/reproject';
 import { buildKmz } from '@/lib/geo/kmz-exporter';
+import {
+  probeMapWebglSupport, markMapWebglUnsupported, takeMapWebglReportSlot,
+  getMapWebglVerdict, describeMapInitFailure, type MapWebglFailureReason,
+} from '@/lib/geo/map-webgl-support';
+import { posthog } from '@/lib/analytics';
 
 // Lazy-load maplibre-gl to avoid bloating the initial bundle
 let maplibrePromise: Promise<typeof import('maplibre-gl')> | null = null;
@@ -58,6 +63,35 @@ export interface LocationMapProps {
 }
 
 type MapState = 'idle' | 'loading' | 'ready' | 'error';
+
+/**
+ * Why the minimap could not be shown. Kept separate from `MapState`, which
+ * tracks *coordinate resolution*: the two are independent, and folding them
+ * together would let a later reprojection silently clear a device-level
+ * failure and re-trigger the very construction that failed.
+ *
+ * `map_load_failed` is the one non-device reason — the maplibre chunk itself
+ * failed to download — and it deliberately does NOT latch, because a chunk
+ * fetch is transient in a way a missing GPU capability is not.
+ */
+type MapUnavailableReason = MapWebglFailureReason | 'map_load_failed';
+
+/**
+ * Dispose a MapLibre map, containing any throw from its teardown.
+ *
+ * After a context loss MapLibre has already run `painter.destroy()`, and
+ * `remove()` runs it again and then reaches through `painter.context.gl` — so
+ * teardown is exactly the moment a second throw is most likely. This runs from
+ * React cleanup, where an uncaught throw unmounts the surrounding tree, so the
+ * failure has to stop here.
+ */
+function disposeMap(map: InstanceType<typeof import('maplibre-gl').Map>) {
+  try {
+    map.remove();
+  } catch (err) {
+    console.warn('[location-map] map teardown failed; continuing:', err);
+  }
+}
 
 // Debounce helper
 function useDebouncedValue<T>(value: T, delayMs: number): T {
@@ -168,6 +202,42 @@ export function LocationMap({
   const [mapState, setMapState] = useState<MapState>('idle');
   const [latLon, setLatLon] = useState<LatLon | null>(null);
   const [error, setError] = useState<string | null>(null);
+
+  // Seeded from the session latch, so a remount on a device already known to
+  // refuse WebGL paints the fallback immediately — no probe, no construction,
+  // no half-built canvas. This is what turns the accordion's collapse/expand
+  // cycle from "throw again" into "already answered".
+  const [mapUnavailable, setMapUnavailable] = useState<MapUnavailableReason | null>(() => {
+    const verdict = getMapWebglVerdict();
+    return verdict && !verdict.supported ? verdict.reason ?? 'probe_no_context' : null;
+  });
+
+  /**
+   * Degrade to the no-map fallback and report once per session.
+   *
+   * `posthog.captureException` (rather than letting the throw escape) is the
+   * point: an explicit capture is recorded as HANDLED, so an unsupported GPU
+   * stops arriving as an error-level uncaught exception for something no user
+   * and no code change can fix.
+   */
+  const degradeMap = useCallback((reason: MapUnavailableReason, err: unknown) => {
+    // A missing GPU capability is a property of the device, so latch it for the
+    // session. A failed chunk download is not — leave that one retryable.
+    if (reason !== 'map_load_failed') markMapWebglUnsupported(reason);
+    setMapUnavailable(reason);
+    if (!takeMapWebglReportSlot()) return;
+    const detail = describeMapInitFailure(err);
+    posthog.captureException(err, {
+      context: 'location_map_webgl',
+      map_unavailable_reason: reason,
+      // `webgl_status`, not `..._message`: the analytics scrub deletes any key
+      // containing the word `message` (free text is where model names leak).
+      // This value is a driver capability string — it describes the GPU and
+      // carries nothing about the model — so it is worth keeping intact.
+      ...(detail.status ? { webgl_status: detail.status } : {}),
+      ...(detail.eventType ? { webgl_event_type: detail.eventType } : {}),
+    });
+  }, []);
 
   // Picked position state (user-placed pin)
   const [pickedLatLon, setPickedLatLon] = useState<LatLon | null>(null);
@@ -350,6 +420,8 @@ export function LocationMap({
   // Initialize/update the map when we have a valid lat/lon
   useEffect(() => {
     if (!latLon || !containerRef.current) return;
+    // Already known to be unavailable: never touch the GPU again this session.
+    if (mapUnavailable) return;
 
     let cancelled = false;
 
@@ -365,14 +437,62 @@ export function LocationMap({
         return;
       }
 
-      // Create new map
-      const map = new maplibregl.Map({
-        container: containerRef.current,
-        style: 'https://basemaps.cartocdn.com/gl/positron-gl-style/style.json',
-        center: [latLon.lon, latLon.lat],
-        zoom: 15,
-        attributionControl: false,
-        interactive: true,
+      // Pre-flight, before MapLibre gets anywhere near our container: its
+      // constructor builds the canvas FIRST and asks for a WebGL context
+      // second, so letting it fail leaves a half-built canvas behind. Probing
+      // first makes the fallback the user's first paint instead of a flash of
+      // a broken map.
+      if (!probeMapWebglSupport().supported) {
+        degradeMap('probe_no_context', new Error('Failed to initialize WebGL (pre-flight probe)'));
+        return;
+      }
+
+      // The probe is an optimisation, not a guarantee: it can pass and the
+      // context still be refused a moment later when the GPU process is
+      // contended (the reported `BindToCurrentSequence failed` case). This
+      // callback is a microtask, so anything escaping it becomes an
+      // *unhandled rejection* — which is exactly how this reached error
+      // tracking as an uncaught error.
+      const container = containerRef.current;
+      let map: InstanceType<typeof maplibregl.Map>;
+      try {
+        map = new maplibregl.Map({
+          container,
+          style: 'https://basemaps.cartocdn.com/gl/positron-gl-style/style.json',
+          center: [latLon.lon, latLon.lat],
+          zoom: 15,
+          attributionControl: false,
+          interactive: true,
+        });
+      } catch (err) {
+        // `_setupContainer` already added its class, canvas and control
+        // containers to our div. `mapRef` was never assigned, so the unmount
+        // cleanup cannot reach them — purge them here, before the fallback
+        // renders, so no frame shows a dead canvas.
+        container.replaceChildren();
+        container.classList.remove('maplibregl-map');
+        degradeMap('map_construction_failed', err);
+        return;
+      }
+
+      // A lost context would otherwise be restored by MapLibre calling
+      // `_setupPainter()` again from inside a DOM listener — where a throw is
+      // beyond any try/catch of ours. Tear down deterministically instead:
+      // `remove()` detaches both the lost and restored listeners, so that
+      // un-catchable path can never run. Deferred out of MapLibre's own stack.
+      map.on('webglcontextlost', () => {
+        if (mapRef.current !== map) return;
+        mapRef.current = null;
+        markerRef.current = null;
+        queueMicrotask(() => disposeMap(map));
+        degradeMap('context_lost', new Error('Failed to initialize WebGL (context lost)'));
+      });
+
+      // Without a listener MapLibre logs style/tile fetch failures straight to
+      // console.error. These are transient network problems, not map failures,
+      // so keep a breadcrumb and leave the map running.
+      map.on('error', e => {
+        console.warn('[location-map] maplibre error:', e?.error ?? e);
       });
 
       map.addControl(new maplibregl.NavigationControl({ showCompass: false }), 'top-right');
@@ -404,12 +524,21 @@ export function LocationMap({
           addFootprintToMap(map, footprintRef.current!);
         });
       }
+    }).catch(err => {
+      // The backstop. Nothing above may escape this chain: with no handler the
+      // derived promise rejects unhandled and PostHog records it as an
+      // uncaught, error-level exception (issue #1914). Reaching here means the
+      // maplibre chunk itself failed to load, or a shape the try/catch above
+      // did not cover — either way the panel degrades instead of throwing.
+      if (cancelled) return;
+      console.warn('[location-map] map initialisation failed:', err);
+      degradeMap('map_load_failed', err);
     });
 
     return () => {
       cancelled = true;
     };
-  }, [latLon, handleMapClick]);
+  }, [latLon, handleMapClick, mapUnavailable, degradeMap]);
 
   // Add/update building footprint GeoJSON layer when footprint or style changes
   useEffect(() => {
@@ -434,7 +563,9 @@ export function LocationMap({
       pickedMarkerRef.current = null;
       markerRef.current?.remove();
       markerRef.current = null;
-      mapRef.current?.remove();
+      // Guarded: teardown throws if the context was already lost, and an
+      // uncaught throw in cleanup unmounts the properties panel around us.
+      if (mapRef.current) disposeMap(mapRef.current);
       mapRef.current = null;
     };
   }, []);
@@ -585,19 +716,37 @@ export function LocationMap({
 
       {(mapState === 'ready' || (mapState === 'loading' && latLon)) && (
         <>
-          <div className="relative">
-            <div
-              ref={containerRef}
-              className="h-[180px] w-full [&_.maplibregl-ctrl-attrib]:!text-[7px] [&_.maplibregl-ctrl-attrib]:!bg-white/40 [&_.maplibregl-ctrl-attrib]:dark:!bg-black/30 [&_.maplibregl-ctrl-attrib]:!py-0 [&_.maplibregl-ctrl-attrib]:!px-1 [&_.maplibregl-ctrl-attrib]:!shadow-none [&_.maplibregl-ctrl-attrib]:!text-zinc-400/70 [&_.maplibregl-ctrl-attrib_a]:!text-zinc-400/70 [&_.maplibregl-ctrl-attrib]:!leading-normal"
-              style={{ minHeight: 180 }}
-            />
-            {/* Edit mode hint overlay */}
-            {editable && !pickedLatLon && (
-              <div className="absolute top-2 left-2 bg-white/90 dark:bg-zinc-900/90 backdrop-blur-sm px-2 py-1 text-[9px] text-zinc-500 dark:text-zinc-400 pointer-events-none shadow-sm border border-zinc-200/50 dark:border-zinc-700/50">
-                Click map to place pin
-              </div>
-            )}
-          </div>
+          {mapUnavailable ? (
+            /* No WebGL context on this device. Everything that does not need a
+               GPU stays: the coordinate readout above, the external map links
+               and the KMZ export below, and — in edit mode — place search,
+               which still drives the reverse projection and the Apply button. */
+            <div className="flex flex-col items-center justify-center h-[180px] bg-zinc-50 dark:bg-zinc-900/50 gap-1.5 px-4 text-center">
+              <MapPinOff className="h-4 w-4 text-zinc-400" />
+              <span className="text-[10px] text-zinc-500 dark:text-zinc-400">
+                Map preview unavailable on this device
+              </span>
+              <span className="text-[9px] text-zinc-400 dark:text-zinc-500 max-w-[240px]">
+                {mapUnavailable === 'map_load_failed'
+                  ? 'The map component could not be loaded. Check your connection and reload the page.'
+                  : 'Your browser could not provide graphics for the map. Coordinates, search and the links below still work; reloading the page may restore it.'}
+              </span>
+            </div>
+          ) : (
+            <div className="relative">
+              <div
+                ref={containerRef}
+                className="h-[180px] w-full [&_.maplibregl-ctrl-attrib]:!text-[7px] [&_.maplibregl-ctrl-attrib]:!bg-white/40 [&_.maplibregl-ctrl-attrib]:dark:!bg-black/30 [&_.maplibregl-ctrl-attrib]:!py-0 [&_.maplibregl-ctrl-attrib]:!px-1 [&_.maplibregl-ctrl-attrib]:!shadow-none [&_.maplibregl-ctrl-attrib]:!text-zinc-400/70 [&_.maplibregl-ctrl-attrib_a]:!text-zinc-400/70 [&_.maplibregl-ctrl-attrib]:!leading-normal"
+                style={{ minHeight: 180 }}
+              />
+              {/* Edit mode hint overlay */}
+              {editable && !pickedLatLon && (
+                <div className="absolute top-2 left-2 bg-white/90 dark:bg-zinc-900/90 backdrop-blur-sm px-2 py-1 text-[9px] text-zinc-500 dark:text-zinc-400 pointer-events-none shadow-sm border border-zinc-200/50 dark:border-zinc-700/50">
+                  Click map to place pin
+                </div>
+              )}
+            </div>
+          )}
 
           {/* Picked position info bar */}
           {pickedLatLon && editable && (
@@ -713,12 +862,15 @@ export function LocationMap({
                 <TooltipContent>Download KMZ for Google Earth Pro (desktop), placed at the model location. Google Earth on the web cannot show KMZ 3D models — use Export GLB for the web.</TooltipContent>
               </Tooltip>
             )}
-            <button
-              onClick={handleStyleToggle}
-              className="ml-auto text-[10px] text-zinc-500 dark:text-zinc-400 hover:text-zinc-700 dark:hover:text-zinc-300 transition-colors"
-            >
-              Toggle style
-            </button>
+            {/* Hidden without a map: it would be a permanent no-op. */}
+            {!mapUnavailable && (
+              <button
+                onClick={handleStyleToggle}
+                className="ml-auto text-[10px] text-zinc-500 dark:text-zinc-400 hover:text-zinc-700 dark:hover:text-zinc-300 transition-colors"
+              >
+                Toggle style
+              </button>
+            )}
           </div>
         </>
       )}

--- a/apps/viewer/src/lib/analytics-scrub.ts
+++ b/apps/viewer/src/lib/analytics-scrub.ts
@@ -208,8 +208,13 @@ const OUTLOOK_SAFELINK_NOISE =
 // stable message + the `webglcontextcreationerror` token, never on a minified
 // name — the same discipline as the Cesium matcher above. Deliberately narrow:
 // a WebGL failure that is ever actionable must not be silently dropped.
+// The bare case is ANCHORED, not a substring test: MapLibre throws exactly
+// this message and nothing else, so an unrelated error that merely mentions
+// the phrase ("Failed to initialize WebGL renderer for the ...") must still
+// reach us. Dropping is irreversible — a matcher that is loose here goes
+// blind exactly where it matters.
 const MAPLIBRE_WEBGL_UNAVAILABLE =
-  /Failed to initialize WebGL|"type":\s*"webglcontextcreationerror"/;
+  /^\s*Failed to initialize WebGL\s*$|"type":\s*"webglcontextcreationerror"/;
 
 // The browser's opaque cross-origin error: `window.onerror` reports literally
 // "Script error." with no file, line, or stack when a script from another

--- a/apps/viewer/src/lib/analytics-scrub.ts
+++ b/apps/viewer/src/lib/analytics-scrub.ts
@@ -193,6 +193,24 @@ const CESIUM_REQUEST_ERROR =
 const OUTLOOK_SAFELINK_NOISE =
   /Object Not Found Matching Id:\s*\d+,\s*MethodName:/i;
 
+// MapLibre cannot get a WebGL context: `_setupPainter()` throws either a bare
+// "Failed to initialize WebGL" or that message wrapped in a JSON blob carrying
+// the driver's `statusMessage` and `type: 'webglcontextcreationerror'`. The
+// LocationMap now probes first, catches the construction, and reports the
+// condition ONCE as a handled exception (see lib/geo/map-webgl-support.ts), so
+// this is not the fix — it is the net under the one path we genuinely cannot
+// catch: MapLibre restoring a lost context calls `_setupPainter()` again from
+// inside a DOM event listener, where no try/catch of ours is on the stack.
+//
+// The condition is a property of the user's GPU (missing OES_packed_depth_
+// stencil, or a GPU process that could not serve a context), unactionable in
+// our code and unfixable by the user beyond reloading. Matched on MapLibre's
+// stable message + the `webglcontextcreationerror` token, never on a minified
+// name — the same discipline as the Cesium matcher above. Deliberately narrow:
+// a WebGL failure that is ever actionable must not be silently dropped.
+const MAPLIBRE_WEBGL_UNAVAILABLE =
+  /Failed to initialize WebGL|"type":\s*"webglcontextcreationerror"/;
+
 // The browser's opaque cross-origin error: `window.onerror` reports literally
 // "Script error." with no file, line, or stack when a script from another
 // origin throws (an extension, a translated page, an ISP-injected script). It
@@ -207,6 +225,14 @@ const frameCount = (e: unknown): number => {
   return Array.isArray(frames) ? frames.length : 0;
 };
 
+// posthog-js stamps `mechanism.handled: false` on anything it autocaptured from
+// `onerror` / `onunhandledrejection`, and `true` on an explicit
+// `captureException`. Only the autocaptured ones are "nobody is dealing with
+// this"; a deliberate capture is a report we asked for and must never be
+// dropped by a message matcher aimed at the uncaught form of the same failure.
+const isUnhandled = (e: unknown): boolean =>
+  (e as { mechanism?: { handled?: unknown } } | null)?.mechanism?.handled === false;
+
 const isUnactionableThirdPartyException = (
   event: { event?: string; properties?: Record<string, unknown> },
 ): boolean => {
@@ -218,6 +244,10 @@ const isUnactionableThirdPartyException = (
     if (typeof value !== 'string') return false;
     if (CESIUM_REQUEST_ERROR.test(value)) return true;
     if (OUTLOOK_SAFELINK_NOISE.test(value)) return true;
+    // Scoped to the UNCAUGHT form only: the LocationMap's own once-per-session
+    // handled report carries the same message and has to survive, otherwise
+    // this rule would blind us to the very condition it exists to de-noise.
+    if (MAPLIBRE_WEBGL_UNAVAILABLE.test(value) && isUnhandled(entry)) return true;
     if (OPAQUE_CROSS_ORIGIN.test(value.trim()) && frameCount(entry) === 0) return true;
     return false;
   });

--- a/apps/viewer/src/lib/analytics.test.ts
+++ b/apps/viewer/src/lib/analytics.test.ts
@@ -187,6 +187,21 @@ describe('scrubEvent — noise filter + PII guard (regression)', () => {
     assert.equal(scrubEvent(uncaught('Failed to initialize WebGL')), null);
   });
 
+  it('KEEPS an unrelated error that merely MENTIONS the WebGL phrase', () => {
+    // #1914: the bare-message arm is anchored, not a substring test. Dropping
+    // is irreversible, so a matcher loose enough to eat someone else's WebGL
+    // failure would blind us exactly where it matters. Neither of these is
+    // MapLibre's refusal and both must survive.
+    assert.notEqual(
+      scrubEvent(uncaught('Failed to initialize WebGL renderer for the section overlay')),
+      null,
+    );
+    assert.notEqual(
+      scrubEvent(uncaught('SectionOverlay: Failed to initialize WebGL')),
+      null,
+    );
+  });
+
   it('KEEPS the LocationMap\'s own handled report of the same condition', () => {
     // The whole point of the fix is to convert this failure from an uncaught
     // error into a deliberate, once-per-session handled report. If the drop

--- a/apps/viewer/src/lib/analytics.test.ts
+++ b/apps/viewer/src/lib/analytics.test.ts
@@ -134,6 +134,86 @@ describe('scrubEvent — noise filter + PII guard (regression)', () => {
     assert.notEqual(scrubEvent(exceptionEvent('Failed to load Script error handler module')), null);
     assert.notEqual(scrubEvent(exceptionEvent('Object Not Found in scene graph')), null);
   });
+
+  // ── MapLibre "no WebGL context" (issue #1914) ─────────────────────────────
+  // Both strings are verbatim from error tracking: one user, one session, two
+  // DIFFERENT driver messages, both recorded as UNCAUGHT. The LocationMap now
+  // catches these at the source; this is the net under the one path that can
+  // still escape — MapLibre re-running `_setupPainter()` from a DOM listener
+  // while restoring a lost context.
+  const WEBGL_MISSING_EXTENSION = JSON.stringify({
+    requestedAttributes: {
+      antialias: false, preserveDrawingBuffer: false,
+      powerPreference: 'high-performance', failIfMajorPerformanceCaveat: false,
+      desynchronized: false, alpha: true, depth: true, stencil: true,
+      premultipliedAlpha: true,
+    },
+    statusMessage: 'OES_packed_depth_stencil support is required.',
+    type: 'webglcontextcreationerror',
+    message: 'Failed to initialize WebGL',
+  });
+
+  const WEBGL_GPU_CONTENTION = JSON.stringify({
+    requestedAttributes: {
+      antialias: false, preserveDrawingBuffer: false,
+      powerPreference: 'high-performance', failIfMajorPerformanceCaveat: false,
+      desynchronized: false, alpha: true, depth: true, stencil: true,
+      premultipliedAlpha: true,
+    },
+    statusMessage:
+      'Could not create a WebGL context, VENDOR = 0x1002, DEVICE = 0x1638, '
+      + 'GL_VENDOR = Google Inc. (AMD), GL_RENDERER = ANGLE (AMD, AMD Radeon(TM) '
+      + 'Graphics, D3D11), Sandboxed = yes, ErrorMessage = BindToCurrentSequence failed: .',
+    type: 'webglcontextcreationerror',
+    message: 'Failed to initialize WebGL',
+  });
+
+  /** As posthog-js records an autocaptured (uncaught) exception. */
+  const uncaught = (value: string): CaptureEvent => ({
+    event: '$exception',
+    properties: {
+      $exception_list: [{
+        type: 'Error',
+        value,
+        mechanism: { handled: false, synthetic: false, type: 'generic' },
+      }],
+    },
+  });
+
+  it('drops the UNCAUGHT MapLibre WebGL-unavailable exception (both driver messages)', () => {
+    assert.equal(scrubEvent(uncaught(WEBGL_MISSING_EXTENSION)), null);
+    assert.equal(scrubEvent(uncaught(WEBGL_GPU_CONTENTION)), null);
+    // MapLibre's other shape: no detail object, so it throws the bare message.
+    assert.equal(scrubEvent(uncaught('Failed to initialize WebGL')), null);
+  });
+
+  it('KEEPS the LocationMap\'s own handled report of the same condition', () => {
+    // The whole point of the fix is to convert this failure from an uncaught
+    // error into a deliberate, once-per-session handled report. If the drop
+    // rule above also swallowed that, we would be blind to the condition.
+    const handled: CaptureEvent = {
+      event: '$exception',
+      properties: {
+        $exception_list: [{
+          type: 'Error',
+          value: WEBGL_MISSING_EXTENSION,
+          mechanism: { handled: true, type: 'generic' },
+        }],
+        context: 'location_map_webgl',
+        map_unavailable_reason: 'map_construction_failed',
+      },
+    };
+    const out = scrubEvent(handled);
+    assert.notEqual(out, null);
+    assert.equal(out?.properties?.context, 'location_map_webgl');
+    assert.equal(out?.properties?.map_unavailable_reason, 'map_construction_failed');
+  });
+
+  it('keeps an unrelated WebGL failure that merely mentions the words', () => {
+    // Narrowness guard: an actionable WebGL bug of ours must not be dropped.
+    assert.notEqual(scrubEvent(uncaught('Failed to initialize WebGPU adapter')), null);
+    assert.notEqual(scrubEvent(uncaught('WebGL warning: drawArrays: no program bound')), null);
+  });
 });
 
 describe('scrubEvent — issue grouping', () => {

--- a/apps/viewer/src/lib/geo/map-webgl-support.test.ts
+++ b/apps/viewer/src/lib/geo/map-webgl-support.test.ts
@@ -1,0 +1,223 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  probeMapWebglSupport,
+  markMapWebglUnsupported,
+  takeMapWebglReportSlot,
+  getMapWebglVerdict,
+  isWebglContextCreationError,
+  describeMapInitFailure,
+  resetMapWebglSupportForTests,
+} from './map-webgl-support.js';
+
+// The two production failures, verbatim from error tracking (issue #1914).
+// Both arrived as UNCAUGHT exceptions from one user in one session.
+const MISSING_EXTENSION = JSON.stringify({
+  requestedAttributes: {
+    antialias: false, preserveDrawingBuffer: false,
+    powerPreference: 'high-performance', failIfMajorPerformanceCaveat: false,
+    desynchronized: false, alpha: true, depth: true, stencil: true,
+    premultipliedAlpha: true,
+  },
+  statusMessage: 'OES_packed_depth_stencil support is required.',
+  type: 'webglcontextcreationerror',
+  message: 'Failed to initialize WebGL',
+});
+
+const GPU_PROCESS_CONTENTION = JSON.stringify({
+  requestedAttributes: {
+    antialias: false, preserveDrawingBuffer: false,
+    powerPreference: 'high-performance', failIfMajorPerformanceCaveat: false,
+    desynchronized: false, alpha: true, depth: true, stencil: true,
+    premultipliedAlpha: true,
+  },
+  statusMessage:
+    'Could not create a WebGL context, VENDOR = 0x1002, DEVICE = 0x1638, '
+    + 'GL_VENDOR = Google Inc. (AMD), GL_RENDERER = ANGLE (AMD, AMD Radeon(TM) '
+    + 'Graphics, D3D11), Sandboxed = yes, ErrorMessage = BindToCurrentSequence failed: .',
+  type: 'webglcontextcreationerror',
+  message: 'Failed to initialize WebGL',
+});
+
+/** MapLibre's other shape: no detail object, so it throws the bare message. */
+const BARE_MESSAGE = 'Failed to initialize WebGL';
+
+/** A canvas whose `getContext` always refuses — the unsupported device. */
+function refusingCanvas(calls: string[]) {
+  return {
+    getContext(type: string) {
+      calls.push(type);
+      return null;
+    },
+  };
+}
+
+/** A canvas that serves webgl2, recording whether the context was released. */
+function workingCanvas(calls: string[], released: { count: number }) {
+  return {
+    getContext(type: string) {
+      calls.push(type);
+      if (type !== 'webgl2') return null;
+      return {
+        getExtension(name: string) {
+          if (name !== 'WEBGL_lose_context') return null;
+          return { loseContext: () => { released.count++; } };
+        },
+      };
+    },
+  };
+}
+
+beforeEach(() => {
+  resetMapWebglSupportForTests();
+});
+
+describe('isWebglContextCreationError', () => {
+  it('recognises the production missing-extension failure', () => {
+    assert.equal(isWebglContextCreationError(new Error(MISSING_EXTENSION)), true);
+  });
+
+  it('recognises the production GPU-process-contention failure', () => {
+    assert.equal(isWebglContextCreationError(new Error(GPU_PROCESS_CONTENTION)), true);
+  });
+
+  it('recognises the bare-message shape MapLibre throws without a detail object', () => {
+    assert.equal(isWebglContextCreationError(new Error(BARE_MESSAGE)), true);
+  });
+
+  it('does not over-match an unrelated error', () => {
+    // Guards the narrowness that keeps a real map bug from being swallowed.
+    assert.equal(isWebglContextCreationError(new Error('boom')), false);
+    assert.equal(isWebglContextCreationError(new Error('Failed to fetch')), false);
+    assert.equal(isWebglContextCreationError(null), false);
+    assert.equal(isWebglContextCreationError(undefined), false);
+    assert.equal(isWebglContextCreationError({}), false);
+  });
+});
+
+describe('describeMapInitFailure', () => {
+  it('extracts the driver status and event type from the JSON shape', () => {
+    const detail = describeMapInitFailure(new Error(MISSING_EXTENSION));
+    assert.equal(detail.status, 'OES_packed_depth_stencil support is required.');
+    assert.equal(detail.eventType, 'webglcontextcreationerror');
+  });
+
+  it('extracts the contention status too', () => {
+    const detail = describeMapInitFailure(new Error(GPU_PROCESS_CONTENTION));
+    assert.match(String(detail.status), /BindToCurrentSequence failed/);
+  });
+
+  it('returns nothing extractable for the bare-message shape', () => {
+    assert.deepEqual(describeMapInitFailure(new Error(BARE_MESSAGE)), {});
+  });
+
+  it('survives a message that starts like JSON but is not', () => {
+    assert.deepEqual(describeMapInitFailure(new Error('{not json')), {});
+  });
+});
+
+describe('probeMapWebglSupport', () => {
+  it('reports unsupported when no context can be created', () => {
+    const calls: string[] = [];
+    const result = probeMapWebglSupport(() => refusingCanvas(calls));
+    assert.equal(result.supported, false);
+    assert.equal(result.reason, 'probe_no_context');
+    // MapLibre's own order: webgl2 first, then webgl.
+    assert.deepEqual(calls, ['webgl2', 'webgl']);
+  });
+
+  it('reports supported and RELEASES the probe context', () => {
+    // Load-bearing: a browser allows only ~16 live WebGL contexts per page, so
+    // a leaked probe context could cause the very failure it screens for.
+    const calls: string[] = [];
+    const released = { count: 0 };
+    const result = probeMapWebglSupport(() => workingCanvas(calls, released));
+    assert.equal(result.supported, true);
+    assert.deepEqual(calls, ['webgl2']);
+    assert.equal(released.count, 1);
+  });
+
+  it('treats a throwing getContext as a refusal rather than propagating', () => {
+    const result = probeMapWebglSupport(() => ({
+      getContext() { throw new Error('gpu process gone'); },
+    }));
+    assert.equal(result.supported, false);
+    assert.equal(result.reason, 'probe_no_context');
+  });
+
+  it('stays optimistic when there is no DOM to probe with', () => {
+    // Node / SSR: nothing renders, so deferring to the caller's try/catch is a
+    // better default than guessing "unsupported".
+    assert.equal(probeMapWebglSupport(() => null).supported, true);
+  });
+
+  it('latches the failure so a remount never re-probes', () => {
+    // THE regression assertion. The Georeferencing section is a Radix
+    // Collapsible: collapsing and re-expanding remounts the panel. Before the
+    // fix every remount rebuilt the map and threw again, uncaught.
+    const calls: string[] = [];
+    const first = probeMapWebglSupport(() => refusingCanvas(calls));
+    assert.equal(first.supported, false);
+    assert.deepEqual(calls, ['webgl2', 'webgl']);
+
+    for (let i = 0; i < 20; i++) {
+      const again = probeMapWebglSupport(() => refusingCanvas(calls));
+      assert.equal(again.supported, false);
+      assert.equal(again.reason, 'probe_no_context');
+    }
+    // Zero further getContext calls: the verdict is a property of the device.
+    assert.deepEqual(calls, ['webgl2', 'webgl']);
+  });
+
+  it('latches success too, so the probe costs one context per session', () => {
+    const calls: string[] = [];
+    const released = { count: 0 };
+    probeMapWebglSupport(() => workingCanvas(calls, released));
+    probeMapWebglSupport(() => workingCanvas(calls, released));
+    assert.deepEqual(calls, ['webgl2']);
+    assert.equal(released.count, 1);
+  });
+
+  it('honours a verdict latched by a real construction failure', () => {
+    // The probe can pass and `new maplibregl.Map(...)` still throw under GPU
+    // contention. Once that has happened, the probe must not undo it.
+    const calls: string[] = [];
+    const released = { count: 0 };
+    markMapWebglUnsupported('map_construction_failed');
+    const result = probeMapWebglSupport(() => workingCanvas(calls, released));
+    assert.equal(result.supported, false);
+    assert.equal(result.reason, 'map_construction_failed');
+    assert.deepEqual(calls, []);
+  });
+});
+
+describe('markMapWebglUnsupported', () => {
+  it('keeps the first reason, so the originating failure is what gets reported', () => {
+    markMapWebglUnsupported('map_construction_failed');
+    markMapWebglUnsupported('context_lost');
+    assert.equal(getMapWebglVerdict()?.reason, 'map_construction_failed');
+  });
+
+  it('overrides an earlier positive verdict', () => {
+    probeMapWebglSupport(() => workingCanvas([], { count: 0 }));
+    assert.equal(getMapWebglVerdict()?.supported, true);
+    markMapWebglUnsupported('context_lost');
+    assert.equal(getMapWebglVerdict()?.supported, false);
+    assert.equal(getMapWebglVerdict()?.reason, 'context_lost');
+  });
+});
+
+describe('takeMapWebglReportSlot', () => {
+  it('grants the slot exactly once per session', () => {
+    // Production saw 2 events from 1 user in 1 session; unrationed, a user
+    // toggling the panel would flood the exception quota.
+    assert.equal(takeMapWebglReportSlot(), true);
+    for (let i = 0; i < 10; i++) {
+      assert.equal(takeMapWebglReportSlot(), false);
+    }
+  });
+});

--- a/apps/viewer/src/lib/geo/map-webgl-support.ts
+++ b/apps/viewer/src/lib/geo/map-webgl-support.ts
@@ -175,15 +175,20 @@ export function probeMapWebglSupport(
     if (!canvas) return (verdict = SUPPORTED);
     gl = canvas.getContext('webgl2', MAP_CONTEXT_ATTRIBUTES)
       ?? canvas.getContext('webgl', MAP_CONTEXT_ATTRIBUTES);
-  } catch {
+  } catch (err) {
     // `getContext` is not specified to throw, but a wedged GPU process has been
-    // seen to. Treat a throw exactly like a refusal.
+    // seen to. Treat a throw exactly like a refusal — and say so, because this
+    // branch firing is itself the interesting signal.
+    console.warn('[ifc-lite] WebGL probe threw; treating as unsupported', err);
     gl = null;
   } finally {
     // Hand the context straight back, on every path including the failure one.
     try {
       gl?.getExtension('WEBGL_lose_context')?.loseContext?.();
-    } catch { /* releasing is best-effort; never mask the verdict */ }
+    } catch (err) {
+      // Best-effort: never mask the verdict we already have.
+      console.warn('[ifc-lite] could not release the WebGL probe context', err);
+    }
   }
 
   verdict = gl ? SUPPORTED : { supported: false, reason: 'probe_no_context' };

--- a/apps/viewer/src/lib/geo/map-webgl-support.ts
+++ b/apps/viewer/src/lib/geo/map-webgl-support.ts
@@ -1,0 +1,248 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * WebGL capability gate for the LocationMap minimap.
+ *
+ * MapLibre's `Map` constructor is not fail-soft: `_setupContainer()` mutates the
+ * container we hand it (adds `maplibregl-map`, creates the canvas + control
+ * containers, attaches `webglcontextlost`/`restored` listeners) and only THEN
+ * does `_setupPainter()` ask for a WebGL context. When the browser refuses one,
+ * `_setupPainter` throws synchronously:
+ *
+ *   throw new Error(JSON.stringify({ requestedAttributes, statusMessage, type,
+ *                                    message: 'Failed to initialize WebGL' }))
+ *
+ * — or, when no `webglcontextcreationerror` event carried a detail object, the
+ * bare `new Error('Failed to initialize WebGL')`. Both shapes reached error
+ * tracking as UNCAUGHT exceptions, because the construction site sits inside a
+ * `.then()` callback whose derived promise nobody handled.
+ *
+ * The refusal is a property of the DEVICE, not of the model or of any one
+ * component instance. Two real examples, same session, same machine (an AMD
+ * integrated GPU on ANGLE/D3D11):
+ *
+ *   "OES_packed_depth_stencil support is required."
+ *   "Could not create a WebGL context, ... ErrorMessage = BindToCurrentSequence failed: ."
+ *
+ * The first is a hard capability gap (MapLibre demands depth + stencil; WebGL1
+ * on that ANGLE path cannot back them without the extension). The second is the
+ * GPU process being unable to serve a context at that moment — the viewport
+ * renderer is WebGPU, so MapLibre is a second, independent GPU consumer in the
+ * same process. Neither is actionable by the user beyond reloading.
+ *
+ * Hence: probe once, latch the verdict for the session, and let the caller show
+ * a fallback instead of a blank box. Module state is deliberate — remounting
+ * (the Georeferencing section is a Radix Collapsible, so collapsing and
+ * re-expanding unmounts and remounts the panel) must not re-open the floodgates.
+ * Same principle, and the same test seam, as `gpu-upload-guard.ts`.
+ *
+ * Kept free of `posthog-js` and of `maplibre-gl` on purpose, so the contract is
+ * unit-testable under the Node test runner without a browser or a 1 MB map
+ * bundle (same discipline as `analytics-scrub.ts`). Reporting is the caller's
+ * job; this module only rations it via `takeMapWebglReportSlot`.
+ */
+
+/**
+ * The context attributes MapLibre actually requests.
+ *
+ * `_setupPainter` merges the constructor's `canvasContextAttributes` defaults
+ * with the four values it force-overrides (`alpha`, `depth`, `stencil`,
+ * `premultipliedAlpha`). Probing with anything less faithful would be worse
+ * than not probing at all: `depth` + `stencil` are precisely what the reported
+ * `OES_packed_depth_stencil` failure trips over, so a lazier probe would return
+ * "supported" on the very device this exists for.
+ *
+ * Keep in step with maplibre-gl's `defaultOptions.canvasContextAttributes` on
+ * upgrade — a drift here only costs probe fidelity, never correctness, because
+ * the caller still wraps the real construction in `try/catch`.
+ */
+const MAP_CONTEXT_ATTRIBUTES: Readonly<Record<string, unknown>> = Object.freeze({
+  antialias: false,
+  preserveDrawingBuffer: false,
+  powerPreference: 'high-performance',
+  failIfMajorPerformanceCaveat: false,
+  desynchronized: false,
+  alpha: true,
+  depth: true,
+  stencil: true,
+  premultipliedAlpha: true,
+});
+
+/** Why the map is unavailable. Low-cardinality: safe as an analytics property. */
+export type MapWebglFailureReason =
+  /** The pre-flight probe could not get a context at all. */
+  | 'probe_no_context'
+  /** The probe passed but `new maplibregl.Map(...)` still threw. */
+  | 'map_construction_failed'
+  /** The context was lost after the map had been running. */
+  | 'context_lost';
+
+export interface MapWebglVerdict {
+  supported: boolean;
+  /** Present only when `supported` is false. */
+  reason?: MapWebglFailureReason;
+}
+
+/** Minimal structural types so the probe can be driven by a fake in tests. */
+interface ProbeContext {
+  getExtension(name: string): { loseContext?: () => void } | null;
+}
+interface ProbeCanvas {
+  getContext(type: string, attributes?: unknown): ProbeContext | null;
+}
+
+const SUPPORTED: MapWebglVerdict = Object.freeze({ supported: true });
+
+// ── Session-scoped state ────────────────────────────────────────────────────
+// `null` means "not yet determined". Once set, the verdict stands for the rest
+// of the session: a device that cannot serve a WebGL context will not start
+// doing so because the user re-opened an accordion, and re-probing would burn
+// a context slot each time.
+let verdict: MapWebglVerdict | null = null;
+let reportSlotTaken = false;
+
+/** Reset the session latches. Test seam — not used in production. */
+export function resetMapWebglSupportForTests(): void {
+  verdict = null;
+  reportSlotTaken = false;
+}
+
+/** The latched verdict, or `null` if nothing has been determined yet. */
+export function getMapWebglVerdict(): MapWebglVerdict | null {
+  return verdict;
+}
+
+/**
+ * Latch a negative verdict discovered the hard way — by the real construction
+ * throwing, or by the context being lost later. Idempotent: the FIRST reason
+ * wins, so the originating failure is the one that gets reported.
+ */
+export function markMapWebglUnsupported(reason: MapWebglFailureReason): void {
+  if (verdict && !verdict.supported) return;
+  verdict = { supported: false, reason };
+}
+
+/**
+ * Claim the once-per-session slot for reporting this failure to error tracking.
+ *
+ * Returns `true` exactly once. These failures repeat on every remount, and the
+ * production evidence is two events from a single user in a single session —
+ * enough to show the pattern, and enough to flood the exception quota on a
+ * device where the user keeps toggling the panel.
+ */
+export function takeMapWebglReportSlot(): boolean {
+  if (reportSlotTaken) return false;
+  reportSlotTaken = true;
+  return true;
+}
+
+const defaultCanvasFactory = (): ProbeCanvas | null =>
+  typeof document === 'undefined' ? null : document.createElement('canvas');
+
+/**
+ * Decide whether MapLibre can be constructed, without constructing it.
+ *
+ * Cheap: a detached 1x1 canvas, `webgl2` then `webgl` (MapLibre's own order),
+ * and the context is released immediately via `WEBGL_lose_context`. Releasing
+ * is load-bearing, not tidiness — a browser allows only ~16 live WebGL contexts
+ * per page, so a probe that leaked one could *cause* the failure it screens for.
+ *
+ * The probe is an optimisation, never the sole gate: it lets the fallback be
+ * the user's first paint instead of a caught throw, and it keeps MapLibre from
+ * leaving a half-built canvas in our container. The caller must still wrap the
+ * real construction in `try/catch`, because a probe can pass and the context
+ * still be refused a moment later under GPU-process contention — which is
+ * exactly the `BindToCurrentSequence failed` case.
+ *
+ * When there is no `document` (the Node test runner, SSR) the verdict is
+ * optimistic: nothing renders there anyway, and guessing "unsupported" would
+ * be a worse default than deferring to the `try/catch`.
+ *
+ * @param createCanvas Injected canvas factory. Tests only.
+ */
+export function probeMapWebglSupport(
+  createCanvas: () => ProbeCanvas | null = defaultCanvasFactory,
+): MapWebglVerdict {
+  if (verdict) return verdict;
+
+  let gl: ProbeContext | null = null;
+  let canvas: ProbeCanvas | null = null;
+  try {
+    canvas = createCanvas();
+    // No DOM to probe with: stay optimistic and let the `try/catch` decide.
+    if (!canvas) return (verdict = SUPPORTED);
+    gl = canvas.getContext('webgl2', MAP_CONTEXT_ATTRIBUTES)
+      ?? canvas.getContext('webgl', MAP_CONTEXT_ATTRIBUTES);
+  } catch {
+    // `getContext` is not specified to throw, but a wedged GPU process has been
+    // seen to. Treat a throw exactly like a refusal.
+    gl = null;
+  } finally {
+    // Hand the context straight back, on every path including the failure one.
+    try {
+      gl?.getExtension('WEBGL_lose_context')?.loseContext?.();
+    } catch { /* releasing is best-effort; never mask the verdict */ }
+  }
+
+  verdict = gl ? SUPPORTED : { supported: false, reason: 'probe_no_context' };
+  return verdict;
+}
+
+// ── Failure-shape recognition ───────────────────────────────────────────────
+
+/** MapLibre's message when it cannot get a context, both shapes share it. */
+const MAP_WEBGL_INIT_MESSAGE = 'Failed to initialize WebGL';
+
+/**
+ * Is this the MapLibre "no WebGL context" failure?
+ *
+ * Deliberately narrow. It matches MapLibre's own wording and its
+ * `webglcontextcreationerror` detail token — never a minified class name, which
+ * changes every build (the same discipline the Cesium matcher in
+ * `analytics-scrub.ts` spells out). Over-matching here would silently swallow
+ * an actionable map bug.
+ */
+export function isWebglContextCreationError(err: unknown): boolean {
+  const message = err instanceof Error ? err.message : typeof err === 'string' ? err : '';
+  if (!message) return false;
+  return message.includes(MAP_WEBGL_INIT_MESSAGE)
+    || message.includes('"type":"webglcontextcreationerror"');
+}
+
+export interface MapInitFailureDetail {
+  /**
+   * The driver's explanation, e.g. `OES_packed_depth_stencil support is
+   * required.` Carries no model, file or user data — it describes the GPU.
+   */
+  status?: string;
+  /** The DOM event type MapLibre captured, normally `webglcontextcreationerror`. */
+  eventType?: string;
+}
+
+/**
+ * Pull the diagnostic fields out of MapLibre's JSON-stringified error.
+ *
+ * This is the difference between an unactionable "Failed to initialize WebGL"
+ * bucket and knowing whether a device is missing an extension or merely lost a
+ * race with the GPU process. `requestedAttributes` is deliberately NOT
+ * extracted — it is a constant (see `MAP_CONTEXT_ATTRIBUTES`) and would only
+ * add payload.
+ */
+export function describeMapInitFailure(err: unknown): MapInitFailureDetail {
+  const message = err instanceof Error ? err.message : typeof err === 'string' ? err : '';
+  if (!message.startsWith('{')) return {};
+  try {
+    const parsed: unknown = JSON.parse(message);
+    if (!parsed || typeof parsed !== 'object') return {};
+    const { statusMessage, type } = parsed as Record<string, unknown>;
+    const detail: MapInitFailureDetail = {};
+    if (typeof statusMessage === 'string' && statusMessage) detail.status = statusMessage;
+    if (typeof type === 'string' && type) detail.eventType = type;
+    return detail;
+  } catch {
+    // Not JSON after all — the bare-message shape. No detail to add.
+    return {};
+  }
+}


### PR DESCRIPTION
Closes #1914.

## Root cause

`new maplibregl.Map(...)` was constructed inside an un-`catch`ed `.then()` callback in `LocationMap`. maplibre's constructor calls `_setupContainer()` then `_setupPainter()`, which throws **synchronously** when the browser refuses a WebGL context — so the throw became an unhandled rejection that PostHog autocaptured with `mechanism.handled === false`.

The two production samples had *different* status messages, which is why this is not one narrow GPU quirk:

- `OES_packed_depth_stencil support is required.`
- `Could not create a WebGL context, VENDOR = 0x1002 … ANGLE (AMD Radeon, D3D11) … ErrorMessage = BindToCurrentSequence failed:`

And it fired twice in one session because every collapse/expand of the Radix Collapsible around the Georeferencing panel remounted the component and re-threw.

## The fix

Removes the cause rather than only catching the throw:

- A cheap WebGL capability **probe** before construction, plus a **session latch** so an unsupported device does not re-attempt on every remount.
- Graceful fallback UI — the rest of the properties panel keeps working.
- The condition is reported as *handled* with a `reason` (`map_construction_failed` / `map_load_failed`) and a `webgl_status`, not as an unhandled error, and a one-slot report cap stops remount churn from spamming.
- A `.catch()` backstop around the async load path.

New `apps/viewer/src/lib/geo/map-webgl-support.ts` (+ 223 lines of unit tests) and an `analytics-scrub.ts` rule.

## Adversarial verification

The reviewer reproduced the fail-then-pass proof, then simulated the refusal by patching `HTMLCanvasElement.prototype.getContext` to dispatch a `webglcontextcreationerror` carrying `statusMessage` and return `null` — **the resulting Error payload matched the production one in shape exactly.** Verified live in Chrome. Found no regressions.

## Reviewer notes / known gaps

- **Dead export:** `isWebglContextCreationError` is exported with 6 unit tests but is never used in production code (knip would flag it; knip is in `package.json` but not wired into any workflow). Consequence: the `catch` around `new maplibregl.Map` does not discriminate, so *any* synchronous ctor throw latches a device-level "no WebGL" verdict for the session. Practical risk is low — the options are fixed and a refused context is the only realistic sync throw — and it stays distinguishable in PostHog via `reason: map_construction_failed` with no `webgl_status`. Left deliberately: every alternative traded label accuracy for remount churn.
- `takeMapWebglReportSlot()` is **one global slot shared across all reasons**, so a transient `map_load_failed` consumed first means a genuine device failure later in the same session is never reported.
- The `.catch()` backstop labels everything `map_load_failed`. An error thrown *after* successful construction (`addControl`, `new Marker`) would get the wrong copy and leave the map undisposed, because `mapRef.current` was never assigned. Narrow, and it converts a hypothetical app bug from uncaught to handled.
- The maplibre chunk (1,027 kB / 273 kB gzip) is still downloaded before the probe runs, so the **first** mount on an unsupported device pays the download; subsequent mounts short-circuit.
- The container purge in the catch does not undo two side effects maplibre performs before throwing (the `scroll` listener on our container, and the global `ImageRequest.addThrottleControl` handle). One dead Map object retained per session. Cosmetic.
- **Not verified on the reported hardware** (Chrome 150 / Windows 10 / AMD Radeon on ANGLE-D3D11).
- The repo has no jsdom/testing-library and zero `*.test.tsx`, so the component-level behaviour was verified live in Chrome but is **not** captured as an automated regression test.

## Merge-order note

This branch and `fix/posthog-1903-safari-load-failed` (#1903) both edit `apps/viewer/src/lib/analytics-scrub.ts`. Whichever merges second will need a rebase there.
