### PR TITLE
fix(geometry): a wasm trap must not brick every geometry consumer in the document (#1898)

### DIFF
--- a/.changeset/wasm-runtime-trap-recovery.md
+++ b/.changeset/wasm-runtime-trap-recovery.md
@@ -1,0 +1,14 @@
+---
+"@ifc-lite/geometry": minor
+---
+
+A WebAssembly runtime trap no longer bricks every geometry consumer in the document.
+
+`IfcLiteBridge` used to store one `Error` in a module-level global the first time any operation trapped, and then throw that same object from every subsequent `init()` for the rest of the page's life. Because the global is per-realm, a trap in one consumer (a GLB export, say) disabled every other main-thread consumer — the next model load, the grid and drawing meshers, all the other exporters — even though the trap could only ever have damaged the engine handle that took it. The stored object also carried the stack of the call that first trapped, so the error reported later, from an unrelated call, was undiagnosable.
+
+Now:
+
+- A trap taken by an *operation* drops (and `free()`s — it used to leak) only the `IfcAPI` handle that took it, and propagates unchanged to the caller. Any later `init()`, on that bridge or another, builds a fresh handle and works.
+- A trap taken while *initializing* is the one unrecoverable case: this realm has no working engine, and neither half is retryable in practice (a trap in `new IfcAPI()` leaves the module singleton already built, a trap in instantiation is deterministic). It is reported as a freshly constructed error whose message carries the stable `WASM_RUNTIME_UNRECOVERABLE` marker and the underlying trap verbatim, with the trap as `cause`, and it dispatches `WASM_RUNTIME_UNRECOVERABLE_EVENT` on `globalThis` so the host can offer the user a reload. The library never reloads the page itself.
+
+New exports: `isWasmRuntimeTrap`, `isWasmRuntimeUnrecoverableError`, `WASM_RUNTIME_UNRECOVERABLE_CODE`, `WASM_RUNTIME_UNRECOVERABLE_EVENT`.

--- a/apps/viewer/src/components/viewer/GLBExportDialog.tsx
+++ b/apps/viewer/src/components/viewer/GLBExportDialog.tsx
@@ -44,6 +44,7 @@ import { buildHiddenIfcTypes } from '@/store/typeVisibilityFilter';
 import { posthog } from '@/lib/analytics';
 import { toast } from '@/components/ui/toast';
 import { GeometryProcessor, isNoRenderGeometryError, type MeshData } from '@ifc-lite/geometry';
+import { classifyLoadError, formatLoadError } from '@/lib/load-errors';
 import { exportGlbFromGeometry } from '@/lib/export/glb';
 import { downloadBlob, sanitizeFilename } from '@/lib/export/download';
 import { withInstancedMeshes } from '../../utils/instancedExport.js';
@@ -196,6 +197,12 @@ export function GLBExportDialog({ trigger }: GLBExportDialogProps) {
     setIsExporting(true);
     setExportResult(null);
 
+    // Which of the two assemblers ran, recorded outside the try so a failure
+    // report can say which one trapped (they have very different memory
+    // profiles: from-bytes re-meshes the whole model in wasm, from-meshes
+    // copies what the GPU already holds).
+    let fromSourceBytes = false;
+
     try {
       // Assemble the GLB in Rust over the meshes the viewer already holds (no
       // re-meshing). Visibility + colour-source selection is applied here because
@@ -232,6 +239,8 @@ export function GLBExportDialog({ trigger }: GLBExportDialogProps) {
         idOffset === 0 &&
         !!sourceFile &&
         /\.ifc$/i.test(sourceFile.name);
+
+      fromSourceBytes = canUseSource;
 
       let glb: Uint8Array;
       if (canUseSource) {
@@ -308,13 +317,30 @@ export function GLBExportDialog({ trigger }: GLBExportDialogProps) {
       });
     } catch (err) {
       console.error('Export failed:', err);
+      const kind = classifyLoadError(err);
       // The Rust boundary fails closed on an empty visible set; translate the
       // typed error into the operator-friendly message.
       const errMsg = isNoRenderGeometryError(err)
         ? 'GLB export produced 0 meshes — nothing visible to export with the current filters.'
-        : `GLB export failed: ${err instanceof Error ? err.message : 'Unknown error'}`;
+        // A wasm trap here used to reach the user as raw engine text (or, once
+        // it had poisoned the module, as an internal sentence about recreating
+        // a worker process). Hand it to the shared humaniser instead, which
+        // explains the crash and offers a reload when the engine can't restart
+        // (#1898).
+        : kind === 'wasm_runtime_crashed'
+          ? formatLoadError(err, selectedModel.name)
+          : `GLB export failed: ${err instanceof Error ? err.message : 'Unknown error'}`;
       setExportResult({ success: false, message: errMsg });
       toast.error(errMsg);
+      // This export failed silently in production: the catch only logged +
+      // toasted, so PostHog saw nothing and the trap that started the whole
+      // chain was never recorded anywhere but the user's console (#1898).
+      posthog.capture('export_failed', {
+        format: 'glb',
+        error_kind: kind,
+        from_source_bytes: fromSourceBytes,
+      });
+      posthog.captureException(err, { context: 'export_glb', error_kind: kind });
     } finally {
       setIsExporting(false);
     }

--- a/apps/viewer/src/components/viewer/GLBExportDialog.tsx
+++ b/apps/viewer/src/components/viewer/GLBExportDialog.tsx
@@ -340,7 +340,14 @@ export function GLBExportDialog({ trigger }: GLBExportDialogProps) {
         error_kind: kind,
         from_source_bytes: fromSourceBytes,
       });
-      posthog.captureException(err, { context: 'export_glb', error_kind: kind });
+      // …but only the *unexpected* failures belong in error tracking. An empty
+      // visible set is a typed, expected outcome of the user's own filters, and
+      // it classifies as `unknown`, so capturing it would mint a fresh PostHog
+      // issue per filter mistake and bury the trap signal this capture exists
+      // to surface.
+      if (!isNoRenderGeometryError(err)) {
+        posthog.captureException(err, { context: 'export_glb', error_kind: kind });
+      }
     } finally {
       setIsExporting(false);
     }

--- a/apps/viewer/src/lib/load-errors.test.ts
+++ b/apps/viewer/src/lib/load-errors.test.ts
@@ -219,3 +219,80 @@ describe('formatLoadError', () => {
     assert.match(msg, /the model/);
   });
 });
+
+// ── #1898: wasm runtime traps must be a bucket of their own ────────────────
+//
+// The reported occurrence was recorded as `error_kind: unknown` with an
+// internal sentence ("…recreate the worker process before calling init()
+// again") shown to the user, because a bare wasm trap matched none of the
+// buckets above.
+describe('wasm runtime traps (#1898)', () => {
+  it('classifies a bare WebAssembly trap as wasm_runtime_crashed', () => {
+    assert.equal(
+      classifyLoadError(new WebAssembly.RuntimeError('unreachable')),
+      'wasm_runtime_crashed',
+    );
+  });
+
+  it('classifies a cross-realm trap by its stable .name', () => {
+    // Re-raised out of a worker: `instanceof` fails, `.name` survives.
+    const crossRealm = new Error('unreachable');
+    crossRealm.name = 'RuntimeError';
+    assert.equal(classifyLoadError(crossRealm), 'wasm_runtime_crashed');
+  });
+
+  it('keeps a stringified trap unknown, so #1196 stays settled', () => {
+    // The analytics path only ever sees text. Matching trap phrasing there
+    // would sweep other viewer wasm (space-plate, parquet) into this family's
+    // single issue fingerprint — the exact mis-bucketing #1196 forbids.
+    assert.equal(classifyLoadError('RuntimeError: unreachable executed'), 'unknown');
+    assert.equal(classifyLoadError(new Error('unreachable')), 'unknown');
+  });
+
+  it('classifies the engine unrecoverable marker', () => {
+    assert.equal(
+      classifyLoadError(
+        new Error('WASM_RUNTIME_UNRECOVERABLE: … (underlying wasm trap: unreachable)'),
+      ),
+      'wasm_runtime_crashed',
+    );
+  });
+
+  it('does not steal a worker-attributed trap from the worker bucket', () => {
+    assert.equal(
+      classifyLoadError(new Error('Geometry worker error: unreachable')),
+      'geometry_worker_crash',
+    );
+  });
+
+  it('does not steal an explicit OOM from the memory bucket', () => {
+    assert.equal(
+      classifyLoadError(new WebAssembly.RuntimeError('memory access out of bounds')),
+      'out_of_memory',
+    );
+  });
+
+  it('offers a reload for an unrecoverable engine crash, without the internal text', () => {
+    const msg = formatLoadError(
+      new Error(
+        'WASM_RUNTIME_UNRECOVERABLE: the IFC-Lite WebAssembly geometry engine trapped during ' +
+          'init, so this document has no working engine instance. Reload the page to get a ' +
+          'fresh one. (underlying wasm trap: unreachable)',
+      ),
+      'tower.ifc',
+    );
+    assert.match(msg, /reload the page/i);
+    // The user must never see the engine's internal prose — no diagnostic code,
+    // no raw trap text, no "call init() again"/"recreate the worker process".
+    assert.doesNotMatch(msg, /WASM_RUNTIME_UNRECOVERABLE|underlying wasm trap|unreachable/i);
+    assert.doesNotMatch(msg, /wasm-bindgen|init\(\)|worker process/i);
+  });
+
+  it('explains a recoverable operation trap without demanding a reload first', () => {
+    const msg = formatLoadError(new WebAssembly.RuntimeError('unreachable'), 'tower.ifc');
+    assert.match(msg, /"tower\.ifc"/);
+    assert.match(msg, /geometry engine crashed/i);
+    assert.match(msg, /memory/i);
+    assert.doesNotMatch(msg, /unreachable/);
+  });
+});

--- a/apps/viewer/src/lib/load-errors.ts
+++ b/apps/viewer/src/lib/load-errors.ts
@@ -46,6 +46,17 @@ export type LoadErrorKind =
    * the user just needs to pick the file again.
    */
   | 'file_unreadable'
+  /**
+   * The WebAssembly geometry engine trapped at runtime on THIS thread — a Rust
+   * panic, a failed `assert!` or an allocator abort, all of which reach JS
+   * identically as `RuntimeError: unreachable` (`panic = "abort"`). Distinct
+   * from `geometry_worker_crash`, which is the same class of failure inside a
+   * worker: there the worker dies and is replaced, here the trap surfaces
+   * straight to the caller. Also covers the `WASM_RUNTIME_UNRECOVERABLE`
+   * marker, which the engine raises when it trapped while initializing and
+   * therefore cannot be rebuilt without a page reload (#1898).
+   */
+  | 'wasm_runtime_crashed'
   /** The user (or a superseding load) cancelled the operation. */
   | 'cancelled'
   /** Anything else. */
@@ -155,6 +166,32 @@ function isGeometryWorkerCrashError(message: string): boolean {
   return /geometry worker (?:failed|error|crashed|terminated)/i.test(message);
 }
 
+/**
+ * A bare WebAssembly trap that reached us on this thread (#1898). Before this
+ * bucket existed such a trap fell through to `unknown`, so the user was shown
+ * the raw engine text and error tracking could not group the family at all —
+ * which is exactly how the reported occurrence was recorded (`error_kind:
+ * unknown`, message = an internal sentence about recreating a worker process).
+ *
+ * Matched ONLY on hard identity: the error's `.name`, which the spec fixes to
+ * `RuntimeError` for every wasm trap and which survives a cross-realm hop where
+ * `instanceof` does not, or the engine's explicit unrecoverable marker.
+ *
+ * Deliberately NOT matched on trap phrasing in the message. Issue #1196 settled
+ * that a bare "unreachable" / "RuntimeError: …" *string* must stay `unknown`:
+ * on the analytics path (`analytics-scrub`) all we ever have is stringified
+ * text, and the viewer runs other wasm (space-plate, parquet) whose traps would
+ * then be swept into this family's single issue fingerprint. A live error
+ * object carries its `.name`, so nothing real is lost. Checked AFTER the worker
+ * bucket so a worker-attributed trap keeps its own bucket.
+ */
+const WASM_RUNTIME_UNRECOVERABLE_MARKER = 'WASM_RUNTIME_UNRECOVERABLE'; // == @ifc-lite/geometry's WASM_RUNTIME_UNRECOVERABLE_CODE
+function isWasmRuntimeCrashError(err: unknown, message: string): boolean {
+  return (
+    errorNameOf(err) === 'RuntimeError' || message.includes(WASM_RUNTIME_UNRECOVERABLE_MARKER)
+  );
+}
+
 function isCancelledError(message: string): boolean {
   return /\bcancel(?:led|ed)?\b|aborterror|the operation was aborted/i.test(message);
 }
@@ -177,6 +214,7 @@ export function classifyLoadError(err: unknown): LoadErrorKind {
   if (isOutOfMemoryError(message)) return 'out_of_memory';
   if (isStreamStalledError(message)) return 'geometry_stream_stalled';
   if (isGeometryWorkerCrashError(message)) return 'geometry_worker_crash';
+  if (isWasmRuntimeCrashError(err, message)) return 'wasm_runtime_crashed';
   if (isCancelledError(message)) return 'cancelled';
   return 'unknown';
 }
@@ -221,6 +259,24 @@ export function formatLoadError(err: unknown, fileName?: string): string {
         `It may have been moved, renamed, deleted, or unloaded by a cloud-sync client ` +
         `(OneDrive/Dropbox/iCloud) since you picked it. Please select the file again.`
       );
+    case 'wasm_runtime_crashed':
+      // Two sub-cases, and the difference matters to the user: a trap taken by
+      // one operation costs only that operation (the engine rebuilds itself on
+      // the next one), while a trap taken while the engine was starting cannot
+      // be undone without a new document. Never show the raw engine text here —
+      // the reported occurrence put an internal sentence about "recreating the
+      // worker process" in front of a user (#1898).
+      return messageOf(err).includes(WASM_RUNTIME_UNRECOVERABLE_MARKER)
+        ? (
+          `The 3D geometry engine crashed and can't restart in this tab. ` +
+          `Please reload the page (Ctrl/Cmd+R) — your work in other tabs is unaffected. ` +
+          `If it happens again on the same model, it is likely too large for this device's memory.`
+        )
+        : (
+          `The 3D geometry engine crashed while processing ${subject} and the operation was stopped. ` +
+          `This is usually memory pressure on a large or complex model — try closing other tabs, ` +
+          `or exporting/loading a smaller selection. Reload the page if it keeps happening.`
+        );
     case 'cancelled':
       return `Loading ${subject} was cancelled.`;
     default:

--- a/packages/geometry/src/ifc-lite-bridge.test.ts
+++ b/packages/geometry/src/ifc-lite-bridge.test.ts
@@ -177,6 +177,35 @@ describe('IfcLiteBridge', () => {
     expect(wasmMocks.free).toHaveBeenCalledTimes(1);
   });
 
+  it('survives a SECOND trap raised by free() while recovering from the first (#1898)', async () => {
+    const bridge = new IfcLiteBridge();
+    await bridge.init();
+
+    const trap = new WebAssembly.RuntimeError('unreachable');
+    wasmMocks.exportGlb.mockImplementationOnce(() => {
+      throw trap;
+    });
+    // `free()` runs Rust: if the allocator is what aborted, releasing the
+    // handle aborts again. The double fault must not escape the recovery path
+    // and replace the original trap on its way to the caller.
+    wasmMocks.free.mockImplementationOnce(() => {
+      throw new WebAssembly.RuntimeError('unreachable');
+    });
+
+    let caught: unknown;
+    try {
+      bridge.exportGlb(new Uint8Array([1]));
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBe(trap);
+
+    // …and the handle is dropped anyway, so the bridge still rebuilds.
+    expect(bridge.isInitialized()).toBe(false);
+    await expect(bridge.init()).resolves.toBeUndefined();
+    expect(() => bridge.getApi()).not.toThrow();
+  });
+
   it('propagates the ORIGINAL trap from an operation, not a stored guard error (#1898)', async () => {
     const bridge = new IfcLiteBridge();
     await bridge.init();

--- a/packages/geometry/src/ifc-lite-bridge.test.ts
+++ b/packages/geometry/src/ifc-lite-bridge.test.ts
@@ -8,6 +8,7 @@ const wasmMocks = vi.hoisted(() => {
   const parseSymbolicRepresentations = vi.fn();
   const setMergeLayers = vi.fn();
   const free = vi.fn();
+  const exportGlb = vi.fn();
 
   class MockIfcAPI {
     parseSymbolicRepresentations(content: string) {
@@ -15,6 +16,9 @@ const wasmMocks = vi.hoisted(() => {
     }
     setMergeLayers(enabled: boolean) {
       return setMergeLayers(enabled);
+    }
+    exportGlb(...args: unknown[]) {
+      return exportGlb(...args);
     }
     free() {
       return free();
@@ -25,6 +29,7 @@ const wasmMocks = vi.hoisted(() => {
     init: vi.fn(async () => undefined),
     parseSymbolicRepresentations,
     setMergeLayers,
+    exportGlb,
     free,
     MockIfcAPI,
   };
@@ -36,12 +41,18 @@ vi.mock('@ifc-lite/wasm', () => ({
 }));
 
 import { IfcLiteBridge } from './ifc-lite-bridge.js';
+import {
+  isWasmRuntimeTrap,
+  isWasmRuntimeUnrecoverableError,
+  WASM_RUNTIME_UNRECOVERABLE_EVENT,
+} from './wasm-runtime-trap.js';
 
 describe('IfcLiteBridge', () => {
   beforeEach(() => {
     wasmMocks.init.mockClear();
     wasmMocks.parseSymbolicRepresentations.mockReset();
     wasmMocks.setMergeLayers.mockReset();
+    wasmMocks.exportGlb.mockReset();
     wasmMocks.free.mockReset();
   });
 
@@ -106,22 +117,125 @@ describe('IfcLiteBridge', () => {
     expect(wasmMocks.free).not.toHaveBeenCalled();
   });
 
-  // NB: this test must run LAST in the file — `fatalWasmRuntimeError` in
-  // ifc-lite-bridge.ts is a module-level singleton with no reset hook, so
-  // once it fires every later `init()` call in this module instance
-  // (including in other `it()` blocks below it) throws immediately.
-  it('blocks in-process reinitialization after a fatal wasm runtime error', async () => {
+  // ── #1898: a wasm trap must not brick the whole document ────────────────
+  //
+  // Production sequence (PostHog 019fa277): a GLB export trapped the engine,
+  // the bridge recorded the trap in a MODULE-GLOBAL singleton, and every later
+  // `init()` in the realm — including the next model load, the grid/drawing
+  // meshers and every other exporter, all of which construct their own
+  // `IfcLiteBridge` on the main thread — threw the stored guard Error. A wasm
+  // trap can damage at most the engine instance that took it; the caches it
+  // can wedge all live on the `IfcAPI` handle, which the trap path drops.
+
+  it('a trap in one bridge does not block init() of another bridge (#1898)', async () => {
+    const trapped = new IfcLiteBridge();
+    await trapped.init();
+
+    wasmMocks.exportGlb.mockImplementationOnce(() => {
+      throw new WebAssembly.RuntimeError('unreachable');
+    });
+    expect(() => trapped.exportGlb(new Uint8Array([1, 2, 3]))).toThrow(WebAssembly.RuntimeError);
+
+    // An unrelated consumer (model load, grid mesher, another exporter) must
+    // still be able to stand up its own engine in the same document.
+    const fresh = new IfcLiteBridge();
+    await expect(fresh.init()).resolves.toBeUndefined();
+    expect(fresh.isInitialized()).toBe(true);
+    expect(() => fresh.getApi()).not.toThrow();
+  });
+
+  it('the bridge that trapped recovers on the next init() with a fresh IfcAPI (#1898)', async () => {
+    const bridge = new IfcLiteBridge();
+    await bridge.init();
+    const before = bridge.getApi();
+
+    wasmMocks.exportGlb.mockImplementationOnce(() => {
+      throw new WebAssembly.RuntimeError('unreachable');
+    });
+    expect(() => bridge.exportGlb(new Uint8Array([1]))).toThrow(WebAssembly.RuntimeError);
+    // The trap dropped the handle, so the bridge is no longer usable as-is …
+    expect(bridge.isInitialized()).toBe(false);
+
+    // … but re-initializing it rebuilds the engine instead of throwing.
+    await expect(bridge.init()).resolves.toBeUndefined();
+    expect(bridge.getApi()).not.toBe(before);
+  });
+
+  it('frees the WASM handle when an operation traps, instead of leaking it (#1898)', async () => {
     const bridge = new IfcLiteBridge();
     await bridge.init();
 
-    wasmMocks.parseSymbolicRepresentations.mockImplementationOnce(() => {
-      throw new WebAssembly.RuntimeError('panic');
+    wasmMocks.exportGlb.mockImplementationOnce(() => {
+      throw new WebAssembly.RuntimeError('unreachable');
+    });
+    expect(() => bridge.exportGlb(new Uint8Array([1]))).toThrow(WebAssembly.RuntimeError);
+
+    // Exactly once: the trap path frees, and the caller's `finally { dispose() }`
+    // must not double-free the same wasm-bindgen pointer.
+    expect(wasmMocks.free).toHaveBeenCalledTimes(1);
+    bridge.dispose();
+    expect(wasmMocks.free).toHaveBeenCalledTimes(1);
+  });
+
+  it('propagates the ORIGINAL trap from an operation, not a stored guard error (#1898)', async () => {
+    const bridge = new IfcLiteBridge();
+    await bridge.init();
+
+    const trap = new WebAssembly.RuntimeError('unreachable');
+    wasmMocks.exportGlb.mockImplementationOnce(() => {
+      throw trap;
+    });
+    // The reported PostHog Error was a module-global object constructed at the
+    // trap site and rethrown much later from an unrelated call, which is why
+    // its stack pointed at `exportGlb` while its capture context said
+    // `ifc_model_load`. Callers must get the real trap.
+    let caught: unknown;
+    try {
+      bridge.exportGlb(new Uint8Array([1]));
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBe(trap);
+    expect(isWasmRuntimeTrap(caught)).toBe(true);
+  });
+
+  it('a trap during init() is reported as unrecoverable, with the trap as cause (#1898)', async () => {
+    const trap = new WebAssembly.RuntimeError('unreachable');
+    wasmMocks.init.mockImplementationOnce(async () => {
+      throw trap;
     });
 
-    expect(() => bridge.parseSymbolicRepresentations('broken ifc')).toThrow(WebAssembly.RuntimeError);
-    await expect(bridge.init()).rejects.toThrow(
-      'IFC-Lite WASM cannot recover from a fatal runtime error within the same document lifetime.',
-    );
-    expect(wasmMocks.init).toHaveBeenCalledTimes(1);
+    // The dispatcher is feature-detected (`globalThis.dispatchEvent` +
+    // `CustomEvent`), so stub it rather than relying on a DOM: these tests run
+    // under the node environment, exactly like the CLI/MCP hosts where the
+    // library must stay silent.
+    const events: CustomEvent[] = [];
+    const g = globalThis as unknown as { dispatchEvent?: (e: Event) => boolean };
+    const previousDispatch = g.dispatchEvent;
+    g.dispatchEvent = (e: Event) => {
+      events.push(e as CustomEvent);
+      return true;
+    };
+
+    const bridge = new IfcLiteBridge();
+    let caught: unknown;
+    try {
+      await bridge.init();
+    } catch (err) {
+      caught = err;
+    } finally {
+      if (previousDispatch) g.dispatchEvent = previousDispatch;
+      else delete g.dispatchEvent;
+    }
+
+    // Freshly constructed (its stack is the real throw site), typed, and it
+    // carries the underlying trap for triage instead of discarding it.
+    expect(isWasmRuntimeUnrecoverableError(caught)).toBe(true);
+    expect((caught as Error).cause).toBe(trap);
+    expect((caught as Error).message).toContain('unreachable');
+    // …and the host is told, so it can offer a reload rather than fail silently.
+    expect(events).toHaveLength(1);
+    expect(events[0].type).toBe(WASM_RUNTIME_UNRECOVERABLE_EVENT);
+    expect(events[0].detail.message).toContain('unreachable');
   });
 });

--- a/packages/geometry/src/ifc-lite-bridge.ts
+++ b/packages/geometry/src/ifc-lite-bridge.ts
@@ -11,6 +11,11 @@ import { createLogger } from '@ifc-lite/data';
 import type { KmzAltitudeMode, TessellationQuality } from './types.js';
 import type { GeometryDiagnostics } from './diagnostics.js';
 import { getStartedSharedWasmModule } from './wasm-shared-module.js';
+import {
+  isWasmRuntimeTrap,
+  notifyWasmRuntimeUnrecoverable,
+  wasmRuntimeUnrecoverableError,
+} from './wasm-runtime-trap.js';
 import init, {
   IfcAPI,
   SymbolicRepresentationCollection,
@@ -32,8 +37,6 @@ export type {
 };
 
 const log = createLogger('Geometry');
-const FATAL_WASM_RELOAD_REQUIRED_MESSAGE = 'IFC-Lite WASM cannot recover from a fatal runtime error within the same document lifetime. Reload the page or recreate the worker process before calling init() again.';
-let fatalWasmRuntimeError: Error | null = null;
 
 /**
  * Typed wrapper for the IFC-Lite WASM API including the optional
@@ -89,12 +92,34 @@ export class IfcLiteBridge {
   private skipSmallCuts: boolean = false;
 
   private isWasmRuntimeError(error: unknown): boolean {
-    return error instanceof WebAssembly.RuntimeError;
+    return isWasmRuntimeTrap(error);
   }
 
-  private markFatalWasmRuntimeError(): void {
-    fatalWasmRuntimeError = new Error(FATAL_WASM_RELOAD_REQUIRED_MESSAGE);
-    this.reset();
+  /**
+   * An operation on THIS bridge's engine took a WebAssembly runtime trap
+   * (#1898). Everything a trap can wedge lives on the `IfcAPI` handle — the
+   * per-load pre-pass / entity / style caches behind its mutexes — so the
+   * recovery is to drop that handle. The next `init()` (on this bridge or any
+   * other) builds a clean one and works; the trap itself propagates to the
+   * caller unchanged, so the failing operation still fails loudly with its own
+   * stack.
+   *
+   * This deliberately does NOT latch any realm-wide state. The previous
+   * behaviour stored one Error in a module global and refused every later
+   * `init()` in the document, which bricked every unrelated main-thread
+   * consumer (model load, grid / drawing meshers, the other exporters) after a
+   * single failed export — while bridges that happened to be initialized
+   * already kept running, so the "unrecoverable" claim contradicted itself.
+   */
+  private recordWasmRuntimeTrap(): void {
+    try {
+      this.dispose();
+    } catch {
+      // `free()` runs Rust code. If the allocator is what trapped, freeing can
+      // trap again — drop the reference anyway. A secondary failure here must
+      // never replace the original trap on its way to the caller.
+      this.reset();
+    }
   }
 
   /**
@@ -103,9 +128,6 @@ export class IfcLiteBridge {
    */
   async init(): Promise<void> {
     if (this.initialized) return;
-    if (fatalWasmRuntimeError) {
-      throw fatalWasmRuntimeError;
-    }
 
     try {
       // Initialize WASM module. In the browser/worker, wasm-bindgen resolves the
@@ -168,10 +190,18 @@ export class IfcLiteBridge {
       log.error('Failed to initialize WASM geometry engine', error, {
         operation: 'init',
       });
+      this.reset();
       if (this.isWasmRuntimeError(error)) {
-        this.markFatalWasmRuntimeError();
-      } else {
-        this.reset();
+        // The one genuinely unrecoverable case: the engine trapped while
+        // standing itself up, so there is no `IfcAPI` to drop and this realm
+        // has no working engine to fall back on. Report it as such — freshly
+        // constructed so the stack is this throw site, carrying the trap as
+        // `cause` — and tell the host, which offers the user a reload. The
+        // verdict is advisory, not a latch: a later `init()` still tries, so no
+        // unrelated consumer is disabled by it. (#1898)
+        const fatal = wasmRuntimeUnrecoverableError(error, 'init');
+        notifyWasmRuntimeUnrecoverable(fatal);
+        throw fatal;
       }
       throw error;
     }
@@ -231,7 +261,7 @@ export class IfcLiteBridge {
         data: { contentLength: content.length },
       });
       if (this.isWasmRuntimeError(error)) {
-        this.markFatalWasmRuntimeError();
+        this.recordWasmRuntimeTrap();
       }
       throw error;
     }
@@ -257,7 +287,7 @@ export class IfcLiteBridge {
         data: { contentLength: content.length },
       });
       if (this.isWasmRuntimeError(error)) {
-        this.markFatalWasmRuntimeError();
+        this.recordWasmRuntimeTrap();
       }
       throw error;
     }
@@ -285,7 +315,7 @@ export class IfcLiteBridge {
         data: { contentLength: content.length },
       });
       if (this.isWasmRuntimeError(error)) {
-        this.markFatalWasmRuntimeError();
+        this.recordWasmRuntimeTrap();
       }
       throw error;
     }
@@ -311,7 +341,7 @@ export class IfcLiteBridge {
         data: { contentLength: content.length },
       });
       if (this.isWasmRuntimeError(error)) {
-        this.markFatalWasmRuntimeError();
+        this.recordWasmRuntimeTrap();
       }
       throw error;
     }
@@ -340,7 +370,7 @@ export class IfcLiteBridge {
         data: { contentLength: content.length },
       });
       if (this.isWasmRuntimeError(error)) {
-        this.markFatalWasmRuntimeError();
+        this.recordWasmRuntimeTrap();
       }
       throw error;
     }
@@ -377,7 +407,7 @@ export class IfcLiteBridge {
     } catch (error) {
       log.error('Failed to diagnose geometry', error, { operation: 'diagnoseGeometry' });
       if (this.isWasmRuntimeError(error)) {
-        this.markFatalWasmRuntimeError();
+        this.recordWasmRuntimeTrap();
       }
       throw error;
     }
@@ -456,7 +486,7 @@ export class IfcLiteBridge {
     } catch (error) {
       log.error('Failed to exportMerged', error, { operation: 'exportMerged' });
       if (this.isWasmRuntimeError(error)) {
-        this.markFatalWasmRuntimeError();
+        this.recordWasmRuntimeTrap();
       }
       throw error;
     }
@@ -514,7 +544,7 @@ export class IfcLiteBridge {
     } catch (error) {
       log.error('Failed to exportGlbFromMeshes', error, { operation: 'exportGlbFromMeshes' });
       if (this.isWasmRuntimeError(error)) {
-        this.markFatalWasmRuntimeError();
+        this.recordWasmRuntimeTrap();
       }
       throw error;
     }
@@ -554,7 +584,7 @@ export class IfcLiteBridge {
     } catch (error) {
       log.error('Failed to simplifyMeshes', error, { operation: 'simplifyMeshes' });
       if (this.isWasmRuntimeError(error)) {
-        this.markFatalWasmRuntimeError();
+        this.recordWasmRuntimeTrap();
       }
       throw error;
     }
@@ -582,7 +612,7 @@ export class IfcLiteBridge {
     } catch (error) {
       log.error('Failed to exportKmz', error, { operation: 'exportKmz' });
       if (this.isWasmRuntimeError(error)) {
-        this.markFatalWasmRuntimeError();
+        this.recordWasmRuntimeTrap();
       }
       throw error;
     }
@@ -624,7 +654,7 @@ export class IfcLiteBridge {
     } catch (error) {
       log.error('Failed to exportKmzFromMeshes', error, { operation: 'exportKmzFromMeshes' });
       if (this.isWasmRuntimeError(error)) {
-        this.markFatalWasmRuntimeError();
+        this.recordWasmRuntimeTrap();
       }
       throw error;
     }
@@ -652,7 +682,7 @@ export class IfcLiteBridge {
     } catch (error) {
       log.error(`Failed to ${op}`, error, { operation: op, data: { contentLength: content.length } });
       if (this.isWasmRuntimeError(error)) {
-        this.markFatalWasmRuntimeError();
+        this.recordWasmRuntimeTrap();
       }
       throw error;
     }

--- a/packages/geometry/src/index.ts
+++ b/packages/geometry/src/index.ts
@@ -53,6 +53,18 @@ export {
   isWasmAssetUnavailableError,
   WASM_ASSET_UNAVAILABLE_EVENT,
 } from './wasm-asset-error.js';
+// WebAssembly runtime-trap contract (#1898). A trap taken by an operation
+// drops only the engine handle that took it and propagates unchanged, so the
+// host can report it; a trap taken while INITIALIZING cannot be recovered in
+// this document and is reported as `WASM_RUNTIME_UNRECOVERABLE` + the event,
+// which the host answers by offering a reload (never automatically — a crash
+// mid-session would discard the user's work).
+export {
+  isWasmRuntimeTrap,
+  isWasmRuntimeUnrecoverableError,
+  WASM_RUNTIME_UNRECOVERABLE_CODE,
+  WASM_RUNTIME_UNRECOVERABLE_EVENT,
+} from './wasm-runtime-trap.js';
 export {
   // `isInstancedShard` / `INSTANCED_SHARD_MAGIC` / `INSTANCED_SHARD_VERSION`
   // are intentionally NOT re-exported — they have no consumer outside the

--- a/packages/geometry/src/wasm-runtime-trap.test.ts
+++ b/packages/geometry/src/wasm-runtime-trap.test.ts
@@ -1,0 +1,90 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  isWasmRuntimeTrap,
+  isWasmRuntimeUnrecoverableError,
+  notifyWasmRuntimeUnrecoverable,
+  wasmRuntimeUnrecoverableError,
+  WASM_RUNTIME_UNRECOVERABLE_CODE,
+  WASM_RUNTIME_UNRECOVERABLE_EVENT,
+} from './wasm-runtime-trap.js';
+
+const g = globalThis as unknown as { dispatchEvent?: (e: Event) => boolean };
+const originalDispatch = g.dispatchEvent;
+
+afterEach(() => {
+  if (originalDispatch) g.dispatchEvent = originalDispatch;
+  else delete g.dispatchEvent;
+});
+
+describe('isWasmRuntimeTrap', () => {
+  it('matches a same-realm WebAssembly.RuntimeError', () => {
+    expect(isWasmRuntimeTrap(new WebAssembly.RuntimeError('unreachable'))).toBe(true);
+  });
+
+  it('matches a cross-realm trap by name (structured-cloned out of a Worker)', () => {
+    // A trap re-raised from another realm fails `instanceof` because that realm
+    // has its own `WebAssembly.RuntimeError` constructor; `.name` survives.
+    const crossRealm = new Error('unreachable');
+    crossRealm.name = 'RuntimeError';
+    expect(isWasmRuntimeTrap(crossRealm)).toBe(true);
+  });
+
+  it('does not match ordinary errors, strings or null', () => {
+    expect(isWasmRuntimeTrap(new Error('NO_RENDER_GEOMETRY'))).toBe(false);
+    expect(isWasmRuntimeTrap(new TypeError('boom'))).toBe(false);
+    expect(isWasmRuntimeTrap('RuntimeError: unreachable')).toBe(false);
+    expect(isWasmRuntimeTrap(null)).toBe(false);
+    expect(isWasmRuntimeTrap(undefined)).toBe(false);
+  });
+});
+
+describe('wasmRuntimeUnrecoverableError', () => {
+  it('is a fresh object every time, so its stack is the real throw site', () => {
+    const trap = new WebAssembly.RuntimeError('unreachable');
+    const a = wasmRuntimeUnrecoverableError(trap, 'init');
+    const b = wasmRuntimeUnrecoverableError(trap, 'init');
+    expect(a).not.toBe(b);
+  });
+
+  it('keeps the underlying trap in the message tail and as cause', () => {
+    const trap = new WebAssembly.RuntimeError('unreachable');
+    const err = wasmRuntimeUnrecoverableError(trap, 'init');
+    expect(err.message).toContain(WASM_RUNTIME_UNRECOVERABLE_CODE);
+    expect(err.message).toContain('unreachable');
+    expect(err.cause).toBe(trap);
+    expect(isWasmRuntimeUnrecoverableError(err)).toBe(true);
+  });
+
+  it('classifies from the message alone (analytics / postMessage round trip)', () => {
+    const err = wasmRuntimeUnrecoverableError(new WebAssembly.RuntimeError('unreachable'), 'init');
+    expect(isWasmRuntimeUnrecoverableError(err.message)).toBe(true);
+    expect(isWasmRuntimeUnrecoverableError('RuntimeError: unreachable')).toBe(false);
+  });
+});
+
+describe('notifyWasmRuntimeUnrecoverable', () => {
+  it('dispatches the event with the message when the host has a DOM dispatcher', () => {
+    const seen: CustomEvent[] = [];
+    g.dispatchEvent = (e: Event) => {
+      seen.push(e as CustomEvent);
+      return true;
+    };
+
+    notifyWasmRuntimeUnrecoverable(
+      wasmRuntimeUnrecoverableError(new WebAssembly.RuntimeError('unreachable'), 'init'),
+    );
+
+    expect(seen).toHaveLength(1);
+    expect(seen[0].type).toBe(WASM_RUNTIME_UNRECOVERABLE_EVENT);
+    expect(seen[0].detail.message).toContain(WASM_RUNTIME_UNRECOVERABLE_CODE);
+  });
+
+  it('is a silent no-op in a non-DOM host (CLI / MCP under Node)', () => {
+    delete g.dispatchEvent;
+    expect(() => notifyWasmRuntimeUnrecoverable(new Error('boom'))).not.toThrow();
+  });
+});

--- a/packages/geometry/src/wasm-runtime-trap.ts
+++ b/packages/geometry/src/wasm-runtime-trap.ts
@@ -1,0 +1,144 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Classify WebAssembly runtime traps and, for the one case that genuinely
+ * cannot be recovered in-document, broadcast it so the host can offer a reload
+ * (#1898).
+ *
+ * A trap is what reaches JS when the engine executes `unreachable`: with
+ * `panic = "abort"` (rust/Cargo.toml) a Rust panic, a failed `assert!` and an
+ * allocator abort are ALL indistinguishable from here — see the same caveat in
+ * `huge-file-error.ts`. What a trap can damage is bounded: the wasm instance's
+ * linear memory keeps whatever the aborted call leaked, and any Rust state the
+ * call was mutating is left mid-flight. It does NOT invalidate the module, and
+ * it says nothing about other engine handles in the realm, let alone about
+ * other realms (each Worker instantiates its own `@ifc-lite/wasm`).
+ *
+ * So the recovery contract is:
+ *
+ *  - a trap taken inside an *operation* is the caller's failure. The bridge
+ *    that took it drops (and frees) its `IfcAPI` handle — that is where the
+ *    wedgeable per-load caches live — and the original trap propagates
+ *    unchanged. A later `init()`, on that bridge or any other, builds a fresh
+ *    handle and works.
+ *  - a trap taken while *initializing* means this realm could not produce a
+ *    working engine at all, and neither half of that is retryable in practice:
+ *    if the trap came from `new IfcAPI()` the module singleton is already built
+ *    and wasm-bindgen's `init()` will keep returning it, and if it came from
+ *    instantiation itself it is a deterministic module-level failure that
+ *    recurs. That is the only case that earns
+ *    {@link WASM_RUNTIME_UNRECOVERABLE_EVENT} — the user is told to reload,
+ *    which is the one thing that really does get a new instance.
+ *
+ * Even then nothing is latched: a later `init()` still tries, so the
+ * "unrecoverable" verdict is a diagnosis for the user, never a lock that could
+ * disable an unrelated consumer. Recovery is lazy — it happens on the next
+ * `init()` a consumer asks for — so there is no retry loop to bound either.
+ *
+ * Detection lives here as a pure, unit-testable predicate; the host app owns
+ * the reload policy and subscribes to the event. This library never reloads
+ * the page on its own — same division of labour as `wasm-asset-error.ts`.
+ */
+
+/**
+ * Stable marker in the message of the error thrown when the engine cannot be
+ * initialized after a trap. Kept in the message (not only in a field) so it
+ * survives the string-only round trip through error tracking, and so the host
+ * app can classify it without importing this package.
+ */
+export const WASM_RUNTIME_UNRECOVERABLE_CODE = 'WASM_RUNTIME_UNRECOVERABLE';
+
+/**
+ * Dispatched on `globalThis` when the WebAssembly geometry engine trapped
+ * while initializing and therefore cannot be rebuilt in this document.
+ * `detail.message` carries the originating trap text. Hosts that opt in tell
+ * the user to reload; unlike the version-skew event this must NOT trigger an
+ * automatic reload — a crash mid-session would discard the user's work.
+ */
+export const WASM_RUNTIME_UNRECOVERABLE_EVENT = 'ifclite:wasm-runtime-unrecoverable';
+
+function messageOf(err: unknown): string {
+  if (err == null) return '';
+  if (typeof err === 'string') return err;
+  if (typeof err === 'object' && 'message' in err) {
+    const m = (err as { message?: unknown }).message;
+    if (typeof m === 'string') return m;
+  }
+  return String(err);
+}
+
+/**
+ * True when `err` is a WebAssembly runtime trap.
+ *
+ * `instanceof WebAssembly.RuntimeError` alone is not enough: an error thrown
+ * inside a Worker/iframe realm and re-raised here fails the identity check
+ * because each realm has its own `WebAssembly.RuntimeError` constructor. The
+ * `.name` fallback is the cross-realm-safe half — `RuntimeError` is the class
+ * name the spec fixes for wasm traps, and structured-cloned errors keep it.
+ */
+export function isWasmRuntimeTrap(err: unknown): boolean {
+  if (typeof WebAssembly !== 'undefined' && err instanceof WebAssembly.RuntimeError) return true;
+  if (typeof err !== 'object' || err === null) return false;
+  return (err as { name?: unknown }).name === 'RuntimeError';
+}
+
+/**
+ * True for the typed error {@link wasmRuntimeUnrecoverableError} produces —
+ * matched on the message marker so it also works on an error that only
+ * survived as text (an analytics payload, a `postMessage` hop).
+ */
+export function isWasmRuntimeUnrecoverableError(err: unknown): boolean {
+  return messageOf(err).includes(WASM_RUNTIME_UNRECOVERABLE_CODE);
+}
+
+/**
+ * Build the error thrown when the engine trapped while initializing.
+ *
+ * Constructed FRESH at every throw site on purpose. The bug this replaces
+ * stored one Error object in a module global and rethrew it forever, so the
+ * stack shipped to error tracking pointed at whichever call first trapped —
+ * the production report for #1898 showed a `exportGlb` stack captured under a
+ * model-load context, which made it undiagnosable. The underlying trap is kept
+ * verbatim in the message tail (for triage from text alone) and as `.cause`
+ * (for programmatic inspection), mirroring `largeFilePrepassError`.
+ */
+export function wasmRuntimeUnrecoverableError(cause: unknown, operation: string): Error {
+  const raw = messageOf(cause) || String(cause);
+  return new Error(
+    `${WASM_RUNTIME_UNRECOVERABLE_CODE}: the IFC-Lite WebAssembly geometry engine trapped during ` +
+      `${operation}, so this document has no working engine instance. Reload the page to get a ` +
+      `fresh one. (underlying wasm trap: ${raw})`,
+    { cause },
+  );
+}
+
+interface DomDispatcher {
+  dispatchEvent: (event: Event) => boolean;
+}
+
+function domDispatcher(): DomDispatcher | null {
+  const g = globalThis as unknown as Partial<DomDispatcher> & { CustomEvent?: unknown };
+  return typeof g.dispatchEvent === 'function' && typeof g.CustomEvent === 'function'
+    ? (g as DomDispatcher)
+    : null;
+}
+
+/**
+ * Broadcast {@link WASM_RUNTIME_UNRECOVERABLE_EVENT} on `globalThis` so an
+ * opted-in host can tell the user the engine is gone and offer a reload.
+ * No-op in non-DOM hosts such as Node (CLI/MCP), where the thrown error is the
+ * whole story.
+ */
+export function notifyWasmRuntimeUnrecoverable(err: unknown): void {
+  const target = domDispatcher();
+  if (!target) return;
+  try {
+    target.dispatchEvent(
+      new CustomEvent(WASM_RUNTIME_UNRECOVERABLE_EVENT, { detail: { message: messageOf(err) } }),
+    );
+  } catch {
+    /* CustomEvent unavailable — best effort, nothing more to do */
+  }
+}

--- a/scripts/api-surface.json
+++ b/scripts/api-surface.json
@@ -1808,6 +1808,8 @@
     "TessellationQuality: type",
     "Vec3: interface",
     "WASM_ASSET_UNAVAILABLE_EVENT: const",
+    "WASM_RUNTIME_UNRECOVERABLE_CODE: const",
+    "WASM_RUNTIME_UNRECOVERABLE_EVENT: const",
     "WatchdogInputs: interface",
     "WorkerCountInputs: interface",
     "WorkerCountResult: interface",
@@ -1818,6 +1820,8 @@
     "isNoRenderGeometryError: function",
     "isTauri: function",
     "isWasmAssetUnavailableError: function",
+    "isWasmRuntimeTrap: function",
+    "isWasmRuntimeUnrecoverableError: function",
     "mergeGeometryDiagnostics: function",
     "pickWorkerCount: function",
     "prewarmSharedWasmModule: function"


### PR DESCRIPTION
Closes #1898.

## Root cause

`IfcLiteBridge` stored one `Error` in a **module-scoped global** (`fatalWasmRuntimeError`) the first time *any* operation took a WebAssembly trap, then threw that same stale object from every subsequent `init()` for the life of the realm.

So an ordinary, per-operation memory-exhaustion abort during a GLB export **permanently disabled every other main-thread geometry consumer** — the next model load, the grid and drawing meshers, every other exporter. Mis-classifying a recoverable, per-operation failure as realm-fatal is the actual bug, and the guard text in the issue is just that mis-classification talking.

## The fix

- An **operation** trap now drops and frees only the `IfcAPI` handle that took it, and propagates unchanged. The next `init()` builds a fresh handle.
- Only an **init-time** trap is reported as unrecoverable — and advisory, never latched.
- New `packages/geometry/src/wasm-runtime-trap.ts` centralises trap detection/recording, with `context` / `error_kind` / `from_source_bytes` telemetry so the *next* occurrence tells us why the wasm trapped.
- `GLBExportDialog` gets a humanised message instead of raw engine text.

## Adversarial verification

The reviewer confirmed the root-cause claim against the code, re-ran the fail-then-pass proof, and drove the **real 4.1.4 wasm binary** in a Node harness. Two things it fixed itself (commit 158b4ce6):

- `GLBExportDialog` called `posthog.captureException` unconditionally in its catch, **including for the typed, expected `NO_RENDER_GEOMETRY` case** (user filtered every element out of the export). That classifies as `unknown`, so `stampFingerprint` leaves it on PostHog's default per-message grouping and every filter mistake mints its own PostHog issue — noise that would bury the wasm-trap signal this capture exists to surface. Now gated; the `export_failed` product event still counts it.
- The double-fault branch of `recordWasmRuntimeTrap` (the `try`/`catch` around `dispose()`, for when `free()` itself traps because the allocator is what aborted) had no test. Added one, verified red when the guard is removed.

It also probed the one new hazard it identified: switching the trap path from `reset()` to `dispose()` means we now `free()` a handle other code may still hold (`useIfcLoader.ts:1130` passes `geometryProcessor.getApi()` to the main-thread parser and holds it across awaits). Probed free-then-use against real wasm — wasm-bindgen guards it with a clean `Error: null pointer passed to rust` (**not** a `RuntimeError`, so no cascade), and a fresh bridge in the same realm still exports correctly afterwards. Degrades safely, but it is newer surface than main's leak-but-keep-alive behaviour.

## Reviewer notes / known gaps

- **Why the wasm trapped originally is still unknown.** Circumstantial evidence (the reporting user's 409/440 MB GLBs, the from-bytes path re-meshing into wasm linear memory) points at memory exhaustion, and the reviewer's own repro is that class of abort — but a Rust panic and an allocator abort are indistinguishable from JS under `panic='abort'` (`rust/Cargo.toml:39`). The new telemetry is what will answer it on the next occurrence. Post-fix this costs one export instead of the document either way.
- `rust/export/src/gltf.rs` still uses `assert!` for the glTF 4 GiB container limit, turning a user-actionable size limit into an `unreachable` trap. Worth a separate Rust issue converting it to a typed `ExportError::TooLarge`.
- **`WASM_RUNTIME_UNRECOVERABLE_EVENT` has zero subscribers anywhere in the repo** (contrast `WASM_ASSET_UNAVAILABLE_EVENT`, which `wasm-version-skew.ts:128` listens for). The "host offers a reload" promise is delivered only via `formatLoadError` text in the paths that call it. An init-time trap raised from `wasm-prewarm.ts`, `useGridLines3D`, `useSymbolicAnnotations` or `useDrawingGeneration` dispatches into the void.
- Only `GLBExportDialog` got the humanised message + telemetry. `HbjsonExportDialog.tsx:93`, `KmzExportDialog`, and the csv/obj paths still surface raw `err.message` and capture nothing.
- `wasm_runtime_crashed` is deliberately not in `RESOURCE_LIMIT_KINDS`, so a main-thread trap gets no automatic tessellation-tier downgrade even though `geometry_worker_crash` — the same failure class inside a worker — does. No change versus main, but an asymmetry worth a follow-up given the repro shows main-thread traps are memory-driven.
- Concurrent `init()` on one bridge still leaks an `IfcAPI` (`if (this.initialized) return` is not set until after `new IfcAPI()`). Pre-existing, but more reachable now that re-init after a trap is routine rather than refused.
- **No browser verification** on the reported Chrome 150 / Windows 10; verification is unit-level plus the Node + real-wasm harness.

## Merge-order note

This branch and `fix/posthog-1903-safari-load-failed` (#1903) both edit `packages/geometry/src/ifc-lite-bridge.ts` and `apps/viewer/src/lib/load-errors.ts`. Whichever merges second will need a rebase.
