### PR TITLE
feat(moonshot): B5.5 scan-to-parametric - 12 of 16 quantities within 5% on a real scan

### DIFF
--- a/.github/workflows/moonshot.yml
+++ b/.github/workflows/moonshot.yml
@@ -420,6 +420,32 @@ jobs:
           node tools/world-gym/determinism-check.mjs
           echo '- **E8 world-gym determinism** -- 20/20 seeds byte-identical' >> "$GITHUB_STEP_SUMMARY"
 
+      # --- E8b: the B5.5 scan-to-parametric pipeline ------------------------
+      # B5.5's headline comes off a 3.9 GB client scan that cannot be
+      # committed, fetched, or run here, so the usual shape of this lane -- a
+      # fixture-backed re-run asserted against a golden -- is not available for
+      # it. This step runs the REAL stage scripts (extract -> generate ->
+      # score) over a synthetic two-room cloud whose every quantity is known in
+      # closed form, and asserts the numbers: the fitted planes, the room
+      # areas and heights, the measured partition width, the emitted model's
+      # ABSOLUTE placement datum, and the scorer's deviation arithmetic against
+      # deliberate misses placed either side of the 5% bar.
+      #
+      # The placement case is why this exists. `addIfcWall`/`addIfcSlab` place
+      # relative to the storey while `addIfcSpace` places relative to the
+      # world, so handing the same Z to both puts the walls at 2x the storey
+      # elevation -- and the exam cannot see it, because every quantity it
+      # scores is an IfcSpace quantity and therefore invariant under a rigid Z
+      # shift of the walls. The suite carries a negative control that rebuilds
+      # the model the broken way and requires the check to reject it.
+      #
+      # ~0.5 s: the cloud is 0.4 M points and the models are a few solids.
+      - name: E8b B5.5 scan-to-parametric pipeline (synthetic, closed-form)
+        shell: bash
+        run: |
+          node scripts/moonshot/ci/b55-pipeline-regression.mjs
+          echo '- **E8b B5.5 pipeline** -- extraction, placement datum and scoring arithmetic asserted on a synthetic apartment' >> "$GITHUB_STEP_SUMMARY"
+
       # --- E9: the claim NOBODY else in this lane checks --------------------
       # Every other step re-runs code and asserts the result. This one reads the
       # PROSE and asserts that each numeral in it either matches an artifact or

--- a/docs/vision/moonshots-execution-plan.md
+++ b/docs/vision/moonshots-execution-plan.md
@@ -248,7 +248,8 @@ an agent team) plus named human time, because that is the actual currency here.
    the current kernel structure produces, sinks to 0.8x-1.1x on three of five models.
    Remaining M6c exam is retargeted to publication (B6.3), not a speedup. Consequence:
 
-<!-- numeral-ok: 0.20x, 194 :: 0.20x is the endpoint of a RANGE measured against the
+<!-- numeral-src: 0.20x :: none - endpoint of a RANGE against the production adaptive-Shewchuk path; no artifact emits it. Negative-bound 2026-08-01 because a union hit made it read as backed by an unrelated slab thickness in B5.5's scorecard - a speedup ratio must not be cleared by a length in metres. -->
+<!-- numeral-ok: 194 :: 0.20x is the endpoint of a RANGE measured against the
      production adaptive-Shewchuk path; report.b25.throughput.json emits speedups against
      the exact BigInt CPU baseline (4.4x / 19.5x / 102x) and holds no production-path
      comparison, so the ratio is computed outside the artifact. 194 is the size of the

--- a/docs/vision/reviews/g4-red-team-2026-07-29.md
+++ b/docs/vision/reviews/g4-red-team-2026-07-29.md
@@ -132,11 +132,13 @@ adjoint claim does not.
      emitted by no report. -->
 <!-- numeral-src: -1 :: none - the other bound, U(-1, 1) m, the COUNTERFACTUAL
      box that was never run. Blocked rather than merely excused: once B4.4's
-     artifacts joined this tree a -1 appeared in the union index and the
-     excuse went STALE, which would invite deleting the marker and letting an
-     unrelated measurement stand in as provenance for a box nobody sampled.
-     A negative binding is the correct treatment for a number that must stay
-     unbacked, as distinct from one that has since become backed. -->
+     and then B5.5's artifacts joined this tree, each independently put a value
+     at -1 in the union index -- two independent coincidences on one
+     counterfactual. Either alone would have made the old excuse go STALE and
+     invited deleting the marker, which would let an unrelated measurement stand
+     in as provenance for a box nobody sampled. A negative binding is the correct
+     treatment for a number that must stay unbacked, as distinct from one that
+     has since become backed. -->
 <!-- numeral-src: 1e-12 :: none - not a measurement. It is the absolute FD-noise
      threshold implied by the old metric's own 1e-6 denominator floor and 1e-6
      tolerance, arithmetic on two bars, done in the sentence. Negative-bound

--- a/scripts/moonshot/b55-scan-to-parametric/REPORT.md
+++ b/scripts/moonshot/b55-scan-to-parametric/REPORT.md
@@ -1,0 +1,358 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+     License, v. 2.0. If a copy of the MPL was not distributed with this
+     file, You can obtain one at https://mozilla.org/MPL/2.0/. -->
+
+# B5.5: scan-to-parametric, one real scanned apartment (M5 final)
+
+Bet: take one real laser scan of a real dwelling, extract its structure, emit
+parametric IFC through `@ifc-lite/create`, mesh it with the kernel, and score
+its headline quantities against a manually modelled reference of the same
+apartment at a 5% bar. This is the first result in the program measured
+against something the program did not author.
+
+Every number below emits from `scorecard.json` in this directory. Nothing in
+this directory is source data: see [privacy](#8-privacy) for what was
+deliberately not committed and how that is enforced.
+
+## 1. Verdict
+
+**Partial pass. 12 of 16 scored rows are inside the 5% bar; 4 are outside, and
+all 4 are the same quantity failing for the same reason.**
+
+| Scope | Quantity | Scan-derived | Reference | Deviation | 5% bar |
+|---|---|---|---|---|---|
+| model | floor area | 64.726 m2 | 64.567 m2 | **+0.25%** | pass |
+| model | volume | 163.443 m3 | 155.918 m3 | **+4.83%** | pass |
+| model | area-weighted clear height | 2.525 m | 2.430 m | **+3.93%** | pass |
+| model | bounding wall surface | 180.015 m2 | 159.021 m2 | **+13.20%** | **fail** |
+| scan_room_001 | floor area | 45.576 m2 | 45.781 m2 | **-0.45%** | pass |
+| scan_room_001 | clear height | 2.539 m | 2.438 m | **+4.11%** | pass |
+| scan_room_001 | volume | 115.702 m3 | 110.677 m3 | **+4.54%** | pass |
+| scan_room_001 | bounding wall surface | 120.771 m2 | 101.985 m2 | **+18.42%** | **fail** |
+| scan_room_002 | floor area | 14.496 m2 | 14.203 m2 | **+2.06%** | pass |
+| scan_room_002 | clear height | 2.559 m | 2.438 m | **+4.93%** | pass |
+| scan_room_002 | volume | 37.089 m3 | 34.631 m3 | **+7.10%** | **fail** |
+| scan_room_002 | bounding wall surface | 39.310 m2 | 36.934 m2 | **+6.43%** | **fail** |
+| scan_room_003 | floor area | 4.654 m2 | 4.583 m2 | **+1.55%** | pass |
+| scan_room_003 | clear height | 2.289 m | 2.315 m | **-1.14%** | pass |
+| scan_room_003 | volume | 10.652 m3 | 10.611 m3 | **+0.39%** | pass |
+| scan_room_003 | bounding wall surface | 19.934 m2 | 20.102 m2 | **-0.84%** | pass |
+
+The headline the exam asked for -- "headline quantities within 5% of a manually
+modelled reference" -- is **met for floor area, clear height and volume at
+model scale, and met for all four quantities in one of the three rooms**. It is
+**not met for the bounding wall surface**, which is perimeter times height and
+is the one quantity that punishes a ragged boundary. Section 5 names that
+obstruction and sizes it.
+
+Read the floor-area row first, because it is the least deniable number here:
+a 3.94 GB point cloud went in and 64.726 m2 came out against a human's
+64.567 m2, with no reference data touching any stage of the extraction.
+
+## 2. What the scan actually contains
+
+`ingest-scan.mjs` streams the E57 through the repository's existing
+`E57StreamingSource` (`@ifc-lite/pointcloud`) rather than a new parser. Node's
+`openAsBlob` supplies the lazy `Blob` that source expects, so the 3.94 GB file
+is never resident and never copied.
+
+| | |
+|---|---|
+| container | E57 (ASTM E2807-11), one `Data3D` scan, page size 1024 |
+| points | **69,453,196**, all finite (**0** non-finite) |
+| per-point record | cartesian XYZ single-float, surface normals, RGB |
+| colour / intensity | colour yes, intensity no |
+| also inside the file | 250 registered pinhole photographs (4032 by 3024) with poses |
+| extent | **11.81 x 11.63 x 2.74 m** |
+| density | **506,008** points per m2 of plan |
+| ingest | **3.163 s**, **22.0 M points/s**, whole file, one pass (page-cache dependent; the first cold run of the same pass took roughly 5.5 s) |
+
+So this is not a survey-grade tripod scan of an empty shell. It is a dense,
+coloured, photo-registered capture of a **furnished, occupied dwelling**, whose
+vertical extent (2.74 m) is barely more than one storey. That matters for what
+follows: every occlusion in the result is furniture.
+
+The two structural surfaces are unmistakable in the full-cloud z histogram:
+the floor's single strongest 1 cm bin holds **5,812,039** points and the
+ceiling's holds **2,730,281**, against a background of roughly 0.2 M per bin
+through the open air of the rooms. Fitted by count-weighted mean over a
++-3 cm band:
+
+- floor plane **1.3687 m** below the scan's local origin (**15,699,994** points in band)
+- main ceiling plane **z = 1.1626 m** (**8,160,054** points in band)
+- **clear height 2.5312 m**
+
+## 3. How the structure was extracted
+
+Deliberately not "RANSAC over everything". On a furnished apartment that
+returns a hundred planes -- table tops, doors, cupboard sides -- and the work
+then moves to classifying and assembling them, which is where scan-to-BIM
+research actually lives and is not a one-session bet. The narrower observation
+that carries this exam:
+
+1. **Two horizontal planes.** Fit only the floor and the ceiling, from the
+   z histogram above.
+2. **Rooms are the connected components of ceiling visibility in plan.** A
+   wall's own footprint is never scanned: a scanner standing inside the rooms
+   sees both faces of a partition and nothing between them, so partitions
+   appear as empty channels in a 25 mm plan raster. Doorways do not leak the
+   segmentation, because a doorway has a lintel above it -- looking up from a
+   doorway you see the lintel soffit, not the ceiling.
+3. **Wall thickness is the width of that empty channel.**
+
+### The one threshold that matters, and why it is not hand-set
+
+Step 2 needs a height above the floor at which a cell counts as "under a
+ceiling". Too low and every room merges through the door lintels; too high and
+a room with a dropped ceiling vanishes. `chooseCeilingCut` sweeps the cut over
+**23** values from the fitted clear height down to **1.40 m** and records the room
+count and total room area at each. It then takes the **finest stable
+segmentation**: the longest run of consecutive cuts that agree on the room
+count and whose total area varies by under 2%, ranked by room count first.
+
+That ranking is load-bearing and was corrected during the run. The first
+version took the *longest* plateau, and a cut low enough to merge the whole
+apartment through the lintels is trivially stable over a wide band -- the
+one-room plateau is 8 samples wide against the three-room plateau's 5, so
+"longest" reliably returns the degenerate answer. Merging is a strict loss of
+structure, so room count ranks first and width only breaks ties. The full
+sweep is in `scorecard.json` (`variants.*.ceilingCut.sweep`) so the choice is
+auditable rather than asserted.
+
+Chosen: **cut 2.131 m**, midpoint of the plateau **2.031 m to 2.231 m**, which
+holds **3** rooms.
+
+### What came out
+
+| room | polygon area | perimeter | height | vertices | filled voids | unfilled voids |
+|---|---|---|---|---|---|---|
+| scan_room_001 | 45.576 m2 | 47.573 m | 2.539 m | 76 | 920 (1.855 m2) | 1 (0.251 m2) |
+| scan_room_002 | 14.496 m2 | 15.364 m | 2.559 m | 11 | 268 (0.319 m2) | 1 (1.278 m2) |
+| scan_room_003 | 4.654 m2 | 8.710 m | 2.289 m | 7 | 4 (0.003 m2) | 0 |
+
+`scan_room_003`'s height of 2.289 m is a genuinely dropped ceiling, found
+without being told to look for one: its own ceiling mode sits about 0.25 m
+below the other two rooms'.
+
+Wall channels measured between components: **0.075 m**, **0.075 m** and
+**0.400 m**.
+
+## 4. The emitted model
+
+`generate-ifc.mjs` builds through the shipped `@ifc-lite/create` API -- no
+hand-written STEP -- and produces a **30,535**-byte IFC holding **3**
+`IfcSpace` extruded solids, **29** `IfcWall`s and **1** `IfcSlab`. The
+measurement side (`measure-ifc.mjs`) then meshes it with the production kernel
+(`buildPrePassOnce` + `processGeometryBatch`) and reduces the triangles to
+quantities. **The reference model goes through the identical call.** Neither
+file's stored quantities are read -- the reference carries no
+`IfcElementQuantity` at all, and scoring a stored number against a computed one
+would be meaningless.
+
+Two things in the emitted model are **not measurements** and are flagged as
+such in `emitted.json` rather than scored: the slab thickness (**0.20 m**
+nominal -- an interior scan never sees the slab soffit) and the exterior wall
+thickness (emitted at the modal *interior* channel width, because a
+single-sided interior scan carries no information about how thick an outside
+wall is).
+
+## 5. Where it misses, precisely
+
+All four failures are one quantity, `lateralArea` -- the room's bounding wall
+surface, which is perimeter times height -- plus the one volume row that
+inherits from it. Two independent causes, and they are separable:
+
+**(a) The extraction merged two reference spaces into one room.** The
+reference has **4** `IfcSpace`s; the extraction found **3**. The missing one is
+the reference's smallest at **2.420 m2**: its ceiling region is connected to
+its neighbour's in the raster, so it never separates. The scorer handles this
+honestly instead of dropping it -- correspondence is by plan-centroid
+containment, so both reference spaces map to `scan_room_001` and that row is
+scored against their aggregate and flagged `mergedReferenceSpaces: 2`. A merge
+is roughly neutral for area (**-0.45%**) and badly non-neutral for perimeter,
+because merging two rooms should *remove* the shared partition's two faces and
+the ragged raster boundary does not.
+
+**(b) Boundary raggedness in the poorly-covered region.** `scan_room_001`'s
+outline is **47.573 m** against the merged reference's **41.825 m**: an excess
+of **5.748 m**, **+13.74%**. The other two rooms show no such excess --
+`scan_room_002` at **15.364 m** against **15.147 m** and `scan_room_003` at
+**8.710 m** against **8.683 m**, both inside 1.5%. So the perimeter machinery
+is sound and the excess is local: it is concentrated in the part of
+`scan_room_001` where the ceiling was barely captured, which is the same
+region that swallowed the merged space.
+
+**It is not raster staircase.** That was the first hypothesis, and it is
+wrong. The apartment sits at **51.087 degrees** to the E57 axes, so an
+axis-aligned 25 mm raster should inflate perimeter by up to sqrt(2) on every
+wall. A second full run (`--principal-frame`) rasterizes in the building's own
+frame instead -- the angle taken from the minimum-area rectangle of the
+scanned footprint, i.e. from the scan and nothing else -- and it cleans the
+outlines up dramatically (`scan_room_002` from **11** vertices to **4**,
+`scan_room_003` from **7** to **4**) while changing the verdict not at all:
+**12** of **16** rows, model bounding wall surface **+13.09%** against
+**+13.20%**. Both runs are in `scorecard.json`. That variant was added after
+seeing the primary run's 76-vertex outline, which is a defect visible in the
+scan without the reference; it is reported beside the pre-registered primary
+run, not instead of it.
+
+**Closing the gap** needs the segmentation to separate the fourth space and
+the boundary to be regularised into wall lines rather than traced from cells:
+fit 2D lines to the wall-channel points, snap room outlines to the fitted line
+arrangement, and take the room polygon as a face of that arrangement. That is
+the standard next step in the literature and is a day or two of work, not a
+research programme. It would move `lateralArea` and leave the area rows where
+they are.
+
+## 6. The reference is wrong about height, and the scan can prove it
+
+The clear-height rows pass, but at **+3.93%** model-wide they pass
+uncomfortably, and the honest reading is not that the extraction is 4% off.
+
+**3** of the reference's **4** spaces have a height of exactly **2.4384** m,
+which is 8 feet -- an authoring-tool default. To test whether it was measured,
+`score.mjs` counts scan points within +-1 cm of each reference space's
+modelled top elevation and compares against the background level: the median
+1 cm bin in the open air of the rooms, times three bins, **540,204** points.
+
+| reference space | height | top elevation | scan points within +-1 cm | supported? |
+|---|---|---|---|---|
+| ref_space_A | 2.4384 m | 1.0724 m | 351,062 | **no** |
+| ref_space_B | 2.4384 m | 1.0724 m | 351,062 | **no** |
+| ref_space_C | 2.3150 m | 0.9490 m | 1,645,945 | yes |
+| ref_space_D | 2.4384 m | 1.0724 m | 351,062 | **no** |
+
+The scan's own fitted ceiling carries **6,586,376** points in the same window
+-- **18.8x** more than the three defaulted tops, which themselves sit *below*
+the empty-air background. Meanwhile `ref_space_C`, the one room whose modelled
+height the modeller clearly did measure (its dropped ceiling), is the room
+where this pipeline lands within **-1.14%** on height, **+1.55%** on area,
+**+0.39%** on volume and **-0.84%** on wall surface: every quantity inside
+1.6%.
+
+So on the height quantity, **the scan-derived model is closer to the building
+than the reference model is**, by **0.093 m**. That propagates: `scan_room_002`
+misses volume by **+7.10%**, and volume decomposes exactly as area times
+height -- **+2.06%** area against **+4.93%** height. Take the height error out
+and that row passes.
+
+This is reported as a finding, not used as an excuse: the scored table in
+section 1 scores against the reference as it is, defaults and all. But a bet
+whose stated purpose is contact with the outside world should say plainly when
+the outside world's artifact is the one that drifted.
+
+## 7. What was NOT done, and every shortcut taken
+
+- **The second half of the B5.5 exam clause was not attempted.** The bet as
+  written is "one real scanned room to parametric IFC ... **plus one
+  world-model scene imported with a bill of quantities**". Only the first
+  clause was run. The second is a separate ingest path against a different
+  kind of input and shares no machinery with what is here; it is not blocked
+  by anything above, it was simply out of budget.
+- **No openings.** No windows or doors were detected or emitted. The reference
+  has **3** windows, **3** doors and **6** opening elements. Opening detection
+  from an interior scan is tractable (wall-plane point voids) and was cut for
+  time, not for difficulty.
+- **No wall-thickness validation.** Channel widths came out at **0.075 m**,
+  **0.075 m** and **0.400 m** in the primary run and **0.05 m**, **0.05 m**,
+  **0.325 m** in the principal-frame run. The reference's wall types span
+  90 mm to 350 mm, so the measurement is the right order and the thin channels
+  are biased low -- the topmost points on a wall's visible face fall at ceiling
+  height and are themselves counted as ceiling cells, eating roughly one cell
+  per side. That bias is stated, not corrected: correcting it after seeing the
+  reference's thickness set would be exactly the kind of move this bet is
+  supposed to refuse. The third channel is between two rooms that are not
+  directly adjacent everywhere and should be treated as unvalidated.
+- **Areas are ceiling-derived, not floor-derived.** Room area here is the
+  plan area of ceiling visibility. For a room with vertical walls that equals
+  the floor area, which is the assumption; a sloped or stepped ceiling would
+  break it and this scan has neither.
+- **Single storey.** The scan is 2.74 m tall. Nothing here handles more than
+  one storey.
+- **Subsampled.** The geometric passes run on every 10th point
+  (**6,945,320** of **69,453,196**). The plane fits and histograms use all
+  **69,453,196**.
+- **No registration was needed or performed.** The scan and the reference
+  share a coordinate frame -- verified, not assumed: the two models' space
+  bounding boxes agree to a maximum corner offset of **0.118 m** with no
+  transform applied to either side (`frameCheck` in `scorecard.json`). That is
+  a gift from this particular data pairing (the reference was modelled on this
+  scan) and would not hold for an arbitrary scan/model pair. **A bet run on
+  unregistered inputs would have to solve registration first, and that is a
+  real piece of work this exam did not have to do.**
+- **`scan_room_002` carries a 1.278 m2 unscanned void** inside its outline.
+  The emitted `IfcSpace` profile is a single outer loop, so the void is
+  included in the emitted area by construction of the output format.
+- **Ordering disclosure.** The reference's per-space quantities were computed
+  before the extraction pipeline was finalised -- unavoidable, since the
+  reference had to be parsed to know what was comparable at all. The mitigation
+  is structural rather than procedural: `ingest-scan.mjs`, `extract-rooms.mjs`
+  and `generate-ifc.mjs` do not read the reference, no threshold in them was
+  chosen by watching a deviation, and the two changes made after the first
+  scored run (the plateau ranking in section 3, the principal-frame variant in
+  section 5) were both driven by defects visible in the scan alone. The
+  principal-frame variant made the score marginally *worse*, which is what an
+  honest non-tuning change looks like.
+
+## 8. Privacy
+
+The scan and the reference are client data, and both carry a real site
+location: the reference has `IfcSite` latitude and longitude, the E57 carries a
+projected-CRS definition. Neither source file, nor the generated IFC, nor any
+room polygon, nor any string from either file is committed. `scorecard.json`
+holds derived scalars only, in the scan's own local metres, with neutral labels
+(`ref_space_A`, `scan_room_001`).
+
+That is enforced, not promised. `run.mjs::assertNoIdentifiers` fails the run if
+the committed artifact contains a string value outside a fixed allowlist, a key
+outside an identifier pattern, any quoted string of 10 or more characters
+lifted from the reference file, or anything shaped like a
+degrees/minutes/seconds tuple. It fired twice during development and both leaks
+were removed.
+
+## 9. Reproduction
+
+```bash
+node scripts/moonshot/b55-scan-to-parametric/run.mjs \
+  --scan /path/to/Apartment.e57 \
+  --reference /path/to/reference.ifc \
+  --work "$SCRATCH/b55-work"
+```
+
+Requires a built tree (`pnpm build`) with staged wasm. Peak on-disk cost
+outside the repository is the subsample at **83,343,840** bytes; the source
+file is read in place and never copied. Ingest is **3.16 s** and
+everything after it is **1.15 s**.
+
+## 10. One side effect on the numerals gate, flagged not fixed
+
+`check-report-numerals.mjs --gate` passes on this directory: every numeral in
+this report is either backed by `scorecard.json` or carries a marked reason,
+and none is unbacked. It does **not** pass on the whole tree with this
+directory present, and the reason is worth a maintainer's attention rather than
+a quiet edit.
+
+The `docs/vision` prose set is checked against the UNION of every moonshot
+artifact in the tree. Adding this bet's several hundred numbers to that union
+coincidentally puts a value within half-ULP of two tokens that other documents
+had legitimately marked as unbacked, so those markers now read as STALE: this
+scorecard's nominal slab thickness lands on a `0.20x` speedup endpoint in
+`moonshots-tech.md` and in the G4 review, and one ceiling-sweep total area
+lands on a count in the G2 review that belongs to a bet on another branch.
+Neither marker's reason stopped being true; an unrelated file merely grew a
+number of the right size.
+
+Deleting those markers would be wrong -- the excuses are still correct -- and
+`docs/vision` is outside this bet's writable domain, so nothing was changed
+there. The structural fix is for the union-index check to bind a marker to the
+artifact set its own bet emits, or to require the backing value to come from
+the document's own bet. Left for the maintainer.
+
+<!-- numeral-ok: 350, 250, 4032, 3024, 1024 ::
+     domain and format constants that no artifact stores, plus two bounds.
+     350 is the top of the reference's wall-type range in mm, read from its
+     IfcMaterialLayerSet and
+     deliberately NOT emitted to the scorecard because it is reference detail
+     this bet has no business republishing. 250 / 4032 / 3024 / 1024 are the
+     E57's own embedded-photo count, pixel dimensions and page size, read from
+     its XML section, which this pipeline characterises but does not decode. -->

--- a/scripts/moonshot/b55-scan-to-parametric/REPORT.md
+++ b/scripts/moonshot/b55-scan-to-parametric/REPORT.md
@@ -65,7 +65,7 @@ is never resident and never copied.
 | also inside the file | 250 registered pinhole photographs (4032 by 3024) with poses |
 | extent | **11.81 x 11.63 x 2.74 m** |
 | density | **506,008** points per m2 of plan |
-| ingest | **3.163 s**, **22.0 M points/s**, whole file, one pass (page-cache dependent; the first cold run of the same pass took roughly 5.5 s) |
+| ingest | **3.152 s**, **22.0 M points/s**, whole file, one pass (page-cache and machine-load dependent, and the only figure in this report that is; the first cold run of the same pass took roughly 5.5 s) |
 
 So this is not a survey-grade tripod scan of an empty shell. It is a dense,
 coloured, photo-registered capture of a **furnished, occupied dwelling**, whose
@@ -113,11 +113,13 @@ count and whose total area varies by under 2%, ranked by room count first.
 That ranking is load-bearing and was corrected during the run. The first
 version took the *longest* plateau, and a cut low enough to merge the whole
 apartment through the lintels is trivially stable over a wide band -- the
-one-room plateau is 8 samples wide against the three-room plateau's 5, so
+one-room plateau is 9 samples wide against the three-room plateau's 5, so
 "longest" reliably returns the degenerate answer. Merging is a strict loss of
 structure, so room count ranks first and width only breaks ties. The full
-sweep is in `scorecard.json` (`variants.*.ceilingCut.sweep`) so the choice is
-auditable rather than asserted.
+sweep is in `scorecard.json` (`variants.*.ceilingCut.sweep`), and the widest
+stable plateau at each room count is emitted beside it
+(`variants.*.ceilingCut.plateausByRoomCount`), so the choice is auditable
+rather than asserted.
 
 Chosen: **cut 2.131 m**, midpoint of the plateau **2.031 m to 2.231 m**, which
 holds **3** rooms.
@@ -321,8 +323,8 @@ node scripts/moonshot/b55-scan-to-parametric/run.mjs \
 
 Requires a built tree (`pnpm build`) with staged wasm. Peak on-disk cost
 outside the repository is the subsample at **83,343,840** bytes; the source
-file is read in place and never copied. Ingest is **3.16 s** and
-everything after it is **1.15 s**.
+file is read in place and never copied. Ingest is **3.15 s** and
+everything after it is **1.29 s**.
 
 ## 10. One side effect on the numerals gate, flagged not fixed
 

--- a/scripts/moonshot/b55-scan-to-parametric/REPORT.md
+++ b/scripts/moonshot/b55-scan-to-parametric/REPORT.md
@@ -65,7 +65,7 @@ is never resident and never copied.
 | also inside the file | 250 registered pinhole photographs (4032 by 3024) with poses |
 | extent | **11.81 x 11.63 x 2.74 m** |
 | density | **506,008** points per m2 of plan |
-| ingest | **3.152 s**, **22.0 M points/s**, whole file, one pass (page-cache and machine-load dependent, and the only figure in this report that is; the first cold run of the same pass took roughly 5.5 s) |
+| ingest | **3.606 s**, **19.3 M points/s**, whole file, one pass (page-cache and machine-load dependent, and the only figure in this report that is; the first cold run of the same pass took roughly 5.5 s) |
 
 So this is not a survey-grade tripod scan of an empty shell. It is a dense,
 coloured, photo-registered capture of a **furnished, occupied dwelling**, whose
@@ -142,7 +142,7 @@ Wall channels measured between components: **0.075 m**, **0.075 m** and
 ## 4. The emitted model
 
 `generate-ifc.mjs` builds through the shipped `@ifc-lite/create` API -- no
-hand-written STEP -- and produces a **30,535**-byte IFC holding **3**
+hand-written STEP -- and produces a **30,056**-byte IFC holding **3**
 `IfcSpace` extruded solids, **29** `IfcWall`s and **1** `IfcSlab`. The
 measurement side (`measure-ifc.mjs`) then meshes it with the production kernel
 (`buildPrePassOnce` + `processGeometryBatch`) and reduces the triangles to
@@ -157,6 +157,38 @@ nominal -- an interior scan never sees the slab soffit) and the exterior wall
 thickness (emitted at the modal *interior* channel width, because a
 single-sided interior scan carries no information about how thick an outside
 wall is).
+
+### The one defect the exam could not have caught
+
+Review found, and measurement confirmed, that the first revision of this file
+placed the walls and the slab **one storey elevation too low**. The builder's
+placement parents are not uniform: `addIfcWall` and `addIfcSlab` place relative
+to the storey, whose own placement the builder puts at the storey elevation,
+while `addIfcSpace` places relative to the world. Handing the fitted floor
+plane to all three applied it twice, so the walls and the slab resolved to
+*twice* the fitted floor elevation while the spaces resolved to it -- a
+storey's worth of separation between a room and the walls bounding it. The
+corrected model puts the storey, its spaces and its walls all at the fitted
+floor plane and hangs the slab body its own thickness below, and that datum is
+now emitted (`variants.*.emitted.worldBaseZByType`) rather than asserted.
+
+**The exam is blind to this by construction.** Every quantity it scores is an
+`IfcSpace` quantity, and all four -- floor area, clear height, volume,
+bounding wall surface -- are invariant under a rigid Z shift of the walls. The
+scored rows do not move by so much as a digit when the defect is fixed; the
+only published figure that changed is the file size. So the check had to look
+at the artifact rather than at the score: `generate-ifc.mjs` now walks the
+`IfcLocalPlacement` chain of the STEP it just wrote and refuses to write a
+model whose spaces, walls and slab top do not land on the same datum, and
+`scripts/moonshot/ci/b55-pipeline-regression.mjs` carries a negative control
+that rebuilds the model the broken way and requires the check to reject it.
+
+That regression suite is the standing coverage for this bet. The source scan
+cannot be committed or fetched, so it runs the real stage scripts over a
+synthetic two-room apartment whose quantities are known in closed form and
+asserts them: fitted planes, room areas and heights, the measured partition
+width, the placement datum, and the scorer's deviation arithmetic against
+deliberate misses placed either side of the bar.
 
 ## 5. Where it misses, precisely
 
@@ -174,6 +206,18 @@ scored against their aggregate and flagged `mergedReferenceSpaces: 2`. A merge
 is roughly neutral for area (**-0.45%**) and badly non-neutral for perimeter,
 because merging two rooms should *remove* the shared partition's two faces and
 the ragged raster boundary does not.
+
+The plan point that containment is tested with is the midpoint of the
+reference space's bounding box, which for a **concave** space is not its
+centroid and can in principle fall in a neighbouring room. Two of the four
+reference spaces here *are* concave, so the scorer computes the true
+area-weighted plan centroid as well, resolves both, and **fails the run** if
+they ever land in different rooms. On this data they never do, and the margin
+is committed rather than claimed: the largest gap between the two points is
+**0.405 m** against **1.469 m** of clearance to the nearest boundary of the
+room it landed in, and the tightest case is **0.091 m** against **0.390 m**.
+The shortcut cannot change an assignment here; the guard is what makes that a
+measurement instead of a hope.
 
 **(b) Boundary raggedness in the poorly-covered region.** `scan_room_001`'s
 outline is **47.573 m** against the merged reference's **41.825 m**: an excess
@@ -323,7 +367,7 @@ node scripts/moonshot/b55-scan-to-parametric/run.mjs \
 
 Requires a built tree (`pnpm build`) with staged wasm. Peak on-disk cost
 outside the repository is the subsample at **83,343,840** bytes; the source
-file is read in place and never copied. Ingest is **3.15 s** and
+file is read in place and never copied. Ingest is **3.61 s** and
 everything after it is **1.29 s**.
 
 ## 10. One side effect on the numerals gate, flagged not fixed

--- a/scripts/moonshot/b55-scan-to-parametric/extract-rooms.mjs
+++ b/scripts/moonshot/b55-scan-to-parametric/extract-rooms.mjs
@@ -50,9 +50,27 @@
 import { readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
+const USAGE = 'usage: node extract-rooms.mjs <workDir> [--cell 0.025] [--ceiling-cut N] [--principal-frame]';
+const die = (msg) => { console.error(`${msg}\n${USAGE}`); process.exit(2); };
+
 const args = process.argv.slice(2);
 const WORK = args[0];
-const num = (n, d) => { const i = args.indexOf(n); return i >= 0 ? Number(args[i + 1]) : d; };
+if (!WORK || WORK.startsWith('--')) die('missing <workDir>');
+/**
+ * Every threshold below is a measurement input, so a typo must stop the run
+ * rather than propagate: `Number(undefined)` and `Number('0.o25')` are both
+ * NaN, and NaN silently poisons the raster (`Math.ceil(NaN)`, every comparison
+ * false) all the way to a rooms.json full of nulls.
+ */
+const num = (n, d) => {
+  const i = args.indexOf(n);
+  if (i < 0) return d;
+  const v = Number(args[i + 1]);
+  if (args[i + 1] === undefined || args[i + 1] === '' || !Number.isFinite(v)) {
+    die(`${n} needs a finite number, got ${JSON.stringify(args[i + 1])}`);
+  }
+  return v;
+};
 
 /** Plan raster cell, metres. 25 mm keeps a 90 mm partition 3.6 cells wide. */
 const CELL = num('--cell', 0.025);
@@ -71,6 +89,16 @@ const MAX_FILL_HOLE = num('--max-fill-hole', 0.25);
 const SWEEP_LO = num('--sweep-lo', 1.40);
 const SWEEP_STEP = 0.05;
 const PLATEAU_TOL = num('--plateau-tol', 0.02);
+// Ranges, not just finiteness: a zero or negative cell size divides the plan
+// raster by zero, and a min-cell count below 1 makes every empty cell occupied.
+if (!(CELL > 0)) die('--cell must be greater than 0');
+if (!(PLANE_BAND > 0)) die('--plane-band must be greater than 0');
+if (!(MIN_CELL_POINTS >= 1)) die('--min-cell-points must be at least 1');
+if (!(MIN_ROOM_AREA > 0)) die('--min-room-area must be greater than 0');
+if (!(DP_EPS >= 0)) die('--dp-eps must not be negative');
+if (!(MAX_FILL_HOLE >= 0)) die('--max-fill-hole must not be negative');
+if (!(PLATEAU_TOL >= 0)) die('--plateau-tol must not be negative');
+if (!(SWEEP_LO > 0)) die('--sweep-lo must be greater than 0');
 
 /**
  * `--principal-frame` rasterizes in the BUILDING's frame instead of the
@@ -86,8 +114,15 @@ const PRINCIPAL = args.includes('--principal-frame');
 
 const ingest = JSON.parse(readFileSync(join(WORK, 'ingest.json'), 'utf8'));
 const rawBytes = readFileSync(join(WORK, 'sub.f32'));
+// sub.f32 is a flat run of xyz float32 triples, 12 B each. A length that is
+// not a multiple of 12 means a truncated ingest (a killed run, a full disk),
+// and a trailing partial record would be read as a point at whatever the
+// pooled buffer happened to hold.
+if (rawBytes.byteLength === 0 || rawBytes.byteLength % 12 !== 0) {
+  throw new Error(`${join(WORK, 'sub.f32')} is ${rawBytes.byteLength} B, not a whole number of 12 B xyz records -- re-run ingest-scan.mjs`);
+}
 const rawPts = new Float32Array(rawBytes.buffer, rawBytes.byteOffset, rawBytes.byteLength / 4);
-const N = rawPts.length / 3;
+const N = rawBytes.byteLength / 12;
 
 /** Andrew's monotone chain over a decimated point set. */
 function convexHull(ps) {
@@ -156,6 +191,10 @@ function fitHorizontalPlane(h, lo, hi) {
     if (z < lo || z >= hi) continue;
     if (h.counts[i] > bestCount) { bestCount = h.counts[i]; best = i; }
   }
+  // No bin in the window, or a window with no point mass at all, is missing
+  // data -- not a plane at z = NaN. Returning NaN here would flow into the
+  // ceiling cut, the room heights and every quantity downstream as a number.
+  if (best < 0) throw new Error(`no z-histogram bin inside [${lo}, ${hi}) -- the scan has no horizontal accumulation there`);
   const zPeak = h.origin + best * h.binSize;
   let wsum = 0, w = 0;
   for (let i = 0; i < h.counts.length; i++) {
@@ -163,6 +202,7 @@ function fitHorizontalPlane(h, lo, hi) {
     if (Math.abs(z - zPeak) > PLANE_BAND) continue;
     wsum += z * h.counts[i]; w += h.counts[i];
   }
+  if (!(w > 0)) throw new Error(`z-histogram band +-${PLANE_BAND} m around ${zPeak} holds no points -- cannot fit a horizontal plane`);
   return { z: wsum / w, peakZ: zPeak, peakBinPoints: bestCount, bandPoints: w };
 }
 
@@ -236,6 +276,9 @@ function chooseCeilingCut() {
     sweep.push({ cut: +c.toFixed(3), roomCount: rooms.length, totalArea: rooms.reduce((a, b) => a + b, 0), areas: rooms.map((a) => +a.toFixed(3)) });
   }
   let best = null;
+  /** Widest stable plateau per room count, emitted so the ranking rule below
+   *  can be checked against the data instead of taken on the prose's word. */
+  const widestPerRoomCount = new Map();
   for (let i = 0; i < sweep.length; i++) {
     for (let j = i; j < sweep.length; j++) {
       if (sweep[j].roomCount !== sweep[i].roomCount) break;
@@ -245,11 +288,13 @@ function chooseCeilingCut() {
       if (mean > 0 && spread / mean > PLATEAU_TOL) break;
       // FINEST stable segmentation, not longest. A cut low enough to merge
       // everything through the door lintels is trivially stable over a wide
-      // band -- on this scan the one-room plateau is 8 samples wide against
-      // the three-room plateau's 6 -- so "longest plateau" reliably picks the
+      // band -- on this scan the one-room plateau is 9 samples wide against
+      // the three-room plateau's 5 -- so "longest plateau" reliably picks the
       // degenerate answer. Merging is a strict loss of structure, so rank by
       // room count first and use plateau width only to break ties.
       const cand = { length: slice.length, lo: slice[slice.length - 1].cut, hi: slice[0].cut, roomCount: sweep[i].roomCount };
+      const widest = widestPerRoomCount.get(cand.roomCount);
+      if (!widest || cand.length > widest.length) widestPerRoomCount.set(cand.roomCount, cand);
       const better = !best
         || cand.roomCount > best.roomCount
         || (cand.roomCount === best.roomCount && cand.length > best.length);
@@ -257,7 +302,8 @@ function chooseCeilingCut() {
     }
   }
   if (!best) throw new Error('no stable ceiling-cut plateau found');
-  return { cut: +((best.lo + best.hi) / 2).toFixed(4), plateau: best, sweep };
+  const plateausByRoomCount = [...widestPerRoomCount.values()].sort((a, b) => b.roomCount - a.roomCount);
+  return { cut: +((best.lo + best.hi) / 2).toFixed(4), plateau: best, plateausByRoomCount, sweep };
 }
 
 const cutChoice = chooseCeilingCut();
@@ -331,7 +377,11 @@ function fillHoles(cells) {
  * exactly -- no marching-squares half-cell bias.
  */
 function traceOutline(cellSet) {
-  const has = (x, y) => cellSet.has(y * nx + x);
+  // The column bound is load-bearing: without it `has(-1, y)` reads
+  // `y * nx - 1`, the LAST cell of the row below, and `has(nx, y)` reads the
+  // first cell of the row above -- so a room touching either edge of the
+  // raster loses boundary edges to a neighbour that is not adjacent to it.
+  const has = (x, y) => x >= 0 && x < nx && y >= 0 && y < ny && cellSet.has(y * nx + x);
   const edges = new Map(); // "x,y" -> [[x,y], ...] successors
   const push = (a, b) => {
     const key = `${a[0]},${a[1]}`;

--- a/scripts/moonshot/b55-scan-to-parametric/extract-rooms.mjs
+++ b/scripts/moonshot/b55-scan-to-parametric/extract-rooms.mjs
@@ -1,0 +1,555 @@
+#!/usr/bin/env node
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * B5.5 stage 2 -- planar structure and room extraction from the subsampled
+ * cloud. NOTHING IN HERE READS THE REFERENCE MODEL. Every threshold is either
+ * a stated resolution choice or is derived from the scan's own statistics by
+ * a rule written down before it was run (see `--ceiling-cut` below).
+ *
+ * WHY A CEILING CARVE AND NOT RANSAC-EVERYTHING. The textbook move is RANSAC
+ * plane fitting over the whole cloud. On a furnished apartment that yields a
+ * hundred planes (table tops, doors, cupboard sides) which then have to be
+ * classified and assembled, and the assembly is where scan-to-BIM research
+ * actually lives. The structure this exam needs -- one room's floor area, its
+ * height, its bounding wall surface -- is recoverable from a much narrower
+ * and much more robust observation:
+ *
+ *   1. Floor and ceiling are the two overwhelming horizontal accumulations in
+ *      the z histogram. Fit those two only.
+ *   2. Rooms are the connected components of CEILING VISIBILITY in plan. A
+ *      wall's own footprint is never scanned -- a scanner standing inside the
+ *      rooms sees both wall faces but nothing between them -- so walls appear
+ *      as empty channels in the plan raster. Door openings do not leak,
+ *      because a doorway has a lintel above it: looking up from a doorway you
+ *      see the lintel soffit, not the ceiling.
+ *   3. Wall thickness is then the width of the empty channel between two room
+ *      components, measured directly in the raster.
+ *
+ * THE ONE THRESHOLD THAT MATTERS is the height above the floor at which a
+ * cell counts as "under a ceiling". Too low and every room merges through the
+ * door lintels; too high and a room with a dropped ceiling disappears. It is
+ * NOT hand-set. `chooseCeilingCut` sweeps the cut over the whole plausible
+ * band and takes the FINEST STABLE segmentation: among runs of consecutive
+ * cut values that agree on the room count AND whose total room area varies by
+ * less than PLATEAU_TOL, the one with the most rooms, ties broken by the
+ * wider plateau, and the cut is that plateau's midpoint. Ranking by room
+ * count rather than by plateau width is load-bearing -- see the comment at
+ * the ranking itself. That is a stability/persistence criterion computed from
+ * the scan alone; the sweep it is chosen from is written into rooms.json so
+ * the choice is auditable rather than asserted.
+ *
+ * Usage: node extract-rooms.mjs <workDir> [--cell 0.025] [--ceiling-cut N]
+ *                                 [--principal-frame]
+ * Reads  <workDir>/sub.f32, <workDir>/ingest.json
+ * Writes <workDir>/rooms.json
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const args = process.argv.slice(2);
+const WORK = args[0];
+const num = (n, d) => { const i = args.indexOf(n); return i >= 0 ? Number(args[i + 1]) : d; };
+
+/** Plan raster cell, metres. 25 mm keeps a 90 mm partition 3.6 cells wide. */
+const CELL = num('--cell', 0.025);
+/** Half-width of the band used to refine a horizontal plane, metres. */
+const PLANE_BAND = num('--plane-band', 0.03);
+/** A plan cell must hold at least this many subsampled points to count. */
+const MIN_CELL_POINTS = num('--min-cell-points', 2);
+/** Components smaller than this are scan speckle, not rooms. m^2. */
+const MIN_ROOM_AREA = num('--min-room-area', 1.0);
+/** Douglas-Peucker tolerance for the emitted room outline, metres. */
+const DP_EPS = num('--dp-eps', 0.05);
+/** Enclosed voids up to this area are sensor dropout and get filled; larger
+ *  ones are treated as real (an un-entered room, a duct) and left out. m^2. */
+const MAX_FILL_HOLE = num('--max-fill-hole', 0.25);
+/** Ceiling-cut sweep: range, step, and the plateau's area-agreement band. */
+const SWEEP_LO = num('--sweep-lo', 1.40);
+const SWEEP_STEP = 0.05;
+const PLATEAU_TOL = num('--plateau-tol', 0.02);
+
+/**
+ * `--principal-frame` rasterizes in the BUILDING's frame instead of the
+ * world's. This apartment sits at roughly 45 degrees to the E57 axes, and an
+ * axis-aligned raster turns every wall into a staircase: the cell-count area
+ * is unaffected (a staircase has the same area as the line it approximates)
+ * but the PERIMETER is inflated by up to sqrt(2), and everything derived from
+ * perimeter -- the bounding wall surface, the wall runs -- inherits that.
+ * The angle is the orientation of the minimum-area rectangle of the scanned
+ * footprint, i.e. it comes from the scan and nothing else.
+ */
+const PRINCIPAL = args.includes('--principal-frame');
+
+const ingest = JSON.parse(readFileSync(join(WORK, 'ingest.json'), 'utf8'));
+const rawBytes = readFileSync(join(WORK, 'sub.f32'));
+const rawPts = new Float32Array(rawBytes.buffer, rawBytes.byteOffset, rawBytes.byteLength / 4);
+const N = rawPts.length / 3;
+
+/** Andrew's monotone chain over a decimated point set. */
+function convexHull(ps) {
+  const s = ps.slice().sort((a, b) => a[0] - b[0] || a[1] - b[1]);
+  const cross = (o, a, b) => (a[0] - o[0]) * (b[1] - o[1]) - (a[1] - o[1]) * (b[0] - o[0]);
+  const lower = [];
+  for (const p of s) { while (lower.length >= 2 && cross(lower[lower.length - 2], lower[lower.length - 1], p) <= 0) lower.pop(); lower.push(p); }
+  const upper = [];
+  for (let i = s.length - 1; i >= 0; i--) { const p = s[i]; while (upper.length >= 2 && cross(upper[upper.length - 2], upper[upper.length - 1], p) <= 0) upper.pop(); upper.push(p); }
+  lower.pop(); upper.pop();
+  return lower.concat(upper);
+}
+/** Orientation of the minimum-area bounding rectangle, radians in [0, pi/2). */
+function principalAngle(ps) {
+  const hull = convexHull(ps);
+  let best = { area: Infinity, theta: 0 };
+  for (const [i, a] of hull.entries()) {
+    const b = hull[(i + 1) % hull.length];
+    const th = Math.atan2(b[1] - a[1], b[0] - a[0]);
+    const c = Math.cos(-th), s = Math.sin(-th);
+    let x0 = Infinity, y0 = Infinity, x1 = -Infinity, y1 = -Infinity;
+    for (const [px, py] of hull) {
+      const x = px * c - py * s, y = px * s + py * c;
+      if (x < x0) x0 = x; if (x > x1) x1 = x;
+      if (y < y0) y0 = y; if (y > y1) y1 = y;
+    }
+    const area = (x1 - x0) * (y1 - y0);
+    if (area < best.area) best = { area, theta: th };
+  }
+  let t = best.theta % (Math.PI / 2);
+  if (t < 0) t += Math.PI / 2;
+  return t;
+}
+
+let THETA = 0;
+let pts = rawPts;
+if (PRINCIPAL) {
+  // Hull of every 97th subsampled point (a prime stride, so the decimation
+  // does not alias with the E57 record order) -- plenty for a hull.
+  const sample = [];
+  for (let i = 0; i < N; i += 97) sample.push([rawPts[i * 3], rawPts[i * 3 + 1]]);
+  THETA = principalAngle(sample);
+  const c = Math.cos(-THETA), s = Math.sin(-THETA);
+  pts = new Float32Array(rawPts.length);
+  for (let i = 0; i < N; i++) {
+    const x = rawPts[i * 3], y = rawPts[i * 3 + 1];
+    pts[i * 3] = x * c - y * s;
+    pts[i * 3 + 1] = x * s + y * c;
+    pts[i * 3 + 2] = rawPts[i * 3 + 2];
+  }
+}
+/** Rotate a plan point from the raster frame back to the world frame. */
+const unrotate = ([x, y]) => {
+  if (!PRINCIPAL) return [x, y];
+  const c = Math.cos(THETA), s = Math.sin(THETA);
+  return [x * c - y * s, x * s + y * c];
+};
+
+// ---------------------------------------------------------------- planes ---
+/** Argmax bin of the full-cloud z histogram inside [lo, hi), then a
+ *  count-weighted mean over +-PLANE_BAND around it. */
+function fitHorizontalPlane(h, lo, hi) {
+  let best = -1, bestCount = -1;
+  for (let i = 0; i < h.counts.length; i++) {
+    const z = h.origin + i * h.binSize;
+    if (z < lo || z >= hi) continue;
+    if (h.counts[i] > bestCount) { bestCount = h.counts[i]; best = i; }
+  }
+  const zPeak = h.origin + best * h.binSize;
+  let wsum = 0, w = 0;
+  for (let i = 0; i < h.counts.length; i++) {
+    const z = h.origin + i * h.binSize;
+    if (Math.abs(z - zPeak) > PLANE_BAND) continue;
+    wsum += z * h.counts[i]; w += h.counts[i];
+  }
+  return { z: wsum / w, peakZ: zPeak, peakBinPoints: bestCount, bandPoints: w };
+}
+
+const hz = ingest.histograms.z;
+const zMid = (ingest.bbox.min[2] + ingest.bbox.max[2]) / 2;
+const floorPlane = fitHorizontalPlane(hz, ingest.bbox.min[2], zMid);
+const ceilPlane = fitHorizontalPlane(hz, zMid, ingest.bbox.max[2] + 1);
+
+// ------------------------------------------------------------ plan raster ---
+// Raster extent from the (possibly rotated) points, not from ingest.bbox:
+// under --principal-frame the world bbox no longer bounds the plan.
+let pminX = Infinity, pminY = Infinity, pmaxX = -Infinity, pmaxY = -Infinity;
+for (let i = 0; i < N; i++) {
+  const x = pts[i * 3], y = pts[i * 3 + 1];
+  if (x < pminX) pminX = x; if (x > pmaxX) pmaxX = x;
+  if (y < pminY) pminY = y; if (y > pmaxY) pmaxY = y;
+}
+const ox = pminX, oy = pminY;
+const nx = Math.ceil((pmaxX - ox) / CELL) + 1;
+const ny = Math.ceil((pmaxY - oy) / CELL) + 1;
+const maxZ = new Float32Array(nx * ny).fill(-Infinity);
+const count = new Int32Array(nx * ny);
+for (let i = 0; i < N; i++) {
+  const k = (((pts[i * 3 + 1] - oy) / CELL) | 0) * nx + (((pts[i * 3] - ox) / CELL) | 0);
+  count[k]++;
+  if (pts[i * 3 + 2] > maxZ[k]) maxZ[k] = pts[i * 3 + 2];
+}
+
+function maskFor(cut) {
+  const m = new Uint8Array(nx * ny);
+  for (let k = 0; k < m.length; k++) {
+    if (count[k] >= MIN_CELL_POINTS && maxZ[k] - floorPlane.z >= cut) m[k] = 1;
+  }
+  return m;
+}
+
+/** 4-connected labelling; returns cell-index arrays per component. */
+function components(m) {
+  const lab = new Int32Array(nx * ny).fill(-1);
+  const out = [];
+  const st = new Int32Array(nx * ny);
+  for (let s = 0; s < m.length; s++) {
+    if (!m[s] || lab[s] >= 0) continue;
+    const id = out.length;
+    let sp = 0; st[sp++] = s; lab[s] = id;
+    const cells = [];
+    while (sp > 0) {
+      const k = st[--sp];
+      cells.push(k);
+      const x = k % nx, y = (k / nx) | 0;
+      const P = (j) => { if (m[j] && lab[j] < 0) { lab[j] = id; st[sp++] = j; } };
+      if (x > 0) P(k - 1);
+      if (x < nx - 1) P(k + 1);
+      if (y > 0) P(k - nx);
+      if (y < ny - 1) P(k + nx);
+    }
+    out.push(cells);
+  }
+  return { lab, comps: out };
+}
+
+const cellArea = CELL * CELL;
+
+function chooseCeilingCut() {
+  const sweep = [];
+  for (let c = ceilPlane.z - floorPlane.z; c >= SWEEP_LO - 1e-9; c -= SWEEP_STEP) {
+    const rooms = components(maskFor(c)).comps
+      .map((cs) => cs.length * cellArea)
+      .filter((a) => a >= MIN_ROOM_AREA)
+      .sort((a, b) => b - a);
+    sweep.push({ cut: +c.toFixed(3), roomCount: rooms.length, totalArea: rooms.reduce((a, b) => a + b, 0), areas: rooms.map((a) => +a.toFixed(3)) });
+  }
+  let best = null;
+  for (let i = 0; i < sweep.length; i++) {
+    for (let j = i; j < sweep.length; j++) {
+      if (sweep[j].roomCount !== sweep[i].roomCount) break;
+      const slice = sweep.slice(i, j + 1);
+      const mean = slice.reduce((a, s) => a + s.totalArea, 0) / slice.length;
+      const spread = Math.max(...slice.map((s) => s.totalArea)) - Math.min(...slice.map((s) => s.totalArea));
+      if (mean > 0 && spread / mean > PLATEAU_TOL) break;
+      // FINEST stable segmentation, not longest. A cut low enough to merge
+      // everything through the door lintels is trivially stable over a wide
+      // band -- on this scan the one-room plateau is 8 samples wide against
+      // the three-room plateau's 6 -- so "longest plateau" reliably picks the
+      // degenerate answer. Merging is a strict loss of structure, so rank by
+      // room count first and use plateau width only to break ties.
+      const cand = { length: slice.length, lo: slice[slice.length - 1].cut, hi: slice[0].cut, roomCount: sweep[i].roomCount };
+      const better = !best
+        || cand.roomCount > best.roomCount
+        || (cand.roomCount === best.roomCount && cand.length > best.length);
+      if (slice.length >= 3 && better) best = cand;
+    }
+  }
+  if (!best) throw new Error('no stable ceiling-cut plateau found');
+  return { cut: +((best.lo + best.hi) / 2).toFixed(4), plateau: best, sweep };
+}
+
+const cutChoice = chooseCeilingCut();
+const CEILING_CUT = num('--ceiling-cut', cutChoice.cut);
+const mask = maskFor(CEILING_CUT);
+const { comps } = components(mask);
+
+// --------------------------------------------------------------- topology ---
+/** Fill enclosed voids up to MAX_FILL_HOLE by flood-filling the complement
+ *  from outside a 1-cell margin: what the outside fill cannot reach is
+ *  interior. Returns the filled cell set plus a per-hole size list. */
+function fillHoles(cells) {
+  let x0 = Infinity, y0 = Infinity, x1 = -Infinity, y1 = -Infinity;
+  for (const k of cells) {
+    const x = k % nx, y = (k / nx) | 0;
+    if (x < x0) x0 = x; if (x > x1) x1 = x;
+    if (y < y0) y0 = y; if (y > y1) y1 = y;
+  }
+  x0--; y0--; x1++; y1++;
+  const w = x1 - x0 + 1, h = y1 - y0 + 1;
+  const local = new Uint8Array(w * h);
+  for (const k of cells) local[((k / nx | 0) - y0) * w + (k % nx) - x0] = 1;
+  const seen = new Uint8Array(w * h);
+  const stack = [0]; seen[0] = 1;
+  while (stack.length) {
+    const k = stack.pop();
+    const x = k % w, y = (k / w) | 0;
+    const P = (j) => { if (!local[j] && !seen[j]) { seen[j] = 1; stack.push(j); } };
+    if (x > 0) P(k - 1); if (x < w - 1) P(k + 1);
+    if (y > 0) P(k - w); if (y < h - 1) P(k + w);
+  }
+  // Enclosed voids, grouped so each can be size-tested on its own.
+  const holeLab = new Int32Array(w * h).fill(-1);
+  const holes = [];
+  for (let s = 0; s < local.length; s++) {
+    if (local[s] || seen[s] || holeLab[s] >= 0) continue;
+    const id = holes.length;
+    const st = [s]; holeLab[s] = id;
+    const cs = [];
+    while (st.length) {
+      const k = st.pop(); cs.push(k);
+      const x = k % w, y = (k / w) | 0;
+      const P = (j) => { if (!local[j] && !seen[j] && holeLab[j] < 0) { holeLab[j] = id; st.push(j); } };
+      if (x > 0) P(k - 1); if (x < w - 1) P(k + 1);
+      if (y > 0) P(k - w); if (y < h - 1) P(k + w);
+    }
+    holes.push(cs);
+  }
+  const filledLocal = local.slice();
+  let filledHoles = 0, filledHoleCells = 0, keptHoles = 0;
+  for (const cs of holes) {
+    if (cs.length * cellArea > MAX_FILL_HOLE) { keptHoles++; continue; }
+    filledHoles++; filledHoleCells += cs.length;
+    for (const k of cs) filledLocal[k] = 1;
+  }
+  const filled = [];
+  for (let j = 0; j < filledLocal.length; j++) {
+    if (filledLocal[j]) filled.push((y0 + ((j / w) | 0)) * nx + x0 + (j % w));
+  }
+  return {
+    filled, filledHoles, filledHoleCells, keptHoles,
+    largestHoleM2: holes.length ? Math.max(...holes.map((c) => c.length)) * cellArea : 0,
+  };
+}
+
+/**
+ * Outer boundary of a cell set as a lattice polygon, by chaining the boundary
+ * EDGES of the union (each cell side with no filled neighbour) into loops.
+ * Directions are chosen so the interior is on the left, i.e. loops come out
+ * counter-clockwise, and the polygon's area equals the cell-count area
+ * exactly -- no marching-squares half-cell bias.
+ */
+function traceOutline(cellSet) {
+  const has = (x, y) => cellSet.has(y * nx + x);
+  const edges = new Map(); // "x,y" -> [[x,y], ...] successors
+  const push = (a, b) => {
+    const key = `${a[0]},${a[1]}`;
+    if (!edges.has(key)) edges.set(key, []);
+    edges.get(key).push(b);
+  };
+  for (const k of cellSet) {
+    const x = k % nx, y = (k / nx) | 0;
+    if (!has(x, y - 1)) push([x, y], [x + 1, y]);
+    if (!has(x + 1, y)) push([x + 1, y], [x + 1, y + 1]);
+    if (!has(x, y + 1)) push([x + 1, y + 1], [x, y + 1]);
+    if (!has(x - 1, y)) push([x, y + 1], [x, y]);
+  }
+  const loops = [];
+  for (const [startKey, succ] of edges) {
+    while (succ.length) {
+      const loop = [];
+      let cur = startKey.split(',').map(Number);
+      for (let guard = 0; guard < 4 * cellSet.size + 16; guard++) {
+        const key = `${cur[0]},${cur[1]}`;
+        const list = edges.get(key);
+        if (!list || !list.length) break;
+        const nxt = list.shift();
+        loop.push(cur);
+        cur = nxt;
+        if (cur[0] === Number(startKey.split(',')[0]) && cur[1] === Number(startKey.split(',')[1])) break;
+      }
+      if (loop.length >= 4) loops.push(loop);
+      else break;
+    }
+  }
+  if (!loops.length) return [];
+  // The outer boundary is the loop of greatest absolute area.
+  const areaOf = (l) => {
+    let a = 0;
+    for (let i = 0; i < l.length; i++) {
+      const q = l[(i + 1) % l.length];
+      a += l[i][0] * q[1] - q[0] * l[i][1];
+    }
+    return a / 2;
+  };
+  loops.sort((a, b) => Math.abs(areaOf(b)) - Math.abs(areaOf(a)));
+  const outer = loops[0];
+  const pruned = [];
+  for (let i = 0; i < outer.length; i++) {
+    const a = outer[(i - 1 + outer.length) % outer.length], b = outer[i], c = outer[(i + 1) % outer.length];
+    if ((b[0] - a[0]) * (c[1] - b[1]) === (b[1] - a[1]) * (c[0] - b[0])) continue;
+    pruned.push(b);
+  }
+  const src = pruned.length >= 3 ? pruned : outer;
+  const poly = src.map(([x, y]) => unrotate([ox + x * CELL, oy + y * CELL]));
+  return areaOf(src) < 0 ? poly.reverse() : poly;
+}
+
+function polygonArea(p) {
+  let a = 0;
+  for (let i = 0; i < p.length; i++) {
+    const q = p[(i + 1) % p.length];
+    a += p[i][0] * q[1] - q[0] * p[i][1];
+  }
+  return Math.abs(a) / 2;
+}
+function polygonPerimeter(p) {
+  let s = 0;
+  for (let i = 0; i < p.length; i++) {
+    const q = p[(i + 1) % p.length];
+    s += Math.hypot(q[0] - p[i][0], q[1] - p[i][1]);
+  }
+  return s;
+}
+/** Closed-polyline Douglas-Peucker. */
+function simplify(poly, eps) {
+  const dp = (ps) => {
+    if (ps.length < 3) return ps;
+    let maxD = 0, idx = 0;
+    const [axx, ayy] = ps[0], [bxx, byy] = ps[ps.length - 1];
+    const len = Math.hypot(bxx - axx, byy - ayy);
+    for (let i = 1; i < ps.length - 1; i++) {
+      const [px, py] = ps[i];
+      const d = len === 0 ? Math.hypot(px - axx, py - ayy)
+        : Math.abs((bxx - axx) * (ayy - py) - (axx - px) * (byy - ayy)) / len;
+      if (d > maxD) { maxD = d; idx = i; }
+    }
+    if (maxD <= eps) return [ps[0], ps[ps.length - 1]];
+    return [...dp(ps.slice(0, idx + 1)).slice(0, -1), ...dp(ps.slice(idx))];
+  };
+  // Anchor the split at the two most distant vertices so the recursion cannot
+  // simplify the whole loop away to a degenerate pair.
+  let ia = 0, ib = 0, bestD = -1;
+  for (let i = 0; i < poly.length; i++) {
+    for (let j = i + 1; j < poly.length; j++) {
+      const d = Math.hypot(poly[j][0] - poly[i][0], poly[j][1] - poly[i][1]);
+      if (d > bestD) { bestD = d; ia = i; ib = j; }
+    }
+  }
+  const first = poly.slice(ia, ib + 1);
+  const second = [...poly.slice(ib), ...poly.slice(0, ia + 1)];
+  const out = [...dp(first).slice(0, -1), ...dp(second).slice(0, -1)];
+  return out;
+}
+
+// ----------------------------------------------------------------- rooms ---
+const rooms = [];
+comps.forEach((cells, compIndex) => {
+  if (cells.length * cellArea < MIN_ROOM_AREA) return;
+  const fh = fillHoles(cells);
+  const set = new Set(fh.filled);
+  const outline = traceOutline(set);
+  const simple = simplify(outline, DP_EPS);
+  // Ceiling level of THIS room: mode of the per-cell max height over its
+  // MEASURED cells (filled holes carry no measurement).
+  const bins = new Map();
+  for (const k of cells) {
+    const b = Math.round(maxZ[k] / 0.01);
+    bins.set(b, (bins.get(b) ?? 0) + 1);
+  }
+  let modeBin = 0, modeCount = -1;
+  for (const [b, c] of bins) if (c > modeCount) { modeCount = c; modeBin = b; }
+  const zCeil = modeBin * 0.01;
+  let cx = 0, cy = 0;
+  for (const k of fh.filled) { cx += (k % nx); cy += ((k / nx) | 0); }
+  rooms.push({
+    compIndex,
+    rasterAreaM2: fh.filled.length * cellArea,
+    measuredCells: cells.length,
+    filledCells: fh.filled.length,
+    filledHoles: fh.filledHoles,
+    filledHoleAreaM2: fh.filledHoleCells * cellArea,
+    unfilledHoles: fh.keptHoles,
+    largestHoleM2: fh.largestHoleM2,
+    outlineVertices: outline.length,
+    outlineAreaM2: polygonArea(outline),
+    polygon: simple.map(([x, y]) => [+x.toFixed(4), +y.toFixed(4)]),
+    polygonAreaM2: polygonArea(simple),
+    polygonPerimeterM: polygonPerimeter(simple),
+    zCeiling: zCeil,
+    heightM: zCeil - floorPlane.z,
+    centroid: unrotate([ox + (cx / fh.filled.length) * CELL, oy + (cy / fh.filled.length) * CELL]),
+  });
+});
+rooms.sort((a, b) => b.rasterAreaM2 - a.rasterAreaM2);
+rooms.forEach((r, i) => { r.id = `scan_room_${String(i + 1).padStart(3, '0')}`; });
+
+// -------------------------------------------------- wall-channel thickness ---
+/**
+ * Between two room components the unscanned wall footprint is a run of mask-0
+ * cells. Sweep every raster row and column; each maximal 0-run bounded by two
+ * DIFFERENT rooms is one wall crossing. Perpendicular thickness is the
+ * SHORTEST family of crossings (oblique scan lines through the same wall are
+ * longer, never shorter), so the 10th percentile is the noise-tolerant
+ * estimate.
+ */
+function wallChannels() {
+  const { lab } = components(mask);
+  const roomOfComp = new Map(rooms.map((r) => [r.compIndex, r.id]));
+  const pairRuns = new Map();
+  const sweep = (idx, inner, outer) => {
+    for (let o = 0; o < outer; o++) {
+      let run = 0, prev = -1;
+      for (let i = 0; i < inner; i++) {
+        const l = lab[idx(o, i)];
+        if (l < 0 || !roomOfComp.has(l)) { run++; continue; }
+        if (run > 0 && prev >= 0 && prev !== l) {
+          const key = prev < l ? `${prev}|${l}` : `${l}|${prev}`;
+          if (!pairRuns.has(key)) pairRuns.set(key, []);
+          pairRuns.get(key).push(run * CELL);
+        }
+        prev = l; run = 0;
+      }
+    }
+  };
+  sweep((y, x) => y * nx + x, nx, ny);
+  sweep((x, y) => y * nx + x, ny, nx);
+  const out = [];
+  for (const [key, runs] of pairRuns) {
+    if (runs.length < 8) continue;
+    runs.sort((a, b) => a - b);
+    const [a, b] = key.split('|').map(Number);
+    out.push({
+      between: [roomOfComp.get(a), roomOfComp.get(b)],
+      crossings: runs.length,
+      thicknessM: runs[Math.floor(runs.length * 0.10)],
+      medianCrossingM: runs[Math.floor(runs.length / 2)],
+    });
+  }
+  return out.sort((a, b) => b.crossings - a.crossings);
+}
+const channels = wallChannels();
+
+const result = {
+  params: { CELL, PLANE_BAND, MIN_CELL_POINTS, MIN_ROOM_AREA, DP_EPS, MAX_FILL_HOLE, PLATEAU_TOL, SWEEP_LO, SWEEP_STEP },
+  principalFrame: { enabled: PRINCIPAL, thetaRad: THETA, thetaDeg: (THETA * 180) / Math.PI },
+  planes: {
+    floor: floorPlane,
+    ceiling: ceilPlane,
+    clearHeightM: ceilPlane.z - floorPlane.z,
+  },
+  ceilingCut: { used: CEILING_CUT, sweepLoM: SWEEP_LO, sweepStepM: SWEEP_STEP, ...cutChoice },
+  raster: { nx, ny, ox, oy, cell: CELL, occupiedCells: count.reduce((a, v) => a + (v >= MIN_CELL_POINTS ? 1 : 0), 0), maskCells: mask.reduce((a, v) => a + v, 0) },
+  rooms,
+  wallChannels: channels,
+  totals: {
+    roomCount: rooms.length,
+    totalRasterAreaM2: rooms.reduce((a, r) => a + r.rasterAreaM2, 0),
+    totalPolygonAreaM2: rooms.reduce((a, r) => a + r.polygonAreaM2, 0),
+  },
+};
+writeFileSync(join(WORK, 'rooms.json'), JSON.stringify(result, null, 2));
+
+console.log(JSON.stringify({
+  principalFrame: PRINCIPAL, thetaDeg: +((THETA * 180) / Math.PI).toFixed(3),
+  floorZ: +floorPlane.z.toFixed(4), ceilingZ: +ceilPlane.z.toFixed(4),
+  clearHeight: +(ceilPlane.z - floorPlane.z).toFixed(4),
+  ceilingCut: CEILING_CUT, plateau: cutChoice.plateau,
+  rooms: rooms.map((r) => ({
+    id: r.id, raster: +r.rasterAreaM2.toFixed(3), outline: +r.outlineAreaM2.toFixed(3),
+    poly: +r.polygonAreaM2.toFixed(3), verts: r.polygon.length, h: +r.heightM.toFixed(3),
+    holes: r.filledHoles, unfilled: r.unfilledHoles, c: r.centroid.map((v) => +v.toFixed(2)),
+  })),
+  channels,
+}, null, 2));

--- a/scripts/moonshot/b55-scan-to-parametric/generate-ifc.mjs
+++ b/scripts/moonshot/b55-scan-to-parametric/generate-ifc.mjs
@@ -46,6 +46,13 @@ const WALL_MIN_EDGE = 0.60;
 const WALL_DP_EPS = 0.12;
 
 const rooms = JSON.parse(readFileSync(join(WORK, 'rooms.json'), 'utf8'));
+// With no rooms there is nothing to extrude and, further down, the slab's
+// bounding box stays at +-Infinity -- which would emit an IfcSlab with
+// Infinity extents rather than fail. An empty extraction is a result to
+// report, not a model to write.
+if (!Array.isArray(rooms.rooms) || rooms.rooms.length === 0) {
+  throw new Error(`${join(WORK, 'rooms.json')} contains no rooms; there is no space, wall or slab to generate`);
+}
 const floorZ = rooms.planes.floor.z;
 
 /** Modal interior partition thickness from the measured wall channels. */

--- a/scripts/moonshot/b55-scan-to-parametric/generate-ifc.mjs
+++ b/scripts/moonshot/b55-scan-to-parametric/generate-ifc.mjs
@@ -33,6 +33,7 @@
 import { readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { IfcCreator } from '../../../packages/create/dist/index.js';
+import { assertCoherentStoreyDatum } from './placement-check.mjs';
 
 const WORK = process.argv[2];
 const OUT = process.argv[3];
@@ -54,6 +55,27 @@ if (!Array.isArray(rooms.rooms) || rooms.rooms.length === 0) {
   throw new Error(`${join(WORK, 'rooms.json')} contains no rooms; there is no space, wall or slab to generate`);
 }
 const floorZ = rooms.planes.floor.z;
+
+/**
+ * PLACEMENT PARENTS ARE NOT UNIFORM in `@ifc-lite/create`, and getting this
+ * wrong moves the whole model rather than a millimetre of it.
+ *
+ *   addIfcWall / addIfcSlab  place relative to the STOREY, whose own placement
+ *                            the builder puts at [0, 0, Elevation].
+ *   addIfcSpace              places relative to the WORLD.
+ *
+ * So the fitted floor elevation must be supplied exactly once per element: as
+ * part of the coordinate for spaces, and NOT AT ALL for walls and the slab,
+ * whose storey parent already carries it. Passing `floorZ` to all three -- as
+ * this file did until it was measured -- lands the walls at 2 x floorZ, which
+ * on this scan is 1.369 m below the spaces they are supposed to bound.
+ *
+ * This is invisible to the exam (it scores IfcSpace quantities, every one of
+ * which is invariant under a rigid Z shift of the walls), so
+ * `assertCoherentStoreyDatum` reads the datum back out of the emitted STEP
+ * before the file is written.
+ */
+const STOREY_RELATIVE_Z = 0;
 
 /** Modal interior partition thickness from the measured wall channels. */
 const measuredThicknesses = rooms.wallChannels.map((c) => c.thicknessM);
@@ -124,8 +146,8 @@ for (const room of rooms.rooms) {
     const t = modalThickness;
     const ox2 = (dy / len) * (t / 2), oy2 = (-dx / len) * (t / 2);
     const wid = creator.addIfcWall(storey, {
-      Start: [a[0] + ox2, a[1] + oy2, floorZ],
-      End: [b[0] + ox2, b[1] + oy2, floorZ],
+      Start: [a[0] + ox2, a[1] + oy2, STOREY_RELATIVE_Z],
+      End: [b[0] + ox2, b[1] + oy2, STOREY_RELATIVE_Z],
       Thickness: t,
       Height: room.heightM,
       Name: `${room.id}_wall_${i}`,
@@ -141,7 +163,9 @@ for (const r of rooms.rooms) for (const [x, y] of r.polygon) {
   if (y < y0) y0 = y; if (y > y1) y1 = y;
 }
 const slabId = creator.addIfcSlab(storey, {
-  Position: [x0, y0, floorZ - SLAB_THICKNESS],
+  // Storey-relative, like the walls: the slab body hangs below the storey
+  // datum by its own thickness, so its TOP is the floor the spaces stand on.
+  Position: [x0, y0, STOREY_RELATIVE_Z - SLAB_THICKNESS],
   Thickness: SLAB_THICKNESS,
   Width: x1 - x0,
   Depth: y1 - y0,
@@ -150,10 +174,17 @@ const slabId = creator.addIfcSlab(storey, {
 emitted.slab = { expressId: slabId, thicknessM: SLAB_THICKNESS, thicknessInferred: false };
 
 const { content } = creator.toIfc();
+// Read the datum back out of the STEP before anything is written: spaces,
+// walls and the slab top must all land on the fitted floor plane.
+const datum = assertCoherentStoreyDatum(content, {
+  elevationM: floorZ,
+  slabThicknessM: SLAB_THICKNESS,
+});
 writeFileSync(OUT, content);
 writeFileSync(join(WORK, 'emitted.json'), JSON.stringify({
   out: OUT, bytes: content.length,
   storeyElevation: floorZ,
+  worldBaseZByType: datum,
   modalWallThicknessM: modalThickness,
   slabThicknessNominalM: SLAB_THICKNESS,
   ...emitted,

--- a/scripts/moonshot/b55-scan-to-parametric/generate-ifc.mjs
+++ b/scripts/moonshot/b55-scan-to-parametric/generate-ifc.mjs
@@ -1,0 +1,157 @@
+#!/usr/bin/env node
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * B5.5 stage 3 -- rooms.json to a real parametric IFC, through the shipped
+ * `@ifc-lite/create` builder. No hand-written STEP: every entity here comes
+ * out of the same API a user would call, so the output is a model the rest of
+ * the toolchain (kernel, viewer, exporters) reads without special-casing.
+ *
+ * What is emitted, and what each thing is grounded in:
+ *   IfcBuildingStorey  elevation = the fitted floor plane
+ *   IfcSpace (n)       profile = the room's simplified ceiling-visibility
+ *                      outline; height = that room's ceiling mode minus the
+ *                      floor plane. Extruded solid, so its quantities are
+ *                      derivable rather than asserted.
+ *   IfcSlab            floor slab under the union of the rooms. Thickness is
+ *                      NOT measurable from an interior scan (the scanner
+ *                      never sees the slab soffit) -- it is emitted at the
+ *                      nominal SLAB_THICKNESS and flagged, never scored.
+ *   IfcWall (n)        one per room-outline edge at or above WALL_MIN_EDGE,
+ *                      axis offset outward by half the thickness so the room
+ *                      face lands on the measured outline. Interior partition
+ *                      thickness comes from the measured wall channels;
+ *                      EXTERIOR thickness is not observable from a
+ *                      single-sided interior scan and is emitted at the modal
+ *                      interior thickness with `inferred: false` recorded.
+ *
+ * Usage: node generate-ifc.mjs <workDir> <out.ifc>
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { IfcCreator } from '../../../packages/create/dist/index.js';
+
+const WORK = process.argv[2];
+const OUT = process.argv[3];
+
+/** Nominal, NOT measured -- an interior scan never sees the slab soffit. */
+const SLAB_THICKNESS = 0.20;
+/** Outline edges shorter than this are raster staircase, not wall runs. */
+const WALL_MIN_EDGE = 0.60;
+/** Douglas-Peucker tolerance for the wall-generation outline (coarser than
+ *  the space profile: a wall run should not chase 5 cm of scan noise). */
+const WALL_DP_EPS = 0.12;
+
+const rooms = JSON.parse(readFileSync(join(WORK, 'rooms.json'), 'utf8'));
+const floorZ = rooms.planes.floor.z;
+
+/** Modal interior partition thickness from the measured wall channels. */
+const measuredThicknesses = rooms.wallChannels.map((c) => c.thicknessM);
+const modalThickness = measuredThicknesses.length
+  ? measuredThicknesses.slice().sort((a, b) => a - b)[Math.floor(measuredThicknesses.length / 2)]
+  : 0.10;
+
+function simplify(poly, eps) {
+  const dp = (ps) => {
+    if (ps.length < 3) return ps;
+    let maxD = 0, idx = 0;
+    const [ax, ay] = ps[0], [bx, by] = ps[ps.length - 1];
+    const len = Math.hypot(bx - ax, by - ay);
+    for (let i = 1; i < ps.length - 1; i++) {
+      const [px, py] = ps[i];
+      const d = len === 0 ? Math.hypot(px - ax, py - ay)
+        : Math.abs((bx - ax) * (ay - py) - (ax - px) * (by - ay)) / len;
+      if (d > maxD) { maxD = d; idx = i; }
+    }
+    if (maxD <= eps) return [ps[0], ps[ps.length - 1]];
+    return [...dp(ps.slice(0, idx + 1)).slice(0, -1), ...dp(ps.slice(idx))];
+  };
+  let ia = 0, ib = 0, bestD = -1;
+  for (let i = 0; i < poly.length; i++) {
+    for (let j = i + 1; j < poly.length; j++) {
+      const d = Math.hypot(poly[j][0] - poly[i][0], poly[j][1] - poly[i][1]);
+      if (d > bestD) { bestD = d; ia = i; ib = j; }
+    }
+  }
+  return [...dp(poly.slice(ia, ib + 1)).slice(0, -1), ...dp([...poly.slice(ib), ...poly.slice(0, ia + 1)]).slice(0, -1)];
+}
+function signedArea(p) {
+  let a = 0;
+  for (let i = 0; i < p.length; i++) {
+    const q = p[(i + 1) % p.length];
+    a += p[i][0] * q[1] - q[0] * p[i][1];
+  }
+  return a / 2;
+}
+
+const creator = new IfcCreator({ Name: 'Scan-derived apartment (B5.5)' });
+const storey = creator.addIfcBuildingStorey({ Name: 'Storey 0', Elevation: floorZ });
+
+const emitted = { spaces: [], walls: [], slab: null };
+
+for (const room of rooms.rooms) {
+  const id = creator.addIfcSpace(storey, {
+    Position: [0, 0, floorZ],
+    Profile: room.polygon,
+    Height: room.heightM,
+    Name: room.id,
+    LongName: room.id,
+  });
+  emitted.spaces.push({
+    expressId: id, roomId: room.id, height: room.heightM,
+    profileVertices: room.polygon.length, profileAreaM2: room.polygonAreaM2,
+  });
+
+  // Walls along the coarsened outline. Outward normal from a CCW polygon is
+  // the edge direction rotated -90 degrees.
+  const coarse = simplify(room.polygon, WALL_DP_EPS);
+  const ccw = signedArea(coarse) > 0 ? coarse : coarse.slice().reverse();
+  for (let i = 0; i < ccw.length; i++) {
+    const a = ccw[i], b = ccw[(i + 1) % ccw.length];
+    const dx = b[0] - a[0], dy = b[1] - a[1];
+    const len = Math.hypot(dx, dy);
+    if (len < WALL_MIN_EDGE) continue;
+    const t = modalThickness;
+    const ox2 = (dy / len) * (t / 2), oy2 = (-dx / len) * (t / 2);
+    const wid = creator.addIfcWall(storey, {
+      Start: [a[0] + ox2, a[1] + oy2, floorZ],
+      End: [b[0] + ox2, b[1] + oy2, floorZ],
+      Thickness: t,
+      Height: room.heightM,
+      Name: `${room.id}_wall_${i}`,
+    });
+    emitted.walls.push({ expressId: wid, roomId: room.id, lengthM: len, thicknessM: t, thicknessInferred: false });
+  }
+}
+
+// Floor slab: bounding rectangle of every room, at nominal thickness.
+let x0 = Infinity, y0 = Infinity, x1 = -Infinity, y1 = -Infinity;
+for (const r of rooms.rooms) for (const [x, y] of r.polygon) {
+  if (x < x0) x0 = x; if (x > x1) x1 = x;
+  if (y < y0) y0 = y; if (y > y1) y1 = y;
+}
+const slabId = creator.addIfcSlab(storey, {
+  Position: [x0, y0, floorZ - SLAB_THICKNESS],
+  Thickness: SLAB_THICKNESS,
+  Width: x1 - x0,
+  Depth: y1 - y0,
+  Name: 'Floor slab (nominal thickness, not measured)',
+});
+emitted.slab = { expressId: slabId, thicknessM: SLAB_THICKNESS, thicknessInferred: false };
+
+const { content } = creator.toIfc();
+writeFileSync(OUT, content);
+writeFileSync(join(WORK, 'emitted.json'), JSON.stringify({
+  out: OUT, bytes: content.length,
+  storeyElevation: floorZ,
+  modalWallThicknessM: modalThickness,
+  slabThicknessNominalM: SLAB_THICKNESS,
+  ...emitted,
+}, null, 2));
+console.log(JSON.stringify({
+  bytes: content.length, spaces: emitted.spaces.length, walls: emitted.walls.length,
+  modalWallThicknessM: modalThickness,
+}, null, 2));

--- a/scripts/moonshot/b55-scan-to-parametric/ingest-scan.mjs
+++ b/scripts/moonshot/b55-scan-to-parametric/ingest-scan.mjs
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * B5.5 stage 1 -- ingest and characterize the scan.
+ *
+ * Reads a multi-GB E57 through `@ifc-lite/pointcloud`'s existing
+ * `E57StreamingSource` (bounded window, page-CRC stripped on the fly) rather
+ * than a new parser: the repo already ships a reader that does not allocate
+ * the file. Node's `openAsBlob` supplies the lazy `Blob` the source expects,
+ * so nothing is copied to disk.
+ *
+ * Emits, into a caller-supplied OUT directory (never the repo -- the source
+ * is client data):
+ *   sub.f32       every Nth point, xyz float32 little-endian
+ *   ingest.json   full-cloud statistics: exact bbox, per-axis 1 cm histograms,
+ *                 point count, timing, throughput
+ *
+ * Statistics are over ALL points, not the subsample: the stride only governs
+ * what is retained for the later geometric passes.
+ *
+ * Usage: node ingest-scan.mjs <file.e57> <outDir> [--stride N] [--chunk N]
+ */
+
+import { openAsBlob, writeFileSync, mkdirSync, createWriteStream } from 'node:fs';
+import { join } from 'node:path';
+import { E57StreamingSource } from '../../../packages/pointcloud/dist/index.js';
+
+const args = process.argv.slice(2);
+const src = args[0];
+const outDir = args[1];
+const flag = (n, d) => {
+  const i = args.indexOf(n);
+  return i >= 0 ? Number(args[i + 1]) : d;
+};
+const STRIDE = flag('--stride', 10);
+const CHUNK = flag('--chunk', 2_000_000);
+/** Histogram bin, metres. 1 cm resolves a floor slab from its screed. */
+const BIN = 0.01;
+/** Histogram window per axis, metres, centred on 0 (E57 declares |x|<=9). */
+const HALF = 16;
+const NBINS = Math.round((2 * HALF) / BIN);
+
+mkdirSync(outDir, { recursive: true });
+
+const t0 = Date.now();
+const blob = await openAsBlob(src);
+const source = new E57StreamingSource(blob, { downsample: { stride: 1 } });
+const info = await source.open();
+
+const hist = [new Float64Array(NBINS), new Float64Array(NBINS), new Float64Array(NBINS)];
+const min = [Infinity, Infinity, Infinity];
+const max = [-Infinity, -Infinity, -Infinity];
+let total = 0;
+let kept = 0;
+let nonFinite = 0;
+let outOfHistRange = 0;
+
+const out = createWriteStream(join(outDir, 'sub.f32'));
+const writeBuf = (buf) => new Promise((res) => { if (!out.write(buf)) out.once('drain', res); else res(); });
+
+for (;;) {
+  const chunk = await source.next(CHUNK);
+  if (!chunk) break;
+  const p = chunk.positions;
+  const n = chunk.pointCount;
+  const keepIdx = [];
+  for (let i = 0; i < n; i++) {
+    const gi = total + i;
+    const x = p[i * 3], y = p[i * 3 + 1], z = p[i * 3 + 2];
+    if (!Number.isFinite(x) || !Number.isFinite(y) || !Number.isFinite(z)) { nonFinite++; continue; }
+    const v = [x, y, z];
+    for (let a = 0; a < 3; a++) {
+      if (v[a] < min[a]) min[a] = v[a];
+      if (v[a] > max[a]) max[a] = v[a];
+      const b = Math.floor((v[a] + HALF) / BIN);
+      if (b >= 0 && b < NBINS) hist[a][b]++; else outOfHistRange++;
+    }
+    if (gi % STRIDE === 0) keepIdx.push(i);
+  }
+  total += n;
+  if (keepIdx.length) {
+    const buf = Buffer.allocUnsafe(keepIdx.length * 12);
+    let o = 0;
+    for (const i of keepIdx) {
+      buf.writeFloatLE(p[i * 3], o); o += 4;
+      buf.writeFloatLE(p[i * 3 + 1], o); o += 4;
+      buf.writeFloatLE(p[i * 3 + 2], o); o += 4;
+    }
+    await writeBuf(buf);
+    kept += keepIdx.length;
+  }
+  if (total % 10_000_000 < CHUNK) {
+    process.stderr.write(`  ${(total / 1e6).toFixed(1)}M points, ${((Date.now() - t0) / 1000).toFixed(1)}s\n`);
+  }
+}
+source.close();
+await new Promise((r) => out.end(r));
+
+const elapsedMs = Date.now() - t0;
+/** Compress a histogram to its non-empty run so ingest.json stays small. */
+const pack = (h) => {
+  let lo = 0; while (lo < NBINS && h[lo] === 0) lo++;
+  let hi = NBINS - 1; while (hi > lo && h[hi] === 0) hi--;
+  return { binSize: BIN, origin: -HALF + lo * BIN, counts: Array.from(h.subarray(lo, hi + 1)) };
+};
+const extent = [max[0] - min[0], max[1] - min[1], max[2] - min[2]];
+writeFileSync(join(outDir, 'ingest.json'), JSON.stringify({
+  sourceBytes: blob.size,
+  declaredPointCount: info.pointCount ?? info.totalPoints ?? null,
+  decodedPointCount: total,
+  keptPointCount: kept,
+  stride: STRIDE,
+  nonFinite,
+  outOfHistRange,
+  hasColor: info.hasColor,
+  hasIntensity: info.hasIntensity,
+  bbox: { min, max, extent },
+  /** Points per m3 of the bounding box, and per m2 of its plan footprint. */
+  densityPerM3: total / (extent[0] * extent[1] * extent[2]),
+  densityPerPlanM2: total / (extent[0] * extent[1]),
+  histograms: { x: pack(hist[0]), y: pack(hist[1]), z: pack(hist[2]) },
+  elapsedMs,
+  megaPointsPerSecond: total / 1e3 / elapsedMs,
+}, null, 2));
+process.stderr.write(`done: ${total} points in ${(elapsedMs / 1000).toFixed(1)}s, kept ${kept}\n`);

--- a/scripts/moonshot/b55-scan-to-parametric/ingest-scan.mjs
+++ b/scripts/moonshot/b55-scan-to-parametric/ingest-scan.mjs
@@ -12,8 +12,9 @@
  * the file. Node's `openAsBlob` supplies the lazy `Blob` the source expects,
  * so nothing is copied to disk.
  *
- * Emits, into a caller-supplied OUT directory (never the repo -- the source
- * is client data):
+ * Emits, into a caller-supplied OUT directory (never the repo -- the source is
+ * client data, and an OUT directory that canonicalises to anywhere inside the
+ * worktree is refused before anything is created):
  *   sub.f32       every Nth point, xyz float32 little-endian
  *   ingest.json   full-cloud statistics: exact bbox, per-axis 1 cm histograms,
  *                 point count, timing, throughput
@@ -24,26 +25,71 @@
  * Usage: node ingest-scan.mjs <file.e57> <outDir> [--stride N] [--chunk N]
  */
 
-import { openAsBlob, writeFileSync, mkdirSync, createWriteStream } from 'node:fs';
-import { join } from 'node:path';
+import { openAsBlob, writeFileSync, mkdirSync, createWriteStream, existsSync, realpathSync } from 'node:fs';
+import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { E57StreamingSource } from '../../../packages/pointcloud/dist/index.js';
+
+const USAGE = 'usage: node ingest-scan.mjs <file.e57> <outDir> [--stride N] [--chunk N]';
+const die = (msg) => { console.error(`${msg}\n${USAGE}`); process.exit(2); };
 
 const args = process.argv.slice(2);
 const src = args[0];
 const outDir = args[1];
-const flag = (n, d) => {
+// Validated BEFORE anything is created on disk: a mistyped invocation must not
+// leave a directory behind, and a non-integer stride would silently turn
+// `gi % STRIDE` into a filter that keeps everything or nothing.
+if (!src || src.startsWith('--')) die('missing <file.e57>');
+if (!outDir || outDir.startsWith('--')) die('missing <outDir>');
+if (!existsSync(src)) die(`no such scan file: ${src}`);
+const positiveInt = (n, d) => {
   const i = args.indexOf(n);
-  return i >= 0 ? Number(args[i + 1]) : d;
+  if (i < 0) return d;
+  const raw = args[i + 1];
+  const v = Number(raw);
+  if (raw === undefined || raw === '' || !Number.isSafeInteger(v) || v <= 0) {
+    die(`${n} needs a positive integer, got ${JSON.stringify(raw)}`);
+  }
+  return v;
 };
-const STRIDE = flag('--stride', 10);
-const CHUNK = flag('--chunk', 2_000_000);
+const STRIDE = positiveInt('--stride', 10);
+const CHUNK = positiveInt('--chunk', 2_000_000);
 /** Histogram bin, metres. 1 cm resolves a floor slab from its screed. */
 const BIN = 0.01;
 /** Histogram window per axis, metres, centred on 0 (E57 declares |x|<=9). */
 const HALF = 16;
 const NBINS = Math.round((2 * HALF) / BIN);
 
-mkdirSync(outDir, { recursive: true });
+/**
+ * Canonical absolute path, resolving symlinks over the longest EXISTING
+ * prefix -- the output directory usually does not exist yet, so `realpathSync`
+ * on the whole path would throw and a plain `resolve` would let a symlinked
+ * ancestor point back into the repository.
+ */
+function canonicalPath(p) {
+  let cur = resolve(p);
+  const tail = [];
+  for (;;) {
+    if (existsSync(cur)) return tail.length ? join(realpathSync(cur), ...tail) : realpathSync(cur);
+    const parent = dirname(cur);
+    if (parent === cur) return resolve(p);
+    tail.unshift(basename(cur));
+    cur = parent;
+  }
+}
+const REPO_ROOT = realpathSync(join(dirname(fileURLToPath(import.meta.url)), '../../..'));
+const OUT_DIR = canonicalPath(outDir);
+const insideRepo = (p) => {
+  const rel = relative(REPO_ROOT, p);
+  return rel === '' || (!rel.startsWith(`..${sep}`) && rel !== '..' && !isAbsolute(rel));
+};
+// The source is client data and so is everything derived from it point-wise.
+// Nothing this script writes may land in the worktree, including its root.
+if (insideRepo(OUT_DIR)) die(`refusing to write inside the repository: ${OUT_DIR}`);
+
+const SUB_PATH = join(OUT_DIR, 'sub.f32');
+const INGEST_PATH = join(OUT_DIR, 'ingest.json');
+mkdirSync(OUT_DIR, { recursive: true });
 
 const t0 = Date.now();
 const blob = await openAsBlob(src);
@@ -55,49 +101,83 @@ const min = [Infinity, Infinity, Infinity];
 const max = [-Infinity, -Infinity, -Infinity];
 let total = 0;
 let kept = 0;
+let finitePoints = 0;
 let nonFinite = 0;
 let outOfHistRange = 0;
 
-const out = createWriteStream(join(outDir, 'sub.f32'));
-const writeBuf = (buf) => new Promise((res) => { if (!out.write(buf)) out.once('drain', res); else res(); });
+const out = createWriteStream(SUB_PATH);
+/** First error the output stream reported, latched so it cannot be missed. */
+let streamError = null;
+out.on('error', (e) => { streamError ??= e; });
+/**
+ * Backpressure-aware write that REJECTS on a stream error. The earlier version
+ * resolved unconditionally and awaited `drain`, so a failed write (ENOSPC, a
+ * vanished directory) either passed silently or hung forever waiting for a
+ * `drain` that a destroyed stream never emits.
+ */
+const writeBuf = (buf) => new Promise((res, rej) => {
+  if (streamError) { rej(streamError); return; }
+  const ok = out.write(buf, (err) => { if (err) rej(err); });
+  if (ok) { res(); return; }
+  const onDrain = () => { out.off('error', onErr); res(); };
+  const onErr = (e) => { out.off('drain', onDrain); rej(e); };
+  out.once('drain', onDrain);
+  out.once('error', onErr);
+});
+/** A close failure must never mask the failure that got us here. */
+const closeSource = () => { try { source.close(); } catch { /* ignore */ } };
 
-for (;;) {
-  const chunk = await source.next(CHUNK);
-  if (!chunk) break;
-  const p = chunk.positions;
-  const n = chunk.pointCount;
-  const keepIdx = [];
-  for (let i = 0; i < n; i++) {
-    const gi = total + i;
-    const x = p[i * 3], y = p[i * 3 + 1], z = p[i * 3 + 2];
-    if (!Number.isFinite(x) || !Number.isFinite(y) || !Number.isFinite(z)) { nonFinite++; continue; }
-    const v = [x, y, z];
-    for (let a = 0; a < 3; a++) {
-      if (v[a] < min[a]) min[a] = v[a];
-      if (v[a] > max[a]) max[a] = v[a];
-      const b = Math.floor((v[a] + HALF) / BIN);
-      if (b >= 0 && b < NBINS) hist[a][b]++; else outOfHistRange++;
+try {
+  for (;;) {
+    const chunk = await source.next(CHUNK);
+    if (!chunk) break;
+    const p = chunk.positions;
+    const n = chunk.pointCount;
+    const keepIdx = [];
+    for (let i = 0; i < n; i++) {
+      const gi = total + i;
+      const x = p[i * 3], y = p[i * 3 + 1], z = p[i * 3 + 2];
+      if (!Number.isFinite(x) || !Number.isFinite(y) || !Number.isFinite(z)) { nonFinite++; continue; }
+      finitePoints++;
+      const v = [x, y, z];
+      for (let a = 0; a < 3; a++) {
+        if (v[a] < min[a]) min[a] = v[a];
+        if (v[a] > max[a]) max[a] = v[a];
+        const b = Math.floor((v[a] + HALF) / BIN);
+        if (b >= 0 && b < NBINS) hist[a][b]++; else outOfHistRange++;
+      }
+      if (gi % STRIDE === 0) keepIdx.push(i);
     }
-    if (gi % STRIDE === 0) keepIdx.push(i);
-  }
-  total += n;
-  if (keepIdx.length) {
-    const buf = Buffer.allocUnsafe(keepIdx.length * 12);
-    let o = 0;
-    for (const i of keepIdx) {
-      buf.writeFloatLE(p[i * 3], o); o += 4;
-      buf.writeFloatLE(p[i * 3 + 1], o); o += 4;
-      buf.writeFloatLE(p[i * 3 + 2], o); o += 4;
+    total += n;
+    if (keepIdx.length) {
+      const buf = Buffer.allocUnsafe(keepIdx.length * 12);
+      let o = 0;
+      for (const i of keepIdx) {
+        buf.writeFloatLE(p[i * 3], o); o += 4;
+        buf.writeFloatLE(p[i * 3 + 1], o); o += 4;
+        buf.writeFloatLE(p[i * 3 + 2], o); o += 4;
+      }
+      await writeBuf(buf);
+      kept += keepIdx.length;
     }
-    await writeBuf(buf);
-    kept += keepIdx.length;
+    if (total % 10_000_000 < CHUNK) {
+      process.stderr.write(`  ${(total / 1e6).toFixed(1)}M points, ${((Date.now() - t0) / 1000).toFixed(1)}s\n`);
+    }
   }
-  if (total % 10_000_000 < CHUNK) {
-    process.stderr.write(`  ${(total / 1e6).toFixed(1)}M points, ${((Date.now() - t0) / 1000).toFixed(1)}s\n`);
-  }
+} catch (err) {
+  closeSource();
+  out.destroy();
+  throw err;
 }
-source.close();
-await new Promise((r) => out.end(r));
+closeSource();
+await new Promise((res, rej) => out.end((err) => {
+  const e = err ?? streamError;
+  if (e) rej(e); else res();
+}));
+
+if (finitePoints === 0) {
+  throw new Error(`no point in ${src} has a finite xyz position (${total} decoded, ${nonFinite} non-finite)`);
+}
 
 const elapsedMs = Date.now() - t0;
 /** Compress a histogram to its non-empty run so ingest.json stays small. */
@@ -107,10 +187,16 @@ const pack = (h) => {
   return { binSize: BIN, origin: -HALF + lo * BIN, counts: Array.from(h.subarray(lo, hi + 1)) };
 };
 const extent = [max[0] - min[0], max[1] - min[1], max[2] - min[2]];
-writeFileSync(join(outDir, 'ingest.json'), JSON.stringify({
+// The bbox is built from FINITE points only, so the densities must be too --
+// dividing the decoded count by a box that never saw those points overstates
+// the measurement.
+const bboxVolumeM3 = extent[0] * extent[1] * extent[2];
+const bboxPlanAreaM2 = extent[0] * extent[1];
+writeFileSync(INGEST_PATH, JSON.stringify({
   sourceBytes: blob.size,
   declaredPointCount: info.pointCount ?? info.totalPoints ?? null,
   decodedPointCount: total,
+  finitePointCount: finitePoints,
   keptPointCount: kept,
   stride: STRIDE,
   nonFinite,
@@ -118,9 +204,17 @@ writeFileSync(join(outDir, 'ingest.json'), JSON.stringify({
   hasColor: info.hasColor,
   hasIntensity: info.hasIntensity,
   bbox: { min, max, extent },
-  /** Points per m3 of the bounding box, and per m2 of its plan footprint. */
-  densityPerM3: total / (extent[0] * extent[1] * extent[2]),
-  densityPerPlanM2: total / (extent[0] * extent[1]),
+  bboxVolumeM3,
+  bboxPlanAreaM2,
+  /**
+   * Finite points per m3 of the bounding box, and per m2 of its plan
+   * footprint. NULL, not zero, when the corresponding measure is zero (a
+   * planar or single-scanline cloud): the density is then geometrically
+   * undefined, and a 0 there would read as "no points".
+   */
+  densityPerM3: bboxVolumeM3 > 0 ? finitePoints / bboxVolumeM3 : null,
+  densityPerPlanM2: bboxPlanAreaM2 > 0 ? finitePoints / bboxPlanAreaM2 : null,
+  densityBasis: 'finite points per bounding-box measure; null where that measure is zero',
   histograms: { x: pack(hist[0]), y: pack(hist[1]), z: pack(hist[2]) },
   elapsedMs,
   megaPointsPerSecond: total / 1e3 / elapsedMs,

--- a/scripts/moonshot/b55-scan-to-parametric/measure-ifc.mjs
+++ b/scripts/moonshot/b55-scan-to-parametric/measure-ifc.mjs
@@ -82,6 +82,7 @@ export function solidQuantities(meshes) {
   let minX = Infinity, minY = Infinity, minZ = Infinity;
   let maxX = -Infinity, maxY = -Infinity, maxZ = -Infinity;
   let triCount = 0;
+  let validTriCount = 0;
   for (const mesh of meshes) {
     for (const [v0, v1, v2] of triangles(mesh)) {
       triCount++;
@@ -92,6 +93,7 @@ export function solidQuantities(meshes) {
       const nz = n[UP];
       const twiceArea = Math.hypot(n[0], n[1], n[2]);
       if (twiceArea === 0) continue;
+      validTriCount++;
       vol6 += v0[0] * (v1[1] * v2[2] - v1[2] * v2[1])
             - v0[1] * (v1[0] * v2[2] - v1[2] * v2[0])
             + v0[2] * (v1[0] * v2[1] - v1[1] * v2[0]);
@@ -107,6 +109,17 @@ export function solidQuantities(meshes) {
       }
     }
   }
+  /**
+   * FAIL, do not return zeros. With no non-degenerate triangle the bounding
+   * box is still (+Inf, -Inf), so `height` is -Infinity and `bbox` is a pair
+   * of infinities -- and every consumer here (the frame check, the exam rows,
+   * the reference height audit) treats what comes back as a measurement. A
+   * quantity that is silently 0 or Infinity corrupts a comparison instead of
+   * failing it, which is the one thing this exam cannot afford.
+   */
+  if (validTriCount === 0) {
+    throw new Error(`solidQuantities: ${meshes.length} mesh(es), ${triCount} triangle(s), none non-degenerate -- there is nothing to measure`);
+  }
   const bmin = [minX, minY, minZ];
   const bmax = [maxX, maxY, maxZ];
   const height = bmax[UP] - bmin[UP];
@@ -119,6 +132,7 @@ export function solidQuantities(meshes) {
     perimeter: height > 1e-6 ? lateralArea / height : 0,
     bbox: { min: bmin, max: bmax },
     triangleCount: triCount,
+    degenerateTriangleCount: triCount - validTriCount,
   };
 }
 

--- a/scripts/moonshot/b55-scan-to-parametric/measure-ifc.mjs
+++ b/scripts/moonshot/b55-scan-to-parametric/measure-ifc.mjs
@@ -79,6 +79,8 @@ const UP = 1;
 
 export function solidQuantities(meshes) {
   let vol6 = 0, floorArea = 0, ceilArea = 0, lateralArea = 0;
+  // First moment of the XY-projected floor faces, for the TRUE plan centroid.
+  let planMomentA = 0, planMomentB = 0;
   let minX = Infinity, minY = Infinity, minZ = Infinity;
   let maxX = -Infinity, maxY = -Infinity, maxZ = -Infinity;
   let triCount = 0;
@@ -99,8 +101,20 @@ export function solidQuantities(meshes) {
             + v0[2] * (v1[0] * v2[1] - v1[1] * v2[0]);
       const unitZ = nz / twiceArea;
       const projected = nz / 2; // signed XY-projected area
-      if (unitZ < -HORIZ_TOL) floorArea += -projected;
-      else if (unitZ > HORIZ_TOL) ceilArea += projected;
+      if (unitZ < -HORIZ_TOL) {
+        floorArea += -projected;
+        /**
+         * Area-weighted centroid of the floor face. This is the space's TRUE
+         * plan centroid; the midpoint of its bounding box is not, and for a
+         * concave or L-shaped room the two can be metres apart -- far enough
+         * that a containment test can land the space in the wrong room. Two
+         * of this bet's four reference spaces are in fact concave (84%
+         * solidity), so the difference is measured and reported rather than
+         * assumed away. Axes 0 and 2 are the plan in the viewer frame; see UP.
+         */
+        planMomentA += -projected * ((v0[0] + v1[0] + v2[0]) / 3);
+        planMomentB += -projected * ((v0[2] + v1[2] + v2[2]) / 3);
+      } else if (unitZ > HORIZ_TOL) ceilArea += projected;
       if (Math.abs(unitZ) < VERT_TOL) lateralArea += twiceArea / 2;
       for (const v of [v0, v1, v2]) {
         if (v[0] < minX) minX = v[0]; if (v[0] > maxX) maxX = v[0];
@@ -130,6 +144,9 @@ export function solidQuantities(meshes) {
     lateralArea,
     height,
     perimeter: height > 1e-6 ? lateralArea / height : 0,
+    /** Area-weighted centroid of the floor face, viewer-frame axes (0, 2).
+     *  Null when there is no floor face to take a moment of. */
+    planCentroid: floorArea > 1e-9 ? [planMomentA / floorArea, planMomentB / floorArea] : null,
     bbox: { min: bmin, max: bmax },
     triangleCount: triCount,
     degenerateTriangleCount: triCount - validTriCount,

--- a/scripts/moonshot/b55-scan-to-parametric/measure-ifc.mjs
+++ b/scripts/moonshot/b55-scan-to-parametric/measure-ifc.mjs
@@ -1,0 +1,201 @@
+#!/usr/bin/env node
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * B5.5 measurement side. ONE function computes the headline quantities of a
+ * room, and it is run over the kernel's meshes -- so the reference model and
+ * the scan-derived model are measured by identical code on identical
+ * representations (triangles out of `processGeometryBatch`), never by reading
+ * one model's stored quantities against the other's computed ones.
+ *
+ * Usage: node measure-ifc.mjs <file.ifc> [--json out.json] [--redact]
+ *   --redact  omit every string carried from the source file (names, GUIDs);
+ *             required for anything written into the repo, because the
+ *             reference model is client data.
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { initSync, IfcAPI } from '../../../packages/wasm/pkg/ifc-lite.js';
+import { parseMeshesViaPrePass } from '../../lib/mesh-via-prepass.mjs';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(HERE, '../../..');
+
+let api = null;
+export function getApi() {
+  if (!api) {
+    initSync(readFileSync(join(ROOT, 'packages/wasm/pkg/ifc-lite_bg.wasm')));
+    api = new IfcAPI();
+  }
+  return api;
+}
+
+/** World-space triangle iterator over a mesh from `parseMeshesViaPrePass`. */
+function* triangles(mesh) {
+  const p = mesh.positions;
+  const idx = mesh.indices;
+  const [ox, oy, oz] = mesh.origin ?? [0, 0, 0];
+  for (let t = 0; t < idx.length; t += 3) {
+    const a = idx[t] * 3, b = idx[t + 1] * 3, c = idx[t + 2] * 3;
+    yield [
+      [p[a] + ox, p[a + 1] + oy, p[a + 2] + oz],
+      [p[b] + ox, p[b + 1] + oy, p[b + 2] + oz],
+      [p[c] + ox, p[c + 1] + oy, p[c + 2] + oz],
+    ];
+  }
+}
+
+/**
+ * Headline quantities of one closed solid.
+ *
+ *  volume        divergence theorem over the triangle soup (|sum v0.(v1 x v2)|/6)
+ *  floorArea     sum of the XY-projected area of DOWNWARD-facing triangles.
+ *                For a closed solid the signed XY projection sums to zero, so
+ *                this equals the upward-facing sum and is the footprint of any
+ *                vertically monotone room. Not "area of the bottom face", which
+ *                would be wrong the moment the floor is triangulated across a
+ *                step.
+ *  lateralArea   true (un-projected) area of triangles whose normal is within
+ *                VERT_TOL of horizontal -- the room's bounding wall surface.
+ *  height        z extent.
+ */
+const VERT_TOL = 0.05;   // |n_up| below this counts as a vertical (wall) face
+const HORIZ_TOL = 0.95;  // |n_up| above this counts as a horizontal face
+
+/**
+ * UP AXIS. `processGeometryBatch` emits VIEWER-frame meshes (three.js Y-up),
+ * not IFC Z-up: on the reference model every wall's extent on axis 1 is
+ * exactly the two IfcBuildingStorey elevations, and the plan spreads over
+ * axes 0 and 2. Measuring "floor area" off axis 2 therefore returns 0, which
+ * is what the first run of this script did. Both models go through the same
+ * conversion, so this constant is a property of the kernel boundary, not a
+ * per-model fudge.
+ */
+const UP = 1;
+
+export function solidQuantities(meshes) {
+  let vol6 = 0, floorArea = 0, ceilArea = 0, lateralArea = 0;
+  let minX = Infinity, minY = Infinity, minZ = Infinity;
+  let maxX = -Infinity, maxY = -Infinity, maxZ = -Infinity;
+  let triCount = 0;
+  for (const mesh of meshes) {
+    for (const [v0, v1, v2] of triangles(mesh)) {
+      triCount++;
+      // cross(v1-v0, v2-v0)
+      const ax = v1[0] - v0[0], ay = v1[1] - v0[1], az = v1[2] - v0[2];
+      const bx = v2[0] - v0[0], by = v2[1] - v0[1], bz = v2[2] - v0[2];
+      const n = [ay * bz - az * by, az * bx - ax * bz, ax * by - ay * bx];
+      const nz = n[UP];
+      const twiceArea = Math.hypot(n[0], n[1], n[2]);
+      if (twiceArea === 0) continue;
+      vol6 += v0[0] * (v1[1] * v2[2] - v1[2] * v2[1])
+            - v0[1] * (v1[0] * v2[2] - v1[2] * v2[0])
+            + v0[2] * (v1[0] * v2[1] - v1[1] * v2[0]);
+      const unitZ = nz / twiceArea;
+      const projected = nz / 2; // signed XY-projected area
+      if (unitZ < -HORIZ_TOL) floorArea += -projected;
+      else if (unitZ > HORIZ_TOL) ceilArea += projected;
+      if (Math.abs(unitZ) < VERT_TOL) lateralArea += twiceArea / 2;
+      for (const v of [v0, v1, v2]) {
+        if (v[0] < minX) minX = v[0]; if (v[0] > maxX) maxX = v[0];
+        if (v[1] < minY) minY = v[1]; if (v[1] > maxY) maxY = v[1];
+        if (v[2] < minZ) minZ = v[2]; if (v[2] > maxZ) maxZ = v[2];
+      }
+    }
+  }
+  const bmin = [minX, minY, minZ];
+  const bmax = [maxX, maxY, maxZ];
+  const height = bmax[UP] - bmin[UP];
+  return {
+    volume: Math.abs(vol6) / 6,
+    floorArea,
+    ceilingArea: ceilArea,
+    lateralArea,
+    height,
+    perimeter: height > 1e-6 ? lateralArea / height : 0,
+    bbox: { min: bmin, max: bmax },
+    triangleCount: triCount,
+  };
+}
+
+export function meshModel(path) {
+  const content = readFileSync(path, 'utf8');
+  const col = parseMeshesViaPrePass(getApi(), content);
+  const byId = new Map();
+  for (let i = 0; i < col.length; i++) {
+    const m = col.get(i);
+    if (!m) continue;
+    if (!byId.has(m.expressId)) byId.set(m.expressId, { ifcType: m.ifcType, meshes: [] });
+    byId.get(m.expressId).meshes.push(m);
+  }
+  return { byId, content };
+}
+
+/** Pull `#id=IFCSPACE(...)` LongName without a full parse (attribute 8). */
+function spaceLabels(content) {
+  const out = new Map();
+  for (const m of content.matchAll(/#(\d+)\s*=\s*IFCSPACE\s*\(([^]*?)\);/g)) {
+    const args = splitStepArgs(m[2]);
+    out.set(Number(m[1]), {
+      name: unquote(args[2]),
+      longName: unquote(args[7]),
+    });
+  }
+  return out;
+}
+function splitStepArgs(s) {
+  const out = []; let depth = 0, cur = '', inStr = false;
+  for (let i = 0; i < s.length; i++) {
+    const ch = s[i];
+    if (inStr) { cur += ch; if (ch === "'") inStr = (s[i + 1] === "'"); continue; }
+    if (ch === "'") { inStr = true; cur += ch; continue; }
+    if (ch === '(') depth++;
+    if (ch === ')') depth--;
+    if (ch === ',' && depth === 0) { out.push(cur.trim()); cur = ''; continue; }
+    cur += ch;
+  }
+  out.push(cur.trim());
+  return out;
+}
+function unquote(v) {
+  if (!v || v === '$') return null;
+  const m = /^'([^]*)'$/.exec(v);
+  return m ? m[1].replace(/''/g, "'") : v;
+}
+
+export function measureSpaces(path) {
+  const { byId, content } = meshModel(path);
+  const labels = spaceLabels(content);
+  const spaces = [];
+  for (const [id, rec] of byId) {
+    if (rec.ifcType.toUpperCase() !== 'IFCSPACE') continue;
+    const q = solidQuantities(rec.meshes);
+    spaces.push({ expressId: id, ...labels.get(id), ...q });
+  }
+  spaces.sort((a, b) => b.floorArea - a.floorArea);
+  const walls = [];
+  for (const [id, rec] of byId) {
+    if (!/WALL/i.test(rec.ifcType)) continue;
+    walls.push({ expressId: id, ifcType: rec.ifcType, ...solidQuantities(rec.meshes) });
+  }
+  const typeCounts = {};
+  for (const rec of byId.values()) typeCounts[rec.ifcType] = (typeCounts[rec.ifcType] ?? 0) + 1;
+  return { spaces, walls, typeCounts };
+}
+
+if (process.argv[1] && process.argv[1].endsWith('measure-ifc.mjs')) {
+  const file = process.argv[2];
+  const redact = process.argv.includes('--redact');
+  const jsonAt = process.argv.indexOf('--json');
+  const result = measureSpaces(file);
+  if (redact) {
+    for (const s of result.spaces) { delete s.name; delete s.longName; }
+  }
+  const text = JSON.stringify(result, null, 2);
+  if (jsonAt >= 0) writeFileSync(process.argv[jsonAt + 1], text);
+  else console.log(text);
+}

--- a/scripts/moonshot/b55-scan-to-parametric/placement-check.mjs
+++ b/scripts/moonshot/b55-scan-to-parametric/placement-check.mjs
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Resolve ABSOLUTE placement heights out of a STEP file, by walking the
+ * IfcLocalPlacement chain to the world.
+ *
+ * This exists because the placement PARENT is not uniform across
+ * `@ifc-lite/create`'s element constructors: `addIfcWall` and `addIfcSlab`
+ * place relative to the storey (whose own placement is `[0, 0, Elevation]`),
+ * while `addIfcSpace` places relative to the world. A caller that hands the
+ * same Z to both puts them 1x elevation apart, and nothing in the pipeline
+ * downstream would notice: the exam scores IfcSpace quantities only, and every
+ * one of those is invariant under a rigid Z shift of the walls. So the check
+ * has to look at the file.
+ *
+ * Reading it back out of the emitted STEP -- rather than trusting the
+ * arguments that were passed in -- is the point: it is the only form of the
+ * check that can fail if the builder's placement semantics change underneath.
+ */
+
+/** Split STEP arguments at depth 0, honouring `''` escapes inside strings. */
+export function splitStepArgs(s) {
+  const out = [];
+  let depth = 0, cur = '', inStr = false;
+  for (let i = 0; i < s.length; i++) {
+    const ch = s[i];
+    if (inStr) { cur += ch; if (ch === "'") inStr = (s[i + 1] === "'"); continue; }
+    if (ch === "'") { inStr = true; cur += ch; continue; }
+    if (ch === '(') depth++;
+    if (ch === ')') depth--;
+    if (ch === ',' && depth === 0) { out.push(cur.trim()); cur = ''; continue; }
+    cur += ch;
+  }
+  out.push(cur.trim());
+  return out;
+}
+
+/** `#id = TYPE(args);` index of a STEP file. */
+export function indexStep(content) {
+  const byId = new Map();
+  for (const m of content.matchAll(/#(\d+)\s*=\s*([A-Z0-9_]+)\s*\(([^]*?)\);/g)) {
+    byId.set(Number(m[1]), { type: m[2], args: m[3] });
+  }
+  return byId;
+}
+
+const refId = (v) => (v && v[0] === '#' ? Number(v.slice(1)) : null);
+
+/**
+ * World Z of an IfcLocalPlacement, by summing the Z of every
+ * IfcAxis2Placement3D location up the `PlacementRelTo` chain.
+ *
+ * Throws rather than returning a number it cannot justify: a malformed or
+ * cyclic chain must fail the run, not silently contribute 0 to a height that
+ * is then reported as measured.
+ */
+export function worldZOfPlacement(byId, placementRef) {
+  let cur = refId(placementRef);
+  if (cur === null) throw new Error(`not a placement reference: ${placementRef}`);
+  let z = 0;
+  const seen = new Set();
+  while (cur !== null) {
+    if (seen.has(cur)) throw new Error(`cyclic IfcLocalPlacement chain at #${cur}`);
+    seen.add(cur);
+    const e = byId.get(cur);
+    if (!e) throw new Error(`dangling placement reference #${cur}`);
+    if (e.type !== 'IFCLOCALPLACEMENT') throw new Error(`#${cur} is ${e.type}, not IFCLOCALPLACEMENT`);
+    const [relTo, relPlacement] = splitStepArgs(e.args);
+    const axis = byId.get(refId(relPlacement));
+    if (!axis) throw new Error(`#${cur} has no relative placement`);
+    const pt = byId.get(refId(splitStepArgs(axis.args)[0]));
+    if (!pt) throw new Error(`#${cur} placement has no location point`);
+    const coords = splitStepArgs(pt.args)[0].replace(/[()]/g, '').split(',').map(Number);
+    if (coords.length < 3 || !Number.isFinite(coords[2])) {
+      throw new Error(`#${cur} location is not a finite 3D point: ${splitStepArgs(pt.args)[0]}`);
+    }
+    z += coords[2];
+    cur = relTo === '$' ? null : refId(relTo);
+  }
+  return z;
+}
+
+/**
+ * Absolute base Z of every placed product in the file, grouped by IFC type.
+ * `attrIndex` 5 is `ObjectPlacement` on IfcProduct and its subtypes.
+ */
+export function worldBaseZByType(content, types) {
+  const byId = indexStep(content);
+  const out = new Map();
+  for (const [id, e] of byId) {
+    if (!types.includes(e.type)) continue;
+    const z = worldZOfPlacement(byId, splitStepArgs(e.args)[5]);
+    if (!out.has(e.type)) out.set(e.type, []);
+    out.get(e.type).push({ expressId: id, worldZ: z });
+  }
+  return out;
+}
+
+/**
+ * Fail the run unless the storey's spaces, walls and slab all land on the SAME
+ * datum: spaces and walls at the storey elevation, the slab top at it (so the
+ * slab body hangs below by its thickness).
+ *
+ * `tolerance` absorbs the decimal rounding of the STEP serializer, nothing
+ * more -- the failure this guards against is a whole elevation, not a
+ * millimetre.
+ */
+export function assertCoherentStoreyDatum(content, { elevationM, slabThicknessM, toleranceM = 1e-6 }) {
+  const byType = worldBaseZByType(content, ['IFCSPACE', 'IFCWALL', 'IFCSLAB']);
+  const expect = {
+    IFCSPACE: elevationM,
+    IFCWALL: elevationM,
+    IFCSLAB: elevationM - slabThicknessM,
+  };
+  const bad = [];
+  for (const [type, want] of Object.entries(expect)) {
+    const got = byType.get(type) ?? [];
+    if (got.length === 0) bad.push(`${type}: none emitted`);
+    for (const g of got) {
+      if (Math.abs(g.worldZ - want) > toleranceM) {
+        bad.push(`${type} #${g.expressId} base world Z ${g.worldZ} but the storey datum puts it at ${want} (off by ${g.worldZ - want} m)`);
+      }
+    }
+  }
+  if (bad.length) {
+    throw new Error(`incoherent storey datum in the generated model:\n  ${bad.slice(0, 6).join('\n  ')}`);
+  }
+  return Object.fromEntries([...byType].map(([t, v]) => [t, v[0].worldZ]));
+}

--- a/scripts/moonshot/b55-scan-to-parametric/run.mjs
+++ b/scripts/moonshot/b55-scan-to-parametric/run.mjs
@@ -79,6 +79,10 @@ const slim = (v) => ({
     sweepStepM: v.rooms.ceilingCut.sweepStepM,
     sweepSamples: v.rooms.ceilingCut.sweep.length,
     plateau: v.rooms.ceilingCut.plateau,
+    /** Widest stable plateau at EVERY room count, not just the chosen one --
+     *  this is what the "rank by room count, not by width" argument rests on,
+     *  so it is emitted rather than asserted in prose. */
+    plateausByRoomCount: v.rooms.ceilingCut.plateausByRoomCount,
     sweep: v.rooms.ceilingCut.sweep,
   },
   principalFrame: v.rooms.principalFrame,
@@ -203,6 +207,41 @@ const ALLOWED_VALUE = [
   /^full-cloud z histogram, 1 cm bins, \+-1 cm around the tested elevation$/,
   /^Both models meshed by the same kernel, so both boxes are in the viewer frame \(Y up\)\. No transform was applied to either side\.$/,
 ];
+/**
+ * Every quoted STEP string in `text`, with `''` escapes honoured.
+ *
+ * The denylist below used to scan with `/'([^']{10,})'/g`, which loses quote
+ * PARITY at the first doubled quote and then pairs each closing quote with the
+ * next string's opening one for the rest of the file. Measured on this bet's
+ * reference model: 150 of its 570 identifying strings were invisible to the
+ * check, all of them after the first escape, and a string planted past that
+ * point in a leak test was not flagged. The allowlist above still caught it --
+ * that arm is the primary defence and fails closed -- but the denylist exists
+ * precisely so a future widening of the allowlist cannot carry a person, an
+ * organisation or a file name through, and it cannot do that job blind.
+ */
+function stepStrings(text) {
+  const out = [];
+  let i = 0;
+  while (i < text.length) {
+    const start = text.indexOf("'", i);
+    if (start < 0) break;
+    let j = start + 1, buf = '', closed = false;
+    for (;;) {
+      const q = text.indexOf("'", j);
+      if (q < 0) break;                                  // unterminated: stop
+      if (text[q + 1] === "'") { buf += `${text.slice(j, q)}'`; j = q + 2; continue; }
+      buf += text.slice(j, q);
+      i = q + 1;
+      closed = true;
+      break;
+    }
+    if (!closed) break;
+    out.push(buf);
+  }
+  return out;
+}
+
 function assertNoIdentifiers(s, obj) {
   const hits = new Set();
   const walk = (v, path) => {
@@ -221,8 +260,10 @@ function assertNoIdentifiers(s, obj) {
   // are long enough to identify something (short ones like 'Reference' or a
   // bare year collide with this pipeline's own vocabulary and mean nothing).
   const refText = readFileSync(REFERENCE, 'latin1');
-  for (const m of refText.matchAll(/'([^']{10,})'/g)) {
-    if (/[A-Za-z]/.test(m[1]) && s.includes(m[1])) hits.add(`reference string ${JSON.stringify(m[1])}`);
+  for (const str of stepStrings(refText)) {
+    if (str.length >= 10 && /[A-Za-z]/.test(str) && s.includes(str)) {
+      hits.add(`reference string ${JSON.stringify(str)}`);
+    }
   }
   // Anything shaped like the IfcSite degrees/minutes/seconds tuple.
   if (/\b\d{1,3}\s*,\s*\d{1,2}\s*,\s*\d{1,2}\s*,\s*\d{5,}\b/.test(s)) hits.add('<dms tuple>');
@@ -234,6 +275,7 @@ assertNoIdentifiers(text, scorecard);
 writeFileSync(OUT, text);
 
 const p = variants[PRIMARY].card.verdict;
-console.log(`\nprimary (${PRIMARY}): ${p.rowsWithinBar}/${p.rowsTotal} rows within the ${scorecard.bar * 100}% bar`);
+console.log(`\nprimary (${PRIMARY}): ${p.rowsWithinBar}/${p.rowsScored} rows within the ${scorecard.bar * 100}% bar`);
 for (const r of p.rowsOutsideBar) console.log(`  outside: ${r.scope}/${r.quantity} ${r.deviationPercent.toFixed(2)}%`);
+for (const r of p.rowsUnscored) console.log(`  UNSCORED: ${r.scope}/${r.quantity} (no reference space assigned)`);
 console.log(`scorecard -> ${OUT}`);

--- a/scripts/moonshot/b55-scan-to-parametric/run.mjs
+++ b/scripts/moonshot/b55-scan-to-parametric/run.mjs
@@ -107,9 +107,30 @@ const slim = (v) => ({
     slabCount: 1,
     modalWallThicknessM: v.emitted.modalWallThicknessM,
     slabThicknessNominalM: v.emitted.slabThicknessNominalM,
+    /** ABSOLUTE base height of each placed type, resolved out of the emitted
+     *  STEP by walking its IfcLocalPlacement chain to the world -- not the
+     *  arguments that were passed in. The builder's placement parents are not
+     *  uniform (walls and slabs are storey-relative, spaces are
+     *  world-relative), so this is the only form of the check that can fail if
+     *  those semantics change underneath the caller. */
+    worldBaseZByType: v.emitted.worldBaseZByType,
   },
   frameCheck: { maxCornerOffsetM: v.card.frameCheck.maxCornerOffsetM, cornerOffsetsM: v.card.frameCheck.cornerOffsetsM },
-  correspondence: v.card.correspondence.map((c) => ({ reference: c.reference, assignedTo: c.assignedTo })),
+  /**
+   * The margin behind the correspondence, not just its outcome: how far the
+   * bbox midpoint used for the containment test sits from the space's own
+   * area-weighted plan centroid, and how far it sits from the boundary of the
+   * room it landed in. While the clearance exceeds the separation the shortcut
+   * cannot change an assignment on this data -- and `score.mjs` fails the run
+   * outright if the two points ever resolve to different rooms.
+   */
+  correspondence: v.card.correspondence.map((c) => ({
+    reference: c.reference,
+    assignedTo: c.assignedTo,
+    centroidSeparationM: c.centroidSeparationM,
+    boundaryClearanceM: c.boundaryClearanceM,
+    centroidAgrees: c.centroidAgrees,
+  })),
   perRoom: v.card.perRoom,
   totals: v.card.totals,
   verdict: v.card.verdict,

--- a/scripts/moonshot/b55-scan-to-parametric/run.mjs
+++ b/scripts/moonshot/b55-scan-to-parametric/run.mjs
@@ -1,0 +1,239 @@
+#!/usr/bin/env node
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * B5.5 -- one-command reproduction of the whole bet.
+ *
+ *   node run.mjs --scan <Apartment.e57> --reference <reference.ifc> \
+ *                --work <scratchDir> [--stride 10]
+ *
+ * Runs ingest -> extract (both frames) -> generate -> score, and assembles the
+ * committed `scorecard.json` next to this file.
+ *
+ * PRIVACY. The scan and the reference model are client data with a real site
+ * location in them (the reference carries IfcSite RefLatitude/RefLongitude;
+ * the E57 carries a projected-CRS definition). NEITHER source file, nor the
+ * generated IFC, nor any room polygon is written into the repository, and
+ * this script never copies them there. What lands in `scorecard.json` is
+ * derived scalars only -- counts, areas, heights, deviations -- expressed in
+ * the scan's own local metres, plus neutral labels (`ref_space_A`,
+ * `scan_room_001`). `assertNoIdentifiers` fails the run if a string from
+ * either source, or anything shaped like a geographic coordinate, reaches the
+ * committed artifact.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { readFileSync, writeFileSync, mkdirSync, statSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const argv = process.argv.slice(2);
+const opt = (n, d) => { const i = argv.indexOf(n); return i >= 0 ? argv[i + 1] : d; };
+const SCAN = opt('--scan');
+const REFERENCE = opt('--reference');
+const WORK = opt('--work');
+const STRIDE = opt('--stride', '10');
+const SKIP_INGEST = argv.includes('--skip-ingest');
+if (!SCAN || !REFERENCE || !WORK) {
+  console.error('usage: node run.mjs --scan <e57> --reference <ifc> --work <dir> [--stride N] [--skip-ingest]');
+  process.exit(2);
+}
+mkdirSync(WORK, { recursive: true });
+
+const node = process.execPath;
+const run = (script, args) => {
+  process.stderr.write(`\n== ${script} ${args.join(' ')}\n`);
+  execFileSync(node, ['--max-old-space-size=6000', join(HERE, script), ...args], { stdio: ['ignore', 'inherit', 'inherit'] });
+};
+const read = (p) => JSON.parse(readFileSync(p, 'utf8'));
+
+const t0 = Date.now();
+if (!SKIP_INGEST) run('ingest-scan.mjs', [SCAN, WORK, '--stride', STRIDE]);
+const ingest = read(join(WORK, 'ingest.json'));
+
+const variants = {};
+for (const [name, extraArgs] of [['axisAligned', []], ['principalFrame', ['--principal-frame']]]) {
+  run('extract-rooms.mjs', [WORK, ...extraArgs]);
+  const rooms = read(join(WORK, 'rooms.json'));
+  const ifcPath = join(WORK, `scan-derived-${name}.ifc`);
+  run('generate-ifc.mjs', [WORK, ifcPath]);
+  const emitted = read(join(WORK, 'emitted.json'));
+  const cardPath = join(WORK, `scorecard-${name}.json`);
+  run('score.mjs', [WORK, REFERENCE, ifcPath, cardPath]);
+  variants[name] = { rooms, emitted, card: read(cardPath), ifcBytes: statSync(ifcPath).size };
+}
+
+// The pre-registered primary run is the axis-aligned one; the principal-frame
+// run was added after the primary's outline was seen to be a raster staircase
+// (a defect visible in the scan without the reference) and is reported beside
+// it, not instead of it.
+const PRIMARY = 'axisAligned';
+
+const slim = (v) => ({
+  ceilingCut: {
+    used: v.rooms.ceilingCut.used,
+    sweepLoM: v.rooms.ceilingCut.sweepLoM,
+    sweepStepM: v.rooms.ceilingCut.sweepStepM,
+    sweepSamples: v.rooms.ceilingCut.sweep.length,
+    plateau: v.rooms.ceilingCut.plateau,
+    sweep: v.rooms.ceilingCut.sweep,
+  },
+  principalFrame: v.rooms.principalFrame,
+  rooms: v.rooms.rooms.map((r) => ({
+    id: r.id,
+    rasterAreaM2: r.rasterAreaM2,
+    outlineAreaM2: r.outlineAreaM2,
+    polygonAreaM2: r.polygonAreaM2,
+    polygonPerimeterM: r.polygonPerimeterM,
+    polygonVertices: r.polygon.length,
+    heightM: r.heightM,
+    filledHoles: r.filledHoles,
+    filledHoleAreaM2: r.filledHoleAreaM2,
+    unfilledHoles: r.unfilledHoles,
+    largestHoleM2: r.largestHoleM2,
+  })),
+  wallChannels: v.rooms.wallChannels,
+  emitted: {
+    ifcBytes: v.ifcBytes,
+    spaceCount: v.emitted.spaces.length,
+    wallCount: v.emitted.walls.length,
+    slabCount: 1,
+    modalWallThicknessM: v.emitted.modalWallThicknessM,
+    slabThicknessNominalM: v.emitted.slabThicknessNominalM,
+  },
+  frameCheck: { maxCornerOffsetM: v.card.frameCheck.maxCornerOffsetM, cornerOffsetsM: v.card.frameCheck.cornerOffsetsM },
+  correspondence: v.card.correspondence.map((c) => ({ reference: c.reference, assignedTo: c.assignedTo })),
+  perRoom: v.card.perRoom,
+  totals: v.card.totals,
+  verdict: v.card.verdict,
+});
+
+const scorecard = {
+  bet: 'B5.5 scan-to-parametric (M5 final)',
+  generatedAt: new Date().toISOString(),
+  bar: 0.05,
+  elapsedSeconds: (Date.now() - t0) / 1000,
+  /** Wall clock of extract + generate + score + assemble, i.e. everything
+   *  after the one streaming pass over the E57. Reported separately because
+   *  `--skip-ingest` reruns exclude the pass entirely. */
+  elapsedSecondsAfterIngest: (Date.now() - t0) / 1000 - (SKIP_INGEST ? 0 : ingest.elapsedMs / 1000),
+  primaryVariant: PRIMARY,
+  scan: {
+    sourceBytes: ingest.sourceBytes,
+    decodedPointCount: ingest.decodedPointCount,
+    keptPointCount: ingest.keptPointCount,
+    stride: ingest.stride,
+    hasColor: ingest.hasColor,
+    hasIntensity: ingest.hasIntensity,
+    nonFinite: ingest.nonFinite,
+    bboxExtentM: ingest.bbox.extent,
+    densityPerM3: ingest.densityPerM3,
+    densityPerPlanM2: ingest.densityPerPlanM2,
+    ingestSeconds: ingest.elapsedMs / 1000,
+    megaPointsPerSecond: ingest.megaPointsPerSecond,
+    planes: variants[PRIMARY].rooms.planes,
+  },
+  reference: {
+    spaceCount: variants[PRIMARY].card.verdict.referenceSpaceCount,
+    typeCounts: variants[PRIMARY].card.referenceTypeCounts,
+    spaces: variants[PRIMARY].card.referenceSpaces,
+    heightAudit: variants[PRIMARY].card.referenceHeightAudit,
+  },
+  variants: Object.fromEntries(Object.entries(variants).map(([k, v]) => [k, slim(v)])),
+};
+
+/**
+ * Figures the prose quotes that are neither a raw measurement nor a deviation:
+ * emitted here rather than computed in a sentence, so the numerals gate can
+ * back them.
+ */
+{
+  const card = variants[PRIMARY].card;
+  const audit = card.referenceHeightAudit;
+  const defaulted = audit.spaces.filter((s) => s.unsupportedByScan);
+  const primaryRooms = variants[PRIMARY].rooms.rooms;
+  const refPerim = card.referenceSpaces.map((s) => ({ label: s.label, perimeterM: s.lateralAreaM2 / s.clearHeightM }));
+  const mergedRefPerimeter = ['ref_space_A', 'ref_space_D']
+    .map((l) => refPerim.find((p) => p.label === l).perimeterM).reduce((a, b) => a + b, 0);
+  scorecard.derived = {
+    referencePerimeterM: refPerim,
+    generatedPerimeterM: primaryRooms.map((r) => ({ id: r.id, perimeterM: r.polygonPerimeterM })),
+    mergedReferencePerimeterM: mergedRefPerimeter,
+    room001PerimeterExcessM: primaryRooms[0].polygonPerimeterM - mergedRefPerimeter,
+    room001PerimeterExcessPercent: ((primaryRooms[0].polygonPerimeterM - mergedRefPerimeter) / mergedRefPerimeter) * 100,
+    ceilingEvidenceRatio: audit.pointsAtScanFittedCeiling / defaulted[0].scanPointsWithin1cmOfTop,
+    defaultedReferenceSpaceCount: defaulted.length,
+    defaultedReferenceHeightM: defaulted[0].heightM,
+    /** 8 ft in metres -- what the defaulted reference height turns out to be. */
+    eightFeetInMetres: 8 * 0.3048,
+    scanMinusDefaultedHeightM: scorecard.scan.planes.clearHeightM - defaulted[0].heightM,
+    /** Depth of the fitted floor plane below the scan's local origin: the
+     *  same plane as `scan.planes.floor.z`, sign removed, because prose
+     *  quotes the magnitude. */
+    floorPlaneDepthBelowScanOriginM: -scorecard.scan.planes.floor.z,
+    subsampleBytes: statSync(join(WORK, 'sub.f32')).size,
+    derivedIntermediateBytes: ['sub.f32', 'ingest.json', 'rooms.json'].reduce((a, f) => a + statSync(join(WORK, f)).size, 0),
+  };
+}
+
+const OUT = join(HERE, 'scorecard.json');
+const text = JSON.stringify(scorecard, null, 2);
+
+/**
+ * Fail closed if anything identifying reached the committed artifact. Two
+ * independent gates, because either alone is too weak: an allowlist of the
+ * string VALUES this pipeline is allowed to emit (so nothing can leak in by
+ * accident), plus a denylist of the reference file's own quoted strings (so a
+ * future edit that widens the allowlist still cannot carry a person, an
+ * organisation, a file name or a Revit family through).
+ */
+const ALLOWED_VALUE = [
+  /^scan_room_\d{3}$/,
+  /^ref_space_[A-Z]$/,
+  /^Ifc[A-Za-z]+$/,
+  /^(axisAligned|principalFrame)$/,
+  /^model$/,
+  /^(floorAreaM2|clearHeightM|volumeM3|lateralAreaM2|areaWeightedClearHeightM)$/,
+  /^[xyz]$/,
+  /^\d{4}-\d{2}-\d{2}T[\d:.]+Z$/,
+  /^B5\.5 scan-to-parametric \(M5 final\)$/,
+  /^full-cloud z histogram, 1 cm bins, \+-1 cm around the tested elevation$/,
+  /^Both models meshed by the same kernel, so both boxes are in the viewer frame \(Y up\)\. No transform was applied to either side\.$/,
+];
+function assertNoIdentifiers(s, obj) {
+  const hits = new Set();
+  const walk = (v, path) => {
+    if (Array.isArray(v)) { v.forEach((e, i) => walk(e, `${path}[${i}]`)); return; }
+    if (v && typeof v === 'object') {
+      for (const [k, e] of Object.entries(v)) {
+        if (!/^[A-Za-z][A-Za-z0-9_.]*$/.test(k)) hits.add(`key ${path}.${k}`);
+        walk(e, `${path}.${k}`);
+      }
+      return;
+    }
+    if (typeof v === 'string' && !ALLOWED_VALUE.some((re) => re.test(v))) hits.add(`value ${path} = ${JSON.stringify(v)}`);
+  };
+  walk(obj, '$');
+  // Denylist: quoted STEP strings from the reference that carry a letter and
+  // are long enough to identify something (short ones like 'Reference' or a
+  // bare year collide with this pipeline's own vocabulary and mean nothing).
+  const refText = readFileSync(REFERENCE, 'latin1');
+  for (const m of refText.matchAll(/'([^']{10,})'/g)) {
+    if (/[A-Za-z]/.test(m[1]) && s.includes(m[1])) hits.add(`reference string ${JSON.stringify(m[1])}`);
+  }
+  // Anything shaped like the IfcSite degrees/minutes/seconds tuple.
+  if (/\b\d{1,3}\s*,\s*\d{1,2}\s*,\s*\d{1,2}\s*,\s*\d{5,}\b/.test(s)) hits.add('<dms tuple>');
+  if (hits.size) {
+    throw new Error(`scorecard carries identifiers:\n  ${[...hits].slice(0, 8).join('\n  ')}`);
+  }
+}
+assertNoIdentifiers(text, scorecard);
+writeFileSync(OUT, text);
+
+const p = variants[PRIMARY].card.verdict;
+console.log(`\nprimary (${PRIMARY}): ${p.rowsWithinBar}/${p.rowsTotal} rows within the ${scorecard.bar * 100}% bar`);
+for (const r of p.rowsOutsideBar) console.log(`  outside: ${r.scope}/${r.quantity} ${r.deviationPercent.toFixed(2)}%`);
+console.log(`scorecard -> ${OUT}`);

--- a/scripts/moonshot/b55-scan-to-parametric/score.mjs
+++ b/scripts/moonshot/b55-scan-to-parametric/score.mjs
@@ -20,7 +20,13 @@
  * it also handles the many-to-one case honestly, which matters here because
  * the extraction merges two reference spaces into one room. Where n reference
  * spaces map to one generated room, the reference side of that row is their
- * aggregate, and the row is flagged `merged: n`.
+ * aggregate, and the row is flagged `merged: n`. A generated room that no
+ * centroid lands in is reported UNSCORED rather than scored against nothing.
+ *
+ * Which polygon belongs to which generated space is an IDENTITY lookup on the
+ * room id the generator stamped into the IfcSpace Name, checked to be total
+ * and injective -- never an area match, which would be an inference standing
+ * in for a fact at the exact point where the whole correspondence is decided.
  *
  * NO FITTING TO THE REFERENCE. Nothing upstream of this file reads the
  * reference model. The two coordinate frames coincide as a property of the
@@ -70,6 +76,11 @@ const gen = measureSpaces(GEN);
 const refSpaces = ref.spaces
   .map((s, i) => ({ ...s, label: `ref_space_${String.fromCharCode(65 + i)}` }));
 for (const s of refSpaces) { delete s.name; delete s.longName; }
+// The generated model's IfcSpace Name IS the extracted room id -- `generate-ifc.mjs`
+// stamps `Name: room.id` -- so it is the correspondence key. It is lifted out
+// here and then deleted from the space records themselves, so only the
+// RESOLVED `roomId` can reach the output.
+const genRoomIdOf = new Map(gen.spaces.map((s) => [s.expressId, s.name]));
 for (const s of gen.spaces) { delete s.name; }
 
 // -------------------------------------------------------------- frame check ---
@@ -98,11 +109,35 @@ const frameCheck = {
 };
 
 // ----------------------------------------------------------- correspondence ---
+/**
+ * Generated space -> extracted room BY IDENTITY, and verified total and
+ * injective. An earlier revision inferred the link from |polygonArea -
+ * floorArea| < 0.02 with a positional fallback; that is a guess wearing a
+ * measurement's clothes. Two rooms whose areas land within 2 dm2 of each
+ * other, or any future change to the emitted profile, would silently score one
+ * room's quantities against another room's polygon -- and the polygon is what
+ * the reference centroids are tested against, so the whole correspondence
+ * would move without a single error. The id is written by the generator and is
+ * read back here.
+ */
+const roomById = new Map();
+for (const r of rooms.rooms) {
+  if (roomById.has(r.id)) throw new Error(`rooms.json declares room id ${r.id} twice`);
+  roomById.set(r.id, r);
+}
+const claimed = new Set();
 const genRooms = gen.spaces.map((s) => {
-  const room = rooms.rooms.find((r) => Math.abs(r.polygonAreaM2 - s.floorArea) < 0.02)
-    ?? rooms.rooms[gen.spaces.indexOf(s)];
+  const id = genRoomIdOf.get(s.expressId);
+  if (!id) throw new Error(`generated IfcSpace #${s.expressId} carries no Name to resolve against rooms.json`);
+  const room = roomById.get(id);
+  if (!room) throw new Error(`generated IfcSpace #${s.expressId} names room "${id}", which is not in rooms.json`);
+  if (claimed.has(id)) throw new Error(`two generated IfcSpaces resolve to room "${id}"`);
+  claimed.add(id);
   return { ...s, roomId: room.id, polygon: room.polygon };
 });
+if (claimed.size !== rooms.rooms.length) {
+  throw new Error(`rooms.json holds ${rooms.rooms.length} rooms but the generated model has ${claimed.size} spaces`);
+}
 const assignments = [];
 for (const rs of refSpaces) {
   const c = toScanPlan(rs.bbox.min, rs.bbox.max).center;
@@ -116,15 +151,27 @@ const rowsPerRoom = genRooms.map((g) => {
   const refVol = mine.reduce((a, s) => a + s.volume, 0);
   const refLat = mine.reduce((a, s) => a + s.lateralArea, 0);
   const refHeight = refFloor > 0 ? mine.reduce((a, s) => a + s.height * s.floorArea, 0) / refFloor : 0;
+  /**
+   * A generated room that NO reference centroid falls into has no reference
+   * side at all. The sums above are then 0, and 0 as a denominator prints
+   * Infinity into the scorecard exactly where a deviation belongs -- a room
+   * the exam never scored would read as a room that failed by an infinite
+   * margin, or, once `Math.max` is applied, would carry Infinity into the
+   * headline. Such a row is emitted with a null reference and is counted
+   * separately in the verdict (`rowsUnscored`), never as a pass and never as
+   * a fail.
+   */
+  const matched = mine.length > 0;
+  const q = (generated, reference) => ({ generated, reference: matched ? reference : null });
   return {
     room: g.roomId,
     mergedReferenceSpaces: mine.length,
     referenceLabels: mine.map((s) => s.label),
     quantities: {
-      floorAreaM2: { generated: g.floorArea, reference: refFloor },
-      clearHeightM: { generated: g.height, reference: refHeight },
-      volumeM3: { generated: g.volume, reference: refVol },
-      lateralAreaM2: { generated: g.lateralArea, reference: refLat },
+      floorAreaM2: q(g.floorArea, refFloor),
+      clearHeightM: q(g.height, refHeight),
+      volumeM3: q(g.volume, refVol),
+      lateralAreaM2: q(g.lateralArea, refLat),
     },
   };
 });
@@ -192,21 +239,34 @@ const referenceHeightAudit = {
   })),
 };
 
-const withDeviation = (o) => ({
-  ...o,
-  deviation: (o.generated - o.reference) / o.reference,
-  deviationPercent: ((o.generated - o.reference) / o.reference) * 100,
-  // Magnitude carried explicitly: it is what the bar is tested against, and
-  // it is what prose quotes when it says a row is "inside 1%".
-  absDeviationPercent: Math.abs(((o.generated - o.reference) / o.reference) * 100),
-  withinBar: Math.abs((o.generated - o.reference) / o.reference) <= BAR,
-});
+/**
+ * A row is SCORABLE only against a finite, non-zero reference. Anything else
+ * would make the deviation Infinity or NaN, and there is no honest way to
+ * print that as a percentage; the row keeps its generated measurement, states
+ * null for everything derived, and is excluded from the bar count and from
+ * the maximum rather than silently distorting either.
+ */
+const withDeviation = (o) => {
+  if (!Number.isFinite(o.generated) || !Number.isFinite(o.reference) || o.reference === 0) {
+    return { ...o, scored: false, deviation: null, deviationPercent: null, absDeviationPercent: null, withinBar: null };
+  }
+  const d = (o.generated - o.reference) / o.reference;
+  return {
+    ...o,
+    deviation: d,
+    deviationPercent: d * 100,
+    // Magnitude carried explicitly: it is what the bar is tested against, and
+    // it is what prose quotes when it says a row is "inside 1%".
+    absDeviationPercent: Math.abs(d * 100),
+    withinBar: Math.abs(d) <= BAR,
+  };
+};
 for (const r of rowsPerRoom) for (const k of Object.keys(r.quantities)) r.quantities[k] = withDeviation(r.quantities[k]);
 // Volume is area x height, so its deviation is the product of the two -- worth
 // carrying explicitly so a volume miss can be attributed rather than guessed.
 for (const r of rowsPerRoom) {
   const a = r.quantities.floorAreaM2.deviation, h = r.quantities.clearHeightM.deviation;
-  r.quantities.volumeM3.decomposition = { areaDeviation: a, heightDeviation: h, product: (1 + a) * (1 + h) - 1 };
+  r.quantities.volumeM3.decomposition = { areaDeviation: a, heightDeviation: h, product: a === null || h === null ? null : (1 + a) * (1 + h) - 1 };
 }
 for (const k of Object.keys(totals)) totals[k] = withDeviation(totals[k]);
 
@@ -214,12 +274,19 @@ const allRows = [
   ...Object.entries(totals).map(([k, v]) => ({ scope: 'model', quantity: k, ...v })),
   ...rowsPerRoom.flatMap((r) => Object.entries(r.quantities).map(([k, v]) => ({ scope: r.room, quantity: k, ...v }))),
 ];
+// An unscored row is neither a pass nor a fail: it is reported on its own line
+// so `rowsWithinBar / rowsScored` can never be read as a result the exam did
+// not produce, and it is kept out of the maximum, which is otherwise the one
+// place a single Infinity would swallow the whole headline.
+const scoredRows = allRows.filter((r) => r.withinBar !== null);
 const verdict = {
   bar: BAR,
   rowsTotal: allRows.length,
-  rowsWithinBar: allRows.filter((r) => r.withinBar).length,
-  rowsOutsideBar: allRows.filter((r) => !r.withinBar).map((r) => ({ scope: r.scope, quantity: r.quantity, deviationPercent: r.deviationPercent })),
-  maxAbsDeviationPercent: Math.max(...allRows.map((r) => Math.abs(r.deviationPercent))),
+  rowsScored: scoredRows.length,
+  rowsWithinBar: scoredRows.filter((r) => r.withinBar).length,
+  rowsUnscored: allRows.filter((r) => r.withinBar === null).map((r) => ({ scope: r.scope, quantity: r.quantity })),
+  rowsOutsideBar: scoredRows.filter((r) => !r.withinBar).map((r) => ({ scope: r.scope, quantity: r.quantity, deviationPercent: r.deviationPercent })),
+  maxAbsDeviationPercent: scoredRows.length ? Math.max(...scoredRows.map((r) => Math.abs(r.deviationPercent))) : null,
   referenceSpaceCount: refSpaces.length,
   generatedSpaceCount: gen.spaces.length,
   unassignedReferenceSpaces: assignments.filter((a) => !a.assignedTo).length,
@@ -246,4 +313,10 @@ writeFileSync(OUT, JSON.stringify({
   generatedTypeCounts: gen.typeCounts,
 }, null, 2));
 
-console.log(JSON.stringify({ verdict, totals, rows: allRows.map((r) => `${r.scope}/${r.quantity}: ${r.deviationPercent.toFixed(2)}% ${r.withinBar ? 'PASS' : 'FAIL'}`) }, null, 2));
+console.log(JSON.stringify({
+  verdict,
+  totals,
+  rows: allRows.map((r) => (r.withinBar === null
+    ? `${r.scope}/${r.quantity}: UNSCORED (no reference space assigned to this room)`
+    : `${r.scope}/${r.quantity}: ${r.deviationPercent.toFixed(2)}% ${r.withinBar ? 'PASS' : 'FAIL'}`)),
+}, null, 2));

--- a/scripts/moonshot/b55-scan-to-parametric/score.mjs
+++ b/scripts/moonshot/b55-scan-to-parametric/score.mjs
@@ -57,6 +57,8 @@ const toScanPlan = (bboxMin, bboxMax) => ({
   x: [(bboxMin[0] + bboxMax[0]) / 2],
   center: [(bboxMin[0] + bboxMax[0]) / 2, -(bboxMin[2] + bboxMax[2]) / 2],
 });
+/** Viewer-frame plan point (axes 0, 2) -> scan plan. */
+const viewerPlanToScan = (c) => (c ? [c[0], -c[1]] : null);
 
 function pointInPolygon([px, py], poly) {
   let inside = false;
@@ -65,6 +67,20 @@ function pointInPolygon([px, py], poly) {
     if ((yi > py) !== (yj > py) && px < ((xj - xi) * (py - yi)) / (yj - yi) + xi) inside = !inside;
   }
   return inside;
+}
+
+/** Shortest distance from a plan point to a polygon's boundary, metres. */
+function distanceToBoundary([px, py], poly) {
+  let best = Infinity;
+  for (let i = 0; i < poly.length; i++) {
+    const [ax, ay] = poly[i], [bx, by] = poly[(i + 1) % poly.length];
+    const vx = bx - ax, vy = by - ay;
+    const len2 = vx * vx + vy * vy;
+    const t = len2 > 0 ? Math.max(0, Math.min(1, ((px - ax) * vx + (py - ay) * vy) / len2)) : 0;
+    const d = Math.hypot(px - (ax + t * vx), py - (ay + t * vy));
+    if (d < best) best = d;
+  }
+  return best;
 }
 
 const rooms = JSON.parse(readFileSync(join(WORK, 'rooms.json'), 'utf8'));
@@ -138,11 +154,51 @@ const genRooms = gen.spaces.map((s) => {
 if (claimed.size !== rooms.rooms.length) {
   throw new Error(`rooms.json holds ${rooms.rooms.length} rooms but the generated model has ${claimed.size} spaces`);
 }
+/**
+ * ASSIGNMENT RULE, and the failure mode it is checked against.
+ *
+ * The rule is unchanged: a reference space belongs to the generated room whose
+ * outline contains its plan point. The plan point is the midpoint of its
+ * bounding box -- which for a CONCAVE or L-shaped space is not its centroid
+ * and can in principle fall outside the space altogether, or across a
+ * neighbouring room's boundary. That is not hypothetical on this data: two of
+ * the four reference spaces here have a solidity of about 84%.
+ *
+ * So the space's TRUE area-weighted plan centroid is computed as well, and
+ * both are resolved. If they ever land in different rooms the run FAILS rather
+ * than quietly scoring one room's quantities against another room's polygon.
+ * The margin is recorded either way -- the separation between the two points
+ * and the bbox midpoint's clearance from the boundary of the room it landed
+ * in -- so "the shortcut does not bite here" is a committed measurement rather
+ * than a sentence.
+ */
 const assignments = [];
+const disagreements = [];
 for (const rs of refSpaces) {
   const c = toScanPlan(rs.bbox.min, rs.bbox.max).center;
+  const trueC = viewerPlanToScan(rs.planCentroid);
   const hit = genRooms.find((g) => pointInPolygon(c, g.polygon));
-  assignments.push({ reference: rs.label, refExpressId: rs.expressId, planCentroid: c, assignedTo: hit ? hit.roomId : null });
+  const trueHit = trueC ? genRooms.find((g) => pointInPolygon(trueC, g.polygon)) : null;
+  const assignedTo = hit ? hit.roomId : null;
+  const centroidAssignedTo = trueHit ? trueHit.roomId : null;
+  if (trueC && centroidAssignedTo !== assignedTo) {
+    disagreements.push(`${rs.label}: bbox midpoint -> ${assignedTo}, area-weighted plan centroid -> ${centroidAssignedTo}`);
+  }
+  assignments.push({
+    reference: rs.label,
+    refExpressId: rs.expressId,
+    planCentroid: c,
+    areaWeightedPlanCentroid: trueC,
+    centroidSeparationM: trueC ? Math.hypot(c[0] - trueC[0], c[1] - trueC[1]) : null,
+    boundaryClearanceM: hit ? distanceToBoundary(c, hit.polygon) : null,
+    centroidAgrees: trueC ? centroidAssignedTo === assignedTo : null,
+    assignedTo,
+  });
+}
+if (disagreements.length) {
+  throw new Error(`the plan point used for correspondence disagrees with the space's own centroid:\n  ${disagreements.join('\n  ')}\n`
+    + 'A bounding-box midpoint is not a centroid for a concave space. Switch the rule to the '
+    + 'area-weighted centroid rather than scoring across the wrong room boundary.');
 }
 
 const rowsPerRoom = genRooms.map((g) => {

--- a/scripts/moonshot/b55-scan-to-parametric/score.mjs
+++ b/scripts/moonshot/b55-scan-to-parametric/score.mjs
@@ -1,0 +1,249 @@
+#!/usr/bin/env node
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * B5.5 stage 4 -- the exam. Scores the scan-derived IFC against the manually
+ * modelled reference IFC of the same apartment, at the 5% bar.
+ *
+ * MEASUREMENT SYMMETRY. Both models are meshed by the same kernel call
+ * (`measure-ifc.mjs`, which runs `buildPrePassOnce` + `processGeometryBatch`)
+ * and reduced by the same `solidQuantities`. No stored quantity from either
+ * file is read: the reference carries no IfcElementQuantity at all, and using
+ * one model's asserted numbers against the other's computed ones would make
+ * the comparison meaningless.
+ *
+ * CORRESPONDENCE, FIXED BEFORE SCORING. A reference space belongs to the
+ * generated room whose plan outline CONTAINS its plan centroid. This is a
+ * containment test against the scan-derived polygon, so it cannot be tuned;
+ * it also handles the many-to-one case honestly, which matters here because
+ * the extraction merges two reference spaces into one room. Where n reference
+ * spaces map to one generated room, the reference side of that row is their
+ * aggregate, and the row is flagged `merged: n`.
+ *
+ * NO FITTING TO THE REFERENCE. Nothing upstream of this file reads the
+ * reference model. The two coordinate frames coincide as a property of the
+ * data (the reference was modelled on this scan), which this script verifies
+ * and reports rather than assumes -- see `frameCheck`.
+ *
+ * Usage: node score.mjs <workDir> <reference.ifc> <generated.ifc> <out.json>
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { measureSpaces } from './measure-ifc.mjs';
+
+const WORK = process.argv[2];
+const REF = process.argv[3];
+const GEN = process.argv[4];
+const OUT = process.argv[5];
+
+/** The exam bar. */
+const BAR = 0.05;
+
+/**
+ * Kernel meshes come out in the viewer frame (Y up). The scan and the
+ * generated model's authoring frame are IFC/E57 (Z up). Plan coordinates
+ * therefore map viewer (x, z) -> scan (x, -z).
+ */
+const toScanPlan = (bboxMin, bboxMax) => ({
+  x: [(bboxMin[0] + bboxMax[0]) / 2],
+  center: [(bboxMin[0] + bboxMax[0]) / 2, -(bboxMin[2] + bboxMax[2]) / 2],
+});
+
+function pointInPolygon([px, py], poly) {
+  let inside = false;
+  for (let i = 0, j = poly.length - 1; i < poly.length; j = i++) {
+    const [xi, yi] = poly[i], [xj, yj] = poly[j];
+    if ((yi > py) !== (yj > py) && px < ((xj - xi) * (py - yi)) / (yj - yi) + xi) inside = !inside;
+  }
+  return inside;
+}
+
+const rooms = JSON.parse(readFileSync(join(WORK, 'rooms.json'), 'utf8'));
+const ref = measureSpaces(REF);
+const gen = measureSpaces(GEN);
+
+// Neutral labels: the reference is client data, so nothing carried from its
+// strings reaches this file's output.
+const refSpaces = ref.spaces
+  .map((s, i) => ({ ...s, label: `ref_space_${String.fromCharCode(65 + i)}` }));
+for (const s of refSpaces) { delete s.name; delete s.longName; }
+for (const s of gen.spaces) { delete s.name; }
+
+// -------------------------------------------------------------- frame check ---
+const bboxOf = (list) => {
+  const mn = [Infinity, Infinity, Infinity], mx = [-Infinity, -Infinity, -Infinity];
+  for (const s of list) for (let a = 0; a < 3; a++) {
+    if (s.bbox.min[a] < mn[a]) mn[a] = s.bbox.min[a];
+    if (s.bbox.max[a] > mx[a]) mx[a] = s.bbox.max[a];
+  }
+  return { min: mn, max: mx };
+};
+const refBox = bboxOf(refSpaces);
+const genBox = bboxOf(gen.spaces);
+const frameCheck = {
+  note: 'Both models meshed by the same kernel, so both boxes are in the viewer frame (Y up). No transform was applied to either side.',
+  referenceSpacesBBox: refBox,
+  generatedSpacesBBox: genBox,
+  cornerOffsetsM: [0, 1, 2].map((a) => ({
+    axis: 'xyz'[a],
+    minDelta: genBox.min[a] - refBox.min[a],
+    maxDelta: genBox.max[a] - refBox.max[a],
+  })),
+  maxCornerOffsetM: Math.max(...[0, 1, 2].flatMap((a) => [
+    Math.abs(genBox.min[a] - refBox.min[a]), Math.abs(genBox.max[a] - refBox.max[a]),
+  ])),
+};
+
+// ----------------------------------------------------------- correspondence ---
+const genRooms = gen.spaces.map((s) => {
+  const room = rooms.rooms.find((r) => Math.abs(r.polygonAreaM2 - s.floorArea) < 0.02)
+    ?? rooms.rooms[gen.spaces.indexOf(s)];
+  return { ...s, roomId: room.id, polygon: room.polygon };
+});
+const assignments = [];
+for (const rs of refSpaces) {
+  const c = toScanPlan(rs.bbox.min, rs.bbox.max).center;
+  const hit = genRooms.find((g) => pointInPolygon(c, g.polygon));
+  assignments.push({ reference: rs.label, refExpressId: rs.expressId, planCentroid: c, assignedTo: hit ? hit.roomId : null });
+}
+
+const rowsPerRoom = genRooms.map((g) => {
+  const mine = assignments.filter((a) => a.assignedTo === g.roomId).map((a) => refSpaces.find((r) => r.label === a.reference));
+  const refFloor = mine.reduce((a, s) => a + s.floorArea, 0);
+  const refVol = mine.reduce((a, s) => a + s.volume, 0);
+  const refLat = mine.reduce((a, s) => a + s.lateralArea, 0);
+  const refHeight = refFloor > 0 ? mine.reduce((a, s) => a + s.height * s.floorArea, 0) / refFloor : 0;
+  return {
+    room: g.roomId,
+    mergedReferenceSpaces: mine.length,
+    referenceLabels: mine.map((s) => s.label),
+    quantities: {
+      floorAreaM2: { generated: g.floorArea, reference: refFloor },
+      clearHeightM: { generated: g.height, reference: refHeight },
+      volumeM3: { generated: g.volume, reference: refVol },
+      lateralAreaM2: { generated: g.lateralArea, reference: refLat },
+    },
+  };
+});
+
+const totals = {
+  floorAreaM2: {
+    generated: gen.spaces.reduce((a, s) => a + s.floorArea, 0),
+    reference: refSpaces.reduce((a, s) => a + s.floorArea, 0),
+  },
+  volumeM3: {
+    generated: gen.spaces.reduce((a, s) => a + s.volume, 0),
+    reference: refSpaces.reduce((a, s) => a + s.volume, 0),
+  },
+  lateralAreaM2: {
+    generated: gen.spaces.reduce((a, s) => a + s.lateralArea, 0),
+    reference: refSpaces.reduce((a, s) => a + s.lateralArea, 0),
+  },
+  areaWeightedClearHeightM: {
+    generated: gen.spaces.reduce((a, s) => a + s.height * s.floorArea, 0) / gen.spaces.reduce((a, s) => a + s.floorArea, 0),
+    reference: refSpaces.reduce((a, s) => a + s.height * s.floorArea, 0) / refSpaces.reduce((a, s) => a + s.floorArea, 0),
+  },
+};
+
+// ------------------------------------------------------ reference audit ---
+/**
+ * Does the reference's space height come from the building or from the
+ * authoring tool's default? Testable without opening the reference's UI: take
+ * each reference space's TOP elevation and count how many scan points sit
+ * within +-1 cm of it. A modelled ceiling that was measured has the ceiling's
+ * point mass underneath it; a defaulted one sits in empty air.
+ */
+const ingest = JSON.parse(readFileSync(join(WORK, 'ingest.json'), 'utf8'));
+const hz = ingest.histograms.z;
+const pointsNear = (z) => {
+  const i = Math.round((z - hz.origin) / hz.binSize);
+  return (hz.counts[i - 1] ?? 0) + (hz.counts[i] ?? 0) + (hz.counts[i + 1] ?? 0);
+};
+const scanCeilingZ = rooms.planes.ceiling.z;
+/**
+ * Background level: the median 1 cm bin strictly between floor + 0.3 m and
+ * ceiling - 0.3 m, i.e. the open air of the rooms, times three bins. An
+ * elevation carrying LESS than this has no surface at it at all.
+ */
+const interior = [];
+for (let i = 0; i < hz.counts.length; i++) {
+  const z = hz.origin + i * hz.binSize;
+  if (z > rooms.planes.floor.z + 0.3 && z < scanCeilingZ - 0.3) interior.push(hz.counts[i]);
+}
+interior.sort((a, b) => a - b);
+const backgroundPer3Bins = 3 * interior[Math.floor(interior.length / 2)];
+const referenceHeightAudit = {
+  method: 'full-cloud z histogram, 1 cm bins, +-1 cm around the tested elevation',
+  scanFittedCeilingZ: scanCeilingZ,
+  pointsAtScanFittedCeiling: pointsNear(scanCeilingZ),
+  backgroundPer3Bins,
+  spaces: refSpaces.map((s) => ({
+    label: s.label,
+    floorAreaM2: s.floorArea,
+    heightM: s.height,
+    topElevationM: s.bbox.max[1],
+    scanPointsWithin1cmOfTop: pointsNear(s.bbox.max[1]),
+    /** True when the modelled ceiling has no more point mass under it than
+     *  empty air does -- i.e. it was not measured from this scan. */
+    unsupportedByScan: pointsNear(s.bbox.max[1]) < backgroundPer3Bins,
+  })),
+};
+
+const withDeviation = (o) => ({
+  ...o,
+  deviation: (o.generated - o.reference) / o.reference,
+  deviationPercent: ((o.generated - o.reference) / o.reference) * 100,
+  // Magnitude carried explicitly: it is what the bar is tested against, and
+  // it is what prose quotes when it says a row is "inside 1%".
+  absDeviationPercent: Math.abs(((o.generated - o.reference) / o.reference) * 100),
+  withinBar: Math.abs((o.generated - o.reference) / o.reference) <= BAR,
+});
+for (const r of rowsPerRoom) for (const k of Object.keys(r.quantities)) r.quantities[k] = withDeviation(r.quantities[k]);
+// Volume is area x height, so its deviation is the product of the two -- worth
+// carrying explicitly so a volume miss can be attributed rather than guessed.
+for (const r of rowsPerRoom) {
+  const a = r.quantities.floorAreaM2.deviation, h = r.quantities.clearHeightM.deviation;
+  r.quantities.volumeM3.decomposition = { areaDeviation: a, heightDeviation: h, product: (1 + a) * (1 + h) - 1 };
+}
+for (const k of Object.keys(totals)) totals[k] = withDeviation(totals[k]);
+
+const allRows = [
+  ...Object.entries(totals).map(([k, v]) => ({ scope: 'model', quantity: k, ...v })),
+  ...rowsPerRoom.flatMap((r) => Object.entries(r.quantities).map(([k, v]) => ({ scope: r.room, quantity: k, ...v }))),
+];
+const verdict = {
+  bar: BAR,
+  rowsTotal: allRows.length,
+  rowsWithinBar: allRows.filter((r) => r.withinBar).length,
+  rowsOutsideBar: allRows.filter((r) => !r.withinBar).map((r) => ({ scope: r.scope, quantity: r.quantity, deviationPercent: r.deviationPercent })),
+  maxAbsDeviationPercent: Math.max(...allRows.map((r) => Math.abs(r.deviationPercent))),
+  referenceSpaceCount: refSpaces.length,
+  generatedSpaceCount: gen.spaces.length,
+  unassignedReferenceSpaces: assignments.filter((a) => !a.assignedTo).length,
+};
+
+writeFileSync(OUT, JSON.stringify({
+  generatedAt: new Date().toISOString(),
+  bar: BAR,
+  frameCheck,
+  correspondence: assignments,
+  perRoom: rowsPerRoom,
+  totals,
+  referenceHeightAudit,
+  verdict,
+  referenceSpaces: refSpaces.map((s) => ({
+    label: s.label, floorAreaM2: s.floorArea, volumeM3: s.volume,
+    clearHeightM: s.height, lateralAreaM2: s.lateralArea,
+  })),
+  generatedSpaces: genRooms.map((s) => ({
+    room: s.roomId, floorAreaM2: s.floorArea, volumeM3: s.volume,
+    clearHeightM: s.height, lateralAreaM2: s.lateralArea, profileVertices: s.polygon.length,
+  })),
+  referenceTypeCounts: ref.typeCounts,
+  generatedTypeCounts: gen.typeCounts,
+}, null, 2));
+
+console.log(JSON.stringify({ verdict, totals, rows: allRows.map((r) => `${r.scope}/${r.quantity}: ${r.deviationPercent.toFixed(2)}% ${r.withinBar ? 'PASS' : 'FAIL'}`) }, null, 2));

--- a/scripts/moonshot/b55-scan-to-parametric/scorecard.json
+++ b/scripts/moonshot/b55-scan-to-parametric/scorecard.json
@@ -1,9 +1,9 @@
 {
   "bet": "B5.5 scan-to-parametric (M5 final)",
-  "generatedAt": "2026-08-01T05:31:57.608Z",
+  "generatedAt": "2026-08-01T06:43:52.242Z",
   "bar": 0.05,
-  "elapsedSeconds": 4.31,
-  "elapsedSecondsAfterIngest": 1.1469999999999998,
+  "elapsedSeconds": 4.437,
+  "elapsedSecondsAfterIngest": 1.2850000000000001,
   "primaryVariant": "axisAligned",
   "scan": {
     "sourceBytes": 3939103744,
@@ -20,8 +20,8 @@
     ],
     "densityPerM3": 184807.48697576692,
     "densityPerPlanM2": 506007.5984146027,
-    "ingestSeconds": 3.163,
-    "megaPointsPerSecond": 21.958013278533038,
+    "ingestSeconds": 3.152,
+    "megaPointsPerSecond": 22.034643401015227,
     "planes": {
       "floor": {
         "z": -1.368653498211528,
@@ -133,6 +133,26 @@
           "hi": 2.231,
           "roomCount": 3
         },
+        "plateausByRoomCount": [
+          {
+            "length": 5,
+            "lo": 2.031,
+            "hi": 2.231,
+            "roomCount": 3
+          },
+          {
+            "length": 3,
+            "lo": 1.881,
+            "hi": 1.981,
+            "roomCount": 2
+          },
+          {
+            "length": 9,
+            "lo": 1.431,
+            "hi": 1.831,
+            "roomCount": 1
+          }
+        ],
         "sweep": [
           {
             "cut": 2.531,
@@ -642,7 +662,9 @@
       "verdict": {
         "bar": 0.05,
         "rowsTotal": 16,
+        "rowsScored": 16,
         "rowsWithinBar": 12,
+        "rowsUnscored": [],
         "rowsOutsideBar": [
           {
             "scope": "model",
@@ -683,6 +705,26 @@
           "hi": 2.231,
           "roomCount": 3
         },
+        "plateausByRoomCount": [
+          {
+            "length": 5,
+            "lo": 2.031,
+            "hi": 2.231,
+            "roomCount": 3
+          },
+          {
+            "length": 3,
+            "lo": 1.881,
+            "hi": 1.981,
+            "roomCount": 2
+          },
+          {
+            "length": 9,
+            "lo": 1.431,
+            "hi": 1.831,
+            "roomCount": 1
+          }
+        ],
         "sweep": [
           {
             "cut": 2.531,
@@ -1192,7 +1234,9 @@
       "verdict": {
         "bar": 0.05,
         "rowsTotal": 16,
+        "rowsScored": 16,
         "rowsWithinBar": 12,
+        "rowsUnscored": [],
         "rowsOutsideBar": [
           {
             "scope": "model",
@@ -1265,6 +1309,6 @@
     "scanMinusDefaultedHeightM": 0.0928101656168816,
     "floorPlaneDepthBelowScanOriginM": 1.368653498211528,
     "subsampleBytes": 83343840,
-    "derivedIntermediateBytes": 83396346
+    "derivedIntermediateBytes": 83396893
   }
 }

--- a/scripts/moonshot/b55-scan-to-parametric/scorecard.json
+++ b/scripts/moonshot/b55-scan-to-parametric/scorecard.json
@@ -1,0 +1,1270 @@
+{
+  "bet": "B5.5 scan-to-parametric (M5 final)",
+  "generatedAt": "2026-08-01T05:31:57.608Z",
+  "bar": 0.05,
+  "elapsedSeconds": 4.31,
+  "elapsedSecondsAfterIngest": 1.1469999999999998,
+  "primaryVariant": "axisAligned",
+  "scan": {
+    "sourceBytes": 3939103744,
+    "decodedPointCount": 69453196,
+    "keptPointCount": 6945320,
+    "stride": 10,
+    "hasColor": true,
+    "hasIntensity": false,
+    "nonFinite": 0,
+    "bboxExtentM": [
+      11.806451797485352,
+      11.625611305236816,
+      2.738025426864624
+    ],
+    "densityPerM3": 184807.48697576692,
+    "densityPerPlanM2": 506007.5984146027,
+    "ingestSeconds": 3.163,
+    "megaPointsPerSecond": 21.958013278533038,
+    "planes": {
+      "floor": {
+        "z": -1.368653498211528,
+        "peakZ": -1.37,
+        "peakBinPoints": 5812039,
+        "bandPoints": 15699994
+      },
+      "ceiling": {
+        "z": 1.162556697541462,
+        "peakZ": 1.1599999999999997,
+        "peakBinPoints": 2730281,
+        "bandPoints": 8160054
+      },
+      "clearHeightM": 2.53121019575299
+    }
+  },
+  "reference": {
+    "spaceCount": 4,
+    "typeCounts": {
+      "IfcWallStandardCase": 23,
+      "IfcSlab": 4,
+      "IfcSpace": 4,
+      "IfcWindow": 3,
+      "IfcDoor": 3,
+      "IfcBuildingElementProxy": 1,
+      "IfcOpeningElement": 6
+    },
+    "spaces": [
+      {
+        "label": "ref_space_A",
+        "floorAreaM2": 43.36136446244346,
+        "volumeM3": 104.77688911677338,
+        "clearHeightM": 2.4384000301361084,
+        "lateralAreaM2": 83.52852274613126
+      },
+      {
+        "label": "ref_space_B",
+        "floorAreaM2": 14.202596481499,
+        "volumeM3": 34.63060763636469,
+        "clearHeightM": 2.4384000301361084,
+        "lateralAreaM2": 36.93400811734594
+      },
+      {
+        "label": "ref_space_C",
+        "floorAreaM2": 4.583463275531415,
+        "volumeM3": 10.610683868856247,
+        "clearHeightM": 2.314992666244507,
+        "lateralAreaM2": 20.10201541618663
+      },
+      {
+        "label": "ref_space_D",
+        "floorAreaM2": 2.4196738568013245,
+        "volumeM3": 5.900133011061378,
+        "clearHeightM": 2.4384000301361084,
+        "lateralAreaM2": 18.45662822497431
+      }
+    ],
+    "heightAudit": {
+      "method": "full-cloud z histogram, 1 cm bins, +-1 cm around the tested elevation",
+      "scanFittedCeilingZ": 1.162556697541462,
+      "pointsAtScanFittedCeiling": 6586376,
+      "backgroundPer3Bins": 540204,
+      "spaces": [
+        {
+          "label": "ref_space_A",
+          "floorAreaM2": 43.36136446244346,
+          "heightM": 2.4384000301361084,
+          "topElevationM": 1.0723999738693237,
+          "scanPointsWithin1cmOfTop": 351062,
+          "unsupportedByScan": true
+        },
+        {
+          "label": "ref_space_B",
+          "floorAreaM2": 14.202596481499,
+          "heightM": 2.4384000301361084,
+          "topElevationM": 1.0723999738693237,
+          "scanPointsWithin1cmOfTop": 351062,
+          "unsupportedByScan": true
+        },
+        {
+          "label": "ref_space_C",
+          "floorAreaM2": 4.583463275531415,
+          "heightM": 2.314992666244507,
+          "topElevationM": 0.9489926099777222,
+          "scanPointsWithin1cmOfTop": 1645945,
+          "unsupportedByScan": false
+        },
+        {
+          "label": "ref_space_D",
+          "floorAreaM2": 2.4196738568013245,
+          "heightM": 2.4384000301361084,
+          "topElevationM": 1.0723999738693237,
+          "scanPointsWithin1cmOfTop": 351062,
+          "unsupportedByScan": true
+        }
+      ]
+    }
+  },
+  "variants": {
+    "axisAligned": {
+      "ceilingCut": {
+        "used": 2.131,
+        "sweepLoM": 1.4,
+        "sweepStepM": 0.05,
+        "sweepSamples": 23,
+        "plateau": {
+          "length": 5,
+          "lo": 2.031,
+          "hi": 2.231,
+          "roomCount": 3
+        },
+        "sweep": [
+          {
+            "cut": 2.531,
+            "roomCount": 2,
+            "totalArea": 37.22375000000001,
+            "areas": [
+              27.134,
+              10.089
+            ]
+          },
+          {
+            "cut": 2.481,
+            "roomCount": 2,
+            "totalArea": 44.34125000000001,
+            "areas": [
+              31.642,
+              12.699
+            ]
+          },
+          {
+            "cut": 2.431,
+            "roomCount": 3,
+            "totalArea": 45.61562500000001,
+            "areas": [
+              31.751,
+              12.767,
+              1.098
+            ]
+          },
+          {
+            "cut": 2.381,
+            "roomCount": 3,
+            "totalArea": 46.42875000000001,
+            "areas": [
+              31.83,
+              12.786,
+              1.813
+            ]
+          },
+          {
+            "cut": 2.331,
+            "roomCount": 3,
+            "totalArea": 48.13062500000001,
+            "areas": [
+              33.499,
+              12.802,
+              1.829
+            ]
+          },
+          {
+            "cut": 2.281,
+            "roomCount": 3,
+            "totalArea": 58.95500000000001,
+            "areas": [
+              42.602,
+              12.81,
+              3.543
+            ]
+          },
+          {
+            "cut": 2.231,
+            "roomCount": 3,
+            "totalArea": 60.516250000000014,
+            "areas": [
+              43.051,
+              12.817,
+              4.648
+            ]
+          },
+          {
+            "cut": 2.181,
+            "roomCount": 3,
+            "totalArea": 60.76750000000001,
+            "areas": [
+              43.281,
+              12.823,
+              4.663
+            ]
+          },
+          {
+            "cut": 2.131,
+            "roomCount": 3,
+            "totalArea": 60.86062500000001,
+            "areas": [
+              43.366,
+              12.825,
+              4.669
+            ]
+          },
+          {
+            "cut": 2.081,
+            "roomCount": 3,
+            "totalArea": 61.03562500000002,
+            "areas": [
+              43.521,
+              12.837,
+              4.678
+            ]
+          },
+          {
+            "cut": 2.031,
+            "roomCount": 3,
+            "totalArea": 61.17687500000001,
+            "areas": [
+              43.654,
+              12.841,
+              4.682
+            ]
+          },
+          {
+            "cut": 1.981,
+            "roomCount": 2,
+            "totalArea": 61.26750000000001,
+            "areas": [
+              48.423,
+              12.845
+            ]
+          },
+          {
+            "cut": 1.931,
+            "roomCount": 2,
+            "totalArea": 61.32562500000002,
+            "areas": [
+              48.474,
+              12.852
+            ]
+          },
+          {
+            "cut": 1.881,
+            "roomCount": 2,
+            "totalArea": 61.37750000000001,
+            "areas": [
+              48.519,
+              12.859
+            ]
+          },
+          {
+            "cut": 1.831,
+            "roomCount": 1,
+            "totalArea": 61.421250000000015,
+            "areas": [
+              61.421
+            ]
+          },
+          {
+            "cut": 1.781,
+            "roomCount": 1,
+            "totalArea": 61.45750000000001,
+            "areas": [
+              61.458
+            ]
+          },
+          {
+            "cut": 1.731,
+            "roomCount": 1,
+            "totalArea": 61.52500000000001,
+            "areas": [
+              61.525
+            ]
+          },
+          {
+            "cut": 1.681,
+            "roomCount": 1,
+            "totalArea": 61.578125000000014,
+            "areas": [
+              61.578
+            ]
+          },
+          {
+            "cut": 1.631,
+            "roomCount": 1,
+            "totalArea": 61.62937500000001,
+            "areas": [
+              61.629
+            ]
+          },
+          {
+            "cut": 1.581,
+            "roomCount": 1,
+            "totalArea": 61.66562500000001,
+            "areas": [
+              61.666
+            ]
+          },
+          {
+            "cut": 1.531,
+            "roomCount": 1,
+            "totalArea": 61.69687500000001,
+            "areas": [
+              61.697
+            ]
+          },
+          {
+            "cut": 1.481,
+            "roomCount": 1,
+            "totalArea": 61.73000000000001,
+            "areas": [
+              61.73
+            ]
+          },
+          {
+            "cut": 1.431,
+            "roomCount": 1,
+            "totalArea": 61.938125000000014,
+            "areas": [
+              61.938
+            ]
+          }
+        ]
+      },
+      "principalFrame": {
+        "enabled": false,
+        "thetaRad": 0,
+        "thetaDeg": 0
+      },
+      "rooms": [
+        {
+          "id": "scan_room_001",
+          "rasterAreaM2": 45.22562500000001,
+          "outlineAreaM2": 45.47624999999979,
+          "polygonAreaM2": 45.57593750000002,
+          "polygonPerimeterM": 47.572973470290705,
+          "polygonVertices": 76,
+          "heightM": 2.538653498211528,
+          "filledHoles": 920,
+          "filledHoleAreaM2": 1.8550000000000004,
+          "unfilledHoles": 1,
+          "largestHoleM2": 0.25062500000000004
+        },
+        {
+          "id": "scan_room_002",
+          "rasterAreaM2": 13.143750000000002,
+          "outlineAreaM2": 14.421249999999926,
+          "polygonAreaM2": 14.495625,
+          "polygonPerimeterM": 15.363510993794375,
+          "polygonVertices": 11,
+          "heightM": 2.5586534982115277,
+          "filledHoles": 268,
+          "filledHoleAreaM2": 0.3187500000000001,
+          "unfilledHoles": 1,
+          "largestHoleM2": 1.2775000000000003
+        },
+        {
+          "id": "scan_room_003",
+          "rasterAreaM2": 4.671875000000001,
+          "outlineAreaM2": 4.671874999999972,
+          "polygonAreaM2": 4.654374999999993,
+          "polygonPerimeterM": 8.709724485550348,
+          "polygonVertices": 7,
+          "heightM": 2.288653498211528,
+          "filledHoles": 4,
+          "filledHoleAreaM2": 0.0025000000000000005,
+          "unfilledHoles": 0,
+          "largestHoleM2": 0.0006250000000000001
+        }
+      ],
+      "wallChannels": [
+        {
+          "between": [
+            "scan_room_001",
+            "scan_room_002"
+          ],
+          "crossings": 326,
+          "thicknessM": 0.07500000000000001,
+          "medianCrossingM": 0.125
+        },
+        {
+          "between": [
+            "scan_room_003",
+            "scan_room_001"
+          ],
+          "crossings": 144,
+          "thicknessM": 0.07500000000000001,
+          "medianCrossingM": 0.1
+        },
+        {
+          "between": [
+            "scan_room_003",
+            "scan_room_002"
+          ],
+          "crossings": 90,
+          "thicknessM": 0.4,
+          "medianCrossingM": 0.42500000000000004
+        }
+      ],
+      "emitted": {
+        "ifcBytes": 30535,
+        "spaceCount": 3,
+        "wallCount": 29,
+        "slabCount": 1,
+        "modalWallThicknessM": 0.07500000000000001,
+        "slabThicknessNominalM": 0.2
+      },
+      "frameCheck": {
+        "maxCornerOffsetM": 0.11760008335113525,
+        "cornerOffsetsM": [
+          {
+            "axis": "x",
+            "minDelta": 0.005172252655029297,
+            "maxDelta": 0.017572402954101562
+          },
+          {
+            "axis": "y",
+            "minDelta": -0.00265347957611084,
+            "maxDelta": 0.11760008335113525
+          },
+          {
+            "axis": "z",
+            "minDelta": -0.015830039978027344,
+            "maxDelta": -0.009874343872070312
+          }
+        ]
+      },
+      "correspondence": [
+        {
+          "reference": "ref_space_A",
+          "assignedTo": "scan_room_001"
+        },
+        {
+          "reference": "ref_space_B",
+          "assignedTo": "scan_room_002"
+        },
+        {
+          "reference": "ref_space_C",
+          "assignedTo": "scan_room_003"
+        },
+        {
+          "reference": "ref_space_D",
+          "assignedTo": "scan_room_001"
+        }
+      ],
+      "perRoom": [
+        {
+          "room": "scan_room_001",
+          "mergedReferenceSpaces": 2,
+          "referenceLabels": [
+            "ref_space_A",
+            "ref_space_D"
+          ],
+          "quantities": {
+            "floorAreaM2": {
+              "generated": 45.57593773216012,
+              "reference": 45.781038319244786,
+              "deviation": -0.004480033538218111,
+              "deviationPercent": -0.4480033538218111,
+              "absDeviationPercent": 0.4480033538218111,
+              "withinBar": true
+            },
+            "clearHeightM": {
+              "generated": 2.538653612136841,
+              "reference": 2.4384000301361084,
+              "deviation": 0.04111449342261384,
+              "deviationPercent": 4.111449342261384,
+              "absDeviationPercent": 4.111449342261384,
+              "withinBar": true
+            },
+            "volumeM3": {
+              "generated": 115.70151895027215,
+              "reference": 110.67702212783476,
+              "deviation": 0.045397831689345275,
+              "deviationPercent": 4.539783168934528,
+              "absDeviationPercent": 4.539783168934528,
+              "withinBar": true,
+              "decomposition": {
+                "areaDeviation": -0.004480033538218111,
+                "heightDeviation": 0.04111449342261384,
+                "product": 0.036450265574955454
+              }
+            },
+            "lateralAreaM2": {
+              "generated": 120.77130291571135,
+              "reference": 101.98515097110557,
+              "deviation": 0.18420477653583384,
+              "deviationPercent": 18.420477653583383,
+              "absDeviationPercent": 18.420477653583383,
+              "withinBar": false
+            }
+          }
+        },
+        {
+          "room": "scan_room_002",
+          "mergedReferenceSpaces": 1,
+          "referenceLabels": [
+            "ref_space_B"
+          ],
+          "quantities": {
+            "floorAreaM2": {
+              "generated": 14.495624582171416,
+              "reference": 14.202596481499,
+              "deviation": 0.02063200915791198,
+              "deviationPercent": 2.0632009157911977,
+              "absDeviationPercent": 2.0632009157911977,
+              "withinBar": true
+            },
+            "clearHeightM": {
+              "generated": 2.5586535930633545,
+              "reference": 2.4384000301361084,
+              "deviation": 0.049316585236645394,
+              "deviationPercent": 4.93165852366454,
+              "absDeviationPercent": 4.93165852366454,
+              "withinBar": true
+            },
+            "volumeM3": {
+              "generated": 37.08928192087038,
+              "reference": 34.63060763636469,
+              "deviation": 0.07099714536697593,
+              "deviationPercent": 7.099714536697594,
+              "absDeviationPercent": 7.099714536697594,
+              "withinBar": false,
+              "decomposition": {
+                "areaDeviation": 0.02063200915791198,
+                "heightDeviation": 0.049316585236645394,
+                "product": 0.0709660946327968
+              }
+            },
+            "lateralAreaM2": {
+              "generated": 39.30990228769579,
+              "reference": 36.93400811734594,
+              "deviation": 0.06432808924504517,
+              "deviationPercent": 6.432808924504517,
+              "absDeviationPercent": 6.432808924504517,
+              "withinBar": false
+            }
+          }
+        },
+        {
+          "room": "scan_room_003",
+          "mergedReferenceSpaces": 1,
+          "referenceLabels": [
+            "ref_space_C"
+          ],
+          "quantities": {
+            "floorAreaM2": {
+              "generated": 4.654374106526404,
+              "reference": 4.583463275531415,
+              "deviation": 0.015471015416125094,
+              "deviationPercent": 1.5471015416125093,
+              "absDeviationPercent": 1.5471015416125093,
+              "withinBar": true
+            },
+            "clearHeightM": {
+              "generated": 2.288653612136841,
+              "reference": 2.314992666244507,
+              "deviation": -0.011377597213037613,
+              "deviationPercent": -1.1377597213037614,
+              "absDeviationPercent": 1.1377597213037614,
+              "withinBar": true
+            },
+            "volumeM3": {
+              "generated": 10.652250111137837,
+              "reference": 10.610683868856247,
+              "deviation": 0.003917395221206456,
+              "deviationPercent": 0.39173952212064556,
+              "absDeviationPercent": 0.39173952212064556,
+              "withinBar": true,
+              "decomposition": {
+                "areaDeviation": 0.015471015416125094,
+                "heightDeviation": -0.011377597213037613,
+                "product": 0.003917395221205933
+              }
+            },
+            "lateralAreaM2": {
+              "generated": 19.933540673132725,
+              "reference": 20.10201541618663,
+              "deviation": -0.008380987655508723,
+              "deviationPercent": -0.8380987655508723,
+              "absDeviationPercent": 0.8380987655508723,
+              "withinBar": true
+            }
+          }
+        }
+      ],
+      "totals": {
+        "floorAreaM2": {
+          "generated": 64.72593642085795,
+          "reference": 64.5670980762752,
+          "deviation": 0.0024600508512107296,
+          "deviationPercent": 0.24600508512107297,
+          "absDeviationPercent": 0.24600508512107297,
+          "withinBar": true
+        },
+        "volumeM3": {
+          "generated": 163.44305098228037,
+          "reference": 155.91831363305567,
+          "deviation": 0.04826076664049682,
+          "deviationPercent": 4.8260766640496815,
+          "absDeviationPercent": 4.8260766640496815,
+          "withinBar": true
+        },
+        "lateralAreaM2": {
+          "generated": 180.01474587653985,
+          "reference": 159.02117450463814,
+          "deviation": 0.13201745891575836,
+          "deviationPercent": 13.201745891575836,
+          "absDeviationPercent": 13.201745891575836,
+          "withinBar": false
+        },
+        "areaWeightedClearHeightM": {
+          "generated": 2.5251554480347496,
+          "reference": 2.4296396376578975,
+          "deviation": 0.03931274782334658,
+          "deviationPercent": 3.931274782334658,
+          "absDeviationPercent": 3.931274782334658,
+          "withinBar": true
+        }
+      },
+      "verdict": {
+        "bar": 0.05,
+        "rowsTotal": 16,
+        "rowsWithinBar": 12,
+        "rowsOutsideBar": [
+          {
+            "scope": "model",
+            "quantity": "lateralAreaM2",
+            "deviationPercent": 13.201745891575836
+          },
+          {
+            "scope": "scan_room_001",
+            "quantity": "lateralAreaM2",
+            "deviationPercent": 18.420477653583383
+          },
+          {
+            "scope": "scan_room_002",
+            "quantity": "volumeM3",
+            "deviationPercent": 7.099714536697594
+          },
+          {
+            "scope": "scan_room_002",
+            "quantity": "lateralAreaM2",
+            "deviationPercent": 6.432808924504517
+          }
+        ],
+        "maxAbsDeviationPercent": 18.420477653583383,
+        "referenceSpaceCount": 4,
+        "generatedSpaceCount": 3,
+        "unassignedReferenceSpaces": 0
+      }
+    },
+    "principalFrame": {
+      "ceilingCut": {
+        "used": 2.131,
+        "sweepLoM": 1.4,
+        "sweepStepM": 0.05,
+        "sweepSamples": 23,
+        "plateau": {
+          "length": 5,
+          "lo": 2.031,
+          "hi": 2.231,
+          "roomCount": 3
+        },
+        "sweep": [
+          {
+            "cut": 2.531,
+            "roomCount": 2,
+            "totalArea": 37.13937500000001,
+            "areas": [
+              27.044,
+              10.096
+            ]
+          },
+          {
+            "cut": 2.481,
+            "roomCount": 2,
+            "totalArea": 44.23625000000001,
+            "areas": [
+              31.641,
+              12.596
+            ]
+          },
+          {
+            "cut": 2.431,
+            "roomCount": 3,
+            "totalArea": 45.55812500000001,
+            "areas": [
+              31.753,
+              12.706,
+              1.1
+            ]
+          },
+          {
+            "cut": 2.381,
+            "roomCount": 3,
+            "totalArea": 46.12437500000001,
+            "areas": [
+              31.823,
+              12.734,
+              1.568
+            ]
+          },
+          {
+            "cut": 2.331,
+            "roomCount": 3,
+            "totalArea": 48.03687500000001,
+            "areas": [
+              33.47,
+              12.75,
+              1.817
+            ]
+          },
+          {
+            "cut": 2.281,
+            "roomCount": 3,
+            "totalArea": 58.853750000000005,
+            "areas": [
+              42.544,
+              12.759,
+              3.55
+            ]
+          },
+          {
+            "cut": 2.231,
+            "roomCount": 3,
+            "totalArea": 60.44625000000002,
+            "areas": [
+              43.034,
+              12.769,
+              4.643
+            ]
+          },
+          {
+            "cut": 2.181,
+            "roomCount": 3,
+            "totalArea": 60.69062500000001,
+            "areas": [
+              43.258,
+              12.774,
+              4.658
+            ]
+          },
+          {
+            "cut": 2.131,
+            "roomCount": 3,
+            "totalArea": 60.76687500000001,
+            "areas": [
+              43.325,
+              12.778,
+              4.664
+            ]
+          },
+          {
+            "cut": 2.081,
+            "roomCount": 3,
+            "totalArea": 60.93937500000001,
+            "areas": [
+              43.483,
+              12.787,
+              4.669
+            ]
+          },
+          {
+            "cut": 2.031,
+            "roomCount": 3,
+            "totalArea": 61.07375000000002,
+            "areas": [
+              43.606,
+              12.793,
+              4.675
+            ]
+          },
+          {
+            "cut": 1.981,
+            "roomCount": 2,
+            "totalArea": 61.15937500000001,
+            "areas": [
+              48.359,
+              12.801
+            ]
+          },
+          {
+            "cut": 1.931,
+            "roomCount": 2,
+            "totalArea": 61.22250000000001,
+            "areas": [
+              48.412,
+              12.811
+            ]
+          },
+          {
+            "cut": 1.881,
+            "roomCount": 2,
+            "totalArea": 61.28312500000001,
+            "areas": [
+              48.464,
+              12.819
+            ]
+          },
+          {
+            "cut": 1.831,
+            "roomCount": 1,
+            "totalArea": 61.33000000000001,
+            "areas": [
+              61.33
+            ]
+          },
+          {
+            "cut": 1.781,
+            "roomCount": 1,
+            "totalArea": 61.36937500000001,
+            "areas": [
+              61.369
+            ]
+          },
+          {
+            "cut": 1.731,
+            "roomCount": 1,
+            "totalArea": 61.43375000000001,
+            "areas": [
+              61.434
+            ]
+          },
+          {
+            "cut": 1.681,
+            "roomCount": 1,
+            "totalArea": 61.49437500000001,
+            "areas": [
+              61.494
+            ]
+          },
+          {
+            "cut": 1.631,
+            "roomCount": 1,
+            "totalArea": 61.577500000000015,
+            "areas": [
+              61.578
+            ]
+          },
+          {
+            "cut": 1.581,
+            "roomCount": 1,
+            "totalArea": 61.610000000000014,
+            "areas": [
+              61.61
+            ]
+          },
+          {
+            "cut": 1.531,
+            "roomCount": 1,
+            "totalArea": 61.640000000000015,
+            "areas": [
+              61.64
+            ]
+          },
+          {
+            "cut": 1.481,
+            "roomCount": 1,
+            "totalArea": 61.70125000000001,
+            "areas": [
+              61.701
+            ]
+          },
+          {
+            "cut": 1.431,
+            "roomCount": 1,
+            "totalArea": 61.859375000000014,
+            "areas": [
+              61.859
+            ]
+          }
+        ]
+      },
+      "principalFrame": {
+        "enabled": true,
+        "thetaRad": 0.8916435255485657,
+        "thetaDeg": 51.087410844098
+      },
+      "rooms": [
+        {
+          "id": "scan_room_001",
+          "rasterAreaM2": 45.15375000000001,
+          "outlineAreaM2": 45.44312499999998,
+          "polygonAreaM2": 45.47781250000001,
+          "polygonPerimeterM": 47.579049437097325,
+          "polygonVertices": 66,
+          "heightM": 2.538653498211528,
+          "filledHoles": 862,
+          "filledHoleAreaM2": 1.8262500000000004,
+          "unfilledHoles": 1,
+          "largestHoleM2": 0.28937500000000005
+        },
+        {
+          "id": "scan_room_002",
+          "rasterAreaM2": 13.090000000000003,
+          "outlineAreaM2": 14.376249999999983,
+          "polygonAreaM2": 14.496562500000001,
+          "polygonPerimeterM": 15.275241260259317,
+          "polygonVertices": 4,
+          "heightM": 2.5586534982115277,
+          "filledHoles": 268,
+          "filledHoleAreaM2": 0.31187500000000007,
+          "unfilledHoles": 1,
+          "largestHoleM2": 1.2862500000000003
+        },
+        {
+          "id": "scan_room_003",
+          "rasterAreaM2": 4.665000000000001,
+          "outlineAreaM2": 4.664999999999993,
+          "polygonAreaM2": 4.6393749999999985,
+          "polygonPerimeterM": 8.72546389539553,
+          "polygonVertices": 4,
+          "heightM": 2.288653498211528,
+          "filledHoles": 2,
+          "filledHoleAreaM2": 0.0012500000000000002,
+          "unfilledHoles": 0,
+          "largestHoleM2": 0.0006250000000000001
+        }
+      ],
+      "wallChannels": [
+        {
+          "between": [
+            "scan_room_002",
+            "scan_room_001"
+          ],
+          "crossings": 230,
+          "thicknessM": 0.05,
+          "medianCrossingM": 0.07500000000000001
+        },
+        {
+          "between": [
+            "scan_room_003",
+            "scan_room_001"
+          ],
+          "crossings": 103,
+          "thicknessM": 0.05,
+          "medianCrossingM": 0.07500000000000001
+        },
+        {
+          "between": [
+            "scan_room_002",
+            "scan_room_003"
+          ],
+          "crossings": 76,
+          "thicknessM": 0.325,
+          "medianCrossingM": 0.325
+        }
+      ],
+      "emitted": {
+        "ifcBytes": 30026,
+        "spaceCount": 3,
+        "wallCount": 30,
+        "slabCount": 1,
+        "modalWallThicknessM": 0.05,
+        "slabThicknessNominalM": 0.2
+      },
+      "frameCheck": {
+        "maxCornerOffsetM": 0.11760008335113525,
+        "cornerOffsetsM": [
+          {
+            "axis": "x",
+            "minDelta": -0.006827354431152344,
+            "maxDelta": 0.021372318267822266
+          },
+          {
+            "axis": "y",
+            "minDelta": -0.00265347957611084,
+            "maxDelta": 0.11760008335113525
+          },
+          {
+            "axis": "z",
+            "minDelta": -0.007630348205566406,
+            "maxDelta": -0.00867462158203125
+          }
+        ]
+      },
+      "correspondence": [
+        {
+          "reference": "ref_space_A",
+          "assignedTo": "scan_room_001"
+        },
+        {
+          "reference": "ref_space_B",
+          "assignedTo": "scan_room_002"
+        },
+        {
+          "reference": "ref_space_C",
+          "assignedTo": "scan_room_003"
+        },
+        {
+          "reference": "ref_space_D",
+          "assignedTo": "scan_room_001"
+        }
+      ],
+      "perRoom": [
+        {
+          "room": "scan_room_001",
+          "mergedReferenceSpaces": 2,
+          "referenceLabels": [
+            "ref_space_A",
+            "ref_space_D"
+          ],
+          "quantities": {
+            "floorAreaM2": {
+              "generated": 45.477856344468655,
+              "reference": 45.781038319244786,
+              "deviation": -0.006622435530228747,
+              "deviationPercent": -0.6622435530228746,
+              "absDeviationPercent": 0.6622435530228746,
+              "withinBar": true
+            },
+            "clearHeightM": {
+              "generated": 2.538653612136841,
+              "reference": 2.4384000301361084,
+              "deviation": 0.04111449342261384,
+              "deviationPercent": 4.111449342261384,
+              "absDeviationPercent": 4.111449342261384,
+              "withinBar": true
+            },
+            "volumeM3": {
+              "generated": 115.45252428112565,
+              "reference": 110.67702212783476,
+              "deviation": 0.04314809037575172,
+              "deviationPercent": 4.314809037575172,
+              "absDeviationPercent": 4.314809037575172,
+              "withinBar": true,
+              "decomposition": {
+                "areaDeviation": -0.006622435530228747,
+                "heightDeviation": 0.04111449342261384,
+                "product": 0.03421977981033564
+              }
+            },
+            "lateralAreaM2": {
+              "generated": 120.7858895638785,
+              "reference": 101.98515097110557,
+              "deviation": 0.18434780371212625,
+              "deviationPercent": 18.434780371212625,
+              "absDeviationPercent": 18.434780371212625,
+              "withinBar": false
+            }
+          }
+        },
+        {
+          "room": "scan_room_002",
+          "mergedReferenceSpaces": 1,
+          "referenceLabels": [
+            "ref_space_B"
+          ],
+          "quantities": {
+            "floorAreaM2": {
+              "generated": 14.496512025904394,
+              "reference": 14.202596481499,
+              "deviation": 0.020694493770083703,
+              "deviationPercent": 2.0694493770083704,
+              "absDeviationPercent": 2.0694493770083704,
+              "withinBar": true
+            },
+            "clearHeightM": {
+              "generated": 2.5586535930633545,
+              "reference": 2.4384000301361084,
+              "deviation": 0.049316585236645394,
+              "deviationPercent": 4.93165852366454,
+              "absDeviationPercent": 4.93165852366454,
+              "withinBar": true
+            },
+            "volumeM3": {
+              "generated": 37.091552581966404,
+              "reference": 34.63060763636469,
+              "deviation": 0.07106271340782205,
+              "deviationPercent": 7.106271340782206,
+              "absDeviationPercent": 7.106271340782206,
+              "withinBar": false,
+              "decomposition": {
+                "areaDeviation": 0.020694493770083703,
+                "heightDeviation": 0.049316585236645394,
+                "product": 0.07103166077267087
+              }
+            },
+            "lateralAreaM2": {
+              "generated": 39.08398189380322,
+              "reference": 36.93400811734594,
+              "deviation": 0.058211222828197504,
+              "deviationPercent": 5.821122282819751,
+              "absDeviationPercent": 5.821122282819751,
+              "withinBar": false
+            }
+          }
+        },
+        {
+          "room": "scan_room_003",
+          "mergedReferenceSpaces": 1,
+          "referenceLabels": [
+            "ref_space_C"
+          ],
+          "quantities": {
+            "floorAreaM2": {
+              "generated": 4.639460518739128,
+              "reference": 4.583463275531415,
+              "deviation": 0.01221723396512231,
+              "deviationPercent": 1.221723396512231,
+              "absDeviationPercent": 1.221723396512231,
+              "withinBar": true
+            },
+            "clearHeightM": {
+              "generated": 2.288653612136841,
+              "reference": 2.314992666244507,
+              "deviation": -0.011377597213037613,
+              "deviationPercent": -1.1377597213037614,
+              "absDeviationPercent": 1.1377597213037614,
+              "withinBar": true
+            },
+            "volumeM3": {
+              "generated": 10.618118074578566,
+              "reference": 10.610683868856247,
+              "deviation": 0.0007006339849724005,
+              "deviationPercent": 0.07006339849724005,
+              "absDeviationPercent": 0.07006339849724005,
+              "withinBar": true,
+              "decomposition": {
+                "areaDeviation": 0.01221723396512231,
+                "heightDeviation": -0.011377597213037613,
+                "product": 0.0007006339849719989
+              }
+            },
+            "lateralAreaM2": {
+              "generated": 19.969736756909224,
+              "reference": 20.10201541618663,
+              "deviation": -0.006580368014785882,
+              "deviationPercent": -0.6580368014785882,
+              "absDeviationPercent": 0.6580368014785882,
+              "withinBar": true
+            }
+          }
+        }
+      ],
+      "totals": {
+        "floorAreaM2": {
+          "generated": 64.61382888911217,
+          "reference": 64.5670980762752,
+          "deviation": 0.0007237558172703508,
+          "deviationPercent": 0.07237558172703508,
+          "absDeviationPercent": 0.07237558172703508,
+          "withinBar": true
+        },
+        "volumeM3": {
+          "generated": 163.16219493767062,
+          "reference": 155.91831363305567,
+          "deviation": 0.04645946416315778,
+          "deviationPercent": 4.645946416315778,
+          "absDeviationPercent": 4.645946416315778,
+          "withinBar": true
+        },
+        "lateralAreaM2": {
+          "generated": 179.83960821459092,
+          "reference": 159.02117450463814,
+          "deviation": 0.13091611085632862,
+          "deviationPercent": 13.091611085632863,
+          "absDeviationPercent": 13.091611085632863,
+          "withinBar": false
+        },
+        "areaWeightedClearHeightM": {
+          "generated": 2.525190005651631,
+          "reference": 2.4296396376578975,
+          "deviation": 0.03932697117414553,
+          "deviationPercent": 3.932697117414553,
+          "absDeviationPercent": 3.932697117414553,
+          "withinBar": true
+        }
+      },
+      "verdict": {
+        "bar": 0.05,
+        "rowsTotal": 16,
+        "rowsWithinBar": 12,
+        "rowsOutsideBar": [
+          {
+            "scope": "model",
+            "quantity": "lateralAreaM2",
+            "deviationPercent": 13.091611085632863
+          },
+          {
+            "scope": "scan_room_001",
+            "quantity": "lateralAreaM2",
+            "deviationPercent": 18.434780371212625
+          },
+          {
+            "scope": "scan_room_002",
+            "quantity": "volumeM3",
+            "deviationPercent": 7.106271340782206
+          },
+          {
+            "scope": "scan_room_002",
+            "quantity": "lateralAreaM2",
+            "deviationPercent": 5.821122282819751
+          }
+        ],
+        "maxAbsDeviationPercent": 18.434780371212625,
+        "referenceSpaceCount": 4,
+        "generatedSpaceCount": 3,
+        "unassignedReferenceSpaces": 0
+      }
+    }
+  },
+  "derived": {
+    "referencePerimeterM": [
+      {
+        "label": "ref_space_A",
+        "perimeterM": 34.25546330126513
+      },
+      {
+        "label": "ref_space_B",
+        "perimeterM": 15.14682072706681
+      },
+      {
+        "label": "ref_space_C",
+        "perimeterM": 8.683403498118675
+      },
+      {
+        "label": "ref_space_D",
+        "perimeterM": 7.569155182443171
+      }
+    ],
+    "generatedPerimeterM": [
+      {
+        "id": "scan_room_001",
+        "perimeterM": 47.572973470290705
+      },
+      {
+        "id": "scan_room_002",
+        "perimeterM": 15.363510993794375
+      },
+      {
+        "id": "scan_room_003",
+        "perimeterM": 8.709724485550348
+      }
+    ],
+    "mergedReferencePerimeterM": 41.8246184837083,
+    "room001PerimeterExcessM": 5.748354986582406,
+    "room001PerimeterExcessPercent": 13.743950799746157,
+    "ceilingEvidenceRatio": 18.761290028541968,
+    "defaultedReferenceSpaceCount": 3,
+    "defaultedReferenceHeightM": 2.4384000301361084,
+    "eightFeetInMetres": 2.4384,
+    "scanMinusDefaultedHeightM": 0.0928101656168816,
+    "floorPlaneDepthBelowScanOriginM": 1.368653498211528,
+    "subsampleBytes": 83343840,
+    "derivedIntermediateBytes": 83396346
+  }
+}

--- a/scripts/moonshot/b55-scan-to-parametric/scorecard.json
+++ b/scripts/moonshot/b55-scan-to-parametric/scorecard.json
@@ -1,9 +1,9 @@
 {
   "bet": "B5.5 scan-to-parametric (M5 final)",
-  "generatedAt": "2026-08-01T06:43:52.242Z",
+  "generatedAt": "2026-08-02T06:42:52.386Z",
   "bar": 0.05,
-  "elapsedSeconds": 4.437,
-  "elapsedSecondsAfterIngest": 1.2850000000000001,
+  "elapsedSeconds": 4.896,
+  "elapsedSecondsAfterIngest": 1.29,
   "primaryVariant": "axisAligned",
   "scan": {
     "sourceBytes": 3939103744,
@@ -20,8 +20,8 @@
     ],
     "densityPerM3": 184807.48697576692,
     "densityPerPlanM2": 506007.5984146027,
-    "ingestSeconds": 3.152,
-    "megaPointsPerSecond": 22.034643401015227,
+    "ingestSeconds": 3.606,
+    "megaPointsPerSecond": 19.260453688297282,
     "planes": {
       "floor": {
         "z": -1.368653498211528,
@@ -439,12 +439,17 @@
         }
       ],
       "emitted": {
-        "ifcBytes": 30535,
+        "ifcBytes": 30056,
         "spaceCount": 3,
         "wallCount": 29,
         "slabCount": 1,
         "modalWallThicknessM": 0.07500000000000001,
-        "slabThicknessNominalM": 0.2
+        "slabThicknessNominalM": 0.2,
+        "worldBaseZByType": {
+          "IFCSPACE": -1.368653498211528,
+          "IFCWALL": -1.368653498211528,
+          "IFCSLAB": -1.5686534982115279
+        }
       },
       "frameCheck": {
         "maxCornerOffsetM": 0.11760008335113525,
@@ -469,19 +474,31 @@
       "correspondence": [
         {
           "reference": "ref_space_A",
-          "assignedTo": "scan_room_001"
+          "assignedTo": "scan_room_001",
+          "centroidSeparationM": 0.4046862716401687,
+          "boundaryClearanceM": 1.469468209444831,
+          "centroidAgrees": true
         },
         {
           "reference": "ref_space_B",
-          "assignedTo": "scan_room_002"
+          "assignedTo": "scan_room_002",
+          "centroidSeparationM": 0.004209933613335343,
+          "boundaryClearanceM": 1.7441757729165694,
+          "centroidAgrees": true
         },
         {
           "reference": "ref_space_C",
-          "assignedTo": "scan_room_003"
+          "assignedTo": "scan_room_003",
+          "centroidSeparationM": 0.005862630140345153,
+          "boundaryClearanceM": 0.9061401536403308,
+          "centroidAgrees": true
         },
         {
           "reference": "ref_space_D",
-          "assignedTo": "scan_room_001"
+          "assignedTo": "scan_room_001",
+          "centroidSeparationM": 0.09131006752432061,
+          "boundaryClearanceM": 0.38961198788329227,
+          "centroidAgrees": true
         }
       ],
       "perRoom": [
@@ -1011,12 +1028,17 @@
         }
       ],
       "emitted": {
-        "ifcBytes": 30026,
+        "ifcBytes": 29531,
         "spaceCount": 3,
         "wallCount": 30,
         "slabCount": 1,
         "modalWallThicknessM": 0.05,
-        "slabThicknessNominalM": 0.2
+        "slabThicknessNominalM": 0.2,
+        "worldBaseZByType": {
+          "IFCSPACE": -1.368653498211528,
+          "IFCWALL": -1.368653498211528,
+          "IFCSLAB": -1.5686534982115279
+        }
       },
       "frameCheck": {
         "maxCornerOffsetM": 0.11760008335113525,
@@ -1041,19 +1063,31 @@
       "correspondence": [
         {
           "reference": "ref_space_A",
-          "assignedTo": "scan_room_001"
+          "assignedTo": "scan_room_001",
+          "centroidSeparationM": 0.4046862716401687,
+          "boundaryClearanceM": 1.4577883744472546,
+          "centroidAgrees": true
         },
         {
           "reference": "ref_space_B",
-          "assignedTo": "scan_room_002"
+          "assignedTo": "scan_room_002",
+          "centroidSeparationM": 0.004209933613335343,
+          "boundaryClearanceM": 1.7268372197581607,
+          "centroidAgrees": true
         },
         {
           "reference": "ref_space_C",
-          "assignedTo": "scan_room_003"
+          "assignedTo": "scan_room_003",
+          "centroidSeparationM": 0.005862630140345153,
+          "boundaryClearanceM": 0.9063029267495071,
+          "centroidAgrees": true
         },
         {
           "reference": "ref_space_D",
-          "assignedTo": "scan_room_001"
+          "assignedTo": "scan_room_001",
+          "centroidSeparationM": 0.09131006752432061,
+          "boundaryClearanceM": 0.41271053943796254,
+          "centroidAgrees": true
         }
       ],
       "perRoom": [

--- a/scripts/moonshot/ci/b55-pipeline-regression.mjs
+++ b/scripts/moonshot/ci/b55-pipeline-regression.mjs
@@ -1,0 +1,390 @@
+#!/usr/bin/env node
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * B5.5 regression coverage: the scan-to-parametric pipeline on a SYNTHETIC
+ * two-room apartment whose every quantity is known in closed form.
+ *
+ * WHY SYNTHETIC. The bet's committed result comes off a 3.9 GB client scan
+ * that cannot be committed, fetched, or run in CI, so a fixture-backed gate on
+ * the real input is not available. What IS available is the property that
+ * makes the pipeline checkable at all: given a cloud whose rooms are known
+ * rectangles, every stage's output is an arithmetic consequence of those
+ * rectangles. This file builds such a cloud, runs the REAL stage scripts on
+ * it, and asserts the numbers -- not that the scripts exited 0.
+ *
+ * WHAT IS ASSERTED, and what each case would catch:
+ *
+ *  A  extract-rooms.mjs   floor/ceiling plane, room count, per-room area and
+ *                         clear height, and the measured wall-channel width.
+ *                         Catches: a broken plane fit, a lost or merged
+ *                         component, a raster/polygon area drift, a channel
+ *                         measurement that stops finding the partition.
+ *
+ *  B  generate-ifc.mjs    the emitted model's ABSOLUTE placement datum, read
+ *                         back out of the STEP. Catches the defect this file
+ *                         was written for: `addIfcWall`/`addIfcSlab` place
+ *                         relative to the storey while `addIfcSpace` places
+ *                         relative to the world, so handing the same Z to
+ *                         both puts the walls at 2x the storey elevation.
+ *                         The exam cannot see this -- it scores IfcSpace
+ *                         quantities, every one of which is invariant under a
+ *                         rigid Z shift of the walls.
+ *
+ *  B' negative control    the same check must REJECT a model built the old
+ *                         way. An assertion that cannot fail is not evidence,
+ *                         so the doubled-elevation model is rebuilt here
+ *                         through the same builder and required to be caught.
+ *
+ *  C  score.mjs           the scoring arithmetic against a reference model
+ *                         with DELIBERATE, known deviations placed either
+ *                         side of the 5% bar: the deviation percentages are
+ *                         checked against closed-form values and the verdict
+ *                         against the construction. Catches a sign error, a
+ *                         wrong denominator, a bar comparison that drifted to
+ *                         `<`, an unscored row silently counted as a pass, and
+ *                         a correspondence that stops resolving.
+ *
+ * Runtime is a few seconds: the cloud is ~0.4 M points and both scored models
+ * are a handful of extruded solids.
+ *
+ * Usage: node scripts/moonshot/ci/b55-pipeline-regression.mjs [--keep]
+ */
+
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { IfcCreator } from '../../../packages/create/dist/index.js';
+import { measureSpaces } from '../b55-scan-to-parametric/measure-ifc.mjs';
+import { assertCoherentStoreyDatum, worldBaseZByType }
+  from '../b55-scan-to-parametric/placement-check.mjs';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const BET = join(HERE, '../b55-scan-to-parametric');
+const KEEP = process.argv.includes('--keep');
+
+let failures = 0;
+const results = [];
+const fmt = (v) => (typeof v === 'number' ? (Number.isInteger(v) ? String(v) : v.toFixed(6)) : String(v));
+function check(name, ok, detail) {
+  results.push(`${ok ? 'PASS' : 'FAIL'}  ${name}${detail ? `  [${detail}]` : ''}`);
+  if (!ok) failures++;
+  return ok;
+}
+function near(name, got, want, tol, unit = '') {
+  return check(name, Number.isFinite(got) && Math.abs(got - want) <= tol,
+    `${fmt(got)}${unit} vs ${fmt(want)}${unit}, tol ${fmt(tol)}${unit}`);
+}
+
+// =========================================================== the synthetic ===
+/**
+ * Two rectangular rooms sharing one partition, in the same shape as the real
+ * apartment: a floor well below the local origin -- so a placement bug that
+ * doubles the elevation is visible rather than a no-op at z = 0 -- a partition
+ * that appears as an unscanned channel in plan, and a ceiling only over the
+ * rooms.
+ */
+const FLOOR_Z = -1.35;
+const CEILING_Z = 1.15;
+const CLEAR_H = CEILING_Z - FLOOR_Z;       // 2.50 m
+const PARTITION = 0.20;                     // m, the unscanned channel width
+/** Plan raster cell the extractor uses by default. Every plan-quantity
+ *  tolerance below is stated as a multiple of it, never fitted to an output:
+ *  a boundary is located to within one cell, so a channel measured between
+ *  two boundaries carries at most two cells of quantization. */
+const CELL = 0.025;
+const ROOM_A = { x0: 0.0, y0: 0.0, x1: 4.0, y1: 3.0 };
+const ROOM_B = { x0: 4.0 + PARTITION, y0: 0.0, x1: 4.0 + PARTITION + 2.5, y1: 3.0 };
+const AREA_A = (ROOM_A.x1 - ROOM_A.x0) * (ROOM_A.y1 - ROOM_A.y0);   // 12.00 m2
+const AREA_B = (ROOM_B.x1 - ROOM_B.x0) * (ROOM_B.y1 - ROOM_B.y0);   //  7.50 m2
+
+/** Point spacing: 12.5 mm puts >= 4 points in every 25 mm raster cell, which
+ *  is what the extractor's `--min-cell-points 2` needs on floor and ceiling. */
+const SPACING = 0.0125;
+const BIN = 0.01;
+const HALF = 16;
+
+/** Deviations built into the reference, and therefore assertable in closed
+ *  form. Room A lands inside the 5% bar, room B outside it. */
+const REF_AREA_SCALE_A = 0.98;
+const REF_HEIGHT_SCALE_B = 0.90;
+
+function buildCloud() {
+  const xyz = [];
+  for (const r of [ROOM_A, ROOM_B]) {
+    for (let x = r.x0; x <= r.x1 + 1e-9; x += SPACING) {
+      for (let y = r.y0; y <= r.y1 + 1e-9; y += SPACING) {
+        xyz.push(x, y, FLOOR_Z, x, y, CEILING_Z);
+      }
+    }
+  }
+  return Float32Array.from(xyz);
+}
+
+/** The `ingest.json` fields the later stages actually read: bbox and the 1 cm
+ *  z histogram. Built from the cloud itself, so it cannot disagree with it. */
+function buildIngest(pts) {
+  const n = pts.length / 3;
+  const min = [Infinity, Infinity, Infinity], max = [-Infinity, -Infinity, -Infinity];
+  const origin = -HALF;
+  const counts = new Array(Math.round((2 * HALF) / BIN)).fill(0);
+  for (let i = 0; i < n; i++) {
+    for (let a = 0; a < 3; a++) {
+      const v = pts[i * 3 + a];
+      if (v < min[a]) min[a] = v;
+      if (v > max[a]) max[a] = v;
+    }
+    const b = Math.round((pts[i * 3 + 2] - origin) / BIN);
+    if (b >= 0 && b < counts.length) counts[b]++;
+  }
+  return {
+    sourceBytes: 0, decodedPointCount: n, keptPointCount: n, stride: 1,
+    hasColor: false, hasIntensity: false, nonFinite: 0, elapsedMs: 0, megaPointsPerSecond: 0,
+    bbox: { min, max, extent: [max[0] - min[0], max[1] - min[1], max[2] - min[2]] },
+    densityPerM3: 0, densityPerPlanM2: 0,
+    histograms: { z: { origin, binSize: BIN, counts } },
+  };
+}
+
+/**
+ * A reference model whose spaces deviate from the generated ones by EXACTLY
+ * the factors case C asserts.
+ *
+ * The scales are applied to what the generated model MEASURES, not to the
+ * nominal rectangles the cloud was built from: the extraction's plan raster
+ * over-reads a room by up to half a cell all round, so a reference derived
+ * from the nominal rectangle would carry that quantization into the deviation
+ * and case C would be asserting the raster's bias rather than the scorer's
+ * arithmetic. Deriving it from the measurement makes the expected deviation
+ * `1/scale - 1` to meshing precision, which is what a scoring test wants.
+ *
+ * Each reference space is a rectangle centred on its generated room's plan
+ * centroid, so the containment test that decides correspondence resolves the
+ * way the construction intends.
+ */
+function writeReference(path, specs) {
+  const creator = new IfcCreator({ Name: 'B5.5 regression reference' });
+  const storey = creator.addIfcBuildingStorey({ Name: 'Storey 0', Elevation: FLOOR_Z });
+  for (const s of specs) {
+    const half = Math.sqrt(s.targetAreaM2) / 2;   // square, so its own area is exact
+    creator.addIfcSpace(storey, {
+      Position: [0, 0, FLOOR_Z],
+      Profile: [
+        [s.centroid[0] - half, s.centroid[1] - half], [s.centroid[0] + half, s.centroid[1] - half],
+        [s.centroid[0] + half, s.centroid[1] + half], [s.centroid[0] - half, s.centroid[1] + half],
+      ],
+      Height: s.targetHeightM,
+      Name: 'reference space',
+    });
+  }
+  writeFileSync(path, creator.toIfc().content);
+}
+
+/**
+ * The model as the REVIEWED revision built it: the storey carries the floor
+ * elevation and the wall and slab coordinates carry it a second time. Used
+ * only as the negative control for the datum check.
+ */
+function buildDoubledElevationModel(floorZ, slabThickness) {
+  const creator = new IfcCreator({ Name: 'B5.5 negative control' });
+  const storey = creator.addIfcBuildingStorey({ Name: 'Storey 0', Elevation: floorZ });
+  creator.addIfcSpace(storey, {
+    Position: [0, 0, floorZ],
+    Profile: [[0, 0], [4, 0], [4, 3], [0, 3]],
+    Height: CLEAR_H,
+    Name: 'scan_room_001',
+  });
+  creator.addIfcWall(storey, {
+    Start: [0, 0, floorZ], End: [4, 0, floorZ], Thickness: 0.1, Height: CLEAR_H, Name: 'w',
+  });
+  creator.addIfcSlab(storey, {
+    Position: [0, 0, floorZ - slabThickness], Thickness: slabThickness, Width: 4, Depth: 3, Name: 's',
+  });
+  return creator.toIfc().content;
+}
+
+// ===================================================================== run ===
+const WORK = mkdtempSync(join(tmpdir(), 'b55-regression-'));
+const node = process.execPath;
+const runStage = (script, args) =>
+  execFileSync(node, [join(BET, script), ...args], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'], maxBuffer: 64 * 1024 * 1024 });
+
+try {
+  const pts = buildCloud();
+  writeFileSync(join(WORK, 'sub.f32'), Buffer.from(pts.buffer, pts.byteOffset, pts.byteLength));
+  writeFileSync(join(WORK, 'ingest.json'), JSON.stringify(buildIngest(pts)));
+
+  // ------------------------------------------------------------- case A ---
+  runStage('extract-rooms.mjs', [WORK]);
+  const rooms = JSON.parse(readFileSync(join(WORK, 'rooms.json'), 'utf8'));
+  const floorZ = rooms.planes.floor.z;
+
+  near('A1 fitted floor plane', floorZ, FLOOR_Z, 0.005, ' m');
+  near('A2 fitted ceiling plane', rooms.planes.ceiling.z, CEILING_Z, 0.005, ' m');
+  near('A3 clear height', rooms.planes.clearHeightM, CLEAR_H, 0.01, ' m');
+  check('A4 room count', rooms.rooms.length === 2, `${rooms.rooms.length} rooms, expected 2`);
+
+  if (rooms.rooms.length === 2) {
+    const [big, small] = [...rooms.rooms].sort((a, b) => b.polygonAreaM2 - a.polygonAreaM2);
+    // The raster over-reads by up to half a cell all round; on a 4 x 3 m room
+    // that is under 2%. The tolerance is stated, not fitted to the output.
+    near('A5 larger room polygon area', big.polygonAreaM2, AREA_A, AREA_A * 0.03, ' m2');
+    near('A6 smaller room polygon area', small.polygonAreaM2, AREA_B, AREA_B * 0.03, ' m2');
+    near('A7 larger room clear height', big.heightM, CLEAR_H, 0.02, ' m');
+    near('A8 smaller room clear height', small.heightM, CLEAR_H, 0.02, ' m');
+  } else {
+    check('A5-A8 per-room quantities', false, 'skipped: room count wrong');
+  }
+
+  // The partition is never scanned, so it reads as an empty channel exactly
+  // one partition wide, to within a raster cell either side.
+  check('A9 exactly one wall channel found', rooms.wallChannels.length === 1, `${rooms.wallChannels.length} channels`);
+  if (rooms.wallChannels[0]) {
+    near('A10 measured partition thickness', rooms.wallChannels[0].thicknessM, PARTITION, 2 * CELL, ' m');
+  }
+
+  // ------------------------------------------------------------- case B ---
+  const genPath = join(WORK, 'generated.ifc');
+  runStage('generate-ifc.mjs', [WORK, genPath]);
+  const emitted = JSON.parse(readFileSync(join(WORK, 'emitted.json'), 'utf8'));
+  const genText = readFileSync(genPath, 'utf8');
+  const slabT = emitted.slabThicknessNominalM;
+
+  const baseZ = worldBaseZByType(genText, ['IFCBUILDINGSTOREY', 'IFCSPACE', 'IFCWALL', 'IFCSLAB']);
+  const zsOf = (t) => (baseZ.get(t) ?? []).map((e) => e.worldZ);
+  const allNear = (list, want) => list.length > 0 && list.every((z) => Math.abs(z - want) <= 1e-6);
+  const show = (t) => `${[...new Set(zsOf(t).map(fmt))].join(', ') || 'none'} (n=${zsOf(t).length})`;
+
+  check('B1 storey elevation is the fitted floor plane', allNear(zsOf('IFCBUILDINGSTOREY'), floorZ), `${show('IFCBUILDINGSTOREY')} vs ${fmt(floorZ)}`);
+  check('B2 spaces stand ON the floor plane', allNear(zsOf('IFCSPACE'), floorZ), `${show('IFCSPACE')} vs ${fmt(floorZ)}`);
+  check('B3 walls stand ON the floor plane, not at 2x the elevation', allNear(zsOf('IFCWALL'), floorZ), `${show('IFCWALL')} vs ${fmt(floorZ)}`);
+  check('B4 slab hangs below the floor plane by its own thickness', allNear(zsOf('IFCSLAB'), floorZ - slabT), `${show('IFCSLAB')} vs ${fmt(floorZ - slabT)}`);
+  check('B5 the model has spaces, walls and a slab',
+    zsOf('IFCSPACE').length === 2 && zsOf('IFCWALL').length > 0 && zsOf('IFCSLAB').length === 1,
+    `${zsOf('IFCSPACE').length} spaces / ${zsOf('IFCWALL').length} walls / ${zsOf('IFCSLAB').length} slabs`);
+
+  // ------------------------------------------------------------ case B' ---
+  let caught = null;
+  try {
+    assertCoherentStoreyDatum(buildDoubledElevationModel(floorZ, slabT), { elevationM: floorZ, slabThicknessM: slabT });
+  } catch (e) { caught = String(e.message); }
+  check("B' the datum check REJECTS a doubled storey elevation",
+    caught !== null && /IFCWALL .* base world Z/.test(caught) && /IFCSLAB .* base world Z/.test(caught),
+    caught ? caught.split('\n').slice(1, 3).map((s) => s.trim()).join(' | ') : 'the doubled model was ACCEPTED');
+  // ...and must still accept the real one, so B' is not passing by rejecting
+  // everything it is handed.
+  let acceptedGood = true;
+  try { assertCoherentStoreyDatum(genText, { elevationM: floorZ, slabThicknessM: slabT }); }
+  catch (e) { acceptedGood = false; results.push(`      (control detail: ${String(e.message).split('\n')[1]?.trim()})`); }
+  check("B'' the same check ACCEPTS the corrected model", acceptedGood);
+
+  // ------------------------------------------------------------- case C ---
+  // Measure the generated model with the bet's own measurement code, then
+  // build the reference off that measurement, one scale per room.
+  const genMeasured = measureSpaces(genPath).spaces;   // sorted by floor area, descending
+  check('C0 the generated model measures two spaces', genMeasured.length === 2, `${genMeasured.length} spaces`);
+  const scaleOf = [
+    { areaScale: REF_AREA_SCALE_A, heightScale: 1 },                  // largest room
+    { areaScale: 1, heightScale: REF_HEIGHT_SCALE_B },                // the other one
+  ];
+  const specs = genMeasured.map((s, i) => {
+    const room = rooms.rooms.find((r) => r.id === s.name);
+    if (!room) throw new Error(`generated space ${s.name} is not in rooms.json`);
+    return {
+      roomId: room.id,
+      centroid: room.centroid,
+      targetAreaM2: s.floorArea * scaleOf[i].areaScale,
+      targetHeightM: s.height * scaleOf[i].heightScale,
+      ...scaleOf[i],
+    };
+  });
+  const refPath = join(WORK, 'reference.ifc');
+  writeReference(refPath, specs);
+  const cardPath = join(WORK, 'card.json');
+  runStage('score.mjs', [WORK, refPath, genPath, cardPath]);
+  const card = JSON.parse(readFileSync(cardPath, 'utf8'));
+
+  check('C1 every reference space is assigned to a room', card.verdict.unassignedReferenceSpaces === 0, `${card.verdict.unassignedReferenceSpaces} unassigned`);
+  check('C2 no unscored rows', card.verdict.rowsUnscored.length === 0, JSON.stringify(card.verdict.rowsUnscored));
+  check('C3 every row scored', card.verdict.rowsScored === card.verdict.rowsTotal && card.verdict.rowsTotal === 12,
+    `${card.verdict.rowsScored}/${card.verdict.rowsTotal}, expected 12/12 (4 totals + 2 rooms x 4)`);
+
+  const q = (room, name) => card.perRoom.find((r) => r.room === room)?.quantities[name];
+  // The correspondence must land each reference space on the room its
+  // rectangle was centred in -- checked here rather than assumed, because
+  // every deviation below is read through it.
+  const assignedRooms = card.correspondence.map((c) => c.assignedTo);
+  check('C4 correspondence resolved to distinct rooms, one per reference space',
+    assignedRooms.length === specs.length && new Set(assignedRooms).size === specs.length && assignedRooms.every(Boolean),
+    JSON.stringify(assignedRooms));
+
+  /** A reference scaled by `s` must read as `1/s - 1`: the deviation is
+   *  generated-over-reference. Tolerance is meshing/serialization noise. */
+  const expected = (s) => (1 / s - 1) * 100;
+  const TOL = 0.02;   // percentage points
+  for (const spec of specs) {
+    const assigned = card.correspondence.filter((c) => c.assignedTo === spec.roomId);
+    if (assigned.length !== 1) { check(`C5 ${spec.roomId} has exactly one reference space`, false, `${assigned.length}`); continue; }
+    const tag = `${spec.roomId} (area x${spec.areaScale}, height x${spec.heightScale})`;
+    near(`C5 ${tag} floorArea deviation`, q(spec.roomId, 'floorAreaM2').deviationPercent, expected(spec.areaScale), TOL, '%');
+    near(`C6 ${tag} clearHeight deviation`, q(spec.roomId, 'clearHeightM').deviationPercent, expected(spec.heightScale), TOL, '%');
+    near(`C7 ${tag} volume deviation`, q(spec.roomId, 'volumeM3').deviationPercent,
+      expected(spec.areaScale * spec.heightScale), TOL, '%');
+    // The decomposition the scorer records must reconstruct its own volume row.
+    near(`C8 ${tag} volume decomposition reconstructs its row`,
+      q(spec.roomId, 'volumeM3').decomposition.product * 100, q(spec.roomId, 'volumeM3').deviationPercent, 1e-9, '%');
+    // And the bar must fall where the construction put it: 1/0.98 - 1 is
+    // inside 5%, 1/0.90 - 1 is outside it.
+    const inside = Math.abs(expected(spec.areaScale * spec.heightScale)) <= 5;
+    check(`C9 ${tag} volume lands ${inside ? 'INSIDE' : 'OUTSIDE'} the 5% bar`,
+      q(spec.roomId, 'volumeM3').withinBar === inside, `${fmt(q(spec.roomId, 'volumeM3').deviationPercent)}%`);
+  }
+
+  // The totals are a SECOND, independent route to the same reference numbers:
+  // a per-room row that is right while the total is wrong means the
+  // aggregation is broken, not the deviation.
+  const refFloor = card.referenceSpaces.reduce((a, s) => a + s.floorAreaM2, 0);
+  const genFloor = card.generatedSpaces.reduce((a, s) => a + s.floorAreaM2, 0);
+  near('C15 total floorArea deviation is its own rows aggregated',
+    card.totals.floorAreaM2.deviationPercent, ((genFloor - refFloor) / refFloor) * 100, 1e-9, '%');
+
+  // The headline reduction: the maximum must be the maximum of the rows it
+  // reduces, over the SCORED rows only.
+  const scored = [
+    ...Object.values(card.totals),
+    ...card.perRoom.flatMap((r) => Object.values(r.quantities)),
+  ].filter((r) => r.withinBar !== null);
+  near('C16 maxAbsDeviationPercent is the max over the scored rows',
+    card.verdict.maxAbsDeviationPercent, Math.max(...scored.map((r) => Math.abs(r.deviationPercent))), 1e-9, '%');
+  check('C17 rowsWithinBar counts exactly the rows flagged withinBar',
+    card.verdict.rowsWithinBar === scored.filter((r) => r.withinBar).length,
+    `${card.verdict.rowsWithinBar} vs ${scored.filter((r) => r.withinBar).length}`);
+} catch (e) {
+  /**
+   * A stage that THROWS is a failure of this suite, not a crash of it: the
+   * pipeline's own fail-closed guards (the empty-extraction refusal, the
+   * placement datum check) surface here, and they must be reported as a red
+   * check with the rest rather than as an unhandled rejection that scrolls
+   * the passing lines off the top of a CI log.
+   */
+  const msg = String(e?.stderr || e?.message || e);
+  const informative = msg.split('\n')
+    .map((l) => l.trim())
+    .filter((l) => l && !/^at\s/.test(l) && !/^Node\.js v/.test(l));
+  check('stage completed', false, informative.slice(0, 4).join(' | ').slice(0, 600) || msg.slice(0, 300));
+} finally {
+  if (KEEP) process.stderr.write(`kept work dir: ${WORK}\n`);
+  else rmSync(WORK, { recursive: true, force: true });
+}
+
+for (const line of results) console.log(line);
+console.log(`\n${results.filter((l) => l.startsWith('PASS')).length}/${results.filter((l) => /^(PASS|FAIL)/.test(l)).length} checks passed`);
+if (failures) {
+  console.error(`::error::B5.5 pipeline regression: ${failures} check(s) failed.`);
+  process.exit(1);
+}


### PR DESCRIPTION
Bet B5.5, **the unbuilt M5 final** — one of the two bets whose absence made Phase 4 a failed phase, and the one the plan calls "the highest-variance bet in the program and the one whose success would be least deniable."

Scored on a real **69,453,196-point** E57 capture of a furnished, occupied dwelling against a manually modelled reference of the same apartment.

## Exam: 12 of 16 rows inside 5%

| Scope | Quantity | Dev |
|---|---|---|
| model | floor area | **+0.25%** |
| model | volume | **+4.83%** |
| model | clear height (area-weighted) | **+3.93%** |
| model | bounding wall surface | +13.20% FAIL |
| room_003 | area / height / volume / wall surface | +1.55% / −1.14% / +0.39% / −0.84% |

Floor area, height and volume meet the bar model-wide; one room meets all four.

## Method, and what it deliberately is not

Not RANSAC-everything — that becomes plane classification, which is a research field. Fit only the floor and ceiling planes, then take **rooms as connected components of ceiling visibility in plan**: a wall's own footprint is never scanned, and doorways do not leak because a doorway has a lintel above it. The one load-bearing threshold comes from a finest-stable-segmentation sweep over 23 cuts, not a hand-set constant. It found a genuinely dropped ceiling without being told to look.

Output is real IFC via `@ifc-lite/create` (3 `IfcSpace` + 29 `IfcWall` + 1 `IfcSlab`), meshed by the production kernel. **The reference goes through the identical kernel call and identical quantity reducer** — neither file's stored quantities are read.

## The obstruction

All four failures are perimeter-driven, from two separable causes: the extraction found 3 rooms where the reference has 4 (the smallest, 2.42 m², never separates and is scored honestly as a merge), and ~5.75 m of ragged boundary local to the one room whose ceiling was barely captured. The other two rooms' perimeters land within 1.5%, so the machinery is sound. The obvious excuse was tested and **refuted**: rasterizing in the building's own frame (51.087°) cleaned the outlines dramatically and moved the verdict 13.20% → 13.09%, i.e. not at all. Closing it needs line-fitting the wall channels — a day or two, not a research programme.

## The finding worth escalating

**The reference model's space heights are an authoring-tool default, and the scan proves it.** Three of its four spaces are exactly 2.4384 m (8 ft). Counting scan points within ±1 cm of each modelled ceiling, those three sit *below* the empty-air background, while the scan's own fitted ceiling carries **18.76× more** evidence. The one space whose height the modeller actually measured is the room where this pipeline lands inside 1.6% on every quantity. On height, **the scan-derived model is closer to the building than the reference is**, by 0.093 m. Section 1 still scores against the reference as it is.

## Anti-tuning, since this is the easiest bet in the program to fake

Wall thickness was measured and deliberately **not** bias-corrected — correcting after seeing the reference's thickness set is the move this bet must refuse. The principal-frame variant made the score marginally **worse** and was kept; that is what an honest non-tuning change looks like. Ordering is disclosed in full: the reference's quantities were parsed before the pipeline was finalised (unavoidable), with structural mitigation — ingest/extract/generate never read the reference, and no threshold was chosen by watching a deviation.

## Not done, stated plainly

The bet's second clause (a world-model scene with a bill of quantities) **was not attempted at all**. No openings. Single storey. Areas are ceiling-derived. Registration was verified unnecessary rather than assumed (max corner offset 0.118 m, no transform) — a gift from this pairing that would not generalise.

## Privacy

Both sources carry a real site location. No source file, generated IFC, room polygon or string from either is committed; the scorecard holds derived scalars only, enforced by `run.mjs::assertNoIdentifiers`, which **fired twice during development and caught both leaks**.

Also converts two `docs/vision` markers to negative bindings: this bet's numbers coincidentally satisfied them through the union haystack, which would have let a speedup **ratio** read as backed by a slab thickness in **metres**. Deleting them, which the checker advises, would have been wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a scan-to-parametric workflow that converts point-cloud scans into room geometry and IFC models.
  - Added quantity measurement and comparison against reference models, including room dimensions, areas, volumes, and placement validation.
  - Added privacy safeguards that restrict generated results to neutral labels and non-identifying metrics.

- **Bug Fixes**
  - Empty or invalid scan/model inputs now fail with clear validation errors.
  - Added checks for incorrect placement elevations and invalid room correspondences.

- **Documentation**
  - Added a detailed report covering results, limitations, reproducibility, and privacy considerations.

- **Tests**
  - Added automated regression coverage for extraction, generation, scoring, and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->