### PR TITLE
feat(viewer): align a georeferenced DXF underlay to the model via IfcMapConversion (#1929)

### DIFF
--- a/apps/viewer/src/components/viewer/DxfUnderlayPanel.test.tsx
+++ b/apps/viewer/src/components/viewer/DxfUnderlayPanel.test.tsx
@@ -1,0 +1,146 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Rendering tests for the tri-state "Align to model georeference" checkbox
+ * in `DxfUnderlayPanel` (issue #1929, tri-state per the PR #1965 review).
+ *
+ * `resolveEffectiveGeoreferenced` and `setDxfUnderlayGeoreferenced`'s store
+ * action are already unit-tested (`dxfUnderlayMath.test.ts`,
+ * `drawing2DSlice.ts`), but nothing had ever rendered the CONTROL that
+ * wires them together — the maths was covered, the checkbox that decides
+ * whether it applies was not (louistrue's PR #1965 review, finding 2).
+ * These exercise the real `useViewerStore` (seeded directly, no context
+ * needed — it's a module-level Zustand store) through the actual
+ * `DxfUnderlayPanel` component: auto-mode display, pinning on click, and
+ * that a pinned value stops following `georeferenceAvailable`.
+ */
+
+import '@/test/setup-dom.js';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { useViewerStore } from '@/store';
+import type { DxfUnderlayState } from '@/store/slices/drawing2DSlice';
+import { DEFAULT_DXF_PLACEMENT, type DxfUnderlay } from '@ifc-lite/drawing-2d';
+import { DxfUnderlayPanel } from './DxfUnderlayPanel.js';
+
+function emptyUnderlay(name: string): DxfUnderlay {
+  return {
+    name,
+    layers: [],
+    bounds: { min: { x: 0, y: 0 }, max: { x: 0, y: 0 } },
+    unitScale: 1,
+    skipped: {},
+    warnings: [],
+  };
+}
+
+function underlayState(overrides: Partial<DxfUnderlayState> = {}): DxfUnderlayState {
+  return {
+    id: 'u1',
+    name: 'site.dxf',
+    underlay: emptyUnderlay('site.dxf'),
+    visible: true,
+    opacity: 1,
+    layerVisibility: {},
+    placement: { ...DEFAULT_DXF_PLACEMENT },
+    georeferenced: undefined, // auto, unless overridden
+    ...overrides,
+  };
+}
+
+const mounted: Array<{ root: Root; container: HTMLElement }> = [];
+
+function renderPanel(georeferenceAvailable: boolean): HTMLElement {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(
+      <DxfUnderlayPanel
+        onClose={() => {}}
+        onCenterOnModel={() => {}}
+        planViewActive={true}
+        georeferenceAvailable={georeferenceAvailable}
+      />,
+    );
+  });
+  mounted.push({ root, container });
+  return container;
+}
+
+function georefCheckbox(container: HTMLElement): HTMLInputElement {
+  const label = [...container.querySelectorAll('label')].find((el) =>
+    el.textContent?.includes('Align to model georeference'),
+  );
+  assert.ok(label, 'expected the "Align to model georeference" label to render');
+  const input = label.querySelector('input[type="checkbox"]');
+  assert.ok(input instanceof HTMLInputElement, 'expected a checkbox inside the label');
+  return input;
+}
+
+describe('DxfUnderlayPanel: "Align to model georeference" tri-state control (PR #1965 review)', () => {
+  beforeEach(() => {
+    useViewerStore.setState({ dxfUnderlays: [] });
+  });
+
+  afterEach(() => {
+    for (const { root, container } of mounted.splice(0)) {
+      act(() => {
+        root.unmount();
+      });
+      container.remove();
+    }
+    useViewerStore.setState({ dxfUnderlays: [] });
+  });
+
+  it('auto entry (georeferenced === undefined) shows checked when the anchor georeference is available', () => {
+    useViewerStore.setState({ dxfUnderlays: [underlayState({ georeferenced: undefined })] });
+    const container = renderPanel(true);
+    assert.equal(georefCheckbox(container).checked, true);
+    assert.ok(container.textContent?.includes('(auto)'), 'auto mode label suffix renders');
+  });
+
+  it('auto entry shows unchecked when no anchor georeference is available', () => {
+    useViewerStore.setState({ dxfUnderlays: [underlayState({ georeferenced: undefined })] });
+    const container = renderPanel(false);
+    assert.equal(georefCheckbox(container).checked, false);
+  });
+
+  it('explicit true stays checked even when the anchor georeference is unavailable', () => {
+    useViewerStore.setState({ dxfUnderlays: [underlayState({ georeferenced: true })] });
+    const container = renderPanel(false);
+    assert.equal(georefCheckbox(container).checked, true);
+    assert.ok(!container.textContent?.includes('(auto)'), 'pinned entry does not show the auto suffix');
+  });
+
+  it('explicit false stays unchecked even when the anchor georeference is available', () => {
+    useViewerStore.setState({ dxfUnderlays: [underlayState({ georeferenced: false })] });
+    const container = renderPanel(true);
+    assert.equal(georefCheckbox(container).checked, false);
+  });
+
+  it('clicking an auto entry PINS it to an explicit value in the store, through the real action', async () => {
+    useViewerStore.setState({ dxfUnderlays: [underlayState({ id: 'u1', georeferenced: undefined })] });
+    const container = renderPanel(true); // auto resolves to checked
+    const checkbox = georefCheckbox(container);
+    assert.equal(checkbox.checked, true);
+
+    // User unchecks it explicitly.
+    await act(async () => {
+      checkbox.click();
+    });
+
+    const entry = useViewerStore.getState().dxfUnderlays.find((u) => u.id === 'u1');
+    assert.equal(entry?.georeferenced, false, 'click must write an explicit false, not leave it auto');
+  });
+
+  it('once pinned, the control no longer follows georeferenceAvailable (re-render with availability flipped)', () => {
+    useViewerStore.setState({ dxfUnderlays: [underlayState({ id: 'u1', georeferenced: false })] });
+    const container = renderPanel(true); // availability true, but pinned false wins
+    assert.equal(georefCheckbox(container).checked, false, 'pinned false must not follow availability=true');
+  });
+});

--- a/apps/viewer/src/components/viewer/DxfUnderlayPanel.tsx
+++ b/apps/viewer/src/components/viewer/DxfUnderlayPanel.tsx
@@ -14,8 +14,15 @@
  * DXFs authored in map/CRS coordinates (eastings/northings) rather than
  * the model's local frame — the inverse IfcMapConversion, resolved from
  * the federation anchor, is applied before the offset/rotation/scale
- * placement above. Defaults on only when the anchor model had a usable
- * IfcMapConversion at import time.
+ * placement above.
+ *
+ * PR #1965 review: the toggle is now tri-state (`DxfUnderlayState`'s
+ * `georeferenced` field doc, `drawing2DSlice.ts`). `ingestDxfFile` seeds a
+ * fresh entry to "auto" (`undefined`) rather than baking in a boolean at
+ * import time; the checkbox below shows the EFFECTIVE resolved state
+ * (`resolveEffectiveGeoreferenced`, following `georeferenceAvailable`
+ * while in auto mode) and only becomes an explicit `true`/`false` — pinned
+ * regardless of anchor availability — once the user actually clicks it.
  */
 
 import React, { useCallback, useRef, useState } from 'react';
@@ -31,6 +38,7 @@ import {
 import { useViewerStore } from '@/store';
 import { posthog } from '@/lib/analytics';
 import { ingestDxfFile } from '@/hooks/ingest/dxfIngest';
+import { resolveEffectiveGeoreferenced } from '@/hooks/dxfUnderlayMath';
 import type { DxfUnderlayState } from '@/store/slices/drawing2DSlice';
 
 interface DxfUnderlayPanelProps {
@@ -39,6 +47,12 @@ interface DxfUnderlayPanelProps {
   onCenterOnModel: (id: string) => void;
   /** False when the current section is not a cardinal plan view. */
   planViewActive: boolean;
+  /**
+   * Whether an anchor model currently has a usable IfcMapConversion (issue
+   * #1929 / PR #1965 review) — drives the checkbox's displayed state for
+   * any underlay still in "auto" mode (`entry.georeferenced === undefined`).
+   */
+  georeferenceAvailable: boolean;
 }
 
 /** One numeric placement field with a label. */
@@ -74,10 +88,12 @@ function UnderlayCard({
   state,
   onCenterOnModel,
   planViewActive,
+  georeferenceAvailable,
 }: {
   state: DxfUnderlayState;
   onCenterOnModel: (id: string) => void;
   planViewActive: boolean;
+  georeferenceAvailable: boolean;
 }): React.ReactElement {
   const removeDxfUnderlay = useViewerStore((s) => s.removeDxfUnderlay);
   const setDxfUnderlayVisible = useViewerStore((s) => s.setDxfUnderlayVisible);
@@ -153,20 +169,36 @@ function UnderlayCard({
       {/* Georeference alignment (issue #1929) — mirrors the .laz/.las
           "Align to model georeference" toggle (issue #1804), but per-DXF
           since each imported file may or may not be in map/CRS
-          coordinates. Off by default unless the model already carries a
-          usable IfcMapConversion at import time (see `ingestDxfFile`). */}
-      <label
-        className="flex items-center justify-between gap-2 cursor-pointer px-1"
-        title="Applies the inverse IfcMapConversion so this DXF's map/CRS coordinates (eastings/northings) line up with the IFC model. Turn off if this DXF is already drawn in the model's local coordinates."
-      >
-        <span className="text-[10px] text-muted-foreground">Align to model georeference</span>
-        <input
-          type="checkbox"
-          checked={state.georeferenced ?? false}
-          onChange={(e) => setDxfUnderlayGeoreferenced(state.id, e.target.checked)}
-          className="accent-primary"
-        />
-      </label>
+          coordinates. Tri-state (PR #1965 review): a freshly-imported
+          entry starts in "auto" (`state.georeferenced === undefined`) and
+          the checkbox shows the EFFECTIVE resolved state — following
+          `georeferenceAvailable` — until the user clicks it, at which
+          point it becomes an explicit true/false that no longer moves on
+          its own. */}
+      {(() => {
+        const isAuto = state.georeferenced === undefined;
+        const effectiveChecked = resolveEffectiveGeoreferenced(state, georeferenceAvailable);
+        return (
+          <label
+            className="flex items-center justify-between gap-2 cursor-pointer px-1"
+            title={
+              isAuto
+                ? `Auto: currently ${effectiveChecked ? 'ON' : 'OFF'} — follows whether the anchor model has a usable georeference. Click to pin this explicitly.`
+                : "Applies the inverse IfcMapConversion so this DXF's map/CRS coordinates (eastings/northings) line up with the IFC model. Turn off if this DXF is already drawn in the model's local coordinates."
+            }
+          >
+            <span className="text-[10px] text-muted-foreground">
+              Align to model georeference{isAuto ? ' (auto)' : ''}
+            </span>
+            <input
+              type="checkbox"
+              checked={effectiveChecked}
+              onChange={(e) => setDxfUnderlayGeoreferenced(state.id, e.target.checked)}
+              className="accent-primary"
+            />
+          </label>
+        );
+      })()}
 
       {/* DXF layers */}
       <Collapsible open={layersOpen} onOpenChange={setLayersOpen}>
@@ -253,7 +285,7 @@ function UnderlayCard({
   );
 }
 
-export function DxfUnderlayPanel({ onClose, onCenterOnModel, planViewActive }: DxfUnderlayPanelProps): React.ReactElement {
+export function DxfUnderlayPanel({ onClose, onCenterOnModel, planViewActive, georeferenceAvailable }: DxfUnderlayPanelProps): React.ReactElement {
   const dxfUnderlays = useViewerStore((s) => s.dxfUnderlays);
 
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -330,7 +362,7 @@ export function DxfUnderlayPanel({ onClose, onCenterOnModel, planViewActive }: D
         )}
 
         {dxfUnderlays.map((state) => (
-          <UnderlayCard key={state.id} state={state} onCenterOnModel={onCenterOnModel} planViewActive={planViewActive} />
+          <UnderlayCard key={state.id} state={state} onCenterOnModel={onCenterOnModel} planViewActive={planViewActive} georeferenceAvailable={georeferenceAvailable} />
         ))}
       </div>
     </div>

--- a/apps/viewer/src/components/viewer/DxfUnderlayPanel.tsx
+++ b/apps/viewer/src/components/viewer/DxfUnderlayPanel.tsx
@@ -9,6 +9,13 @@
  * per-file visibility/opacity, per-DXF-layer toggles, centre-on-model, and
  * placement (offset / rotation / scale) against the model's coordinate
  * system. Underlays render on plan ('down') sections.
+ *
+ * "Align to model georeference" (issue #1929) is a per-underlay toggle for
+ * DXFs authored in map/CRS coordinates (eastings/northings) rather than
+ * the model's local frame — the inverse IfcMapConversion, resolved from
+ * the federation anchor, is applied before the offset/rotation/scale
+ * placement above. Defaults on only when the anchor model had a usable
+ * IfcMapConversion at import time.
  */
 
 import React, { useCallback, useRef, useState } from 'react';
@@ -77,6 +84,7 @@ function UnderlayCard({
   const setDxfUnderlayOpacity = useViewerStore((s) => s.setDxfUnderlayOpacity);
   const toggleDxfUnderlayLayer = useViewerStore((s) => s.toggleDxfUnderlayLayer);
   const updateDxfUnderlayPlacement = useViewerStore((s) => s.updateDxfUnderlayPlacement);
+  const setDxfUnderlayGeoreferenced = useViewerStore((s) => s.setDxfUnderlayGeoreferenced);
 
   const [layersOpen, setLayersOpen] = useState(false);
   const [placementOpen, setPlacementOpen] = useState(false);
@@ -141,6 +149,24 @@ function UnderlayCard({
         />
         <span className="text-[10px] text-muted-foreground w-8 text-right">{Math.round(state.opacity * 100)}%</span>
       </div>
+
+      {/* Georeference alignment (issue #1929) — mirrors the .laz/.las
+          "Align to model georeference" toggle (issue #1804), but per-DXF
+          since each imported file may or may not be in map/CRS
+          coordinates. Off by default unless the model already carries a
+          usable IfcMapConversion at import time (see `ingestDxfFile`). */}
+      <label
+        className="flex items-center justify-between gap-2 cursor-pointer px-1"
+        title="Applies the inverse IfcMapConversion so this DXF's map/CRS coordinates (eastings/northings) line up with the IFC model. Turn off if this DXF is already drawn in the model's local coordinates."
+      >
+        <span className="text-[10px] text-muted-foreground">Align to model georeference</span>
+        <input
+          type="checkbox"
+          checked={state.georeferenced ?? false}
+          onChange={(e) => setDxfUnderlayGeoreferenced(state.id, e.target.checked)}
+          className="accent-primary"
+        />
+      </label>
 
       {/* DXF layers */}
       <Collapsible open={layersOpen} onOpenChange={setLayersOpen}>

--- a/apps/viewer/src/components/viewer/Section2DPanel.tsx
+++ b/apps/viewer/src/components/viewer/Section2DPanel.tsx
@@ -419,20 +419,29 @@ export function Section2DPanel({
   // the render hook applies, including the current rotation/scale and,
   // for a georeferenced underlay, the inverse IfcMapConversion — issue
   // #1929, same transform `dxfUnderlayData` above resolves).
-  const dxfMapToWorld = useDxfMapToWorldTransform();
+  const { transform: dxfMapToWorld, available: dxfGeoreferenceAvailable } = useDxfMapToWorldTransform();
   const handleCenterDxfUnderlay = useCallback((id: string) => {
     const entry = dxfUnderlays.find((u) => u.id === id);
     if (!entry || !drawing) return;
     const shift = dxfWorldShift(geometryResult?.coordinateInfo);
     const mirrorX = sectionPlane.flipped && sectionPlane.custom === undefined;
-    const underlayBounds = dxfUnderlayDrawingBounds(entry, shift, mirrorX, dxfMapToWorld);
+    const underlayBounds = dxfUnderlayDrawingBounds(entry, shift, mirrorX, dxfMapToWorld, dxfGeoreferenceAvailable);
     if (!underlayBounds) return;
     const modelCx = (drawing.bounds.min.x + drawing.bounds.max.x) / 2;
     const modelCy = (drawing.bounds.min.y + drawing.bounds.max.y) / 2;
     const underlayCx = (underlayBounds.min.x + underlayBounds.max.x) / 2;
     const underlayCy = (underlayBounds.min.y + underlayBounds.max.y) / 2;
-    updateDxfUnderlayPlacement(id, { offsetX: modelCx - underlayCx, offsetY: modelCy - underlayCy });
-  }, [dxfUnderlays, drawing, geometryResult, sectionPlane.flipped, sectionPlane.custom, updateDxfUnderlayPlacement, dxfMapToWorld]);
+    const offsetX = modelCx - underlayCx;
+    const offsetY = modelCy - underlayCy;
+    // Defense-in-depth (PR #1965 review): `dxfUnderlayDrawingBounds`
+    // already returns null on a non-finite bound (so `underlayBounds`
+    // above would have short-circuited), but guard the DERIVED offset too
+    // — `drawing.bounds` comes from the generated drawing, not the
+    // underlay, and a NaN here would otherwise still get written into the
+    // stored placement, which survives toggling georeferencing back off.
+    if (!Number.isFinite(offsetX) || !Number.isFinite(offsetY)) return;
+    updateDxfUnderlayPlacement(id, { offsetX, offsetY });
+  }, [dxfUnderlays, drawing, geometryResult, sectionPlane.flipped, sectionPlane.custom, updateDxfUnderlayPlacement, dxfMapToWorld, dxfGeoreferenceAvailable]);
 
   // Point-cloud scan overlay (issue #1805): a thin band of the loaded
   // scan(s) around the active section plane, projected into the SAME
@@ -1252,6 +1261,7 @@ export function Section2DPanel({
             onClose={() => setDxfPanelOpen(false)}
             onCenterOnModel={handleCenterDxfUnderlay}
             planViewActive={sectionPlane.axis === 'down' && sectionPlane.custom === undefined}
+            georeferenceAvailable={dxfGeoreferenceAvailable}
           />
         </div>
       )}

--- a/apps/viewer/src/components/viewer/Section2DPanel.tsx
+++ b/apps/viewer/src/components/viewer/Section2DPanel.tsx
@@ -40,7 +40,7 @@ import { useAnnotation2D } from '@/hooks/useAnnotation2D';
 import { useViewControls } from '@/hooks/useViewControls';
 import { useDrawingExport } from '@/hooks/useDrawingExport';
 import { useSymbolicAnnotationsForDrawing } from '@/hooks/useSymbolicAnnotations';
-import { useDxfUnderlaysForDrawing, dxfWorldShift, dxfUnderlayDrawingBounds } from '@/hooks/useDxfUnderlay';
+import { useDxfUnderlaysForDrawing, useDxfMapToWorldTransform, dxfWorldShift, dxfUnderlayDrawingBounds } from '@/hooks/useDxfUnderlay';
 import { useScanSectionLayer } from '@/hooks/useScanSectionLayer';
 
 interface Section2DPanelProps {
@@ -416,20 +416,23 @@ export function Section2DPanel({
 
   // Centre an underlay on the generated drawing: offset = model-drawing
   // centre − underlay centre at zero offset (same world→drawing mapping
-  // the render hook applies, including the current rotation/scale).
+  // the render hook applies, including the current rotation/scale and,
+  // for a georeferenced underlay, the inverse IfcMapConversion — issue
+  // #1929, same transform `dxfUnderlayData` above resolves).
+  const dxfMapToWorld = useDxfMapToWorldTransform();
   const handleCenterDxfUnderlay = useCallback((id: string) => {
     const entry = dxfUnderlays.find((u) => u.id === id);
     if (!entry || !drawing) return;
     const shift = dxfWorldShift(geometryResult?.coordinateInfo);
     const mirrorX = sectionPlane.flipped && sectionPlane.custom === undefined;
-    const underlayBounds = dxfUnderlayDrawingBounds(entry, shift, mirrorX);
+    const underlayBounds = dxfUnderlayDrawingBounds(entry, shift, mirrorX, dxfMapToWorld);
     if (!underlayBounds) return;
     const modelCx = (drawing.bounds.min.x + drawing.bounds.max.x) / 2;
     const modelCy = (drawing.bounds.min.y + drawing.bounds.max.y) / 2;
     const underlayCx = (underlayBounds.min.x + underlayBounds.max.x) / 2;
     const underlayCy = (underlayBounds.min.y + underlayBounds.max.y) / 2;
     updateDxfUnderlayPlacement(id, { offsetX: modelCx - underlayCx, offsetY: modelCy - underlayCy });
-  }, [dxfUnderlays, drawing, geometryResult, sectionPlane.flipped, sectionPlane.custom, updateDxfUnderlayPlacement]);
+  }, [dxfUnderlays, drawing, geometryResult, sectionPlane.flipped, sectionPlane.custom, updateDxfUnderlayPlacement, dxfMapToWorld]);
 
   // Point-cloud scan overlay (issue #1805): a thin band of the loaded
   // scan(s) around the active section plane, projected into the SAME

--- a/apps/viewer/src/components/viewer/Section2DPanel.tsx
+++ b/apps/viewer/src/components/viewer/Section2DPanel.tsx
@@ -22,6 +22,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { useViewerStore } from '@/store';
+import { toast } from '@/components/ui/toast';
 import { toGlobalIdFromModels } from '@/store/globalId';
 import { useIfc } from '@/hooks/useIfc';
 import { useDraggablePanel } from '@/hooks/useDraggablePanel';
@@ -426,7 +427,16 @@ export function Section2DPanel({
     const shift = dxfWorldShift(geometryResult?.coordinateInfo);
     const mirrorX = sectionPlane.flipped && sectionPlane.custom === undefined;
     const underlayBounds = dxfUnderlayDrawingBounds(entry, shift, mirrorX, dxfMapToWorld, dxfGeoreferenceAvailable);
-    if (!underlayBounds) return;
+    if (!underlayBounds) {
+      // PR #1965 review: this guard fires when the underlay has no usable
+      // bounds AT ALL (missing extents) OR the georeference produced a
+      // non-finite corner (`dxfUnderlayDrawingBounds` collapses both into
+      // `null` — see its docstring). Either way the button used to do
+      // nothing with no explanation; tell the user so a malformed
+      // `IfcMapConversion` doesn't read as an unresponsive button.
+      toast.error("Couldn't centre this underlay: its bounds are missing or the georeference produced non-finite coordinates.");
+      return;
+    }
     const modelCx = (drawing.bounds.min.x + drawing.bounds.max.x) / 2;
     const modelCy = (drawing.bounds.min.y + drawing.bounds.max.y) / 2;
     const underlayCx = (underlayBounds.min.x + underlayBounds.max.x) / 2;
@@ -439,7 +449,10 @@ export function Section2DPanel({
     // — `drawing.bounds` comes from the generated drawing, not the
     // underlay, and a NaN here would otherwise still get written into the
     // stored placement, which survives toggling georeferencing back off.
-    if (!Number.isFinite(offsetX) || !Number.isFinite(offsetY)) return;
+    if (!Number.isFinite(offsetX) || !Number.isFinite(offsetY)) {
+      toast.error("Couldn't centre this underlay: the drawing bounds are not finite.");
+      return;
+    }
     updateDxfUnderlayPlacement(id, { offsetX, offsetY });
   }, [dxfUnderlays, drawing, geometryResult, sectionPlane.flipped, sectionPlane.custom, updateDxfUnderlayPlacement, dxfMapToWorld, dxfGeoreferenceAvailable]);
 

--- a/apps/viewer/src/hooks/dxfExportGeoref.test.ts
+++ b/apps/viewer/src/hooks/dxfExportGeoref.test.ts
@@ -774,4 +774,50 @@ describe('buildDxfMapToWorldTransform', () => {
       close(mapPoint.y, 6_000_000 + 2001);
     });
   }
+
+  // PR #1965 review, round 2: the loop above only exercises a bad component
+  // paired with a ZERO good component (xAxisOrdinate: 0), which doesn't
+  // distinguish "falls back to (1, 0)" from "keeps the good component and
+  // discards only the bad one" -- both produce (1, 0) when the good
+  // component is already 0. A MIXED pair with a genuinely non-zero good
+  // component (e.g. XAxisAbscissa: NaN, XAxisOrdinate: 0.6) tells them
+  // apart: the previous implementation substituted only the bad component to
+  // its identity default (1) and then normalized THAT against the real 0.6,
+  // manufacturing a bogus ~31-degree rotation the file never authored,
+  // instead of discarding the whole pair for the (1, 0) no-rotation
+  // fallback like the near-zero-magnitude case does.
+  it('falls back the WHOLE axis pair to (1, 0) when only one component is non-finite, not a half-fabricated rotation', () => {
+    const georeference = {
+      mapConversion: {
+        id: 1, sourceCRS: 1, targetCRS: 1,
+        eastings: 500_000, northings: 6_000_000, orthogonalHeight: 0,
+        xAxisAbscissa: NaN, xAxisOrdinate: 0.6, scale: 1,
+      },
+      projectedCRS: { id: 1, name: 'EPSG:32632', mapUnit: 'METRE', mapUnitScale: 1 },
+      lengthUnitScale: 1,
+    };
+
+    const inverse = buildDxfMapToWorldTransform(georeference);
+    const world = inverse({ x: 500_000 + 1007, y: 6_000_000 + 2001 });
+    assert.ok(Number.isFinite(world.x), `expected finite x, got ${world.x}`);
+    assert.ok(Number.isFinite(world.y), `expected finite y, got ${world.y}`);
+    // With the correct (1, 0) fallback the inverse is exact, not just finite
+    // -- a bogus partial rotation would land world.x/y off by the rotation
+    // it fabricated instead of matching these values.
+    close(world.x, 1007);
+    close(world.y, 2001);
+
+    const forward = buildDxfExportTransform({
+      coordinateInfo: undefined,
+      sectionAxis: 'down',
+      isCustomPlane: false,
+      flipped: false,
+      georeference,
+    });
+    const mapPoint = forward({ x: 1007, y: -2001 });
+    assert.ok(Number.isFinite(mapPoint.x), `expected finite x, got ${mapPoint.x}`);
+    assert.ok(Number.isFinite(mapPoint.y), `expected finite y, got ${mapPoint.y}`);
+    close(mapPoint.x, 500_000 + 1007);
+    close(mapPoint.y, 6_000_000 + 2001);
+  });
 });

--- a/apps/viewer/src/hooks/dxfExportGeoref.test.ts
+++ b/apps/viewer/src/hooks/dxfExportGeoref.test.ts
@@ -690,4 +690,43 @@ describe('buildDxfMapToWorldTransform', () => {
     close(out.x, 1007);
     close(out.y, 2001);
   });
+
+  // PR #1965 review, "NaN can permanently corrupt placement state": a
+  // malformed IfcMapConversion.Eastings (or Northings) must not make every
+  // transformed point NaN. `resolveGeorefLinearParams`'s finite guard is
+  // the last line of defence even though `mergeMapConversion`
+  // (effective-georef.ts) already stops most NaNs earlier in the chain —
+  // this exercises the transform functions directly with a raw
+  // `DxfExportGeoreference` that skipped that earlier guard (e.g. a caller
+  // constructing one without going through `getEffectiveGeoreference`).
+  it('guards a non-finite Eastings/Northings instead of propagating NaN through every point (PR #1965 review)', () => {
+    const georeference = {
+      mapConversion: {
+        id: 1, sourceCRS: 1, targetCRS: 1,
+        eastings: NaN, northings: 6_000_000, orthogonalHeight: 0,
+        xAxisAbscissa: 1, xAxisOrdinate: 0, scale: 1,
+      },
+      projectedCRS: { id: 1, name: 'EPSG:32632', mapUnit: 'METRE', mapUnitScale: 1 },
+      lengthUnitScale: 1,
+    };
+    const inverse = buildDxfMapToWorldTransform(georeference);
+    const world = inverse({ x: 1007, y: 6_000_000 + 2001 });
+    // NaN eastings falls back to 0 (same convention as `mergeMapConversion`'s
+    // `?? 0`), NOT NaN -- so the result must be finite, not NaN.
+    assert.ok(Number.isFinite(world.x), `expected finite x, got ${world.x}`);
+    assert.ok(Number.isFinite(world.y), `expected finite y, got ${world.y}`);
+    close(world.x, 1007);
+    close(world.y, 2001);
+
+    const forward = buildDxfExportTransform({
+      coordinateInfo: undefined,
+      sectionAxis: 'down',
+      isCustomPlane: false,
+      flipped: false,
+      georeference,
+    });
+    const mapPoint = forward({ x: 1007, y: -2001 });
+    assert.ok(Number.isFinite(mapPoint.x), `expected finite x, got ${mapPoint.x}`);
+    assert.ok(Number.isFinite(mapPoint.y), `expected finite y, got ${mapPoint.y}`);
+  });
 });

--- a/apps/viewer/src/hooks/dxfExportGeoref.test.ts
+++ b/apps/viewer/src/hooks/dxfExportGeoref.test.ts
@@ -16,7 +16,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert';
 import { exportToDXF, parseDxf, DEFAULT_SECTION_CONFIG, type Drawing2D } from '@ifc-lite/drawing-2d';
 import { IfcParser } from '@ifc-lite/parser';
-import { buildDxfExportTransform, resolveDxfExportGeoreference } from './dxfExportGeoref.js';
+import { buildDxfExportTransform, buildDxfMapToWorldTransform, resolveDxfExportGeoreference } from './dxfExportGeoref.js';
 import { dxfWorldShift, dxfUnderlayToDrawing } from './dxfUnderlayMath.js';
 import type { DxfUnderlayState } from '@/store/slices/drawing2DSlice';
 import type { GeorefMutationDataLike } from '@/lib/geo/effective-georef';
@@ -557,5 +557,137 @@ describe('resolveDxfExportGeoreference (PR #1871 review: edited georeferencing m
     const out = exportPoint(georef);
     close(out.x, 2_600_504);
     close(out.y, 1_200_494);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// buildDxfMapToWorldTransform (issue #1929): the INVERSE of the georeferenced
+// branch of buildDxfExportTransform, for the DXF-underlay IMPORT path. A
+// surveyor's DXF is typically authored in map/CRS coordinates; this maps it
+// back to IFC world coordinates so it lands where the model actually is.
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('buildDxfMapToWorldTransform', () => {
+  it('is the identity when no georeference is available', () => {
+    const transform = buildDxfMapToWorldTransform(null);
+    const p = { x: 2_600_123, y: 1_200_456 };
+    assert.deepStrictEqual(transform(p), p);
+    assert.deepStrictEqual(buildDxfMapToWorldTransform(undefined)(p), p);
+  });
+
+  it('inverts a known rotated+offset georeference to the exact world coordinate', () => {
+    // Same georeference and expected numbers as buildDxfExportTransform's
+    // "applies IfcMapConversion" test above: world (1007, 2001) forward-maps
+    // to (500000 - 2001, 6000000 + 1007) under a 90deg rotation. The inverse
+    // must recover the original world point from that exact map point.
+    const georeference = {
+      mapConversion: {
+        id: 1, sourceCRS: 1, targetCRS: 1,
+        eastings: 500_000, northings: 6_000_000, orthogonalHeight: 0,
+        xAxisAbscissa: 0, xAxisOrdinate: 1, // 90-degree rotation
+        scale: 1,
+      },
+      projectedCRS: { id: 1, name: 'EPSG:32632', mapUnit: 'METRE', mapUnitScale: 1 },
+      lengthUnitScale: 1,
+    };
+    const transform = buildDxfMapToWorldTransform(georeference);
+    const world = transform({ x: 500_000 - 2001, y: 6_000_000 + 1007 });
+    close(world.x, 1007);
+    close(world.y, 2001);
+  });
+
+  it('round-trips through buildDxfExportTransform: forward(inverse(p)) === p and inverse(forward(p)) === p', () => {
+    const georeference = {
+      mapConversion: {
+        id: 1, sourceCRS: 1, targetCRS: 1,
+        eastings: 2_600_000, northings: 1_200_000, orthogonalHeight: 400,
+        xAxisAbscissa: 0.8, xAxisOrdinate: 0.6, // non-axis-aligned rotation, non-unit-length input
+        scale: 1.0000002,
+      },
+      projectedCRS: { id: 1, name: 'EPSG:2056', mapUnit: 'METRE', mapUnitScale: 1 },
+      lengthUnitScale: 1,
+    };
+    const toWorld = buildDxfMapToWorldTransform(georeference);
+    // buildDxfExportTransform's georeferenced branch needs a section/coordinateInfo
+    // context; drive it with no render-frame shift, but its `toWorld` step
+    // ALSO y-flips its drawing-space input (`y: shift.y - p.y`, matching a
+    // plan section's drawing convention — see the module docstring). With
+    // shift = (0, 0) that reduces to `world = (p.x, -p.y)`, so a drawing
+    // input of `(worldX, -worldY)` reproduces a given world point exactly —
+    // undo that same flip on both sides to compare pure world<->map values.
+    const toMap = buildDxfExportTransform({
+      coordinateInfo: undefined,
+      sectionAxis: 'down',
+      isCustomPlane: false,
+      flipped: false,
+      georeference,
+    });
+    const worldPoint = { x: 1234.5, y: -678.25 };
+    const mapPoint = toMap({ x: worldPoint.x, y: -worldPoint.y });
+    const backToWorld = toWorld(mapPoint);
+    close(backToWorld.x, worldPoint.x, 1e-6);
+    close(backToWorld.y, worldPoint.y, 1e-6);
+
+    const mapPoint2 = { x: 2_600_500.75, y: 1_199_800.25 };
+    const worldFromMap = toWorld(mapPoint2);
+    const backToMap = toMap({ x: worldFromMap.x, y: -worldFromMap.y });
+    close(backToMap.x, mapPoint2.x, 1e-6);
+    close(backToMap.y, mapPoint2.y, 1e-6);
+  });
+
+  it('guards a pathological IfcMapConversion.Scale of 0 the same way the forward transform does', () => {
+    const buildTransform = (scale: number) => buildDxfMapToWorldTransform({
+      mapConversion: {
+        id: 1, sourceCRS: 1, targetCRS: 1,
+        eastings: 500_000, northings: 6_000_000, orthogonalHeight: 0,
+        xAxisAbscissa: 1, xAxisOrdinate: 0, scale,
+      },
+      projectedCRS: { id: 1, name: 'EPSG:32632', mapUnit: 'METRE', mapUnitScale: 1 },
+      lengthUnitScale: 1,
+    });
+    const zeroed = buildTransform(0);
+    const unit = buildTransform(1);
+    const a = zeroed({ x: 500_004, y: 6_000_006 });
+    const b = zeroed({ x: 500_040, y: 6_000_060 });
+    // Distinct map points must stay distinct (no division-by-zero collapse)…
+    assert.ok(Math.abs(a.x - b.x) > 1, 'points collapsed under Scale=0');
+    // …and behave exactly like Scale=1 (the same fallback the forward transform uses).
+    const u = unit({ x: 500_004, y: 6_000_006 });
+    close(a.x, u.x);
+    close(a.y, u.y);
+  });
+
+  it('falls back to the no-rotation default (1, 0) for a near-zero axis vector', () => {
+    const transform = buildDxfMapToWorldTransform({
+      mapConversion: {
+        id: 1, sourceCRS: 1, targetCRS: 1,
+        eastings: 0, northings: 0, orthogonalHeight: 0,
+        xAxisAbscissa: 0, xAxisOrdinate: 0, scale: 1,
+      },
+      projectedCRS: { id: 1, name: 'EPSG:32632', mapUnit: 'METRE', mapUnitScale: 1 },
+      lengthUnitScale: 1,
+    });
+    // With the (1, 0) fallback: worldX = mapX, worldY = mapY.
+    const out = transform({ x: 1007, y: 2001 });
+    close(out.x, 1007);
+    close(out.y, 2001);
+  });
+
+  it('bridges a non-metre CRS map unit the same way the forward transform does (PR #1871 review parity)', () => {
+    const FT_US = 0.3048006096;
+    const transform = buildDxfMapToWorldTransform({
+      mapConversion: {
+        id: 1, sourceCRS: 1, targetCRS: 1,
+        eastings: 500_000, northings: 6_000_000, orthogonalHeight: 0, // authored in ftUS
+        xAxisAbscissa: 1, xAxisOrdinate: 0,
+        scale: 1 / FT_US, // spec unit bridge: metre project -> ftUS map
+      },
+      projectedCRS: { id: 1, name: 'EPSG:2230', mapUnit: 'USSURVEYFOOT', mapUnitScale: FT_US },
+      lengthUnitScale: 1,
+    });
+    // effective scale = (1/FT_US) * FT_US / 1 = 1; map point = eastings*FT_US + world.
+    const out = transform({ x: 500_000 * FT_US + 1007, y: 6_000_000 * FT_US + 2001 });
+    close(out.x, 1007);
+    close(out.y, 2001);
   });
 });

--- a/apps/viewer/src/hooks/dxfExportGeoref.test.ts
+++ b/apps/viewer/src/hooks/dxfExportGeoref.test.ts
@@ -601,7 +601,7 @@ describe('buildDxfMapToWorldTransform', () => {
       mapConversion: {
         id: 1, sourceCRS: 1, targetCRS: 1,
         eastings: 2_600_000, northings: 1_200_000, orthogonalHeight: 400,
-        xAxisAbscissa: 0.8, xAxisOrdinate: 0.6, // non-axis-aligned rotation, non-unit-length input
+        xAxisAbscissa: 8, xAxisOrdinate: 6, // non-axis-aligned rotation, non-unit-length input (normalizes to 0.8, 0.6)
         scale: 1.0000002,
       },
       projectedCRS: { id: 1, name: 'EPSG:2056', mapUnit: 'METRE', mapUnitScale: 1 },

--- a/apps/viewer/src/hooks/dxfExportGeoref.test.ts
+++ b/apps/viewer/src/hooks/dxfExportGeoref.test.ts
@@ -729,4 +729,49 @@ describe('buildDxfMapToWorldTransform', () => {
     assert.ok(Number.isFinite(mapPoint.x), `expected finite x, got ${mapPoint.x}`);
     assert.ok(Number.isFinite(mapPoint.y), `expected finite y, got ${mapPoint.y}`);
   });
+
+  // PR #1965 second review round: `axisLen < 1e-9` only catches the
+  // near-zero MAGNITUDE case -- `NaN < 1e-9` and `Infinity < 1e-9` are both
+  // `false`, so a non-finite XAxisAbscissa/XAxisOrdinate used to take the
+  // *divide* branch and manufacture a NaN axis instead of falling back to
+  // the no-rotation default (1, 0), unlike the near-zero case just above
+  // and the Eastings/Northings guard just below. Covers both NaN and
+  // Infinity, and both the forward and inverse transforms, since both read
+  // `resolveGeorefLinearParams`.
+  for (const [label, bad] of [['NaN', NaN], ['Infinity', Infinity]] as const) {
+    it(`guards a non-finite (${label}) axis component instead of propagating NaN through every point`, () => {
+      const georeference = {
+        mapConversion: {
+          id: 1, sourceCRS: 1, targetCRS: 1,
+          eastings: 500_000, northings: 6_000_000, orthogonalHeight: 0,
+          xAxisAbscissa: bad, xAxisOrdinate: 0, scale: 1,
+        },
+        projectedCRS: { id: 1, name: 'EPSG:32632', mapUnit: 'METRE', mapUnitScale: 1 },
+        lengthUnitScale: 1,
+      };
+
+      const inverse = buildDxfMapToWorldTransform(georeference);
+      const world = inverse({ x: 500_000 + 1007, y: 6_000_000 + 2001 });
+      assert.ok(Number.isFinite(world.x), `expected finite x, got ${world.x}`);
+      assert.ok(Number.isFinite(world.y), `expected finite y, got ${world.y}`);
+      // A non-finite abscissa with ordinate 0 falls back to the (1, 0)
+      // no-rotation default, same as the near-zero-vector case, so the
+      // inverse is exact, not just finite.
+      close(world.x, 1007);
+      close(world.y, 2001);
+
+      const forward = buildDxfExportTransform({
+        coordinateInfo: undefined,
+        sectionAxis: 'down',
+        isCustomPlane: false,
+        flipped: false,
+        georeference,
+      });
+      const mapPoint = forward({ x: 1007, y: -2001 });
+      assert.ok(Number.isFinite(mapPoint.x), `expected finite x, got ${mapPoint.x}`);
+      assert.ok(Number.isFinite(mapPoint.y), `expected finite y, got ${mapPoint.y}`);
+      close(mapPoint.x, 500_000 + 1007);
+      close(mapPoint.y, 6_000_000 + 2001);
+    });
+  }
 });

--- a/apps/viewer/src/hooks/dxfExportGeoref.ts
+++ b/apps/viewer/src/hooks/dxfExportGeoref.ts
@@ -45,6 +45,17 @@
  * Only a plan ('down', non-custom-plane) section has a 2D CAD-meaningful
  * georeference; front/side/custom sections pass through unchanged (per
  * issue #1861: "vertical sections ... export in drawing coordinates").
+ *
+ * `buildDxfMapToWorldTransform` (issue #1929) is the INVERSE of the
+ * georeferenced branch above: it maps map/CRS coordinates (as authored in a
+ * surveyor's georeferenced DXF) back to IFC world coordinates, for the DXF
+ * UNDERLAY import path (`dxfUnderlayMath.ts`). Because `IfcMapConversion`'s
+ * axis vector is normalized to unit length, its rotation matrix is
+ * orthonormal — its inverse is its transpose — so the inverse is a
+ * closed-form transpose-and-translate, not a division-heavy general
+ * inverse. Both directions share the same scale/axis/map-unit resolution
+ * (`resolveGeorefLinearParams`) so the two transforms can never disagree
+ * about e.g. the Scale=0 or degenerate-axis guards.
  */
 
 import type { Point2D } from '@ifc-lite/drawing-2d';
@@ -117,33 +128,86 @@ export function buildDxfExportTransform(params: DxfExportTransformParams): (p: P
 
   if (!georeference) return toWorld;
 
-  const { mapConversion, projectedCRS, lengthUnitScale } = georeference;
-  const mapUnitScale = resolveMapUnitToMetreScale(projectedCRS.mapUnitScale, lengthUnitScale);
-  // Guard the pathological IfcMapConversion.Scale = 0 (or negative/NaN):
-  // getEffectiveHorizontalScale passes an explicit 0 through, which would
-  // collapse every exported point onto the eastings/northings origin.
-  // Exporting unscaled (1) keeps the geometry intact, which is strictly
-  // less wrong than a single-point file.
-  const rawEffectiveScale = getEffectiveHorizontalScale(mapConversion.scale, mapUnitScale, lengthUnitScale);
-  const scale = Number.isFinite(rawEffectiveScale) && rawEffectiveScale > 0 ? rawEffectiveScale : 1;
-  // IfcMapConversion.XAxisAbscissa/XAxisOrdinate form a direction vector, not
-  // necessarily unit length — the IFC spec allows an authoring tool to write
-  // any non-zero (cos, sin)-proportional pair. Used raw, a non-unit vector
-  // scales the whole exported drawing by its magnitude. Normalize exactly
-  // like the Rust source of truth (rust/core/src/georef.rs normalize_axis);
-  // a near-zero vector (both components ~0) falls back to the no-rotation
-  // default (1, 0), matching that function's guard.
-  const rawAbscissa = mapConversion.xAxisAbscissa ?? 1;
-  const rawOrdinate = mapConversion.xAxisOrdinate ?? 0;
-  const axisLen = Math.hypot(rawAbscissa, rawOrdinate);
-  const abscissa = axisLen < 1e-9 ? 1 : rawAbscissa / axisLen;
-  const ordinate = axisLen < 1e-9 ? 0 : rawOrdinate / axisLen;
+  const { mapConversion, mapUnitScale, scale, abscissa, ordinate } = resolveGeorefLinearParams(georeference);
 
   return (p) => {
     const world = toWorld(p);
     return {
       x: mapConversion.eastings * mapUnitScale + scale * (abscissa * world.x - ordinate * world.y),
       y: mapConversion.northings * mapUnitScale + scale * (ordinate * world.x + abscissa * world.y),
+    };
+  };
+}
+
+/**
+ * Shared scale/axis/map-unit resolution for both the forward
+ * ({@link buildDxfExportTransform}) and inverse
+ * ({@link buildDxfMapToWorldTransform}) georeference transforms — see the
+ * module docstring. Keeping this in one place means the Scale=0 and
+ * degenerate-axis guards can never drift between the two directions.
+ */
+function resolveGeorefLinearParams(georeference: DxfExportGeoreference): {
+  mapConversion: MapConversion;
+  mapUnitScale: number;
+  scale: number;
+  abscissa: number;
+  ordinate: number;
+} {
+  const { mapConversion, projectedCRS, lengthUnitScale } = georeference;
+  const mapUnitScale = resolveMapUnitToMetreScale(projectedCRS.mapUnitScale, lengthUnitScale);
+  // Guard the pathological IfcMapConversion.Scale = 0 (or negative/NaN):
+  // getEffectiveHorizontalScale passes an explicit 0 through, which would
+  // collapse every exported point onto the eastings/northings origin (or,
+  // inverted, make every map point resolve to the same world point).
+  // Falling back to unscaled (1) keeps the geometry intact, which is
+  // strictly less wrong than a single-point result.
+  const rawEffectiveScale = getEffectiveHorizontalScale(mapConversion.scale, mapUnitScale, lengthUnitScale);
+  const scale = Number.isFinite(rawEffectiveScale) && rawEffectiveScale > 0 ? rawEffectiveScale : 1;
+  // IfcMapConversion.XAxisAbscissa/XAxisOrdinate form a direction vector, not
+  // necessarily unit length — the IFC spec allows an authoring tool to write
+  // any non-zero (cos, sin)-proportional pair. Used raw, a non-unit vector
+  // scales the whole transform by its magnitude. Normalize exactly like the
+  // Rust source of truth (rust/core/src/georef.rs normalize_axis); a
+  // near-zero vector (both components ~0) falls back to the no-rotation
+  // default (1, 0), matching that function's guard.
+  const rawAbscissa = mapConversion.xAxisAbscissa ?? 1;
+  const rawOrdinate = mapConversion.xAxisOrdinate ?? 0;
+  const axisLen = Math.hypot(rawAbscissa, rawOrdinate);
+  const abscissa = axisLen < 1e-9 ? 1 : rawAbscissa / axisLen;
+  const ordinate = axisLen < 1e-9 ? 0 : rawOrdinate / axisLen;
+  return { mapConversion, mapUnitScale, scale, abscissa, ordinate };
+}
+
+/**
+ * Build the map/CRS-space → IFC-world-space point transform (issue #1929):
+ * the inverse of {@link buildDxfExportTransform}'s georeferenced branch.
+ * `null`/undefined `georeference` (no usable IfcMapConversion resolved for
+ * the federation anchor) returns the identity function, so a DXF underlay
+ * imported before any model with a map conversion loads passes through
+ * unchanged — matching the "off" state of the per-underlay toggle.
+ *
+ * Because the rotation matrix built from (abscissa, ordinate) is
+ * orthonormal, its inverse is its transpose:
+ *   dE = E - Eastings*mapUnitScale, dN = N - Northings*mapUnitScale
+ *   worldX = ( abscissa*dE + ordinate*dN) / scale
+ *   worldY = (-ordinate*dE + abscissa*dN) / scale
+ * — the exact algebraic inverse of `buildDxfExportTransform`'s
+ *   easting  = Eastings*mapUnitScale + scale*(abscissa*worldX - ordinate*worldY)
+ *   northing = Northings*mapUnitScale + scale*(ordinate*worldX + abscissa*worldY)
+ */
+export function buildDxfMapToWorldTransform(
+  georeference: DxfExportGeoreference | null | undefined,
+): (p: Point2D) => Point2D {
+  if (!georeference) return (p) => p;
+
+  const { mapConversion, mapUnitScale, scale, abscissa, ordinate } = resolveGeorefLinearParams(georeference);
+
+  return (p) => {
+    const dE = p.x - mapConversion.eastings * mapUnitScale;
+    const dN = p.y - mapConversion.northings * mapUnitScale;
+    return {
+      x: (abscissa * dE + ordinate * dN) / scale,
+      y: (-ordinate * dE + abscissa * dN) / scale,
     };
   };
 }

--- a/apps/viewer/src/hooks/dxfExportGeoref.ts
+++ b/apps/viewer/src/hooks/dxfExportGeoref.ts
@@ -216,8 +216,7 @@ function resolveGeorefLinearParams(georeference: DxfExportGeoreference): {
   // PR #1965 review: `axisLen < 1e-9` alone only catches the near-zero
   // MAGNITUDE case — `NaN < 1e-9` and `Infinity < 1e-9` are both `false`, so
   // a non-finite component used to fall through to the divide branch and
-  // manufacture a NaN axis. `finiteOr` closes that before `Math.hypot` ever
-  // sees the raw values, same as the eastings/northings guard below.
+  // manufacture a NaN axis.
   //
   // This is a DELIBERATE divergence from `normalize_axis`, not an oversight
   // left over from the "exactly like Rust" framing above: `normalize_axis`
@@ -229,11 +228,25 @@ function resolveGeorefLinearParams(georeference: DxfExportGeoreference): {
   // finite (1, 0) fallback rather than propagating NaN, consistent with
   // every other guard in this function (Scale, eastings, northings) always
   // preferring a finite fallback over an exact-parity NaN.
-  const rawAbscissa = finiteOr(mapConversion.xAxisAbscissa ?? 1, 1);
-  const rawOrdinate = finiteOr(mapConversion.xAxisOrdinate ?? 0, 0);
-  const axisLen = Math.hypot(rawAbscissa, rawOrdinate);
-  const abscissa = axisLen < 1e-9 ? 1 : rawAbscissa / axisLen;
-  const ordinate = axisLen < 1e-9 ? 0 : rawOrdinate / axisLen;
+  //
+  // PR #1965 review, round 2: a MIXED pair (one finite, one not -- e.g.
+  // XAxisAbscissa: NaN, XAxisOrdinate: 0.6) needs the SAME fallback as the
+  // both-non-finite case, not a half-fabricated one. The previous version
+  // ran `finiteOr` on each component independently BEFORE computing
+  // `axisLen`, substituting only the bad component to its identity default
+  // (1 or 0) and then normalizing that against the other, still-real
+  // component -- manufacturing a bogus rotation the file never authored
+  // (NaN, 0.6) silently became a real ~31° rotation instead of the (1, 0)
+  // no-rotation fallback. Checking finiteness of the RAW pair up front, and
+  // falling back to (1, 0) for the whole pair when either component fails,
+  // closes that: a malformed axis component discards the other component
+  // too, exactly like the near-zero-magnitude branch already does.
+  const rawAbscissa = mapConversion.xAxisAbscissa ?? 1;
+  const rawOrdinate = mapConversion.xAxisOrdinate ?? 0;
+  const axisIsFinite = Number.isFinite(rawAbscissa) && Number.isFinite(rawOrdinate);
+  const axisLen = axisIsFinite ? Math.hypot(rawAbscissa, rawOrdinate) : 0;
+  const abscissa = axisIsFinite && axisLen >= 1e-9 ? rawAbscissa / axisLen : 1;
+  const ordinate = axisIsFinite && axisLen >= 1e-9 ? rawOrdinate / axisLen : 0;
   // Guard eastings/northings against NaN/Infinity the same way the Scale
   // and axis guards above already do (issue #1965 review): a malformed
   // IfcMapConversion's `?? 0` in `mergeMapConversion` (effective-georef.ts)

--- a/apps/viewer/src/hooks/dxfExportGeoref.ts
+++ b/apps/viewer/src/hooks/dxfExportGeoref.ts
@@ -169,6 +169,18 @@ export function buildDxfExportTransform(params: DxfExportTransformParams): (p: P
 }
 
 /**
+ * `Number.isFinite(value) ? value : fallback` — the shape shared by the
+ * axis-component and eastings/northings NaN/Infinity guards below (PR #1965
+ * review). The *reason* each site needs guarding differs (a malformed
+ * `XAxisAbscissa`/`XAxisOrdinate` pair vs. a `mergeMapConversion` `?? 0`
+ * that stops most NaNs but not all) and stays documented at each call site;
+ * this only removes the repeated `Number.isFinite(x) ? x : y` boilerplate.
+ */
+function finiteOr(value: number, fallback: number): number {
+  return Number.isFinite(value) ? value : fallback;
+}
+
+/**
  * Shared scale/axis/map-unit resolution for both the forward
  * ({@link buildDxfExportTransform}) and inverse
  * ({@link buildDxfMapToWorldTransform}) georeference transforms — see the
@@ -195,12 +207,30 @@ function resolveGeorefLinearParams(georeference: DxfExportGeoreference): {
   // IfcMapConversion.XAxisAbscissa/XAxisOrdinate form a direction vector, not
   // necessarily unit length — the IFC spec allows an authoring tool to write
   // any non-zero (cos, sin)-proportional pair. Used raw, a non-unit vector
-  // scales the whole transform by its magnitude. Normalize exactly like the
-  // Rust source of truth (rust/core/src/georef.rs normalize_axis); a
-  // near-zero vector (both components ~0) falls back to the no-rotation
-  // default (1, 0), matching that function's guard.
-  const rawAbscissa = mapConversion.xAxisAbscissa ?? 1;
-  const rawOrdinate = mapConversion.xAxisOrdinate ?? 0;
+  // scales the whole transform by its magnitude. Normalize like the Rust
+  // source of truth (rust/core/src/georef.rs normalize_axis) for the
+  // general and near-zero cases: a near-zero vector (both components ~0)
+  // falls back to the no-rotation default (1, 0), matching that function's
+  // guard. NOT exact parity for non-finite input, though -- see below.
+  //
+  // PR #1965 review: `axisLen < 1e-9` alone only catches the near-zero
+  // MAGNITUDE case — `NaN < 1e-9` and `Infinity < 1e-9` are both `false`, so
+  // a non-finite component used to fall through to the divide branch and
+  // manufacture a NaN axis. `finiteOr` closes that before `Math.hypot` ever
+  // sees the raw values, same as the eastings/northings guard below.
+  //
+  // This is a DELIBERATE divergence from `normalize_axis`, not an oversight
+  // left over from the "exactly like Rust" framing above: `normalize_axis`
+  // tests `len > f64::EPSILON` (also false for NaN) but then *skips*
+  // normalization on the degenerate branch, leaving the raw (possibly NaN)
+  // value in place -- `local_to_map` would still consume that NaN as
+  // cos_r/sin_r. The TS side instead substitutes the no-rotation default
+  // BEFORE computing `axisLen`, so a non-finite component here produces a
+  // finite (1, 0) fallback rather than propagating NaN, consistent with
+  // every other guard in this function (Scale, eastings, northings) always
+  // preferring a finite fallback over an exact-parity NaN.
+  const rawAbscissa = finiteOr(mapConversion.xAxisAbscissa ?? 1, 1);
+  const rawOrdinate = finiteOr(mapConversion.xAxisOrdinate ?? 0, 0);
   const axisLen = Math.hypot(rawAbscissa, rawOrdinate);
   const abscissa = axisLen < 1e-9 ? 1 : rawAbscissa / axisLen;
   const ordinate = axisLen < 1e-9 ? 0 : rawOrdinate / axisLen;
@@ -215,8 +245,8 @@ function resolveGeorefLinearParams(georeference: DxfExportGeoreference): {
   // which then makes `dxfUnderlayDrawingBounds` return NaN bounds instead of
   // null, which then writes NaN into the stored `placement` via
   // `handleCenterDxfUnderlay` -- a corruption that outlives the toggle.
-  const eastings = Number.isFinite(mapConversion.eastings) ? mapConversion.eastings : 0;
-  const northings = Number.isFinite(mapConversion.northings) ? mapConversion.northings : 0;
+  const eastings = finiteOr(mapConversion.eastings, 0);
+  const northings = finiteOr(mapConversion.northings, 0);
   const safeMapConversion: MapConversion = (eastings === mapConversion.eastings && northings === mapConversion.northings)
     ? mapConversion
     : { ...mapConversion, eastings, northings };

--- a/apps/viewer/src/hooks/dxfExportGeoref.ts
+++ b/apps/viewer/src/hooks/dxfExportGeoref.ts
@@ -58,6 +58,35 @@
  * about e.g. the Scale=0 or degenerate-axis guards.
  */
 
+/**
+ * GUARD PHILOSOPHY, stated explicitly per PR #1965 review: this file
+ * (issue #1929) and `hooks/ingest/pointCloudAlignment.ts` (issue #1804)
+ * both implement the inverse of `rust/core/src/georef.rs`'s
+ * `local_to_map`/`map_to_local` -- now THREE independent TS/Rust copies of
+ * the same inverse (Rust, `pointCloudAlignment.ts`, and this file) -- but
+ * they diverge on what a malformed `IfcMapConversion` does to the caller:
+ *
+ *   - `pointCloudAlignment.ts`'s `invertMapConversion` /
+ *     `computePointCloudAlignment` return `null` on a degenerate axis or a
+ *     ~zero Scale, and the caller hides/disables the alignment toggle
+ *     entirely -- there is no un-alignable-but-still-on state.
+ *   - This file instead falls back: Scale=0 (or NaN/negative) becomes 1,
+ *     a degenerate axis becomes the no-rotation default (1, 0), and the
+ *     DXF underlay's "aligned" toggle still seeds on. See
+ *     `resolveGeorefLinearParams` below.
+ *
+ * Both are defensible for where they sit: a point cloud's alignment toggle
+ * has an obvious "off" state (raw coordinates, exactly the pre-#1804
+ * behaviour) so hiding it on failure costs nothing, whereas a DXF underlay
+ * has no equivalently safe fallback transform to fall back TO -- the
+ * points still need to land SOMEWHERE, and "some rotation" beats "no
+ * rendering at all" for a reference drawing the user can still nudge with
+ * the placement offset. This file and `pointCloudAlignment.ts` are each
+ * aware the other exists and chose differently on purpose; if you're
+ * touching either file's malformed-input handling, check the other one
+ * too before assuming your choice generalizes.
+ */
+
 import type { Point2D } from '@ifc-lite/drawing-2d';
 import type { GeometryResult } from '@ifc-lite/geometry';
 import type { MapConversion, ProjectedCRS } from '@ifc-lite/parser';
@@ -175,7 +204,23 @@ function resolveGeorefLinearParams(georeference: DxfExportGeoreference): {
   const axisLen = Math.hypot(rawAbscissa, rawOrdinate);
   const abscissa = axisLen < 1e-9 ? 1 : rawAbscissa / axisLen;
   const ordinate = axisLen < 1e-9 ? 0 : rawOrdinate / axisLen;
-  return { mapConversion, mapUnitScale, scale, abscissa, ordinate };
+  // Guard eastings/northings against NaN/Infinity the same way the Scale
+  // and axis guards above already do (issue #1965 review): a malformed
+  // IfcMapConversion's `?? 0` in `mergeMapConversion` (effective-georef.ts)
+  // already stops most NaNs before they get here, but this function is the
+  // single point both the forward (`buildDxfExportTransform`) and inverse
+  // (`buildDxfMapToWorldTransform`) transforms read `mapConversion` through,
+  // so guarding here closes the chain regardless of how `georeference` was
+  // built. Left un-guarded, a NaN eastings makes every underlay point NaN,
+  // which then makes `dxfUnderlayDrawingBounds` return NaN bounds instead of
+  // null, which then writes NaN into the stored `placement` via
+  // `handleCenterDxfUnderlay` -- a corruption that outlives the toggle.
+  const eastings = Number.isFinite(mapConversion.eastings) ? mapConversion.eastings : 0;
+  const northings = Number.isFinite(mapConversion.northings) ? mapConversion.northings : 0;
+  const safeMapConversion: MapConversion = (eastings === mapConversion.eastings && northings === mapConversion.northings)
+    ? mapConversion
+    : { ...mapConversion, eastings, northings };
+  return { mapConversion: safeMapConversion, mapUnitScale, scale, abscissa, ordinate };
 }
 
 /**

--- a/apps/viewer/src/hooks/dxfUnderlayMath.test.ts
+++ b/apps/viewer/src/hooks/dxfUnderlayMath.test.ts
@@ -89,4 +89,46 @@ describe('dxfUnderlayToDrawing', () => {
     const data = dxfUnderlayToDrawing(e, { x: 0, y: 0 }, false);
     assert.strictEqual(data.lines.length, 0);
   });
+
+  // issue #1929: a per-underlay toggle for DXFs authored in map/CRS
+  // coordinates rather than IFC world coordinates. `mapToWorld` must only
+  // be applied when the entry opts in — this is the regression guard for
+  // existing users whose DXFs already line up in IFC world coordinates.
+  const mapToWorld = (p: { x: number; y: number }): { x: number; y: number } => ({ x: p.x + 1000, y: p.y + 2000 });
+
+  it('applies mapToWorld before the world->drawing mapping when georeferenced is true', () => {
+    const e = entry();
+    e.georeferenced = true;
+    const data = dxfUnderlayToDrawing(e, { x: 0, y: 0 }, false, mapToWorld);
+    const [a] = data.lines[0].points;
+    // Raw point (0,0) -> mapToWorld -> (1000, 2000) -> drawing (x, -y).
+    close(a.x, 1000);
+    close(a.y, -2000);
+  });
+
+  it('does NOT apply mapToWorld when georeferenced is false, even if a transform is supplied (default-off regression guard)', () => {
+    const e = entry();
+    e.georeferenced = false;
+    const data = dxfUnderlayToDrawing(e, { x: 0, y: 0 }, false, mapToWorld);
+    const [a] = data.lines[0].points;
+    close(a.x, 0);
+    close(a.y, 0);
+  });
+
+  it('does NOT apply mapToWorld when georeferenced is omitted (pre-#1929 entries behave exactly as before)', () => {
+    const e = entry(); // e.georeferenced is undefined
+    const data = dxfUnderlayToDrawing(e, { x: 0, y: 0 }, false, mapToWorld);
+    const [a] = data.lines[0].points;
+    close(a.x, 0);
+    close(a.y, 0);
+  });
+
+  it('defaults mapToWorld itself to identity when the caller omits it, even for a georeferenced entry', () => {
+    const e = entry();
+    e.georeferenced = true;
+    const data = dxfUnderlayToDrawing(e, { x: 0, y: 0 }, false); // no 4th arg
+    const [a] = data.lines[0].points;
+    close(a.x, 0);
+    close(a.y, 0);
+  });
 });

--- a/apps/viewer/src/hooks/dxfUnderlayMath.test.ts
+++ b/apps/viewer/src/hooks/dxfUnderlayMath.test.ts
@@ -8,7 +8,7 @@
 
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
-import { dxfWorldShift, dxfUnderlayToDrawing } from './dxfUnderlayMath.js';
+import { dxfWorldShift, dxfUnderlayToDrawing, dxfUnderlayDrawingBounds, resolveEffectiveGeoreferenced } from './dxfUnderlayMath.js';
 import type { DxfUnderlayState } from '@/store/slices/drawing2DSlice';
 
 const close = (a: number, b: number, eps = 1e-9) =>
@@ -130,5 +130,159 @@ describe('dxfUnderlayToDrawing', () => {
     const [a] = data.lines[0].points;
     close(a.x, 0);
     close(a.y, 0);
+  });
+
+  // PR #1965 review, item 3: all four gate tests above use shift={0,0} and
+  // a pure-translation mock, both of which COMMUTE with the shift
+  // subtraction -- so they can't tell "apply mapToWorld, then subtract
+  // shift" (correct) apart from "subtract shift, then apply mapToWorld"
+  // (wrong by |R*shift - shift|, which is kilometres for a rotated georef
+  // at RTC magnitude). A nonzero shift + a rotating, non-commuting mock
+  // closes that gap.
+  describe('mapToWorld/shift ordering (PR #1965 review, item 3)', () => {
+    // 90-degree rotation: (x, y) -> (y, -x). Does NOT commute with
+    // translation, unlike the pure-translation mock above.
+    const rotate = (p: { x: number; y: number }): { x: number; y: number } => ({ x: p.y, y: -p.x });
+    const shift = { x: 100, y: 50 };
+
+    it('applies mapToWorld BEFORE the shift subtraction (mirrorX false)', () => {
+      const e = entry();
+      e.georeferenced = true;
+      const data = dxfUnderlayToDrawing(e, shift, false, rotate);
+      const [a, b] = data.lines[0].points;
+      // world = rotate(0,0) = (0,0); x = 0-100 = -100; y = -(0-50) = 50.
+      close(a.x, -100);
+      close(a.y, 50);
+      // world = rotate(10,20) = (20,-10); x = 20-100 = -80; y = -(-10-50) = 60.
+      close(b.x, -80);
+      close(b.y, 60);
+    });
+
+    it('applies mapToWorld BEFORE the shift subtraction (mirrorX true)', () => {
+      const e = entry();
+      e.georeferenced = true;
+      const data = dxfUnderlayToDrawing(e, shift, true, rotate);
+      const [a, b] = data.lines[0].points;
+      close(a.x, 100);
+      close(a.y, 50);
+      close(b.x, 80);
+      close(b.y, 60);
+    });
+  });
+});
+
+describe('resolveEffectiveGeoreferenced (PR #1965 review, tri-state georeferenced field)', () => {
+  it('explicit true always wins, regardless of availability', () => {
+    assert.strictEqual(resolveEffectiveGeoreferenced({ georeferenced: true }, false), true);
+    assert.strictEqual(resolveEffectiveGeoreferenced({ georeferenced: true }, true), true);
+  });
+
+  it('explicit false always wins, regardless of availability', () => {
+    assert.strictEqual(resolveEffectiveGeoreferenced({ georeferenced: false }, true), false);
+    assert.strictEqual(resolveEffectiveGeoreferenced({ georeferenced: false }, false), false);
+  });
+
+  it('undefined ("auto") follows availability', () => {
+    assert.strictEqual(resolveEffectiveGeoreferenced({ georeferenced: undefined }, true), true);
+    assert.strictEqual(resolveEffectiveGeoreferenced({ georeferenced: undefined }, false), false);
+  });
+});
+
+describe('dxfUnderlayToDrawing auto-mode (PR #1965 review: closes the import-time race)', () => {
+  const entry = (placement: Partial<DxfUnderlayState['placement']> = {}): DxfUnderlayState => ({
+    id: 'u1',
+    name: 'test.dxf',
+    visible: true,
+    opacity: 1,
+    layerVisibility: {},
+    placement: { offsetX: 0, offsetY: 0, rotationDeg: 0, scale: 1, ...placement },
+    underlay: {
+      name: 'test.dxf',
+      unitScale: 1,
+      skipped: {},
+      warnings: [],
+      bounds: { min: { x: 0, y: 0 }, max: { x: 10, y: 10 } },
+      layers: [
+        {
+          name: 'L',
+          color: '#000000',
+          visible: true,
+          fills: [],
+          texts: [],
+          paths: [{ points: [{ x: 0, y: 0 }, { x: 10, y: 20 }], closed: false }],
+        },
+      ],
+    },
+  });
+  const mapToWorld = (p: { x: number; y: number }): { x: number; y: number } => ({ x: p.x + 1000, y: p.y + 2000 });
+
+  it('an auto entry (georeferenced omitted) follows the anchor once one becomes available', () => {
+    const e = entry(); // e.georeferenced is undefined ("auto")
+    const data = dxfUnderlayToDrawing(e, { x: 0, y: 0 }, false, mapToWorld, /* georeferenceAvailable */ true);
+    const [a] = data.lines[0].points;
+    close(a.x, 1000);
+    close(a.y, -2000);
+  });
+
+  it('an auto entry stays off while no anchor georeference resolves (the pre-#1929, pre-existing-entry-safe default)', () => {
+    const e = entry();
+    const data = dxfUnderlayToDrawing(e, { x: 0, y: 0 }, false, mapToWorld, /* georeferenceAvailable */ false);
+    const [a] = data.lines[0].points;
+    close(a.x, 0);
+    close(a.y, 0);
+  });
+
+  it('an entry the user explicitly turned OFF stays off even when an anchor georeference is available', () => {
+    const e = entry();
+    e.georeferenced = false;
+    const data = dxfUnderlayToDrawing(e, { x: 0, y: 0 }, false, mapToWorld, /* georeferenceAvailable */ true);
+    const [a] = data.lines[0].points;
+    close(a.x, 0);
+    close(a.y, 0);
+  });
+
+  it('an entry the user explicitly turned ON stays on even when no anchor georeference resolves', () => {
+    const e = entry();
+    e.georeferenced = true;
+    const data = dxfUnderlayToDrawing(e, { x: 0, y: 0 }, false, mapToWorld, /* georeferenceAvailable */ false);
+    const [a] = data.lines[0].points;
+    close(a.x, 1000);
+    close(a.y, -2000);
+  });
+});
+
+describe('dxfUnderlayDrawingBounds (PR #1965 review: NaN bounds must become null)', () => {
+  const entry = (): DxfUnderlayState => ({
+    id: 'u1',
+    name: 'test.dxf',
+    visible: true,
+    opacity: 1,
+    layerVisibility: {},
+    placement: { offsetX: 0, offsetY: 0, rotationDeg: 0, scale: 1 },
+    underlay: {
+      name: 'test.dxf',
+      unitScale: 1,
+      skipped: {},
+      warnings: [],
+      bounds: { min: { x: 0, y: 0 }, max: { x: 10, y: 10 } },
+      layers: [],
+    },
+  });
+
+  it('returns finite bounds for a well-formed mapToWorld', () => {
+    const e = entry();
+    e.georeferenced = true;
+    const bounds = dxfUnderlayDrawingBounds(e, { x: 0, y: 0 }, false, (p) => ({ x: p.x + 5, y: p.y + 5 }));
+    assert.ok(bounds);
+    close(bounds!.min.x, 5);
+    close(bounds!.min.y, -15);
+  });
+
+  it('returns null (not NaN bounds) when mapToWorld yields a non-finite point — e.g. a malformed IfcMapConversion.Eastings=NaN reaching the chain', () => {
+    const e = entry();
+    e.georeferenced = true;
+    const nanTransform = (p: { x: number; y: number }): { x: number; y: number } => ({ x: p.x + NaN, y: p.y });
+    const bounds = dxfUnderlayDrawingBounds(e, { x: 0, y: 0 }, false, nanTransform);
+    assert.strictEqual(bounds, null);
   });
 });

--- a/apps/viewer/src/hooks/dxfUnderlayMath.test.ts
+++ b/apps/viewer/src/hooks/dxfUnderlayMath.test.ts
@@ -169,6 +169,47 @@ describe('dxfUnderlayToDrawing', () => {
       close(b.y, 60);
     });
   });
+
+  // PR #1965 review, item 2 (Codex): a non-unit IfcMapConversion.Scale
+  // uniformly scales every mapped line/fill point via `mapToWorld`, but
+  // text height used to be computed from `entry.placement.scale` alone --
+  // skipping the map transform's own scale factor entirely. A mock
+  // `mapToWorld` that scales map-space by 2x (e.g. Scale=0.5, since the
+  // inverse transform divides by Scale) makes that omission visible: the
+  // text height must scale by the same 2x the geometry does.
+  describe('text height follows the mapToWorld scale (PR #1965 review, item 2)', () => {
+    const scaledMapToWorld = (p: { x: number; y: number }): { x: number; y: number } => ({ x: p.x * 2, y: p.y * 2 });
+
+    const entryWithText = (): DxfUnderlayState => {
+      const e = entry();
+      e.underlay.layers[0].texts = [
+        { position: { x: 1, y: 1 }, dirX: 1, dirY: 0, height: 3, text: 'LABEL', align: 'left', valign: 'baseline' },
+      ];
+      return e;
+    };
+
+    it('scales text height by the mapToWorld factor when georeferenced', () => {
+      const e = entryWithText();
+      e.georeferenced = true;
+      const data = dxfUnderlayToDrawing(e, { x: 0, y: 0 }, false, scaledMapToWorld);
+      close(data.texts[0].height, 3 * 2); // placement.scale (1) * mapToWorld scale (2)
+    });
+
+    it('leaves text height at placement.scale alone when NOT georeferenced, even with a scaling transform supplied', () => {
+      const e = entryWithText();
+      e.georeferenced = false;
+      const data = dxfUnderlayToDrawing(e, { x: 0, y: 0 }, false, scaledMapToWorld);
+      close(data.texts[0].height, 3);
+    });
+
+    it('composes with a non-1 placement.scale', () => {
+      const e = entryWithText();
+      e.georeferenced = true;
+      e.placement.scale = 5;
+      const data = dxfUnderlayToDrawing(e, { x: 0, y: 0 }, false, scaledMapToWorld);
+      close(data.texts[0].height, 3 * 5 * 2);
+    });
+  });
 });
 
 describe('resolveEffectiveGeoreferenced (PR #1965 review, tri-state georeferenced field)', () => {

--- a/apps/viewer/src/hooks/dxfUnderlayMath.ts
+++ b/apps/viewer/src/hooks/dxfUnderlayMath.ts
@@ -121,6 +121,30 @@ function worldToDrawing(p: Point2D, t: WorldToDrawingParams): Point2D {
 }
 
 /**
+ * Magnitude of the linear part of `mapToWorld` (issue #1965 review, item
+ * 2): the inverse IfcMapConversion is `translate` then `rotate+scale`
+ * (`buildDxfMapToWorldTransform`'s (abscissa,ordinate) matrix is
+ * orthonormal, divided by `Scale`), so the distance between the images of
+ * any two map-space points 1 unit apart IS that transform's uniform scale
+ * factor -- translation cancels out of the difference, and rotation
+ * doesn't change vector length. Sampling two points, rather than
+ * threading `resolveGeorefLinearParams`'s internals through, keeps this
+ * module free of a dependency on `dxfExportGeoref.ts`'s IfcMapConversion
+ * types -- the caller already has `mapToWorld` as an opaque function for
+ * exactly this reason. Text height needs this because, unlike line/fill
+ * points, it is carried as a scalar (world-space glyph size) rather than
+ * a pair of points the transform can act on directly -- the paths/fills
+ * above are correctly scaled because `worldToDrawing` applies
+ * `mapToWorld` to every point, but the text height line below used to
+ * apply only `entry.placement.scale`, silently skipping this factor.
+ */
+function mapToWorldScale(mapToWorld: (p: Point2D) => Point2D): number {
+  const origin = mapToWorld({ x: 0, y: 0 });
+  const unit = mapToWorld({ x: 1, y: 0 });
+  return Math.hypot(unit.x - origin.x, unit.y - origin.y);
+}
+
+/**
  * IFC-frame XY shift the render frame subtracts from world coordinates.
  * Per the canonical pipeline (reproject.ts computeModelCenterInIfcMeters):
  * `world_yup = render + originShift + rtc_as_yup`, so BOTH offsets combine.
@@ -184,6 +208,12 @@ export function dxfUnderlayToDrawing(
   const lines: DxfUnderlayRenderLine[] = [];
   const fills: DxfUnderlayRenderFill[] = [];
   const texts: DxfUnderlayRenderText[] = [];
+  // Same uniform factor `worldToDrawing` applies to every line/fill point
+  // via `t.mapToWorld`, but text height is a scalar, not a point pair --
+  // see `mapToWorldScale`'s docstring. `t.mapToWorld` is already gated on
+  // the entry's effective georeferenced state, so this is 1 exactly when
+  // paths/fills aren't map-transformed either.
+  const textMapScale = t.mapToWorld ? mapToWorldScale(t.mapToWorld) : 1;
 
   for (const layer of entry.underlay.layers) {
     if (!(entry.layerVisibility[layer.name] ?? layer.visible)) continue;
@@ -217,7 +247,7 @@ export function dxfUnderlayToDrawing(
         y: anchor.y,
         dirX: tip.x - anchor.x,
         dirY: tip.y - anchor.y,
-        height: text.height * entry.placement.scale,
+        height: text.height * entry.placement.scale * textMapScale,
         text: text.text,
         color: text.color ?? layer.color,
         align: text.align,

--- a/apps/viewer/src/hooks/dxfUnderlayMath.ts
+++ b/apps/viewer/src/hooks/dxfUnderlayMath.ts
@@ -16,16 +16,36 @@
  *
  * Issue #1929 challenges the "already in world coordinates" assumption: a
  * surveyor's DXF is typically drawn in map/CRS coordinates (eastings,
- * northings), not the IFC model's local frame. When a per-underlay entry
- * has `georeferenced: true`, the underlay's raw coordinates are first
- * passed through a caller-supplied `mapToWorld` transform — the inverse
- * IfcMapConversion, built by `dxfExportGeoref.ts`'s
+ * northings), not the IFC model's local frame. When a per-underlay entry's
+ * EFFECTIVE `georeferenced` state is true, the underlay's raw coordinates
+ * are first passed through a caller-supplied `mapToWorld` transform — the
+ * inverse IfcMapConversion, built by `dxfExportGeoref.ts`'s
  * `buildDxfMapToWorldTransform` — before the world→drawing mapping below
- * runs. `mapToWorld` defaults to the identity function and `georeferenced`
- * defaults to falsy, so an underlay entry that predates this issue (or a
- * test fixture that never sets the field) behaves EXACTLY as before:
- * existing users' DXFs that already line up in IFC world coordinates are
- * not moved by this change.
+ * runs.
+ *
+ * `entry.georeferenced` is TRI-STATE (PR #1965 review, closing an import
+ * race — see `dxfIngest.ts`'s module doc for the full race description):
+ *   - `true` / `false`: explicit, only ever written by the user flipping
+ *     the "Align to model georeference" checkbox
+ *     (`setDxfUnderlayGeoreferenced`). Always wins regardless of anchor
+ *     availability.
+ *   - `undefined` ("auto"): follow anchor georeference availability,
+ *     resolved HERE at render/call time via the `georeferenceAvailable`
+ *     parameter — not baked in at import time. `resolveEffectiveGeoreferenced`
+ *     below is the single place that resolves the tri-state.
+ * `addDxfUnderlay` (drawing2DSlice.ts) defaults an entry's `georeferenced`
+ * to `false`, NOT auto, unless the caller explicitly opts into `'auto'` —
+ * so anything constructing an entry outside the DXF-ingest feature
+ * (including a hypothetical future load/migration path for entries that
+ * predate this issue) is conservative by construction: it never starts
+ * following the anchor's georeference on its own. Only `ingestDxfFile`
+ * opts a freshly-imported entry into `'auto'`. That is how "created before
+ * this feature existed" (`false`) stays distinct from "created by this
+ * feature in auto mode" (`undefined`) even though both currently apply the
+ * SAME identity transform the instant a session starts with no anchor
+ * georeference loaded — the difference only shows up once a georeferenced
+ * model appears, at which point auto entries follow it and explicit-`false`
+ * entries do not, by design.
  */
 
 import { applyDxfPlacement, type DxfPlacement, type Point2D } from '@ifc-lite/drawing-2d';
@@ -117,25 +137,49 @@ export function dxfWorldShift(coordinateInfo: GeometryResult['coordinateInfo'] |
 }
 
 /**
+ * Resolve an underlay entry's TRI-STATE `georeferenced` field to the actual
+ * boolean the world→drawing mapping applies (PR #1965 review). `true` /
+ * `false` are explicit (the user toggled the checkbox) and always win;
+ * `undefined` ("auto") follows whether the caller currently has an anchor
+ * `mapToWorld` transform available (`georeferenceAvailable` — see
+ * `useDxfMapToWorldTransform`'s `available` flag). Shared by
+ * `dxfUnderlayToDrawing`, `dxfUnderlayDrawingBounds`, and the underlay
+ * panel checkbox (`DxfUnderlayPanel.tsx`) so all three can never disagree
+ * about what "on" currently means for an auto entry.
+ */
+export function resolveEffectiveGeoreferenced(
+  entry: Pick<DxfUnderlayState, 'georeferenced'>,
+  georeferenceAvailable: boolean,
+): boolean {
+  return entry.georeferenced ?? georeferenceAvailable;
+}
+
+/**
  * Map one underlay entry to drawing space, honouring layer visibility.
  *
  * `mapToWorld` (issue #1929) is the resolved inverse-IfcMapConversion
  * transform (or identity, when unavailable); it is only actually applied
- * when `entry.georeferenced` is true, so callers can pass the same
- * transform for every underlay regardless of each one's toggle state.
+ * when the entry's EFFECTIVE georeferenced state
+ * ({@link resolveEffectiveGeoreferenced}) is true, so callers can pass the
+ * same transform for every underlay regardless of each one's toggle state.
+ * `georeferenceAvailable` defaults to `false` so an omitted 5th argument
+ * reproduces the pre-tri-state behaviour exactly (an `undefined`-flagged
+ * entry stays off) — existing callers/tests that only ever set
+ * `entry.georeferenced` explicitly are unaffected.
  */
 export function dxfUnderlayToDrawing(
   entry: DxfUnderlayState,
   shift: { x: number; y: number },
   mirrorX: boolean,
   mapToWorld: (p: Point2D) => Point2D = (p) => p,
+  georeferenceAvailable = false,
 ): DxfUnderlayRenderData {
   const t: WorldToDrawingParams = {
     shiftX: shift.x,
     shiftY: shift.y,
     mirrorX,
     placement: entry.placement,
-    mapToWorld: entry.georeferenced ? mapToWorld : undefined,
+    mapToWorld: resolveEffectiveGeoreferenced(entry, georeferenceAvailable) ? mapToWorld : undefined,
   };
   const lines: DxfUnderlayRenderLine[] = [];
   const fills: DxfUnderlayRenderFill[] = [];
@@ -184,12 +228,27 @@ export function dxfUnderlayToDrawing(
   return { id: entry.id, opacity: entry.opacity, lines, fills, texts };
 }
 
-/** Drawing-space bounds of an underlay at zero offset (for centre-on-model). */
+/**
+ * Drawing-space bounds of an underlay at zero offset (for centre-on-model).
+ * `georeferenceAvailable` — see {@link resolveEffectiveGeoreferenced} —
+ * defaults to `false` for the same backward-compat reason as
+ * {@link dxfUnderlayToDrawing}.
+ *
+ * Returns `null` (not NaN bounds) whenever any corner is non-finite (PR
+ * #1965 review): a malformed `IfcMapConversion` that slips a NaN into
+ * `mapToWorld` used to make `Math.min`/`Math.max` return NaN silently, and
+ * the caller (`Section2DPanel.handleCenterDxfUnderlay`) would then write
+ * `offsetX: NaN, offsetY: NaN` straight into the stored placement — a
+ * corruption that survives even toggling georeferencing back off, since the
+ * NaN is now IN the placement, not just in the transform. A NaN bound is a
+ * lie about the data; null says "can't centre this" instead, which is true.
+ */
 export function dxfUnderlayDrawingBounds(
   entry: DxfUnderlayState,
   shift: { x: number; y: number },
   mirrorX: boolean,
   mapToWorld: (p: Point2D) => Point2D = (p) => p,
+  georeferenceAvailable = false,
 ): { min: Point2D; max: Point2D } | null {
   const b = entry.underlay.bounds;
   if (!b) return null;
@@ -198,7 +257,7 @@ export function dxfUnderlayDrawingBounds(
     shiftY: shift.y,
     mirrorX,
     placement: { ...entry.placement, offsetX: 0, offsetY: 0 },
-    mapToWorld: entry.georeferenced ? mapToWorld : undefined,
+    mapToWorld: resolveEffectiveGeoreferenced(entry, georeferenceAvailable) ? mapToWorld : undefined,
   };
   // Rotation in the placement makes axis-aligned min/max insufficient:
   // map all four corners.
@@ -208,9 +267,11 @@ export function dxfUnderlayDrawingBounds(
     worldToDrawing({ x: b.max.x, y: b.max.y }, t),
     worldToDrawing({ x: b.min.x, y: b.max.y }, t),
   ];
-  return {
-    min: { x: Math.min(...corners.map((c) => c.x)), y: Math.min(...corners.map((c) => c.y)) },
-    max: { x: Math.max(...corners.map((c) => c.x)), y: Math.max(...corners.map((c) => c.y)) },
-  };
+  const minX = Math.min(...corners.map((c) => c.x));
+  const minY = Math.min(...corners.map((c) => c.y));
+  const maxX = Math.max(...corners.map((c) => c.x));
+  const maxY = Math.max(...corners.map((c) => c.y));
+  if (![minX, minY, maxX, maxY].every(Number.isFinite)) return null;
+  return { min: { x: minX, y: minY }, max: { x: maxX, y: maxY } };
 }
 

--- a/apps/viewer/src/hooks/dxfUnderlayMath.ts
+++ b/apps/viewer/src/hooks/dxfUnderlayMath.ts
@@ -5,14 +5,27 @@
 /**
  * DXF underlay → 2D drawing space, pure mapping math (issue #1782).
  *
- * Converted DXF underlays are in world plan coordinates (metres, IFC XY —
- * DXF and IFC are both Z-up). The 2D drawing pipeline works in the render
- * frame: RTC/origin-shifted, projected via `projectTo2D` (plan:
- * `x_d = worldX`, `y_d = -worldY_ifc`), with a flipped section mirroring
- * X. These helpers apply that mapping, then the per-underlay placement
- * (offset/rotation/scale in drawing space), and filter by layer
- * visibility. Kept free of React/store imports so they are unit-testable;
- * the `useDxfUnderlaysForDrawing` hook wraps them.
+ * Converted DXF underlays are, BY DEFAULT, assumed to already be in world
+ * plan coordinates (metres, IFC XY — DXF and IFC are both Z-up). The 2D
+ * drawing pipeline works in the render frame: RTC/origin-shifted, projected
+ * via `projectTo2D` (plan: `x_d = worldX`, `y_d = -worldY_ifc`), with a
+ * flipped section mirroring X. These helpers apply that mapping, then the
+ * per-underlay placement (offset/rotation/scale in drawing space), and
+ * filter by layer visibility. Kept free of React/store imports so they are
+ * unit-testable; the `useDxfUnderlaysForDrawing` hook wraps them.
+ *
+ * Issue #1929 challenges the "already in world coordinates" assumption: a
+ * surveyor's DXF is typically drawn in map/CRS coordinates (eastings,
+ * northings), not the IFC model's local frame. When a per-underlay entry
+ * has `georeferenced: true`, the underlay's raw coordinates are first
+ * passed through a caller-supplied `mapToWorld` transform — the inverse
+ * IfcMapConversion, built by `dxfExportGeoref.ts`'s
+ * `buildDxfMapToWorldTransform` — before the world→drawing mapping below
+ * runs. `mapToWorld` defaults to the identity function and `georeferenced`
+ * defaults to falsy, so an underlay entry that predates this issue (or a
+ * test fixture that never sets the field) behaves EXACTLY as before:
+ * existing users' DXFs that already line up in IFC world coordinates are
+ * not moved by this change.
  */
 
 import { applyDxfPlacement, type DxfPlacement, type Point2D } from '@ifc-lite/drawing-2d';
@@ -63,17 +76,26 @@ interface WorldToDrawingParams {
   shiftY: number;
   mirrorX: boolean;
   placement: DxfPlacement;
+  /**
+   * Map/CRS-space → IFC-world-space transform, applied BEFORE the
+   * render-frame shift below (issue #1929). `undefined` when the entry
+   * isn't georeferenced (or no anchor georeference is available) — the
+   * point is used as-is, exactly like before this issue.
+   */
+  mapToWorld?: (p: Point2D) => Point2D;
 }
 
 function worldToDrawing(p: Point2D, t: WorldToDrawingParams): Point2D {
-  // World → plan drawing space (render-frame shift + y-flip), then the
-  // flipped-section mirror, then the user placement. Mirror-before-
-  // placement keeps the placement offset in final drawing space, so
-  // centre-on-model and the offset fields behave the same on flipped
-  // sections.
-  const x = p.x - t.shiftX;
+  // Map/CRS → IFC world (issue #1929), only for underlays flagged
+  // georeferenced. Then: world → plan drawing space (render-frame shift +
+  // y-flip), then the flipped-section mirror, then the user placement.
+  // Mirror-before-placement keeps the placement offset in final drawing
+  // space, so centre-on-model and the offset fields behave the same on
+  // flipped sections.
+  const world = t.mapToWorld ? t.mapToWorld(p) : p;
+  const x = world.x - t.shiftX;
   return applyDxfPlacement(
-    { x: t.mirrorX ? -x : x, y: -(p.y - t.shiftY) },
+    { x: t.mirrorX ? -x : x, y: -(world.y - t.shiftY) },
     t.placement,
   );
 }
@@ -94,17 +116,26 @@ export function dxfWorldShift(coordinateInfo: GeometryResult['coordinateInfo'] |
   };
 }
 
-/** Map one underlay entry to drawing space, honouring layer visibility. */
+/**
+ * Map one underlay entry to drawing space, honouring layer visibility.
+ *
+ * `mapToWorld` (issue #1929) is the resolved inverse-IfcMapConversion
+ * transform (or identity, when unavailable); it is only actually applied
+ * when `entry.georeferenced` is true, so callers can pass the same
+ * transform for every underlay regardless of each one's toggle state.
+ */
 export function dxfUnderlayToDrawing(
   entry: DxfUnderlayState,
   shift: { x: number; y: number },
   mirrorX: boolean,
+  mapToWorld: (p: Point2D) => Point2D = (p) => p,
 ): DxfUnderlayRenderData {
   const t: WorldToDrawingParams = {
     shiftX: shift.x,
     shiftY: shift.y,
     mirrorX,
     placement: entry.placement,
+    mapToWorld: entry.georeferenced ? mapToWorld : undefined,
   };
   const lines: DxfUnderlayRenderLine[] = [];
   const fills: DxfUnderlayRenderFill[] = [];
@@ -158,6 +189,7 @@ export function dxfUnderlayDrawingBounds(
   entry: DxfUnderlayState,
   shift: { x: number; y: number },
   mirrorX: boolean,
+  mapToWorld: (p: Point2D) => Point2D = (p) => p,
 ): { min: Point2D; max: Point2D } | null {
   const b = entry.underlay.bounds;
   if (!b) return null;
@@ -166,6 +198,7 @@ export function dxfUnderlayDrawingBounds(
     shiftY: shift.y,
     mirrorX,
     placement: { ...entry.placement, offsetX: 0, offsetY: 0 },
+    mapToWorld: entry.georeferenced ? mapToWorld : undefined,
   };
   // Rotation in the placement makes axis-aligned min/max insufficient:
   // map all four corners.

--- a/apps/viewer/src/hooks/ingest/dxfIngest.test.ts
+++ b/apps/viewer/src/hooks/ingest/dxfIngest.test.ts
@@ -1,0 +1,180 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * DXF ingest race + tri-state seeding (PR #1965 review, item 1).
+ *
+ * Reproduces the reporter's ACTUAL workflow: `ViewportContainer.handleDrop`
+ * splits DXFs off first and fires `ingestDxfFiles` concurrently with model
+ * loading (see `dxfIngest.ts`'s module doc) -- so a combined `model.ifc` +
+ * `survey.dxf` drop used to ingest the DXF, resolve no georeference yet,
+ * and seed the "aligned" toggle permanently OFF. This test drives
+ * `ingestDxfFile` with NO model loaded (the race's exact state), then
+ * simulates the model finishing loading afterwards, and checks that the
+ * underlay's EFFECTIVE alignment -- resolved the same way
+ * `useDxfMapToWorldTransform` + `dxfUnderlayToDrawing` resolve it at
+ * render time -- follows the model without any user action. A second
+ * entry seeded the pre-#1929 way (explicit `false`, simulating an entry
+ * that predates this feature) must NOT move under the identical sequence.
+ */
+
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert';
+import { IfcParser } from '@ifc-lite/parser';
+import { useViewerStore } from '@/store';
+import { resolveDxfExportGeoreference } from '@/hooks/dxfExportGeoref';
+import { resolveEffectiveGeoreferenced } from '@/hooks/dxfUnderlayMath';
+import { ingestDxfFile } from './dxfIngest.js';
+
+// Same minimal georeferenced fixture shape as dxfExportGeoref.test.ts's
+// GEOREF_FIXTURE (EPSG:2056, no rotation).
+const GEOREF_FIXTURE = `ISO-10303-21;
+HEADER;
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('Proj0000000000000000001',$,'P',$,$,$,$,(#10),#20);
+#10=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.E-5,#11,$);
+#11=IFCAXIS2PLACEMENT3D(#12,$,$);
+#12=IFCCARTESIANPOINT((0.,0.,0.));
+#20=IFCUNITASSIGNMENT((#21));
+#21=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+#30=IFCPROJECTEDCRS('EPSG:2056','CH1903+ / LV95','CH1903+','LN02',$,$,#21);
+#31=IFCMAPCONVERSION(#10,#30,2600000.,1200000.,400.,1.,0.,1.);
+ENDSEC;
+END-ISO-10303-21;
+`;
+
+async function parseGeorefStore() {
+  const bytes = new TextEncoder().encode(GEOREF_FIXTURE);
+  return new IfcParser().parseColumnar(bytes.buffer as ArrayBuffer, { disableWorkerScan: true });
+}
+
+/** Small (<5000-unit extent) DXF so the "assumed millimetres" heuristic never fires. */
+function makeDxfFile(name = 'survey.dxf'): File {
+  const text = [
+    '0', 'SECTION',
+    '2', 'ENTITIES',
+    '0', 'LINE',
+    '8', 'walls',
+    '10', '0',
+    '20', '0',
+    '11', '4',
+    '21', '6',
+    '0', 'ENDSEC',
+    '0', 'EOF',
+    '',
+  ].join('\n');
+  return new File([text], name, { type: 'application/dxf' });
+}
+
+/** Large (>5000-unit extent), unitless DXF -- triggers `importDxf`'s "assumed
+ *  millimetres" heuristic (`@ifc-lite/drawing-2d`'s `UNITLESS_MM_EXTENT_THRESHOLD`). */
+function makeUnitlessLargeDxfFile(name = 'unitless-survey.dxf'): File {
+  const text = [
+    '0', 'SECTION',
+    '2', 'ENTITIES',
+    '0', 'LINE',
+    '8', 'walls',
+    '10', '0',
+    '20', '0',
+    '11', '6000',
+    '21', '6000',
+    '0', 'ENDSEC',
+    '0', 'EOF',
+    '',
+  ].join('\n');
+  return new File([text], name, { type: 'application/dxf' });
+}
+
+/** Resolve an entry's effective alignment exactly the way the render path does
+ *  (`useDxfMapToWorldTransform` + `resolveEffectiveGeoreferenced`), without needing React. */
+function effectivelyAligned(georeferencedField: boolean | undefined): boolean {
+  const state = useViewerStore.getState();
+  const georeference = resolveDxfExportGeoreference({
+    models: state.models,
+    legacyDataStore: state.ifcDataStore,
+    anchorModelIdOverride: state.anchorModelIdOverride,
+    georefMutations: state.georefMutations,
+  });
+  return resolveEffectiveGeoreferenced({ georeferenced: georeferencedField }, georeference !== null);
+}
+
+describe('ingestDxfFile tri-state race (PR #1965 review, item 1)', () => {
+  beforeEach(() => {
+    useViewerStore.getState().resetViewerState();
+    useViewerStore.getState().clearDxfUnderlays();
+  });
+
+  it('a DXF ingested with no model loaded seeds "auto", then aligns once a georeferenced model loads -- no user action', async () => {
+    // Reproduces the race: DXF ingest runs while `store.ifcDataStore` is
+    // still null (the model hasn't finished loading).
+    assert.strictEqual(useViewerStore.getState().ifcDataStore, null);
+    await ingestDxfFile(makeDxfFile());
+
+    const entries = useViewerStore.getState().dxfUnderlays;
+    assert.strictEqual(entries.length, 1);
+    const autoEntry = entries[0];
+    assert.strictEqual(autoEntry.georeferenced, undefined, 'seeded to auto, not baked-in false');
+
+    // Not aligned yet -- no georeference is available.
+    assert.strictEqual(effectivelyAligned(autoEntry.georeferenced), false);
+
+    // The model finishes loading (the other half of the race).
+    useViewerStore.setState({ ifcDataStore: await parseGeorefStore() });
+
+    // The SAME entry, un-touched by the user, now resolves aligned.
+    assert.strictEqual(effectivelyAligned(autoEntry.georeferenced), true);
+  });
+
+  it('an entry that predates this feature (explicit georeferenced: false) does NOT move under the identical sequence', async () => {
+    // First produce a real parsed DxfUnderlay via the actual import path...
+    await ingestDxfFile(makeDxfFile('legacy.dxf'));
+    const parsedUnderlay = useViewerStore.getState().dxfUnderlays[0]!.underlay;
+    useViewerStore.getState().clearDxfUnderlays();
+
+    // ...then register it the way any call site that does NOT explicitly
+    // request 'auto' would -- this is what a pre-#1929 entry (or a future
+    // load/migration path for one) looks like: explicit `false`, never
+    // reachable to auto-follow the anchor.
+    const preExistingId = useViewerStore.getState().addDxfUnderlay(parsedUnderlay, { georeferenced: false });
+    const preExisting = useViewerStore.getState().dxfUnderlays.find((u) => u.id === preExistingId)!;
+    assert.strictEqual(preExisting.georeferenced, false);
+
+    assert.strictEqual(effectivelyAligned(preExisting.georeferenced), false);
+
+    useViewerStore.setState({ ifcDataStore: await parseGeorefStore() });
+
+    // Still off -- a pre-existing entry must never start following the
+    // anchor on its own, even once one becomes available.
+    assert.strictEqual(effectivelyAligned(preExisting.georeferenced), false);
+  });
+
+  // PR #1965 review, item 6: a unitless DXF whose extent forced the
+  // "assumed millimetres" heuristic cannot also be safely auto-georeferenced
+  // -- the divide-by-1000 and the inverse map-conversion subtraction (which
+  // subtracts FULL eastings/northings) compound into a placement millions
+  // of metres off. Seeding must suppress 'auto' in that case even when a
+  // georeferenced model is already loaded.
+  it('suppresses auto-georeference seeding when the "assumed millimetres" heuristic fired, even with a georeferenced model already loaded', async () => {
+    useViewerStore.setState({ ifcDataStore: await parseGeorefStore() });
+    assert.notStrictEqual(resolveDxfExportGeoreference({
+      models: useViewerStore.getState().models,
+      legacyDataStore: useViewerStore.getState().ifcDataStore,
+      anchorModelIdOverride: useViewerStore.getState().anchorModelIdOverride,
+      georefMutations: useViewerStore.getState().georefMutations,
+    }), null, 'sanity: a georeference IS available for this test');
+
+    await ingestDxfFile(makeUnitlessLargeDxfFile());
+
+    const entry = useViewerStore.getState().dxfUnderlays[0]!;
+    assert.ok(
+      entry.underlay.warnings.some((w) => w.includes('assumed millimetres')),
+      'sanity: the mm-assumption heuristic actually fired',
+    );
+    // Explicit false, NOT 'auto' -- even though a georeference is available.
+    assert.strictEqual(entry.georeferenced, false);
+    assert.strictEqual(effectivelyAligned(entry.georeferenced), false);
+  });
+});

--- a/apps/viewer/src/hooks/ingest/dxfIngest.ts
+++ b/apps/viewer/src/hooks/ingest/dxfIngest.ts
@@ -15,12 +15,35 @@
  * Issue #1929: a surveyor's DXF is usually authored in map/CRS coordinates
  * (eastings/northings), not the IFC model's local frame — the mirror image
  * of the `.laz`/`.las` point-cloud alignment issue #1804 already solved.
- * `ingestDxfFile` resolves the anchor model's georeference the same way the
- * DXF export path does and seeds the new underlay's `georeferenced` toggle
- * from whether one is available, so a georeferenced model gets a DXF that
- * lands in the right place by default, while a model with no
- * IfcMapConversion (or none loaded yet) keeps the pre-#1929 behaviour: the
- * DXF's raw coordinates are treated as IFC world coordinates, unmodified.
+ *
+ * PR #1965 review: `ingestDxfFile` used to resolve the anchor's
+ * georeference SYNCHRONOUSLY at import time and bake the result into the
+ * new underlay's `georeferenced` toggle as a plain boolean. That races the
+ * REPORTER'S ACTUAL WORKFLOW: `ViewportContainer.handleDrop` splits DXFs
+ * off first (`splitDxfFiles`) and fires `void ingestDxfFiles(dxfFiles)`
+ * immediately, concurrently with — not after — the model files' load. Drop
+ * `model.ifc` and `survey.dxf` together and this function used to run
+ * before `ifcDataStore`/`models` had the new model in them, resolve no
+ * georeference, and seed the toggle OFF — the DXF lands kilometres away and
+ * the toast says nothing wrong. That made the documented "DXF dropped
+ * before any IFC model loads" case the DEFAULT outcome for a combined
+ * drop, not a rare edge.
+ *
+ * Fix: `ingestDxfFile` now seeds the toggle to `'auto'` (stored as
+ * `undefined` — see `DxfUnderlayState.georeferenced`'s doc in
+ * `drawing2DSlice.ts`), which `dxfUnderlayMath.ts`'s
+ * `resolveEffectiveGeoreferenced` resolves LAZILY every render from
+ * whatever the anchor's georeference currently is. A same-drop model that
+ * finishes loading after the DXF still ends up aligned, with no race,
+ * and an anchor removed/re-added later in the session is followed too.
+ * Explicit `true`/`false` are written ONLY when the user flips the
+ * checkbox (`setDxfUnderlayGeoreferenced`) — auto-seeded entries and
+ * user-set entries are stored identically once explicit, but only THIS
+ * function's import path ever creates an entry in auto mode; every other
+ * `addDxfUnderlay` call site defaults to `false` (see that action's doc),
+ * so an entry that predates this feature (or any future load/migration
+ * path that doesn't explicitly request `'auto'`) can never silently start
+ * following the anchor.
  */
 
 import { importDxf } from '@ifc-lite/drawing-2d';
@@ -77,27 +100,49 @@ export async function ingestDxfFile(file: File): Promise<void> {
   }
 
   const store = useViewerStore.getState();
-  // Default the "DXF is in map/CRS coordinates" toggle ON iff the
-  // federation anchor currently has a usable IfcMapConversion (issue
-  // #1929) — the same resolution the DXF EXPORT path uses
-  // (`resolveDxfExportGeoreference`), so import and export always agree on
-  // which model's georeference is authoritative and on user placement
-  // edits held in `georefMutations`. No usable map conversion (the common
-  // case today, and every session before this issue) leaves the toggle
-  // off, so existing DXFs that already line up in IFC world coordinates
-  // are never silently moved.
-  const georeference = resolveDxfExportGeoreference({
-    models: store.models,
-    legacyDataStore: store.ifcDataStore,
-    georefMutations: store.georefMutations,
-  });
-  const georeferenced = georeference !== null;
-  store.addDxfUnderlay(underlay, { georeferenced });
-
   const layerCount = underlay.layers.length;
   const assumedMm = underlay.warnings.some((w) => w.includes('assumed millimetres'));
-  const unitsNote = assumedMm ? ' (unitless file, assumed mm)' : '';
-  const georefNote = georeferenced ? ', aligned to the model georeference' : '';
+
+  // Seed the "DXF is in map/CRS coordinates" toggle (issue #1929, tri-state
+  // per the PR #1965 review — see the module doc above for the race this
+  // closes). Normally 'auto': resolved lazily at render time from whatever
+  // the anchor's georeference is THEN, not baked in now.
+  //
+  // Exception: a unitless DXF whose extents forced the "assumed
+  // millimetres" heuristic (`@ifc-lite/drawing-2d`'s `importDxf`,
+  // dividing every coordinate by 1000) cannot also be safely
+  // auto-georeferenced. The inverse IfcMapConversion subtracts FULL
+  // eastings/northings (metres, ~1e5-1e7 magnitude); applied to
+  // coordinates that were just divided by 1000 on top of an unverified
+  // unit guess, the two assumptions compound into a placement millions of
+  // metres off (e.g. an LV95 model: raw survey coordinates already close
+  // to the model's eastings, misread as mm, land the underlay around
+  // -2,597,400 m instead of near the model). Seed `false` (explicit "off",
+  // not auto) so a later-loaded georeferenced model can't silently apply
+  // that compounded error, and tell the user why in the toast below.
+  const georeferenced: boolean | 'auto' = assumedMm ? false : 'auto';
+  store.addDxfUnderlay(underlay, { georeferenced });
+
+  // For the import toast's wording ONLY — this does not seed the toggle
+  // (that's always 'auto' above, resolved lazily) — snapshot whether an
+  // anchor georeference happens to be available right now, including
+  // `anchorModelIdOverride` so this agrees with the pinned-anchor rule
+  // `useDxfUnderlay.ts` and `useDrawingExport.ts` both apply (previously
+  // omitted here; this function's own claim that import and export "always
+  // agree on which model is authoritative" was not true until this
+  // matched).
+  const georeference = assumedMm
+    ? null
+    : resolveDxfExportGeoreference({
+      models: store.models,
+      legacyDataStore: store.ifcDataStore,
+      anchorModelIdOverride: store.anchorModelIdOverride,
+      georefMutations: store.georefMutations,
+    });
+  const unitsNote = assumedMm
+    ? ' (unitless file, assumed mm — georeference alignment left off to avoid compounding the unit guess with a map-coordinate subtraction; enable it manually once you\'ve confirmed the units)'
+    : '';
+  const georefNote = georeference ? ', aligned to the model georeference' : '';
   if (store.models.size > 0) {
     // Surface the result immediately: the underlay renders in the 2D
     // drawing panel, so open it (the user still picks/moves the section).

--- a/apps/viewer/src/hooks/ingest/dxfIngest.ts
+++ b/apps/viewer/src/hooks/ingest/dxfIngest.ts
@@ -124,8 +124,9 @@ export async function ingestDxfFile(file: File): Promise<void> {
   store.addDxfUnderlay(underlay, { georeferenced });
 
   // For the import toast's wording ONLY — this does not seed the toggle
-  // (that's always 'auto' above, resolved lazily) — snapshot whether an
-  // anchor georeference happens to be available right now, including
+  // (that is seeded above: 'auto' normally, explicit `false` when the
+  // "assumed millimetres" heuristic fired) — snapshot whether an anchor
+  // georeference happens to be available right now, including
   // `anchorModelIdOverride` so this agrees with the pinned-anchor rule
   // `useDxfUnderlay.ts` and `useDrawingExport.ts` both apply (previously
   // omitted here; this function's own claim that import and export "always

--- a/apps/viewer/src/hooks/ingest/dxfIngest.ts
+++ b/apps/viewer/src/hooks/ingest/dxfIngest.ts
@@ -11,11 +11,22 @@
  * with `@ifc-lite/drawing-2d`'s `importDxf` and registered as an underlay
  * consumed by the 2D drawing view. Every file entry point (drop, Open)
  * splits DXFs off first via `splitDxfFiles` and routes the rest onward.
+ *
+ * Issue #1929: a surveyor's DXF is usually authored in map/CRS coordinates
+ * (eastings/northings), not the IFC model's local frame — the mirror image
+ * of the `.laz`/`.las` point-cloud alignment issue #1804 already solved.
+ * `ingestDxfFile` resolves the anchor model's georeference the same way the
+ * DXF export path does and seeds the new underlay's `georeferenced` toggle
+ * from whether one is available, so a georeferenced model gets a DXF that
+ * lands in the right place by default, while a model with no
+ * IfcMapConversion (or none loaded yet) keeps the pre-#1929 behaviour: the
+ * DXF's raw coordinates are treated as IFC world coordinates, unmodified.
  */
 
 import { importDxf } from '@ifc-lite/drawing-2d';
 import { useViewerStore } from '@/store';
 import { toast } from '@/components/ui/toast';
+import { resolveDxfExportGeoreference } from '@/hooks/dxfExportGeoref';
 
 export function isDxfFileName(name: string): boolean {
   return name.toLowerCase().endsWith('.dxf');
@@ -66,17 +77,33 @@ export async function ingestDxfFile(file: File): Promise<void> {
   }
 
   const store = useViewerStore.getState();
-  store.addDxfUnderlay(underlay);
+  // Default the "DXF is in map/CRS coordinates" toggle ON iff the
+  // federation anchor currently has a usable IfcMapConversion (issue
+  // #1929) — the same resolution the DXF EXPORT path uses
+  // (`resolveDxfExportGeoreference`), so import and export always agree on
+  // which model's georeference is authoritative and on user placement
+  // edits held in `georefMutations`. No usable map conversion (the common
+  // case today, and every session before this issue) leaves the toggle
+  // off, so existing DXFs that already line up in IFC world coordinates
+  // are never silently moved.
+  const georeference = resolveDxfExportGeoreference({
+    models: store.models,
+    legacyDataStore: store.ifcDataStore,
+    georefMutations: store.georefMutations,
+  });
+  const georeferenced = georeference !== null;
+  store.addDxfUnderlay(underlay, { georeferenced });
 
   const layerCount = underlay.layers.length;
   const assumedMm = underlay.warnings.some((w) => w.includes('assumed millimetres'));
   const unitsNote = assumedMm ? ' (unitless file, assumed mm)' : '';
+  const georefNote = georeferenced ? ', aligned to the model georeference' : '';
   if (store.models.size > 0) {
     // Surface the result immediately: the underlay renders in the 2D
     // drawing panel, so open it (the user still picks/moves the section).
     store.setDrawing2DPanelVisible(true);
     toast.success(
-      `"${file.name}" imported as reference layer: ${count} elements on ${layerCount} layer${layerCount === 1 ? '' : 's'}${unitsNote}.`,
+      `"${file.name}" imported as reference layer: ${count} elements on ${layerCount} layer${layerCount === 1 ? '' : 's'}${unitsNote}${georefNote}.`,
     );
   } else {
     toast.success(

--- a/apps/viewer/src/hooks/ingest/pointCloudAlignment.ts
+++ b/apps/viewer/src/hooks/ingest/pointCloudAlignment.ts
@@ -29,6 +29,17 @@
  *     second model across CRSs — see that function's comments for the
  *     step-by-step frame diagram this mirrors.
  *
+ * GUARD PHILOSOPHY (PR #1965 review): `../dxfExportGeoref.ts` (issue #1929)
+ * implements the SAME inverse map conversion for DXF underlays -- a third
+ * copy alongside this file and `rust/core/src/georef.rs` -- but chooses
+ * differently on malformed input. `invertMapConversion` /
+ * `computePointCloudAlignment` below return `null` on a degenerate axis or
+ * ~zero Scale and the caller hides the alignment toggle entirely; DXF
+ * export instead falls back to safe defaults (Scale=0→1, degenerate
+ * axis→(1,0)) and keeps its toggle available. Both are deliberate for
+ * where they sit -- see `dxfExportGeoref.ts`'s "GUARD PHILOSOPHY" comment
+ * for the reasoning -- not an inconsistency to fix.
+ *
  * Precision (f32 vs f64): map coordinates run ~1e6-1e7 m. Subtracting
  * `Eastings`/`Northings`/`OrthogonalHeight` must happen in f64 BEFORE any
  * f32 narrowing, or the subtraction itself inherits the f32 quantisation

--- a/apps/viewer/src/hooks/useDxfUnderlay.ts
+++ b/apps/viewer/src/hooks/useDxfUnderlay.ts
@@ -14,6 +14,14 @@
  * and builds the inverse-IfcMapConversion transform underlays flagged
  * `georeferenced` need. `Section2DPanel`'s "Center on model" handler uses
  * it too, so centering agrees with what's actually rendered.
+ *
+ * PR #1965 review: also returns `available` — whether an anchor
+ * georeference currently resolves — because `entry.georeferenced` is now
+ * tri-state (`drawing2DSlice.ts`'s field doc) and an `undefined` ("auto")
+ * entry's EFFECTIVE state depends on this same availability
+ * (`resolveEffectiveGeoreferenced` in `dxfUnderlayMath.ts`). Every caller
+ * that gates on an entry's georeferenced state needs both the transform
+ * AND this flag, so they're returned together to keep them from drifting.
  */
 
 import { useMemo } from 'react';
@@ -35,13 +43,20 @@ export {
 
 import type { DxfUnderlayRenderData } from './dxfUnderlayMath';
 
+export interface DxfMapToWorld {
+  /** Map/CRS -> IFC-world transform; identity when `available` is false. */
+  transform: (p: Point2D) => Point2D;
+  /** Whether an anchor georeference actually resolved (drives auto-mode entries). */
+  available: boolean;
+}
+
 /**
  * Resolve the map/CRS → IFC-world transform for georeferenced DXF
  * underlays (issue #1929). Identity when no loaded model has a usable
- * IfcMapConversion — the underlay's `georeferenced` flag then has nothing
- * to apply, same as before this issue.
+ * IfcMapConversion — the underlay's EFFECTIVE georeferenced state then has
+ * nothing to apply, same as before this issue.
  */
-export function useDxfMapToWorldTransform(): (p: Point2D) => Point2D {
+export function useDxfMapToWorldTransform(): DxfMapToWorld {
   const models = useViewerStore((s) => s.models);
   const ifcDataStore = useViewerStore((s) => s.ifcDataStore);
   const anchorModelIdOverride = useViewerStore((s) => s.anchorModelIdOverride);
@@ -57,7 +72,7 @@ export function useDxfMapToWorldTransform(): (p: Point2D) => Point2D {
       anchorModelIdOverride,
       georefMutations,
     });
-    return buildDxfMapToWorldTransform(georeference);
+    return { transform: buildDxfMapToWorldTransform(georeference), available: georeference !== null };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [models, ifcDataStore, anchorModelIdOverride, georefMutations, mutationVersion]);
 }
@@ -71,7 +86,7 @@ export function useDxfUnderlaysForDrawing(params: {
 }): readonly DxfUnderlayRenderData[] {
   const { enabled, sectionAxis, isCustomPlane, flipped, coordinateInfo } = params;
   const dxfUnderlays = useViewerStore((s) => s.dxfUnderlays);
-  const mapToWorld = useDxfMapToWorldTransform();
+  const { transform: mapToWorld, available: georeferenceAvailable } = useDxfMapToWorldTransform();
 
   return useMemo(() => {
     // Plan-view content only: elevation/section/custom planes have no
@@ -82,6 +97,6 @@ export function useDxfUnderlaysForDrawing(params: {
     const shift = dxfWorldShift(coordinateInfo);
     // Cardinal flipped sections mirror the drawing's X axis (see
     // projectTo2D's flipped-U rule); the underlay must follow.
-    return visible.map((u) => dxfUnderlayToDrawing(u, shift, flipped, mapToWorld));
-  }, [enabled, sectionAxis, isCustomPlane, flipped, coordinateInfo, dxfUnderlays, mapToWorld]);
+    return visible.map((u) => dxfUnderlayToDrawing(u, shift, flipped, mapToWorld, georeferenceAvailable));
+  }, [enabled, sectionAxis, isCustomPlane, flipped, coordinateInfo, dxfUnderlays, mapToWorld, georeferenceAvailable]);
 }

--- a/apps/viewer/src/hooks/useDxfUnderlay.ts
+++ b/apps/viewer/src/hooks/useDxfUnderlay.ts
@@ -7,11 +7,20 @@
  * `dxfUnderlayMath.ts` (store-free, unit-tested); this hook wires it to the
  * viewer store and filters by section axis: underlays are plan content, so
  * anything but a cardinal 'down' section yields no data.
+ *
+ * `useDxfMapToWorldTransform` (issue #1929) resolves the federation
+ * anchor's effective georeference the SAME way the DXF export path does
+ * (`resolveDxfExportGeoreference`, which folds in `georefMutations` edits)
+ * and builds the inverse-IfcMapConversion transform underlays flagged
+ * `georeferenced` need. `Section2DPanel`'s "Center on model" handler uses
+ * it too, so centering agrees with what's actually rendered.
  */
 
 import { useMemo } from 'react';
+import type { Point2D } from '@ifc-lite/drawing-2d';
 import type { GeometryResult } from '@ifc-lite/geometry';
 import { useViewerStore } from '@/store';
+import { buildDxfMapToWorldTransform, resolveDxfExportGeoreference } from './dxfExportGeoref';
 import { dxfUnderlayToDrawing, dxfWorldShift } from './dxfUnderlayMath';
 
 export {
@@ -26,6 +35,33 @@ export {
 
 import type { DxfUnderlayRenderData } from './dxfUnderlayMath';
 
+/**
+ * Resolve the map/CRS → IFC-world transform for georeferenced DXF
+ * underlays (issue #1929). Identity when no loaded model has a usable
+ * IfcMapConversion — the underlay's `georeferenced` flag then has nothing
+ * to apply, same as before this issue.
+ */
+export function useDxfMapToWorldTransform(): (p: Point2D) => Point2D {
+  const models = useViewerStore((s) => s.models);
+  const ifcDataStore = useViewerStore((s) => s.ifcDataStore);
+  const anchorModelIdOverride = useViewerStore((s) => s.anchorModelIdOverride);
+  const georefMutations = useViewerStore((s) => s.georefMutations);
+  // Georef edits replace the map, but subscribe to mutationVersion too so
+  // the dependency is explicit (matches useDrawingExport / useAnchorGeoreference).
+  const mutationVersion = useViewerStore((s) => s.mutationVersion);
+
+  return useMemo(() => {
+    const georeference = resolveDxfExportGeoreference({
+      models,
+      legacyDataStore: ifcDataStore,
+      anchorModelIdOverride,
+      georefMutations,
+    });
+    return buildDxfMapToWorldTransform(georeference);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [models, ifcDataStore, anchorModelIdOverride, georefMutations, mutationVersion]);
+}
+
 export function useDxfUnderlaysForDrawing(params: {
   enabled: boolean;
   sectionAxis: 'down' | 'front' | 'side';
@@ -35,6 +71,7 @@ export function useDxfUnderlaysForDrawing(params: {
 }): readonly DxfUnderlayRenderData[] {
   const { enabled, sectionAxis, isCustomPlane, flipped, coordinateInfo } = params;
   const dxfUnderlays = useViewerStore((s) => s.dxfUnderlays);
+  const mapToWorld = useDxfMapToWorldTransform();
 
   return useMemo(() => {
     // Plan-view content only: elevation/section/custom planes have no
@@ -45,6 +82,6 @@ export function useDxfUnderlaysForDrawing(params: {
     const shift = dxfWorldShift(coordinateInfo);
     // Cardinal flipped sections mirror the drawing's X axis (see
     // projectTo2D's flipped-U rule); the underlay must follow.
-    return visible.map((u) => dxfUnderlayToDrawing(u, shift, flipped));
-  }, [enabled, sectionAxis, isCustomPlane, flipped, coordinateInfo, dxfUnderlays]);
+    return visible.map((u) => dxfUnderlayToDrawing(u, shift, flipped, mapToWorld));
+  }, [enabled, sectionAxis, isCustomPlane, flipped, coordinateInfo, dxfUnderlays, mapToWorld]);
 }

--- a/apps/viewer/src/lib/geo/effective-georef.test.ts
+++ b/apps/viewer/src/lib/geo/effective-georef.test.ts
@@ -114,22 +114,27 @@ describe('effective georeferencing', () => {
 
   it('falls back NaN eastings/northings/orthogonalHeight to 0 instead of poisoning downstream math (PR #1965 review)', () => {
     // A malformed IfcMapConversion or a bad mutation edit must not let a
-    // NaN reach `resolveGeorefLinearParams`'s eastings/northings math --
-    // `?? 0` alone passes NaN through untouched (NaN ?? 0 === NaN).
+    // NaN reach `resolveGeorefLinearParams`'s eastings/northings math, or
+    // `hasStandardGeoreferencing`'s orthogonalHeight finiteness check --
+    // `?? 0` alone passes NaN through untouched (NaN ?? 0 === NaN). The
+    // maintainer's PR #1965 review flagged that the previous version of this
+    // test asserted eastings/northings but never actually exercised
+    // orthogonalHeight, even though the title claimed it did -- exercise it
+    // for real here so a regression on that field fails this test.
     const original: MapConversion = {
       id: 2,
       sourceCRS: 10,
       targetCRS: 11,
       eastings: NaN,
       northings: 200,
-      orthogonalHeight: 5,
+      orthogonalHeight: NaN,
     };
 
     const merged = mergeMapConversion(original, { northings: NaN });
 
     assert.strictEqual(merged?.eastings, 0);
     assert.strictEqual(merged?.northings, 0);
-    assert.strictEqual(merged?.orthogonalHeight, 5);
+    assert.strictEqual(merged?.orthogonalHeight, 0);
   });
 
   it('overlays edited IfcMapConversion fields without dropping original rotation and scale', () => {
@@ -376,6 +381,46 @@ describe('effective georeferencing', () => {
           mapConversion: { ...mapConversion, northings: Infinity },
         }),
         false,
+      );
+    });
+
+    it('rejects a mapConversion with non-finite orthogonalHeight (PR #1965 review round 2, NaN guard)', () => {
+      // The finiteness check previously stopped at eastings/northings.
+      // `hasUsableMapGeoref` (pick-to-geo.ts) delegates here for the XYZ
+      // readout, which adds `mapConversion.orthogonalHeight` straight into
+      // the returned height with no fallback -- a NaN here must be rejected
+      // at this gate exactly like a NaN eastings/northings is, or it lands
+      // directly in Z.
+      assert.strictEqual(
+        hasStandardGeoreferencing({
+          source: 'mapConversion',
+          projectedCRS: { id: 1, name: 'EPSG:28992' },
+          mapConversion: { ...mapConversion, orthogonalHeight: NaN },
+        }),
+        false,
+      );
+    });
+
+    it('accepts a mapConversion with non-finite Scale or axis components (deliberate, not a gap)', () => {
+      // Unlike orthogonalHeight, Scale and the XAxisAbscissa/XAxisOrdinate
+      // axis pair are NOT part of this gate's finiteness check. The DXF
+      // export/underlay path's `resolveGeorefLinearParams`
+      // (dxfExportGeoref.ts) already substitutes finite fallbacks for
+      // exactly this case (Scale=0/NaN → 1, degenerate/non-finite axis →
+      // (1, 0)) so a malformed Scale/axis still renders the DXF underlay
+      // somewhere. `selectAnchorGeoref` gates anchor selection through this
+      // same predicate, so rejecting non-finite Scale/axis here would reject
+      // that model as an anchor before the fallback ever runs -- turning a
+      // georeference that currently renders (via the fallback) into one
+      // that's silently disabled. This test locks that the gate stays
+      // permissive for these two fields.
+      assert.strictEqual(
+        hasStandardGeoreferencing({
+          source: 'mapConversion',
+          projectedCRS: { id: 1, name: 'EPSG:28992' },
+          mapConversion: { ...mapConversion, scale: NaN, xAxisAbscissa: NaN, xAxisOrdinate: Infinity },
+        }),
+        true,
       );
     });
   });

--- a/apps/viewer/src/lib/geo/effective-georef.test.ts
+++ b/apps/viewer/src/lib/geo/effective-georef.test.ts
@@ -112,6 +112,26 @@ describe('effective georeferencing', () => {
     );
   });
 
+  it('falls back NaN eastings/northings/orthogonalHeight to 0 instead of poisoning downstream math (PR #1965 review)', () => {
+    // A malformed IfcMapConversion or a bad mutation edit must not let a
+    // NaN reach `resolveGeorefLinearParams`'s eastings/northings math --
+    // `?? 0` alone passes NaN through untouched (NaN ?? 0 === NaN).
+    const original: MapConversion = {
+      id: 2,
+      sourceCRS: 10,
+      targetCRS: 11,
+      eastings: NaN,
+      northings: 200,
+      orthogonalHeight: 5,
+    };
+
+    const merged = mergeMapConversion(original, { northings: NaN });
+
+    assert.strictEqual(merged?.eastings, 0);
+    assert.strictEqual(merged?.northings, 0);
+    assert.strictEqual(merged?.orthogonalHeight, 5);
+  });
+
   it('overlays edited IfcMapConversion fields without dropping original rotation and scale', () => {
     const original: MapConversion = {
       id: 2,
@@ -338,6 +358,25 @@ describe('effective georeferencing', () => {
     it('rejects null / undefined', () => {
       assert.strictEqual(hasStandardGeoreferencing(null), false);
       assert.strictEqual(hasStandardGeoreferencing(undefined), false);
+    });
+
+    it('rejects a mapConversion with non-finite eastings or northings (PR #1965 review, NaN guard)', () => {
+      assert.strictEqual(
+        hasStandardGeoreferencing({
+          source: 'mapConversion',
+          projectedCRS: { id: 1, name: 'EPSG:28992' },
+          mapConversion: { ...mapConversion, eastings: NaN },
+        }),
+        false,
+      );
+      assert.strictEqual(
+        hasStandardGeoreferencing({
+          source: 'mapConversion',
+          projectedCRS: { id: 1, name: 'EPSG:28992' },
+          mapConversion: { ...mapConversion, northings: Infinity },
+        }),
+        false,
+      );
     });
   });
 });

--- a/apps/viewer/src/lib/geo/effective-georef.ts
+++ b/apps/viewer/src/lib/geo/effective-georef.ts
@@ -43,7 +43,14 @@ export function hasStandardGeoreferencing(
     georef
     && georef.source !== 'siteLocation'
     && georef.projectedCRS?.name
-    && georef.mapConversion,
+    && georef.mapConversion
+    // PR #1965 review: presence alone isn't enough -- a malformed
+    // IfcMapConversion with a NaN eastings/northings must not pass this
+    // gate. `hasUsableMapGeoref` (pick-to-geo.ts) delegates here for the
+    // XYZ readout and federation-alignment gate, so this finiteness check
+    // protects both, not just the DXF underlay path.
+    && Number.isFinite(georef.mapConversion.eastings)
+    && Number.isFinite(georef.mapConversion.northings),
   );
 }
 
@@ -95,6 +102,21 @@ export function mergeProjectedCRS(
   };
 }
 
+/**
+ * `?? 0` alone lets a malformed `IfcMapConversion` (or a bad mutation edit)
+ * pass a NaN eastings/northings/orthogonalHeight straight through -- PR #1965
+ * review: `mergeMapConversion` used to do exactly that, and the NaN then
+ * poisons every point `dxfExportGeoref.ts`'s forward/inverse transform
+ * touches, permanently (the corrupted value can land in the DXF underlay's
+ * stored `placement`, which survives toggling "georeferenced" back off --
+ * see `resolveGeorefLinearParams` and `dxfUnderlayDrawingBounds`). Falls
+ * back to 0 exactly like `?? 0` already did for the "missing" case, just
+ * extended to the "present but non-finite" case too.
+ */
+function finiteOr0(value: number | undefined): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : 0;
+}
+
 export function mergeMapConversion(
   original: MapConversion | undefined,
   mutations: Partial<MapConversion> | undefined,
@@ -104,9 +126,9 @@ export function mergeMapConversion(
     id: original?.id ?? 0,
     sourceCRS: original?.sourceCRS ?? 0,
     targetCRS: original?.targetCRS ?? 0,
-    eastings: (mutations?.eastings ?? original?.eastings ?? 0) as number,
-    northings: (mutations?.northings ?? original?.northings ?? 0) as number,
-    orthogonalHeight: (mutations?.orthogonalHeight ?? original?.orthogonalHeight ?? 0) as number,
+    eastings: finiteOr0(mutations?.eastings ?? original?.eastings),
+    northings: finiteOr0(mutations?.northings ?? original?.northings),
+    orthogonalHeight: finiteOr0(mutations?.orthogonalHeight ?? original?.orthogonalHeight),
     xAxisAbscissa: mutations?.xAxisAbscissa ?? original?.xAxisAbscissa,
     xAxisOrdinate: mutations?.xAxisOrdinate ?? original?.xAxisOrdinate,
     scale: mutations?.scale ?? original?.scale,

--- a/apps/viewer/src/lib/geo/effective-georef.ts
+++ b/apps/viewer/src/lib/geo/effective-georef.ts
@@ -45,12 +45,43 @@ export function hasStandardGeoreferencing(
     && georef.projectedCRS?.name
     && georef.mapConversion
     // PR #1965 review: presence alone isn't enough -- a malformed
-    // IfcMapConversion with a NaN eastings/northings must not pass this
-    // gate. `hasUsableMapGeoref` (pick-to-geo.ts) delegates here for the
-    // XYZ readout and federation-alignment gate, so this finiteness check
-    // protects both, not just the DXF underlay path.
+    // IfcMapConversion with a NaN eastings/northings/orthogonalHeight must
+    // not pass this gate. `hasUsableMapGeoref` (pick-to-geo.ts) delegates
+    // here for the XYZ readout and federation-alignment gate, so this
+    // finiteness check protects both, not just the DXF underlay path.
+    // `orthogonalHeight` joins eastings/northings here (2nd PR #1965 review
+    // round) because every consumer reads it straight through with no
+    // fallback -- `viewerPointToProjected` (pick-to-geo.ts) adds it directly
+    // into the returned height, and `federationAlign.ts`'s `hC`/`hS`/`ifcZr`
+    // computations multiply it by the map-unit scale and add it to the IFC Z
+    // used to align two models. A NaN here has nowhere to go but straight
+    // into Z.
     && Number.isFinite(georef.mapConversion.eastings)
-    && Number.isFinite(georef.mapConversion.northings),
+    && Number.isFinite(georef.mapConversion.northings)
+    && Number.isFinite(georef.mapConversion.orthogonalHeight)
+    // Scale and the XAxisAbscissa/XAxisOrdinate axis pair are DELIBERATELY
+    // NOT part of this finiteness gate, unlike orthogonalHeight above. The
+    // DXF export/underlay path (`dxfExportGeoref.ts`'s
+    // `resolveGeorefLinearParams`) already substitutes finite fallbacks for
+    // exactly this case -- Scale=0/NaN/negative becomes 1, a degenerate or
+    // non-finite axis becomes the no-rotation default (1, 0) -- specifically
+    // so a malformed Scale/axis still renders the DXF underlay somewhere
+    // rather than disabling it outright (see that file's "GUARD PHILOSOPHY"
+    // header comment). `selectAnchorGeoref` (useAnchorGeoreference.ts) gates
+    // anchor selection through this same function, so adding Scale/axis here
+    // would make `hasUsableMapGeoref` reject that model as an anchor before
+    // `resolveGeorefLinearParams` ever gets a chance to apply its fallback --
+    // turning a georeference that currently renders (via the fallback) into
+    // one that's silently disabled instead. `orthogonalHeight` has no such
+    // downstream fallback anywhere, which is why it's guarded here and
+    // Scale/axis are not.
+    //
+    // This does leave `federationAlign.ts`'s `getAxis()` and
+    // `getEffectiveHorizontalScale()` reading a NaN Scale or axis pair
+    // without an equivalent fallback (unlike the DXF path) -- a real gap,
+    // but a pre-existing one this gate change doesn't widen, and fixing it
+    // belongs in that file's own math, not in loosening/tightening this
+    // shared presence gate.
   );
 }
 

--- a/apps/viewer/src/store/slices/drawing2DSlice.test.ts
+++ b/apps/viewer/src/store/slices/drawing2DSlice.test.ts
@@ -1,0 +1,68 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { createStore } from 'zustand/vanilla';
+import type { DxfUnderlay } from '@ifc-lite/drawing-2d';
+import { createDrawing2DSlice, type Drawing2DSlice } from './drawing2DSlice.js';
+
+const makeStore = () => createStore<Drawing2DSlice>(createDrawing2DSlice);
+
+const makeUnderlay = (): DxfUnderlay => ({
+  name: 'test.dxf',
+  layers: [],
+  bounds: { min: { x: 0, y: 0 }, max: { x: 10, y: 10 } },
+  unitScale: 1,
+  skipped: {},
+  warnings: [],
+});
+
+// PR #1965 review, item 1: `georeferenced` is tri-state (`true`/`false`
+// explicit, `undefined` "auto"). The invariant that must never break: an
+// entry created WITHOUT explicitly opting into 'auto' can never end up
+// auto -- only `ingestDxfFile`'s own call site does that, so anything else
+// constructing an entry (a hypothetical future load/migration path for
+// entries that predate this field, a test fixture, another call site)
+// stays conservative by construction.
+describe('drawing2DSlice.addDxfUnderlay (PR #1965 review: tri-state georeferenced seeding)', () => {
+  it('defaults to explicit false (never auto) when options are omitted entirely', () => {
+    const s = makeStore();
+    const id = s.getState().addDxfUnderlay(makeUnderlay());
+    const entry = s.getState().dxfUnderlays.find((u) => u.id === id);
+    assert.strictEqual(entry?.georeferenced, false);
+  });
+
+  it('defaults to explicit false when options.georeferenced is omitted', () => {
+    const s = makeStore();
+    const id = s.getState().addDxfUnderlay(makeUnderlay(), {});
+    const entry = s.getState().dxfUnderlays.find((u) => u.id === id);
+    assert.strictEqual(entry?.georeferenced, false);
+  });
+
+  it('stores true/false verbatim when the caller passes them explicitly', () => {
+    const s = makeStore();
+    const onId = s.getState().addDxfUnderlay(makeUnderlay(), { georeferenced: true });
+    const offId = s.getState().addDxfUnderlay(makeUnderlay(), { georeferenced: false });
+    assert.strictEqual(s.getState().dxfUnderlays.find((u) => u.id === onId)?.georeferenced, true);
+    assert.strictEqual(s.getState().dxfUnderlays.find((u) => u.id === offId)?.georeferenced, false);
+  });
+
+  it("stores 'auto' as undefined -- ONLY reachable by explicitly requesting it", () => {
+    const s = makeStore();
+    const id = s.getState().addDxfUnderlay(makeUnderlay(), { georeferenced: 'auto' });
+    const entry = s.getState().dxfUnderlays.find((u) => u.id === id);
+    assert.strictEqual(entry?.georeferenced, undefined);
+    assert.ok('georeferenced' in (entry ?? {}), 'the field itself is still present, just undefined');
+  });
+
+  it('setDxfUnderlayGeoreferenced always writes an explicit boolean, never undefined -- the user-touch escape hatch out of auto mode', () => {
+    const s = makeStore();
+    const id = s.getState().addDxfUnderlay(makeUnderlay(), { georeferenced: 'auto' });
+    s.getState().setDxfUnderlayGeoreferenced(id, true);
+    assert.strictEqual(s.getState().dxfUnderlays.find((u) => u.id === id)?.georeferenced, true);
+    s.getState().setDxfUnderlayGeoreferenced(id, false);
+    assert.strictEqual(s.getState().dxfUnderlays.find((u) => u.id === id)?.georeferenced, false);
+  });
+});

--- a/apps/viewer/src/store/slices/drawing2DSlice.ts
+++ b/apps/viewer/src/store/slices/drawing2DSlice.ts
@@ -81,6 +81,19 @@ export interface DxfUnderlayState {
   layerVisibility: Record<string, boolean>;
   /** User placement (offset/rotation/scale) in drawing space */
   placement: DxfPlacement;
+  /**
+   * Whether this underlay's raw coordinates are map/CRS (eastings,
+   * northings) rather than IFC world coordinates — issue #1929. When true,
+   * `dxfUnderlayToDrawing`/`dxfUnderlayDrawingBounds` apply the inverse
+   * IfcMapConversion (the federation anchor's, via
+   * `resolveDxfExportGeoreference`) before the existing world→drawing
+   * mapping and per-underlay placement. `addDxfUnderlay` defaults this to
+   * `true` only when the anchor model actually has a usable IfcMapConversion
+   * at import time; otherwise (and for any entry that predates this field)
+   * it is falsy, so existing DXFs that already line up in IFC world
+   * coordinates are never silently moved.
+   */
+  georeferenced?: boolean;
 }
 
 export interface Drawing2DState {
@@ -279,14 +292,21 @@ export interface Drawing2DSlice extends Drawing2DState {
   clearAllAnnotations2D: () => void;
 
   // DXF Underlay Actions (issue #1782)
-  /** Register an imported DXF underlay; returns its id */
-  addDxfUnderlay: (underlay: DxfUnderlay) => string;
+  /**
+   * Register an imported DXF underlay; returns its id. `georeferenced`
+   * (issue #1929) seeds the per-underlay "DXF is in map/CRS coordinates"
+   * toggle — the caller (`ingestDxfFile`) resolves it from whether the
+   * federation anchor currently has a usable IfcMapConversion.
+   */
+  addDxfUnderlay: (underlay: DxfUnderlay, options?: { georeferenced?: boolean }) => string;
   removeDxfUnderlay: (id: string) => void;
   setDxfUnderlayVisible: (id: string, visible: boolean) => void;
   setDxfUnderlayOpacity: (id: string, opacity: number) => void;
   /** Toggle one DXF layer within an underlay */
   toggleDxfUnderlayLayer: (id: string, layerName: string) => void;
   updateDxfUnderlayPlacement: (id: string, placement: Partial<DxfPlacement>) => void;
+  /** Flip whether an underlay's coordinates are map/CRS vs. IFC world (issue #1929) */
+  setDxfUnderlayGeoreferenced: (id: string, georeferenced: boolean) => void;
   clearDxfUnderlays: () => void;
 }
 
@@ -721,7 +741,7 @@ export const createDrawing2DSlice: StateCreator<Drawing2DSlice, [], [], Drawing2
   },
 
   // DXF Underlay Actions (issue #1782)
-  addDxfUnderlay: (underlay) => {
+  addDxfUnderlay: (underlay, options) => {
     const id = `dxf-${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
     const layerVisibility: Record<string, boolean> = {};
     for (const layer of underlay.layers) layerVisibility[layer.name] = layer.visible;
@@ -733,6 +753,7 @@ export const createDrawing2DSlice: StateCreator<Drawing2DSlice, [], [], Drawing2
       opacity: 1,
       layerVisibility,
       placement: { ...DEFAULT_DXF_PLACEMENT },
+      georeferenced: options?.georeferenced ?? false,
     };
     set((state) => ({ dxfUnderlays: [...state.dxfUnderlays, entry] }));
     return id;
@@ -766,6 +787,10 @@ export const createDrawing2DSlice: StateCreator<Drawing2DSlice, [], [], Drawing2
     dxfUnderlays: state.dxfUnderlays.map((u) =>
       u.id === id ? { ...u, placement: { ...u.placement, ...placement } } : u
     ),
+  })),
+
+  setDxfUnderlayGeoreferenced: (id, georeferenced) => set((state) => ({
+    dxfUnderlays: state.dxfUnderlays.map((u) => (u.id === id ? { ...u, georeferenced } : u)),
   })),
 
   clearDxfUnderlays: () => set({ dxfUnderlays: [] }),

--- a/apps/viewer/src/store/slices/drawing2DSlice.ts
+++ b/apps/viewer/src/store/slices/drawing2DSlice.ts
@@ -83,15 +83,34 @@ export interface DxfUnderlayState {
   placement: DxfPlacement;
   /**
    * Whether this underlay's raw coordinates are map/CRS (eastings,
-   * northings) rather than IFC world coordinates — issue #1929. When true,
-   * `dxfUnderlayToDrawing`/`dxfUnderlayDrawingBounds` apply the inverse
-   * IfcMapConversion (the federation anchor's, via
+   * northings) rather than IFC world coordinates — issue #1929, made
+   * TRI-STATE by the PR #1965 review round:
+   *
+   *   - `true` / `false`: explicit — written ONLY by the user flipping the
+   *     "Align to model georeference" checkbox (`setDxfUnderlayGeoreferenced`).
+   *     Always wins, regardless of whether an anchor georeference is
+   *     currently available.
+   *   - `undefined` ("auto"): follow anchor georeference availability,
+   *     resolved LAZILY at render time (`resolveEffectiveGeoreferenced` in
+   *     `dxfUnderlayMath.ts`, fed by `useDxfMapToWorldTransform`'s
+   *     `available` flag) instead of once at import time. This closes the
+   *     race where a combined model+DXF drop ingests the DXF before the
+   *     model has finished loading (`ViewportContainer.handleDrop` fires
+   *     `ingestDxfFiles` concurrently with model loading — see
+   *     `dxfIngest.ts`'s module doc) and also covers the anchor being
+   *     removed/re-added later in the session.
+   *
+   * `addDxfUnderlay` defaults a caller that doesn't explicitly request
+   * `'auto'` to `false`, NEVER to `undefined` — see its doc below. Only
+   * `ingestDxfFile` (the DXF-import feature itself) opts a freshly-created
+   * entry into `'auto'`; every other construction path, including a
+   * hypothetical future load/migration path for entries that predate this
+   * field, is conservative by construction and never starts following the
+   * anchor on its own. `dxfUnderlayToDrawing`/`dxfUnderlayDrawingBounds`
+   * apply the inverse IfcMapConversion (the federation anchor's, via
    * `resolveDxfExportGeoreference`) before the existing world→drawing
-   * mapping and per-underlay placement. `addDxfUnderlay` defaults this to
-   * `true` only when the anchor model actually has a usable IfcMapConversion
-   * at import time; otherwise (and for any entry that predates this field)
-   * it is falsy, so existing DXFs that already line up in IFC world
-   * coordinates are never silently moved.
+   * mapping and per-underlay placement, gated on the EFFECTIVE (tri-state
+   * resolved) value, not the raw field.
    */
   georeferenced?: boolean;
 }
@@ -293,12 +312,18 @@ export interface Drawing2DSlice extends Drawing2DState {
 
   // DXF Underlay Actions (issue #1782)
   /**
-   * Register an imported DXF underlay; returns its id. `georeferenced`
-   * (issue #1929) seeds the per-underlay "DXF is in map/CRS coordinates"
-   * toggle — the caller (`ingestDxfFile`) resolves it from whether the
-   * federation anchor currently has a usable IfcMapConversion.
+   * Register an imported DXF underlay; returns its id. `options.georeferenced`
+   * (issue #1929, made tri-state by the PR #1965 review) seeds the
+   * per-underlay "DXF is in map/CRS coordinates" toggle:
+   *   - omitted, or `true`/`false`: written verbatim (default `false` when
+   *     omitted — the pre-#1929, always-safe behaviour for any call site
+   *     that isn't the DXF-ingest feature itself).
+   *   - `'auto'`: stored as `undefined`, meaning "follow anchor
+   *     georeference availability, resolved at render time" — only
+   *     `ingestDxfFile` passes this, so an entry only ever starts in auto
+   *     mode when it was created by THIS feature's own import path.
    */
-  addDxfUnderlay: (underlay: DxfUnderlay, options?: { georeferenced?: boolean }) => string;
+  addDxfUnderlay: (underlay: DxfUnderlay, options?: { georeferenced?: boolean | 'auto' }) => string;
   removeDxfUnderlay: (id: string) => void;
   setDxfUnderlayVisible: (id: string, visible: boolean) => void;
   setDxfUnderlayOpacity: (id: string, opacity: number) => void;
@@ -745,6 +770,13 @@ export const createDrawing2DSlice: StateCreator<Drawing2DSlice, [], [], Drawing2
     const id = `dxf-${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
     const layerVisibility: Record<string, boolean> = {};
     for (const layer of underlay.layers) layerVisibility[layer.name] = layer.visible;
+    // Tri-state resolution (PR #1965 review, see the field doc above):
+    // 'auto' -> undefined; anything else (including omitted) -> boolean,
+    // defaulting to false. A caller that doesn't explicitly ask for 'auto'
+    // can never accidentally create an auto entry.
+    const georeferenced = options?.georeferenced === 'auto'
+      ? undefined
+      : (options?.georeferenced ?? false);
     const entry: DxfUnderlayState = {
       id,
       name: underlay.name,
@@ -753,7 +785,7 @@ export const createDrawing2DSlice: StateCreator<Drawing2DSlice, [], [], Drawing2
       opacity: 1,
       layerVisibility,
       placement: { ...DEFAULT_DXF_PLACEMENT },
-      georeferenced: options?.georeferenced ?? false,
+      georeferenced,
     };
     set((state) => ({ dxfUnderlays: [...state.dxfUnderlays, entry] }));
     return id;


### PR DESCRIPTION
## What and why

Closes #1929 (@Hans-Lammerts).

A surveyor's DXF is authored in **map/CRS coordinates** (eastings/northings). The DXF underlay path assumed a DXF's raw coordinates were already IFC world coordinates (`dxfUnderlayMath.ts`: "underlays are in world plan coordinates"), so a georeferenced DXF rendered wherever those eastings put it — typically kilometres from the model.

The issue asks for "the contra values of ifcmapconversion", i.e. the inverse, "just like the feature of .laz now uses".

## The transform

The **forward** direction (IFC world → map/CRS) already existed for georeferenced DXF *export* (`buildDxfExportTransform`, #1871):

```
E = Eastings*mapUnitScale  + scale*(abscissa*wx - ordinate*wy)
N = Northings*mapUnitScale + scale*(ordinate*wx + abscissa*wy)
```

`buildDxfMapToWorldTransform` is its exact algebraic inverse. Because `IfcMapConversion`'s axis vector is normalized to unit length, the rotation matrix is orthonormal, so the inverse is its **transpose** rather than a general matrix inverse:

```
dE = E - Eastings*mapUnitScale ; dN = N - Northings*mapUnitScale
wx = ( abscissa*dE + ordinate*dN) / scale
wy = (-ordinate*dE + abscissa*dN) / scale
```

Both directions now share `resolveGeorefLinearParams`, so the `Scale = 0` and degenerate-axis guards (which mirror `rust/core/src/georef.rs` `normalize_axis`) **cannot drift apart** between import and export.

## Existing underlays are not moved — please sanity-check this bit

Applying the inverse unconditionally would displace every DXF that users have already aligned by hand, which would be a regression dressed up as a feature. So:

- a new per-underlay `georeferenced` flag gates the inverse;
- `ingestDxfFile` defaults it **on only when the federation anchor actually has a usable `IfcMapConversion`** at import time — this is the reporter's "let the default be that dxf is georeferenced";
- **anything imported before this change has no such field → falsy → identity transform.** An existing user upgrading sees no movement at all until they tick the new "Align to model georeference" checkbox.

The vocabulary and the "default reflects availability" rule are copied from the point-cloud alignment feature (#1804) the reporter cites, so the two behave consistently. The one deliberate difference: point-cloud alignment is a single global toggle, whereas DXF underlays are per-file and users may mix georeferenced and hand-placed DXFs — so this toggle is per-underlay.

## Georeference source

Resolved via `resolveDxfExportGeoreference` / `selectAnchorGeoref` — the *same* anchor selection the export path uses — rather than reading `ifcDataStore`. That matters: user placement edits live in the store's `georefMutations`, so reading the data store alone would make the underlay disagree with the placement the viewer is displaying (the trap documented in the #1871 review). Import and export now always agree on which model is authoritative.

The inverse composes with, rather than replaces, the existing per-underlay offset/rotation/scale placement.

## Known edge

A DXF dropped **before** any IFC model loads resolves no georeference, so it imports with the toggle off. The user can switch it on afterwards. Flagging rather than hiding it — auto-flipping it later would move an underlay the user may have since placed by hand.

## Verification

- Viewer suite **2171 tests / 2169 passed / 0 failed / 2 skipped** (+10 new)
- `pnpm typecheck` 33/33 · `check-test-wiring` clean
- New tests: identity when no georeference, direct-value inversion, **forward↔inverse round-trip**, `Scale = 0` guard, degenerate-axis guard, non-metre map-unit bridge, plus four covering the `georeferenced` gate in the underlay mapping
- Round-trip independently re-verified against a forward formula written from the issue rather than from the code — exact to 9 decimals — and a null georeference confirmed to be a true identity
- Mutation-tested: negating the `ordinate` sign fails 2 tests; forcing the axis-normalisation fallback fails 3 (including the existing forward-rotation test, confirming the shared helper is genuinely shared)

No changeset — `apps/viewer` is not published and no `packages/*` are touched.

## Not verified

I have not driven this in the running app against a real georeferenced DXF + IFC pair; verification is unit- and type-level. If you have a survey DXF handy that pairs with a georeferenced model, that is the check I would most want before this leaves draft.

## Checklist

- [x] Tests assert real behaviour, each verified to fail when its behaviour is broken
- [x] No `as any` / `@ts-ignore` / `as unknown as`, including fixtures
- [x] Exact IFC EXPRESS names (`IfcMapConversion`, `IfcProjectedCRS`) in identifiers and UI copy
- [x] No client or project identifiers in code, tests, commit messages, or this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * DXF underlays now support automatic or explicit alignment with the model’s georeference.
  * Added controls to pin automatic alignment on or off.
  * DXF positioning and centering now account for map-to-world transformations.
  * Improved handling of malformed georeference data with safe fallback behavior.

* **Bug Fixes**
  * Prevented invalid coordinates and offsets from causing incorrect underlay placement.
  * Improved georeference detection and alignment during model-loading races.
  * Unitless DXF files assumed to use millimetres are now kept unaligned with an explanatory notice.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->