### PR TITLE
fix(viewer): keep dropdown popups opaque in the colorful theme (#1924)

### DIFF
--- a/apps/viewer/src/components/ui/combo-input.tsx
+++ b/apps/viewer/src/components/ui/combo-input.tsx
@@ -133,7 +133,7 @@ export function ComboInput({
           // so selecting a value doesn't also close the whole modal.
           style={{ position: 'fixed', left: anchor.left, top: anchor.top + 4, minWidth: anchor.width, pointerEvents: 'auto' }}
           onPointerDown={(e) => e.stopPropagation()}
-          className="z-[120] max-h-60 w-max max-w-[20rem] overflow-y-auto rounded-md border border-zinc-200 bg-white py-1 shadow-lg dark:border-zinc-800 dark:bg-zinc-950"
+          className="popover-surface z-[120] max-h-60 w-max max-w-[20rem] overflow-y-auto rounded-md border border-zinc-200 bg-white py-1 shadow-lg dark:border-zinc-800 dark:bg-zinc-950"
         >
           {filtered.map((o, i) => (
             <button

--- a/apps/viewer/src/components/viewer/LensPanel.tsx
+++ b/apps/viewer/src/components/viewer/LensPanel.tsx
@@ -120,7 +120,7 @@ function SearchableSelect({
         <ChevronDown className="h-3 w-3 flex-shrink-0 opacity-50" />
       </button>
       {open && (
-        <div className="absolute z-50 top-full left-0 right-0 mt-0.5 bg-white dark:bg-zinc-800 border border-zinc-300 dark:border-zinc-600 rounded-sm shadow-lg max-h-[200px] flex flex-col">
+        <div className="popover-surface absolute z-50 top-full left-0 right-0 mt-0.5 bg-white dark:bg-zinc-800 border border-zinc-300 dark:border-zinc-600 rounded-sm shadow-lg max-h-[200px] flex flex-col">
           {options.length > 8 && (
             <div className="flex items-center gap-1 px-1.5 py-1 border-b border-zinc-200 dark:border-zinc-700">
               <Search className="h-3 w-3 text-zinc-400 flex-shrink-0" />

--- a/apps/viewer/src/components/viewer/colorful-popover-opacity.test.ts
+++ b/apps/viewer/src/components/viewer/colorful-popover-opacity.test.ts
@@ -1,0 +1,89 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Issue #1924: dropdown popups were see-through in the secret "colorful" theme.
+ *
+ * The theme deliberately glasses panel surfaces — `.colorful .bg-white` is
+ * rewritten to `--cf-glass` (48% alpha) with `!important`, and `--color-popover`
+ * was `--cf-glass-strong` (68%). Panels sit against the aurora backdrop so that
+ * reads well, but a dropdown floats over arbitrary content and at those alphas
+ * the option text becomes unreadable.
+ *
+ * These assertions run against the stylesheet source rather than a rendered
+ * DOM: the rules are plain CSS with no JS behaviour to exercise, and Tailwind's
+ * utilities are not materialised in the test environment, so a jsdom/happy-dom
+ * `getComputedStyle` check would pass whatever the file said. Reading the
+ * source is the honest way to pin an `!important` ordering contract.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CSS = readFileSync(join(__dirname, '../../index.css'), 'utf-8');
+
+/**
+ * Just the `.colorful { ... }` token block. `--color-popover` is also defined
+ * for the light and dark themes, so an unscoped search matches the light one
+ * first and the assertion silently tests nothing.
+ */
+const COLORFUL_BLOCK = (() => {
+  const start = CSS.indexOf('.colorful {');
+  assert.ok(start > 0, '.colorful token block must exist');
+  const end = CSS.indexOf('\n}', start);
+  assert.ok(end > start, '.colorful token block must terminate');
+  return CSS.slice(start, end);
+})();
+
+/** Alpha of an `rgba(r, g, b, a)` literal; 1 for any opaque form. */
+function alphaOf(color: string): number {
+  const m = color.match(/rgba\(\s*[\d.]+\s*,\s*[\d.]+\s*,\s*[\d.]+\s*,\s*([\d.]+)\s*\)/);
+  return m ? Number(m[1]) : 1;
+}
+
+describe('colorful theme: dropdown popups stay opaque (#1924)', () => {
+  it('--cf-popover-solid is fully opaque', () => {
+    const m = COLORFUL_BLOCK.match(/--cf-popover-solid:\s*([^;]+);/);
+    assert.ok(m, '--cf-popover-solid must be defined');
+    assert.equal(alphaOf(m[1].trim()), 1, `popup surface must be opaque, got ${m[1].trim()}`);
+  });
+
+  it('--color-popover resolves to the solid token, not the glass one', () => {
+    const m = COLORFUL_BLOCK.match(/--color-popover:\s*([^;]+?)\s*(?:!important)?;/);
+    assert.ok(m, '--color-popover must be defined in .colorful');
+    assert.match(
+      m[1],
+      /--cf-popover-solid/,
+      'Radix Select/DropdownMenu render on `bg-popover`; pointing this at a glass token is exactly what made them see-through',
+    );
+  });
+
+  it('the popover-surface rule comes AFTER the .bg-white glass rule', () => {
+    // Both carry `!important` and equal specificity would not save us — the
+    // later rule wins. If the glass block is ever moved below this one, the
+    // hand-rolled popups silently go transparent again.
+    const glass = CSS.indexOf('.colorful .bg-white');
+    const popover = CSS.indexOf('.colorful .popover-surface');
+    assert.ok(glass > 0, '.colorful .bg-white glass rule must exist');
+    assert.ok(popover > 0, '.colorful .popover-surface rule must exist');
+    assert.ok(
+      popover > glass,
+      'the opaque popup rule must come after the glass rule, or the glass wins the cascade',
+    );
+  });
+
+  it('the popover-surface rule disables backdrop-filter', () => {
+    const block = CSS.slice(CSS.indexOf('.colorful .popover-surface'));
+    const body = block.slice(0, block.indexOf('}'));
+    assert.match(
+      body,
+      /backdrop-filter:\s*none\s*!important/,
+      'backdrop-filter creates a stacking context and containing block — the likely cause of the reported paint-order inversion',
+    );
+  });
+});

--- a/apps/viewer/src/index.css
+++ b/apps/viewer/src/index.css
@@ -507,13 +507,20 @@ body {
   /* Glass */
   --cf-glass: rgba(255, 255, 255, 0.48);
   --cf-glass-strong: rgba(255, 255, 255, 0.68);
+  /* Popup surfaces are OPAQUE (issue #1924). Glass reads beautifully on panels,
+     which sit against the aurora backdrop — but a dropdown floats over arbitrary
+     content (the 3D viewport, another panel, its own trigger), so at 0.48-0.68
+     alpha whatever is behind it shows through the option text and the list stops
+     being readable. Tinted to keep the theme's cast rather than reverting to
+     flat white. */
+  --cf-popover-solid: #eceefa;
 
   /* ── Semantic tokens ── */
   --color-background: #e0e6f0 !important;
   --color-foreground: #1a1b2e !important;
   --color-card: var(--cf-glass) !important;
   --color-card-foreground: #1a1b2e !important;
-  --color-popover: var(--cf-glass-strong) !important;
+  --color-popover: var(--cf-popover-solid) !important;
   --color-popover-foreground: #1a1b2e !important;
   --color-primary: var(--cf-purple) !important;
   --color-primary-foreground: #fff !important;
@@ -570,6 +577,29 @@ body {
 .colorful .bg-zinc-50,
 .colorful .bg-zinc-100 {
   background-color: rgba(255, 255, 255, 0.25) !important;
+}
+
+/* ── Popup surfaces stay opaque (issue #1924) ──
+   Must come AFTER the .bg-white / .bg-zinc-900 glass rules above: those match
+   any element carrying the utility, including the hand-rolled dropdown popups
+   (`SearchableSelect`, `ComboInput`) which are `bg-white dark:bg-zinc-800`.
+   Glassing them is what made "some pull-downs transparent" — and only *some*,
+   because a native <select>'s option list is drawn by the browser outside page
+   CSS and never picks the override up.
+
+   Radix-based dropdowns (`ui/select.tsx`, `ui/dropdown-menu.tsx`) use
+   `bg-popover` and are already handled by `--color-popover` being solid; the
+   `[data-radix-popper-content-wrapper]` arm keeps any future popper content
+   opaque even if it reaches for a raw utility instead. */
+.colorful .popover-surface,
+.colorful [data-radix-popper-content-wrapper] > * {
+  background: var(--cf-popover-solid) !important;
+  /* No backdrop-filter: besides being pointless on an opaque surface, it
+     creates a stacking context and a containing block, which is the likely
+     cause of the reported paint-order inversion (footer buttons rendering
+     over the option rows). */
+  backdrop-filter: none !important;
+  -webkit-backdrop-filter: none !important;
 }
 
 .colorful .bg-zinc-900,


### PR DESCRIPTION
## What and why

Closes #1924.

@MennoMekes filed this from the **secret colorful mode** (shift-click the theme switcher), and that detail is what makes the symptom make sense: in that theme the popups genuinely *are* transparent, by the theme's own doing.

`.colorful` rewrites `.bg-white` to `--cf-glass` — `rgba(255, 255, 255, 0.48)` — with `!important` (`index.css:562-568`), and `--color-popover` was `--cf-glass-strong`, `rgba(255, 255, 255, 0.68)`. Glass reads beautifully on panels, which sit against the aurora backdrop. A dropdown does not sit against the backdrop: it floats over arbitrary content — the 3D viewport, another panel, its own trigger — so at 48-68% alpha whatever is behind it shows straight through the option text.

**"Some pull-downs are transparent, but not all"** is explained exactly by this. The `Source` field in the first screenshot is a native `<select>`, and the browser draws a native option list outside the page's CSS, so `.colorful .bg-white` can never reach it. Every hand-rolled or Radix popup gets glassed; every native one does not.

## The fix

- `--color-popover` now resolves to a new **opaque** `--cf-popover-solid`, which covers every Radix `bg-popover` surface (`ui/select.tsx`, `ui/dropdown-menu.tsx`).
- The two hand-rolled popups that carry `bg-white` — `SearchableSelect` in `LensPanel.tsx` and `ComboInput` — are tagged `popover-surface`, with a rule placed **after** the glass block so it wins the cascade.
- That rule also sets `backdrop-filter: none`. Beyond being pointless on an opaque surface, `backdrop-filter` establishes a stacking context *and* a containing block — which is the most likely cause of the paint-order inversion in the second screenshot, where Save/Cancel render over the option rows.

Tinted `#eceefa` rather than flat white, so the theme keeps its cast instead of punching a plain hole in it.

## Verification

- 4 new tests, each mutation-checked: pointing `--color-popover` back at the glass token fails the token assertion; making `--cf-popover-solid` translucent fails the opacity assertion.
- The cascade-order assertion is deliberate. Both rules carry `!important` and have comparable specificity, so source order decides — if the glass block ever moves below the popup rule, the popups silently go see-through again and nothing else would catch it.
- `pnpm typecheck` 33/33 · viewer 2175 passed, 2 skipped (fixture-gated), 0 failed.
- No changeset: `apps/viewer` is not published and no `packages/*` surface changes.

## Relationship to #1958

Different defect, same component. #1958 fixes **clipping** of the `SearchableSelect` popup by `overflow` ancestors, which is real and worth having. But its stated premise — *"It is not transparency, and not a missing background — the popup already sets `bg-white dark:bg-zinc-800`"* — holds for light/dark and not for the mode this issue was filed from: setting `bg-white` is precisely what the colorful theme overrides. So #1958 should not close #1924, and this PR does not make #1958 redundant.

The two touch one shared line in `LensPanel.tsx` (the popup's `className`), so whichever lands second needs a one-line rebase.
