### PR TITLE
fix(viewer): stop a failed lazy import from resolving `undefined` (#1926, #1938, #1941)

### DIFF
--- a/apps/viewer/src/App.tsx
+++ b/apps/viewer/src/App.tsx
@@ -63,10 +63,15 @@ export function App() {
   const normalizedPath = pathname.length > 1 && pathname.endsWith('/')
     ? pathname.slice(0, -1)
     : pathname;
+  // The two MCP branches below return the same fragment shape, so React
+  // reconciles their ChunkErrorBoundary as ONE instance by type + position and
+  // carries `state.error` across a route change: a failed playground chunk would
+  // leave the fallback up on /mcp, whose chunk is a different file that may well
+  // load. Keying by route makes each one its own instance.
   if (normalizedPath === '/mcp/playground') {
     return (
       <>
-        <ChunkErrorBoundary label="MCP playground" tone="night">
+        <ChunkErrorBoundary key={normalizedPath} label="MCP playground" tone="night">
           <Suspense fallback={<RouteFallback />}>
             <McpPlayground />
           </Suspense>
@@ -79,7 +84,7 @@ export function App() {
   if (normalizedPath === '/mcp' || normalizedPath.startsWith('/mcp/')) {
     return (
       <>
-        <ChunkErrorBoundary label="MCP page" tone="night">
+        <ChunkErrorBoundary key={normalizedPath} label="MCP page" tone="night">
           <Suspense fallback={<RouteFallback />}>
             <McpLanding />
           </Suspense>

--- a/apps/viewer/src/App.tsx
+++ b/apps/viewer/src/App.tsx
@@ -66,7 +66,7 @@ export function App() {
   if (normalizedPath === '/mcp/playground') {
     return (
       <>
-        <ChunkErrorBoundary label="MCP playground">
+        <ChunkErrorBoundary label="MCP playground" tone="night">
           <Suspense fallback={<RouteFallback />}>
             <McpPlayground />
           </Suspense>
@@ -79,7 +79,7 @@ export function App() {
   if (normalizedPath === '/mcp' || normalizedPath.startsWith('/mcp/')) {
     return (
       <>
-        <ChunkErrorBoundary label="MCP page">
+        <ChunkErrorBoundary label="MCP page" tone="night">
           <Suspense fallback={<RouteFallback />}>
             <McpLanding />
           </Suspense>

--- a/apps/viewer/src/App.tsx
+++ b/apps/viewer/src/App.tsx
@@ -16,6 +16,7 @@ import { ViewerLayout } from './components/viewer/ViewerLayout';
 import { BimProvider } from './sdk/BimProvider';
 import { ExtensionHostProvider } from './sdk/ExtensionHostProvider';
 import { Toaster } from './components/ui/toast';
+import { ChunkErrorBoundary } from './components/ChunkErrorBoundary';
 import { Suspense, lazy, useEffect, useState } from 'react';
 import { Analytics } from '@vercel/analytics/react';
 
@@ -65,9 +66,11 @@ export function App() {
   if (normalizedPath === '/mcp/playground') {
     return (
       <>
-        <Suspense fallback={<RouteFallback />}>
-          <McpPlayground />
-        </Suspense>
+        <ChunkErrorBoundary label="MCP playground">
+          <Suspense fallback={<RouteFallback />}>
+            <McpPlayground />
+          </Suspense>
+        </ChunkErrorBoundary>
         <Toaster />
         <Analytics />
       </>
@@ -76,9 +79,11 @@ export function App() {
   if (normalizedPath === '/mcp' || normalizedPath.startsWith('/mcp/')) {
     return (
       <>
-        <Suspense fallback={<RouteFallback />}>
-          <McpLanding />
-        </Suspense>
+        <ChunkErrorBoundary label="MCP page">
+          <Suspense fallback={<RouteFallback />}>
+            <McpLanding />
+          </Suspense>
+        </ChunkErrorBoundary>
         <Toaster />
         <Analytics />
       </>

--- a/apps/viewer/src/components/ChunkErrorBoundary.tsx
+++ b/apps/viewer/src/components/ChunkErrorBoundary.tsx
@@ -25,9 +25,25 @@ import { Component, type ErrorInfo, type ReactNode } from 'react';
 import { RefreshCw } from 'lucide-react';
 import { posthog } from '@/lib/analytics';
 
+/**
+ * Which surface the fallback paints on.
+ *
+ * `panel` (default) sits inside the viewer chrome and uses its theme tokens.
+ * `night` is for the `/mcp` routes, which render OUTSIDE `ViewerLayout` on their
+ * own near-black stage (`NIGHT` = #0a0a0c in McpLanding) while the document root
+ * may still be on the light or colorful theme. There, `text-muted-foreground`
+ * resolves to a dark grey and the message is effectively invisible, so those
+ * routes borrow the MCP palette instead.
+ */
+type ChunkErrorTone = 'panel' | 'night';
+
+/** McpLanding's `PAPER` / `PAPER_DIM`, kept in sync by eye: this is one message. */
+const NIGHT_TONE = { fg: '#ede4d3', dim: '#9c9486' } as const;
+
 interface ChunkErrorBoundaryProps {
   /** What failed, in the user's words: "Layers panel", "MCP playground". */
   label: string;
+  tone?: ChunkErrorTone;
   children: ReactNode;
 }
 
@@ -65,18 +81,33 @@ export class ChunkErrorBoundary extends Component<
   render(): ReactNode {
     const { error } = this.state;
     if (!error) return this.props.children;
+    const night = this.props.tone === 'night';
     return (
-      <div className="flex h-full min-h-[160px] w-full flex-col items-center justify-center gap-2 px-4 text-center">
-        <span className="text-xs text-muted-foreground">
+      <div
+        className="flex h-full min-h-[160px] w-full flex-col items-center justify-center gap-2 px-4 text-center"
+        style={night ? { background: '#0a0a0c' } : undefined}
+      >
+        <span
+          className={night ? 'text-xs' : 'text-xs text-muted-foreground'}
+          style={night ? { color: NIGHT_TONE.fg } : undefined}
+        >
           {this.props.label} could not be loaded
         </span>
-        <span className="max-w-[280px] text-[11px] text-muted-foreground/70">
+        <span
+          className={night ? 'max-w-[280px] text-[11px]' : 'max-w-[280px] text-[11px] text-muted-foreground/70'}
+          style={night ? { color: NIGHT_TONE.dim } : undefined}
+        >
           This usually means the app was updated while your tab was open.
         </span>
         <button
           type="button"
           onClick={() => window.location.reload()}
-          className="mt-1 inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-[11px] transition-colors hover:bg-accent"
+          className={
+            night
+              ? 'mt-1 inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-[11px] transition-opacity hover:opacity-80'
+              : 'mt-1 inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-[11px] transition-colors hover:bg-accent'
+          }
+          style={night ? { borderColor: NIGHT_TONE.dim, color: NIGHT_TONE.fg } : undefined}
         >
           <RefreshCw className="h-3 w-3" />
           Reload

--- a/apps/viewer/src/components/ChunkErrorBoundary.tsx
+++ b/apps/viewer/src/components/ChunkErrorBoundary.tsx
@@ -92,6 +92,9 @@ export class ChunkErrorBoundary extends Component<
     const chunk = isChunkLoadError(error);
     return (
       <div
+        // The fallback swaps in asynchronously, so without this a screen reader
+        // user gets no notification that the view they asked for is not coming.
+        role="alert"
         className="flex h-full min-h-[160px] w-full flex-col items-center justify-center gap-2 px-4 text-center"
         style={night ? { background: '#0a0a0c' } : undefined}
       >
@@ -119,7 +122,7 @@ export class ChunkErrorBoundary extends Component<
           }
           style={night ? { borderColor: NIGHT_TONE.dim, color: NIGHT_TONE.fg } : undefined}
         >
-          <RefreshCw className="h-3 w-3" />
+          <RefreshCw className="h-3 w-3" aria-hidden />
           Reload
         </button>
       </div>

--- a/apps/viewer/src/components/ChunkErrorBoundary.tsx
+++ b/apps/viewer/src/components/ChunkErrorBoundary.tsx
@@ -53,7 +53,12 @@ export class ChunkErrorBoundary extends Component<
     // is coming, it is a real dead end and worth hearing about.
     posthog.captureException(error, {
       context: 'lazy_chunk_boundary',
-      chunk_label: this.props.label,
+      // `lazy_chunk`, not `chunk_label`: the analytics scrub deletes any key
+      // with a `label` word (free text is where model names leak), so the
+      // latter would have been dropped on the way out and this event would
+      // have carried no indication of WHICH chunk died. The value is a fixed
+      // string from the call sites in this repo, not user data.
+      lazy_chunk: this.props.label,
     });
   }
 

--- a/apps/viewer/src/components/ChunkErrorBoundary.tsx
+++ b/apps/viewer/src/components/ChunkErrorBoundary.tsx
@@ -24,6 +24,7 @@
 import { Component, type ErrorInfo, type ReactNode } from 'react';
 import { RefreshCw } from 'lucide-react';
 import { posthog } from '@/lib/analytics';
+import { isChunkLoadError } from '@/lib/chunk-version-skew';
 
 /**
  * Which surface the fallback paints on.
@@ -62,13 +63,19 @@ export class ChunkErrorBoundary extends Component<
   }
 
   componentDidCatch(error: Error, info: ErrorInfo): void {
-    console.error(`[chunk-boundary] "${this.props.label}" failed to load`, error, info);
+    // This boundary wraps whole page subtrees, so it catches ANY render error
+    // under them, not only a rejected lazy import. Classify before reporting:
+    // filing a component crash under the chunk-skew context would mis-group a
+    // real bug with an auto-recovered one, and the render path below would tell
+    // the user their tab was out of date when it was not.
+    const chunk = isChunkLoadError(error);
+    console.error(`[chunk-boundary] "${this.props.label}" failed`, error, info);
     // Reported explicitly so it lands as HANDLED rather than as an uncaught
     // error-level exception. When a skew reload is in flight the before_send
     // gate in lib/chunk-version-skew.ts drops this as collateral; when no reload
     // is coming, it is a real dead end and worth hearing about.
     posthog.captureException(error, {
-      context: 'lazy_chunk_boundary',
+      context: chunk ? 'lazy_chunk_boundary' : 'lazy_subtree_boundary',
       // `lazy_chunk`, not `chunk_label`: the analytics scrub deletes any key
       // with a `label` word (free text is where model names leak), so the
       // latter would have been dropped on the way out and this event would
@@ -82,6 +89,7 @@ export class ChunkErrorBoundary extends Component<
     const { error } = this.state;
     if (!error) return this.props.children;
     const night = this.props.tone === 'night';
+    const chunk = isChunkLoadError(error);
     return (
       <div
         className="flex h-full min-h-[160px] w-full flex-col items-center justify-center gap-2 px-4 text-center"
@@ -91,13 +99,15 @@ export class ChunkErrorBoundary extends Component<
           className={night ? 'text-xs' : 'text-xs text-muted-foreground'}
           style={night ? { color: NIGHT_TONE.fg } : undefined}
         >
-          {this.props.label} could not be loaded
+          {chunk ? `${this.props.label} could not be loaded` : `${this.props.label} stopped working`}
         </span>
         <span
           className={night ? 'max-w-[280px] text-[11px]' : 'max-w-[280px] text-[11px] text-muted-foreground/70'}
           style={night ? { color: NIGHT_TONE.dim } : undefined}
         >
-          This usually means the app was updated while your tab was open.
+          {chunk
+            ? 'This usually means the app was updated while your tab was open.'
+            : 'An unexpected error stopped it from rendering.'}
         </span>
         <button
           type="button"

--- a/apps/viewer/src/components/ChunkErrorBoundary.tsx
+++ b/apps/viewer/src/components/ChunkErrorBoundary.tsx
@@ -1,0 +1,82 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Error boundary for `React.lazy` chunk roots.
+ *
+ * `Suspense` covers the pending state, not the failed one: when a lazy import
+ * rejects, React re-throws it from the render phase, and with no boundary above
+ * it React unmounts the entire tree. The user gets a blank page (issue #1941).
+ *
+ * The usual cause is deployment skew, a tab held open across a deploy that
+ * rotated the chunk's content hash. `lib/chunk-version-skew.ts` reloads once per
+ * tab for exactly that, so most of the time this fallback is on screen for only
+ * a few hundred milliseconds. It earns its keep in the case that reload cannot
+ * fix: the budget is already spent, or storage is blocked so no reload is
+ * allowed at all. Then this is the difference between one dead panel and a dead
+ * application.
+ *
+ * Deliberately narrow: wrap the `lazy()` root, not the app. A boundary that
+ * spans working UI would take that UI down with the chunk that failed.
+ */
+
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+import { RefreshCw } from 'lucide-react';
+import { posthog } from '@/lib/analytics';
+
+interface ChunkErrorBoundaryProps {
+  /** What failed, in the user's words: "Layers panel", "MCP playground". */
+  label: string;
+  children: ReactNode;
+}
+
+interface ChunkErrorBoundaryState {
+  error: Error | null;
+}
+
+export class ChunkErrorBoundary extends Component<
+  ChunkErrorBoundaryProps,
+  ChunkErrorBoundaryState
+> {
+  state: ChunkErrorBoundaryState = { error: null };
+
+  static getDerivedStateFromError(error: Error): ChunkErrorBoundaryState {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    console.error(`[chunk-boundary] "${this.props.label}" failed to load`, error, info);
+    // Reported explicitly so it lands as HANDLED rather than as an uncaught
+    // error-level exception. When a skew reload is in flight the before_send
+    // gate in lib/chunk-version-skew.ts drops this as collateral; when no reload
+    // is coming, it is a real dead end and worth hearing about.
+    posthog.captureException(error, {
+      context: 'lazy_chunk_boundary',
+      chunk_label: this.props.label,
+    });
+  }
+
+  render(): ReactNode {
+    const { error } = this.state;
+    if (!error) return this.props.children;
+    return (
+      <div className="flex h-full min-h-[160px] w-full flex-col items-center justify-center gap-2 px-4 text-center">
+        <span className="text-xs text-muted-foreground">
+          {this.props.label} could not be loaded
+        </span>
+        <span className="max-w-[280px] text-[11px] text-muted-foreground/70">
+          This usually means the app was updated while your tab was open.
+        </span>
+        <button
+          type="button"
+          onClick={() => window.location.reload()}
+          className="mt-1 inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-[11px] transition-colors hover:bg-accent"
+        >
+          <RefreshCw className="h-3 w-3" />
+          Reload
+        </button>
+      </div>
+    );
+  }
+}

--- a/apps/viewer/src/components/viewer/BasketPresentationDock.tsx
+++ b/apps/viewer/src/components/viewer/BasketPresentationDock.tsx
@@ -154,8 +154,18 @@ export function BasketPresentationDock() {
   }, []);
 
   const activateSavedView = useCallback(async (viewId: string) => {
-    const { activateBasketViewFromStore } = await import('@/store/basket/basketViewActivator');
-    activateBasketViewFromStore(viewId);
+    try {
+      const { activateBasketViewFromStore } = await import('@/store/basket/basketViewActivator');
+      activateBasketViewFromStore(viewId);
+    } catch (err) {
+      // Contained here so BOTH call sites are covered: the `void` in the
+      // thumbnail's onClick below, and `startPlayAll`, whose try/finally has no
+      // catch - either would otherwise become an unhandled rejection when a
+      // deploy rotates this chunk's hash under an open tab (see
+      // lib/chunk-version-skew.ts). Play-all keeps cycling rather than aborting;
+      // the skew handler's reload is the real recovery.
+      console.warn('[basket-dock] could not load the basket-view activator', err);
+    }
   }, []);
 
   const startPlayAll = useCallback(async (loop = false) => {

--- a/apps/viewer/src/components/viewer/BasketPresentationDock.tsx
+++ b/apps/viewer/src/components/viewer/BasketPresentationDock.tsx
@@ -153,18 +153,28 @@ export function BasketPresentationDock() {
     setPlayingAll(false);
   }, []);
 
-  const activateSavedView = useCallback(async (viewId: string) => {
+  /**
+   * Activate a saved view. Resolves `false` when the activator chunk could not
+   * be loaded.
+   *
+   * Contained here so BOTH call sites are covered: the `void` in the thumbnail's
+   * onClick below, and `startPlayAll`, whose try/finally has no catch - either
+   * would otherwise become an unhandled rejection when a deploy rotates this
+   * chunk's hash under an open tab (see lib/chunk-version-skew.ts).
+   *
+   * The result is REPORTED rather than swallowed because the recovery is not
+   * guaranteed: the skew handler reloads at most once per debounce window, so a
+   * chunk that stays missing leaves the tab running. Play-all must stop there
+   * instead of looping forever over views that can no longer be applied.
+   */
+  const activateSavedView = useCallback(async (viewId: string): Promise<boolean> => {
     try {
       const { activateBasketViewFromStore } = await import('@/store/basket/basketViewActivator');
       activateBasketViewFromStore(viewId);
+      return true;
     } catch (err) {
-      // Contained here so BOTH call sites are covered: the `void` in the
-      // thumbnail's onClick below, and `startPlayAll`, whose try/finally has no
-      // catch - either would otherwise become an unhandled rejection when a
-      // deploy rotates this chunk's hash under an open tab (see
-      // lib/chunk-version-skew.ts). Play-all keeps cycling rather than aborting;
-      // the skew handler's reload is the real recovery.
       console.warn('[basket-dock] could not load the basket-view activator', err);
+      return false;
     }
   }, []);
 
@@ -179,7 +189,13 @@ export function BasketPresentationDock() {
       do {
         for (const view of orderedViews) {
           if (stopPlayRef.current) break;
-          await activateSavedView(view.id);
+          if (!(await activateSavedView(view.id))) {
+            // The activator chunk is gone. Reuse the normal stop signal so the
+            // `while` below also ends and the finally block resets the UI, and
+            // do not wait out this view's transition on the way out.
+            stopPlayRef.current = true;
+            break;
+          }
           const transitionMs = toTransitionMs(view.transitionMs);
           await wait(transitionMs + 180);
         }

--- a/apps/viewer/src/components/viewer/properties/LocationMap.tsx
+++ b/apps/viewer/src/components/viewer/properties/LocationMap.tsx
@@ -52,8 +52,11 @@ function loadMaplibre() {
     // later remount would degrade instantly without retrying. Drop the memo on
     // failure so the next mount gets a real attempt.
     maplibrePromise = pending;
-    void pending.catch(() => {
+    void pending.catch((err) => {
       if (maplibrePromise === pending) maplibrePromise = null;
+      // Logged per the no-silent-catch rule. This handler exists only to clear
+      // the memo; `pending` itself stays rejected for its real callers.
+      console.warn('[location-map] maplibre module load failed; a retry will be allowed:', err);
     });
   }
   return maplibrePromise;

--- a/apps/viewer/src/components/viewer/properties/LocationMap.tsx
+++ b/apps/viewer/src/components/viewer/properties/LocationMap.tsx
@@ -394,7 +394,13 @@ export function LocationMap({
     if (!editableRef.current) return;
     const pos = { lat: e.lngLat.lat, lon: e.lngLat.lng };
     setPickedLatLon(pos);
-    loadMaplibre().then(ml => updatePickedMarker(pos, ml));
+    // These two chains reach maplibre only to move a marker, so a failed chunk
+    // is not worth degrading the panel for: the pin state above is already set
+    // and the coordinate readout still updates. Without a handler the rejection
+    // would surface as an uncaught error (see lib/chunk-version-skew.ts).
+    loadMaplibre()
+      .then(ml => updatePickedMarker(pos, ml))
+      .catch(err => console.warn('[location-map] could not update the picked marker:', err));
   }, [updatePickedMarker]);
 
   // Handle search result selection
@@ -405,10 +411,12 @@ export function LocationMap({
     setSearchQuery('');
     setSearchResults([]);
 
-    loadMaplibre().then(ml => {
-      updatePickedMarker(pos, ml);
-      mapRef.current?.flyTo({ center: [pos.lon, pos.lat], zoom: 16, duration: 1200 });
-    });
+    loadMaplibre()
+      .then(ml => {
+        updatePickedMarker(pos, ml);
+        mapRef.current?.flyTo({ center: [pos.lon, pos.lat], zoom: 16, duration: 1200 });
+      })
+      .catch(err => console.warn('[location-map] could not move to the search result:', err));
   }, [updatePickedMarker]);
 
   // Handle apply position (waits for elevation to finish loading)

--- a/apps/viewer/src/components/viewer/properties/LocationMap.tsx
+++ b/apps/viewer/src/components/viewer/properties/LocationMap.tsx
@@ -35,7 +35,26 @@ import { posthog } from '@/lib/analytics';
 let maplibrePromise: Promise<typeof import('maplibre-gl')> | null = null;
 function loadMaplibre() {
   if (!maplibrePromise) {
-    maplibrePromise = import('maplibre-gl');
+    const pending = import('maplibre-gl').then(ml => {
+      // Defence in depth against a namespace that resolves without throwing.
+      // Vite's preload helper returns `undefined` from a failed import whenever
+      // a `vite:preloadError` listener calls `preventDefault()` (ours no longer
+      // does - see lib/chunk-version-skew.ts), and every consumer below reads
+      // `.Map` / `.Marker` off this value. Failing here routes the problem into
+      // the `.catch` backstop, which degrades the panel with the right reason,
+      // instead of throwing a bare "Cannot read properties of undefined
+      // (reading 'Map')" that the WebGL try/catch misreads as a dead GPU.
+      if (!ml) throw new Error('Failed to load the maplibre-gl module');
+      return ml;
+    });
+    // A rejected promise stays rejected, so memoising one would make a single
+    // transient chunk failure permanent for the rest of the session - every
+    // later remount would degrade instantly without retrying. Drop the memo on
+    // failure so the next mount gets a real attempt.
+    maplibrePromise = pending;
+    void pending.catch(() => {
+      if (maplibrePromise === pending) maplibrePromise = null;
+    });
   }
   return maplibrePromise;
 }

--- a/apps/viewer/src/lib/analytics.test.ts
+++ b/apps/viewer/src/lib/analytics.test.ts
@@ -5,6 +5,8 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { scrubEvent } from './analytics-scrub.js';
+import { beforeSend } from './analytics.js';
+import { __setChunkReloadPendingForTests } from './chunk-version-skew.js';
 
 // `scrubEvent` is the single `before_send` gate every captured event passes
 // through: it drops unactionable third-party noise, tags the geometry
@@ -506,5 +508,53 @@ describe('scrubEvent — benign network failures (#1903)', () => {
     // is `error_type`. Do not rename it.
     const named = scrubEvent(safariLoadFailed({ error_name: 'TypeError' }));
     assert.equal(named?.properties?.error_name, undefined);
+  });
+});
+
+// ── before_send wiring ──────────────────────────────────────────────────────
+// The two skew gates are unit-tested in isolation (chunk-version-skew.test.ts,
+// wasm-skew-noise.test.ts). What only a test of `beforeSend` itself can catch is
+// the gate being DISCONNECTED from the pipeline: delete the call in analytics.ts
+// and every isolated test still passes while the noise silently returns.
+describe('beforeSend - chunk-skew gate wiring', () => {
+  it('drops an exception captured while a chunk-skew reload is in flight', () => {
+    __setChunkReloadPendingForTests(Date.now());
+    try {
+      // The collateral from #1926/#1938/#1941: an arbitrary TypeError from a
+      // consumer still awaiting the chunk that just 404'd.
+      const dropped = beforeSend(
+        exceptionEvent("Cannot read properties of undefined (reading 'Map')"),
+      );
+      assert.equal(dropped, null);
+    } finally {
+      __setChunkReloadPendingForTests(null);
+    }
+  });
+
+  it('keeps the same exception when no reload is in flight', () => {
+    __setChunkReloadPendingForTests(null);
+    const kept = beforeSend(
+      exceptionEvent("Cannot read properties of undefined (reading 'Map')"),
+    );
+    assert.notEqual(kept, null);
+  });
+
+  it('still runs the scrub on events the gates let through', () => {
+    // Ordering guard: a `return null` accidentally placed before scrubEvent, or
+    // a gate that short-circuits the pipeline, would lose the tagging that the
+    // rest of error tracking is grouped by.
+    __setChunkReloadPendingForTests(null);
+    const out = beforeSend(exceptionEvent('Geometry worker error: unreachable'));
+    assert.equal(out?.properties?.error_kind, 'geometry_worker_crash');
+  });
+
+  it('never drops a non-exception event, even mid-reload', () => {
+    __setChunkReloadPendingForTests(Date.now());
+    try {
+      const kept = beforeSend({ event: 'ifc_model_loaded', properties: {} });
+      assert.notEqual(kept, null);
+    } finally {
+      __setChunkReloadPendingForTests(null);
+    }
   });
 });

--- a/apps/viewer/src/lib/analytics.ts
+++ b/apps/viewer/src/lib/analytics.ts
@@ -17,7 +17,10 @@ import { shouldSuppressChunkSkewNoise } from './chunk-version-skew.js';
 // scrub on everything that remains. Kept here rather than inside scrubEvent so
 // analytics-scrub.ts stays dependency-free (no @ifc-lite/geometry import) and
 // independently unit-testable.
-const beforeSend = <
+// Exported for ./analytics.test.ts. Both gates are unit-tested in isolation, but
+// only a test of THIS function can catch the gate being disconnected from the
+// pipeline, which is the failure that would silently restore the noise.
+export const beforeSend = <
   T extends { event?: string; properties?: Record<string, unknown> } | null,
 >(event: T): T | null => {
   if (shouldSuppressWasmSkewNoise(event)) return null;

--- a/apps/viewer/src/lib/analytics.ts
+++ b/apps/viewer/src/lib/analytics.ts
@@ -5,17 +5,23 @@
 import posthogClient from 'posthog-js';
 import { scrubEvent } from './analytics-scrub.js';
 import { shouldSuppressWasmSkewNoise } from './wasm-version-skew.js';
+import { shouldSuppressChunkSkewNoise } from './chunk-version-skew.js';
 
-// `before_send` gate: drop the noise from an auto-recovered wasm version-skew
-// (the tab reloads onto fresh assets, so the captured exception describes a
-// failure the user never actually hits — see shouldSuppressWasmSkewNoise),
-// then run the privacy/tagging scrub on everything that remains. Kept here
-// rather than inside scrubEvent so analytics-scrub.ts stays dependency-free
-// (no @ifc-lite/geometry import) and independently unit-testable.
+// `before_send` gate: drop the noise from an auto-recovered version skew - the
+// tab reloads onto fresh assets, so the captured exception describes a failure
+// the user never actually hits. Two sibling gates, because the two skews are
+// detected differently: the wasm one by the error's own signature
+// (shouldSuppressWasmSkewNoise), the JS/CSS chunk one by the reload we have
+// already committed to (shouldSuppressChunkSkewNoise) - a failed chunk's
+// collateral shares no vocabulary with its cause. Then run the privacy/tagging
+// scrub on everything that remains. Kept here rather than inside scrubEvent so
+// analytics-scrub.ts stays dependency-free (no @ifc-lite/geometry import) and
+// independently unit-testable.
 const beforeSend = <
   T extends { event?: string; properties?: Record<string, unknown> } | null,
 >(event: T): T | null => {
   if (shouldSuppressWasmSkewNoise(event)) return null;
+  if (shouldSuppressChunkSkewNoise(event)) return null;
   return scrubEvent(event);
 };
 

--- a/apps/viewer/src/lib/chunk-version-skew.test.ts
+++ b/apps/viewer/src/lib/chunk-version-skew.test.ts
@@ -156,6 +156,21 @@ describe('handlePreloadError', () => {
     assert.equal(h.reloads, 2);
   });
 
+  it('treats a FUTURE reload stamp as stale rather than a permanent block', () => {
+    // A negative elapsed time satisfies `< RELOAD_DEBOUNCE_MS` on its own, so
+    // without the `>= 0` guard a clock that moved backward (NTP correction, VM
+    // resume) would pin the tab at "recently reloaded" and disable skew recovery
+    // until wall time caught up. Exercised through the PRODUCTION predicate
+    // shape, which is what the guard lives in.
+    const recent = (now: number, ts: number) => {
+      const elapsed = now - ts;
+      return Number.isFinite(ts) && elapsed >= 0 && elapsed < DEBOUNCE_MS;
+    };
+    assert.equal(recent(1_000, 1_000_000), false, 'stamp far in the future must not block');
+    assert.equal(recent(1_000_000, 999_000), true, 'a genuinely recent stamp still blocks');
+    assert.equal(recent(1_000_000, 800_000), false, 'an old stamp lets recovery run again');
+  });
+
   it('refuses to reload when the attempt cannot be read', () => {
     // Unbounded retries on a permanently missing chunk would loop forever.
     const h = makeDeps({ unreadable: true });

--- a/apps/viewer/src/lib/chunk-version-skew.test.ts
+++ b/apps/viewer/src/lib/chunk-version-skew.test.ts
@@ -1,0 +1,250 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  handlePreloadError,
+  isCssPreloadFailure,
+  shouldSuppressChunkSkewNoise,
+  type ChunkSkewDeps,
+  type VitePreloadErrorEvent,
+} from './chunk-version-skew.js';
+
+/** Minimal stand-in for the cancelable `vite:preloadError` event. */
+function makeEvent(payload: unknown): VitePreloadErrorEvent & { defaultPrevented: boolean } {
+  return {
+    payload,
+    defaultPrevented: false,
+    preventDefault(this: { defaultPrevented: boolean }) {
+      this.defaultPrevented = true;
+    },
+  } as unknown as VitePreloadErrorEvent & { defaultPrevented: boolean };
+}
+
+interface Harness {
+  deps: ChunkSkewDeps;
+  reloads: number;
+  pendingAt: number | null;
+  /** Epoch-ms of the last recorded reload, mirroring the sessionStorage key. */
+  stored: number | null;
+  /** Advance the harness clock, so the debounce window can be crossed. */
+  clock: number;
+}
+
+/** Mirrors the real 60s debounce in chunk-version-skew.ts. */
+const DEBOUNCE_MS = 60_000;
+
+function makeDeps(opts: {
+  /** Seed a previous reload at this epoch-ms. */
+  lastReloadAt?: number;
+  /** Storage cannot be read (private mode / sandboxed frame). */
+  unreadable?: boolean;
+  /** setItem is accepted but silently discarded, or throws. */
+  unwritable?: boolean;
+  now?: number;
+} = {}): Harness {
+  const h: Harness = {
+    reloads: 0,
+    pendingAt: null,
+    stored: opts.lastReloadAt ?? null,
+    clock: opts.now ?? 1_000_000,
+    deps: null as unknown as ChunkSkewDeps,
+  };
+  h.deps = {
+    now: () => h.clock,
+    reload: () => { h.reloads += 1; },
+    // The production reader returns `true` when storage throws, so an
+    // unrecordable attempt is never performed.
+    hasRecentReload: (now) =>
+      opts.unreadable ? true : h.stored !== null && now - h.stored < DEBOUNCE_MS,
+    rememberReload: (now) => {
+      if (opts.unwritable) return false;
+      h.stored = now;
+      return true;
+    },
+    markReloadPending: (now) => { h.pendingAt = now; },
+  };
+  return h;
+}
+
+// The whole point of the fix: which arm of Vite's preload helper we are on
+// decides whether suppressing the re-throw is safe. See chunk-version-skew.ts.
+describe('isCssPreloadFailure', () => {
+  it('matches Vite\'s CSS-preload arm, the only reason it constructs itself', () => {
+    assert.equal(
+      isCssPreloadFailure(new Error('Unable to preload CSS for /assets/panel-a1b2c3.css')),
+      true,
+    );
+  });
+
+  it('does not match a failed module import, whatever the engine calls it', () => {
+    // Chromium, WebKit and Gecko each word this differently; none of them is
+    // Vite's CSS string, which is what the discriminator relies on.
+    for (const message of [
+      'Failed to fetch dynamically imported module: https://x/assets/bcf-C3r7vdyE.js',
+      'Importing a module script failed.',
+      'error loading dynamically imported module',
+    ]) {
+      assert.equal(isCssPreloadFailure(new Error(message)), false, message);
+    }
+  });
+
+  it('reads a bare string or an error-shaped object, and tolerates neither', () => {
+    assert.equal(isCssPreloadFailure('Unable to preload CSS for /a.css'), true);
+    assert.equal(isCssPreloadFailure({ message: 'Unable to preload CSS for /a.css' }), true);
+    assert.equal(isCssPreloadFailure(undefined), false);
+    assert.equal(isCssPreloadFailure(null), false);
+    assert.equal(isCssPreloadFailure(42), false);
+  });
+});
+
+describe('handlePreloadError', () => {
+  it('does NOT preventDefault on a module failure, so the import rejects', () => {
+    // The regression this whole PR exists for. `preventDefault()` here makes
+    // Vite's handler return undefined from `baseModule().catch(...)`, so
+    // `await import(...)` resolves to `undefined` and every consumer
+    // dereferences it (issues #1926, #1938, #1941).
+    const h = makeDeps();
+    const event = makeEvent(new Error('Failed to fetch dynamically imported module: /assets/x.js'));
+    assert.equal(handlePreloadError(event, h.deps), 'reloaded');
+    assert.equal(event.defaultPrevented, false);
+    assert.equal(h.reloads, 1);
+  });
+
+  it('DOES preventDefault on a CSS preload failure, which cannot poison the module', () => {
+    // Vite carries on to call baseModule() after this arm, so suppressing keeps
+    // a stylesheet that failed to warm the cache from failing a good import.
+    const h = makeDeps();
+    const event = makeEvent(new Error('Unable to preload CSS for /assets/panel.css'));
+    assert.equal(handlePreloadError(event, h.deps), 'reloaded');
+    assert.equal(event.defaultPrevented, true);
+    assert.equal(h.reloads, 1);
+  });
+
+  it('never spends two reloads on one skew', () => {
+    const h = makeDeps();
+    assert.equal(handlePreloadError(makeEvent(new Error('boom')), h.deps), 'reloaded');
+    assert.equal(handlePreloadError(makeEvent(new Error('boom')), h.deps), 'surfaced');
+    assert.equal(handlePreloadError(makeEvent(new Error('boom')), h.deps), 'surfaced');
+    assert.equal(h.reloads, 1);
+  });
+
+  it('does not loop on a chunk that stays missing across reloads', () => {
+    // The regression the timestamp replaced a counter for. The old counter was
+    // cleared on every mount, and a LAZY chunk only fails AFTER mount, so the
+    // budget was always fresh: a permanently-missing chunk reloaded forever on a
+    // blank page. Simulate that by re-running the handler on each fresh document
+    // (a new tab-lifetime is NOT simulated: sessionStorage survives a reload).
+    const h = makeDeps();
+    for (let i = 0; i < 20; i++) {
+      h.clock += 250; // a reload cycle, far inside the debounce window
+      handlePreloadError(makeEvent(new Error('boom')), h.deps);
+    }
+    assert.equal(h.reloads, 1);
+  });
+
+  it('lets a genuinely later deploy recover once the window elapses', () => {
+    const h = makeDeps();
+    assert.equal(handlePreloadError(makeEvent(new Error('boom')), h.deps), 'reloaded');
+    h.clock += DEBOUNCE_MS - 1;
+    assert.equal(handlePreloadError(makeEvent(new Error('boom')), h.deps), 'surfaced');
+    h.clock += 2;
+    assert.equal(handlePreloadError(makeEvent(new Error('boom')), h.deps), 'reloaded');
+    assert.equal(h.reloads, 2);
+  });
+
+  it('refuses to reload when the attempt cannot be read', () => {
+    // Unbounded retries on a permanently missing chunk would loop forever.
+    const h = makeDeps({ unreadable: true });
+    assert.equal(handlePreloadError(makeEvent(new Error('boom')), h.deps), 'surfaced');
+    assert.equal(h.reloads, 0);
+    assert.equal(h.pendingAt, null);
+  });
+
+  it('refuses to reload when the attempt cannot be persisted', () => {
+    const h = makeDeps({ unwritable: true });
+    assert.equal(handlePreloadError(makeEvent(new Error('boom')), h.deps), 'surfaced');
+    assert.equal(h.reloads, 0);
+    assert.equal(h.pendingAt, null);
+  });
+
+  it('still suppresses the CSS arm when no reload is allowed', () => {
+    // The two decisions are independent: whether to reload is a budget question,
+    // whether to suppress is about what the import resolves to.
+    const h = makeDeps({ unreadable: true });
+    const event = makeEvent(new Error('Unable to preload CSS for /assets/panel.css'));
+    assert.equal(handlePreloadError(event, h.deps), 'surfaced');
+    assert.equal(event.defaultPrevented, true);
+    assert.equal(h.reloads, 0);
+  });
+
+  it('marks the reload pending only on the path that actually reloads', () => {
+    const h = makeDeps({ now: 5_000 });
+    handlePreloadError(makeEvent(new Error('boom')), h.deps);
+    assert.equal(h.pendingAt, 5_000);
+
+    const debounced = makeDeps({ now: 5_000, lastReloadAt: 4_900 });
+    handlePreloadError(makeEvent(new Error('boom')), debounced.deps);
+    assert.equal(debounced.pendingAt, null);
+  });
+});
+
+describe('shouldSuppressChunkSkewNoise', () => {
+  const exception = { event: '$exception', properties: { $exception_values: ['boom'] } };
+
+  it('suppresses nothing when no reload is in flight', () => {
+    assert.equal(
+      shouldSuppressChunkSkewNoise(exception, { now: () => 0, reloadPendingSince: () => null }),
+      false,
+    );
+  });
+
+  it('drops the collateral captured while a reload is committing', () => {
+    // These are the arbitrary TypeErrors from every consumer still awaiting the
+    // dead chunk. They share no vocabulary with the cause, which is why the gate
+    // is time-based rather than a message matcher.
+    assert.equal(
+      shouldSuppressChunkSkewNoise(
+        { event: '$exception', properties: { $exception_values: ["Cannot read properties of undefined (reading 'Map')"] } },
+        { now: () => 1_200, reloadPendingSince: () => 1_000 },
+      ),
+      true,
+    );
+  });
+
+  it('keeps non-exception events, which are still true in that window', () => {
+    for (const e of [{ event: '$pageleave' }, { event: 'ifc_model_loaded' }]) {
+      assert.equal(
+        shouldSuppressChunkSkewNoise(e, { now: () => 1_200, reloadPendingSince: () => 1_000 }),
+        false,
+      );
+    }
+    assert.equal(
+      shouldSuppressChunkSkewNoise(null, { now: () => 1_200, reloadPendingSince: () => 1_000 }),
+      false,
+    );
+  });
+
+  it('stops suppressing once the window elapses', () => {
+    // A cancelled navigation (beforeunload prompt) must not silence the tab for
+    // the rest of its life.
+    assert.equal(
+      shouldSuppressChunkSkewNoise(exception, { now: () => 11_001, reloadPendingSince: () => 1_000 }),
+      false,
+    );
+    assert.equal(
+      shouldSuppressChunkSkewNoise(exception, { now: () => 10_999, reloadPendingSince: () => 1_000 }),
+      true,
+    );
+  });
+
+  it('does not suppress indefinitely if the clock jumps backwards', () => {
+    assert.equal(
+      shouldSuppressChunkSkewNoise(exception, { now: () => 500, reloadPendingSince: () => 1_000 }),
+      false,
+    );
+  });
+});

--- a/apps/viewer/src/lib/chunk-version-skew.test.ts
+++ b/apps/viewer/src/lib/chunk-version-skew.test.ts
@@ -7,6 +7,7 @@ import assert from 'node:assert/strict';
 
 import {
   handlePreloadError,
+  isChunkLoadError,
   isCssPreloadFailure,
   shouldSuppressChunkSkewNoise,
   type ChunkSkewDeps,
@@ -92,12 +93,56 @@ describe('isCssPreloadFailure', () => {
     }
   });
 
-  it('reads a bare string or an error-shaped object, and tolerates neither', () => {
+  it('reads a bare string or an error-shaped object, and matches neither a missing nor a non-error payload', () => {
     assert.equal(isCssPreloadFailure('Unable to preload CSS for /a.css'), true);
     assert.equal(isCssPreloadFailure({ message: 'Unable to preload CSS for /a.css' }), true);
     assert.equal(isCssPreloadFailure(undefined), false);
     assert.equal(isCssPreloadFailure(null), false);
     assert.equal(isCssPreloadFailure(42), false);
+  });
+});
+
+// The boundary wraps whole page subtrees, so it must tell a chunk that failed to
+// LOAD apart from a crash inside a chunk that loaded fine.
+describe('isChunkLoadError', () => {
+  it('matches how each engine words a failed dynamic import', () => {
+    for (const message of [
+      // Chromium
+      'Failed to fetch dynamically imported module: https://x/assets/bcf-C3r7vdyE.js',
+      // Gecko
+      'error loading dynamically imported module',
+      // WebKit
+      'Importing a module script failed.',
+      // A host that answers a missing asset with its SPA fallback instead of a
+      // 404: the browser gets index.html and rejects the MIME type.
+      'Failed to load module script: Expected a JavaScript module script but the server responded with a MIME type of text/html.',
+      // Vite's own CSS arm
+      'Unable to preload CSS for /assets/panel.css',
+    ]) {
+      assert.equal(isChunkLoadError(new Error(message)), true, message);
+    }
+  });
+
+  it('does NOT match an ordinary crash inside a chunk that loaded fine', () => {
+    // These would otherwise be filed under the chunk-skew context and told the
+    // user their tab was out of date. Includes shapes that merely mention
+    // modules or loading, so the matcher cannot be loose about it.
+    for (const message of [
+      "Cannot read properties of undefined (reading 'rows')",
+      'Maximum update depth exceeded',
+      'Failed to fetch',
+      'Cannot access module before initialization',
+      'Objects are not valid as a React child',
+    ]) {
+      assert.equal(isChunkLoadError(new Error(message)), false, message);
+    }
+  });
+
+  it('tolerates a non-Error payload', () => {
+    assert.equal(isChunkLoadError('Importing a module script failed.'), true);
+    assert.equal(isChunkLoadError(undefined), false);
+    assert.equal(isChunkLoadError(null), false);
+    assert.equal(isChunkLoadError(42), false);
   });
 });
 

--- a/apps/viewer/src/lib/chunk-version-skew.ts
+++ b/apps/viewer/src/lib/chunk-version-skew.ts
@@ -138,7 +138,14 @@ const defaultDeps: ChunkSkewDeps = {
       const raw = sessionStorage.getItem(RELOAD_TS_KEY);
       if (raw == null) return false;
       const ts = Number(raw);
-      return Number.isFinite(ts) && now - ts < RELOAD_DEBOUNCE_MS;
+      // `elapsed >= 0` is not pedantry: a stored timestamp in the FUTURE (an NTP
+      // correction, a VM resume, a user changing the clock) makes `elapsed`
+      // negative, which satisfies the `<` on its own and would pin this tab at
+      // "recently reloaded" until wall time caught up - disabling skew recovery
+      // for hours. Treat a future stamp as stale and allow the reload. Matches
+      // the same guard in shouldSuppressChunkSkewNoise below.
+      const elapsed = now - ts;
+      return Number.isFinite(ts) && elapsed >= 0 && elapsed < RELOAD_DEBOUNCE_MS;
     } catch (err) {
       // Private mode / sandboxed frame / "block all cookies". Treated as
       // "recently reloaded" so the reload is refused: rememberReload would fail

--- a/apps/viewer/src/lib/chunk-version-skew.ts
+++ b/apps/viewer/src/lib/chunk-version-skew.ts
@@ -98,6 +98,29 @@ const RELOAD_DEBOUNCE_MS = 60_000;
 /** Vite's wording for arm 1. The only rejection reason it constructs itself. */
 const CSS_PRELOAD_FAILURE = /unable to preload css for /i;
 
+/**
+ * How each engine words a failed dynamic import. Chromium and Gecko say
+ * "Failed to fetch dynamically imported module" / "error loading dynamically
+ * imported module"; WebKit says "Importing a module script failed."
+ *
+ * The `module script` arm covers the OTHER shape a rotated chunk takes: a host
+ * that answers a missing asset with its SPA fallback rather than a 404 serves
+ * `index.html`, and the browser rejects it as "Failed to load module script:
+ * Expected a JavaScript module script but the server responded with a MIME type
+ * of text/html". Same skew, no 404 anywhere. ifclite.com does return a real 404
+ * for `/assets/*`, but the recovery should not depend on that staying true.
+ */
+const MODULE_LOAD_FAILURE =
+  /failed to fetch dynamically imported module|error loading dynamically imported module|importing a module script failed|failed to load module script/i;
+
+/** Pull a message out of whatever was thrown, without assuming an Error. */
+function messageOf(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  if (typeof err === 'string') return err;
+  const m = (err as { message?: unknown } | null)?.message;
+  return typeof m === 'string' ? m : '';
+}
+
 /** The `vite:preloadError` event, which carries the underlying error on `payload`. */
 export interface VitePreloadErrorEvent extends Event {
   payload?: unknown;
@@ -108,15 +131,24 @@ export interface VitePreloadErrorEvent extends Event {
  * re-throw cannot poison the resolved module (Vite still calls `baseModule()`).
  */
 export function isCssPreloadFailure(payload: unknown): boolean {
-  const message =
-    payload instanceof Error
-      ? payload.message
-      : typeof payload === 'string'
-        ? payload
-        : typeof (payload as { message?: unknown } | null)?.message === 'string'
-          ? ((payload as { message: string }).message)
-          : '';
-  return CSS_PRELOAD_FAILURE.test(message);
+  return CSS_PRELOAD_FAILURE.test(messageOf(payload));
+}
+
+/**
+ * True when `err` is a chunk that failed to load, rather than a crash inside a
+ * chunk that loaded fine.
+ *
+ * `ChunkErrorBoundary` wraps whole page subtrees, so it catches every render
+ * error under them, not just a rejected `lazy()` import. Without this
+ * distinction an ordinary component crash would tell the user their tab was out
+ * of date and would be filed under the chunk-skew context in error tracking,
+ * mis-grouping a real bug with an auto-recovered one. That is the same
+ * mis-classification that made a failed maplibre import look like a dead GPU in
+ * issue #1926, so it is worth not reintroducing one file over.
+ */
+export function isChunkLoadError(err: unknown): boolean {
+  const message = messageOf(err);
+  return MODULE_LOAD_FAILURE.test(message) || CSS_PRELOAD_FAILURE.test(message);
 }
 
 export interface ChunkSkewDeps {

--- a/apps/viewer/src/lib/chunk-version-skew.ts
+++ b/apps/viewer/src/lib/chunk-version-skew.ts
@@ -1,0 +1,280 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Recover from JS/CSS "deployment skew": a tab open across a production deploy
+ * holds an entry chunk whose lazy imports point at content-hashed asset URLs the
+ * new deploy rotated away. The lazy `import()` then 404s and Vite dispatches
+ * `vite:preloadError`. The asset is gone for good, so the only fix is to reload
+ * the document and pull the current deployment's HTML plus its fresh asset URLs.
+ *
+ * This is the JS sibling of ./wasm-version-skew.ts, which does the same for the
+ * `ifc-lite_bg.wasm` engine binary (fetched inside a worker, so invisible to
+ * `vite:preloadError`).
+ *
+ * ## Why `preventDefault()` is not a free "we own the recovery" switch
+ *
+ * Vite's generated preload helper calls its error handler from TWO places:
+ *
+ * ```js
+ * function handlePreloadError(err) {
+ *   const e = new Event('vite:preloadError', { cancelable: true });
+ *   e.payload = err;
+ *   window.dispatchEvent(e);
+ *   if (!e.defaultPrevented) throw err;      // <-- preventDefault() => returns undefined
+ * }
+ * return promise.then((res) => {
+ *   for (const item of res || []) {
+ *     if (item.status !== 'rejected') continue;
+ *     handlePreloadError(item.reason);       // arm 1: a CSS <link> preload failed
+ *   }
+ *   return baseModule().catch(handlePreloadError); // arm 2: the import itself failed
+ * });
+ * ```
+ *
+ * In **arm 1** suppressing the throw is harmless and useful: Vite carries on to
+ * call `baseModule()`, so a stylesheet that merely failed to warm the cache
+ * cannot fail the import on its own.
+ *
+ * In **arm 2** the handler's return value *is* the resolved module namespace.
+ * Calling `preventDefault()` there makes a failed `import()` **resolve with
+ * `undefined`** instead of rejecting - and because `window.location.reload()` is
+ * asynchronous, every consumer awaiting that chunk keeps running for the
+ * hundreds of milliseconds before the navigation commits, dereferencing
+ * `undefined`:
+ *
+ *   - `React.lazy(() => import(...))` -> `_result.default` ->
+ *     `TypeError: Cannot read properties of undefined (reading 'default')` - an
+ *     UNCAUGHT render-phase throw that tears the tree down (issue #1941)
+ *   - `const { fn } = await import(...)` ->
+ *     `TypeError: Cannot destructure property 'fn' of '(intermediate value)' as
+ *     it is undefined.` (issue #1938)
+ *   - `import('maplibre-gl').then(ml => new ml.Map(...))` ->
+ *     `TypeError: Cannot read properties of undefined (reading 'Map')`, which
+ *     LocationMap's GPU `try/catch` then misread as a WebGL failure and latched
+ *     for the session (issue #1926)
+ *
+ * None of those describe what went wrong, none are actionable, and each new
+ * call site mints a fresh error-tracking issue. So: `preventDefault()` only on
+ * arm 1. On arm 2 the import is left to reject, which is both the truth and the
+ * shape every call site already handles - a React error boundary for `lazy`, a
+ * `catch` at the await sites.
+ *
+ * The reload is still ours, and still bounded: debounced per tab, and refused
+ * outright when the attempt cannot be recorded (a permanently-missing chunk
+ * would otherwise reload forever). What the rejection costs us is telemetry
+ * noise from an outcome the user never sees - handled by
+ * {@link shouldSuppressChunkSkewNoise} below rather than by lying to the module
+ * graph.
+ */
+
+/**
+ * sessionStorage key holding the epoch-ms of the last chunk-skew reload.
+ *
+ * A TIMESTAMP, not a counter. The counter this replaces was reset on every mount
+ * ("the entry executed, so the prior reload succeeded"), which is sound for the
+ * ENTRY chunk that `index.html`'s boot watchdog guards, but not for a LAZY one:
+ * the entry always executes, and the lazy chunk is not even requested until
+ * after mount. The budget was therefore always fresh by the time the failure
+ * happened, so a permanently-missing chunk (a genuinely broken deploy, a proxy
+ * blocking the asset) reloaded in a tight loop on a blank page rather than
+ * surfacing after one try. Reproduced in a browser against a 404ing lazy chunk.
+ *
+ * Debouncing on time fixes that and keeps the property the counter was there
+ * for: a successful reload lands well inside the window, so it is never spent
+ * twice on one skew, while a genuinely new deploy later in a long session still
+ * gets to recover. Same policy, same reasoning as ./wasm-version-skew.ts.
+ */
+const RELOAD_TS_KEY = 'ifclite:chunk-skew-reload-ts';
+
+/**
+ * Minimum gap between chunk-skew reloads in one tab. Matches the wasm sibling:
+ * long enough that one skew cannot spend two reloads, short enough that a second
+ * deploy during a long session can still self-heal.
+ */
+const RELOAD_DEBOUNCE_MS = 60_000;
+
+/** Vite's wording for arm 1. The only rejection reason it constructs itself. */
+const CSS_PRELOAD_FAILURE = /unable to preload css for /i;
+
+/** The `vite:preloadError` event, which carries the underlying error on `payload`. */
+export interface VitePreloadErrorEvent extends Event {
+  payload?: unknown;
+}
+
+/**
+ * True when this event came from Vite's CSS-preload arm, where suppressing the
+ * re-throw cannot poison the resolved module (Vite still calls `baseModule()`).
+ */
+export function isCssPreloadFailure(payload: unknown): boolean {
+  const message =
+    payload instanceof Error
+      ? payload.message
+      : typeof payload === 'string'
+        ? payload
+        : typeof (payload as { message?: unknown } | null)?.message === 'string'
+          ? ((payload as { message: string }).message)
+          : '';
+  return CSS_PRELOAD_FAILURE.test(message);
+}
+
+export interface ChunkSkewDeps {
+  now: () => number;
+  reload: () => void;
+  /** Has a chunk-skew reload already run inside the debounce window? */
+  hasRecentReload: (now: number) => boolean;
+  /** Persist the attempt. Returning false VETOES the reload (storage unavailable). */
+  rememberReload: (now: number) => boolean;
+  /** Record that a reload is in flight, so consequential exceptions can be dropped. */
+  markReloadPending: (now: number) => void;
+}
+
+const defaultDeps: ChunkSkewDeps = {
+  now: () => Date.now(),
+  reload: () => window.location.reload(),
+  hasRecentReload: (now) => {
+    try {
+      const raw = sessionStorage.getItem(RELOAD_TS_KEY);
+      if (raw == null) return false;
+      const ts = Number(raw);
+      return Number.isFinite(ts) && now - ts < RELOAD_DEBOUNCE_MS;
+    } catch (err) {
+      // Private mode / sandboxed frame / "block all cookies". Treated as
+      // "recently reloaded" so the reload is refused: rememberReload would fail
+      // too, and an unrecordable attempt must never be performed.
+      console.warn('[chunk-reload] sessionStorage unreadable; letting preload error surface', err);
+      return true;
+    }
+  },
+  rememberReload: (now) => {
+    try {
+      sessionStorage.setItem(RELOAD_TS_KEY, String(now));
+      // Confirm the write actually stuck: some embedders accept `setItem` and
+      // silently discard it, which would leave the reload unbounded.
+      return sessionStorage.getItem(RELOAD_TS_KEY) === String(now);
+    } catch (err) {
+      console.warn('[chunk-reload] sessionStorage unwritable; letting preload error surface', err);
+      return false;
+    }
+  },
+  markReloadPending: (now) => {
+    reloadPendingSince = now;
+  },
+};
+
+/** What the handler decided, exposed for tests and for the caller's own logging. */
+export type ChunkSkewOutcome =
+  /** Debounced or storage unusable - Vite re-throws, the error surfaces. */
+  | 'surfaced'
+  /** A reload was triggered. The import still rejects (arm 2) or continues (arm 1). */
+  | 'reloaded';
+
+/**
+ * Decide what to do with one `vite:preloadError`. Exported with injectable deps
+ * so the policy is unit-testable without a real `window`.
+ */
+export function handlePreloadError(
+  event: VitePreloadErrorEvent,
+  deps: ChunkSkewDeps = defaultDeps,
+): ChunkSkewOutcome {
+  // Arm 1 only (see the module doc): suppressing Vite's re-throw here keeps a
+  // failed stylesheet preload from failing an import that would have succeeded.
+  // Decided BEFORE the reload budget, because it is about what the import
+  // resolves to, not about whether we reload.
+  if (isCssPreloadFailure(event.payload)) event.preventDefault();
+
+  const now = deps.now();
+  if (deps.hasRecentReload(now)) return 'surfaced'; // already tried; do not loop
+  if (!deps.rememberReload(now)) return 'surfaced'; // could not bound the retry
+
+  deps.markReloadPending(now);
+  deps.reload();
+  return 'reloaded';
+}
+
+// ── Telemetry noise suppression ─────────────────────────────────────────────
+// Between `reload()` and the navigation actually committing, the document keeps
+// running: pending microtasks resolve, React commits a frame, timers fire. Every
+// consumer still waiting on the chunk that just 404'd fails in that window. Those
+// failures are consequences of a condition we have ALREADY fixed - the tab is
+// about to come back on fresh assets - so they are pure noise, and each distinct
+// call site mints its own error-tracking issue (and its own auto-filed GitHub
+// issue) for the same one bug. That is how #1926, #1938 and #1941 arrived as
+// three unrelated-looking TypeErrors.
+//
+// The gate is TIME, not message matching, and deliberately so: the consequences
+// carry arbitrary messages ("Cannot read properties of undefined (reading
+// 'Map')") that share no vocabulary with the cause, so any matcher would have to
+// enumerate call sites and would silently rot as new ones are added.
+//
+// Two properties keep this from hiding real breakage:
+//   - The flag lives in MODULE MEMORY, never in storage, so it cannot outlive
+//     the document. A reload always lands with a clean slate.
+//   - It is only ever set on the path that actually reloads. When the budget is
+//     spent (`surfaced`) - i.e. a reload already failed to fix this, the
+//     genuinely-broken-deploy case - nothing is suppressed and every exception
+//     reaches error tracking, which is exactly when we need to hear about it.
+let reloadPendingSince: number | null = null;
+
+/**
+ * Upper bound on the suppression window. `reload()` normally commits in tens of
+ * milliseconds, but a `beforeunload` prompt or a slow server can stretch it  -
+ * and if the navigation is cancelled outright it would never end at all. After
+ * this long, errors surface again even though the flag was set.
+ */
+const RELOAD_SUPPRESSION_WINDOW_MS = 10_000;
+
+export interface ChunkSkewNoiseDeps {
+  now: () => number;
+  reloadPendingSince: () => number | null;
+}
+
+const defaultNoiseDeps: ChunkSkewNoiseDeps = {
+  now: () => Date.now(),
+  reloadPendingSince: () => reloadPendingSince,
+};
+
+/**
+ * Decide whether a captured PostHog event is collateral from an in-flight
+ * chunk-skew reload and should be dropped. Returns `true` to DROP.
+ *
+ * Only `$exception` events are eligible: a `$pageleave` or a product event fired
+ * in the same window is still true and still worth having.
+ */
+export function shouldSuppressChunkSkewNoise(
+  event: { event?: string; properties?: Record<string, unknown> } | null,
+  deps: ChunkSkewNoiseDeps = defaultNoiseDeps,
+): boolean {
+  if (!event || event.event !== '$exception') return false;
+  const since = deps.reloadPendingSince();
+  if (since === null) return false;
+  const elapsed = deps.now() - since;
+  // A clock that jumped backwards would make `elapsed` negative and suppress
+  // indefinitely; treat anything outside the forward window as "not pending".
+  return elapsed >= 0 && elapsed < RELOAD_SUPPRESSION_WINDOW_MS;
+}
+
+let installed = false;
+
+/**
+ * Wire the `vite:preloadError` recovery. Idempotent; call once at app boot. No-op
+ * outside a browser window (SSR / tests without a DOM).
+ *
+ * Complements the inline boot self-heal in `index.html`, which handles the ENTRY
+ * chunk failing to load; this handles a LAZY chunk (exporters / ids / bcf /
+ * sandbox ...) 404ing after a newer deploy ships fresh hashes mid-session.
+ */
+export function installChunkVersionSkewRecovery(): void {
+  if (installed || typeof window === 'undefined') return;
+  installed = true;
+  window.addEventListener('vite:preloadError', (event) => {
+    handlePreloadError(event as VitePreloadErrorEvent);
+  });
+}
+
+/** Test-only: reset the install guard and the in-flight reload flag. */
+export function __resetChunkVersionSkewForTests(): void {
+  installed = false;
+  reloadPendingSince = null;
+}

--- a/apps/viewer/src/lib/chunk-version-skew.ts
+++ b/apps/viewer/src/lib/chunk-version-skew.ts
@@ -278,3 +278,15 @@ export function __resetChunkVersionSkewForTests(): void {
   installed = false;
   reloadPendingSince = null;
 }
+
+/**
+ * Test-only: drive the module-private in-flight flag directly.
+ *
+ * The flag is normally set by {@link handlePreloadError} through its default
+ * deps, which need a real `window` and `sessionStorage`. This lets the
+ * `before_send` wiring in ./analytics.ts be tested for what it actually has to
+ * guarantee - that the gate is CONNECTED - without a DOM.
+ */
+export function __setChunkReloadPendingForTests(now: number | null): void {
+  reloadPendingSince = now;
+}

--- a/apps/viewer/src/lib/panels/renderPanelBody.tsx
+++ b/apps/viewer/src/lib/panels/renderPanelBody.tsx
@@ -13,6 +13,7 @@
 
 import { lazy, Suspense, type ReactNode } from 'react';
 import type { WorkspacePanelId } from './registry';
+import { ChunkErrorBoundary } from '@/components/ChunkErrorBoundary';
 import { HierarchyPanel } from '@/components/viewer/HierarchyPanel';
 import { PropertiesPanel } from '@/components/viewer/PropertiesPanel';
 import { ComparePanel } from '@/components/viewer/ComparePanel';
@@ -55,9 +56,11 @@ export function renderPanelBody(id: WorkspacePanelId, onClose: () => void): Reac
     case 'collab': return <RoomPanel onClose={onClose} />;
     case 'zones': return <ZonesPanel onClose={onClose} />;
     case 'layers': return (
-      <Suspense fallback={null}>
-        <LayersPanel onClose={onClose} />
-      </Suspense>
+      <ChunkErrorBoundary label="Layers panel">
+        <Suspense fallback={null}>
+          <LayersPanel onClose={onClose} />
+        </Suspense>
+      </ChunkErrorBoundary>
     );
   }
 }

--- a/apps/viewer/src/lib/wasm-version-skew.ts
+++ b/apps/viewer/src/lib/wasm-version-skew.ts
@@ -42,7 +42,13 @@ function recentlyReloaded(now: number): boolean {
     const raw = sessionStorage.getItem(RELOAD_TS_KEY);
     if (raw == null) return false;
     const ts = Number(raw);
-    return Number.isFinite(ts) && now - ts < RELOAD_DEBOUNCE_MS;
+    // A stored timestamp in the FUTURE (an NTP correction, a VM resume, a user
+    // changing the clock) makes the difference negative, which satisfies the
+    // `<` on its own and would pin this tab at "recently reloaded" until wall
+    // time caught up, disabling wasm skew recovery for hours. Treat a future
+    // stamp as stale. Same guard as ./chunk-version-skew.ts.
+    const elapsed = now - ts;
+    return Number.isFinite(ts) && elapsed >= 0 && elapsed < RELOAD_DEBOUNCE_MS;
   } catch {
     return false;
   }

--- a/apps/viewer/src/main.tsx
+++ b/apps/viewer/src/main.tsx
@@ -32,6 +32,7 @@ import 'maplibre-gl/dist/maplibre-gl.css';
 // itself so its overlay-path logic stays unit-testable.
 import './lib/placement-edit.boot';
 import { installWasmVersionSkewRecovery } from './lib/wasm-version-skew';
+import { installChunkVersionSkewRecovery } from './lib/chunk-version-skew';
 import { scheduleWasmPrewarm } from './lib/wasm-prewarm';
 
 // WASM engine-binary recovery — the sibling of the chunk recovery below for the
@@ -46,42 +47,9 @@ installWasmVersionSkewRecovery();
 // index.html. The boot watchdog handles the ENTRY failing to load; this handles
 // a LAZY chunk (exporters / ids / bcf / sandbox …) 404ing after a newer deploy
 // ships fresh hashes mid-session. Vite dispatches `vite:preloadError` for that;
-// reload once (sessionStorage-bounded) to pull the matching new chunks.
-window.addEventListener('vite:preloadError', (event) => {
-  const KEY = 'ifc-lite:chunk-reload';
-  // Bound the retry with sessionStorage. If storage is unavailable (private mode
-  // / sandboxed frame) we can't record the attempt, so we must NOT reload — that
-  // would loop forever on a permanently-missing chunk. In that case fall through
-  // and let Vite surface the error.
-  let attempt = 0;
-  try {
-    attempt = Number(sessionStorage.getItem(KEY)) || 0;
-  } catch (err) {
-    console.warn('[chunk-reload] sessionStorage unreadable; letting preload error surface', err);
-    return;
-  }
-  if (attempt >= 1) return; // already retried this session — let the error surface
-  let recorded = false;
-  try {
-    sessionStorage.setItem(KEY, String(attempt + 1));
-    recorded = (Number(sessionStorage.getItem(KEY)) || 0) > attempt;
-  } catch (err) {
-    console.warn('[chunk-reload] sessionStorage unwritable; letting preload error surface', err);
-  }
-  if (!recorded) return; // couldn't bound the retry → don't suppress Vite's error or loop
-  // Stop Vite from re-throwing as an unhandled rejection; we own the recovery.
-  event.preventDefault();
-  window.location.reload();
-});
-
-// Reaching here means the entry executed and is about to mount, so any prior
-// boot/chunk reload succeeded — reset the chunk guard for a fresh budget.
-try {
-  sessionStorage.removeItem('ifc-lite:chunk-reload');
-} catch (err) {
-  // Storage unavailable — nothing was persisted to clear; log per the no-silent-catch rule.
-  console.warn('[chunk-reload] could not clear retry guard', err);
-}
+// reload once (sessionStorage-bounded) to pull the matching new chunks. See
+// chunk-version-skew.ts for why the reload must NOT suppress Vite's re-throw.
+installChunkVersionSkewRecovery();
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>

--- a/apps/viewer/src/store/slices/pinboardSlice.ts
+++ b/apps/viewer/src/store/slices/pinboardSlice.ts
@@ -427,9 +427,17 @@ export const createPinboardSlice: StateCreator<
   },
 
   activateBasketView: (viewId) => {
-    void import('../basket/basketViewActivator.js').then(({ activateBasketViewFromStore }) => {
-      activateBasketViewFromStore(viewId);
-    });
+    void import('../basket/basketViewActivator.js')
+      .then(({ activateBasketViewFromStore }) => {
+        activateBasketViewFromStore(viewId);
+      })
+      // Fire-and-forget: with no handler a rejected chunk load (a deploy rotated
+      // the hash under this tab - see lib/chunk-version-skew.ts) becomes an
+      // unhandled rejection. The view simply does not activate; the reload the
+      // skew handler schedules is the recovery.
+      .catch((err) => {
+        console.warn('[pinboard] could not load the basket-view activator', err);
+      });
   },
 
   removeBasketView: (viewId) => {


### PR DESCRIPTION
All three open PostHog-filed issues are the same bug in the chunk version-skew recovery in `main.tsx`.

## Root cause

Vite's generated preload helper calls its error handler from two places:

```js
function handlePreloadError(err) {
  const e = new Event('vite:preloadError', { cancelable: true });
  e.payload = err;
  window.dispatchEvent(e);
  if (!e.defaultPrevented) throw err;   // preventDefault() => returns undefined
}
return promise.then((res) => {
  for (const item of res || []) {
    if (item.status !== 'rejected') continue;
    handlePreloadError(item.reason);          // arm 1: a CSS <link> preload failed
  }
  return baseModule().catch(handlePreloadError);  // arm 2: the import itself failed
});
```

Our listener called `event.preventDefault()` unconditionally ("we own the recovery"). On **arm 2** the handler's return value *is* the resolved module namespace, so suppressing the throw made a failed `import()` **resolve with `undefined`** instead of rejecting. `window.location.reload()` is asynchronous, so every consumer awaiting that chunk kept running for the hundreds of milliseconds before the navigation committed, and dereferenced `undefined`:

| Issue | Call site | Resulting message |
|---|---|---|
| #1941 | `React.lazy(() => import(...))` reading `_result.default` | `Cannot read properties of undefined (reading 'default')`, uncaught in the render phase |
| #1938 | `const { activateBasketViewFromStore } = await import(...)` | `Cannot destructure property 'activateBasketViewFromStore' of '(intermediate value)' as it is undefined.` |
| #1926 | `loadMaplibre().then(ml => new ml.Map(...))` | `Cannot read properties of undefined (reading 'Map')`, which `LocationMap`'s WebGL `try/catch` then misread as a dead GPU and latched for the whole session |

### Evidence from the PostHog events

Every one of the three `$exception` events is followed by a `$pageleave` within ~250 ms, and the next event in the same session carries a **newer `app_build_sha`**. Those are our own recovery reloads:

```
10:53:12.861  $exception  c7fdd704  "Cannot destructure property 'activateBasketViewFromStore' ..."
10:53:13.117  $pageleave  c7fdd704
10:53:27.990  ifc_model_loaded  4e138e5e     <- reloaded onto the newer deploy
```

`#1938` and `#1941` are the same user in one session, 41 minutes apart, each crossing a production deploy (four went out in the 15 minutes before `#1941`).

## A second defect found while reproducing

The reload budget was a counter cleared on every mount, on the reasoning "the entry executed, so the prior reload succeeded". That holds for the ENTRY chunk `index.html`'s boot watchdog guards, but not for a LAZY one: the entry always executes, and the lazy chunk is not even requested until after mount. The budget was therefore always fresh by the time the failure happened, so a **permanently**-missing chunk (a broken deploy, a proxy blocking the asset) reload-looped on a blank page instead of surfacing after one try. Measured in the browser: **53 requests for the dead chunk in 8 seconds**.

## What changed

- `preventDefault()` **only on arm 1**, where Vite still goes on to call `baseModule()`, so a stylesheet that merely failed to warm the cache cannot fail an import that would have succeeded. Arm 2 is left to reject: that is the truth, and it is the shape every call site already handles. `Unable to preload CSS for ...` is the only rejection reason Vite constructs itself, so the discriminator is exhaustive rather than heuristic.
- The counter becomes a **60s debounce**, the same policy and reasoning as the wasm sibling in `wasm-version-skew.ts`.
- A `before_send` gate drops the collateral exceptions captured between `reload()` and the navigation committing. Time-based, not message-based, because the consequences share no vocabulary with the cause. The flag lives in module memory only (it cannot outlive the document) and is set solely on the path that actually reloads, so a genuinely broken deploy still reports everything.
- New `ChunkErrorBoundary` around the three `React.lazy` roots. `Suspense` covers the pending state, not the failed one; without a boundary a rejected lazy import unmounts the entire tree.
- Call-site hardening: `.catch` on the fire-and-forget basket-view import; containment inside `activateSavedView` (both of its call sites were uncovered, including `startPlayAll`'s `try/finally` with no `catch`); `loadMaplibre` no longer memoises a rejected promise for the rest of the session, and no longer lets a nullish namespace reach `new ml.Map(...)`.

The new module carries the reasoning, so the next person who reaches for `preventDefault()` here sees why it is not free.

## Verification

**Browser A/B against the same production bundle**, served with the `McpLanding` lazy chunk 404ing. "Before" re-injects the removed `preventDefault()` line via an init script, so the only variable is the defect itself:

| | before | after |
|---|---|---|
| error | `TypeError: Cannot read properties of undefined (reading 'default')` at `F (createLucideIcon-*.js:1:3687)`, `va` | `TypeError: Failed to fetch dynamically imported module: /assets/McpLanding-CYqkaA4Z.js` |
| UI | fallback (blank before the boundary existed) | fallback |

The "before" stack is **identical to #1941's production stack down to the frame names and column** (`F` at `createLucideIcon-*.js:1:3687`, then `va`), which is what pins the diagnosis.

Emulating the full pre-PR behaviour (both defects): blank page, `#root` empty, 53 chunk requests in 8 s. After: 2 main-frame navigations, fallback rendered.

- 17 new unit tests, all 7 mutations of the policy verified to fail the suite (unconditional `preventDefault`, never `preventDefault`, unbounded budget, reload despite unpersistable attempt, unbounded suppression window, suppressing non-exception events, marking pending on the surfaced path).
- `apps/viewer` suite: 2127 tests, 0 failures. `tsc --noEmit` clean. Production build clean.

Closes #1926
Closes #1938
Closes #1941


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recovery from stale or failed page assets, including automatic reloads when appropriate.
  - Added clear fallback screens and reload actions for failed pages and panels.
  - Prevented unavailable views and map-loading failures from disrupting playback or causing unhandled errors.
  - Reduced misleading error telemetry during automatic recovery.
- **Tests**
  - Added coverage for asset recovery, retry behavior, error handling, and telemetry filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->