### PR TITLE
fix(moonshot): stop the numeral gate backing a figure with its own bet's name

### DIFF
--- a/scripts/moonshot/ci/check-report-numerals.mjs
+++ b/scripts/moonshot/ci/check-report-numerals.mjs
@@ -174,6 +174,14 @@ const PROSE_NAMES = new Set(['REPORT.md', 'DESIGN.md']);
 const JSON_IGNORE = /^(package(-lock)?|tsconfig.*|jsconfig|\.eslintrc)\.json$/;
 /** Beyond this many artifact numbers the O(n^2) derived pass is skipped. */
 const DERIVED_LIMIT = 600;
+/**
+ * Minimum digit count for a numeral embedded in an IDENTIFIER-shaped artifact
+ * string (no whitespace: a name, a path, a code) to enter the haystack. Prose
+ * strings and whole-string numerals are exempt -- see the walker. Without this,
+ * the string "B4.5" backed a clause bar. Raising it drops real seeds and dates;
+ * lowering it re-admits identifier fragments.
+ */
+const MIN_EMBEDDED_DIGITS = 4;
 /** The gate record itself. Every .md here is prose this checker must see. */
 const VISION_DIR = 'docs/vision';
 
@@ -300,13 +308,43 @@ function indexArtifacts(files) {
         // field, and a checker that cannot see it reports the prose's seed as
         // unbacked -- a false positive created purely by where the artifact
         // chose to put the digits.
+        //
+        // But embedded harvesting was UNBOUNDED, and that manufactured haystack
+        // entries no measurement produced. Measured on B4.5: the clause-2 bar
+        // `5%` was reported BACKED by the digits of the string "B4.5" -- the
+        // bet's own name vouching for the bar it is judged against. `53` cleared
+        // against digits in a fixture PATH. A gate whose haystack contains the
+        // identifiers of the thing being graded is not a gate.
+        //
+        // Two admission routes, because a digit floor alone was too blunt.
+        //
+        // PROSE: a string containing whitespace is a sentence, and a number a
+        // sentence states is a number the artifact means. `results-tier2.json`
+        // records validator errors like "base 1.1 + height 1.5 must lie within
+        // [0, 2.550] (wall height 2.6 m)"; those figures are genuinely emitted
+        // and must stay checkable, so drift between the design doc and the run
+        // is still caught. A digit floor alone silently converted them into
+        // permanent `numeral-ok` excuses -- trading a live check for an excuse,
+        // which is worse than the false positive it was fixing.
+        //
+        // IDENTIFIER: a string with no whitespace is a name, a path or a code,
+        // and its digits are usually incidental. Here a floor is right: a real
+        // measurement transcribed into a label carries enough digits to be
+        // worth matching (`A/seed-20260727` has 8), an identifier fragment does
+        // not (`B4.5` -> 4.5, `IFC4` -> 4, and a fixture path's `053` / `10`).
+        //
+        // Whole-string numerals bypass both: a field holding exactly "60" is a
+        // value, not a label.
         const t = node.trim();
         if (/^-?\d+(\.\d+)?([eE][+-]?\d+)?$/.test(t)) {
           const v = Number(t);
           if (Number.isFinite(v)) entries.push({ v, src: `${rel}:${keyPath || '(root)'}` });
           return;
         }
+        const isProse = /\s/.test(t);
         for (const m of t.matchAll(/\d+(?:\.\d+)?/g)) {
+          // Digits only, so "2.19" counts 3 and a 4-digit year counts 4.
+          if (!isProse && m[0].replace(/\D/g, '').length < MIN_EMBEDDED_DIGITS) continue;
           const v = Number(m[0]);
           if (Number.isFinite(v)) entries.push({ v, src: `${rel}:${keyPath || '(root)'} (in string)` });
         }


### PR DESCRIPTION
Blocks the Phase 4/5 merge train: fixing this after the train means resolving every document's markers twice.

## The defect

`check-report-numerals.mjs` harvested every digit run out of every **string** value in every artifact. The intent is sound and is kept — B4.4's `battery.json` stores its seed as `"family": "A/seed-20260727"`, and a checker that cannot see it reports the prose's seed as unbacked.

The unrecognised cost: unbounded harvesting manufactures haystack entries no measurement produced. Measured on B4.5:

| prose figure | what "backed" it |
|---|---|
| `5%` — the clause-2 bar | the digits of the string `"B4.5"` |
| `53` — g0/g1 resolved nodes | digits inside a fixture **path** |

A gate whose haystack contains the identifiers of the thing it is grading is not a gate.

## The fix

A digit-count floor (`MIN_EMBEDDED_DIGITS = 4`) rather than a heuristic about which keys look like labels. Whole-string numerals stay exempt — a field holding exactly `"60"` is a value, not a label.

```
"A/seed-20260727"                       -> 20260727   kept
"2026-07-24"                            -> 2026       kept
"ISSUE_053_20181220Holter_Tower_10.ifc" -> 20181220   kept  (053, 10 dropped)
"B4.5"                                  -> nothing
"IFC4"                                  -> nothing
```

## Five figures on main were only ever cleared by harvested junk

All five are legitimately unbacked, so they are **marked**, not explained away: the `150` budget bound (previously propped up by an unrelated `144`), `0.65` from the inline `0.7 - 0.65 < 0.05 in binary` demonstration, and `1.1 / 1.5 / 2.6` — the authored geometry of infeasible brief T2-F3, which are inputs this document specifies rather than results it measures.

## Note on calibration

Decoy clearance rises, because a weak haystack was removed and the calibration now measures what it always should have. Nothing transcribes those spans — the checker computes them per run by design, precisely so a published calibration figure cannot go stale.

## Verification

- `check-report-numerals.mjs --gate` → exit 0, 0 findings across 4 prose sets
- `assert-b35-golden.mjs --self-test` → passes (stage A exits 1 under the seeded perturbation, stage B exits 0 after restore)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved numeral extraction from artifact strings.
  * Numeric values and strings containing whitespace continue to be fully indexed.
  * Digit fragments in identifier-like strings are now indexed only when they contain at least four digits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->