### PR TITLE
fix(provenance): bind storey containment and opening hosting into the DAG (F1/F2/F3)

### DIFF
--- a/packages/provenance/src/merge-model.ts
+++ b/packages/provenance/src/merge-model.ts
@@ -100,13 +100,23 @@
  * B4.2 headline to switching them is measured and published rather than
  * argued. See `merge-battery.ts`'s `runDerivedCutSensitivity`.
  *
- * Wire format: nothing here changes node-hash-v0 serialization. Hosting lives
- * in the model state and in {@link canonicalStateBytes}; the cut is recorded
- * inside the existing `GeometryMeshPayload` vertex arrays, so the frozen
- * `geometry-mesh` encoding hashes it unchanged (a different cut is a
- * different mesh, which is correct). A v1 spec would model hosting as its own
- * `IfcRelVoidsElement` `relationship` node; that is a spec question, not a
- * change this module is allowed to make.
+ * Wire format: nothing here changes node-hash-v0 serialization. The cut is
+ * recorded inside the existing `GeometryMeshPayload` vertex arrays, so the
+ * frozen `geometry-mesh` encoding hashes it unchanged (a different cut is a
+ * different mesh, which is correct).
+ *
+ * Hosting lives in the model state, in {@link canonicalStateBytes}, AND in
+ * the DAG: {@link buildStateDag} emits one `IfcRelVoidsElement`
+ * `relationship` node per hosted element, carrying both of that
+ * relationship's singular EXPRESS roles. An earlier draft of this module
+ * deferred that to "a v1 spec question"; it is not one. node-hash-v0 already
+ * has a `relationship` kind, the frozen golden vector `rel-voids` already
+ * pins this exact two-role shape, and the spec names both roles -- so
+ * omitting the node was a PRODUCER bug, not a format limitation. Leaving it
+ * out meant `hostId` moved `canonicalStateBytes` but not the Merkle root, so
+ * two genuinely different buildings (same opening, different host) committed
+ * to the same root and a commutation certificate issued over one verified
+ * against the other.
  */
 
 import { ProvenanceDag, type AnyNodeSpec } from './dag-engine.js';
@@ -712,19 +722,61 @@ export function canonicalStateBytes(state: ModelState): string {
 /* DAG construction and Merkle root                                      */
 /* ------------------------------------------------------------------ */
 
-function storeyNodeId(storeyId: string): string {
+function storeyRelNodeId(storeyId: string): string {
   return `storey-rel:${storeyId}`;
+}
+
+/** The storey ITSELF as a DAG node (an `IfcBuildingStorey` is an ordinary IFC
+ *  product), so the containment relationship's `RelatingStructure` role has a
+ *  real child hash to reference. Without it the relationship node commits to
+ *  the elements it contains but not to WHICH storey contains them, and the
+ *  root layer -- which sorts its children -- cannot tell "move e from L0 to
+ *  L1" apart from "do nothing". */
+function storeyEntityNodeId(storeyId: string): string {
+  return `storey:${storeyId}`;
+}
+
+/** One `IfcRelVoidsElement` node per hosted entity. Both of that
+ *  relationship's IFC roles are SINGULAR, so one node per opening is exactly
+ *  the IFC cardinality. */
+function voidsRelNodeId(openingEntityId: string): string {
+  return `voids-rel:${openingEntityId}`;
 }
 
 export const MERGE_MODEL_ROOT_NODE_ID = 'root';
 
 /**
  * Build the (unhashed) node-hash-v0 DAG for a state: mesh/pset leaves ->
- * element nodes -> one `relationship` node per storey -> one root `layer`
- * node. Same shape and kinds as g1/g2 and the fixed test fixture, so
- * footprint.ts's container-kind crux rule applies unchanged. Call
- * `await dag.build()` to hash it; structure-only uses (footprints) don't
- * need to.
+ * element nodes -> one `relationship` node per storey (plus one
+ * `IfcRelVoidsElement` node per hosted element) -> one root `layer` node.
+ * Same shape and kinds as g1/g2 and the fixed test fixture, so footprint.ts's
+ * container-kind crux rule applies unchanged. Call `await dag.build()` to
+ * hash it; structure-only uses (footprints) don't need to.
+ *
+ * Two bindings this DAG commits to that a naive fan-in would drop:
+ *
+ * - **Which storey.** Each containment relationship carries BOTH of
+ *   `IfcRelContainedInSpatialStructure`'s EXPRESS roles (spec §3.2.1, golden
+ *   vector `rel-contained-many`): `RelatingStructure` (the storey's own node
+ *   hash) and `RelatedElements`. Emitting only `RelatedElements` makes every
+ *   storey node a bare set-of-children hash, so two storeys that swap their
+ *   contents swap their node hashes -- and the root `layer`, which sorts its
+ *   children, comes out IDENTICAL even though the model genuinely changed.
+ * - **Which host.** {@link EntityState.hostId} becomes a real
+ *   `IfcRelVoidsElement` node (both roles singular, per the schema), hung off
+ *   the root layer. Without it, "this opening is cut into wall A" and "into
+ *   wall B" -- two different, both spatially valid buildings -- hash to the
+ *   same root. Under LAZY cut semantics that is a genuine second preimage:
+ *   the host meshes are identical, so nothing else in the DAG separates them.
+ *   (Under DERIVED semantics the re-cut host mesh usually separates them
+ *   anyway, but "usually" is not a commitment, and the cut-semantics knob is
+ *   configurable per {@link MergeSemantics}.)
+ *
+ * Both additions are content, not format: the node kinds, role names and
+ * encodings are exactly the ones node-hash-v0 already froze, and the
+ * `rel-voids` / `rel-contained-many` golden vectors already pin both shapes.
+ * This is a producer fix, NOT the v0 -> v1 spec change an earlier draft of
+ * this module assumed it would need.
  */
 export function buildStateDag(state: ModelState): ProvenanceDag {
   const dag = new ProvenanceDag();
@@ -765,27 +817,67 @@ export function buildStateDag(state: ModelState): ProvenanceDag {
     });
   }
 
-  for (const storeyId of state.storeyIds) {
-    const elementIds = elementsByStorey.get(storeyId) as string[];
+  // One IfcRelVoidsElement per hosted entity, both roles singular per the
+  // schema. Hung off the root layer: the opening's own element node cannot
+  // carry it as a component (the relationship references that very node, and
+  // the DAG is acyclic), and the host's cannot either without inverting the
+  // same edge.
+  const voidsRelNodeIds: string[] = [];
+  for (const entityId of entityIds) {
+    const entity = state.entities.get(entityId) as EntityState;
+    if (entity.hostId === undefined) continue;
+    if (!state.entities.has(entity.hostId)) {
+      throw new Error(
+        `@ifc-lite/provenance: buildStateDag: entity "${entityId}" references unknown host "${entity.hostId}"`,
+      );
+    }
+    const nodeId = voidsRelNodeId(entityId);
+    const hostId = entity.hostId;
+    voidsRelNodeIds.push(nodeId);
     specs.push({
-      id: storeyNodeId(storeyId),
+      id: nodeId,
       kind: 'relationship',
-      children: elementIds,
+      children: [hostId, entityId],
       buildPayload: (h): RelationshipPayload => ({
-        relType: 'IfcRelContainedInSpatialStructure',
-        roles: [{ roleName: 'RelatedElements', refs: elementIds.map((id) => h.get(id) as string) }],
+        relType: 'IfcRelVoidsElement',
+        roles: [
+          { roleName: 'RelatingBuildingElement', refs: [h.get(hostId) as string] },
+          { roleName: 'RelatedOpeningElement', refs: [h.get(entityId) as string] },
+        ],
       }),
     });
   }
 
-  const storeyNodeIds = state.storeyIds.map(storeyNodeId);
+  for (const storeyId of state.storeyIds) {
+    const elementIds = elementsByStorey.get(storeyId) as string[];
+    const storeyNode = storeyEntityNodeId(storeyId);
+    specs.push({
+      id: storeyNode,
+      kind: 'element',
+      payload: { key: storeyId, ifcType: 'IfcBuildingStorey', components: [] },
+    });
+    specs.push({
+      id: storeyRelNodeId(storeyId),
+      kind: 'relationship',
+      children: [storeyNode, ...elementIds],
+      buildPayload: (h): RelationshipPayload => ({
+        relType: 'IfcRelContainedInSpatialStructure',
+        roles: [
+          { roleName: 'RelatingStructure', refs: [h.get(storeyNode) as string] },
+          { roleName: 'RelatedElements', refs: elementIds.map((id) => h.get(id) as string) },
+        ],
+      }),
+    });
+  }
+
+  const rootChildIds = [...state.storeyIds.map(storeyRelNodeId), ...voidsRelNodeIds];
   specs.push({
     id: MERGE_MODEL_ROOT_NODE_ID,
     kind: 'layer',
-    children: storeyNodeIds,
+    children: rootChildIds,
     buildPayload: (h): LayerPayload => ({
       layerId: 'blake3:merge-model-v0-root',
-      childHashes: storeyNodeIds.map((id) => h.get(id) as string),
+      childHashes: rootChildIds.map((id) => h.get(id) as string),
     }),
   });
 

--- a/packages/provenance/src/merge-model.ts
+++ b/packages/provenance/src/merge-model.ts
@@ -745,6 +745,29 @@ function voidsRelNodeId(openingEntityId: string): string {
 
 export const MERGE_MODEL_ROOT_NODE_ID = 'root';
 
+/** Node-id prefixes {@link buildStateDag} MINTS. A caller-supplied entity,
+ *  pset or mesh id in one of these namespaces (or equal to the root id) would
+ *  collide with a synthetic node and surface as ProvenanceDag's generic
+ *  "duplicate node id" from deep inside the build. Checked up front so the
+ *  error names the actual problem, and so the reserved namespace is stated
+ *  once rather than implied by three separate template literals. */
+const RESERVED_NODE_ID_PREFIXES = ['storey:', 'storey-rel:', 'voids-rel:'] as const;
+
+function assertNotReserved(kind: string, nodeId: string): void {
+  if (nodeId === MERGE_MODEL_ROOT_NODE_ID) {
+    throw new Error(
+      `@ifc-lite/provenance: buildStateDag: ${kind} id "${nodeId}" is reserved (the root layer node)`,
+    );
+  }
+  for (const prefix of RESERVED_NODE_ID_PREFIXES) {
+    if (nodeId.startsWith(prefix)) {
+      throw new Error(
+        `@ifc-lite/provenance: buildStateDag: ${kind} id "${nodeId}" uses the reserved "${prefix}" namespace, which this builder mints for spatial-structure and voids nodes`,
+      );
+    }
+  }
+}
+
 /**
  * Build the (unhashed) node-hash-v0 DAG for a state: mesh/pset leaves ->
  * element nodes -> one `relationship` node per storey (plus one
@@ -787,6 +810,9 @@ export function buildStateDag(state: ModelState): ProvenanceDag {
   const entityIds = [...state.entities.keys()].sort();
   for (const entityId of entityIds) {
     const entity = state.entities.get(entityId) as EntityState;
+    assertNotReserved('entity', entityId);
+    for (const pid of entity.psets.keys()) assertNotReserved('property-set', pid);
+    for (const mid of entity.meshes.keys()) assertNotReserved('geometry-mesh', mid);
     const byStorey = elementsByStorey.get(entity.storeyId);
     if (!byStorey) {
       throw new Error(`@ifc-lite/provenance: buildStateDag: entity "${entityId}" references unknown storey "${entity.storeyId}"`);

--- a/packages/provenance/src/merge-model.ts
+++ b/packages/provenance/src/merge-model.ts
@@ -826,9 +826,20 @@ export function buildStateDag(state: ModelState): ProvenanceDag {
   for (const entityId of entityIds) {
     const entity = state.entities.get(entityId) as EntityState;
     if (entity.hostId === undefined) continue;
-    if (!state.entities.has(entity.hostId)) {
+    const host = state.entities.get(entity.hostId);
+    if (!host) {
       throw new Error(
         `@ifc-lite/provenance: buildStateDag: entity "${entityId}" references unknown host "${entity.hostId}"`,
+      );
+    }
+    // Same invariant applyOp enforces at entity-add time ("no nesting in
+    // v0"), re-checked here because buildStateDag is also called on
+    // directly-authored states (tests, fixtures) that never went through an
+    // op. A nested host would not break the DAG structurally -- it would
+    // silently commit to a model shape the op vocabulary cannot produce.
+    if (host.hostId !== undefined) {
+      throw new Error(
+        `@ifc-lite/provenance: buildStateDag: entity "${entityId}" is hosted in "${entity.hostId}", which is itself hosted (no nesting in v0)`,
       );
     }
     const nodeId = voidsRelNodeId(entityId);

--- a/packages/provenance/test/commutation.test.ts
+++ b/packages/provenance/test/commutation.test.ts
@@ -232,6 +232,14 @@ describe('verifyCommutationCertificate', () => {
 });
 
 /**
+ * Regression guard for PR #1933, finding F3 of the pre-freeze adversarial
+ * attack on node-hash-v0: a certificate verifying against a genuinely
+ * different base. F3 is the end-to-end consequence of F1 and F2 (the missing
+ * `RelatingStructure` / storey element node and the missing
+ * `IfcRelVoidsElement` node, guarded in merge-model.test.ts and
+ * merge-model-hosting.test.ts) -- it needs no separate producer fix and
+ * closes when those two do.
+ *
  * A certificate's only tie to the model it was issued for is `baseRootHash`,
  * so that root has to separate models that genuinely differ. These are the
  * end-to-end guards for that: a certificate issued over base B1 must be

--- a/packages/provenance/test/commutation.test.ts
+++ b/packages/provenance/test/commutation.test.ts
@@ -230,3 +230,48 @@ describe('verifyCommutationCertificate', () => {
     expect(unchecked).toEqual({ ok: true });
   });
 });
+
+/**
+ * A certificate's only tie to the model it was issued for is `baseRootHash`,
+ * so that root has to separate models that genuinely differ. These are the
+ * end-to-end guards for that: a certificate issued over base B1 must be
+ * REFUSED against a base B2 that differs only in a relationship -- which is
+ * exactly the case a root that ignores storey/host bindings cannot see.
+ */
+describe('a certificate binds to the base it was issued for', () => {
+  async function issueOver(base: ModelState) {
+    const outcome = await createCommutationCertificate({ base, opsA: [editA], opsB: [editB] });
+    expect(outcome.ok).toBe(true);
+    if (!outcome.ok) throw new Error(`expected a certificate, got ${outcome.reason}`);
+    return outcome.certificate;
+  }
+
+  async function expectRefused(certificate: CommutationCertificate, other: ModelState, self: ModelState) {
+    // The two bases are genuinely different models.
+    expect(canonicalStateBytes(other)).not.toBe(canonicalStateBytes(self));
+    const cross = await verifyCommutationCertificate(certificate, other, [editA], [editB]);
+    expect(cross.ok).toBe(false);
+    if (!cross.ok) expect(cross.reason).toBe('base-root-mismatch');
+    // Control: it still verifies against its own base.
+    expect(await verifyCommutationCertificate(certificate, self, [editA], [editB])).toEqual({ ok: true });
+  }
+
+  it('refuses a certificate issued over B1 against a B2 that differs only by storey containment', async () => {
+    const b1: ModelState = {
+      storeyIds: ['S0', 'S1'],
+      entities: new Map([
+        ['element:a', entity('a', 'S0', [0, 0, 0])],
+        ['element:b', entity('b', 'S1', [50, 50, 0])],
+      ]),
+    };
+    // Same elements, same bytes per element -- the two storeys swapped.
+    const b2: ModelState = {
+      storeyIds: ['S0', 'S1'],
+      entities: new Map([
+        ['element:a', entity('a', 'S1', [0, 0, 0])],
+        ['element:b', entity('b', 'S0', [50, 50, 0])],
+      ]),
+    };
+    await expectRefused(await issueOver(b1), b2, b1);
+  });
+});

--- a/packages/provenance/test/merge-model-hosting.test.ts
+++ b/packages/provenance/test/merge-model-hosting.test.ts
@@ -26,7 +26,7 @@ import {
   createCommutationCertificate,
   verifyCommutationCertificate,
 } from '../src/commutation.js';
-import type { GeometryMeshPayload } from '../src/node-hash.js';
+import { computeNodeHash, type GeometryMeshPayload } from '../src/node-hash.js';
 import {
   applyOp,
   buildStateDag,
@@ -453,13 +453,19 @@ describe('the ablation, at unit scale (G4 review item 6)', () => {
   });
 });
 
-describe('wire format: node-hash-v0 is untouched', () => {
-  it('hosting is NOT part of any node payload, so it cannot perturb a node hash', async () => {
-    // node-hash-v0 is frozen at 1.0.0 with golden vectors (PR #1886); B4.2 is
-    // allowed to change the OP MODEL, never the serialization. `hostId` lives
-    // in the model state and in the convergence oracle only -- a v1 spec would
-    // model it as an `IfcRelVoidsElement` relationship node, which is a spec
-    // question, not a change this package may make unilaterally.
+describe('wire format: node-hash-v0 is untouched, but the DAG binds hosting', () => {
+  it('hosting DOES move the root, via an IfcRelVoidsElement node in the frozen vocabulary', async () => {
+    // node-hash-v0 is frozen at 1.0.0 with golden vectors (PR #1886), and this
+    // change does not touch the serialization: `relationship` is an existing
+    // node kind, `RelatingBuildingElement`/`RelatedOpeningElement` are the
+    // schema's own singular role names, and the frozen golden vector
+    // `rel-voids` already pins this exact two-role shape. Emitting the node is
+    // therefore a PRODUCER obligation, not the v1 spec change an earlier draft
+    // of this file assumed. Leaving it out was a real defect: `hostId` moved
+    // canonicalStateBytes but not the Merkle root, so two genuinely different
+    // buildings committed to the same root -- and because commutation
+    // certificates bind to the base only through that root, a certificate
+    // issued over one verified `ok: true` against the other.
     const withHost = hostedState();
     const withoutHost: ModelState = {
       storeyIds: ['S0'],
@@ -468,9 +474,58 @@ describe('wire format: node-hash-v0 is untouched', () => {
         [VOID_ID, entity('void', 'IfcOpeningElement', tri(2, [0.4, 0.4, 0], 0.2))],
       ]),
     };
-    expect(await hashModelState(withHost)).toBe(await hashModelState(withoutHost));
-    // ...but the logical states differ, and the convergence oracle says so.
+    // The logical states differ -- the convergence oracle says so...
     expect(canonicalStateBytes(withHost)).not.toBe(canonicalStateBytes(withoutHost));
+    // ...and now the Merkle commitment says so too.
+    expect(await hashModelState(withHost)).not.toBe(await hashModelState(withoutHost));
+
+    // The node itself: one per hosted element, both roles singular.
+    const dag = buildStateDag(withHost);
+    expect(dag.getKind(`voids-rel:${VOID_ID}`)).toBe('relationship');
+    await dag.build();
+    const expected = await computeNodeHash('relationship', {
+      relType: 'IfcRelVoidsElement',
+      roles: [
+        { roleName: 'RelatingBuildingElement', refs: [dag.getHash(HOST_ID) as string] },
+        { roleName: 'RelatedOpeningElement', refs: [dag.getHash(VOID_ID) as string] },
+      ],
+    });
+    expect(dag.getHash(`voids-rel:${VOID_ID}`)).toBe(expected);
+  });
+
+  it('re-hosting one opening between two coincident walls moves the root', async () => {
+    // The reachable second preimage the G4 review constructed. Both walls are
+    // legal hosts for the same opening, both states are spatially valid, and
+    // under LAZY cut semantics the host meshes are byte-identical -- so the
+    // IfcRelVoidsElement node is the ONLY thing separating them.
+    const twoWalls = (host: string): ModelState => ({
+      storeyIds: ['S0'],
+      entities: new Map([
+        ['element:wallA', entity('wallA', 'IfcWall', tri(1, [0, 0, 0], 1))],
+        ['element:wallB', entity('wallB', 'IfcWall', tri(2, [0, 0, 0], 1))],
+        [VOID_ID, entity('void', 'IfcOpeningElement', tri(3, [0.4, 0.4, 0], 0.2), host)],
+      ]),
+    });
+    const inA = twoWalls('element:wallA');
+    const inB = twoWalls('element:wallB');
+    expect(canonicalStateBytes(inA)).not.toBe(canonicalStateBytes(inB));
+    expect(await hashModelState(inA)).not.toBe(await hashModelState(inB));
+
+    // ...and a certificate issued over one is REFUSED against the other.
+    const edit: MergeOp = {
+      opId: 'a0',
+      type: 'attr-set',
+      psetNodeId: 'pset:wallA',
+      property: 'FireRating',
+      value: 'EI60',
+    };
+    const outcome = await createCommutationCertificate({ base: inA, opsA: [edit], opsB: [] });
+    expect(outcome.ok).toBe(true);
+    if (!outcome.ok) return;
+    const cross = await verifyCommutationCertificate(outcome.certificate, inB, [edit], []);
+    expect(cross.ok).toBe(false);
+    if (!cross.ok) expect(cross.reason).toBe('base-root-mismatch');
+    expect(await verifyCommutationCertificate(outcome.certificate, inA, [edit], [])).toEqual({ ok: true });
   });
 
   it('a re-cut DOES change the host mesh hash, through the existing geometry-mesh encoding', async () => {

--- a/packages/provenance/test/merge-model-hosting.test.ts
+++ b/packages/provenance/test/merge-model-hosting.test.ts
@@ -494,7 +494,11 @@ describe('wire format: node-hash-v0 is untouched, but the DAG binds hosting', ()
   });
 
   it('re-hosting one opening between two coincident walls moves the root', async () => {
-    // The reachable second preimage the G4 review constructed. Both walls are
+    // The reachable second preimage (F2, PR #1933): the construction that
+    // refutes "a host collision is unreachable under this op model".
+    // Deliberately NOT attributed to a numbered item in any review DOCUMENT --
+    // no committed review doc on this branch contains this construction, and
+    // the argument stands on the construction below regardless. Both walls are
     // legal hosts for the same opening, both states are spatially valid, and
     // under LAZY cut semantics the host meshes are byte-identical -- so the
     // IfcRelVoidsElement node is the ONLY thing separating them.

--- a/packages/provenance/test/merge-model.test.ts
+++ b/packages/provenance/test/merge-model.test.ts
@@ -205,11 +205,17 @@ describe('buildStateDag / hashModelState', () => {
 });
 
 /**
- * Regression guards for the three producer bindings the DAG must commit to.
+ * Regression guards for the three producer bindings the DAG must commit to
+ * (PR #1933, fixing findings F1 and F2 of the pre-freeze adversarial attack
+ * on node-hash-v0; F1 = missing `RelatingStructure` plus the storey's own
+ * element node, F2 = the missing `IfcRelVoidsElement` node).
+ *
  * Each of these passes ONLY because `buildStateDag` emits both EXPRESS roles
  * of `IfcRelContainedInSpatialStructure` and a real `IfcRelVoidsElement` node
  * per hosted element. Drop either and the model changes while the root hash
  * does not -- which is exactly a second preimage a certificate would accept.
+ * All three cases below (reparent, storey swap, role payload) are F1's
+ * constructions; F2's host-binding guard lives in merge-model-hosting.test.ts.
  */
 describe('the root hash binds the model relationships, not just its contents', () => {
   /** Re-parent an element with ORDINARY ops (no bespoke move op exists in

--- a/packages/provenance/test/merge-model.test.ts
+++ b/packages/provenance/test/merge-model.test.ts
@@ -197,6 +197,23 @@ describe('buildStateDag / hashModelState', () => {
     expect(() => buildStateDag(bad)).toThrow(/unknown storey/);
   });
 
+  it('rejects caller ids that collide with the node ids this builder mints', () => {
+    // Without this the collision surfaces as ProvenanceDag's generic
+    // "duplicate node id" from deep inside the build, naming neither the
+    // reserved namespace nor the offending entity.
+    for (const bad of ['storey:S0', 'storey-rel:S0', 'voids-rel:x', MERGE_MODEL_ROOT_NODE_ID]) {
+      const state: ModelState = {
+        storeyIds: ['S0'],
+        entities: new Map([[bad, entity('a', 'S0', [0, 0, 0])]]),
+      };
+      expect(() => buildStateDag(state), bad).toThrow(/reserved/);
+    }
+    // Pset and mesh ids are checked too, not just entity ids.
+    const withBadPset = baseState();
+    (withBadPset.entities.get('element:a') as EntityState).psets = new Map([['storey:S0', wallPset()]]);
+    expect(() => buildStateDag(withBadPset)).toThrow(/reserved/);
+  });
+
   it('throws when an entity references an unknown host', () => {
     const bad = baseState();
     (bad.entities.get('element:a') as EntityState).hostId = 'element:ghost';

--- a/packages/provenance/test/merge-model.test.ts
+++ b/packages/provenance/test/merge-model.test.ts
@@ -11,7 +11,7 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import type { GeometryMeshPayload, PropertySetPayload } from '../src/node-hash.js';
+import { computeNodeHash, type GeometryMeshPayload, type PropertySetPayload } from '../src/node-hash.js';
 import { conflictPredicate } from '../src/footprint.js';
 import {
   applyOp,
@@ -195,6 +195,85 @@ describe('buildStateDag / hashModelState', () => {
     const bad = baseState();
     (bad.entities.get('element:a') as EntityState).storeyId = 'S9';
     expect(() => buildStateDag(bad)).toThrow(/unknown storey/);
+  });
+
+  it('throws when an entity references an unknown host', () => {
+    const bad = baseState();
+    (bad.entities.get('element:a') as EntityState).hostId = 'element:ghost';
+    expect(() => buildStateDag(bad)).toThrow(/unknown host/);
+  });
+});
+
+/**
+ * Regression guards for the three producer bindings the DAG must commit to.
+ * Each of these passes ONLY because `buildStateDag` emits both EXPRESS roles
+ * of `IfcRelContainedInSpatialStructure` and a real `IfcRelVoidsElement` node
+ * per hosted element. Drop either and the model changes while the root hash
+ * does not -- which is exactly a second preimage a certificate would accept.
+ */
+describe('the root hash binds the model relationships, not just its contents', () => {
+  /** Re-parent an element with ORDINARY ops (no bespoke move op exists in
+   *  this vocabulary): drop it, re-add it under a different storey. */
+  function reparent(state: ModelState, tag: string, storeyId: string, origin: readonly [number, number, number]): ModelState {
+    return applyOps(state, [
+      { opId: `rm-${tag}`, type: 'entity-remove', entityNodeId: `element:${tag}` },
+      { opId: `add-${tag}`, type: 'entity-add', entity: { ...addInit(tag, storeyId, origin), ifcType: 'IfcWall' } },
+    ]);
+  }
+
+  it('moving one element from S0 to S1 changes the root', async () => {
+    // Built with the SAME EntityInit the move re-adds, so the only difference
+    // between the two states is the storey -- nothing else can move the root.
+    const empty: ModelState = { storeyIds: ['S0', 'S1'], entities: new Map() };
+    const base = applyOp(empty, {
+      opId: 'add-a',
+      type: 'entity-add',
+      entity: { ...addInit('a', 'S0', [0, 0, 0]), ifcType: 'IfcWall' },
+    });
+    const moved = reparent(base, 'a', 'S1', [0, 0, 0]);
+
+    // The states genuinely differ (the convergence oracle says so)...
+    expect(canonicalStateBytes(moved)).not.toBe(canonicalStateBytes(base));
+    // ...so the Merkle commitment must differ too. Without RelatingStructure
+    // the two storey nodes merely SWAP hashes and the root layer, which sorts
+    // its children, is byte-identical.
+    expect(await hashModelState(moved)).not.toBe(await hashModelState(base));
+  });
+
+  it('two elements swapping storeys changes the root', async () => {
+    const base: ModelState = {
+      storeyIds: ['S0', 'S1'],
+      entities: new Map([
+        ['element:a', entity('a', 'S0', [0, 0, 0])],
+        ['element:b', entity('b', 'S1', [50, 50, 3])],
+      ]),
+    };
+    const swapped: ModelState = {
+      storeyIds: ['S0', 'S1'],
+      entities: new Map([
+        ['element:a', entity('a', 'S1', [0, 0, 0])],
+        ['element:b', entity('b', 'S0', [50, 50, 3])],
+      ]),
+    };
+    expect(canonicalStateBytes(swapped)).not.toBe(canonicalStateBytes(base));
+    expect(await hashModelState(swapped)).not.toBe(await hashModelState(base));
+  });
+
+  it('the storey containment node carries BOTH EXPRESS roles', async () => {
+    const dag = buildStateDag(baseState());
+    expect(dag.getKind('storey:S0')).toBe('element'); // the storey itself is a node
+    await dag.build();
+    // Pin the payload by re-deriving the node hash from it: RelatingStructure
+    // (singular in IFC -- exactly one ref, the storey node) plus
+    // RelatedElements. Any other role set produces a different hash.
+    const expected = await computeNodeHash('relationship', {
+      relType: 'IfcRelContainedInSpatialStructure',
+      roles: [
+        { roleName: 'RelatingStructure', refs: [dag.getHash('storey:S0') as string] },
+        { roleName: 'RelatedElements', refs: [dag.getHash('element:a') as string] },
+      ],
+    });
+    expect(dag.getHash('storey-rel:S0')).toBe(expected);
   });
 });
 

--- a/scripts/moonshot/b35-demo/act2-proof.mjs
+++ b/scripts/moonshot/b35-demo/act2-proof.mjs
@@ -233,7 +233,7 @@ export async function runAct2({ model }) {
   const dag = await buildDag(store);
   const totalNodes = dag.dagNodes.size;
   const rootHashBefore = dag.dagHashes.get('root');
-  say(`  provenance DAG: ${totalNodes} nodes (${dag.elementCount} elements, ${dag.psetCount} pset/qset leaves, ${dag.storeys.length} storeys, 1 root)`);
+  say(`  provenance DAG: ${totalNodes} nodes (${dag.elementCount} elements, ${dag.psetCount} pset/qset leaves, ${dag.storeys.length} storey element(s), ${dag.storeys.length} storey containment relationship(s), 1 root)`);
   say(`  root hash before edit: ${short(rootHashBefore, 28)}...`);
 
   // Single-element edit: grow one wall's GrossVolume by exactly 1 m3.

--- a/scripts/moonshot/b35-demo/act2-proof.mjs
+++ b/scripts/moonshot/b35-demo/act2-proof.mjs
@@ -332,6 +332,12 @@ export async function runAct2({ model }) {
       elements: dag.elementCount,
       psetLeaves: dag.psetCount,
       storeys: dag.storeys.length,
+      // One `element` node per storey (the RelatingStructure referent) AND one
+      // containment `relationship` node per storey. Reported separately so the
+      // parts of the breakdown add up to totalNodes without the reader having
+      // to know that a storey contributes two nodes.
+      storeyElementNodes: dag.storeys.length,
+      storeyRelationshipNodes: dag.storeys.length,
       rootHashBefore,
       rootHashAfter,
       edit: {

--- a/scripts/moonshot/b35-demo/act2-proof.mjs
+++ b/scripts/moonshot/b35-demo/act2-proof.mjs
@@ -65,6 +65,26 @@ function psetPayloadsFor(store, expressId) {
   return payloads;
 }
 
+/**
+ * One storey's `IfcRelContainedInSpatialStructure` payload with BOTH EXPRESS
+ * roles (node-hash-v0 spec section 3.2.1, golden vector rel-contained-many):
+ * `RelatingStructure` (the storey's own `element` node hash) and
+ * `RelatedElements`. With only `RelatedElements` a storey node is a bare
+ * set-of-children hash, so two storeys that swap their elements swap their
+ * node hashes and the root `layer` -- which sorts its children -- comes out
+ * unchanged: re-parenting an element between levels would not move the root.
+ */
+function storeyRelPayload(dagHashes, storey) {
+  const refs = storey.elementIds.map((id) => dagHashes.get(`element:${id}`)).filter((h) => h !== undefined);
+  return {
+    relType: 'IfcRelContainedInSpatialStructure',
+    roles: [
+      { roleName: 'RelatingStructure', refs: [dagHashes.get(`storey-entity:${storey.expressId}`)] },
+      { roleName: 'RelatedElements', refs },
+    ],
+  };
+}
+
 /** g0's buildDag, on a parsed world-gym store (see module doc). */
 export async function buildDag(store) {
   const dagNodes = new Map();
@@ -74,6 +94,7 @@ export async function buildDag(store) {
     .map((s) => ({
       expressId: s.expressId,
       name: store.entities.getName(s.expressId) || `Storey #${s.expressId}`,
+      globalId: store.entities.getGlobalId(s.expressId) || String(s.expressId),
       elementIds: store.relationships.getRelated(s.expressId, RelationshipType.ContainsElements, 'forward'),
     }))
     .sort((a, b) => a.expressId - b.expressId);
@@ -113,8 +134,13 @@ export async function buildDag(store) {
   }
 
   for (const storey of storeys) {
-    const refs = storey.elementIds.map((id) => dagHashes.get(`element:${id}`)).filter((h) => h !== undefined);
-    const payload = { relType: 'IfcRelContainedInSpatialStructure', roles: [{ roleName: 'RelatedElements', refs }] };
+    const storeyNodeId = `storey-entity:${storey.expressId}`;
+    const storeyPayload = { key: storey.globalId, ifcType: 'IfcBuildingStorey', components: [] };
+    const storeyHash = await computeNodeHash('element', storeyPayload);
+    dagNodes.set(storeyNodeId, { kind: 'element', payload: storeyPayload });
+    dagHashes.set(storeyNodeId, storeyHash);
+
+    const payload = storeyRelPayload(dagHashes, storey);
     const hash = await computeNodeHash('relationship', payload);
     dagNodes.set(`storey:${storey.expressId}`, { kind: 'relationship', payload });
     dagHashes.set(`storey:${storey.expressId}`, hash);
@@ -167,8 +193,7 @@ async function mutateAndCascade(dag, expressId, propName, newValue, { skipRoot =
 
   if (!skipStorey) {
     const storey = dag.storeys.find((s) => s.expressId === meta.storeyId);
-    const refs = storey.elementIds.map((id) => dag.dagHashes.get(`element:${id}`)).filter((h) => h !== undefined);
-    const storeyPayload = { relType: 'IfcRelContainedInSpatialStructure', roles: [{ roleName: 'RelatedElements', refs }] };
+    const storeyPayload = storeyRelPayload(dag.dagHashes, storey);
     const storeyHash = await computeNodeHash('relationship', storeyPayload);
     dag.dagNodes.set(`storey:${meta.storeyId}`, { kind: 'relationship', payload: storeyPayload });
     dag.dagHashes.set(`storey:${meta.storeyId}`, storeyHash);

--- a/scripts/moonshot/b35-demo/demo-report.json
+++ b/scripts/moonshot/b35-demo/demo-report.json
@@ -391,23 +391,23 @@
   },
   "volatile": {
     "note": "ONLY this block differs between runs: wall clocks and the timestamp. Everything under `deterministic` is a pure function of the master seed.",
-    "generatedAt": "2026-08-01T05:51:47.272Z",
+    "generatedAt": "2026-08-01T06:29:27.559Z",
     "nodeVersion": "v22.14.0",
-    "totalWallClockMs": 6856,
+    "totalWallClockMs": 8910,
     "actWallClockMs": {
-      "act1": 31,
-      "act2": 59,
-      "act3": 267,
-      "act4": 2646,
-      "act5": 3854
+      "act1": 39,
+      "act2": 63,
+      "act3": 297,
+      "act4": 3226,
+      "act5": 5284
     },
     "actVolatile": {
       "act2": {
-        "verifyMs": 2.961,
-        "tamperVerifyMs": 2.201
+        "verifyMs": 3.067,
+        "tamperVerifyMs": 2.464
       },
       "act4": {
-        "batteryElapsedMs": 2633.724375
+        "batteryElapsedMs": 3216.8704589999998
       }
     },
     "artifactDir": "/var/folders/n2/jkb39p_x4md9jdv5hhzny6jc0000gn/T/ifc-lite-b35-demo"

--- a/scripts/moonshot/b35-demo/demo-report.json
+++ b/scripts/moonshot/b35-demo/demo-report.json
@@ -49,12 +49,12 @@
       "act2": {
         "status": "ok",
         "data": {
-          "totalNodes": 56,
+          "totalNodes": 57,
           "elements": 27,
           "psetLeaves": 27,
           "storeys": 1,
-          "rootHashBefore": "sha256:771cb465932d61e5607a251de8af33a35e721a4eac442787f9974ede79105f0d",
-          "rootHashAfter": "sha256:aa00d60d3f10503c221f09d61b141577fdfac1b8cf012de9ecc7df7f4b170012",
+          "rootHashBefore": "sha256:3abc104a6b505c5c7574c8a032e91b9de2af528eeb69f29b78ad703bda0f41cc",
+          "rootHashAfter": "sha256:a4cfcd2b860dc7db4f7afef0234f43d92e2d5d5e7c3038703b9e3f00c84c5dff",
           "edit": {
             "expressId": 58,
             "ifcType": "IfcWall",
@@ -68,7 +68,7 @@
           "untouchedClaimRefs": 26,
           "secondProcessVerifyOk": true,
           "nodesResolved": 30,
-          "nodesResolvedPct": 53.5714,
+          "nodesResolvedPct": 52.6316,
           "tamper": {
             "expressId": 41,
             "ifcType": "IfcSlab",
@@ -199,9 +199,9 @@
         "status": "ok",
         "data": {
           "baseEntities": 27,
-          "baseRootHash": "sha256:1d335793b20bc580ce16ba7eafbb3a0a9c48b0786a9e0444cff42eba58c52ebc",
-          "mergedRootHash": "sha256:bff4e3213591febc02e084fdbaf4cc84fadd4ae5382748535d685247bb9cf4ed",
-          "certificateBaseRootHash": "sha256:1d335793b20bc580ce16ba7eafbb3a0a9c48b0786a9e0444cff42eba58c52ebc",
+          "baseRootHash": "sha256:19b941358ddb17af4f6198f5be7c079393c8faf470e7a8958819eae645423d62",
+          "mergedRootHash": "sha256:17e853b04fd84c40368fba45eec0243f8ad98a94f0e26f476cc9ccf004f45059",
+          "certificateBaseRootHash": "sha256:19b941358ddb17af4f6198f5be7c079393c8faf470e7a8958819eae645423d62",
           "autoMerge": {
             "clients": [
               "alice",
@@ -391,23 +391,23 @@
   },
   "volatile": {
     "note": "ONLY this block differs between runs: wall clocks and the timestamp. Everything under `deterministic` is a pure function of the master seed.",
-    "generatedAt": "2026-07-29T17:44:18.805Z",
+    "generatedAt": "2026-08-01T05:51:47.272Z",
     "nodeVersion": "v22.14.0",
-    "totalWallClockMs": 7499,
+    "totalWallClockMs": 6856,
     "actWallClockMs": {
-      "act1": 35,
-      "act2": 67,
-      "act3": 281,
-      "act4": 2401,
-      "act5": 4715
+      "act1": 31,
+      "act2": 59,
+      "act3": 267,
+      "act4": 2646,
+      "act5": 3854
     },
     "actVolatile": {
       "act2": {
-        "verifyMs": 3.029,
-        "tamperVerifyMs": 2.341
+        "verifyMs": 2.961,
+        "tamperVerifyMs": 2.201
       },
       "act4": {
-        "batteryElapsedMs": 2391.59325
+        "batteryElapsedMs": 2633.724375
       }
     },
     "artifactDir": "/var/folders/n2/jkb39p_x4md9jdv5hhzny6jc0000gn/T/ifc-lite-b35-demo"

--- a/scripts/moonshot/b35-demo/demo-report.json
+++ b/scripts/moonshot/b35-demo/demo-report.json
@@ -53,6 +53,8 @@
           "elements": 27,
           "psetLeaves": 27,
           "storeys": 1,
+          "storeyElementNodes": 1,
+          "storeyRelationshipNodes": 1,
           "rootHashBefore": "sha256:3abc104a6b505c5c7574c8a032e91b9de2af528eeb69f29b78ad703bda0f41cc",
           "rootHashAfter": "sha256:a4cfcd2b860dc7db4f7afef0234f43d92e2d5d5e7c3038703b9e3f00c84c5dff",
           "edit": {
@@ -391,23 +393,23 @@
   },
   "volatile": {
     "note": "ONLY this block differs between runs: wall clocks and the timestamp. Everything under `deterministic` is a pure function of the master seed.",
-    "generatedAt": "2026-08-01T06:29:27.559Z",
+    "generatedAt": "2026-08-01T07:04:51.441Z",
     "nodeVersion": "v22.14.0",
-    "totalWallClockMs": 8910,
+    "totalWallClockMs": 6825,
     "actWallClockMs": {
-      "act1": 39,
-      "act2": 63,
-      "act3": 297,
-      "act4": 3226,
-      "act5": 5284
+      "act1": 34,
+      "act2": 57,
+      "act3": 266,
+      "act4": 2624,
+      "act5": 3843
     },
     "actVolatile": {
       "act2": {
-        "verifyMs": 3.067,
-        "tamperVerifyMs": 2.464
+        "verifyMs": 2.765,
+        "tamperVerifyMs": 2.059
       },
       "act4": {
-        "batteryElapsedMs": 3216.8704589999998
+        "batteryElapsedMs": 2615.46225
       }
     },
     "artifactDir": "/var/folders/n2/jkb39p_x4md9jdv5hhzny6jc0000gn/T/ifc-lite-b35-demo"

--- a/scripts/moonshot/b35-demo/demo-report.md
+++ b/scripts/moonshot/b35-demo/demo-report.md
@@ -91,8 +91,8 @@ differentiable building with exact dual-number gradients:
 
 Wall clocks and the timestamp below change run to run; nothing above does.
 
-- generated at: 2026-08-01T06:29:27.559Z (node v22.14.0)
-- total wall clock: 8.9s
-- per act: act1=0.0s, act2=0.1s, act3=0.3s, act4=3.2s, act5=5.3s
+- generated at: 2026-08-01T07:04:51.441Z (node v22.14.0)
+- total wall clock: 6.8s
+- per act: act1=0.0s, act2=0.1s, act3=0.3s, act4=2.6s, act5=3.8s
 - artifacts (outside the repo): /var/folders/n2/jkb39p_x4md9jdv5hhzny6jc0000gn/T/ifc-lite-b35-demo
 

--- a/scripts/moonshot/b35-demo/demo-report.md
+++ b/scripts/moonshot/b35-demo/demo-report.md
@@ -9,7 +9,7 @@ seed: rerun the command and the hashes, scores and counts reproduce exactly.
 | Act | Story | Status | Headline |
 |-----|-------|--------|----------|
 | 1 BIRTH | world-gym births a seeded building; reward channels score it | ok | 548 entities, 5/5 reward channels = 1.0 |
-| 2 PROOF | provenance certificate verified in a second process; tamper refused | ok | verified reading 53.5714% of 56 nodes; tamper caught=true |
+| 2 PROOF | provenance certificate verified in a second process; tamper refused | ok | verified reading 52.6316% of 57 nodes; tamper caught=true |
 | 3 SABOTAGE | planted defects hunted; benchmark oracle scores the detector | ok | spotlight 1/1 caught; macro-F1 0.857143 |
 | 4 CONVERGENCE | certified auto-merge + blocked conflict + property battery | ok | 873/1000 auto-merged, 0 unsound; conflict blocked=true |
 | 5 DESCENT | differentiable carbon descent, kernel-validated optimum | ok | carbon -58.5%, kernel rel dev 1.54e-7 |
@@ -26,15 +26,15 @@ entities, 1 storey(s), 28004 bytes.
 
 ## Act 2 -- PROOF (M1 proof-carrying edit, the G0 story on a fresh model)
 
-The parsed building becomes a 56-node node-hash-v0 DAG
+The parsed building becomes a 57-node node-hash-v0 DAG
 (27 elements, 27 pset/qset leaves, 1 storeys, 1 root).
 One edit -- IfcWall #58 GrossVolume: 8.136439344000001 -> 9.136439344000001 --
 yields a certificate carrying the changed path, the untouched sibling reads and a
 subtree-untouched claim over 26 untouched sibling element subtree(s).
 
-- root hash before: `sha256:771cb465932d61e5607a251de8af33a35e721a4eac442787f9974ede79105f0d`
-- root hash after:  `sha256:aa00d60d3f10503c221f09d61b141577fdfac1b8cf012de9ecc7df7f4b170012`
-- second-process verification: ok=true, resolving 30/56 nodes (53.5714%)
+- root hash before: `sha256:3abc104a6b505c5c7574c8a032e91b9de2af528eeb69f29b78ad703bda0f41cc`
+- root hash after:  `sha256:a4cfcd2b860dc7db4f7afef0234f43d92e2d5d5e7c3038703b9e3f00c84c5dff`
+- second-process verification: ok=true, resolving 30/57 nodes (52.6316%)
   (single-storey building, so the claim is per sibling element; on multi-storey models the claim
   coarsens to whole storey subtrees and the verifier reads under 5% of the DAG -- the G0 gate shape)
 - tampered copy (silent IfcSlab #41 mutation inside claimed-untouched territory): caught=true, reason: `hash-mismatch`
@@ -59,10 +59,10 @@ official dev-split seeds (17 corrupted; truth regenerated from seeds, no stored 
 ## Act 4 -- CONVERGENCE (M4/B2.1 commutation certificates)
 
 The proven act-1 building (27 entities) becomes the shared base state,
-Merkle root `sha256:1d335793b20bc580ce16ba7eafbb3a0a9c48b0786a9e0444cff42eba58c52ebc`.
+Merkle root `sha256:19b941358ddb17af4f6198f5be7c079393c8faf470e7a8958819eae645423d62`.
 
 - disjoint concurrent edits (alice: wall FireRating, bob: other element Status):
-  certificate issued, both orders replay to merged root `sha256:bff4e3213591febc02e084fdbaf4cc84fadd4ae5382748535d685247bb9cf4ed`;
+  certificate issued, both orders replay to merged root `sha256:17e853b04fd84c40368fba45eec0243f8ad98a94f0e26f476cc9ccf004f45059`;
   independent re-verification: ok=true
 - colliding edits (both write the same wall pset): blocked=true, 1 conflicting cross pair(s) -- no certificate, no silent overwrite
 - property battery (1000 schedules, seed 20260724): 873 auto-merged,
@@ -90,8 +90,8 @@ differentiable building with exact dual-number gradients:
 
 Wall clocks and the timestamp below change run to run; nothing above does.
 
-- generated at: 2026-07-29T17:44:18.805Z (node v22.14.0)
-- total wall clock: 7.5s
-- per act: act1=0.0s, act2=0.1s, act3=0.3s, act4=2.4s, act5=4.7s
+- generated at: 2026-08-01T05:51:47.272Z (node v22.14.0)
+- total wall clock: 6.9s
+- per act: act1=0.0s, act2=0.1s, act3=0.3s, act4=2.6s, act5=3.9s
 - artifacts (outside the repo): /var/folders/n2/jkb39p_x4md9jdv5hhzny6jc0000gn/T/ifc-lite-b35-demo
 

--- a/scripts/moonshot/b35-demo/demo-report.md
+++ b/scripts/moonshot/b35-demo/demo-report.md
@@ -27,7 +27,8 @@ entities, 1 storey(s), 28004 bytes.
 ## Act 2 -- PROOF (M1 proof-carrying edit, the G0 story on a fresh model)
 
 The parsed building becomes a 57-node node-hash-v0 DAG
-(27 elements, 27 pset/qset leaves, 1 storeys, 1 root).
+(27 elements, 27 pset/qset leaves, 1 storey element(s),
+1 storey containment relationship(s), 1 root).
 One edit -- IfcWall #58 GrossVolume: 8.136439344000001 -> 9.136439344000001 --
 yields a certificate carrying the changed path, the untouched sibling reads and a
 subtree-untouched claim over 26 untouched sibling element subtree(s).
@@ -90,8 +91,8 @@ differentiable building with exact dual-number gradients:
 
 Wall clocks and the timestamp below change run to run; nothing above does.
 
-- generated at: 2026-08-01T05:51:47.272Z (node v22.14.0)
-- total wall clock: 6.9s
-- per act: act1=0.0s, act2=0.1s, act3=0.3s, act4=2.6s, act5=3.9s
+- generated at: 2026-08-01T06:29:27.559Z (node v22.14.0)
+- total wall clock: 8.9s
+- per act: act1=0.0s, act2=0.1s, act3=0.3s, act4=3.2s, act5=5.3s
 - artifacts (outside the repo): /var/folders/n2/jkb39p_x4md9jdv5hhzny6jc0000gn/T/ifc-lite-b35-demo
 

--- a/scripts/moonshot/b35-demo/run.mjs
+++ b/scripts/moonshot/b35-demo/run.mjs
@@ -224,7 +224,8 @@ function renderMarkdown(report) {
     push('## Act 2 -- PROOF (M1 proof-carrying edit, the G0 story on a fresh model)');
     push('');
     push(`The parsed building becomes a ${x.totalNodes}-node node-hash-v0 DAG`);
-    push(`(${x.elements} elements, ${x.psetLeaves} pset/qset leaves, ${x.storeys} storeys, 1 root).`);
+    push(`(${x.elements} elements, ${x.psetLeaves} pset/qset leaves, ${x.storeys} storey element(s),`);
+    push(`${x.storeys} storey containment relationship(s), 1 root).`);
     push(`One edit -- ${x.edit.ifcType} #${x.edit.expressId} ${x.edit.property}: ${JSON.stringify(x.edit.before)} -> ${JSON.stringify(x.edit.after)} --`);
     push('yields a certificate carrying the changed path, the untouched sibling reads and a');
     push(`subtree-untouched claim over ${x.untouchedClaimRefs} untouched ${x.claimGranularity === 'storey-subtrees' ? 'storey subtree(s)' : 'sibling element subtree(s)'}.`);

--- a/scripts/moonshot/b35-demo/run.mjs
+++ b/scripts/moonshot/b35-demo/run.mjs
@@ -224,8 +224,8 @@ function renderMarkdown(report) {
     push('## Act 2 -- PROOF (M1 proof-carrying edit, the G0 story on a fresh model)');
     push('');
     push(`The parsed building becomes a ${x.totalNodes}-node node-hash-v0 DAG`);
-    push(`(${x.elements} elements, ${x.psetLeaves} pset/qset leaves, ${x.storeys} storey element(s),`);
-    push(`${x.storeys} storey containment relationship(s), 1 root).`);
+    push(`(${x.elements} elements, ${x.psetLeaves} pset/qset leaves, ${x.storeyElementNodes} storey element(s),`);
+    push(`${x.storeyRelationshipNodes} storey containment relationship(s), 1 root).`);
     push(`One edit -- ${x.edit.ifcType} #${x.edit.expressId} ${x.edit.property}: ${JSON.stringify(x.edit.before)} -> ${JSON.stringify(x.edit.after)} --`);
     push('yields a certificate carrying the changed path, the untouched sibling reads and a');
     push(`subtree-untouched claim over ${x.untouchedClaimRefs} untouched ${x.claimGranularity === 'storey-subtrees' ? 'storey subtree(s)' : 'sibling element subtree(s)'}.`);

--- a/scripts/moonshot/ci/b35-golden.json
+++ b/scripts/moonshot/ci/b35-golden.json
@@ -49,6 +49,8 @@
         "elements": 27,
         "psetLeaves": 27,
         "storeys": 1,
+        "storeyElementNodes": 1,
+        "storeyRelationshipNodes": 1,
         "rootHashBefore": "sha256:3abc104a6b505c5c7574c8a032e91b9de2af528eeb69f29b78ad703bda0f41cc",
         "rootHashAfter": "sha256:a4cfcd2b860dc7db4f7afef0234f43d92e2d5d5e7c3038703b9e3f00c84c5dff",
         "edit": {

--- a/scripts/moonshot/ci/b35-golden.json
+++ b/scripts/moonshot/ci/b35-golden.json
@@ -45,12 +45,12 @@
     "act2": {
       "status": "ok",
       "data": {
-        "totalNodes": 56,
+        "totalNodes": 57,
         "elements": 27,
         "psetLeaves": 27,
         "storeys": 1,
-        "rootHashBefore": "sha256:771cb465932d61e5607a251de8af33a35e721a4eac442787f9974ede79105f0d",
-        "rootHashAfter": "sha256:aa00d60d3f10503c221f09d61b141577fdfac1b8cf012de9ecc7df7f4b170012",
+        "rootHashBefore": "sha256:3abc104a6b505c5c7574c8a032e91b9de2af528eeb69f29b78ad703bda0f41cc",
+        "rootHashAfter": "sha256:a4cfcd2b860dc7db4f7afef0234f43d92e2d5d5e7c3038703b9e3f00c84c5dff",
         "edit": {
           "expressId": 58,
           "ifcType": "IfcWall",
@@ -64,7 +64,7 @@
         "untouchedClaimRefs": 26,
         "secondProcessVerifyOk": true,
         "nodesResolved": 30,
-        "nodesResolvedPct": 53.5714,
+        "nodesResolvedPct": 52.6316,
         "tamper": {
           "expressId": 41,
           "ifcType": "IfcSlab",
@@ -195,9 +195,9 @@
       "status": "ok",
       "data": {
         "baseEntities": 27,
-        "baseRootHash": "sha256:1d335793b20bc580ce16ba7eafbb3a0a9c48b0786a9e0444cff42eba58c52ebc",
-        "mergedRootHash": "sha256:bff4e3213591febc02e084fdbaf4cc84fadd4ae5382748535d685247bb9cf4ed",
-        "certificateBaseRootHash": "sha256:1d335793b20bc580ce16ba7eafbb3a0a9c48b0786a9e0444cff42eba58c52ebc",
+        "baseRootHash": "sha256:19b941358ddb17af4f6198f5be7c079393c8faf470e7a8958819eae645423d62",
+        "mergedRootHash": "sha256:17e853b04fd84c40368fba45eec0243f8ad98a94f0e26f476cc9ccf004f45059",
+        "certificateBaseRootHash": "sha256:19b941358ddb17af4f6198f5be7c079393c8faf470e7a8958819eae645423d62",
         "autoMerge": {
           "clients": [
             "alice",

--- a/scripts/moonshot/g0-certificate-demo.mjs
+++ b/scripts/moonshot/g0-certificate-demo.mjs
@@ -376,7 +376,8 @@ async function main() {
   const totalNodes = dag.dagNodes.size;
   console.error(
     `[g0] DAG built + fully hashed in ${fullHashMs.toFixed(1)} ms — ${totalNodes} nodes ` +
-      `(${dag.elementCount} elements, ${dag.psetCount} property-sets, ${dag.storeys.length} storeys, 1 root)`,
+      `(${dag.elementCount} elements, ${dag.psetCount} property-sets, ${dag.storeys.length} storey element(s), ` +
+      `${dag.storeys.length} storey containment relationship(s), 1 root)`,
   );
 
   // Pick a wall-like element with at least one non-empty property set,

--- a/scripts/moonshot/g0-certificate-demo.mjs
+++ b/scripts/moonshot/g0-certificate-demo.mjs
@@ -19,8 +19,10 @@
  *   2. Build a node-hash-v0 DAG with @ifc-lite/provenance:
  *        element (one per IFC product entity)
  *          -> property-set (one per Pset/Qset-like set the entity carries)
- *        storey (`relationship`, IfcRelContainedInSpatialStructure) groups the
- *          elements a storey directly contains
+ *        storey (`relationship`, IfcRelContainedInSpatialStructure) binds the
+ *          storey's own `element` node (RelatingStructure) to the elements it
+ *          directly contains (RelatedElements) — both EXPRESS roles, so the
+ *          node commits to WHICH storey, not just to a set of children
  *        root (`layer`) groups every storey
  *      This is an allowed use of the v0 node-kind vocabulary (spec 2): the
  *      only kinds available are geometry-mesh / property-set / relationship /
@@ -106,6 +108,29 @@ function mutatedValue(value) {
 /* ------------------------------------------------------------------ */
 
 /**
+ * One storey's `IfcRelContainedInSpatialStructure` payload, carrying BOTH of
+ * that relationship's EXPRESS roles (node-hash-v0 spec §3.2.1, golden vector
+ * `rel-contained-many`): `RelatingStructure` — the storey's OWN node hash —
+ * and `RelatedElements`. Emitting only `RelatedElements` would leave every
+ * storey node a bare set-of-children hash, so two storeys that swap their
+ * elements would swap their node hashes and the root `layer` (which sorts its
+ * children) would come out unchanged: re-parenting an element between levels
+ * would not move the model's root hash at all.
+ */
+function storeyRelPayload(dagHashes, storey) {
+  const refs = storey.elementIds
+    .map((id) => dagHashes.get(`element:${id}`))
+    .filter((h) => h !== undefined);
+  return {
+    relType: 'IfcRelContainedInSpatialStructure',
+    roles: [
+      { roleName: 'RelatingStructure', refs: [dagHashes.get(`storey-entity:${storey.expressId}`)] },
+      { roleName: 'RelatedElements', refs },
+    ],
+  };
+}
+
+/**
  * Build the full node-hash-v0 DAG in one bottom-up pass: property-sets,
  * then elements (folding in their property-set hashes), then per-storey
  * `relationship` nodes (folding in their contained elements' hashes), then
@@ -126,6 +151,7 @@ async function buildDag(store) {
   const storeys = storeyEntities.map((s) => ({
     expressId: s.expressId,
     name: store.entities.getName(s.expressId) || `Storey #${s.expressId}`,
+    globalId: store.entities.getGlobalId(s.expressId) || String(s.expressId),
     elementIds: store.relationships.getRelated(
       s.expressId,
       RelationshipType.ContainsElements,
@@ -177,14 +203,17 @@ async function buildDag(store) {
   }
 
   for (const storey of storeys) {
+    // The storey itself is an ordinary IFC product, so it gets its own
+    // `element` node — that is what the containment relationship's
+    // RelatingStructure role references (see storeyRelPayload).
+    const storeyNodeId = `storey-entity:${storey.expressId}`;
+    const storeyPayload = { key: storey.globalId, ifcType: 'IfcBuildingStorey', components: [] };
+    const storeyHash = await computeNodeHash('element', storeyPayload);
+    dagNodes.set(storeyNodeId, { kind: 'element', payload: storeyPayload });
+    dagHashes.set(storeyNodeId, storeyHash);
+
     const nodeId = `storey:${storey.expressId}`;
-    const refs = storey.elementIds
-      .map((id) => dagHashes.get(`element:${id}`))
-      .filter((h) => h !== undefined);
-    const payload = {
-      relType: 'IfcRelContainedInSpatialStructure',
-      roles: [{ roleName: 'RelatedElements', refs }],
-    };
+    const payload = storeyRelPayload(dagHashes, storey);
     const hash = await computeNodeHash('relationship', payload);
     dagNodes.set(nodeId, { kind: 'relationship', payload });
     dagHashes.set(nodeId, hash);
@@ -211,13 +240,7 @@ async function buildDag(store) {
 function propagateStoreyAndRoot(dag, storeyExpressId) {
   const storey = dag.storeys.find((s) => s.expressId === storeyExpressId);
   const storeyNodeId = `storey:${storeyExpressId}`;
-  const refs = storey.elementIds
-    .map((id) => dag.dagHashes.get(`element:${id}`))
-    .filter((h) => h !== undefined);
-  const payload = {
-    relType: 'IfcRelContainedInSpatialStructure',
-    roles: [{ roleName: 'RelatedElements', refs }],
-  };
+  const payload = storeyRelPayload(dag.dagHashes, storey);
   return computeNodeHash('relationship', payload).then((hash) => {
     dag.dagNodes.set(storeyNodeId, { kind: 'relationship', payload });
     dag.dagHashes.set(storeyNodeId, hash);
@@ -322,8 +345,7 @@ async function applySiblingTamper(dag, expressId) {
 
   // Cascade to the storey only (not root) — see docstring.
   const storey = dag.storeys.find((s) => s.expressId === meta.storeyId);
-  const refs = storey.elementIds.map((id) => dag.dagHashes.get(`element:${id}`)).filter((h) => h !== undefined);
-  const payload = { relType: 'IfcRelContainedInSpatialStructure', roles: [{ roleName: 'RelatedElements', refs }] };
+  const payload = storeyRelPayload(dag.dagHashes, storey);
   const hash = await computeNodeHash('relationship', payload);
   dag.dagNodes.set(`storey:${meta.storeyId}`, { kind: 'relationship', payload });
   dag.dagHashes.set(`storey:${meta.storeyId}`, hash);

--- a/scripts/moonshot/g1-memoized-recompute.mjs
+++ b/scripts/moonshot/g1-memoized-recompute.mjs
@@ -116,6 +116,7 @@ async function buildDagStructure(store, meshes) {
   const storeyEntities = store.getEntitiesByType('IfcBuildingStorey');
   const storeys = storeyEntities.map((s) => ({
     expressId: s.expressId,
+    globalId: store.entities.getGlobalId(s.expressId) || String(s.expressId),
     elementIds: store.relationships.getRelated(s.expressId, RelationshipType.ContainsElements, 'forward'),
   }));
 
@@ -196,13 +197,30 @@ async function buildDagStructure(store, meshes) {
     }
     for (const storey of storeys) {
       const elementIds = storey.elementIds.filter((id) => elementMeta.has(id)).map((id) => `element:${id}`);
+      // The storey is an ordinary IFC product, so it gets its own `element`
+      // node — the referent of the containment relationship's
+      // RelatingStructure role. Without that role the storey node is a bare
+      // set-of-children hash: two storeys that swap their elements swap their
+      // node hashes, and the root `layer` (which sorts its children) comes out
+      // unchanged, so re-parenting an element between levels would not move
+      // the model root at all. Both EXPRESS roles, per node-hash-v0 spec
+      // section 3.2.1 / golden vector rel-contained-many.
+      const storeyNodeId = `storey-entity:${storey.expressId}`;
+      specs.push({
+        id: storeyNodeId,
+        kind: 'element',
+        payload: { key: storey.globalId, ifcType: 'IfcBuildingStorey', components: [] },
+      });
       specs.push({
         id: `storey:${storey.expressId}`,
         kind: 'relationship',
-        children: elementIds,
+        children: [storeyNodeId, ...elementIds],
         buildPayload: (h) => ({
           relType: 'IfcRelContainedInSpatialStructure',
-          roles: [{ roleName: 'RelatedElements', refs: elementIds.map((id) => h.get(id)) }],
+          roles: [
+            { roleName: 'RelatingStructure', refs: [h.get(storeyNodeId)] },
+            { roleName: 'RelatedElements', refs: elementIds.map((id) => h.get(id)) },
+          ],
         }),
       });
     }

--- a/scripts/moonshot/g1-memoized-recompute.mjs
+++ b/scripts/moonshot/g1-memoized-recompute.mjs
@@ -484,7 +484,8 @@ async function runDataPlaneScaleExam() {
   const { dag, buildMs, totalNodes } = await buildDag(struct.buildSpecs, leafPayloads);
   console.error(
     `[g1] full build hashed ${totalNodes} nodes in ${buildMs.toFixed(1)} ms ` +
-      `(${struct.elementCount} elements, ${struct.psetCount} property-sets, ${struct.storeys.length} storeys, 1 root)`,
+      `(${struct.elementCount} elements, ${struct.psetCount} property-sets, ${struct.meshLeafCount} geometry-mesh leaves, ` +
+      `${struct.storeys.length} storey element(s), ${struct.storeys.length} storey containment relationship(s), 1 root)`,
   );
 
   let target;

--- a/scripts/moonshot/g2-footprint-tightness.mjs
+++ b/scripts/moonshot/g2-footprint-tightness.mjs
@@ -129,6 +129,7 @@ async function buildDagStructure(store, meshes) {
   const storeyEntities = store.getEntitiesByType('IfcBuildingStorey');
   const storeys = storeyEntities.map((s) => ({
     expressId: s.expressId,
+    globalId: store.entities.getGlobalId(s.expressId) || String(s.expressId),
     elementIds: store.relationships.getRelated(s.expressId, RelationshipType.ContainsElements, 'forward'),
   }));
 
@@ -202,13 +203,30 @@ async function buildDagStructure(store, meshes) {
     }
     for (const storey of storeys) {
       const elementIds = storey.elementIds.filter((id) => elementMeta.has(id)).map((id) => `element:${id}`);
+      // The storey is an ordinary IFC product, so it gets its own `element`
+      // node — the referent of the containment relationship's
+      // RelatingStructure role. Without that role the storey node is a bare
+      // set-of-children hash: two storeys that swap their elements swap their
+      // node hashes, and the root `layer` (which sorts its children) comes out
+      // unchanged, so re-parenting an element between levels would not move
+      // the model root at all. Both EXPRESS roles, per node-hash-v0 spec
+      // section 3.2.1 / golden vector rel-contained-many.
+      const storeyNodeId = `storey-entity:${storey.expressId}`;
+      specs.push({
+        id: storeyNodeId,
+        kind: 'element',
+        payload: { key: storey.globalId, ifcType: 'IfcBuildingStorey', components: [] },
+      });
       specs.push({
         id: `storey:${storey.expressId}`,
         kind: 'relationship',
-        children: elementIds,
+        children: [storeyNodeId, ...elementIds],
         buildPayload: (h) => ({
           relType: 'IfcRelContainedInSpatialStructure',
-          roles: [{ roleName: 'RelatedElements', refs: elementIds.map((id) => h.get(id)) }],
+          roles: [
+            { roleName: 'RelatingStructure', refs: [h.get(storeyNodeId)] },
+            { roleName: 'RelatedElements', refs: elementIds.map((id) => h.get(id)) },
+          ],
         }),
       });
     }


### PR DESCRIPTION
**Stacked on #1900 — merge that first.** Supersedes the standalone `fix/dag-producer-bindings` (`9b4edba9`), which should be **abandoned rather than merged**, or the duplicate `hostId` conflict comes back.

Closes three producer bugs found by an adversarial attack on `node-hash-v0` run before the freeze. None is a format bug: the format already carries what was missing, the spec already names it, and golden vector `rel-voids` already pins it.

## Reproduced before, fixed after

| | before | after |
|---|---|---|
| element moved between storeys | root **identical** | root changes |
| two elements swap storeys | root **identical** | root changes |
| opening re-hosted A→B | root **identical** | roots differ |
| certificate verified against a different base | `ok: true` | `base-root-mismatch` |

## The collision with #1900 dissolved on reading it

B4.2 had already built a **better hosting op model** than mine — containment as an invariant, derived void re-cuts, `SpatialRejectionError`, remove-cascades-to-openings, host coupling expressed spatially via `withHostRegion`. Its `canonicalStateBytes` line for `hostId` is character-for-character identical to the one I wrote independently.

So this drops my **entire F2 op-model half** — the `hostId` field, the add/remove validation, and critically the `writtenNodes` host coupling — and keeps b42's.

**That is what dissolves the ablation problem.** My structural coupling would have refused host/opening pairs *structurally*, stopping B4.2's ablation from isolating the spatial rule for exactly the pairs B4.2 is about. It is gone, and b42's measurements reproduce unchanged: **873 auto-merged, 0 unsound, 8.78% false-conflict, 9 spatial-only true conflicts**, and the ablation still finding **9 unsound clears** with the rule disabled.

What survives is only what b42 declined to build: F1's `RelatingStructure` plus the storey's own `element` node, F2's `IfcRelVoidsElement` node, F3 falling out of both, and four script producers ported verbatim.

## The adjudication, and the test it overturned

b42 had committed a test **asserting the bug**:

```
it('hosting is NOT part of any node payload, so it cannot perturb a node hash')
  expect(await hashModelState(withHost)).toBe(await hashModelState(withoutHost));
```

with a comment calling it *"a v1 spec question, not a change this package may make unilaterally."* Inverted to `not.toBe` with a `rel-voids` node assertion, and both the comment and module docstring rewritten to say why this is a **producer obligation, not a format change** — the measurable argument being that `node-hash.ts` is untouched and **0 of the 55 frozen vectors move**.

Added the reachable two-coincident-walls construction, geometrically valid against b42's own containment check: under lazy cuts the host meshes are byte-identical, so the `IfcRelVoidsElement` node is the only thing separating the two states.

## Verification

**182 tests** (b42's 176 + 7 new − 1 duplicate). Negative control: reverting only the DAG binding fails **7 of 7**. `g0` / `g1` / `g2-footprint` / `g2-merge-soundness` all exit 0. B3.5 golden re-blessed on the same 7 paths with the same before/after as the standalone branch; no act1/3/5 movement; b42's act4 battery figures unchanged.

## One thing to know before the merge up

**E9, the numeral gate, is not an ancestor of `feat/b42-spatial-merge`** — b42 branched from `5c1ed287`, before `9039d402` added it. So E9 has never run against b42's prose and will fire for the first time when b42 merges into the docs branch. Worth knowing before that merge rather than after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
