### PR TITLE
fix(viewer,cli): HBJSON export honours the mutation view (#1908)

### DIFF
--- a/.changeset/olive-rooms-export.md
+++ b/.changeset/olive-rooms-export.md
@@ -1,0 +1,9 @@
+---
+"@ifc-lite/cli": patch
+---
+
+Fix HBJSON export ignoring in-store edits. `export.hbjson` read the model's original bytes rather than the mutation view, so spaces authored in the editor were invisible to the exporter by construction and the file came back with no rooms. It now regenerates through `StepExporter` when the overlay carries pending changes, matching what STEP export already did, and falls back to the original bytes otherwise.
+
+The gate is `hasPendingChanges()`, not `hasChanges()`: the latter reads the append-only mutation history, which `restoreNewEntity` does not touch, so a restored overlay would have silently taken the original-bytes path and dropped its spaces again.
+
+Closes #1908.

--- a/apps/viewer/src/components/viewer/HbjsonExportDialog.test.tsx
+++ b/apps/viewer/src/components/viewer/HbjsonExportDialog.test.tsx
@@ -1,0 +1,108 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import '@/test/setup-dom.js';
+import { describe, it, beforeEach, mock } from 'node:test';
+import assert from 'node:assert/strict';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { GeometryProcessor } from '@ifc-lite/geometry';
+import { useViewerStore } from '@/store/index.js';
+import type { FederatedModel } from '@/store/types.js';
+import { HbjsonExportDialog } from './HbjsonExportDialog.js';
+
+function makeModel(): FederatedModel {
+  return {
+    id: 'model-1',
+    name: 'model-1.ifc',
+    ifcDataStore: null,
+    geometryResult: null,
+    visible: true,
+    collapsed: false,
+    schemaVersion: 'IFC4',
+    loadedAt: 1,
+    fileSize: 3,
+    sourceFile: new File([new Uint8Array([1, 2, 3])], 'model-1.ifc'),
+    idOffset: 0,
+    maxExpressId: 0,
+  };
+}
+
+const mounted: Array<{ root: Root; container: HTMLElement }> = [];
+
+function renderDialog(): HTMLElement {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(<HbjsonExportDialog />);
+  });
+  mounted.push({ root, container });
+  return container;
+}
+
+async function clickExport(container: HTMLElement): Promise<void> {
+  const trigger = [...container.querySelectorAll('button')].find((b) =>
+    b.textContent?.includes('Export HBJSON'),
+  );
+  assert.ok(trigger, 'trigger button must render');
+  await act(async () => {
+    trigger.click();
+  });
+
+  const exportButton = [...document.body.querySelectorAll('button')].find(
+    (b) => b.textContent?.includes('Export') && !b.textContent?.includes('Export HBJSON'),
+  );
+  assert.ok(exportButton, 'the dialog Export button must render once opened');
+  await act(async () => {
+    exportButton.click();
+  });
+}
+
+describe('HbjsonExportDialog WASM disposal (#1956 review fix)', () => {
+  beforeEach(() => {
+    for (const { root, container } of mounted.splice(0)) {
+      act(() => {
+        root.unmount();
+      });
+      container.remove();
+    }
+    useViewerStore.setState({ models: new Map([['model-1', makeModel()]]) });
+  });
+
+  it('disposes the GeometryProcessor WASM handle on the success path', async () => {
+    const initMock = mock.method(GeometryProcessor.prototype, 'init', async () => undefined);
+    const exportMock = mock.method(GeometryProcessor.prototype, 'exportHbjson', () =>
+      new TextEncoder().encode('{"rooms":[]}'),
+    );
+    const disposeMock = mock.method(GeometryProcessor.prototype, 'dispose', () => undefined);
+    try {
+      const container = renderDialog();
+      await clickExport(container);
+      assert.equal(disposeMock.mock.callCount(), 1, 'dispose runs exactly once on success');
+    } finally {
+      initMock.mock.restore();
+      exportMock.mock.restore();
+      disposeMock.mock.restore();
+    }
+  });
+
+  it('disposes the GeometryProcessor WASM handle even when exportHbjson returns null (throw path)', async () => {
+    const initMock = mock.method(GeometryProcessor.prototype, 'init', async () => undefined);
+    // Mirrors the real "geometry engine unavailable" case: exportHbjson
+    // returning null makes handleExport's own `throw new Error(...)` fire —
+    // the early-return-via-throw the fix's inner try/finally must cover.
+    const exportMock = mock.method(GeometryProcessor.prototype, 'exportHbjson', () => null);
+    const disposeMock = mock.method(GeometryProcessor.prototype, 'dispose', () => undefined);
+    try {
+      const container = renderDialog();
+      await clickExport(container);
+      assert.equal(disposeMock.mock.callCount(), 1, 'dispose runs exactly once even though export threw');
+    } finally {
+      initMock.mock.restore();
+      exportMock.mock.restore();
+      disposeMock.mock.restore();
+    }
+  });
+});

--- a/apps/viewer/src/components/viewer/HbjsonExportDialog.tsx
+++ b/apps/viewer/src/components/viewer/HbjsonExportDialog.tsx
@@ -5,11 +5,21 @@
 /**
  * Export Dialog for HBJSON (Honeybee / Ladybug Tools energy & daylight model).
  *
- * HBJSON is built analytically from the original IFC bytes (rooms from IfcSpace
+ * HBJSON is built analytically from IFC STEP bytes (rooms from IfcSpace
  * volumes, windows/doors as apertures/doors, railings as shades, and material
- * layer sets as opaque constructions) — so it needs the model's `sourceFile`,
- * not the tessellated geometry. There are no per-export settings beyond the
- * model name, so the dialog is just a picker + a short description.
+ * layer sets as opaque constructions). When the model's mutation view carries
+ * actual edits (e.g. spaces drawn with the Space Sketch tool), those bytes
+ * are regenerated through `StepExporter` first — the same mutation-view
+ * application STEP export already uses (see `ExportDialog.tsx`) — so
+ * anything authored in the editor is visible to the analytic exporter. Falls
+ * back to the model's `sourceFile` bytes verbatim otherwise, which is the
+ * common case: a mutation view with zero edits is register-on-open, not
+ * edit-on-open (the Properties panel, `BulkPropertyEditor`, `DataConnector`,
+ * and `ExportDialog` all construct and register one just by being opened),
+ * so gating on mere existence would route every export through a redundant
+ * regeneration the moment any of those panels had been touched. There are no
+ * per-export settings beyond the model name, so the dialog is just a picker
+ * + a short description.
  */
 
 import { useState, useCallback, useMemo, useEffect } from 'react';
@@ -41,7 +51,9 @@ import {
 import { useViewerStore } from '@/store';
 import { toast } from '@/components/ui/toast';
 import { GeometryProcessor } from '@ifc-lite/geometry';
+import { StepExporter } from '@ifc-lite/export';
 import { downloadBlob, sanitizeFilename } from '@/lib/export/download';
+import { resolveHbjsonMutationSource } from './hbjson-export-source';
 
 interface HbjsonExportDialogProps {
   trigger?: React.ReactNode;
@@ -49,6 +61,7 @@ interface HbjsonExportDialogProps {
 
 export function HbjsonExportDialog({ trigger }: HbjsonExportDialogProps) {
   const models = useViewerStore((s) => s.models);
+  const getMutationView = useViewerStore((s) => s.getMutationView);
 
   const [open, setOpen] = useState(false);
   const [selectedModelId, setSelectedModelId] = useState<string>('');
@@ -63,7 +76,13 @@ export function HbjsonExportDialog({ trigger }: HbjsonExportDialogProps) {
     () =>
       Array.from(models.values())
         .filter((m) => m.sourceFile && /\.(ifc|ifcx|ifczip)$/i.test(m.sourceFile.name))
-        .map((m) => ({ id: m.id, name: m.name, sourceFile: m.sourceFile as File })),
+        .map((m) => ({
+          id: m.id,
+          name: m.name,
+          sourceFile: m.sourceFile as File,
+          ifcDataStore: m.ifcDataStore,
+          schemaVersion: m.schemaVersion,
+        })),
     [models],
   );
 
@@ -85,7 +104,28 @@ export function HbjsonExportDialog({ trigger }: HbjsonExportDialogProps) {
     setExportResult(null);
 
     try {
-      const bytes = new Uint8Array(await selectedModel.sourceFile.arrayBuffer());
+      // Regenerate STEP bytes through the mutation view when it carries actual
+      // edits, so anything authored in-editor (e.g. Space Sketch rooms) is
+      // visible to the analytic exporter — mirrors how full STEP export
+      // applies `getMutationView` (see ExportDialog.tsx). IFC5/IFCX models
+      // have no STEP representation to regenerate, and a mutation view with
+      // no pending changes (the common case — see the module doc comment)
+      // falls straight through to the original file bytes, unchanged from
+      // before this fix.
+      const mutationView = getMutationView(selectedModel.id);
+      const dataStore = selectedModel.ifcDataStore;
+      const mutationSource = resolveHbjsonMutationSource({
+        mutationView,
+        dataStore,
+        schemaVersion: selectedModel.schemaVersion,
+      });
+      let bytes: Uint8Array;
+      if (mutationSource) {
+        const exporter = new StepExporter(mutationSource.dataStore, mutationSource.mutationView);
+        bytes = exporter.export({ schema: mutationSource.dataStore.schemaVersion }).content;
+      } else {
+        bytes = new Uint8Array(await selectedModel.sourceFile.arrayBuffer());
+      }
       const baseName = selectedModel.name.replace(/\.[^.]+$/, '');
 
       // A fresh processor is cheap: wasm-bindgen shares one module singleton,
@@ -111,7 +151,7 @@ export function HbjsonExportDialog({ trigger }: HbjsonExportDialogProps) {
     } finally {
       setIsExporting(false);
     }
-  }, [selectedModel]);
+  }, [selectedModel, getMutationView]);
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>

--- a/apps/viewer/src/components/viewer/HbjsonExportDialog.tsx
+++ b/apps/viewer/src/components/viewer/HbjsonExportDialog.tsx
@@ -129,12 +129,24 @@ export function HbjsonExportDialog({ trigger }: HbjsonExportDialogProps) {
       const baseName = selectedModel.name.replace(/\.[^.]+$/, '');
 
       // A fresh processor is cheap: wasm-bindgen shares one module singleton,
-      // so init() no-ops when the viewer already initialised the engine.
+      // so init() no-ops when the viewer already initialised the engine. It
+      // owns a WASM `IfcLiteBridge` handle, so it must be freed on every
+      // path out of this block, success or throw — mirrors the CLI-side fix
+      // in `packages/cli/src/hbjson-export.ts` (#1956 review fix). Scoped to
+      // its own try/finally (not merged into the outer one) so disposal runs
+      // exactly when the processor's lifetime ends, independent of
+      // `setIsExporting(false)` in the outer `finally` below.
       const processor = new GeometryProcessor();
-      await processor.init();
-      const hbjson = processor.exportHbjson(bytes, baseName);
-      if (hbjson === null) {
-        throw new Error('Geometry engine unavailable');
+      let hbjson: Uint8Array;
+      try {
+        await processor.init();
+        const result = processor.exportHbjson(bytes, baseName);
+        if (result === null) {
+          throw new Error('Geometry engine unavailable');
+        }
+        hbjson = result;
+      } finally {
+        processor.dispose();
       }
 
       const blob = new Blob([hbjson as BlobPart], { type: 'application/json' });

--- a/apps/viewer/src/components/viewer/hbjson-export-source.test.ts
+++ b/apps/viewer/src/components/viewer/hbjson-export-source.test.ts
@@ -8,9 +8,10 @@
  * overlay-authored entities) is exercised for real by
  * `packages/cli/src/headless-backend.hbjson.test.ts`, which shares the same
  * `StepExporter` + `GeometryProcessor` pipeline this dialog calls into — this
- * suite covers only the branching that decides which bytes source to use,
- * since this app has no `.test.tsx` component harness (AGENTS.md "Writing
- * tests").
+ * suite covers only the branching that decides which bytes source to use.
+ * The dialog itself is exercised in `HbjsonExportDialog.test.tsx` against the
+ * happy-dom harness (`src/test/setup-dom.ts`); keeping the branch logic in a
+ * plain module keeps these cases readable without rendering anything.
  */
 
 import { describe, it } from 'node:test';

--- a/apps/viewer/src/components/viewer/hbjson-export-source.test.ts
+++ b/apps/viewer/src/components/viewer/hbjson-export-source.test.ts
@@ -1,0 +1,108 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Unit coverage for the #1908 fix's routing decision logic. The end-to-end
+ * behaviour (StepExporter actually regenerating bytes that include
+ * overlay-authored entities) is exercised for real by
+ * `packages/cli/src/headless-backend.hbjson.test.ts`, which shares the same
+ * `StepExporter` + `GeometryProcessor` pipeline this dialog calls into — this
+ * suite covers only the branching that decides which bytes source to use,
+ * since this app has no `.test.tsx` component harness (AGENTS.md "Writing
+ * tests").
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { MutablePropertyView, StoreEditor, type MutationStoreShape, type NewEntity } from '@ifc-lite/mutations';
+import { resolveHbjsonMutationSource, type HbjsonSourceStore } from './hbjson-export-source.js';
+
+function makeStore(): HbjsonSourceStore & { source: Uint8Array } {
+  return { source: new Uint8Array([1, 2, 3]), schemaVersion: 'IFC4' };
+}
+
+// Minimal StoreEditor-compatible shape (mirrors packages/create's space.test.ts).
+function makeMutationStore(maxId: number): MutationStoreShape {
+  const byId = new Map();
+  for (let id = 1; id <= maxId; id++) {
+    byId.set(id, { expressId: id, type: 'IFCDUMMY', byteOffset: 0, byteLength: 1, lineNumber: id });
+  }
+  return { entityIndex: { byId } };
+}
+
+describe('resolveHbjsonMutationSource', () => {
+  it('returns null (raw-bytes path) when there is no mutation view', () => {
+    const store = makeStore();
+    const result = resolveHbjsonMutationSource({ mutationView: null, dataStore: store, schemaVersion: 'IFC4' });
+    assert.strictEqual(result, null);
+  });
+
+  it('returns null when the mutation view is registered but carries no edits — the common case', () => {
+    // Opening the Properties panel, BulkPropertyEditor, DataConnector, or
+    // ExportDialog all construct-and-register a MutablePropertyView with zero
+    // edits. Gating on mere existence (rather than hasPendingChanges()) would
+    // route every later export through a StepExporter regeneration just
+    // because some panel had been opened.
+    const store = makeStore();
+    const view = new MutablePropertyView(null, 'm1');
+    assert.strictEqual(view.hasPendingChanges(), false);
+    const result = resolveHbjsonMutationSource({ mutationView: view, dataStore: store, schemaVersion: 'IFC4' });
+    assert.strictEqual(result, null);
+  });
+
+  it('resolves the regeneration path for an entity restored via restoreNewEntity, not just freshly authored', () => {
+    // restoreNewEntity (undo of delete-then-restore, called from
+    // apps/viewer/src/store/slices/mutationSlice.ts) repopulates
+    // `newEntities` WITHOUT pushing to `mutationHistory` — so `hasChanges()`
+    // (append-only history) would read false here even though the overlay
+    // genuinely carries a new IfcSpace. A test that only exercises
+    // StoreEditor.addEntity (like the one above) passes under either
+    // `hasChanges()` or `hasPendingChanges()` and would not catch a
+    // regression back to the former; this one isolates the restore path.
+    const store = makeStore();
+    const restored: NewEntity = { expressId: 500, type: 'IfcSpace', attributes: ['guid', null, 'Restored Space'] };
+    const view = new MutablePropertyView(null, 'm1');
+    view.restoreNewEntity(restored);
+    assert.strictEqual(view.hasChanges(), false);
+    assert.strictEqual(view.hasPendingChanges(), true);
+    const result = resolveHbjsonMutationSource({ mutationView: view, dataStore: store, schemaVersion: 'IFC4' });
+    assert.notStrictEqual(result, null);
+  });
+
+  it('returns null when there is no data store', () => {
+    const view = new MutablePropertyView(null, 'm1');
+    const result = resolveHbjsonMutationSource({ mutationView: view, dataStore: null, schemaVersion: 'IFC4' });
+    assert.strictEqual(result, null);
+  });
+
+  it('returns null for IFC5/IFCX (no STEP representation to regenerate), even with real edits', () => {
+    const store = makeStore();
+    const view = new MutablePropertyView(null, 'm1');
+    const editor = new StoreEditor(makeMutationStore(40), view);
+    editor.addEntity('IfcSpace', ['guid', null, 'New Space']);
+    assert.strictEqual(view.hasChanges(), true);
+    const result = resolveHbjsonMutationSource({ mutationView: view, dataStore: store, schemaVersion: 'IFC5' });
+    assert.strictEqual(result, null);
+  });
+
+  it('returns null when source bytes were not retained (avoids a degenerate StepExporter regen), even with real edits', () => {
+    const store = { ...makeStore(), source: new Uint8Array(0) };
+    const view = new MutablePropertyView(null, 'm1');
+    const editor = new StoreEditor(makeMutationStore(40), view);
+    editor.addEntity('IfcSpace', ['guid', null, 'New Space']);
+    const result = resolveHbjsonMutationSource({ mutationView: view, dataStore: store, schemaVersion: 'IFC4' });
+    assert.strictEqual(result, null);
+  });
+
+  it('resolves the mutation-view regeneration path when the view has real edits + source + a STEP schema', () => {
+    const store = makeStore();
+    const view = new MutablePropertyView(null, 'm1');
+    const editor = new StoreEditor(makeMutationStore(40), view);
+    editor.addEntity('IfcSpace', ['guid', null, 'New Space']);
+    const result = resolveHbjsonMutationSource({ mutationView: view, dataStore: store, schemaVersion: 'IFC4' });
+    assert.notStrictEqual(result, null);
+    assert.strictEqual(result?.dataStore, store);
+    assert.strictEqual(result?.mutationView, view);
+  });
+});

--- a/apps/viewer/src/components/viewer/hbjson-export-source.test.ts
+++ b/apps/viewer/src/components/viewer/hbjson-export-source.test.ts
@@ -71,7 +71,15 @@ describe('resolveHbjsonMutationSource', () => {
   });
 
   it('returns null when there is no data store', () => {
+    // Must carry real edits so hasPendingChanges() is true and execution
+    // actually reaches the `!dataStore` branch — otherwise the earlier
+    // hasPendingChanges() short-circuit returns null regardless of the
+    // `!dataStore` check, and this test would pass even if that guard were
+    // deleted entirely.
     const view = new MutablePropertyView(null, 'm1');
+    const editor = new StoreEditor(makeMutationStore(40), view);
+    editor.addEntity('IfcSpace', ['guid', null, 'New Space']);
+    assert.strictEqual(view.hasPendingChanges(), true);
     const result = resolveHbjsonMutationSource({ mutationView: view, dataStore: null, schemaVersion: 'IFC4' });
     assert.strictEqual(result, null);
   });

--- a/apps/viewer/src/components/viewer/hbjson-export-source.ts
+++ b/apps/viewer/src/components/viewer/hbjson-export-source.ts
@@ -1,0 +1,72 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Pure decision logic for `HbjsonExportDialog` (issue #1908), split out so it
+ * is unit-testable without mounting a React component (this codebase has no
+ * `.test.tsx` component tests — see AGENTS.md "Writing tests").
+ *
+ * `dataStore` is generic (structurally typed) rather than the concrete
+ * `IfcDataStore` so tests can pass a minimal fixture with only the fields
+ * these functions actually read, without an `as unknown as` cast (banned by
+ * AGENTS.md). The production call site still passes a real `IfcDataStore`,
+ * which satisfies the structural bound.
+ */
+
+import type { MutablePropertyView } from '@ifc-lite/mutations';
+import type { SchemaVersion } from '@/store/types';
+
+/** The subset of `IfcDataStore` these functions read. */
+export interface HbjsonSourceStore {
+  source?: Uint8Array;
+  schemaVersion: SchemaVersion;
+}
+
+/** Non-null pair resolved by {@link resolveHbjsonMutationSource}. */
+export interface HbjsonMutationSource<T extends HbjsonSourceStore> {
+  dataStore: T;
+  mutationView: MutablePropertyView;
+}
+
+/**
+ * Resolve whether HBJSON export should regenerate STEP bytes through
+ * `StepExporter` (applying the mutation view) instead of reading the model's
+ * original `sourceFile` bytes verbatim. Returns the pair to pass to
+ * `StepExporter` when it should, or `null` when the raw-bytes path applies.
+ *
+ * Regeneration only happens when the mutation view actually carries edits
+ * (`mutationView.hasPendingChanges()`) — a registered-but-untouched view is
+ * the common case (opening the Properties panel, `BulkPropertyEditor`,
+ * `DataConnector`, or `ExportDialog` all construct and register one on open,
+ * with zero edits) and must NOT route export through a StepExporter
+ * regeneration — plus a parsed data store to regenerate from, source bytes
+ * for `StepExporter` to re-serialize un-mutated entities from, and a STEP
+ * schema (IFC5/IFCX has no STEP representation to regenerate — that stays on
+ * the raw-bytes path, unchanged from before this fix).
+ *
+ * `hasPendingChanges()`, not `hasChanges()`: the latter reads the
+ * append-only `mutationHistory`, which `restoreNewEntity` (undo of a
+ * delete-then-restore, called from `mutationSlice.ts`) repopulates
+ * `newEntities` WITHOUT pushing to. `hasPendingChanges()` reads the current
+ * overlay footprint instead — the same set the exporter actually reads — so
+ * a restored overlay-created space is not silently missed.
+ */
+export function resolveHbjsonMutationSource<T extends HbjsonSourceStore>(params: {
+  mutationView: MutablePropertyView | null;
+  dataStore: T | null | undefined;
+  schemaVersion: SchemaVersion;
+}): HbjsonMutationSource<T> | null {
+  const { mutationView, dataStore, schemaVersion } = params;
+  if (
+    !mutationView ||
+    !mutationView.hasPendingChanges() ||
+    !dataStore ||
+    !dataStore.source ||
+    dataStore.source.length === 0 ||
+    schemaVersion === 'IFC5'
+  ) {
+    return null;
+  }
+  return { dataStore, mutationView };
+}

--- a/packages/cli/src/hbjson-export.ts
+++ b/packages/cli/src/hbjson-export.ts
@@ -63,13 +63,17 @@ export async function exportHbjson(
   }
 
   const processor = new GeometryProcessor();
-  await processor.init();
-  const baseName = name.replace(/\.[^.]+$/, '');
-  const result = processor.exportHbjson(bytes, baseName);
-  if (result === null) {
-    throw new Error('Geometry engine unavailable for HBJSON export.');
+  try {
+    await processor.init();
+    const baseName = name.replace(/\.[^.]+$/, '');
+    const result = processor.exportHbjson(bytes, baseName);
+    if (result === null) {
+      throw new Error('Geometry engine unavailable for HBJSON export.');
+    }
+    // The lens contract carries a string; HBJSON payloads are far below the
+    // V8 string ceiling, so decoding here is safe.
+    return new TextDecoder().decode(result);
+  } finally {
+    processor.dispose();
   }
-  // The lens contract carries a string; HBJSON payloads are far below the
-  // V8 string ceiling, so decoding here is safe.
-  return new TextDecoder().decode(result);
 }

--- a/packages/cli/src/hbjson-export.ts
+++ b/packages/cli/src/hbjson-export.ts
@@ -1,0 +1,75 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * HBJSON export for `HeadlessBackend` (issue #1908).
+ *
+ * Split out of `headless-backend.ts` (already over the ~400-line module
+ * guideline) rather than inlined there. HBJSON is rebuilt analytically from
+ * IFC STEP bytes (rooms/openings/shades/constructions/adjacency) via the
+ * wasm geometry engine. When the mutation view carries actual edits
+ * (`mutationView.hasPendingChanges()` — e.g. `bim.store.addSpace` /
+ * `bim.spaces.generate` ran earlier in this session), bytes are regenerated
+ * through `StepExporter` first — the same mutation-view application the
+ * `ifc:` STEP export adapter already uses in `headless-backend.ts` — so
+ * overlay-authored entities (drawn spaces, in particular) are visible to the
+ * analytic exporter. A mutation view with no pending changes (the common
+ * case — `getOrCreateStoreEditor` can register a view before any edit lands,
+ * e.g. `bim.store.removeEntity` on an id that doesn't exist still allocates
+ * one) falls straight through to `store.source`, unchanged from before this
+ * fix.
+ *
+ * `hasPendingChanges()`, not `hasChanges()`: the latter reads the
+ * append-only `mutationHistory`, which `restoreNewEntity` repopulates
+ * `newEntities` WITHOUT pushing to (it's the undo-of-delete path for an
+ * overlay-created entity). `hasPendingChanges()` reads the current overlay
+ * footprint instead — the same set `StepExporter` actually serializes — so a
+ * restored overlay-created space is not silently missed.
+ *
+ * No IFC5/IFCX guard here (unlike the viewer's `resolveHbjsonMutationSource`,
+ * which excludes `schemaVersion === 'IFC5'`): `loader.ts` only ever parses
+ * with `IfcParser` (the STEP/columnar parser) and never constructs an
+ * IFCX/IFC5 data store, so a CLI-loaded `IfcDataStore` cannot carry IFC5
+ * content to regenerate in the first place. The `ifc:` STEP-export adapter
+ * directly above this one in `headless-backend.ts` makes the same assumption
+ * (it applies `mutationView` unconditionally, with no schema check).
+ */
+
+import type { IfcDataStore } from '@ifc-lite/parser';
+import type { MutablePropertyView } from '@ifc-lite/mutations';
+import { StepExporter } from '@ifc-lite/export';
+import { GeometryProcessor } from '@ifc-lite/geometry';
+
+export async function exportHbjson(
+  store: IfcDataStore,
+  mutationView: MutablePropertyView | null,
+  name: string,
+): Promise<string> {
+  let bytes: Uint8Array | undefined;
+  if (mutationView && mutationView.hasPendingChanges() && store.source && store.source.length > 0) {
+    // StepExporter re-serializes un-mutated entities from `store.source` (via
+    // EntityExtractor), so only attempt the regeneration when source bytes
+    // are actually retained — otherwise fall through to the same clear error
+    // below instead of silently emitting a degenerate STEP file.
+    const schema = store.schemaVersion ?? 'IFC4';
+    const exporter = new StepExporter(store, mutationView);
+    bytes = exporter.export({ schema }).content;
+  } else {
+    bytes = store.source;
+  }
+  if (!bytes || bytes.length === 0) {
+    throw new Error('HBJSON export needs the source IFC bytes, which this store did not retain.');
+  }
+
+  const processor = new GeometryProcessor();
+  await processor.init();
+  const baseName = name.replace(/\.[^.]+$/, '');
+  const result = processor.exportHbjson(bytes, baseName);
+  if (result === null) {
+    throw new Error('Geometry engine unavailable for HBJSON export.');
+  }
+  // The lens contract carries a string; HBJSON payloads are far below the
+  // V8 string ceiling, so decoding here is safe.
+  return new TextDecoder().decode(result);
+}

--- a/packages/cli/src/headless-backend.hbjson.test.ts
+++ b/packages/cli/src/headless-backend.hbjson.test.ts
@@ -1,0 +1,147 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Regression coverage for issue #1908: HBJSON export read the model's original
+ * IFC bytes (`store.source`) instead of the mutation view, so anything
+ * authored through the in-store edit APIs (the CLI equivalent of the viewer's
+ * Space Sketch tool) was invisible to the exporter by construction.
+ *
+ * `bim.store.addSpace` is the same `StoreEditor` / `MutablePropertyView`
+ * overlay the viewer's Space Sketch editor writes to (both go through
+ * `StoreEditor` in `@ifc-lite/mutations`), so exercising it here proves the
+ * headless/CLI export path, not just the viewer dialog.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { MutablePropertyView, StoreEditor } from '@ifc-lite/mutations';
+import { addSpaceToStore, resolveSpatialAnchor } from '@ifc-lite/create';
+import { createHeadlessContext } from './loader.js';
+import { exportHbjson } from './hbjson-export.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+// Committed viewer demo sample (not the network-fetched tests/models/ fixture
+// set) — always present, so this suite never needs `pnpm fixtures`. It ships
+// one storey (#42) and one pre-existing IfcSpace ("My Space") whose Body is a
+// Tessellation (IfcPolygonalFaceSet), not an extruded-area profile — rooms.rs
+// only builds rooms from extrusion profiles (BRep/tessellated spaces are an
+// explicit backlog item, out of scope for #1908), so that space is skipped
+// for a reason unrelated to the mutation-view bug. It still exercises the
+// exact real-world shape: a model with some rooms exportable and some not.
+const SAMPLE_IFC = join(__dirname, '../../../apps/viewer/public/samples/hello-wall.ifc');
+const STOREY_EXPRESS_ID = 42;
+const WALL_EXPRESS_ID = 1222;
+
+function roomCount(hbjson: string): number {
+  const parsed = JSON.parse(hbjson) as { rooms?: unknown[] };
+  return Array.isArray(parsed.rooms) ? parsed.rooms.length : 0;
+}
+
+describe('HeadlessBackend hbjson export (#1908)', () => {
+  it('an unedited model (no mutation view) exports unchanged — the common case must not regress', async () => {
+    const { bim } = await createHeadlessContext(SAMPLE_IFC);
+    const hbjson = await bim.export.hbjson({ name: 'baseline' });
+    // The one pre-existing space is a Tessellation body (see SAMPLE_IFC comment
+    // above) and is skipped for a reason unrelated to #1908 — this asserts the
+    // no-mutation-view path still runs `store.source` straight through, exactly
+    // as before the fix, not that this particular space becomes a room.
+    expect(roomCount(hbjson)).toBe(0);
+  }, 30_000);
+
+  it('a space drawn through the in-store editor is present in the HBJSON output', async () => {
+    const { bim } = await createHeadlessContext(SAMPLE_IFC);
+    const modelId = bim.model.activeId();
+    expect(modelId).not.toBeNull();
+
+    bim.store.addSpace(modelId as string, STOREY_EXPRESS_ID, {
+      Position: [10, 10, 0],
+      Width: 4,
+      Depth: 3,
+      Height: 3,
+      LongName: 'Drawn Room',
+    });
+
+    const hbjson = await bim.export.hbjson({ name: 'edited' });
+    // The newly drawn (extruded-profile) space becomes a room; the pre-existing
+    // tessellated space stays skipped (unrelated, out of scope). Before the fix,
+    // export read `store.source` directly and this overlay-only entity was
+    // invisible to it, so this stayed at 0.
+    expect(roomCount(hbjson)).toBe(1);
+  }, 30_000);
+
+  it('a mutation view that is registered but carries no edits exports unchanged — the common case', async () => {
+    const { bim } = await createHeadlessContext(SAMPLE_IFC);
+    const modelId = bim.model.activeId() as string;
+
+    // `bim.store.removeEntity` on an id that exists in neither the parsed
+    // store nor the overlay lazily registers a mutation view (any
+    // `bim.store.*` call does, via `getOrCreateStoreEditor`) but
+    // `StoreEditor.removeEntity` returns false *before* calling
+    // `view.deleteEntity`, so no mutation is ever recorded — the same shape
+    // as the viewer eagerly registering a `MutablePropertyView` when the
+    // Properties panel / BulkPropertyEditor / DataConnector / ExportDialog
+    // opens, with zero edits made. Gating on mere mutation-view existence
+    // (rather than `hasPendingChanges()`) would route this export through a
+    // redundant StepExporter regeneration.
+    const removed = bim.store.removeEntity({ modelId, expressId: 999_999_999 });
+    expect(removed).toBe(false);
+
+    const hbjson = await bim.export.hbjson({ name: 'registered-but-empty' });
+    expect(roomCount(hbjson)).toBe(0);
+  }, 30_000);
+
+  it('a space restored via restoreNewEntity (not freshly authored) is still present in the output', async () => {
+    // `restoreNewEntity` (undo of delete-then-restore, called from
+    // apps/viewer/src/store/slices/mutationSlice.ts) repopulates
+    // `newEntities` WITHOUT pushing to `mutationHistory` — so a view built
+    // this way has `hasChanges() === false` but `hasPendingChanges() ===
+    // true`. A test that only exercises `StoreEditor.addEntity` (like the
+    // "drawn through the in-store editor" test above) passes under EITHER
+    // gate and would not have caught a `hasChanges()` regression; this one
+    // isolates the restore path specifically.
+    const { store } = await createHeadlessContext(SAMPLE_IFC);
+
+    // Build the space's entity graph (space, profile, rel aggregates, ...)
+    // against a throwaway view/editor pair, exactly like `bim.store.addSpace`
+    // does in headless-backend.ts, so ids allocate above this file's real max.
+    const buildView = new MutablePropertyView(store.properties ?? null, 'default');
+    const buildEditor = new StoreEditor(store, buildView);
+    const anchor = resolveSpatialAnchor(store, STOREY_EXPRESS_ID);
+    addSpaceToStore(buildEditor, anchor, {
+      Position: [10, 10, 0],
+      Width: 4,
+      Depth: 3,
+      Height: 3,
+      LongName: 'Restored Room',
+    });
+    const createdEntities = buildView.getNewEntities();
+    expect(createdEntities.length).toBeGreaterThan(0);
+
+    // A *fresh* view that never called addEntity/deleteEntity on itself —
+    // only restoreNewEntity, mirroring what the undo stack does after a
+    // delete-then-restore (or, for the viewer, a session restore).
+    const restoredView = new MutablePropertyView(store.properties ?? null, 'default');
+    for (const entity of createdEntities) {
+      restoredView.restoreNewEntity(entity);
+    }
+    expect(restoredView.hasChanges()).toBe(false);
+    expect(restoredView.hasPendingChanges()).toBe(true);
+
+    const hbjson = await exportHbjson(store, restoredView, 'restored');
+    expect(roomCount(hbjson)).toBe(1);
+  }, 30_000);
+
+  it('a mutation unrelated to spaces (a renamed wall) does not change room output', async () => {
+    const { bim } = await createHeadlessContext(SAMPLE_IFC);
+    const modelId = bim.model.activeId() as string;
+
+    // Positional index 2 on IFCWALL is Name (GlobalId, OwnerHistory, Name, ...).
+    bim.store.setPositionalAttribute({ modelId, expressId: WALL_EXPRESS_ID }, 2, 'Renamed Wall');
+
+    const hbjson = await bim.export.hbjson({ name: 'renamed-wall' });
+    expect(roomCount(hbjson)).toBe(0);
+  }, 30_000);
+});

--- a/packages/cli/src/headless-backend.hbjson.test.ts
+++ b/packages/cli/src/headless-backend.hbjson.test.ts
@@ -14,11 +14,13 @@
  * headless/CLI export path, not just the viewer dialog.
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import { MutablePropertyView, StoreEditor } from '@ifc-lite/mutations';
 import { addSpaceToStore, resolveSpatialAnchor } from '@ifc-lite/create';
+import { StepExporter } from '@ifc-lite/export';
+import { GeometryProcessor } from '@ifc-lite/geometry';
 import { createHeadlessContext } from './loader.js';
 import { exportHbjson } from './hbjson-export.js';
 
@@ -89,8 +91,19 @@ describe('HeadlessBackend hbjson export (#1908)', () => {
     const removed = bim.store.removeEntity({ modelId, expressId: 999_999_999 });
     expect(removed).toBe(false);
 
-    const hbjson = await bim.export.hbjson({ name: 'registered-but-empty' });
-    expect(roomCount(hbjson)).toBe(0);
+    // roomCount alone would stay 0 whether or not the StepExporter regen
+    // path runs (re-serializing an unedited overlay reproduces the same
+    // rooms), so it would not catch a regression that drops the
+    // `hasPendingChanges()` gate. Spy on `StepExporter.export` directly to
+    // pin that the gate actually skips the regeneration.
+    const exportSpy = vi.spyOn(StepExporter.prototype, 'export');
+    try {
+      const hbjson = await bim.export.hbjson({ name: 'registered-but-empty' });
+      expect(roomCount(hbjson)).toBe(0);
+      expect(exportSpy).not.toHaveBeenCalled();
+    } finally {
+      exportSpy.mockRestore();
+    }
   }, 30_000);
 
   it('a space restored via restoreNewEntity (not freshly authored) is still present in the output', async () => {
@@ -143,5 +156,35 @@ describe('HeadlessBackend hbjson export (#1908)', () => {
 
     const hbjson = await bim.export.hbjson({ name: 'renamed-wall' });
     expect(roomCount(hbjson)).toBe(0);
+  }, 30_000);
+
+  it('disposes the GeometryProcessor WASM handle on the success path (#1956 review fix)', async () => {
+    const { store } = await createHeadlessContext(SAMPLE_IFC);
+    const disposeSpy = vi.spyOn(GeometryProcessor.prototype, 'dispose');
+    try {
+      await exportHbjson(store, null, 'dispose-success');
+      expect(disposeSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      disposeSpy.mockRestore();
+    }
+  }, 30_000);
+
+  it('disposes the GeometryProcessor WASM handle even when exportHbjson throws (#1956 review fix)', async () => {
+    // `GeometryProcessor.exportHbjson` returning null (engine unavailable)
+    // makes `exportHbjson` in hbjson-export.ts throw. Stub the prototype
+    // method to force that path deterministically — this is the early-return
+    // the fix's try/finally must cover, not just the happy path.
+    const { store } = await createHeadlessContext(SAMPLE_IFC);
+    const disposeSpy = vi.spyOn(GeometryProcessor.prototype, 'dispose');
+    const exportSpy = vi.spyOn(GeometryProcessor.prototype, 'exportHbjson').mockReturnValue(null);
+    try {
+      await expect(exportHbjson(store, null, 'dispose-throw')).rejects.toThrow(
+        'Geometry engine unavailable for HBJSON export.',
+      );
+      expect(disposeSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      exportSpy.mockRestore();
+      disposeSpy.mockRestore();
+    }
   }, 30_000);
 });

--- a/packages/cli/src/headless-backend.ts
+++ b/packages/cli/src/headless-backend.ts
@@ -41,7 +41,6 @@ import type {
 } from '@ifc-lite/sdk';
 import type { IfcDataStore } from '@ifc-lite/parser';
 import { MutablePropertyView, StoreEditor } from '@ifc-lite/mutations';
-import { GeometryProcessor } from '@ifc-lite/geometry';
 import {
   addBeamToStore,
   addColumnToStore,
@@ -80,6 +79,7 @@ import {
   extractScheduleOnDemand,
 } from '@ifc-lite/parser';
 import { exportToStep, StepExporter, type StepExportOptions } from '@ifc-lite/export';
+import { exportHbjson } from './hbjson-export.js';
 
 const MODEL_ID = 'default';
 
@@ -635,24 +635,9 @@ export class HeadlessBackend implements BimBackend {
         }
         return exportToStep(store, exportOpts);
       },
-      hbjson: async (name?: string): Promise<string> => {
-        // HBJSON is rebuilt analytically from the source IFC bytes (rooms/openings/
-        // shades/constructions/adjacency) via the wasm geometry engine.
-        const bytes = store.source;
-        if (!bytes || bytes.length === 0) {
-          throw new Error('HBJSON export needs the source IFC bytes, which this store did not retain.');
-        }
-        const processor = new GeometryProcessor();
-        await processor.init();
-        const baseName = (name ?? modelName).replace(/\.[^.]+$/, '');
-        const result = processor.exportHbjson(bytes, baseName);
-        if (result === null) {
-          throw new Error('Geometry engine unavailable for HBJSON export.');
-        }
-        // The lens contract carries a string; HBJSON payloads are far below the
-        // V8 string ceiling, so decoding here is safe.
-        return new TextDecoder().decode(result);
-      },
+      hbjson: (name?: string): Promise<string> =>
+        // See hbjson-export.ts for the mutation-view application (issue #1908).
+        exportHbjson(store, this.mutationView, name ?? modelName),
       download(_content: string, _filename: string, _mimeType: string): void {
         /* no-op — CLI writes to stdout/file directly */
       },


### PR DESCRIPTION
## What and why

Closes #1908.

HBJSON export read the model's original bytes rather than the mutation view, so spaces authored in the Space Sketch editor were invisible to the exporter by construction and the file came back with no rooms. Your four file:line references were all accurate (`HbjsonExportDialog.tsx` is line 88 rather than 87; the rest exact), including that `rooms.rs` was never at fault — it filters `IfcSpace` correctly and was simply handed the wrong input.

Both the viewer dialog and the CLI now regenerate through `StepExporter` when the overlay carries pending changes, mirroring what STEP export already does at `headless-backend.ts:625-634`. Same mechanism, not a second one.

## Two things that are easy to get wrong here

**The gate is `hasPendingChanges()`, not `hasChanges()`.** I had it on `hasChanges()` first. That reads the append-only mutation history, and `restoreNewEntity` (`mutable-property-view.ts:1104`, called from `mutationSlice.ts:2764` and `:2926`) repopulates `newEntities` without touching it. So a restored overlay would have taken the raw-bytes path and dropped its spaces — this exact bug, one session-restore later. Proved it:

```
v.restoreNewEntity(created);
v.hasChanges()        -> false
v.hasPendingChanges() -> true
```

The docstring on `hasPendingChanges` says it outright — under-reporting silently drops edits — and it is written for gating an export bake. Worth noting a test covering only freshly-authored entities passes under *either* gate, which is why there is one that restores an entity instead.

**Gating on the view merely existing would also have been wrong.** `PropertiesPanel.tsx:207`, `BulkPropertyEditor`, `DataConnector` and `ExportDialog` all construct and register an empty `MutablePropertyView` on open, so "no mutation view" is not "nothing was edited". Every export after opening a panel would have paid for a full re-bake.

## Displaced-path checks

Per your note on #1928 — switching the input changes what *every* export sees, not just edited ones:

- unedited model: unchanged, falls through to the original bytes
- mutation unrelated to spaces (renamed wall): room output identical to baseline
- registered-but-empty overlay: unchanged
- no retained source bytes: still raises the original clear error rather than regenerating from an absent extractor

## Scope: `HbjsonStats.skipped` is deliberately not here

The issue also asks for the silent truncation to be surfaced, and I tried. Rust computes `skipped` but the wasm binding discards it — `export_hbjson.rs:27-30` returns `.0` and drops `.1` — so I re-derived it in TypeScript. That turned out unsound and I removed it: the count read an entity's *parsed* type while `StepExporter` honours retype overlays (`step-exporter.ts:641-653`, reachable via `bulk-query-engine.ts:340`), so it over-reported when a space was retyped away and under-reported the reverse. The message also attributed every skip to a degenerate footprint, when `rooms.rs:150-158` folds duplicate-overlap dedupe into the same counter.

Threading the real `HbjsonStats` through the binding is a Rust plus regenerated-`.d.ts` change and belongs in its own PR. Happy to do it next if you want it.

Also left alone, as backlog rather than bug: the six silent-skip conditions in `rooms.rs`, swept/BRep/mapped-representation spaces, and space names, zones, storeys, programs and HVAC.

## Verification

- `pnpm test` 74/74 · `pnpm typecheck` 33/33 · `check-test-wiring` clean
- `@ifc-lite/cli` 207 passed · `@ifc-lite/viewer` 2113 passed, 2 skipped (fixture-gated)
- Mutation-checked both gates: swapping `hasPendingChanges()` back to `hasChanges()` fails exactly the restore test in each package (CLI 1 of 5, viewer 1 of 7); reverting the CLI gate entirely fails the core regression test
- Rebased onto current `main` and re-ran everything afterwards — the maplibre v6 and happy-dom additions needed a fresh `pnpm install` first
- Changeset added for `@ifc-lite/cli` (patch); `headless-backend.ts` is 697 lines, down from 712

## Checklist

- [x] Test asserts behavior through a real fixture (`hello-wall.ifc`) or a stated invariant; skips cleanly when absent
- [x] Published `packages/*` touched: changeset added. No export surface change (`hbjson-export.ts` is internal)
- [x] No geometry output changed
- [x] House rules: no `as any` / `@ts-ignore` / `as never`, no silent `catch`, no module grown past the guideline, no repo-wide `cargo fmt`
- [x] No client or project identifiers in code, tests, commit messages, or this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - HBJSON exports now include pending in-editor changes, including added or restored spaces.
  - Exports preserve original source content when no applicable edits are present.
  - Improved handling of unsupported schemas, missing source data, and unavailable geometry processing.

- **Bug Fixes**
  - Prevented unrelated edits from incorrectly changing room data in exported HBJSON files.
  - Ensured export resources are released after successful or failed exports.

- **Tests**
  - Added coverage for edited, restored, unchanged, invalid, and failed export scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->