### PR TITLE
chore(deps): close the Dependabot blind spots and stop Cargo.lock drifting

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -49,3 +49,35 @@ updates:
         update-types:
           - minor
           - patch
+
+  # requirements-docs.txt builds ifclite.dev/docs in CI (mkdocs + plugins).
+  # Build-time only, but it is a manifest Dependabot was blind to.
+  #
+  # rust/python/pyproject.toml is deliberately NOT listed: it declares no
+  # runtime dependencies, only `maturin>=1.7,<2.0` under build-system, and
+  # that upper bound is a deliberate pin rather than drift to be chased.
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      pip-minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  # Base images for the three shipped containers. Dependabot only tracks the
+  # image tag/digest here; it does not see CVEs inside a pulled layer, so a
+  # bump landing is the mechanism by which those get picked up at all.
+  - package-ecosystem: docker
+    directories:
+      - /apps/server
+      - /packages/collab-server
+      - /tools/ifcopenshell_reference
+    schedule:
+      interval: weekly
+    groups:
+      docker-minor-and-patch:
+        update-types:
+          - minor
+          - patch

--- a/.github/workflows/moonshot.yml
+++ b/.github/workflows/moonshot.yml
@@ -155,7 +155,7 @@ jobs:
     # without letting a hang sit forever.
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # Fixtures live in a GitHub Release (tests/models/manifest.json,
           # AGENTS.md section 9); the repo does not use Git LFS.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -456,6 +456,14 @@ jobs:
         # The fixtures script is pure Node (no npm deps) so we skip the
         # pnpm install dance Rust-only jobs don't need.
         run: node scripts/fixtures/fetch-fixtures.mjs
+      # Cheap (resolve only, no compile) and it catches a failure mode that
+      # otherwise stays invisible for weeks: a release bumps the manifests but
+      # leaves Cargo.lock recording the old member versions, so every `--locked`
+      # command refuses to run and every local build silently dirties the lock.
+      # `scripts/sync-versions.js` keeps the two in step; this is the gate that
+      # notices if that ever stops being true.
+      - name: Cargo.lock is in sync with the manifests
+        run: cargo metadata --locked --format-version 1 > /dev/null
       # Workspace exclusions:
       #   - ifc-lite-wasm: dev-deps on wasm-bindgen-test; tests target wasm32.
       - name: Clippy (lint gate)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1483,11 +1483,11 @@ checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "ifc-lite-clash"
-version = "4.1.4"
+version = "4.2.0"
 
 [[package]]
 name = "ifc-lite-core"
-version = "4.1.4"
+version = "4.2.0"
 dependencies = [
  "fast-float2",
  "futures-core",
@@ -1505,7 +1505,7 @@ dependencies = [
 
 [[package]]
 name = "ifc-lite-export"
-version = "4.1.4"
+version = "4.2.0"
 dependencies = [
  "arrow",
  "ifc-lite-core",
@@ -1520,7 +1520,7 @@ dependencies = [
 
 [[package]]
 name = "ifc-lite-ffi"
-version = "4.1.4"
+version = "4.2.0"
 dependencies = [
  "ifc-lite-processing",
  "mimalloc",
@@ -1530,7 +1530,7 @@ dependencies = [
 
 [[package]]
 name = "ifc-lite-geometry"
-version = "4.1.4"
+version = "4.2.0"
 dependencies = [
  "approx",
  "bnum",
@@ -1559,7 +1559,7 @@ dependencies = [
 
 [[package]]
 name = "ifc-lite-processing"
-version = "4.1.4"
+version = "4.2.0"
 dependencies = [
  "ifc-lite-core",
  "ifc-lite-geometry",
@@ -1573,7 +1573,7 @@ dependencies = [
 
 [[package]]
 name = "ifc-lite-server"
-version = "4.1.4"
+version = "4.2.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -1609,7 +1609,7 @@ dependencies = [
 
 [[package]]
 name = "ifc-lite-wasm"
-version = "4.1.4"
+version = "4.2.0"
 dependencies = [
  "console_error_panic_hook",
  "futures-util",

--- a/scripts/sync-versions.js
+++ b/scripts/sync-versions.js
@@ -89,7 +89,13 @@ function syncCargoLock(version) {
     let memberToml;
     try {
       memberToml = readFileSync(join(rootDir, dir, 'Cargo.toml'), 'utf8');
-    } catch {
+    } catch (error) {
+      // Say so rather than skipping quietly: a member we cannot read is a
+      // member whose lock entry we then leave on the old version, which is the
+      // exact drift this function exists to prevent. CI's `cargo metadata
+      // --locked` gate would fail afterwards, but on the lock rather than on
+      // the cause, so name the cause here.
+      console.warn(`⚠️  Could not read ${dir}/Cargo.toml; its Cargo.lock version is left alone (${error.message})`);
       continue;
     }
     // `version.workspace = true` or `version = { workspace = true }`

--- a/scripts/sync-versions.js
+++ b/scripts/sync-versions.js
@@ -49,6 +49,81 @@ function getWorkspacePackages() {
   return packages;
 }
 
+/**
+ * Rewrite the workspace members' own `version` entries in Cargo.lock.
+ *
+ * Bumping the manifests without this leaves the lock recording the previous
+ * version for every member, and from then on `cargo` refuses any command
+ * carrying `--locked` ("cannot update the lock file ... because --locked was
+ * passed"), while every local build silently rewrites Cargo.lock and shows it
+ * as dirty. Cargo would fix it in one resolve, but this script has to run
+ * where a toolchain and the registry index may not be available, so the edit
+ * is textual and offline.
+ *
+ * Only entries with no `source` field are touched: in a lock file that is
+ * exactly the set of path/workspace members. Registry crates always carry a
+ * `source`, so a third-party crate that happened to share a name cannot be
+ * caught by this. A member is skipped unless its manifest actually inherits
+ * `version.workspace = true`: one pinning its own version means to hold it.
+ */
+function syncCargoLock(version) {
+  const cargoLockPath = join(rootDir, 'Cargo.lock');
+  let lock;
+  try {
+    lock = readFileSync(cargoLockPath, 'utf8');
+  } catch {
+    console.log('ℹ️  No Cargo.lock to sync');
+    return;
+  }
+
+  const rootToml = readFileSync(join(rootDir, 'Cargo.toml'), 'utf8');
+  const membersMatch = rootToml.match(/^members\s*=\s*\[([^\]]*)\]/m);
+  if (!membersMatch) {
+    console.log('ℹ️  No [workspace] members found; leaving Cargo.lock alone');
+    return;
+  }
+  const memberDirs = [...membersMatch[1].matchAll(/"([^"]+)"/g)].map((m) => m[1]);
+
+  const inheritingCrates = new Set();
+  for (const dir of memberDirs) {
+    let memberToml;
+    try {
+      memberToml = readFileSync(join(rootDir, dir, 'Cargo.toml'), 'utf8');
+    } catch {
+      continue;
+    }
+    // `version.workspace = true` or `version = { workspace = true }`
+    if (!/^\s*version(\.workspace\s*=\s*true|\s*=\s*\{\s*workspace\s*=\s*true\s*\})/m.test(memberToml)) {
+      continue;
+    }
+    const name = memberToml.match(/^\s*name\s*=\s*"([^"]+)"/m);
+    if (name) inheritingCrates.add(name[1]);
+  }
+
+  const updated = [];
+  // Split on the block delimiter and rebuild, so a rewrite stays inside the
+  // block it belongs to instead of running past it.
+  const parts = lock.split('[[package]]');
+  for (let i = 1; i < parts.length; i++) {
+    const block = parts[i];
+    if (/^\s*source\s*=/m.test(block)) continue;
+    const name = block.match(/^\s*name\s*=\s*"([^"]+)"/m);
+    if (!name || !inheritingCrates.has(name[1])) continue;
+    const rewritten = block.replace(/^(\s*version\s*=\s*")[^"]+(")/m, `$1${version}$2`);
+    if (rewritten !== block) {
+      parts[i] = rewritten;
+      updated.push(name[1]);
+    }
+  }
+
+  if (updated.length === 0) {
+    console.log('✅ Cargo.lock member versions already in sync');
+    return;
+  }
+  writeFileSync(cargoLockPath, parts.join('[[package]]'));
+  console.log(`✅ Updated Cargo.lock member versions to ${version} (${updated.join(', ')})`);
+}
+
 function syncVersions() {
   const packagePaths = getWorkspacePackages();
 
@@ -111,6 +186,8 @@ function syncVersions() {
       console.log(`✅ Updated rust/${member}/Cargo.toml internal dep versions to ${version}`);
     }
   }
+
+  syncCargoLock(version);
 
   // Update root package.json
   if (rootPackageJson.version !== version) {


### PR DESCRIPTION
Follow-ups from the Dependabot sweep that merged #1892, #1893, #1894 and #1942. Three findings surfaced while verifying those, none of which any of them owned.

## Cargo.lock drift, and the reason it kept coming back

`Cargo.lock` recorded `4.1.4` for all eight workspace members while the manifests said `4.2.0`. Two consequences, both quiet:

- any cargo command carrying `--locked` refuses to run: *"cannot update the lock file ... because `--locked` was passed to prevent this"*
- every local build silently rewrites the lock, so `Cargo.lock` shows as modified in an otherwise clean tree

The cause is `scripts/sync-versions.js`. After `changeset version` it rewrites the workspace version, the internal path-dependency version literals in each crate manifest, and the root `package.json`. It never touched `Cargo.lock`, so the drift returns with every single release. Refreshing the lock alone would have been treating the symptom.

It now syncs the members' lock entries as well. The edit is textual rather than a cargo resolve because this script runs in the release job, where a Rust toolchain and a warm registry index are not guaranteed. It is deliberately narrow: only entries with no `source` field (in a lock file that is exactly the set of path/workspace members, since registry crates always carry a `source`) and only where the member's manifest actually inherits `version.workspace = true`, so a member pinning its own version is left alone.

Verified by reverting the lock to its drifted state and running the script: the output is **byte-identical** to what `cargo metadata` produces, and a second run reports "already in sync" rather than rewriting.

A `cargo metadata --locked` step in the `rust-tests` job now fails fast if the two ever separate again. It resolves without compiling, so the added CI time is negligible.

## The stale action pin #1894 could not have caught

`moonshot.yml` landed on main *after* #1894's base was cut, so its `actions/checkout` stayed on the v7.0.0 SHA while the other thirteen workflows moved to v7.0.1. Pinned to match; the SHA was verified against the upstream tag rather than copied from the diff.

## Ecosystems Dependabot was blind to

`.github/dependabot.yml` covered github-actions, npm and cargo. Added:

- **pip** for `requirements-docs.txt` (mkdocs and plugins, build-time only, but it was an unwatched manifest)
- **docker** for the three shipped Dockerfiles: `apps/server`, `packages/collab-server`, `tools/ifcopenshell_reference`

`rust/python/pyproject.toml` is deliberately left out, and the config says so: it declares no runtime dependencies, only `maturin>=1.7,<2.0` under `build-system`, and that upper bound is a deliberate pin rather than drift to chase.

## Repo settings changed alongside this (not in the diff)

- Dependabot **security updates** were disabled, so a CVE raised an alert but never opened a fix PR. The clean slate today came from the weekly version-update PRs happening to cover things. Now enabled.
- **Secret scanning** and **push protection** were off on a public repo, where both are free. Now enabled.

## Still open

#1896 (maplibre-gl v6) is held: it is a real migration, not a bump. Blockers documented on that PR.

---

## Update: review round

A real CodeRabbit review (run locally, because the PR check was a rate-limited false pass) raised one minor finding, now fixed in 0a482b12: the version-inheritance scan swallowed a failed `Cargo.toml` read. A member we cannot read is a member whose lock entry we then leave on the old version, which is exactly the drift this function was added to prevent. The new CI gate would still catch the result, but it fails on the lock rather than on the cause, so the cause is now named where it happens.

Verified by removing `rust/clash/Cargo.toml` and re-running: the warning names the member and the errno, and the emitted lock is unchanged and still byte-identical to what cargo produces.

Worth flagging about the check surface here: the **CodeRabbit check reported `pass` on this PR without reviewing it at all**. It was rate-limited under the fair-usage policy and posted a warning comment instead of a review, while still reporting green. The review above was obtained by running the CodeRabbit CLI locally against this branch.