### PR TITLE
chore(scripts): detect leftover Git LFS hooks that block pushes to a fork

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -15,6 +15,9 @@ Cargo.lock linguist-generated=true
 # Test fixtures (.ifc/.IFC/.ifcx) are fetched on demand via
 # `pnpm fixtures`. See tests/models/manifest.json for the catalogue and
 # tests/models/README.md for the rationale. The repo no longer uses Git LFS.
+# History still holds LFS pointers, so a stale `git lfs install` pre-push hook
+# in an older clone can still block pushes to a fork. `pnpm check:git-lfs`
+# detects that; `git lfs uninstall --local` clears it.
 # These overrides on the playground samples are kept as defense-in-depth:
 # if LFS is ever re-introduced for *.ifc, they ensure Vercel still serves
 # the real file bytes for the in-browser playground rather than pointers.

--- a/.gitattributes
+++ b/.gitattributes
@@ -17,7 +17,9 @@ Cargo.lock linguist-generated=true
 # tests/models/README.md for the rationale. The repo no longer uses Git LFS.
 # History still holds LFS pointers, so a stale `git lfs install` pre-push hook
 # in an older clone can still block pushes to a fork. `pnpm check:git-lfs`
-# detects that; `git lfs uninstall --local` clears it.
+# detects that and prints the fixes; read them before running one, because
+# `git lfs uninstall` deletes hooks from whatever `core.hooksPath` resolves to,
+# which other checkouts can share. docs/contributing/setup.md has the detail.
 # These overrides on the playground samples are kept as defense-in-depth:
 # if LFS is ever re-introduced for *.ifc, they ensure Vercel still serves
 # the real file bytes for the in-browser playground rather than pointers.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,18 +64,25 @@ Never hand-edit versions or `CHANGELOG.md`.
 - Keep client and project identifiers out of code, tests, commit messages, and
   PR text.
 
-If your push fails with `You need Push access to upload Git LFS objects`, run
-`git lfs uninstall --local` in this clone and push again. This repo retired
-Git LFS but its history still holds LFS pointer blobs, and a `pre-push` hook
-left by `git lfs install` asks git for the objects being pushed with
-`--not --remotes=<remote>`. With no remote-tracking refs for the remote you are
-pushing to, that widens to the whole history, so git-lfs queues those old
+If your push fails with `You need Push access to upload Git LFS objects`: this
+repo retired Git LFS but its history still holds LFS pointer blobs, and a
+`pre-push` hook left by `git lfs install` asks git for the objects being pushed
+with `--not --remotes=<remote>`. With no remote-tracking refs for the remote you
+are pushing to, that widens to the whole history, so git-lfs queues those old
 pointers for upload and the push dies uploading them. It only affects clones
 predating the retirement, or clones where `git lfs install` was run; a clone
-made today gets no LFS hooks. `--local` is clone-scoped and leaves your global
-Git LFS setup alone. `pnpm check:git-lfs` reports whether your clone has the
-leftover hooks and never changes anything, and `git push --no-verify` gets a
-push out in the meantime. Details in
+made today gets no LFS hooks. `pnpm check:git-lfs` reports whether your clone
+has the leftover hooks and never changes anything.
+
+`git push --no-verify` gets the push out changing nothing. The lasting fix is
+`git lfs uninstall --local`, but check what you are about to delete first:
+`--local` scopes the config edit, not the hook removal, and the hooks it
+removes are the ones in whatever `core.hooksPath` resolves to. That is the main
+clone's `.git/hooks` for every linked worktree, and can be another repository
+entirely if `core.hooksPath` is set. Run
+`git rev-parse --path-format=absolute --git-path hooks` to see the directory; if
+another checkout shares it, delete just the `pre-push` file in it instead.
+Details in
 [docs/contributing/setup.md](./docs/contributing/setup.md#push-fails-with-you-need-push-access-to-upload-git-lfs-objects).
 
 By contributing you agree your contributions are licensed under the repository

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,5 +64,19 @@ Never hand-edit versions or `CHANGELOG.md`.
 - Keep client and project identifiers out of code, tests, commit messages, and
   PR text.
 
+If your push fails with `You need Push access to upload Git LFS objects`, run
+`git lfs uninstall --local` in this clone and push again. This repo retired
+Git LFS but its history still holds LFS pointer blobs, and a `pre-push` hook
+left by `git lfs install` asks git for the objects being pushed with
+`--not --remotes=<remote>`. With no remote-tracking refs for the remote you are
+pushing to, that widens to the whole history, so git-lfs queues those old
+pointers for upload and the push dies uploading them. It only affects clones
+predating the retirement, or clones where `git lfs install` was run; a clone
+made today gets no LFS hooks. `--local` is clone-scoped and leaves your global
+Git LFS setup alone. `pnpm check:git-lfs` reports whether your clone has the
+leftover hooks and never changes anything, and `git push --no-verify` gets a
+push out in the meantime. Details in
+[docs/contributing/setup.md](./docs/contributing/setup.md#push-fails-with-you-need-push-access-to-upload-git-lfs-objects).
+
 By contributing you agree your contributions are licensed under the repository
 license and that you follow the [Code of Conduct](./CODE_OF_CONDUCT.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,15 +74,22 @@ predating the retirement, or clones where `git lfs install` was run; a clone
 made today gets no LFS hooks. `pnpm check:git-lfs` reports whether your clone
 has the leftover hooks and never changes anything.
 
-`git push --no-verify` gets the push out changing nothing. The lasting fix is
-`git lfs uninstall --local`, but check what you are about to delete first:
-`--local` scopes the config edit, not the hook removal, and the hooks it
-removes are the ones in whatever `core.hooksPath` resolves to. That is the main
-clone's `.git/hooks` for every linked worktree, and can be another repository
-entirely if `core.hooksPath` is set. Run
-`git rev-parse --path-format=absolute --git-path hooks` to see the directory; if
-another checkout shares it, delete just the `pre-push` file in it instead.
-Details in
+`git push --no-verify` gets the push out without changing anything on disk, but
+it skips **every** pre-push hook, not only the Git LFS one, so run whatever
+checks your other hooks would have run before you rely on it. Use it for this
+failure, not as a habit.
+
+The lasting fix is `git lfs uninstall --local`, but check what you are about to
+delete first: `--local` scopes the config edit, not the hook removal, and the
+hooks it removes are the ones in whatever `core.hooksPath` resolves to. That is
+the main clone's `.git/hooks` for every linked worktree, and can be another
+repository entirely if `core.hooksPath` is set. Run
+`git rev-parse --path-format=absolute --git-path hooks` to see the directory.
+
+If another checkout shares it, remove just the `pre-push` file there instead,
+and read the file before you delete it: a hook that only carries git-lfs's
+guard and `git lfs pre-push "$@"` is safe to drop, but if yours also runs your
+own commands, delete only the git-lfs lines and keep the rest. Details in
 [docs/contributing/setup.md](./docs/contributing/setup.md#push-fails-with-you-need-push-access-to-upload-git-lfs-objects).
 
 By contributing you agree your contributions are licensed under the repository

--- a/docs/contributing/setup.md
+++ b/docs/contributing/setup.md
@@ -349,15 +349,27 @@ that may not be the one you think, so read
 before picking either.
 
 ```bash
-# 1. Change nothing, get this one push out.
+# 1. Change nothing on disk, get this one push out.
+#    Skips EVERY pre-push hook, not just the Git LFS one.
 git push --no-verify <remote> <branch>
 
 # 2. Narrowest lasting fix: this hook only, no config touched.
+#    Read it first (see below) and delete only if it is git-lfs's.
 rm "$(git rev-parse --path-format=absolute --git-path hooks)/pre-push"
 
 # 3. Whole-clone fix: removes the hooks and this clone's lfs filters.
 git lfs uninstall --local
 ```
+
+Two cautions on the first two.
+
+`--no-verify` skips **all** pre-push hooks. If your clone runs anything else at
+push time, run those checks yourself before leaning on it.
+
+Before running the `rm`, read the file. A hook git-lfs wrote is a shebang, an
+optional "is git-lfs installed" guard, and `git lfs pre-push "$@"`, and dropping
+it costs nothing here because this repo has no LFS content. If yours also runs
+your own commands, delete only the git-lfs lines and keep the rest.
 
 `--local` is clone-scoped in its **config** effect. Per
 `git lfs uninstall --help` it removes the lfs smudge and clean filters from

--- a/docs/contributing/setup.md
+++ b/docs/contributing/setup.md
@@ -343,28 +343,84 @@ clone may report more, because `--all` walks every ref it has and a long-lived
 clone also has remote-tracking refs for forks. None of those objects are at
 HEAD: no `.gitattributes` in this repo declares `filter=lfs` any more.
 
-Fix this clone once, then push again:
+Three fixes, least invasive first. Fixes 2 and 3 both touch a hooks directory
+that may not be the one you think, so read
+[Check which hooks directory you are about to change](#check-which-hooks-directory-you-are-about-to-change)
+before picking either.
 
 ```bash
+# 1. Change nothing, get this one push out.
+git push --no-verify <remote> <branch>
+
+# 2. Narrowest lasting fix: this hook only, no config touched.
+rm "$(git rev-parse --path-format=absolute --git-path hooks)/pre-push"
+
+# 3. Whole-clone fix: removes the hooks and this clone's lfs filters.
 git lfs uninstall --local
 ```
 
-`--local` is clone-scoped. Per `git lfs uninstall --help` it removes the lfs
-smudge and clean filters from this repository's git config instead of the
-global `~/.gitconfig`, so Git LFS keeps working in your other repositories.
-`git lfs install --local` puts this clone's LFS setup back if you ever need it.
+`--local` is clone-scoped in its **config** effect. Per
+`git lfs uninstall --help` it removes the lfs smudge and clean filters from
+this repository's git config instead of the global `~/.gitconfig`, so Git LFS
+keeps working in your other repositories. `git lfs install --local` puts this
+clone's LFS setup back if you ever need it.
 
-`git push --no-verify` skips the hook for one push if you want to get something
-out first, and deleting `.git/hooks/pre-push` by hand stops it for good.
+#### Check which hooks directory you are about to change
+
+`git lfs uninstall` also deletes git-lfs's hook files, and `--local` does not
+scope that part. The hooks it deletes are the ones in whatever `core.hooksPath`
+resolves to, which is not always the `.git/hooks` of the checkout you are
+standing in:
+
+- every **linked worktree** of a clone resolves to the main clone's
+  `.git/hooks`, with nobody having configured anything;
+- `core.hooksPath` can be set, locally or globally, to an absolute path in a
+  **different repository**, and then that repository's hooks are the ones on
+  the chopping block.
+
+Measured with git-lfs 3.7.1 and git 2.50.1: `git lfs uninstall --local` run
+inside a repo whose `core.hooksPath` pointed at another repository's
+`.git/hooks` deleted that other repository's `pre-push`, `post-checkout`,
+`post-commit` and `post-merge`. An unrelated `pre-commit` in the same directory
+survived, so it removes git-lfs's own hooks rather than everything, but the
+repository that owned them is now without a `pre-push`, and per
+`git lfs pre-push --help` that hook is what uploads a commit's LFS objects.
+Pushes from that repository silently stop uploading them.
+
+It only deletes a hook whose body it recognises as one it wrote: given a
+hand-edited body it prints `Hook already exists: <name>` and leaves the file.
+That is a narrower blast radius than the paragraph above might suggest, but it
+is not a safety net, because the hooks git-lfs installed are exactly the ones
+it recognises.
+
+This directory-resolution surprise is not hypothetical here. An earlier,
+automated version of `pnpm check:git-lfs` could delete the hooks itself; run
+from a throwaway directory, it resolved through `core.hooksPath` and deleted
+the real clone's hooks. That is why the check is detection-only now and prints
+commands for you to run instead. The same resolution applies to the commands.
+
+So before running fix 2 or fix 3, print the directory and satisfy yourself that
+no other checkout shares it:
+
+```bash
+git config --get core.hooksPath                         # empty means unset
+git rev-parse --path-format=absolute --git-path hooks   # what will be changed
+```
+
+If it is shared, fix 1 is the one that touches nothing. Reach for fix 2 only
+once you know the checkout that owns that directory does not need its
+`pre-push`.
 
 `pnpm check:git-lfs` reports whether your clone has the leftover hooks and
 never writes anything. Two things about it are worth knowing before you read
 its output: it inspects the repository the script file lives in, not your
-current directory, and the hooks directory it names is whatever
-`core.hooksPath` resolves to, which can be an absolute path outside the
-checkout you are standing in and is shared by every linked worktree of that
-clone. Run it again after `git lfs uninstall --local`; if a hook is still
-listed, read that file and delete it yourself.
+current directory, and the hooks directory it names is that same
+`core.hooksPath` resolution, so it names the directory for you and warns when
+`core.hooksPath` is set. It only stays quiet about the hooks when a
+`filter=lfs` rule actually applies to a path in your checkout, which it asks
+`git check-attr`; a stale rule matching nothing does not buy silence. Run it
+again after the fix; if a hook is still listed, read that file and delete it
+yourself.
 
 Who hits this: clones made before this repo retired Git LFS, and clones where
 someone ran `git lfs install`. A clone made today is unaffected; cloning this
@@ -421,8 +477,9 @@ Push your branch and open a PR on GitHub:
 git push origin feature/my-feature
 ```
 
-If the push fails with `You need Push access to upload Git LFS objects`, run
-`git lfs uninstall --local` and push again. See
+If the push fails with `You need Push access to upload Git LFS objects`,
+`git push --no-verify` gets it out unchanged; for the lasting fix, and for the
+one thing to check before you run it, see
 [Push fails with "You need Push access to upload Git LFS objects"](#push-fails-with-you-need-push-access-to-upload-git-lfs-objects).
 
 **PR Requirements:**

--- a/docs/contributing/setup.md
+++ b/docs/contributing/setup.md
@@ -82,7 +82,10 @@ cd ifc-lite
 
 The repository does not use Git LFS. Test model files (IFC/IFCX fixtures) are
 not stored in git at all; they are fetched from a GitHub Release in the next
-steps.
+steps. A fresh clone installs no Git LFS hooks, so there is nothing to do here
+even if you have Git LFS on your machine. (If a later push fails with
+`You need Push access to upload Git LFS objects`, see
+[Push fails with "You need Push access to upload Git LFS objects"](#push-fails-with-you-need-push-access-to-upload-git-lfs-objects).)
 
 ### 2. Install Dependencies
 
@@ -321,6 +324,69 @@ pnpm install
 pnpm -r build
 ```
 
+### Push fails with "You need Push access to upload Git LFS objects"
+
+Verbatim output from a real push of a text-only commit to a contributor's fork.
+The push dies while Git LFS is uploading objects, before any ref reaches the
+remote.
+
+```
+batch response: You need Push access to upload Git LFS objects.
+Uploading LFS objects:   0% (0/80), 0 B | 0 B/s, done.
+error: failed to push some refs
+```
+
+The 80 is not your commit: it is the number of Git LFS pointer blobs this
+repository's history still holds, as counted over the refs of a plain clone.
+`git lfs ls-files --all` in a fresh clone prints the same 80 files. Your own
+clone may report more, because `--all` walks every ref it has and a long-lived
+clone also has remote-tracking refs for forks. None of those objects are at
+HEAD: no `.gitattributes` in this repo declares `filter=lfs` any more.
+
+Fix this clone once, then push again:
+
+```bash
+git lfs uninstall --local
+```
+
+`--local` is clone-scoped. Per `git lfs uninstall --help` it removes the lfs
+smudge and clean filters from this repository's git config instead of the
+global `~/.gitconfig`, so Git LFS keeps working in your other repositories.
+`git lfs install --local` puts this clone's LFS setup back if you ever need it.
+
+`git push --no-verify` skips the hook for one push if you want to get something
+out first, and deleting `.git/hooks/pre-push` by hand stops it for good.
+
+`pnpm check:git-lfs` reports whether your clone has the leftover hooks and
+never writes anything. Two things about it are worth knowing before you read
+its output: it inspects the repository the script file lives in, not your
+current directory, and the hooks directory it names is whatever
+`core.hooksPath` resolves to, which can be an absolute path outside the
+checkout you are standing in and is shared by every linked worktree of that
+clone. Run it again after `git lfs uninstall --local`; if a hook is still
+listed, read that file and delete it yourself.
+
+Who hits this: clones made before this repo retired Git LFS, and clones where
+someone ran `git lfs install`. A clone made today is unaffected; cloning this
+repository now leaves `.git/hooks` with nothing but git's own `.sample` files.
+
+What is happening: `git lfs install` leaves a `pre-push` hook in `.git/hooks`,
+and hooks are not version-controlled, so retiring LFS on a branch cannot remove
+a hook that already exists in your clone. The hook asks git which objects are
+about to be pushed with `git rev-list --objects <sha> --not --remotes=<remote>`.
+When your clone has no remote-tracking refs for that remote, which is the normal
+state right after `git remote add fork ...`, the `--not` side excludes nothing,
+so the range widens to the entire history, which still contains LFS pointer
+blobs from before the migration. git-lfs queues every one of them for upload,
+and the push fails while it is uploading them, even though the commits you are
+pushing contain only `.ts`/`.md` files. Fetch from that remote once, so the
+clone has remote-tracking refs, and the same push queues nothing: the same
+mechanism seen from the other side.
+
+Why the LFS server refuses the upload is not something we have reproduced, so
+this page does not guess at it. The fix does not depend on the answer: stop the
+hook from offering the objects and the push goes through.
+
 ## Contributing Changes
 
 ### 1. Create a Branch
@@ -354,6 +420,10 @@ Push your branch and open a PR on GitHub:
 ```bash
 git push origin feature/my-feature
 ```
+
+If the push fails with `You need Push access to upload Git LFS objects`, run
+`git lfs uninstall --local` and push again. See
+[Push fails with "You need Push access to upload Git LFS objects"](#push-fails-with-you-need-push-access-to-upload-git-lfs-objects).
 
 **PR Requirements:**
 - All tests pass

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -253,7 +253,7 @@ ifc-lite no longer ships its own desktop app. The published `@ifc-lite/*` packag
 If you need large IFC benchmark fixtures, fetch only the specific files you plan to use:
 
 ```bash
-git lfs pull --include="tests/models/ara3d/AC20-FZK-Haus.ifc"
+pnpm fixtures tests/models/ara3d/AC20-FZK-Haus.ifc
 ```
 
 !!! note "Prerequisites for a Desktop Build"
@@ -280,8 +280,8 @@ git lfs pull --include="tests/models/ara3d/AC20-FZK-Haus.ifc"
 ### Clone and Build
 
 ```bash
-# Clone the repository
-GIT_LFS_SKIP_SMUDGE=1 git clone https://github.com/LTplus-AG/ifc-lite.git
+# Clone the repository (no Git LFS: fixtures are fetched on demand)
+git clone https://github.com/LTplus-AG/ifc-lite.git
 cd ifc-lite
 
 # Install dependencies

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "check:test-wiring": "node scripts/check-test-wiring.mjs",
     "check:api-surface": "node scripts/check-api-surface.mjs",
     "api-surface:update": "node scripts/check-api-surface.mjs --update",
+    "check:git-lfs": "node scripts/check-git-lfs.mjs",
     "generate:server-attr-indices": "pnpm turbo build --filter=@ifc-lite/parser && node scripts/generate-server-attr-indices.mjs",
     "check:server-attr-indices": "pnpm turbo build --filter=@ifc-lite/parser && node scripts/generate-server-attr-indices.mjs --check",
     "test:regression": "node scripts/test-geometry-regression.mjs",

--- a/scripts/check-git-lfs.mjs
+++ b/scripts/check-git-lfs.mjs
@@ -1,0 +1,265 @@
+#!/usr/bin/env node
+/**
+ * check-git-lfs.mjs - a READ-ONLY detector for leftover Git LFS hooks.
+ *
+ * WHAT IT INSPECTS, AND IT IS PROBABLY NOT WHAT YOU EXPECT
+ *
+ *   It inspects THE REPOSITORY THIS SCRIPT FILE LIVES IN, resolved from
+ *   `import.meta.url`, NOT the current working directory. Running it from
+ *   somewhere else, a sandbox included, does not move the target: it still
+ *   reports on this clone.
+ *
+ *   The hooks directory it reads is whatever `git rev-parse --git-path hooks`
+ *   resolves to, and that honours `core.hooksPath`. A fresh clone leaves that
+ *   unset, but if someone has set it, it can be an ABSOLUTE path to another
+ *   checkout's `.git/hooks`, shared by every linked worktree of that clone. In
+ *   that case the directory named in the output is NOT the `.git/hooks` under
+ *   the checkout you are standing in. Read the path it prints before acting on
+ *   it; the output names it whenever `core.hooksPath` is set.
+ *
+ * WHY DETECTION ONLY
+ *
+ *   This script used to have a `--fix` mode that deleted the hook files and
+ *   cleared the repo-local `filter.lfs.*` config. Four rounds of hardening
+ *   kept finding new ways for an automated `.git` mutation to go wrong:
+ *   partial config/hook states, a config value containing a newline that unset
+ *   unrelated keys, a race with a concurrent hook installer, and finally the
+ *   target-resolution surprise above, where a run started from a throwaway
+ *   directory reached through `core.hooksPath` and deleted the real clone's
+ *   hooks. Detection carries none of that risk and gets nearly all of the
+ *   value, because the remedy is a single command the developer runs.
+ *
+ * THIS SCRIPT NEVER WRITES
+ *
+ *   From `node:fs` it imports `readFileSync` and `statSync` and nothing else:
+ *   no `unlink`, no `writeFile`, no `rmSync`. It spawns `git` from exactly one
+ *   place, and that is the complete list of subcommands it can run, all reads:
+ *
+ *       git rev-parse --is-inside-work-tree
+ *       git rev-parse --git-path hooks
+ *       git rev-parse --git-path info/attributes
+ *       git rev-parse --show-toplevel
+ *       git config --get core.hooksPath
+ *       git config --get core.attributesFile
+ *       git ls-files -z --cached --others --exclude-standard -- <pathspecs>
+ *
+ *   No `git config --unset`, no `--remove-section`, no `--replace-all`, no
+ *   `git lfs` at all. `git ls-files` above is git's own index/worktree
+ *   listing, not `git lfs ls-files`: the latter writes
+ *   `lfs.repositoryformatversion` into `.git/config` (confirmed with git-lfs
+ *   3.7.1 in a throwaway clone), which is why "does this repo use Git LFS?"
+ *   is answered from git attributes alone.
+ *
+ * BACKGROUND
+ *
+ *   This repo retired Git LFS, but its history still contains LFS pointer
+ *   blobs; a plain clone from origin holds 80 of them. Nothing at HEAD is a
+ *   pointer: no `.gitattributes` has a `filter=lfs` rule, and fixtures are
+ *   fetched on demand with `pnpm fixtures`.
+ *
+ *   Hooks are not version-controlled, so retiring LFS on a branch cannot
+ *   remove a hook that already sits in someone's clone. The `pre-push` hook
+ *   runs `git lfs pre-push <remote> <url>`, which asks git what is about to be
+ *   pushed with `git rev-list --objects <sha> --not --remotes=<remote>`. With
+ *   no remote-tracking refs for that remote, the normal state right after
+ *   `git remote add fork ...`, the `--not` side excludes nothing, the range
+ *   widens to the whole history, and every historical LFS pointer is queued
+ *   for upload. The push then fails while git-lfs uploads them.
+ *
+ *   Who is affected: clones predating the LFS retirement, and clones where
+ *   someone ran `git lfs install`. A clone made today installs no LFS hooks.
+ *
+ * THE REMEDY IT PRINTS
+ *
+ *   `git lfs uninstall --local`. Per `git lfs uninstall --help`, `--local`
+ *   removes the lfs smudge and clean filters from the local repository's git
+ *   config "instead of the global git config (~/.gitconfig)", so the
+ *   developer's global Git LFS setup keeps working everywhere else.
+ *
+ * EXIT CODES
+ *
+ *   1 when leftover git-lfs hooks are present in this clone, 0 otherwise: no
+ *   such hooks, not a git work tree, this checkout genuinely declares
+ *   `filter=lfs`, or the hooks directory could not be resolved at all.
+ *
+ *   This is a local-developer tool. It is NOT wired into CI or into any
+ *   install hook, and it must stay that way.
+ */
+
+import { readFileSync, statSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { homedir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+const ROOT = resolve(import.meta.dirname, '..');
+
+// The hooks `git lfs install` writes. Only pre-push blocks a push; the others
+// just spawn git-lfs on every checkout/commit/merge for no reason.
+const LFS_HOOKS = ['pre-push', 'post-checkout', 'post-commit', 'post-merge'];
+
+/** Read-only git call, always against this script's own repo. */
+function git(args, opts = {}) {
+  const r = spawnSync('git', args, { cwd: ROOT, encoding: 'utf-8', ...opts });
+  return { ok: r.status === 0, status: r.status, stdout: (r.stdout || '').trim() };
+}
+
+// --- Is this even a git work tree? ----------------------------------------
+// Check the printed value, not just the exit status: a bare repo answers
+// "false" with exit 0.
+const insideWorkTree = git(['rev-parse', '--is-inside-work-tree']);
+if (!insideWorkTree.ok || insideWorkTree.stdout !== 'true') {
+  console.log('✅ Not a git work tree, nothing to check.');
+  process.exit(0);
+}
+
+// --- Where does this clone keep its hooks? --------------------------------
+const hooksDirRaw = git(['rev-parse', '--git-path', 'hooks']);
+if (!hooksDirRaw.ok || !hooksDirRaw.stdout) {
+  console.error(`⚠️  Cannot tell where this clone keeps its hooks
+   (\`git rev-parse --git-path hooks\` exited ${hooksDirRaw.status}), so this
+   check cannot run. Nothing was inspected and nothing was changed.`);
+  process.exit(0);
+}
+const hooksDir = resolve(ROOT, hooksDirRaw.stdout);
+const configuredHooksPath = git(['config', '--get', 'core.hooksPath']).stdout;
+
+// --- Which of those hooks are git-lfs's? ----------------------------------
+// git-lfs hooks are three lines: `#!/bin/sh`, an optional "is git-lfs on
+// PATH?" guard, and `git lfs <hookname> "$@"` last. Requiring that dispatch
+// line is enough to tell one from an unrelated hook such as husky's pre-push.
+// This classifier does not need to be airtight: since nothing is ever
+// deleted, a misclassification costs a wrong message, not a lost file.
+const dispatchRe = (name) => new RegExp(String.raw`^git[- ]lfs\s+${name}\b`, 'm');
+
+const found = [];
+const unreadable = [];
+for (const name of LFS_HOOKS) {
+  const path = join(hooksDir, name);
+  let text;
+  try {
+    text = readFileSync(path, 'utf-8');
+  } catch (err) {
+    if (err.code !== 'ENOENT') unreadable.push(`${path} (${err.message})`);
+    continue;
+  }
+  const lines = text.split('\n').map((l) => l.replace(/\r$/, '').trim());
+  if (!lines.some((l) => dispatchRe(name).test(l))) continue; // somebody else's hook
+  found.push({ name, path });
+}
+
+if (found.length === 0) {
+  console.log(`✅ No leftover Git LFS hooks in ${hooksDir}.`);
+  if (unreadable.length > 0) {
+    console.log(`   (Could not read: ${unreadable.join(', ')})`);
+  }
+  process.exit(0);
+}
+
+// --- Does this checkout genuinely use LFS? --------------------------------
+// A file is an LFS file because a `filter=lfs` attribute applies to it, so the
+// attributes are the authority, and the ones that count are the ones on disk
+// right now: `git lfs track` writes `.gitattributes` without committing it, so
+// a repo half-way through ADOPTING LFS must not read as one that retired it.
+const ATTR_LFS_RE = /(^|\s)filter=lfs(\s|$)/;
+
+function declaresLfs(text) {
+  return text.split('\n').some((raw) => {
+    const line = raw.replace(/\r$/, '').trim();
+    if (!line || line.startsWith('#')) return false;
+    return ATTR_LFS_RE.test(line);
+  });
+}
+
+function readIfFile(path) {
+  try {
+    if (!statSync(path).isFile()) return null;
+    return readFileSync(path, 'utf-8');
+  } catch {
+    return null;
+  }
+}
+
+function globalAttributesPath() {
+  const cfg = git(['config', '--get', 'core.attributesFile']);
+  if (cfg.ok && cfg.stdout) {
+    return cfg.stdout.startsWith('~/') ? join(homedir(), cfg.stdout.slice(2)) : resolve(ROOT, cfg.stdout);
+  }
+  const xdg = process.env.XDG_CONFIG_HOME;
+  return xdg ? join(xdg, 'git', 'attributes') : join(homedir(), '.config', 'git', 'attributes');
+}
+
+function attributeFilesDeclaringLfs() {
+  const candidates = [];
+  // Search from the work tree root, so a `.gitattributes` above this directory
+  // is seen too. Tracked (`--cached`, read from disk) and untracked
+  // (`--others`) alike; nothing here reads blob contents.
+  const top = git(['rev-parse', '--show-toplevel']);
+  if (top.ok && top.stdout) {
+    const ls = git(
+      ['ls-files', '-z', '--cached', '--others', '--exclude-standard', '--', ':(glob)**/.gitattributes', '.gitattributes'],
+      { cwd: top.stdout },
+    );
+    if (ls.ok) candidates.push(...ls.stdout.split('\0').filter(Boolean).map((rel) => resolve(top.stdout, rel)));
+  }
+  // `.git/info/attributes` is not version-controlled but carries the same
+  // weight, and so does the user's global attributes file.
+  const info = git(['rev-parse', '--git-path', 'info/attributes']);
+  if (info.ok && info.stdout) candidates.push(resolve(ROOT, info.stdout));
+  candidates.push(globalAttributesPath());
+
+  const declaring = [];
+  for (const path of [...new Set(candidates)]) {
+    const text = readIfFile(path);
+    if (text !== null && declaresLfs(text)) declaring.push(path);
+  }
+  return declaring;
+}
+
+const declaring = attributeFilesDeclaringLfs();
+if (declaring.length > 0) {
+  console.log(`✅ This checkout tracks files with Git LFS, so its LFS hooks belong there.
+   filter=lfs is declared in:
+${declaring.map((p) => `      ${p}`).join('\n')}`);
+  process.exit(0);
+}
+
+// --- Report. ---------------------------------------------------------------
+console.error(`❌ This clone still has Git LFS hooks, but this repo has no LFS content.
+
+Checked the repo this script lives in (${ROOT}), NOT the current directory.
+
+Leftover hooks in ${hooksDir}:
+${found.map((h) => `   ${h.path}`).join('\n')}
+${
+  configuredHooksPath
+    ? `
+core.hooksPath is set to ${configuredHooksPath}, so that is the directory
+above, and every worktree of that clone shares it. It may well not be the
+.git/hooks of the checkout you are in.
+`
+    : ''
+}
+\`git lfs pre-push\` asks git for the objects being pushed with
+\`--not --remotes=<remote>\`. Push to a remote this clone has no
+remote-tracking refs for, a fork you just added, and that excludes nothing,
+so the range becomes the whole history, which still holds LFS pointer blobs.
+git-lfs queues those for upload and the push fails uploading them, even though
+your own commits contain no LFS files.
+
+Remedy, one command, run it yourself:
+   git lfs uninstall --local
+
+\`--local\` is clone-scoped: per \`git lfs uninstall --help\` it removes the lfs
+filters from this repository's git config instead of the global
+~/.gitconfig, so your Git LFS setup in other repos is left alone.
+
+Then re-run \`pnpm check:git-lfs\`. If a hook is still listed, read it and
+delete the file yourself.
+
+To get one push out without changing anything:
+   git push --no-verify <remote> <branch>
+`);
+if (unreadable.length > 0) {
+  console.error(`Also could not read: ${unreadable.join(', ')}\n`);
+}
+process.exit(1);

--- a/scripts/check-git-lfs.mjs
+++ b/scripts/check-git-lfs.mjs
@@ -142,7 +142,16 @@ const LFS_HOOKS = ['pre-push', 'post-checkout', 'post-commit', 'post-merge'];
 
 /** Read-only git call, always against this script's own repo. */
 function git(args, opts = {}) {
-  const r = spawnSync('git', args, { cwd: ROOT, encoding: 'utf-8', ...opts });
+  // 64 MiB by default, not node's 1 MiB: `ls-files` over a big checkout can
+  // exceed that, and spawnSync truncates silently rather than erroring, which
+  // would make a repo look like it has fewer paths than it does. Callers can
+  // still override.
+  const r = spawnSync('git', args, {
+    cwd: ROOT,
+    encoding: 'utf-8',
+    maxBuffer: 64 * 1024 * 1024,
+    ...opts,
+  });
   // `raw` is for NUL-separated output, where trimming could eat a leading
   // space in the first path.
   return { ok: r.status === 0, status: r.status, stdout: (r.stdout || '').trim(), raw: r.stdout || '' };
@@ -386,10 +395,14 @@ objects on push, and it will not tell you.
 
 Remedies, least invasive first.
 
-1. Change nothing, get this push out:
+1. Change nothing on disk, get this push out. Note this skips EVERY
+   pre-push hook, not only the Git LFS one, so run whatever else your
+   clone checks at push time yourself:
       git push --no-verify <remote> <branch>
 
-2. Narrowest fix, this hook only, no config touched:
+2. Narrowest fix, this hook only, no config touched. Read the file first:
+   if it runs anything besides git-lfs's guard and dispatch, delete only
+   the git-lfs lines instead of the whole file:
       rm ${pushHook ? pushHook.path : join(hooksDir, 'pre-push')}
 
 3. Whole-clone fix, only once you are sure no other checkout shares the

--- a/scripts/check-git-lfs.mjs
+++ b/scripts/check-git-lfs.mjs
@@ -41,14 +41,17 @@
  *       git rev-parse --show-toplevel
  *       git config --get core.hooksPath
  *       git config --get core.attributesFile
- *       git ls-files -z --cached --others --exclude-standard -- <pathspecs>
+ *       git ls-files -z --cached --others --exclude-standard [-- <pathspecs>]
+ *       git check-attr filter --stdin -z
  *
  *   No `git config --unset`, no `--remove-section`, no `--replace-all`, no
  *   `git lfs` at all. `git ls-files` above is git's own index/worktree
  *   listing, not `git lfs ls-files`: the latter writes
  *   `lfs.repositoryformatversion` into `.git/config` (confirmed with git-lfs
  *   3.7.1 in a throwaway clone), which is why "does this repo use Git LFS?"
- *   is answered from git attributes alone.
+ *   is answered from git attributes alone. `git check-attr` only reports the
+ *   attributes that apply to a path; running it in a throwaway repo left
+ *   `git config --local -l` and every file under `.git` byte-identical.
  *
  * BACKGROUND
  *
@@ -69,18 +72,58 @@
  *   Who is affected: clones predating the LFS retirement, and clones where
  *   someone ran `git lfs install`. A clone made today installs no LFS hooks.
  *
- * THE REMEDY IT PRINTS
+ * THE REMEDIES IT PRINTS, AND THE HAZARD IN THE BIGGEST ONE
  *
- *   `git lfs uninstall --local`. Per `git lfs uninstall --help`, `--local`
- *   removes the lfs smudge and clean filters from the local repository's git
- *   config "instead of the global git config (~/.gitconfig)", so the
- *   developer's global Git LFS setup keeps working everywhere else.
+ *   `git lfs uninstall --local` is clone-scoped in its CONFIG effect only.
+ *   Per `git lfs uninstall --help`, `--local` removes the lfs smudge and
+ *   clean filters from the local repository's git config "instead of the
+ *   global git config (~/.gitconfig)"; the same help text also says it will
+ *   "Uninstall the Git LFS pre-push hook if run from inside a Git
+ *   repository", and that hook removal is NOT scoped by `--local`. It deletes
+ *   git-lfs's hooks from whatever `core.hooksPath` resolves to, which is the
+ *   same lookup this script reports on.
+ *
+ *   Measured with git-lfs 3.7.1 and git 2.50.1 in throwaway repos: with
+ *   `core.hooksPath` pointing at ANOTHER repository's `.git/hooks` (set
+ *   locally in one run, globally in another), `git lfs uninstall --local` run
+ *   from a repo that had no LFS config of its own deleted that other
+ *   repository's `pre-push`, `post-checkout`, `post-commit` and `post-merge`.
+ *   An unrelated `pre-commit` hook in the same directory survived, so it
+ *   removes git-lfs's own hooks rather than everything, but the repository
+ *   that owned them loses its `pre-push`, and per `git lfs pre-push --help`
+ *   that hook is what pushes a commit's LFS objects to the LFS API. Without
+ *   it, that repository's pushes stop uploading its LFS objects.
+ *
+ *   Linked worktrees hit the same sharing without anyone setting
+ *   `core.hooksPath`: a linked worktree resolves `--git-path hooks` to the
+ *   main clone's `.git/hooks` (verified with `git rev-parse`), so every
+ *   worktree of a clone shares one hooks directory.
+ *
+ *   That is why the report warns before it prints the command, and offers
+ *   `git push --no-verify` (changes nothing) and deleting the single
+ *   `pre-push` file (narrowest change) first.
+ *
+ * WHEN IT STAYS SILENT, AND WHICH WAY IT ERRS
+ *
+ *   Silence needs a `filter=lfs` rule that APPLIES to a path that exists
+ *   here, not merely a rule somewhere. `git check-attr filter --stdin -z` is
+ *   asked, over the paths `git ls-files --cached --others --exclude-standard`
+ *   lists, capped at CHECK_ATTR_PATH_LIMIT. On this repo that listing is
+ *   ~4.2k paths and the pipe takes ~20ms, so the cap only bites on a checkout
+ *   several times this size; and the scan runs at most once, only after a
+ *   rule was already found, so the usual run never pays for it.
+ *
+ *   If the answer cannot be established, because git refused or because the
+ *   listing was longer than the cap, it REPORTS the hooks and says which of
+ *   the two it was. Reporting a repo that is fine costs a message the reader
+ *   can ignore; staying silent costs the failed push this exists to prevent.
  *
  * EXIT CODES
  *
  *   1 when leftover git-lfs hooks are present in this clone, 0 otherwise: no
- *   such hooks, not a git work tree, this checkout genuinely declares
- *   `filter=lfs`, or the hooks directory could not be resolved at all.
+ *   such hooks, not a git work tree, this checkout genuinely uses
+ *   `filter=lfs` on a path that exists, or the hooks directory could not be
+ *   resolved at all.
  *
  *   This is a local-developer tool. It is NOT wired into CI or into any
  *   install hook, and it must stay that way.
@@ -100,7 +143,9 @@ const LFS_HOOKS = ['pre-push', 'post-checkout', 'post-commit', 'post-merge'];
 /** Read-only git call, always against this script's own repo. */
 function git(args, opts = {}) {
   const r = spawnSync('git', args, { cwd: ROOT, encoding: 'utf-8', ...opts });
-  return { ok: r.status === 0, status: r.status, stdout: (r.stdout || '').trim() };
+  // `raw` is for NUL-separated output, where trimming could eat a leading
+  // space in the first path.
+  return { ok: r.status === 0, status: r.status, stdout: (r.stdout || '').trim(), raw: r.stdout || '' };
 }
 
 // --- Is this even a git work tree? ----------------------------------------
@@ -156,10 +201,21 @@ if (found.length === 0) {
 }
 
 // --- Does this checkout genuinely use LFS? --------------------------------
-// A file is an LFS file because a `filter=lfs` attribute applies to it, so the
-// attributes are the authority, and the ones that count are the ones on disk
-// right now: `git lfs track` writes `.gitattributes` without committing it, so
-// a repo half-way through ADOPTING LFS must not read as one that retired it.
+// A file is an LFS file because a `filter=lfs` attribute APPLIES TO IT, so a
+// rule on its own settles nothing: a leftover `*.psd filter=lfs` in a repo
+// with no `.psd` files would otherwise silence this check for exactly the
+// person who needs it. So this is two questions, and both must answer yes:
+//
+//   1. is there a `filter=lfs` rule at all, and in which file?  (cheap, and
+//      it is what lets the output name the file)
+//   2. does that rule apply to a path that exists in this checkout?  (asked
+//      of `git check-attr`, which is git's own answer to it)
+//
+// The attributes that count are the ones on disk right now: `git lfs track`
+// writes `.gitattributes` without committing it, so a repo half-way through
+// ADOPTING LFS must not read as one that retired it. `git check-attr` without
+// `--cached` reads the working tree, and also honours `.git/info/attributes`
+// and `core.attributesFile` (both verified).
 const ATTR_LFS_RE = /(^|\s)filter=lfs(\s|$)/;
 
 function declaresLfs(text) {
@@ -199,7 +255,7 @@ function attributeFilesDeclaringLfs() {
       ['ls-files', '-z', '--cached', '--others', '--exclude-standard', '--', ':(glob)**/.gitattributes', '.gitattributes'],
       { cwd: top.stdout },
     );
-    if (ls.ok) candidates.push(...ls.stdout.split('\0').filter(Boolean).map((rel) => resolve(top.stdout, rel)));
+    if (ls.ok) candidates.push(...ls.raw.split('\0').filter(Boolean).map((rel) => resolve(top.stdout, rel)));
   }
   // `.git/info/attributes` is not version-controlled but carries the same
   // weight, and so does the user's global attributes file.
@@ -215,30 +271,92 @@ function attributeFilesDeclaringLfs() {
   return declaring;
 }
 
+// How many paths this is willing to hand to `git check-attr`. On this repo the
+// whole listing is ~4.2k paths and `ls-files | check-attr` takes ~20ms, so the
+// bound only bites on a checkout more than about five times this size. It is a
+// bound on work, not on correctness for repos of this size, and the scan runs
+// at most once, only after a `filter=lfs` rule was already found.
+const CHECK_ATTR_PATH_LIMIT = 20000;
+
+/**
+ * Ask git whether `filter=lfs` actually applies to a path that exists here.
+ * Returns 'applies' with the first such path, 'unused' when the complete
+ * listing was checked and nothing matched, or 'unknown' when git would not
+ * answer or the listing was longer than the bound.
+ */
+function lfsFilterAppliesToAPath() {
+  const top = git(['rev-parse', '--show-toplevel']);
+  if (!top.ok || !top.stdout) return { verdict: 'unknown', why: '`git rev-parse --show-toplevel` failed' };
+
+  const ls = git(['ls-files', '-z', '--cached', '--others', '--exclude-standard'], { cwd: top.stdout });
+  if (!ls.ok) return { verdict: 'unknown', why: '`git ls-files` failed' };
+  const paths = ls.raw.split('\0').filter(Boolean);
+  if (paths.length === 0) return { verdict: 'unused', checked: 0 };
+  const checked = paths.slice(0, CHECK_ATTR_PATH_LIMIT);
+
+  // `--stdin -z` so paths with spaces, quotes or newlines survive the trip.
+  const attr = git(['check-attr', 'filter', '--stdin', '-z'], {
+    cwd: top.stdout,
+    input: `${checked.join('\0')}\0`,
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  if (!attr.ok) return { verdict: 'unknown', why: `\`git check-attr\` exited ${attr.status}` };
+
+  // Output is flat NUL-separated triples: <path> <attr> <value>.
+  const f = attr.raw.split('\0');
+  for (let i = 0; i + 2 < f.length; i += 3) {
+    if (f[i + 1] === 'filter' && f[i + 2] === 'lfs') return { verdict: 'applies', path: f[i] };
+  }
+  if (checked.length < paths.length) {
+    return { verdict: 'unknown', why: `checked the first ${checked.length} of ${paths.length} paths`, checked: checked.length };
+  }
+  return { verdict: 'unused', checked: checked.length };
+}
+
 const declaring = attributeFilesDeclaringLfs();
+let applies = null;
 if (declaring.length > 0) {
-  console.log(`✅ This checkout tracks files with Git LFS, so its LFS hooks belong there.
+  applies = lfsFilterAppliesToAPath();
+  if (applies.verdict === 'applies') {
+    console.log(`✅ This checkout tracks files with Git LFS, so its LFS hooks belong there.
    filter=lfs is declared in:
-${declaring.map((p) => `      ${p}`).join('\n')}`);
-  process.exit(0);
+${declaring.map((p) => `      ${p}`).join('\n')}
+   and \`git check-attr\` says it applies to ${applies.path}`);
+    process.exit(0);
+  }
 }
 
 // --- Report. ---------------------------------------------------------------
+// The `filter=lfs` rules that exist but match nothing. Saying which file they
+// are in matters: a stale rule used to silence this check entirely, and the
+// reader may want to delete it.
+const staleRules =
+  declaring.length === 0
+    ? ''
+    : applies.verdict === 'unused'
+      ? `
+A \`filter=lfs\` rule exists here, but it is stale: \`git check-attr filter\`
+finds no path among the ${applies.checked} in this checkout that it applies to,
+so nothing here is an LFS file. The rule is in:
+${declaring.map((p) => `   ${p}`).join('\n')}
+`
+      : `
+A \`filter=lfs\` rule exists here, in:
+${declaring.map((p) => `   ${p}`).join('\n')}
+but whether it applies to any real path could not be established
+(${applies.why}). This errs toward reporting rather than toward
+silence, so if this checkout really does use Git LFS, ignore the rest.
+`;
+
+const pushHook = found.find((h) => h.name === 'pre-push');
+
 console.error(`❌ This clone still has Git LFS hooks, but this repo has no LFS content.
 
 Checked the repo this script lives in (${ROOT}), NOT the current directory.
 
 Leftover hooks in ${hooksDir}:
 ${found.map((h) => `   ${h.path}`).join('\n')}
-${
-  configuredHooksPath
-    ? `
-core.hooksPath is set to ${configuredHooksPath}, so that is the directory
-above, and every worktree of that clone shares it. It may well not be the
-.git/hooks of the checkout you are in.
-`
-    : ''
-}
+${staleRules}
 \`git lfs pre-push\` asks git for the objects being pushed with
 \`--not --remotes=<remote>\`. Push to a remote this clone has no
 remote-tracking refs for, a fork you just added, and that excludes nothing,
@@ -246,18 +364,45 @@ so the range becomes the whole history, which still holds LFS pointer blobs.
 git-lfs queues those for upload and the push fails uploading them, even though
 your own commits contain no LFS files.
 
-Remedy, one command, run it yourself:
-   git lfs uninstall --local
+READ THIS BEFORE RUNNING ANY REMEDY
+${
+  configuredHooksPath
+    ? `
+core.hooksPath is set to
+   ${configuredHooksPath}
+so that, rather than the .git/hooks of whatever checkout you are standing in,
+is the directory listed above. It may be this clone's own, or another
+repository's. Every linked worktree of the clone that owns it shares it too.
+Check which checkouts it serves before you touch it.`
+    : `
+The hooks directory above is shared by every linked worktree of this clone,
+and a core.hooksPath setting elsewhere can point other repositories at it too.`
+}
 
-\`--local\` is clone-scoped: per \`git lfs uninstall --help\` it removes the lfs
-filters from this repository's git config instead of the global
-~/.gitconfig, so your Git LFS setup in other repos is left alone.
+\`git lfs uninstall\` deletes git-lfs's hooks from whatever core.hooksPath
+resolves to, and \`--local\` does NOT scope that: it scopes the config edit
+only. A repository that loses its \`pre-push\` this way stops uploading its LFS
+objects on push, and it will not tell you.
+
+Remedies, least invasive first.
+
+1. Change nothing, get this push out:
+      git push --no-verify <remote> <branch>
+
+2. Narrowest fix, this hook only, no config touched:
+      rm ${pushHook ? pushHook.path : join(hooksDir, 'pre-push')}
+
+3. Whole-clone fix, only once you are sure no other checkout shares the
+   directory above:
+      git lfs uninstall --local
+
+   Per \`git lfs uninstall --help\`, \`--local\` removes the lfs filters from
+   this repository's git config instead of the global ~/.gitconfig, so your
+   Git LFS config in other repos is left alone. Its hook removal is not
+   limited that way.
 
 Then re-run \`pnpm check:git-lfs\`. If a hook is still listed, read it and
 delete the file yourself.
-
-To get one push out without changing anything:
-   git push --no-verify <remote> <branch>
 `);
 if (unreadable.length > 0) {
   console.error(`Also could not read: ${unreadable.join(', ')}\n`);


### PR DESCRIPTION
## What and why

Pushing a branch to a contributor's fork fails like this, on a commit containing no LFS files at all:

```
batch response: You need Push access to upload Git LFS objects.
Uploading LFS objects:   0% (0/80), 0 B | 0 B/s, done.
error: failed to push some refs
```

Observed twice while pushing review fixes to #1928 and #1930 today.

The repo retired Git LFS: `.gitattributes` has no `filter=lfs` rule, nothing at HEAD is a pointer, and fixtures come from `pnpm fixtures`. But history still holds pointer blobs (a plain clone from origin holds 80, which is where the `(0/80)` comes from), and **hooks are not version-controlled**, so retiring LFS on a branch cannot remove a hook already sitting in someone's clone.

The mechanism, verified with `GIT_TRACE=1` in both directions: `git lfs pre-push` asks git what is being pushed via `git rev-list --objects <sha> --not --remotes=<remote>`. Against a remote the clone has no remote-tracking refs for (the normal state right after `git remote add fork ...`), the `--not` side excludes nothing, the range widens to the whole history, and every historical pointer is queued. After `git fetch <remote>` the identical invocation queues nothing.

**This PR asserts nothing about why the LFS server refuses the upload.** That was never reproduced, and three earlier drafts of these docs each guessed differently and each guessed wrong. The remedy does not depend on the answer.

## What it adds

`pnpm check:git-lfs` — a read-only detector. It reports the leftover hooks and prints the one-command remedy:

```
git lfs uninstall --local
```

`--local` is clone-scoped; per `git lfs uninstall --help` it removes the filters from this repository's config rather than `~/.gitconfig`, so a developer's Git LFS setup elsewhere keeps working.

Who is affected: clones predating the LFS retirement, or clones where someone ran `git lfs install`. **A clone made today installs no LFS hooks** — verified by cloning this repo with `filter.lfs.*` set globally and finding only git's `.sample` files.

## Detection only, deliberately

An earlier version of this script could delete the hooks and clear the config. It went through four rounds of hardening and each round's verifier found a new way for an automated `.git` mutation to go wrong:

- partial states where the config was cleared but a push-breaking hook survived, reported as success
- a `filter.lfs.*` value containing a newline that caused unrelated local keys (`user.signingkey`, `core.hooksPath`) to be unset, exit 0
- a TOCTOU race with a concurrent hook installer, deleting a hook rewritten in the window
- and finally: **the script resolves its target from `import.meta.url`, so `cd`ing into a sandbox does not confine it.** A test run started from a throwaway directory reached through `core.hooksPath` and deleted the real clone's hooks. Every prior verification round missed this because they all tested inside sandboxes.

Detection carries none of that risk and gets nearly all of the value, since the remedy is one command. The script imports `readFileSync` and `statSync` and nothing else; the complete set of git subcommands it can execute is seven reads, enumerated in its header. It never calls `git lfs ls-files`, which writes `lfs.repositoryformatversion` into `.git/config`.

It also states in its header **and in its own output** that it inspects the repo the script lives in rather than the current directory, and names the hooks directory it resolved, because `core.hooksPath` can point somewhere unexpected.

## Verification

- Static: `reachableWrites: []` — no fs write API is imported or reachable; every git subcommand enumerated and confirmed a read.
- The main clone's `git config --local -l` and `.git/hooks` (with per-file md5) snapshotted before and after a detector run: identical.
- Exercised read-only against: this clone (exit 1, reports 4 hooks), a fresh clone of origin (exit 0), a sandbox declaring `filter=lfs` in an uncommitted `.gitattributes` (exit 0, correctly reads as a repo adopting LFS), a bare repo, and a non-repo.
- `pnpm typecheck` 33/33 · `check-test-wiring` · `docs:check-samples` 248 snippets · `docs:check-generated` 4 regions · `mkdocs build --strict` clean.

Not wired into CI or any install hook, and the header says it must stay that way.

## Not in scope

Rewriting history to purge the 95 pointer blobs. It would break every existing fork, open PR and clone, for a hook annoyance with a one-line fix.