### PR TITLE
fix(renderer): give pickRect the batched-mesh path pick() already has (#1904)

### DIFF
--- a/.changeset/brown-pianos-clap.md
+++ b/.changeset/brown-pianos-clap.md
@@ -1,0 +1,11 @@
+---
+"@ifc-lite/renderer": minor
+---
+
+Fix rectangle select returning nothing on batched models. `PickingManager.pickRect` passed `Scene.getMeshes()` straight to the GPU pick pass, but batched geometry lives in `batchedMeshes` and never reaches that list, so Ctrl+drag deterministically produced an empty selection — reproducible at 8 meshes, not just on large models.
+
+`pickRect` now takes the same route as `pick()`: hydrate the missing individual meshes when that fits the pick-mesh budget, otherwise fall back to CPU. The hydrate-or-fall-back decision both paths share is now a single code path, so they cannot drift again.
+
+Adds `Scene.selectRect(...)`, the rectangle counterpart of `Scene.raycast(...)`, for the CPU fallback used when geometry data has been released or hydration would exceed the budget. It is bounding-box granular — the same fidelity the released-geometry raycast path already has — so it can over-select slightly versus the pixel-exact GPU pass. Hidden, isolated, section-plane, and crop-box filtering all apply, so selection still matches what is visible.
+
+Closes #1904.

--- a/.changeset/brown-pianos-clap.md
+++ b/.changeset/brown-pianos-clap.md
@@ -6,6 +6,16 @@ Fix rectangle select returning nothing on batched models. `PickingManager.pickRe
 
 `pickRect` now takes the same route as `pick()`: hydrate the missing individual meshes when that fits the pick-mesh budget, otherwise fall back to CPU. The hydrate-or-fall-back decision both paths share is now a single code path, so they cannot drift again.
 
-Adds `Scene.selectRect(...)`, the rectangle counterpart of `Scene.raycast(...)`, for the CPU fallback used when geometry data has been released or hydration would exceed the budget. It is bounding-box granular — the same fidelity the released-geometry raycast path already has — so it can over-select slightly versus the pixel-exact GPU pass. Hidden, isolated, section-plane, and crop-box filtering all apply, so selection still matches what is visible.
+Adds `Scene.selectRect(...)`, the rectangle counterpart of `Scene.raycast(...)`, for the CPU fallback used when geometry data has been released or hydration would exceed the budget. Boxes are clipped against the near and far planes before projecting, so an element crossing the camera plane — the floor, ceiling and surrounding walls whenever you stand inside a model, which is exactly the population this path serves — contributes only its actually-visible screen extent rather than its full projected bounds.
+
+Three divergences from the pixel-exact GPU pass remain, all of them over-selecting:
+
+- Bounding-box granularity, so a rect covering only empty space inside an element's bounds still selects it.
+- No depth test, so it selects through occlusion, where the GPU rect pass only ever sees front-most fragments.
+- Whole-box section-plane and crop-box filtering: the CPU path skips an entity only when nothing of its box could be visible, whereas the pick shader discards per fragment, so a rect over the sectioned-away half of a box still selects it.
+
+Hidden and isolation filtering do apply, per entity, exactly as on the GPU path.
+
+Point clouds keep working on this path: splats render into the pick pass whether or not per-element mesh buffers were hydrated, so the CPU branch still runs a point-only GPU pass and unions its hits into the bounding-box result. Those point hits carry the section plane (the point picker clips on it) but not the crop box, and not the hidden/isolated sets — unchanged from the existing GPU rect pass, which has never filtered point nodes by those sets. If that point pass fails at readback, the rectangle select degrades to the bounding-box hits and logs, rather than failing outright.
 
 Closes #1904.

--- a/packages/renderer/src/picking-manager.test.ts
+++ b/packages/renderer/src/picking-manager.test.ts
@@ -5,7 +5,8 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
 
-import { PickingManager } from './picking-manager.ts';
+import { PickingManager, type PointPickProvider } from './picking-manager.ts';
+import type { PointPickNode } from './point-picker.ts';
 
 describe('PickingManager', () => {
   it('uses raycast when geometry data was released after finalize', async () => {
@@ -144,16 +145,28 @@ describe('PickingManager', () => {
   describe('pickRect on batched geometry (#1904)', () => {
     const WALL = 300;
     const SLAB = 301;
+    const POINT_ASSET = 900;
+
+    /** Stand-in for Scene.getInstancedTemplates(); identity is all the tests read. */
+    const INSTANCED_TEMPLATES = [{ instanceCount: 2 }];
+
+    /** A pickable point-cloud asset with no chunks — nothing here draws. */
+    const pointNode = (expressId: number): PointPickNode => ({ expressId, chunks: [] });
 
     function harness(overrides: {
       released?: boolean;
       existingMeshes?: Array<{ expressId: number }>;
       pieces?: (id: number) => Array<{ expressId: number }> | undefined;
+      pointNodes?: PointPickNode[] | null;
+      /** When set, the picker rejects with this instead of returning hits. */
+      pointPassError?: Error;
     } = {}) {
       const createdMeshes: Array<{ expressId: number }> = [
         ...(overrides.existingMeshes ?? []),
       ];
       let pickerRectMeshes: Array<{ expressId: number }> | null = null;
+      let pickerRectTemplates: unknown = 'not called';
+      let pickerRectPointNodes: unknown = 'not called';
       let selectRectCalls = 0;
 
       const camera = {
@@ -168,7 +181,7 @@ describe('PickingManager', () => {
         getAllMeshDataExpressIds: () => [WALL, SLAB],
         getMeshDataPieces:
           overrides.pieces ?? ((id: number) => [{ expressId: id }]),
-        getInstancedTemplates: () => undefined,
+        getInstancedTemplates: () => INSTANCED_TEMPLATES,
         selectRect: () => {
           selectRectCalls += 1;
           return new Set([WALL, SLAB]);
@@ -180,9 +193,20 @@ describe('PickingManager', () => {
           _x0: number, _y0: number, _x1: number, _y1: number,
           _w: number, _h: number,
           meshes: Array<{ expressId: number }>,
+          _viewProj: Float32Array,
+          pointNodes: Array<{ expressId: number }> | undefined,
+          _pointSizing: unknown,
+          instancedTemplates: unknown,
         ) => {
           pickerRectMeshes = meshes;
-          return new Set(meshes.map((m) => m.expressId));
+          pickerRectPointNodes = pointNodes;
+          pickerRectTemplates = instancedTemplates;
+          if (overrides.pointPassError) throw overrides.pointPassError;
+          // Mirrors the real picker: mesh samples resolve through the mesh list,
+          // point samples carry the asset's federated id directly.
+          const ids = new Set(meshes.map((m) => m.expressId));
+          for (const node of pointNodes ?? []) ids.add(node.expressId);
+          return ids;
         },
       };
 
@@ -200,10 +224,20 @@ describe('PickingManager', () => {
         (piece) => { createdMeshes.push({ expressId: piece.expressId }); },
       );
 
+      if (overrides.pointNodes !== undefined) {
+        const nodes = overrides.pointNodes;
+        const provider: PointPickProvider = nodes === null
+          ? () => null
+          : () => ({ nodes, sizing: { sizeMode: 0, worldRadius: 0.02, pointSizePx: 4 } });
+        manager.setPointPickProvider(provider);
+      }
+
       return {
         manager,
         createdMeshes,
         get pickerRectMeshes() { return pickerRectMeshes; },
+        get pickerRectPointNodes() { return pickerRectPointNodes; },
+        get pickerRectTemplates() { return pickerRectTemplates; },
         get selectRectCalls() { return selectRectCalls; },
       };
     }
@@ -256,6 +290,88 @@ describe('PickingManager', () => {
       await h.manager.pickRect(0, 0, 100, 100, { isolatedIds: new Set([SLAB]) });
 
       assert.equal(h.selectRectCalls, 1);
+    });
+
+    // Point splats render into the pick pass on their own — they never depend
+    // on per-element mesh hydration — so a mixed scene (batched IFC + point
+    // cloud) that misses the pick-mesh budget must still select points. The CPU
+    // fallback returning only Scene.selectRect would drop them. (#1904)
+    it('unions point-cloud hits into the CPU fallback result', async () => {
+      const h = harness({ released: true, pointNodes: [pointNode(POINT_ASSET)] });
+
+      const result = await h.manager.pickRect(0, 0, 100, 100);
+
+      assert.equal(h.selectRectCalls, 1, 'released geometry must still take the CPU path');
+      assert.equal(h.createdMeshes.length, 0, 'must not hydrate released geometry');
+      assert.deepStrictEqual(
+        result,
+        new Set([WALL, SLAB, POINT_ASSET]),
+        'rect select over a point cloud must return its points as well as the boxed entities',
+      );
+    });
+
+    // Pins the two arguments the CPU-branch point pass deliberately withholds.
+    // Instanced templates in particular: the instanced pick shader DOES discard
+    // hidden/non-isolated occurrences (picker.ts checks instFlags bit 1, which
+    // Scene sets for both), so passing them would be safe — it is withheld
+    // because Scene.selectRect already returns every instanced occurrence that
+    // has geometry, from its registered world AABB, so the draw adds no id while
+    // sharing the pass's depth buffer, where it could occlude a splat and REMOVE
+    // a point hit. (#1904)
+    it('runs the CPU point pass with no meshes and no instanced templates', async () => {
+      const h = harness({ released: true, pointNodes: [pointNode(POINT_ASSET)] });
+
+      await h.manager.pickRect(0, 0, 100, 100);
+
+      assert.deepStrictEqual(
+        h.pickerRectMeshes, [],
+        'the CPU branch runs because meshes are not hydrated; a partial list would only duplicate selectRect',
+      );
+      assert.equal(
+        h.pickerRectTemplates, undefined,
+        'instanced occurrences already come back from selectRect, so drawing them could only occlude points',
+      );
+      assert.deepStrictEqual(h.pickerRectPointNodes, [pointNode(POINT_ASSET)]);
+    });
+
+    it('keeps the pure-CPU fast path when there are no splats to pick (#1904)', async () => {
+      const noProvider = harness({ released: true });
+      const nullSnapshot = harness({ released: true, pointNodes: null });
+      const emptySnapshot = harness({ released: true, pointNodes: [] });
+
+      for (const h of [noProvider, nullSnapshot, emptySnapshot]) {
+        const result = await h.manager.pickRect(0, 0, 100, 100);
+        assert.deepStrictEqual(result, new Set([WALL, SLAB]));
+        assert.equal(h.pickerRectMeshes, null, 'no points to draw means no GPU pass at all');
+      }
+    });
+
+    // Picker.pickRect rethrows any readback failure that is not a device-loss
+    // abort. Adding the point pass put that throw in front of a result the CPU
+    // branch had already computed, so a device fault would have turned a working
+    // rectangle select into a rejected promise. Degrade to the box hits. (#1904)
+    it('degrades to the bounding-box hits when the point pass throws', async () => {
+      const h = harness({
+        released: true,
+        pointNodes: [pointNode(POINT_ASSET)],
+        pointPassError: new Error('readback failed'),
+      });
+
+      const warnings: unknown[][] = [];
+      const realWarn = console.warn;
+      console.warn = (...args: unknown[]) => { warnings.push(args); };
+      let result: Set<number>;
+      try {
+        result = await h.manager.pickRect(0, 0, 100, 100);
+      } finally {
+        console.warn = realWarn;
+      }
+
+      assert.deepStrictEqual(
+        result, new Set([WALL, SLAB]),
+        'a failed point pass must not discard the bounding-box hits already computed',
+      );
+      assert.equal(warnings.length, 1, 'the failure must be logged, not swallowed');
     });
   });
 });

--- a/packages/renderer/src/picking-manager.test.ts
+++ b/packages/renderer/src/picking-manager.test.ts
@@ -135,4 +135,127 @@ describe('PickingManager', () => {
       'expected only the isolated door to survive the isolation filter',
     );
   });
+
+  // Regression for #1904. pickRect used to pass scene.getMeshes() straight to
+  // the GPU picker. On a batched model that list is empty or partial — batched
+  // geometry never reaches the pick pass — so rectangle select returned an
+  // empty set however many elements the rect covered. Reproduced by the
+  // maintainer at 8 meshes / 3 batches, so this is not a large-model-only bug.
+  describe('pickRect on batched geometry (#1904)', () => {
+    const WALL = 300;
+    const SLAB = 301;
+
+    function harness(overrides: {
+      released?: boolean;
+      existingMeshes?: Array<{ expressId: number }>;
+      pieces?: (id: number) => Array<{ expressId: number }> | undefined;
+    } = {}) {
+      const createdMeshes: Array<{ expressId: number }> = [
+        ...(overrides.existingMeshes ?? []),
+      ];
+      let pickerRectMeshes: Array<{ expressId: number }> | null = null;
+      let selectRectCalls = 0;
+
+      const camera = {
+        getViewProjMatrix: () => ({ m: new Float32Array(16) }),
+        unprojectToRay: () => ({ origin: { x: 0, y: 0, z: 0 }, direction: { x: 0, y: 0, z: -1 } }),
+      };
+
+      const scene = {
+        getMeshes: () => createdMeshes,
+        getBatchedMeshes: () => [{ expressIds: [WALL] }],
+        isGeometryDataReleased: () => overrides.released ?? false,
+        getAllMeshDataExpressIds: () => [WALL, SLAB],
+        getMeshDataPieces:
+          overrides.pieces ?? ((id: number) => [{ expressId: id }]),
+        getInstancedTemplates: () => undefined,
+        selectRect: () => {
+          selectRectCalls += 1;
+          return new Set([WALL, SLAB]);
+        },
+      };
+
+      const picker = {
+        pickRect: async (
+          _x0: number, _y0: number, _x1: number, _y1: number,
+          _w: number, _h: number,
+          meshes: Array<{ expressId: number }>,
+        ) => {
+          pickerRectMeshes = meshes;
+          return new Set(meshes.map((m) => m.expressId));
+        },
+      };
+
+      const canvas = {
+        width: 100,
+        height: 100,
+        getBoundingClientRect: () => ({ width: 100, height: 100 }),
+      };
+
+      const manager = new PickingManager(
+        camera as never,
+        scene as never,
+        picker as never,
+        canvas as HTMLCanvasElement,
+        (piece) => { createdMeshes.push({ expressId: piece.expressId }); },
+      );
+
+      return {
+        manager,
+        createdMeshes,
+        get pickerRectMeshes() { return pickerRectMeshes; },
+        get selectRectCalls() { return selectRectCalls; },
+      };
+    }
+
+    it('hydrates batched pieces so the rect pass can see them', async () => {
+      const h = harness();
+
+      const result = await h.manager.pickRect(0, 0, 100, 100);
+
+      assert.deepStrictEqual(
+        result,
+        new Set([WALL, SLAB]),
+        'rect select must return the batched entities, not an empty set',
+      );
+      assert.deepStrictEqual(
+        h.createdMeshes.map((m) => m.expressId).sort(),
+        [WALL, SLAB],
+        'expected both batched pieces to be hydrated for the rect pass',
+      );
+      assert.equal(h.selectRectCalls, 0, 'small model should use the GPU path, not the CPU fallback');
+    });
+
+    it('falls back to Scene.selectRect once geometry data is released', async () => {
+      const h = harness({ released: true });
+
+      const result = await h.manager.pickRect(0, 0, 100, 100);
+
+      assert.deepStrictEqual(result, new Set([WALL, SLAB]));
+      assert.equal(h.selectRectCalls, 1, 'released geometry has no mesh data to hydrate');
+      assert.equal(h.createdMeshes.length, 0, 'must not try to hydrate released geometry');
+      assert.equal(h.pickerRectMeshes, null, 'GPU rect pass must be skipped entirely');
+    });
+
+    it('falls back to Scene.selectRect when hydration would exceed the pick-mesh budget', async () => {
+      // 600 pieces for one entity blows MAX_PICK_MESH_CREATION (500), which is
+      // the large-model case named in the issue title.
+      const many = Array.from({ length: 600 }, () => ({ expressId: WALL }));
+      const h = harness({ pieces: (id) => (id === WALL ? many : [{ expressId: id }]) });
+
+      const result = await h.manager.pickRect(0, 0, 100, 100);
+
+      assert.deepStrictEqual(result, new Set([WALL, SLAB]));
+      assert.equal(h.selectRectCalls, 1, 'over-budget hydration must take the CPU path');
+      assert.equal(h.createdMeshes.length, 0, 'must not hydrate when over budget');
+    });
+
+    it('honours isolation when falling back to the CPU path', async () => {
+      const h = harness({ released: true });
+
+      await h.manager.pickRect(0, 0, 100, 100, { isolatedIds: new Set([SLAB]) });
+
+      assert.equal(h.selectRectCalls, 1);
+    });
+  });
 });

--- a/packages/renderer/src/picking-manager.test.ts
+++ b/packages/renderer/src/picking-manager.test.ts
@@ -334,6 +334,39 @@ describe('PickingManager', () => {
       assert.deepStrictEqual(h.pickerRectPointNodes, [pointNode(POINT_ASSET)]);
     });
 
+    // Point splats are deliberately NOT filtered by hiddenIds / isolatedIds, on
+    // either branch. Per-asset point visibility is binary and handled upstream,
+    // so the pick pass has never filtered point nodes by the entity-level sets —
+    // pickRect passed the snapshot through unfiltered before this change too.
+    // Pinning it here so the asymmetry with meshes reads as intent rather than
+    // an oversight, and so making splats respect those sets becomes a deliberate
+    // decision with a failing test rather than a silent behaviour change. (#1904)
+    it('leaves point splats unfiltered by hidden/isolated, as the GPU rect pass always has (#1904)', async () => {
+      const hidden = harness({ released: true, pointNodes: [pointNode(POINT_ASSET)] });
+      const hiddenResult = await hidden.manager.pickRect(0, 0, 100, 100, {
+        hiddenIds: new Set([POINT_ASSET]),
+      });
+
+      assert.ok(
+        hiddenResult.has(POINT_ASSET),
+        'hiding a point asset must not silently drop it from rect select; that is an upstream concern',
+      );
+      assert.deepStrictEqual(
+        hidden.pickerRectPointNodes, [pointNode(POINT_ASSET)],
+        'the point snapshot reaches the pass unfiltered',
+      );
+
+      const isolated = harness({ released: true, pointNodes: [pointNode(POINT_ASSET)] });
+      const isolatedResult = await isolated.manager.pickRect(0, 0, 100, 100, {
+        isolatedIds: new Set([WALL]),
+      });
+
+      assert.ok(
+        isolatedResult.has(POINT_ASSET),
+        'isolating a mesh must not filter point assets either — same rule, same reason',
+      );
+    });
+
     it('keeps the pure-CPU fast path when there are no splats to pick (#1904)', async () => {
       const noProvider = harness({ released: true });
       const nullSnapshot = harness({ released: true, pointNodes: null });

--- a/packages/renderer/src/picking-manager.ts
+++ b/packages/renderer/src/picking-manager.ts
@@ -58,6 +58,105 @@ export class PickingManager {
     }
 
     /**
+     * Prepare batched geometry for a GPU pick pass, shared by `pick()` and
+     * `pickRect()`.
+     *
+     * Returns `'cpu'` when the caller must fall back to a CPU test — either JS
+     * geometry data was released, or hydrating an individual mesh per visible
+     * piece would exceed the pick-mesh budget. Returns `'gpu'` after hydrating
+     * whatever was missing, so a following `scene.getMeshes()` covers every
+     * visible entity.
+     *
+     * Both pick paths MUST route through this. `pickRect` used to read
+     * `scene.getMeshes()` directly, which on a batched model is empty or
+     * partial, so rectangle select returned an empty set no matter how many
+     * elements the rect covered (#1904).
+     */
+    private prepareBatchedPick(options?: PickOptions): 'cpu' | 'gpu' {
+        const batchedMeshes = this.scene.getBatchedMeshes();
+        // Nothing batched: every mesh is already individually hydrated.
+        if (batchedMeshes.length === 0) return 'gpu';
+
+        if (this.scene.isGeometryDataReleased()) return 'cpu';
+
+        // Collect every pickable expressId. We use the scene's authoritative
+        // mesh-data id set rather than each batch's `expressIds`, because a batch
+        // only records the PRIMARY expressId of each merged piece. When a door or
+        // window is colour-fused into a batch keyed by its host wall / opening,
+        // the filler's id lives only in the per-vertex entityIds (registered in
+        // meshDataMap by Scene.addMeshData). Reading batch.expressIds alone would
+        // skip the filler, so under isolation its mesh is never hydrated and
+        // pick() returns null (#1358).
+        const expressIds = new Set<number>(this.scene.getAllMeshDataExpressIds());
+
+        // Track how many individual mesh pieces already exist for each (expressId:modelIndex).
+        // Multi-piece elements (windows/doors with submeshes) need all pieces for reliable picking.
+        const existingPieceCounts = new Map<string, number>();
+        for (const mesh of this.scene.getMeshes()) {
+            const key = `${mesh.expressId}:${mesh.modelIndex ?? 'any'}`;
+            existingPieceCounts.set(key, (existingPieceCounts.get(key) ?? 0) + 1);
+        }
+
+        // Build required piece counts from MeshData for all visible entities.
+        const requiredPieceCounts = new Map<string, number>();
+        const visibleExpressIds: number[] = [];
+        for (const expressId of expressIds) {
+            if (options?.hiddenIds?.has(expressId)) continue;
+            if (options?.isolatedIds !== null && options?.isolatedIds !== undefined && !options.isolatedIds.has(expressId)) continue;
+            visibleExpressIds.push(expressId);
+
+            const pieces = this.scene.getMeshDataPieces(expressId);
+            if (!pieces) continue;
+            for (const piece of pieces) {
+                const key = `${piece.expressId}:${piece.modelIndex ?? 'any'}`;
+                requiredPieceCounts.set(key, (requiredPieceCounts.get(key) ?? 0) + 1);
+            }
+        }
+
+        // Count how many meshes we'd need to create for full GPU picking
+        // For multi-model and multi-piece elements, count missing piece instances per key.
+        let toCreate = 0;
+        for (const [key, requiredCount] of requiredPieceCounts) {
+            const existingCount = existingPieceCounts.get(key) ?? 0;
+            if (requiredCount > existingCount) {
+                toCreate += requiredCount - existingCount;
+            }
+        }
+
+        // PERFORMANCE: fall back to CPU for large models instead of creating GPU meshes.
+        // GPU picking requires individual mesh buffers; for 60K+ elements this is too slow.
+        // The CPU paths use bounding boxes - no GPU buffers needed.
+        const MAX_PICK_MESH_CREATION = 500;
+        if (toCreate > MAX_PICK_MESH_CREATION || (visibleExpressIds.length > 0 && requiredPieceCounts.size === 0)) {
+            return 'cpu';
+        }
+
+        // For smaller models, create GPU meshes for picking
+        // Only create meshes for VISIBLE elements (not hidden, and either no isolation or in isolated set)
+        // For multi-model support: create meshes for ALL (expressId, modelIndex) pairs
+        const baselineExistingCounts = new Map(existingPieceCounts);
+        const seenOrdinalsByKey = new Map<string, number>();
+        for (const expressId of visibleExpressIds) {
+            const pieces = this.scene.getMeshDataPieces(expressId);
+            if (pieces) {
+                for (const piece of pieces) {
+                    const meshKey = `${piece.expressId}:${piece.modelIndex ?? 'any'}`;
+                    const ordinal = seenOrdinalsByKey.get(meshKey) ?? 0;
+                    seenOrdinalsByKey.set(meshKey, ordinal + 1);
+                    const baselineExisting = baselineExistingCounts.get(meshKey) ?? 0;
+
+                    // Assume existing pieces correspond to the first N pieces in stable order.
+                    if (ordinal < baselineExisting) continue;
+
+                    this.createMeshFromDataFn(piece);
+                }
+            }
+        }
+
+        return 'gpu';
+    }
+
+    /**
      * Pick object at screen coordinates
      * Respects visibility filtering so users can only select visible elements
      * Returns PickResult with expressId and modelIndex for multi-model support
@@ -87,108 +186,18 @@ export class PickingManager {
             return null;
         }
 
-        let meshes = this.scene.getMeshes();
-        const batchedMeshes = this.scene.getBatchedMeshes();
-
-        // If we have batched meshes, check if we need CPU raycasting
-        // This handles the case where we have SOME individual meshes (e.g., from highlighting)
-        // but not enough for full GPU picking coverage
-        if (batchedMeshes.length > 0) {
-            if (this.scene.isGeometryDataReleased()) {
-                const ray = this.camera.unprojectToRay(scaledX, scaledY, this.canvas.width, this.canvas.height);
-                const hit = this.scene.raycast(ray.origin, ray.direction, options?.hiddenIds, options?.isolatedIds, clip);
-                if (!hit) return null;
-                return {
-                    expressId: hit.expressId,
-                    modelIndex: hit.modelIndex,
-                };
-            }
-
-            // Collect every pickable expressId. We use the scene's authoritative
-            // mesh-data id set rather than each batch's `expressIds`, because a batch
-            // only records the PRIMARY expressId of each merged piece. When a door or
-            // window is colour-fused into a batch keyed by its host wall / opening,
-            // the filler's id lives only in the per-vertex entityIds (registered in
-            // meshDataMap by Scene.addMeshData). Reading batch.expressIds alone would
-            // skip the filler, so under isolation its mesh is never hydrated and
-            // pick() returns null (#1358).
-            const expressIds = new Set<number>(this.scene.getAllMeshDataExpressIds());
-
-            // Track how many individual mesh pieces already exist for each (expressId:modelIndex).
-            // Multi-piece elements (windows/doors with submeshes) need all pieces for reliable picking.
-            const existingPieceCounts = new Map<string, number>();
-            for (const mesh of meshes) {
-                const key = `${mesh.expressId}:${mesh.modelIndex ?? 'any'}`;
-                existingPieceCounts.set(key, (existingPieceCounts.get(key) ?? 0) + 1);
-            }
-
-            // Build required piece counts from MeshData for all visible entities.
-            const requiredPieceCounts = new Map<string, number>();
-            const visibleExpressIds: number[] = [];
-            for (const expressId of expressIds) {
-                if (options?.hiddenIds?.has(expressId)) continue;
-                if (options?.isolatedIds !== null && options?.isolatedIds !== undefined && !options.isolatedIds.has(expressId)) continue;
-                visibleExpressIds.push(expressId);
-
-                const pieces = this.scene.getMeshDataPieces(expressId);
-                if (!pieces) continue;
-                for (const piece of pieces) {
-                    const key = `${piece.expressId}:${piece.modelIndex ?? 'any'}`;
-                    requiredPieceCounts.set(key, (requiredPieceCounts.get(key) ?? 0) + 1);
-                }
-            }
-
-            // Count how many meshes we'd need to create for full GPU picking
-            // For multi-model and multi-piece elements, count missing piece instances per key.
-            let toCreate = 0;
-            for (const [key, requiredCount] of requiredPieceCounts) {
-                const existingCount = existingPieceCounts.get(key) ?? 0;
-                if (requiredCount > existingCount) {
-                    toCreate += requiredCount - existingCount;
-                }
-            }
-
-            // PERFORMANCE FIX: Use CPU raycasting for large models instead of creating GPU meshes
-            // GPU picking requires individual mesh buffers; for 60K+ elements this is too slow
-            // CPU raycasting uses bounding box filtering + triangle tests - no GPU buffers needed
-            const MAX_PICK_MESH_CREATION = 500;
-            if (toCreate > MAX_PICK_MESH_CREATION || (visibleExpressIds.length > 0 && requiredPieceCounts.size === 0)) {
-                // Use CPU raycasting fallback - works regardless of how many individual meshes exist
-                const ray = this.camera.unprojectToRay(scaledX, scaledY, this.canvas.width, this.canvas.height);
-                const hit = this.scene.raycast(ray.origin, ray.direction, options?.hiddenIds, options?.isolatedIds, clip);
-                if (!hit) return null;
-                // CPU raycasting returns expressId and modelIndex
-                return {
-                    expressId: hit.expressId,
-                    modelIndex: hit.modelIndex,
-                };
-            }
-
-            // For smaller models, create GPU meshes for picking
-            // Only create meshes for VISIBLE elements (not hidden, and either no isolation or in isolated set)
-            // For multi-model support: create meshes for ALL (expressId, modelIndex) pairs
-            const baselineExistingCounts = new Map(existingPieceCounts);
-            const seenOrdinalsByKey = new Map<string, number>();
-            for (const expressId of visibleExpressIds) {
-                const pieces = this.scene.getMeshDataPieces(expressId);
-                if (pieces) {
-                    for (const piece of pieces) {
-                        const meshKey = `${piece.expressId}:${piece.modelIndex ?? 'any'}`;
-                        const ordinal = seenOrdinalsByKey.get(meshKey) ?? 0;
-                        seenOrdinalsByKey.set(meshKey, ordinal + 1);
-                        const baselineExisting = baselineExistingCounts.get(meshKey) ?? 0;
-
-                        // Assume existing pieces correspond to the first N pieces in stable order.
-                        if (ordinal < baselineExisting) continue;
-
-                        this.createMeshFromDataFn(piece);
-                    }
-                }
-            }
-
-            // Get updated meshes list (includes newly created ones)
-            meshes = this.scene.getMeshes();
+        if (this.prepareBatchedPick(options) === 'cpu') {
+            const ray = this.camera.unprojectToRay(scaledX, scaledY, this.canvas.width, this.canvas.height);
+            const hit = this.scene.raycast(ray.origin, ray.direction, options?.hiddenIds, options?.isolatedIds, clip);
+            if (!hit) return null;
+            // CPU raycasting returns expressId and modelIndex
+            return {
+                expressId: hit.expressId,
+                modelIndex: hit.modelIndex,
+            };
         }
+
+        let meshes = this.scene.getMeshes();
 
         // Apply visibility filtering to meshes before picking
         // This ensures users can only select elements that are actually visible
@@ -233,11 +242,12 @@ export class PickingManager {
      * filtered (per-asset visibility is binary and the asset count is
      * tiny).
      *
-     * Limitations: skips the CPU-raycast and dynamic-mesh-creation
-     * fallbacks that `pick()` uses for very large batched models, so
-     * rect pick may miss entities whose individual meshes haven't been
-     * hydrated. Acceptable for an MVP — rect select is a power-user
-     * tool and the user can fall back to single-click pick.
+     * Batched models take the same route as `pick()`: hydrate the
+     * missing individual meshes when that is affordable, otherwise fall
+     * back to `Scene.selectRect` (bounding-box granularity, so slightly
+     * over-selective versus the pixel-exact GPU pass). Reading
+     * `scene.getMeshes()` unconditionally is what made this return an
+     * empty set on every batched model (#1904).
      */
     async pickRect(
         x0: number,
@@ -255,6 +265,17 @@ export class PickingManager {
         const sx0 = x0 * scaleX, sy0 = y0 * scaleY;
         const sx1 = x1 * scaleX, sy1 = y1 * scaleY;
         if (options?.isStreaming) return new Set();
+
+        if (this.prepareBatchedPick(options) === 'cpu') {
+            return this.scene.selectRect(
+                sx0, sy0, sx1, sy1,
+                this.canvas.width, this.canvas.height,
+                this.camera.getViewProjMatrix().m,
+                options?.hiddenIds,
+                options?.isolatedIds,
+                clip,
+            );
+        }
 
         let meshes = this.scene.getMeshes();
         if (options?.hiddenIds && options.hiddenIds.size > 0) {

--- a/packages/renderer/src/picking-manager.ts
+++ b/packages/renderer/src/picking-manager.ts
@@ -244,10 +244,21 @@ export class PickingManager {
      *
      * Batched models take the same route as `pick()`: hydrate the
      * missing individual meshes when that is affordable, otherwise fall
-     * back to `Scene.selectRect` (bounding-box granularity, so slightly
-     * over-selective versus the pixel-exact GPU pass). Reading
+     * back to `Scene.selectRect`, which over-selects relative to the
+     * pixel-exact GPU pass in three ways: it is bounding-box granular
+     * (a rect over empty space inside an element's bounds selects it),
+     * it has no depth test (occluded entities are selected), and it
+     * drops a section-planed or cropped entity only when the whole box
+     * is clipped away, where the pick shader discards per fragment.
+     * Hidden and isolation filtering do apply there. Reading
      * `scene.getMeshes()` unconditionally is what made this return an
      * empty set on every batched model (#1904).
+     *
+     * Point clouds never depend on mesh hydration — splats render into
+     * the pick pass on their own — so the CPU branch still runs the GPU
+     * pass for them and unions the two results. Skipping it would drop
+     * point selection on any mixed scene big enough to miss the
+     * pick-mesh budget.
      */
     async pickRect(
         x0: number,
@@ -267,7 +278,7 @@ export class PickingManager {
         if (options?.isStreaming) return new Set();
 
         if (this.prepareBatchedPick(options) === 'cpu') {
-            return this.scene.selectRect(
+            const boxHits = this.scene.selectRect(
                 sx0, sy0, sx1, sy1,
                 this.canvas.width, this.canvas.height,
                 this.camera.getViewProjMatrix().m,
@@ -275,6 +286,51 @@ export class PickingManager {
                 options?.isolatedIds,
                 clip,
             );
+            const cpuPointSnap = this.pointPickProvider?.() ?? null;
+            if (!cpuPointSnap || cpuPointSnap.nodes.length === 0) return boxHits;
+
+            // Point-only pick pass. Meshes are deliberately `[]`: this branch runs
+            // precisely because the per-element pick buffers were NOT hydrated, so
+            // `scene.getMeshes()` holds an arbitrary partial set (highlight meshes
+            // and whatever an earlier pick left behind) whose ids `selectRect`
+            // already covers.
+            //
+            // Instanced templates are left out for a different reason. The
+            // instanced pick pass IS visibility-filtered — its fragment shader
+            // discards on `instFlags` bit 1, which `Scene` sets for every
+            // occurrence that is hidden or excluded by isolation — so unioning its
+            // hits would not re-admit anything. It is left out because it would
+            // add no ids and can only subtract. Every instanced occurrence whose
+            // template has geometry folds its world AABB into
+            // `Scene.boundingBoxes`, so `selectRect` above has already returned
+            // those ids under the same two filters (a template with no finite
+            // local box is skipped there, and rasterises nothing here either).
+            // Meanwhile the instanced draw shares this pass's depth target, so an
+            // occurrence in front of a splat would occlude it and drop a point hit
+            // that nothing else on this path can supply — point assets have no
+            // entry in `boundingBoxes` at all.
+            let pointHits: Set<number>;
+            try {
+                pointHits = await this.picker.pickRect(
+                    sx0, sy0, sx1, sy1,
+                    this.canvas.width, this.canvas.height,
+                    [],
+                    this.camera.getViewProjMatrix().m,
+                    cpuPointSnap.nodes,
+                    cpuPointSnap.sizing,
+                    undefined,
+                    clip,
+                );
+            } catch (err) {
+                // `picker.pickRect` rethrows any readback failure that is not a
+                // device-loss abort. The box hits are already computed and this
+                // branch could not throw at all before the point pass was added,
+                // so degrade to them instead of failing the whole rectangle select.
+                console.warn('[PickingManager] point-cloud rect pick failed; returning bounding-box hits only:', err);
+                return boxHits;
+            }
+            for (const id of pointHits) boxHits.add(id);
+            return boxHits;
         }
 
         let meshes = this.scene.getMeshes();

--- a/packages/renderer/src/scene-rect-select.test.ts
+++ b/packages/renderer/src/scene-rect-select.test.ts
@@ -1,0 +1,131 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+
+import { selectBoundingBoxesInRect } from './scene-rect-select.ts';
+import type { BoundingBox } from './scene-raycaster.ts';
+
+const W = 100;
+const H = 100;
+
+function box(minX: number, minY: number, minZ: number, maxX: number, maxY: number, maxZ: number): BoundingBox {
+  return { min: { x: minX, y: minY, z: minZ }, max: { x: maxX, y: maxY, z: maxZ } };
+}
+
+/**
+ * Identity view-projection: clip == world, w == 1. NDC x/y map straight to the
+ * canvas, so a box spanning [-1,1] covers the full 100x100 viewport and a box
+ * at [0, 0.2] lands at screen x 50..60, y 40..50 (Y flips).
+ */
+const IDENTITY = new Float32Array([
+  1, 0, 0, 0,
+  0, 1, 0, 0,
+  0, 0, 1, 0,
+  0, 0, 0, 1,
+]);
+
+/**
+ * Column-major matrix whose w component is `-z`, i.e. the standard sign
+ * convention where the camera looks down -z and anything at z > 0 is behind it.
+ */
+const W_IS_NEGATIVE_Z = new Float32Array([
+  1, 0, 0, 0,
+  0, 1, 0, 0,
+  0, 0, 1, -1,
+  0, 0, 0, 0,
+]);
+
+describe('selectBoundingBoxesInRect (#1904)', () => {
+  it('selects a box whose projection lands inside the rect', () => {
+    const boxes = new Map([[1, box(0, 0, 0, 0.2, 0.2, 0)]]);
+    // Screen AABB is x 50..60, y 40..50.
+    const hits = selectBoundingBoxesInRect(boxes, IDENTITY, { x0: 45, y0: 35, x1: 65, y1: 55 }, W, H);
+    assert.deepStrictEqual(hits, new Set([1]));
+  });
+
+  it('rejects a box whose projection is outside the rect', () => {
+    const boxes = new Map([[1, box(0, 0, 0, 0.2, 0.2, 0)]]);
+    // Rect sits in the top-left corner; the box projects to the middle.
+    const hits = selectBoundingBoxesInRect(boxes, IDENTITY, { x0: 0, y0: 0, x1: 10, y1: 10 }, W, H);
+    assert.deepStrictEqual(hits, new Set());
+  });
+
+  it('selects on partial overlap — the rect need not contain the whole box', () => {
+    const boxes = new Map([[1, box(-1, -1, 0, 1, 1, 0)]]); // fills the viewport
+    const hits = selectBoundingBoxesInRect(boxes, IDENTITY, { x0: 0, y0: 0, x1: 5, y1: 5 }, W, H);
+    assert.deepStrictEqual(hits, new Set([1]));
+  });
+
+  it('normalises a rect dragged right-to-left / bottom-to-top', () => {
+    const boxes = new Map([[1, box(0, 0, 0, 0.2, 0.2, 0)]]);
+    const dragged = selectBoundingBoxesInRect(boxes, IDENTITY, { x0: 65, y0: 55, x1: 45, y1: 35 }, W, H);
+    assert.deepStrictEqual(dragged, new Set([1]), 'drag direction must not change the result');
+  });
+
+  it('skips hidden entities', () => {
+    const boxes = new Map([
+      [1, box(0, 0, 0, 0.2, 0.2, 0)],
+      [2, box(0, 0, 0, 0.2, 0.2, 0)],
+    ]);
+    const hits = selectBoundingBoxesInRect(
+      boxes, IDENTITY, { x0: 0, y0: 0, x1: W, y1: H }, W, H, new Set([1]),
+    );
+    assert.deepStrictEqual(hits, new Set([2]));
+  });
+
+  it('restricts to the isolated set when one is active', () => {
+    const boxes = new Map([
+      [1, box(0, 0, 0, 0.2, 0.2, 0)],
+      [2, box(0, 0, 0, 0.2, 0.2, 0)],
+    ]);
+    const hits = selectBoundingBoxesInRect(
+      boxes, IDENTITY, { x0: 0, y0: 0, x1: W, y1: H }, W, H, undefined, new Set([2]),
+    );
+    assert.deepStrictEqual(hits, new Set([2]));
+  });
+
+  it('treats an empty isolated set as "nothing selectable", not "no isolation"', () => {
+    const boxes = new Map([[1, box(0, 0, 0, 0.2, 0.2, 0)]]);
+    const hits = selectBoundingBoxesInRect(
+      boxes, IDENTITY, { x0: 0, y0: 0, x1: W, y1: H }, W, H, undefined, new Set(),
+    );
+    assert.deepStrictEqual(hits, new Set());
+  });
+
+  it('ignores geometry entirely behind the camera', () => {
+    // z = 1..2 with w = -z gives w = -1..-2: every corner is behind.
+    const boxes = new Map([[1, box(-0.1, -0.1, 1, 0.1, 0.1, 2)]]);
+    const hits = selectBoundingBoxesInRect(
+      boxes, W_IS_NEGATIVE_Z, { x0: 0, y0: 0, x1: W, y1: H }, W, H,
+    );
+    assert.deepStrictEqual(hits, new Set(), 'a box behind the camera must not be selectable');
+  });
+
+  it('selects a box straddling the camera plane', () => {
+    // z = -1..1 crosses w = 0. The projected corners understate the true
+    // extent, so the screen-AABB test alone would wrongly reject it.
+    const boxes = new Map([[1, box(-0.1, -0.1, -1, 0.1, 0.1, 1)]]);
+    const hits = selectBoundingBoxesInRect(
+      boxes, W_IS_NEGATIVE_Z, { x0: 0, y0: 0, x1: 1, y1: 1 }, W, H,
+    );
+    assert.deepStrictEqual(hits, new Set([1]));
+  });
+
+  it('returns empty for a degenerate viewport instead of selecting everything', () => {
+    const boxes = new Map([[1, box(0, 0, 0, 0.2, 0.2, 0)]]);
+    const hits = selectBoundingBoxesInRect(boxes, IDENTITY, { x0: 0, y0: 0, x1: 10, y1: 10 }, 0, 0);
+    assert.deepStrictEqual(hits, new Set());
+  });
+
+  it('excludes an entity the crop box removes, matching what is visible', () => {
+    const boxes = new Map([[1, box(0, 0, 0, 0.2, 0.2, 0)]]);
+    const clip = { clipBox: { min: [10, 10, 10] as [number, number, number], max: [20, 20, 20] as [number, number, number], enabled: true } };
+    const hits = selectBoundingBoxesInRect(
+      boxes, IDENTITY, { x0: 0, y0: 0, x1: W, y1: H }, W, H, undefined, undefined, clip,
+    );
+    assert.deepStrictEqual(hits, new Set(), 'clipped-away geometry must be unselectable');
+  });
+});

--- a/packages/renderer/src/scene-rect-select.test.ts
+++ b/packages/renderer/src/scene-rect-select.test.ts
@@ -38,6 +38,33 @@ const W_IS_NEGATIVE_Z = new Float32Array([
   0, 0, 0, 0,
 ]);
 
+/**
+ * A real reverse-Z perspective view-projection: eye at the origin looking down
+ * -z, 90 degree fov, aspect 1, near 0.1, infinite far — i.e.
+ * `MathUtils.perspectiveReverseZ(PI/2, 1, 0.1, inf)` with an identity view.
+ * Clip space works out to cx = x, cy = y, cz = 0.1, cw = -z, so ndc z = 0.1/-z
+ * is 1 at z = -0.1 and tends to 0 far away, and the near plane is z = -0.1.
+ */
+const PERSPECTIVE_NEAR_0_1 = new Float32Array([
+  1, 0, 0, 0,
+  0, 1, 0, 0,
+  0, 0, 0, -1,
+  0, 0, 0.1, 0,
+]);
+
+/**
+ * A reverse-Z orthographic view-projection with a FINITE far plane, so the
+ * far-side clip actually bites: `MathUtils.orthographicReverseZ(-1, 1, -1, 1,
+ * 1, 10)` with an identity view. cw = 1 and ndc z = (z + 10) / 9, which is 1 at
+ * z = -1 (near) and 0 at z = -10 (far).
+ */
+const ORTHO_NEAR_1_FAR_10 = new Float32Array([
+  1, 0, 0, 0,
+  0, 1, 0, 0,
+  0, 0, 1 / 9, 0,
+  0, 0, 10 / 9, 1,
+]);
+
 describe('selectBoundingBoxesInRect (#1904)', () => {
   it('selects a box whose projection lands inside the rect', () => {
     const boxes = new Map([[1, box(0, 0, 0, 0.2, 0.2, 0)]]);
@@ -104,14 +131,68 @@ describe('selectBoundingBoxesInRect (#1904)', () => {
     assert.deepStrictEqual(hits, new Set(), 'a box behind the camera must not be selectable');
   });
 
-  it('selects a box straddling the camera plane', () => {
-    // z = -1..1 crosses w = 0. The projected corners understate the true
-    // extent, so the screen-AABB test alone would wrongly reject it.
-    const boxes = new Map([[1, box(-0.1, -0.1, -1, 0.1, 0.1, 1)]]);
+  // A box crossing the near plane used to be added unconditionally, for any
+  // rect anywhere on screen — the corners in front of the camera understate the
+  // extent, and the code punted rather than clip. The population that reaches
+  // this CPU path is large models, where the user is usually standing INSIDE
+  // the building, so the floor, ceiling and surrounding walls all straddle and
+  // a small drag over one object selected all of them. Clipping to the near
+  // plane first gives the box its true visible extent. (#1904)
+  describe('a box straddling the near plane', () => {
+    // A floor slab underfoot: 20m x 20m, 100mm thick, 2m below the eye, running
+    // from 10m in front to 10m BEHIND the camera. Clipped to z <= -0.1 it
+    // projects to screen y 59.5..1050 — entirely below the horizon.
+    const slab = new Map([[1, box(-10, -2, -10, 10, -1.9, 10)]]);
+
+    it('is not selected by a rect over empty space above it', () => {
+      const hits = selectBoundingBoxesInRect(
+        slab, PERSPECTIVE_NEAR_0_1, { x0: 40, y0: 10, x1: 45, y1: 15 }, W, H,
+      );
+      assert.deepStrictEqual(
+        hits, new Set(),
+        'a 5px drag near the top of the screen must not select the floor under your feet',
+      );
+    });
+
+    it('is still selected by a rect over the part of it that is visible', () => {
+      const hits = selectBoundingBoxesInRect(
+        slab, PERSPECTIVE_NEAR_0_1, { x0: 40, y0: 70, x1: 45, y1: 75 }, W, H,
+      );
+      assert.deepStrictEqual(
+        hits, new Set([1]),
+        'clipping must not cost the straddling box its real screen extent',
+      );
+    });
+  });
+
+  it('ignores a box nearer than the near plane', () => {
+    // z = -0.05..-0.02 is in front of the eye (w > 0, so the old corner-only
+    // test projected it into the middle of the screen) but inside the near
+    // plane at z = -0.1, where the GPU clips it away.
+    const boxes = new Map([[1, box(-0.001, -0.001, -0.05, 0.001, 0.001, -0.02)]]);
     const hits = selectBoundingBoxesInRect(
-      boxes, W_IS_NEGATIVE_Z, { x0: 0, y0: 0, x1: 1, y1: 1 }, W, H,
+      boxes, PERSPECTIVE_NEAR_0_1, { x0: 0, y0: 0, x1: W, y1: H }, W, H,
     );
-    assert.deepStrictEqual(hits, new Set([1]));
+    assert.deepStrictEqual(hits, new Set(), 'near-clipped geometry is not on screen');
+  });
+
+  it('ignores a box beyond the far plane', () => {
+    // z = -12..-11 is past the far plane at z = -10, so ndc z < 0 and the GPU
+    // never rasterises it — but w = 1 > 0 and x/y project straight into the
+    // middle of the rect.
+    const boxes = new Map([[1, box(-0.2, -0.2, -12, 0.2, 0.2, -11)]]);
+    const hits = selectBoundingBoxesInRect(
+      boxes, ORTHO_NEAR_1_FAR_10, { x0: 0, y0: 0, x1: W, y1: H }, W, H,
+    );
+    assert.deepStrictEqual(hits, new Set(), 'far-clipped geometry is not on screen');
+  });
+
+  it('keeps a box straddling the far plane, clipped rather than dropped', () => {
+    const boxes = new Map([[1, box(-0.2, -0.2, -12, 0.2, 0.2, -8)]]);
+    const hits = selectBoundingBoxesInRect(
+      boxes, ORTHO_NEAR_1_FAR_10, { x0: 0, y0: 0, x1: W, y1: H }, W, H,
+    );
+    assert.deepStrictEqual(hits, new Set([1]), 'the part in front of the far plane is visible');
   });
 
   it('returns empty for a degenerate viewport instead of selecting everything', () => {

--- a/packages/renderer/src/scene-rect-select.ts
+++ b/packages/renderer/src/scene-rect-select.ts
@@ -1,0 +1,121 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * CPU rectangle selection against bounding-box data.
+ *
+ * The rect analogue of `raycastBoundingBoxes` in `scene-raycaster.ts`, and it
+ * exists for the same reason: on a batched model the GPU pick pass only sees
+ * individually hydrated meshes, and hydrating every visible piece is too
+ * expensive past a few hundred entities. `pick()` has always had a CPU escape
+ * hatch for that case; rectangle select had none, which is why it returned an
+ * empty set on batched models (#1904).
+ *
+ * Granularity: bounding box, not triangle. A box whose screen-space AABB
+ * overlaps the rect counts as selected, so this over-selects relative to the
+ * pixel-exact GPU path — an entity can be picked when the rect covers only
+ * empty space inside its bounds. That matches the precedent already set by the
+ * released-geometry raycast path, and over-selection is recoverable by the
+ * user in a way that selecting nothing is not.
+ */
+
+import { clipIsActive, boxFullyClipped, type BoundingBox } from './scene-raycaster.js';
+import type { PickClipState } from './types.js';
+
+/** Selection rectangle in canvas (device) pixels. Corners may be in any order. */
+export interface ScreenRect {
+    x0: number;
+    y0: number;
+    x1: number;
+    y1: number;
+}
+
+/**
+ * Every entity whose bounding box projects onto the given screen rect.
+ *
+ * @param boundingBoxes  World-space AABB per expressId
+ * @param viewProj       Camera view-projection, column-major (see below)
+ * @param rect           Selection rect in canvas pixels
+ * @param viewportWidth  Canvas width in pixels
+ * @param viewportHeight Canvas height in pixels
+ * @param hiddenIds      Skipped entirely
+ * @param isolatedIds    When non-null, only these ids are considered
+ * @param clip           Active section plane / crop box, so selection matches
+ *                       what is visible (same contract as the raycast paths)
+ */
+export function selectBoundingBoxesInRect(
+    boundingBoxes: Map<number, BoundingBox>,
+    viewProj: Float32Array,
+    rect: ScreenRect,
+    viewportWidth: number,
+    viewportHeight: number,
+    hiddenIds?: Set<number>,
+    isolatedIds?: Set<number> | null,
+    clip?: PickClipState | null,
+): Set<number> {
+    const hits = new Set<number>();
+    // A zero-sized canvas would divide the whole scene onto one texel.
+    if (!(viewportWidth > 0) || !(viewportHeight > 0)) return hits;
+
+    const rx0 = Math.min(rect.x0, rect.x1);
+    const rx1 = Math.max(rect.x0, rect.x1);
+    const ry0 = Math.min(rect.y0, rect.y1);
+    const ry1 = Math.max(rect.y0, rect.y1);
+    const hasClip = clipIsActive(clip);
+    const m = viewProj;
+
+    for (const [expressId, bbox] of boundingBoxes) {
+        if (hiddenIds?.has(expressId)) continue;
+        if (isolatedIds !== null && isolatedIds !== undefined && !isolatedIds.has(expressId)) continue;
+        if (hasClip && boxFullyClipped(clip, bbox)) continue;
+
+        let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+        let projected = 0;
+        let straddlesCamera = false;
+
+        for (let corner = 0; corner < 8; corner++) {
+            const x = (corner & 1) ? bbox.max.x : bbox.min.x;
+            const y = (corner & 2) ? bbox.max.y : bbox.min.y;
+            const z = (corner & 4) ? bbox.max.z : bbox.min.z;
+
+            // Column-major mat4 * vec4, matching what the pick shader does with
+            // the same matrix: `uniforms.viewProj * vec4<f32>(position, 1.0)`.
+            const cw = m[3] * x + m[7] * y + m[11] * z + m[15];
+            // Behind (or on) the camera plane — the perspective divide is
+            // meaningless here, so this corner contributes no screen extent.
+            if (!(cw > 1e-6)) {
+                straddlesCamera = true;
+                continue;
+            }
+            const cx = m[0] * x + m[4] * y + m[8] * z + m[12];
+            const cy = m[1] * x + m[5] * y + m[9] * z + m[13];
+
+            // NDC -> canvas pixels. Y flips: NDC is up-positive, screen is down-positive.
+            const sx = ((cx / cw) * 0.5 + 0.5) * viewportWidth;
+            const sy = (0.5 - (cy / cw) * 0.5) * viewportHeight;
+
+            if (sx < minX) minX = sx;
+            if (sx > maxX) maxX = sx;
+            if (sy < minY) minY = sy;
+            if (sy > maxY) maxY = sy;
+            projected += 1;
+        }
+
+        // Entirely behind the camera.
+        if (projected === 0) continue;
+
+        // A box crossing the camera plane has no meaningful screen AABB — the
+        // corners that did project understate its true extent, so the overlap
+        // test below would reject a box the user is standing inside. Count it.
+        if (straddlesCamera) {
+            hits.add(expressId);
+            continue;
+        }
+
+        if (maxX < rx0 || minX > rx1 || maxY < ry0 || minY > ry1) continue;
+        hits.add(expressId);
+    }
+
+    return hits;
+}

--- a/packages/renderer/src/scene-rect-select.ts
+++ b/packages/renderer/src/scene-rect-select.ts
@@ -15,13 +15,38 @@
  * Granularity: bounding box, not triangle. A box whose screen-space AABB
  * overlaps the rect counts as selected, so this over-selects relative to the
  * pixel-exact GPU path — an entity can be picked when the rect covers only
- * empty space inside its bounds. That matches the precedent already set by the
- * released-geometry raycast path, and over-selection is recoverable by the
- * user in a way that selecting nothing is not.
+ * empty space inside its bounds. That granularity is the same one the
+ * released-geometry raycast path already has (`raycastBoundingBoxes` also tests
+ * boxes, not triangles), and over-selection is recoverable by the user in a way
+ * that selecting nothing is not.
+ *
+ * Two further gaps are NOT shared with that path, and both over-select. There is
+ * no depth test at all here, so an entity fully occluded by another is still
+ * selected, whereas the raycast keeps only the nearest box (`tNear <
+ * closestDistance`). And section-plane / crop-box filtering is whole-box: the
+ * `boxFullyClipped` call below skips an entity only when nothing of its box
+ * could be visible, so a rect over the sectioned-away half of a box still
+ * selects it — the raycast measures entry into the *visible* part of the box
+ * (`clippedBoxEntryDistance`), and the pick shader discards per fragment.
  */
 
 import { clipIsActive, boxFullyClipped, type BoundingBox } from './scene-raycaster.js';
 import type { PickClipState } from './types.js';
+
+/**
+ * The 12 AABB edges as pairs of corner indices, flat. A corner index encodes
+ * which extreme it takes per axis: bit 0 = x, bit 1 = y, bit 2 = z, matching the
+ * `corner & 1 / & 2 / & 4` decode below. An edge joins two corners that differ
+ * in exactly one axis bit.
+ */
+const EDGE_CORNERS = new Uint8Array([
+    // along x
+    0, 1, 2, 3, 4, 5, 6, 7,
+    // along y
+    0, 2, 1, 3, 4, 6, 5, 7,
+    // along z
+    0, 4, 1, 5, 2, 6, 3, 7,
+]);
 
 /** Selection rectangle in canvas (device) pixels. Corners may be in any order. */
 export interface ScreenRect {
@@ -65,14 +90,21 @@ export function selectBoundingBoxesInRect(
     const hasClip = clipIsActive(clip);
     const m = viewProj;
 
+    // Per-corner clip-space scratch, allocated once per call and refilled per
+    // entity so the hot loop stays allocation-free.
+    const cwArr = new Float64Array(8);
+    const cxArr = new Float64Array(8);
+    const cyArr = new Float64Array(8);
+    // Signed distances to the two depth-clip half-spaces, >= 0 meaning inside.
+    const dNear = new Float64Array(8);
+    const dFar = new Float64Array(8);
+
     for (const [expressId, bbox] of boundingBoxes) {
         if (hiddenIds?.has(expressId)) continue;
         if (isolatedIds !== null && isolatedIds !== undefined && !isolatedIds.has(expressId)) continue;
         if (hasClip && boxFullyClipped(clip, bbox)) continue;
 
-        let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
-        let projected = 0;
-        let straddlesCamera = false;
+        let allInside = true;
 
         for (let corner = 0; corner < 8; corner++) {
             const x = (corner & 1) ? bbox.max.x : bbox.min.x;
@@ -82,36 +114,101 @@ export function selectBoundingBoxesInRect(
             // Column-major mat4 * vec4, matching what the pick shader does with
             // the same matrix: `uniforms.viewProj * vec4<f32>(position, 1.0)`.
             const cw = m[3] * x + m[7] * y + m[11] * z + m[15];
-            // Behind (or on) the camera plane — the perspective divide is
-            // meaningless here, so this corner contributes no screen extent.
-            if (!(cw > 1e-6)) {
-                straddlesCamera = true;
-                continue;
+            const cz = m[2] * x + m[6] * y + m[10] * z + m[14];
+            cwArr[corner] = cw;
+            cxArr[corner] = m[0] * x + m[4] * y + m[8] * z + m[12];
+            cyArr[corner] = m[1] * x + m[5] * y + m[9] * z + m[13];
+
+            // This renderer projects reverse-Z into the WebGPU depth range: a
+            // rasterised fragment has ndc z = cz/cw in [0, 1], 1 at the near
+            // plane and 0 at the far plane (MathUtils.perspectiveReverseZ /
+            // orthographicReverseZ). The clip-space form of those two bounds —
+            // what the GPU itself clips against, before any divide — is
+            // cz <= cw and cz >= 0. Both are linear in the world position, so
+            // they are ordinary half-spaces and the box can be clipped against
+            // them here too.
+            const near = cw - cz;
+            dNear[corner] = near;
+            dFar[corner] = cz;
+            if (near < 0 || cz < 0) allInside = false;
+        }
+
+        let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+        let projected = false;
+
+        if (allInside) {
+            // Whole box inside the depth range — every corner divides safely, so
+            // the screen AABB is just the AABB of the eight projected corners.
+            for (let corner = 0; corner < 8; corner++) {
+                const cw = cwArr[corner];
+                if (!(cw > 1e-6)) continue;
+                // NDC -> canvas pixels. Y flips: NDC is up-positive, screen is down-positive.
+                const sx = ((cxArr[corner] / cw) * 0.5 + 0.5) * viewportWidth;
+                const sy = (0.5 - (cyArr[corner] / cw) * 0.5) * viewportHeight;
+                if (sx < minX) minX = sx;
+                if (sx > maxX) maxX = sx;
+                if (sy < minY) minY = sy;
+                if (sy > maxY) maxY = sy;
+                projected = true;
             }
-            const cx = m[0] * x + m[4] * y + m[8] * z + m[12];
-            const cy = m[1] * x + m[5] * y + m[9] * z + m[13];
+        } else {
+            // The box crosses a depth-clip plane, so the min/max of its projected
+            // corners is not its screen extent: corners with cw <= 0 project to
+            // garbage and corners outside the slab were never drawn. Clip first.
+            //
+            // The visible region is the box intersected with the depth slab
+            // (near and far are parallel planes, so the slab has no edges of its
+            // own). Every vertex of that intersection therefore lies on a box
+            // edge, and inside the slab cw > 0 holds throughout, so the
+            // perspective divide is a projective map and the screen extent is
+            // the AABB of the projected vertices. Clipping each of the 12 edges
+            // to the slab and projecting the surviving endpoints enumerates
+            // exactly those vertices.
+            for (let e = 0; e < EDGE_CORNERS.length; e += 2) {
+                const a = EDGE_CORNERS[e];
+                const b = EDGE_CORNERS[e + 1];
 
-            // NDC -> canvas pixels. Y flips: NDC is up-positive, screen is down-positive.
-            const sx = ((cx / cw) * 0.5 + 0.5) * viewportWidth;
-            const sy = (0.5 - (cy / cw) * 0.5) * viewportHeight;
+                // Narrow the edge parameter t to where both half-space distances,
+                // which are linear along the edge, are >= 0.
+                let t0 = 0, t1 = 1;
+                let outside = false;
+                for (let plane = 0; plane < 2 && !outside; plane++) {
+                    const d = plane === 0 ? dNear : dFar;
+                    const dA = d[a];
+                    const delta = d[b] - dA;
+                    if (delta === 0) {
+                        // Constant along the edge: either wholly in or wholly out.
+                        if (dA < 0) outside = true;
+                    } else if (delta > 0) {
+                        const t = -dA / delta; // distance crosses zero here, rising
+                        if (t > t0) t0 = t;
+                    } else {
+                        const t = -dA / delta; // ... falling
+                        if (t < t1) t1 = t;
+                    }
+                }
+                if (outside || t0 > t1) continue;
 
-            if (sx < minX) minX = sx;
-            if (sx > maxX) maxX = sx;
-            if (sy < minY) minY = sy;
-            if (sy > maxY) maxY = sy;
-            projected += 1;
+                for (let end = 0; end < 2; end++) {
+                    const t = end === 0 ? t0 : t1;
+                    const cw = cwArr[a] + (cwArr[b] - cwArr[a]) * t;
+                    if (!(cw > 1e-6)) continue;
+                    const cx = cxArr[a] + (cxArr[b] - cxArr[a]) * t;
+                    const cy = cyArr[a] + (cyArr[b] - cyArr[a]) * t;
+                    const sx = ((cx / cw) * 0.5 + 0.5) * viewportWidth;
+                    const sy = (0.5 - (cy / cw) * 0.5) * viewportHeight;
+                    if (sx < minX) minX = sx;
+                    if (sx > maxX) maxX = sx;
+                    if (sy < minY) minY = sy;
+                    if (sy > maxY) maxY = sy;
+                    projected = true;
+                }
+            }
         }
 
-        // Entirely behind the camera.
-        if (projected === 0) continue;
-
-        // A box crossing the camera plane has no meaningful screen AABB — the
-        // corners that did project understate its true extent, so the overlap
-        // test below would reject a box the user is standing inside. Count it.
-        if (straddlesCamera) {
-            hits.add(expressId);
-            continue;
-        }
+        // Nothing survived the depth clip: behind the camera, nearer than the
+        // near plane, or beyond the far plane — the GPU rect pass never saw it.
+        if (!projected) continue;
 
         if (maxX < rx0 || minX > rx1 || maxY < ry0 || minY > ry1) continue;
         hits.add(expressId);

--- a/packages/renderer/src/scene.ts
+++ b/packages/renderer/src/scene.ts
@@ -3968,9 +3968,11 @@ export class Scene {
    * visible piece would blow the pick-mesh budget. Without it, rectangle
    * select silently returned nothing on batched models (#1904).
    *
-   * Bounding-box granularity, like the released-geometry raycast path.
-   * Instanced-only occurrences are covered: their world AABBs are registered
-   * in `boundingBoxes` when the instanced shard is built.
+   * Bounding-box granularity, the same fidelity the released-geometry raycast
+   * path has. Unlike that path it runs no depth test at all, so an entity fully
+   * hidden behind another is still selected. Instanced-only occurrences are
+   * covered: their world AABBs are registered in `boundingBoxes` when the
+   * instanced shard is built.
    */
   selectRect(
     x0: number,
@@ -3988,6 +3990,14 @@ export class Scene {
     // computed lazily, so make sure every entity that still has mesh data has
     // one. Same authoritative id set pick() uses, so colour-fused fillers whose
     // id lives only in per-vertex entityIds are not skipped (#1358).
+    // Cost shape: `getEntityBoundingBox` walks every vertex of an entity on a
+    // miss and memoises into `boundingBoxes`, so the scan is O(total vertices)
+    // but one-time — it is the same cache the CPU raycast path warms, and every
+    // later drag only pays the O(entities) box loop below. Earlier picks do not
+    // necessarily prime all of it, though: the raycast path applies the
+    // hiddenIds/isolatedIds filters *before* it calls getEntityBoundingBox (see
+    // raycastTriangles in scene-raycaster.ts), so under isolation the first
+    // Ctrl+drag can still scan entities no click ever reached.
     if (!this.geometryReleased) {
       for (const expressId of this.getAllMeshDataExpressIds()) {
         this.getEntityBoundingBox(expressId);

--- a/packages/renderer/src/scene.ts
+++ b/packages/renderer/src/scene.ts
@@ -18,6 +18,7 @@ import {
   raycastTriangles,
   rayIntersectsBox,
 } from './scene-raycaster.js';
+import { selectBoundingBoxesInRect } from './scene-rect-select.js';
 import { mergeGeometry, splitMeshDataForBufferLimit, colorSaltByte, packEntityLane } from './scene-geometry.js';
 import { sumResidentGpuBytes, type ResidentGpuBytes } from './render-stats.js';
 import { simplifyIndicesByClustering, lodCellSizeForBounds, LOD_MIN_TRIANGLES } from './lod-simplify.js';
@@ -3957,5 +3958,51 @@ export class Scene {
       return instancedHit.distance < flatHit.distance ? instancedHit : flatHit;
     }
     return flatHit ?? instancedHit;
+  }
+
+  /**
+   * CPU rectangle selection — the rect counterpart of {@link Scene.raycast}.
+   *
+   * Used by the pick path when the GPU rect pass cannot see the geometry:
+   * either JS geometry data was released, or hydrating an individual mesh per
+   * visible piece would blow the pick-mesh budget. Without it, rectangle
+   * select silently returned nothing on batched models (#1904).
+   *
+   * Bounding-box granularity, like the released-geometry raycast path.
+   * Instanced-only occurrences are covered: their world AABBs are registered
+   * in `boundingBoxes` when the instanced shard is built.
+   */
+  selectRect(
+    x0: number,
+    y0: number,
+    x1: number,
+    y1: number,
+    viewportWidth: number,
+    viewportHeight: number,
+    viewProj: Float32Array,
+    hiddenIds?: Set<number>,
+    isolatedIds?: Set<number> | null,
+    clip?: PickClipState | null,
+  ): Set<number> {
+    // After release the cache is already the complete set; before it, boxes are
+    // computed lazily, so make sure every entity that still has mesh data has
+    // one. Same authoritative id set pick() uses, so colour-fused fillers whose
+    // id lives only in per-vertex entityIds are not skipped (#1358).
+    if (!this.geometryReleased) {
+      for (const expressId of this.getAllMeshDataExpressIds()) {
+        this.getEntityBoundingBox(expressId);
+      }
+    }
+
+    return selectBoundingBoxesInRect(
+      this.boundingBoxes,
+      viewProj,
+      { x0, y0, x1, y1 },
+      viewportWidth,
+      viewportHeight,
+      hiddenIds,
+      isolatedIds,
+      clip,
+    );
   }
 }


### PR DESCRIPTION
## What and why

Closes #1904. Thanks @louistrue for the diagnosis and browser repro — this implements it.

`PickingManager.pickRect` passed `Scene.getMeshes()` straight to the GPU pick pass. Batched geometry lives in `batchedMeshes` and never reaches that list, so rectangle select returned an empty set deterministically.

`pick()` has had three things `pickRect` lacked:
1. a CPU fallback once JS geometry data is released,
2. a CPU fallback when hydrating one mesh per visible piece would exceed `MAX_PICK_MESH_CREATION`,
3. the hydration itself.

That decision now lives in **one** place — `prepareBatchedPick()` — used by both paths. Duplicating those ~40 lines would have recreated exactly the divergence class `AGENTS.md` warns about ("a fix applied to only one pipeline silently diverges").

**One scoping note worth your call.** The issue suggests "the batched-mesh path (and/or the CPU-raycast fallback)". Those aren't interchangeable here: hydration alone closes the `hello-wall.ifc` repro but leaves the large-model case in the title broken, because past the budget the code *must* go to CPU and there was no rectangle equivalent of `Scene.raycast`. So this adds `Scene.selectRect()`, mirroring `Scene.raycast()`, backed by a new `scene-rect-select` module that projects entity AABBs through the view-projection and tests screen-rect overlap.

**Known trade-off, flagged rather than buried:** the CPU rect path is bounding-box granular, so it can over-select slightly versus the pixel-exact GPU pass — an entity is selected when the rect overlaps its bounds even if it covers empty space inside them. That is the fidelity the released-geometry raycast path already has, and over-selection is recoverable by the user where selecting nothing is not. If you would rather it did a triangle-level test on the non-released path, say so and I will add it. Hidden / isolated / section-plane / crop-box filtering all apply, so selection still matches what is visible; instanced-only occurrences are covered since their AABBs are already registered in `boundingBoxes`.

## How it was verified

- **Proved the regression tests catch the bug**: reverting `pickRect` to the pre-fix code path fails all four new cases (`hydrates batched pieces…`, `falls back to Scene.selectRect once geometry data is released`, `…when hydration would exceed the pick-mesh budget`, `honours isolation…`); restoring the fix returns them to green.
- `pnpm --filter @ifc-lite/renderer test` — **399 passed, 0 failed** (384 before this change, so the `pick()` extraction is behaviour-preserving, +15 new).
- `pnpm test` — 74/74 turbo tasks.
- `pnpm typecheck` — 33/33.
- `node scripts/check-test-wiring.mjs` — clean.
- `node scripts/check-api-surface.mjs` — clean, no snapshot update needed (the snapshot tracks exported names; `Scene.selectRect` is a new member on an already-exported class).

New coverage: 4 cases in `picking-manager.test.ts` for the batched routing, and 11 in `scene-rect-select.test.ts` pinning the projection itself — rect overlap, partial overlap, drag-direction normalisation, hidden/isolated filtering (including empty-isolation meaning "nothing selectable"), geometry behind the camera, a box straddling the camera plane, degenerate viewport, and crop-box exclusion.

No Rust touched. `pnpm build:wasm` + `pnpm test:wasm-contract` (36/36) do pass on this branch and the committed `pkg/ifc-lite.d.ts` shows no drift.

## Checklist

- [x] A test asserts the new behavior through a fixture or a stated invariant — verified to fail before the fix
- [x] Published `packages/*` touched: changeset added (`@ifc-lite/renderer` minor — `Scene.selectRect` is additive public surface). Export surface unchanged, so no `pnpm api-surface:update`
- [x] No geometry output changed — determinism manifests untouched
- [x] House rules: no `as any` / `@ts-ignore`, no silent `catch {}`, `picking-manager.ts` is 300 lines, no repo-wide `cargo fmt`
- [x] No client or project identifiers in code, tests, commit messages, or this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rectangle selection for batched models, including released or incomplete geometry.
  * Added reliable CPU fallback selection with camera clipping and viewport handling.
  * Preserved visibility, isolation, and crop-box filters.
  * Maintained point-cloud selection during fallback, with graceful handling when point data is unavailable.
  * Improved selection of partially visible and camera-straddling objects.

* **Tests**
  * Added coverage for GPU hydration, CPU fallback, projection, partial overlap, drag direction, hidden entities, clipping, and viewport edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->