### PR TITLE
fix(export): read attribute values from the overlay, not the mutation history (#1957)

### DIFF
--- a/.changeset/export-reads-attribute-overlay.md
+++ b/.changeset/export-reads-attribute-overlay.md
@@ -1,0 +1,16 @@
+---
+"@ifc-lite/mutations": minor
+"@ifc-lite/export": patch
+---
+
+Fix undone attribute edits being resurrected on STEP export (#1957).
+
+`StepExporter` reconstructed attribute values by replaying `MutablePropertyView.getMutations()` — the append-only mutation history. Undo applies its reverse edit with `skipHistory: true`, so a superseded `UPDATE_ATTRIBUTE` record keeps its stale `newValue` forever and the exporter baked the pre-undo value into the output. The editor showed the reverted value; the file did not. Silent, with no error and nothing in the output signalling it, and directional: it restored data the user had explicitly reverted.
+
+The exporter now reads attribute values from the overlay via the new `MutablePropertyView.getAttributeMutationsByEntity()`, which returns the current state — an undone edit has had its overlay entry reset to the pre-edit value, or removed outright when the attribute was newly set. This makes attributes consistent with every other overlay-backed path in the exporter: property sets (`getForEntity`), quantities (`getQuantitiesForEntity`), positional attributes (`getPositionalMutationsForEntity`) and retypes (`getEntityTypeMutation`) already read current state, so attributes were the sole outlier rather than an instance of a general pattern.
+
+**Scope.** Only the attribute path was affected. Property and quantity edits take their *values* from the overlay and use the history only to decide which pset names to re-emit, so an undone property edit was already re-emitted with its correct current value. Georeferencing edits reach the exporter through `ExportOptions.georefMutations`, not through the view, and are untouched.
+
+`getAttributeMutationsByEntity()` and the existing `getAttributeMutationsForEntity()` are both backed by a new entityId-keyed secondary index, mirroring the one already used for property and quantity mutations. That also removes a full-map `startsWith` scan from the per-entity accessor, which the properties panel calls on every selection.
+
+No migration: the overlay and the history are both in-process state, and any edit that was not undone exports exactly as before.

--- a/packages/export/src/attribute-undo.test.ts
+++ b/packages/export/src/attribute-undo.test.ts
@@ -1,0 +1,99 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it, expect } from 'vitest';
+import { IfcParser, extractPropertiesOnDemand } from '@ifc-lite/parser';
+import { MutablePropertyView } from '@ifc-lite/mutations';
+import { StepExporter } from './step-exporter.js';
+
+const decode = (b: Uint8Array) => new TextDecoder().decode(b);
+
+// Two walls so the second edit can stay pending while the first is undone —
+// the exact shape of the #1957 repro (undo with the overlay still dirty).
+const IFC = `ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''),'2;1');
+FILE_NAME('t.ifc','',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#10=IFCWALL('0wall00000000000000001',$,'W-original',$,$,$,$,$,$);
+#20=IFCWALL('0wall00000000000000002',$,'W2-original',$,$,$,$,$,$);
+ENDSEC;
+END-ISO-10303-21;`;
+
+async function parse() {
+  const store = await new IfcParser().parseColumnar(
+    new TextEncoder().encode(IFC).buffer,
+    { disableWorkerScan: true },
+  );
+  const view = new MutablePropertyView(null, 'm');
+  view.setOnDemandExtractor((id: number) => extractPropertiesOnDemand(store, id));
+  return { store, view };
+}
+
+const exportStep = (store: Awaited<ReturnType<typeof parse>>['store'], view: MutablePropertyView) =>
+  decode(new StepExporter(store, view).export({ schema: 'IFC4', applyMutations: true }).content);
+
+/** The `Name` argument (index 2) of `#id` in exported STEP text. */
+function nameOf(step: string, id: number): string | undefined {
+  const line = step.split('\n').find(l => l.startsWith(`#${id}=`));
+  return line?.slice(line.indexOf('(') + 1, line.lastIndexOf(');')).split(',')[2];
+}
+
+/** The `Description` argument (index 3) of `#id` in exported STEP text. */
+function descriptionOf(step: string, id: number): string | undefined {
+  const line = step.split('\n').find(l => l.startsWith(`#${id}=`));
+  return line?.slice(line.indexOf('(') + 1, line.lastIndexOf(');')).split(',')[3];
+}
+
+describe('StepExporter — undone attribute edits are not resurrected (#1957)', () => {
+  it('exports the reverted value after an UPDATE_ATTRIBUTE is undone', async () => {
+    const { store, view } = await parse();
+
+    view.setAttribute(10, 'Name', 'W-edited', 'W-original');
+    // A second, unrelated edit: the overlay stays dirty, so the exporter still
+    // takes the mutation branch.
+    view.setAttribute(20, 'Name', 'W2-edited', 'W2-original');
+    // Undo, exactly as mutationSlice does it: replay the inverse with
+    // skipHistory, leaving the superseded record in the history.
+    view.setAttribute(10, 'Name', 'W-original', undefined, true);
+
+    // The stale record is still in the history — that is the whole point: the
+    // exporter must not read it.
+    expect(view.getMutations().some(m => m.entityId === 10 && m.newValue === 'W-edited')).toBe(true);
+
+    const out = exportStep(store, view);
+    expect(nameOf(out, 10)).toBe("'W-original'");
+    expect(nameOf(out, 20)).toBe("'W2-edited'");
+  });
+
+  it('exports the base value after a newly-set attribute is undone', async () => {
+    const { store, view } = await parse();
+
+    // Description was unset ($), so undo removes the overlay entry outright
+    // rather than restoring a prior value.
+    view.setAttribute(10, 'Description', 'D-added');
+    view.setAttribute(20, 'Name', 'W2-edited', 'W2-original');
+    view.removeAttributeMutation(10, 'Description');
+
+    expect(view.getMutations().some(m => m.attributeName === 'Description')).toBe(true);
+
+    const out = exportStep(store, view);
+    expect(descriptionOf(out, 10)).toBe('$');
+    expect(nameOf(out, 10)).toBe("'W-original'");
+    expect(nameOf(out, 20)).toBe("'W2-edited'");
+  });
+
+  it('still bakes attribute edits that were never undone', async () => {
+    const { store, view } = await parse();
+
+    view.setAttribute(10, 'Name', 'W-edited', 'W-original');
+    view.setAttribute(10, 'Description', 'D-added');
+
+    const out = exportStep(store, view);
+    expect(nameOf(out, 10)).toBe("'W-edited'");
+    expect(descriptionOf(out, 10)).toBe("'D-added'");
+  });
+});

--- a/packages/export/src/step-exporter.test.ts
+++ b/packages/export/src/step-exporter.test.ts
@@ -3,8 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import { describe, expect, it } from 'vitest';
-import { IfcParser, EntityExtractor, type IfcDataStore } from '@ifc-lite/parser';
-import type { MutablePropertyView, Mutation } from '@ifc-lite/mutations';
+import { IfcParser, EntityExtractor, extractPropertiesOnDemand, type IfcDataStore } from '@ifc-lite/parser';
 import { PropertyValueType } from '@ifc-lite/data';
 import { isValidIfcGuid } from '@ifc-lite/encoding';
 import { MutablePropertyView as LiveMutablePropertyView } from '@ifc-lite/mutations';
@@ -12,6 +11,18 @@ import { StepExporter } from './step-exporter.js';
 
 /** Decode Uint8Array content to string for test assertions */
 const decode = (bytes: Uint8Array) => new TextDecoder().decode(bytes);
+
+/**
+ * A real `MutablePropertyView` wired to `store`, never a hand-rolled partial.
+ * Partial fakes silently stop exercising the exporter the moment it reads a
+ * method they don't implement — which is how the overlay-vs-history attribute
+ * bug (#1957) could have shipped unnoticed here.
+ */
+function liveView(store: IfcDataStore): LiveMutablePropertyView {
+  const view = new LiveMutablePropertyView(null, 'test-model');
+  view.setOnDemandExtractor((id: number) => extractPropertiesOnDemand(store, id));
+  return view;
+}
 
 type MockEntityRef = { expressId: number; type: string; byteOffset: number; byteLength: number; lineNumber: number };
 
@@ -204,32 +215,8 @@ describe('StepExporter', () => {
   it('updates type-owned HasPropertySets instead of creating a duplicate relationship', async () => {
     const parser = new IfcParser();
     const store = await parser.parseColumnar(new TextEncoder().encode(SIMPLE_TYPE_INHERITANCE_IFC).buffer);
-    const mutations: Mutation[] = [{
-      id: 'mut_1',
-      type: 'UPDATE_PROPERTY',
-      timestamp: Date.now(),
-      modelId: 'test-model',
-      entityId: 67,
-      psetName: 'Pset_WallCommon',
-      propName: 'AcousticRating',
-      oldValue: 'This is Pset of the WallType',
-      newValue: 'Edited type value',
-      valueType: PropertyValueType.Label,
-    }];
-
-    const mutationView = {
-      getMutations: () => mutations,
-      getForEntity: (entityId: number) => entityId === 67 ? [{
-        name: 'Pset_WallCommon',
-        globalId: '3wkd_mjInDCfOthy7w_A6V',
-        properties: [{
-          name: 'AcousticRating',
-          type: PropertyValueType.Label,
-          value: 'Edited type value',
-        }],
-      }] : [],
-      getQuantitiesForEntity: () => [],
-    } as unknown as MutablePropertyView;
+    const mutationView = liveView(store);
+    mutationView.setProperty(67, 'Pset_WallCommon', 'AcousticRating', 'Edited type value', PropertyValueType.Label);
 
     const exporter = new StepExporter(store, mutationView);
     const result = exporter.export({ schema: 'IFC4', applyMutations: true });
@@ -319,32 +306,8 @@ describe('StepExporter', () => {
   it('reuses the project length unit when exporting property units', async () => {
     const parser = new IfcParser();
     const store = await parser.parseColumnar(new TextEncoder().encode(SIMPLE_TYPE_INHERITANCE_IFC).buffer);
-    const mutations: Mutation[] = [{
-      id: 'mut_unit_1',
-      type: 'CREATE_PROPERTY',
-      timestamp: Date.now(),
-      modelId: 'test-model',
-      entityId: 74,
-      psetName: 'Pset_Custom',
-      propName: 'OffsetDistance',
-      newValue: 12.5,
-      valueType: PropertyValueType.Real,
-    }];
-
-    const mutationView = {
-      getMutations: () => mutations,
-      getForEntity: (entityId: number) => entityId === 74 ? [{
-        name: 'Pset_Custom',
-        globalId: 'test-pset',
-        properties: [{
-          name: 'OffsetDistance',
-          type: PropertyValueType.Real,
-          value: 12.5,
-          unit: 'METRE',
-        }],
-      }] : [],
-      getQuantitiesForEntity: () => [],
-    } as unknown as MutablePropertyView;
+    const mutationView = liveView(store);
+    mutationView.setProperty(74, 'Pset_Custom', 'OffsetDistance', 12.5, PropertyValueType.Real, 'METRE');
 
     const exporter = new StepExporter(store, mutationView);
     const result = exporter.export({ schema: 'IFC4', applyMutations: true });
@@ -357,31 +320,8 @@ describe('StepExporter', () => {
   it('generates valid IFC GlobalIds for new STEP entities', async () => {
     const parser = new IfcParser();
     const store = await parser.parseColumnar(new TextEncoder().encode(SIMPLE_TYPE_INHERITANCE_IFC).buffer);
-    const mutations: Mutation[] = [{
-      id: 'mut_guid_1',
-      type: 'CREATE_PROPERTY',
-      timestamp: Date.now(),
-      modelId: 'test-model',
-      entityId: 74,
-      psetName: 'Pset_GUID_Check',
-      propName: 'Marker',
-      newValue: 'ok',
-      valueType: PropertyValueType.Label,
-    }];
-
-    const mutationView = {
-      getMutations: () => mutations,
-      getForEntity: (entityId: number) => entityId === 74 ? [{
-        name: 'Pset_GUID_Check',
-        globalId: '',
-        properties: [{
-          name: 'Marker',
-          type: PropertyValueType.Label,
-          value: 'ok',
-        }],
-      }] : [],
-      getQuantitiesForEntity: () => [],
-    } as unknown as MutablePropertyView;
+    const mutationView = liveView(store);
+    mutationView.setProperty(74, 'Pset_GUID_Check', 'Marker', 'ok', PropertyValueType.Label);
 
     const exporter = new StepExporter(store, mutationView);
     const result = exporter.export({ schema: 'IFC4', applyMutations: true });

--- a/packages/export/src/step-exporter.ts
+++ b/packages/export/src/step-exporter.ts
@@ -266,21 +266,32 @@ export class StepExporter {
     if (this.mutationView && (options.applyMutations !== false)) {
       const mutations = this.mutationView.getMutations();
 
+      // Attribute values come from the *overlay*, never from the mutation
+      // history. The history is append-only and undo writes its reverse edit
+      // with `skipHistory: true`, so a superseded UPDATE_ATTRIBUTE record keeps
+      // its stale `newValue` forever — replaying it resurrects edits the user
+      // undid (#1957). The overlay is what the editor shows, and it is already
+      // the source for psets, quantities, positional attributes and retypes
+      // below, so attributes were the sole outlier.
+      for (const [entityId, attrs] of this.mutationView.getAttributeMutationsByEntity()) {
+        modifiedEntities.add(entityId);
+        let target = modifiedAttributes.get(entityId);
+        if (!target) {
+          target = new Map();
+          modifiedAttributes.set(entityId, target);
+        }
+        for (const [name, value] of attrs) target.set(name, value);
+      }
+
       // Group mutations by entity, separating property vs quantity mutations
       const entityPropMutations = new Map<number, Set<string>>();
       const entityQuantMutations = new Map<number, Set<string>>();
       for (const mutation of mutations) {
-        if (mutation.type === 'UPDATE_ATTRIBUTE' && mutation.attributeName) {
-          modifiedEntities.add(mutation.entityId);
-          if (!modifiedAttributes.has(mutation.entityId)) {
-            modifiedAttributes.set(mutation.entityId, new Map());
-          }
-          modifiedAttributes.get(mutation.entityId)!.set(
-            mutation.attributeName,
-            mutation.newValue == null ? '' : String(mutation.newValue),
-          );
-          continue;
-        }
+        // Handled above, off the overlay. Skipped explicitly because an
+        // UPDATE_ATTRIBUTE record can also carry a `psetName` (georef fields
+        // encode their target entity there) and must not be mistaken for a
+        // property-set edit.
+        if (mutation.type === 'UPDATE_ATTRIBUTE') continue;
 
         if (!mutation.psetName) continue;
 

--- a/packages/mutations/src/mutable-property-view.ts
+++ b/packages/mutations/src/mutable-property-view.ts
@@ -47,6 +47,7 @@ export class MutablePropertyView {
    */
   private propertyKeysByEntity: Map<number, Set<string>> = new Map();
   private quantityKeysByEntity: Map<number, Set<string>> = new Map();
+  private attributeKeysByEntity: Map<number, Set<string>> = new Map();
   private deletedPsets: Set<string> = new Set(); // `${entityId}:${psetName}`
   private deletedQsets: Set<string> = new Set(); // `${entityId}:${qsetName}`
   private newPsets: Map<number, Map<string, PropertySet>> = new Map(); // entityId -> psetName -> PropertySet
@@ -138,6 +139,28 @@ export class MutablePropertyView {
       if (bucket) {
         bucket.delete(key);
         if (bucket.size === 0) this.quantityKeysByEntity.delete(entityId);
+      }
+    }
+    return removed;
+  }
+
+  private setAttributeMutation(entityId: number, key: string, mutation: AttributeMutation): void {
+    this.attributeMutations.set(key, mutation);
+    let bucket = this.attributeKeysByEntity.get(entityId);
+    if (!bucket) {
+      bucket = new Set();
+      this.attributeKeysByEntity.set(entityId, bucket);
+    }
+    bucket.add(key);
+  }
+
+  private deleteAttributeMutation(entityId: number, key: string): boolean {
+    const removed = this.attributeMutations.delete(key);
+    if (removed) {
+      const bucket = this.attributeKeysByEntity.get(entityId);
+      if (bucket) {
+        bucket.delete(key);
+        if (bucket.size === 0) this.attributeKeysByEntity.delete(entityId);
       }
     }
     return removed;
@@ -781,7 +804,7 @@ export class MutablePropertyView {
   ): Mutation {
     const key = attributeKey(entityId, attrName);
 
-    this.attributeMutations.set(key, {
+    this.setAttributeMutation(entityId, key, {
       attribute: attrName,
       value,
       oldValue,
@@ -1120,10 +1143,31 @@ export class MutablePropertyView {
    */
   getAttributeMutationsForEntity(entityId: number): Array<{ name: string; value: string }> {
     const result: Array<{ name: string; value: string }> = [];
-    for (const [key, mutation] of this.attributeMutations) {
-      if (key.startsWith(`${entityId}:attr:`)) {
-        result.push({ name: mutation.attribute, value: mutation.value });
+    for (const key of this.attributeKeysByEntity.get(entityId) ?? []) {
+      const mutation = this.attributeMutations.get(key);
+      if (mutation) result.push({ name: mutation.attribute, value: mutation.value });
+    }
+    return result;
+  }
+
+  /**
+   * Every attribute override currently in the overlay, keyed by entity then
+   * attribute name.
+   *
+   * This is the *current* overlay state, not the append-only mutation history:
+   * an undone edit has had its overlay entry reset to the pre-edit value (or
+   * removed outright), so it does not appear here, whereas its superseded
+   * `UPDATE_ATTRIBUTE` record lives on in {@link getMutations} forever. Export
+   * must read this — replaying the history resurrects undone edits (#1957).
+   */
+  getAttributeMutationsByEntity(): Map<number, Map<string, string>> {
+    const result = new Map<number, Map<string, string>>();
+    for (const entityId of this.attributeKeysByEntity.keys()) {
+      const attrs = new Map<string, string>();
+      for (const { name, value } of this.getAttributeMutationsForEntity(entityId)) {
+        attrs.set(name, value);
       }
+      if (attrs.size > 0) result.set(entityId, attrs);
     }
     return result;
   }
@@ -1171,8 +1215,7 @@ export class MutablePropertyView {
    * Remove an attribute mutation (used by undo for newly set attributes)
    */
   removeAttributeMutation(entityId: number, attrName: string): void {
-    const key = attributeKey(entityId, attrName);
-    this.attributeMutations.delete(key);
+    this.deleteAttributeMutation(entityId, attributeKey(entityId, attrName));
   }
 
   /**
@@ -1250,6 +1293,7 @@ export class MutablePropertyView {
     this.propertyKeysByEntity.clear();
     this.quantityKeysByEntity.clear();
     this.attributeMutations.clear();
+    this.attributeKeysByEntity.clear();
     this.deletedPsets.clear();
     this.deletedQsets.clear();
     this.newPsets.clear();


### PR DESCRIPTION
Closes #1957.

## The bug

An attribute edit that has been **undone is resurrected on export**. The editor shows the reverted value; the exported IFC carries the pre-undo one. Silent — no error, nothing in the output signals it — and directional, in that it restores data the user explicitly reverted.

## Root cause

`StepExporter` reconstructed attribute values by replaying `MutablePropertyView.getMutations()`, which returns the **append-only mutation history**. Undo applies its inverse edit with `skipHistory: true` (`mutationSlice.ts:2712-2719`), so the superseded `UPDATE_ATTRIBUTE` record survives in that history carrying its stale `newValue`, and the exporter read it back out.

Attributes were the **sole outlier**. Every other overlay-backed path in the same method already reads current state:

| path | source | correct? |
|---|---|---|
| property sets | `getForEntity` | yes |
| quantities | `getQuantitiesForEntity` | yes |
| positional attributes | `getPositionalMutationsForEntity` | yes |
| retypes | `getEntityTypeMutation` | yes |
| **attributes** | **`getMutations()` — history** | **no** |

## The fix

Add `MutablePropertyView.getAttributeMutationsByEntity()`, returning the current overlay keyed by entity, and have the exporter read that. Undo already maintains the overlay correctly in both directions — restoring the prior value when one existed, `removeAttributeMutation` when the attribute was newly set — so no change to the mutation model was needed.

Of the two options the issue offered, this is #1 ("read the overlay inside `StepExporter`"). Option #2 (make undo rewrite history) was not taken: it changes the semantics of the mutation model for every other `getMutations()` consumer, and the history is deliberately append-only.

The new accessor and the existing `getAttributeMutationsForEntity()` share an entityId-keyed secondary index, mirroring `propertyKeysByEntity` / `quantityKeysByEntity` already in the class. That also removes a full-map `startsWith` scan from the per-entity accessor, which `PropertiesPanel` calls on every selection.

## Scope, checked rather than assumed

The issue noted only the attribute path was traced. I checked the rest:

- **Property / quantity edits are not affected.** The history is used only to decide *which pset names* to re-emit; the values come from the overlay. An undone property edit is re-emitted with its correct current value — a redundant rewrite with identical output, which is the conservative direction `hasPendingChanges()` already documents.
- **Georeferencing edits are not affected.** They reach the exporter through `ExportOptions.georefMutations`, never through the view. They do carry a `psetName` on their `UPDATE_ATTRIBUTE` records, so the pset loop now skips `UPDATE_ATTRIBUTE` explicitly rather than relying on the `continue` the old attribute branch happened to provide.

## Tests

`packages/export/src/attribute-undo.test.ts` — three cases driving a **real** `MutablePropertyView` and undoing exactly as `mutationSlice` does (inverse edit with `skipHistory`), then asserting the exported STEP argument:

1. undo of an update to a pre-existing attribute → exports the original value;
2. undo of a newly-set attribute → exports `$`;
3. control: an edit that was *never* undone still bakes.

Each asserts the stale record is still in `getMutations()`, so the test proves the exporter reads the overlay rather than an emptied history.

**Mutation-checked:** with the fix reverted, 1 and 2 fail and 3 passes.

## Test doubles replaced

Three tests in `step-exporter.test.ts` used hand-rolled partial `MutablePropertyView` fakes cast `as unknown as MutablePropertyView`, and broke the moment the exporter read a new method. They now use the real class, as the rest of that file already did. All assertions held unchanged, which also confirms the fakes were faithful.

## Verification

- `packages/export`: 248 passed, 28 skipped (was 245 + the 3 rewritten)
- `packages/mutations`: 73 passed, 10 skipped
- `pnpm typecheck`: 33/33
- `scripts/api-surface.json` unchanged — the addition is a class method, not a module export

## Migration

None. Both the overlay and the history are in-process state, and any edit that was not undone exports byte-identically.