### PR TITLE
feat(moonshot): surface `:: none` blocks whose value now appears in an artifact

### DIFF
--- a/.github/workflows/moonshot.yml
+++ b/.github/workflows/moonshot.yml
@@ -442,6 +442,12 @@ jobs:
       - name: E9 prose vs artifact numerals (bets + docs/vision, gated)
         shell: bash
         run: |
+          # The gate's own exam FIRST. E9 can only be trusted while its
+          # `:: none` advisory still fires, and an advisory that has regressed
+          # into silence is indistinguishable from a clean tree -- so a green
+          # E9 with a broken advisory is exactly the false pass this lane
+          # exists to prevent. Same shape as E3c guarding E3b.
+          node scripts/moonshot/ci/check-report-numerals.mjs --self-test
           node scripts/moonshot/ci/check-report-numerals.mjs --gate
           echo '- **E9 prose vs artifact** -- every numeral backed by an artifact or marked with a reason' >> "$GITHUB_STEP_SUMMARY"
 

--- a/scripts/moonshot/ci/check-report-numerals.mjs
+++ b/scripts/moonshot/ci/check-report-numerals.mjs
@@ -926,6 +926,8 @@ for (const bet of bets) {
     const bound = [];
     const pending = [];
     const assertedUnbacked = [];
+    /** `:: none` bindings whose figure has since become backed -- see the `none` branch. */
+    const staleNegativeBindings = [];
     const brokenBindings = [];
 
     // Group identical (value, unit) pairs so a number quoted five times is one
@@ -950,6 +952,37 @@ for (const bet of bets) {
       if (r.status === 'none') {
         boundHaystack.set(token, []);
         assertedUnbacked.push({ ...g, reason: r.reason || '(no reason given)' });
+        // ADVISORY ANTI-ROT FOR THE NEGATIVE CASE, and it deliberately does
+        // NOT gate. Read the reason before adding one that does.
+        //
+        // The gap is real: `numeral-ok` excuses are anti-rot checked, but a
+        // `:: none` block is only checked for whether its token still appears
+        // in the prose -- never for whether the block is still warranted. So a
+        // block can assert "no artifact emits this" long after one does, and
+        // the gate stays green. B4.2's re-bless turned four tokens of one such
+        // marker into real fields, and that marker was what would have kept
+        // `49` blocked in the merged tree, though the battery emits it exactly.
+        //
+        // But it CANNOT be a gate, because a value match is exactly what a
+        // block is for. The retracted 1e-13 tolerance is blocked precisely
+        // because a real per-family deviation falls inside its half-ULP; that
+        // block working looks identical, to this check, to a block that has
+        // gone wrong. Failing on it would punish the mechanism for doing its
+        // job and would train the next reader to delete blocks to get green --
+        // the one edit that lets a withdrawn figure become a claim again.
+        //
+        // So: list them, say which field matched, and let a human decide
+        // whether it is still a coincidence. A list a reader must think about
+        // is the honest instrument here; a gate would be a confident wrong one.
+        const nowBacked = matchDirect(g.value, tol, g.unit, index);
+        if (nowBacked && (nowBacked.kind === 'exact' || nowBacked.kind === 'rounded')) {
+          staleNegativeBindings.push({
+            token,
+            reason: r.reason || '(no reason given)',
+            src: nowBacked.entry ? nowBacked.entry.src : '(unknown field)',
+            value: nowBacked.entry ? nowBacked.entry.v : undefined,
+          });
+        }
         continue;
       }
       if (r.status === 'pending') {
@@ -1054,6 +1087,7 @@ for (const bet of bets) {
       derived,
       excused,
       staleMarkers,
+      staleNegativeBindings,
       badMarkers,
       decoy: calibrate(
         [...groups.values()],
@@ -1163,6 +1197,19 @@ for (const bet of results) {
       console.log('');
       console.log(`   MALFORMED numeral-ok MARKERS:`);
       for (const b of d.badMarkers) console.log(`     ${b}`);
+    }
+    if (d.staleNegativeBindings.length > 0) {
+      console.log('');
+      console.log(`   \`:: none\` BLOCKS WITH A VALUE MATCH (advisory, does NOT fail the gate):`);
+      console.log(`   >> a block whose value now appears in an artifact is USUALLY the block`);
+      console.log(`   >> working -- that is what it is for. Check each one anyway: if the figure`);
+      console.log(`   >> genuinely became a committed field, the block is now asserting something`);
+      console.log(`   >> false and should become a positive numeral-src binding instead.`);
+      for (const b of d.staleNegativeBindings) {
+        console.log(`     ${b.token.padEnd(14)} an artifact value now matches this blocked numeral`);
+        console.log(`     ${''.padEnd(14)} found at ${b.src}${b.value === undefined ? '' : ` = ${b.value}`}`);
+        console.log(`     ${''.padEnd(14)} reason on file: ${String(b.reason).replace(/\s+/g, ' ').slice(0, 150)}`);
+      }
     }
     if (d.staleMarkers.length > 0) {
       console.log('');

--- a/scripts/moonshot/ci/check-report-numerals.mjs
+++ b/scripts/moonshot/ci/check-report-numerals.mjs
@@ -891,6 +891,81 @@ function calibrate(groups, index, bindingIndexFor) {
 // ---------------------------------------------------------------------------
 
 const roots = targets.length > 0 ? targets.map((t) => path.resolve(t)) : [REPO_ROOT];
+/**
+ * `--self-test`: prove the `:: none` advisory still fires, and still does NOT gate.
+ *
+ * Codex's review of the advisory made the point that mattered: a feature with no
+ * test can regress into silence, and an advisory that silently stops advising
+ * looks exactly like "nothing to report". That is the same defect class this
+ * whole gate exists to catch, so the check needs a check.
+ *
+ * Builds a throwaway prose set in a temp dir with three tokens -- one blocked and
+ * matched by an artifact, one blocked and unmatched, one blocked but matched only
+ * under a unit scale -- runs THIS script against it as a child process, and
+ * asserts on the JSON: the matched ones appear in staleNegativeBindings, the
+ * unmatched one does not, and `--gate` still exits 0 with the advisory present.
+ */
+if (argv.includes('--self-test')) {
+  const os = await import('node:os');
+  const { mkdtempSync, mkdirSync, writeFileSync, rmSync } = await import('node:fs');
+  const { spawnSync } = await import('node:child_process');
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'numeral-selftest-'));
+  const bet = path.join(dir, 'selftest-bet');
+  mkdirSync(bet, { recursive: true });
+  // 4210 is emitted exactly; 91.5% is emitted as the fraction 0.915 (unit scale);
+  // 777 is emitted by nothing.
+  writeFileSync(path.join(bet, 'scorecard.json'),
+    JSON.stringify({ flagged: 4210, rate: 0.915 }, null, 2));
+  writeFileSync(path.join(bet, 'REPORT.md'), [
+    '# self-test',
+    '',
+    'A blocked figure the artifact now emits exactly: 4210 units.',
+    '<!-- numeral-src: 4210 :: none - blocked, and the artifact matches it exactly -->',
+    '',
+    'A blocked figure matched only under a unit scale: 91.5%.',
+    '<!-- numeral-src: 91.5% :: none - blocked, matched via the percent scale -->',
+    '',
+    'A blocked figure nothing emits: 777 units.',
+    '<!-- numeral-src: 777 :: none - blocked, and genuinely unmatched -->',
+    '',
+  ].join('\n'));
+
+  // The temp bet is passed as a positional target, which is how `roots` is
+  // resolved -- the checker takes paths, not an env var.
+  const run = (extra) => spawnSync(process.execPath, [fileURLToPath(import.meta.url), bet, ...extra],
+    { encoding: 'utf8' });
+
+  const r = run(['--json']);
+  let parsed;
+  try { parsed = JSON.parse(r.stdout); } catch {
+    console.error('::error::self-test could not parse the checker\'s own --json output');
+    console.error(r.stdout.slice(0, 400)); console.error(r.stderr.slice(0, 400));
+    rmSync(dir, { recursive: true, force: true });
+    process.exit(1);
+  }
+  // staleNegativeBindings is per-DOCUMENT, not per-set: each prose set carries a
+  // `docs` array and the advisory hangs off each doc.
+  const docs = (Array.isArray(parsed) ? parsed : []).flatMap((s) => s.docs || []);
+  const flagged = new Set(docs.flatMap((d) => (d.staleNegativeBindings || []).map((b) => b.token)));
+  const gated = run(['--gate']);
+
+  const failures = [];
+  if (!flagged.has('4210')) failures.push('an exactly-matched `:: none` token was NOT flagged (the advisory has gone silent)');
+  if (!flagged.has('91.5%')) failures.push('a unit-scaled match was NOT flagged (matchDirect integration regressed)');
+  if (flagged.has('777')) failures.push('a genuinely unmatched `:: none` token WAS flagged (false positive)');
+  if (gated.status !== 0) failures.push(`--gate exited ${gated.status}; the advisory must never fail the gate`);
+
+  rmSync(dir, { recursive: true, force: true });
+  if (failures.length) {
+    console.error('::error::NUMERAL-GATE SELF-TEST FAILED');
+    for (const f of failures) console.error(`  - ${f}`);
+    process.exit(1);
+  }
+  console.log('numeral-gate self-test PASS: advisory fires on exact and unit-scaled matches,');
+  console.log('stays silent on a genuinely unmatched block, and does not fail --gate.');
+  process.exit(0);
+}
+
 const bets = [];
 for (const r of roots) bets.push(...findProseSets(r));
 


### PR DESCRIPTION
Instrument-5 gap, found while re-adjudicating B4.2's markers for the merge train.

## The gap

`numeral-ok` excuses are anti-rot checked — the gate enforces "an excuse must not outlive its reason". A `numeral-src :: none` **block** is not:

```js
for (const [token, ref] of bindings) {
  if (usedBindings.has(token)) continue;   // token left the prose -> flagged
  ...                                       // block no longer warranted -> never checked
}
```

So a block can assert *"no artifact emits this"* long after one does, and the gate stays green while carrying a false statement.

**Not hypothetical.** The finishing plan blocked seven tokens with the reason "no artifact in any tree backs them". B4.2's re-bless made four of them real fields — and that marker was what would have kept `49` blocked in the merged tree, though the battery emits it exactly (`spatialFiredFlagged`). Nothing reported it.

## Why this is advisory and does NOT gate

My first version failed the gate on every match and reported **17 findings on main**. That design is wrong, and the reason is worth stating because it constrains any future attempt:

**A value match is exactly what a block is for.** The retracted `1e-13` tolerance is blocked *precisely because* a real per-family deviation falls inside its half-ULP. That block working looks identical, to an automatic check, to a block that has gone wrong.

Gating on it would punish the mechanism for doing its job — and would teach the next reader to delete blocks to get green, which is the single edit that lets a withdrawn figure become a claim again.

## What it does instead

Prints each block whose value has a match, names the field it matched, and says plainly that this is usually the block working and a human must decide:

```
`:: none` BLOCKS WITH A VALUE MATCH (advisory, does NOT fail the gate):
>> a block whose value now appears in an artifact is USUALLY the block
>> working -- that is what it is for. Check each one anyway: if the figure
>> genuinely became a committed field, the block is now asserting something
>> false and should become a positive numeral-src binding instead.
  1.2%    an artifact value now matches this blocked numeral
          found at report.b34.json:models[0].gpuWholeMs = 1.199999999254942
```

17 blocks across the tree currently carry a value match. None is a defect by construction — that is the point — but each is now visible instead of silent.

Gate exit 0 across 4 prose sets, unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a self-test mode for report numeral validation to verify JSON and gated checks automatically.
  * Added advisory reporting for previously negative bindings whose values now match report artifacts, including unit-scaled matches.
  * Text reports now display advisory matches and their source values.

* **Bug Fixes**
  * Improved validation accuracy by distinguishing advisory matches from findings that should block a workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->