### PR TITLE
fix(lens): stop auto-color grouping entities under a system you did not pick (#1923)

### DIFF
--- a/.changeset/lens-classification-system-filter.md
+++ b/.changeset/lens-classification-system-filter.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/lens": patch
+---
+
+Fix the classification "System" picker on auto-color lenses being a no-op. `selectClassificationRef` fell back to an entity's first classification whenever none of its classifications matched the selected system, so every classified entity was grouped and colored regardless of which system was chosen. It now returns no match (the entity ghosts, like an unclassified one) when the selected system isn't among the entity's classifications, actually filtering by system as the picker implies. Closes #1923.

--- a/packages/lens/src/engine.test.ts
+++ b/packages/lens/src/engine.test.ts
@@ -453,6 +453,36 @@ describe('evaluateAutoColorLens', () => {
     expect(result.legend[0].count).toBe(2);
   });
 
+  it('ghosts entities whose classifications never include the selected system, instead of grouping them under an unrelated one (#1923)', () => {
+    const entities = [
+      { id: 1, type: 'IfcWall' },
+      { id: 2, type: 'IfcDoor' },
+      { id: 3, type: 'IfcColumn' },
+    ];
+    const provider = createMockProvider(entities);
+    // Entity 1 is classified under the selected system. Entity 2 carries a
+    // classification, but from an entirely different system ('CCI Construction' —
+    // mirrors the reported bug's second, unrelated system). Entity 3 has none.
+    // Selecting "NL-SfB tabel 1" must filter to entity 1 only: entity 2 must not
+    // leak into the legend under its unrelated system, and must ghost like entity 3.
+    (provider as Record<string, unknown>).getClassifications = (id: number) => {
+      if (id === 1) return [{ system: 'NL-SfB tabel 1', identification: '22.11', name: 'Walls' }];
+      if (id === 2) return [{ system: 'CCI Construction', identification: 'L-AD', name: 'Wall construction' }];
+      return [];
+    };
+
+    const spec: AutoColorSpec = { source: 'classification', psetName: 'NL-SfB tabel 1' };
+    const result = evaluateAutoColorLens(spec, provider);
+
+    expect(result.legend.length).toBe(1);
+    expect(result.legend[0].name).toBe('NL-SfB tabel 1: 22.11 (Walls)');
+    expect(result.legend[0].count).toBe(1);
+    // Entity 2 (unrelated system) and entity 3 (no classification) both ghost —
+    // neither is silently absorbed into entity 1's group or its own bogus group.
+    expect(result.colorMap.get(2)).toEqual(GHOST_COLOR);
+    expect(result.colorMap.get(3)).toEqual(GHOST_COLOR);
+  });
+
   it('should auto-color by material when provider supports getMaterialName', () => {
     const entities = [
       { id: 1, type: 'IfcWall' },

--- a/packages/lens/src/engine.ts
+++ b/packages/lens/src/engine.ts
@@ -222,17 +222,24 @@ interface AutoColorValue {
   label: string;
 }
 
-/** Pick the classification reference to group by - the one whose system matches
- *  `psetName` (case-insensitive substring) when set, else the first. */
+/**
+ * Pick the classification reference to group by - the one whose system matches
+ * `psetName` (case-insensitive substring) when set, else the first.
+ *
+ * When `psetName` is set it acts as a classification-system FILTER: an entity
+ * that carries classifications but none from the selected system must not be
+ * grouped under some other, unrelated system. Returns `undefined` in that
+ * case so the caller ghosts the entity instead of silently falling back to
+ * `cls[0]` (#1923 — the "System" picker on the classification auto-color lens
+ * was a no-op because every entity fell back to its first classification
+ * regardless of which system was selected).
+ */
 function selectClassificationRef(
   cls: ReadonlyArray<ClassificationInfo>,
   psetName?: string,
-): ClassificationInfo {
+): ClassificationInfo | undefined {
   if (!psetName) return cls[0];
-  return (
-    cls.find((ref) => (ref.system ?? '').toLowerCase().includes(psetName.toLowerCase())) ??
-    cls[0]
-  );
+  return cls.find((ref) => (ref.system ?? '').toLowerCase().includes(psetName.toLowerCase()));
 }
 
 /**
@@ -254,6 +261,7 @@ function extractAutoColorValues(
     const cls = provider.getClassifications(globalId);
     if (!cls || cls.length === 0) return [];
     const c = selectClassificationRef(cls, spec.psetName);
+    if (!c) return [];
     const codeParts: string[] = [];
     if (c.system) codeParts.push(c.system);
     if (c.identification) codeParts.push(c.identification);
@@ -324,6 +332,7 @@ function extractAutoColorValue(
         // treat it as a classification-system filter (mirroring matchesClassification),
         // selecting the matching reference instead of unconditionally using the first.
         const c = selectClassificationRef(cls, spec.psetName);
+        if (!c) return undefined;
         const parts: string[] = [];
         if (c.system) parts.push(c.system);
         if (c.identification) parts.push(c.identification);


### PR DESCRIPTION
## What and why

Closes #1923.

@MennoMekes selected a classification system in the Lens auto-color editor and nothing was filtered. `selectClassificationRef` (`packages/lens/src/engine.ts:227` on main) looked for a reference whose system matched the selection and then fell back to `?? cls[0]`:

```ts
return cls.find((ref) => (ref.system ?? '').toLowerCase().includes(psetName.toLowerCase())) ?? cls[0];
```

So an entity carrying only *some other* system was still grouped — under whatever its first classification happened to be. The picker was a no-op, and the legend filled with systems the user had not chosen, which is precisely what his second screenshot shows.

It now returns `undefined` when a system is selected and nothing matches, and both call sites bail so the entity ghosts instead of being misattributed.

## This is not the path it looks like

Worth stating, because I spent a while on the wrong one and the code invites it: `matchesClassification` and the discovery that populates the dropdown are both **correct**. Their comparison is already case-insensitive substring, the viewer's provider does implement `getClassifications`, and the panel does write `criteria.classificationSystem`. Verified end to end against `tests/models/various/01_BIMcollab_Example_ARC.ifc`, which carries two `IfcClassification` roots differing only in case — exactly like the duplicate entries in the reporter's dropdown. 1348/2666 entities matched as expected there.

That near-duplicate is a red herring that makes the rule path look guilty. The screenshots are the **auto-color editor**, which reaches `engine.ts` directly and never touches `matchesCriteria`.

## Verification

- Regression test `ghosts entities whose classifications never include the selected system, instead of grouping them under an unrelated one (#1923)` in `packages/lens/src/engine.test.ts`
- Fails on pre-fix code — the ghosted entity leaks into the legend, `length` 2 vs 1
- Mutation-checked the new guard by removing it: fails again with a `TypeError`, so the guard is load-bearing rather than decorative
- `@ifc-lite/lens` 95 passed · `pnpm test` 74/74 · `pnpm typecheck` 33/33
- Changeset added (`@ifc-lite/lens`, patch)

## Scope

Only `engine.ts` changed — no edits to `matching.ts`, `discovery.ts`, `LensPanel.tsx` or the parser, since none of them were implicated.

Not addressed: the unrelated comment on the issue about rule colours not applying is a different bug and I have not investigated it.

## Checklist

- [x] Test asserts real behaviour, verified to fail without the fix
- [x] Published `packages/*` touched: changeset added. No export surface change
- [x] No geometry output changed
- [x] House rules: no `as any` / `@ts-ignore`, no silent `catch`, no repo-wide `cargo fmt`
- [x] No client or project identifiers in code, tests, commit messages, or this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed System classification filtering for auto-color lenses.
  - Entities without a classification in the selected system are now excluded from legends and displayed with the ghost color.
  - Prevented unrelated classifications from being incorrectly used as fallbacks.

- **Tests**
  - Added regression coverage for classification-based auto-coloring behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->