### PR TITLE
fix(renderer): apply the per-element origin to textured meshes (#1973)

### DIFF
--- a/.changeset/textured-mesh-origin.md
+++ b/.changeset/textured-mesh-origin.md
@@ -1,0 +1,13 @@
+---
+'@ifc-lite/renderer': patch
+---
+
+Fix textured face sets rendering collapsed toward the world origin (#1973).
+
+`transform_mesh_world_framed` (on by default for wasm) stores each element's vertices relative to a per-element `MeshData.origin`, keeping the world magnitude out of f32 so building-scale coordinates can't collapse adjacent vertices into degenerate fans. The contract downstream is `world = origin + position`.
+
+The batch path honours it — `mergeGeometry` folds `origin` into the shared frame and draws with `translate(sharedFrameOrigin)`. The textured sub-pass hard-zeroed its model translation, so every textured mesh drew offset by `-origin`. On a typical textured export that is metres: on the reported model, 107 of 109 meshes are textured and every one of them has a non-zero origin, up to ~19 m. The whole model rendered as a crushed heap around the origin. CPU picking uses the correctly placed geometry, so clicking a visible texture selected nothing.
+
+The zeroing was correct when written: the #961 orphan type-geometry path runs `transform_mesh_local`, which leaves positions absolute and `origin` at zero. #1793 then added the occurrence path (a `Body` textured `IfcTriangulatedFaceSet`, which is what real exporters write) via `apply_submesh_placement` → `transform_mesh_world`, producing local-frame positions and a non-zero origin — and the textured pass was not updated for it.
+
+`TexturedMesh` now carries `origin`, applied as the draw's model translation. Interleaved vertex positions stay local: folding the world magnitude back into f32 vertex data would defeat the local frame this origin exists to provide. Both cases are covered — `origin == 0` for the orphan path is a no-op, `origin != 0` for occurrences is the fix.

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -2407,10 +2407,6 @@ export class Renderer {
                 const texturedMeshes = this.scene.getTexturedMeshes();
                 if (texturedMeshes.length > 0) {
                     pass.setPipeline(this.pipeline.getTexturedPipeline());
-                    // Textured meshes carry absolute (origin-0) positions, so the
-                    // model translation must be identity here — reset the column
-                    // that renderBatch left set to the last opaque batch's origin.
-                    tpl[28] = 0; tpl[29] = 0; tpl[30] = 0;
                     for (const tm of texturedMeshes) {
                         // Honour hide/isolate — textured meshes bypass the batch
                         // visibility filtering above, so apply it per-mesh here or
@@ -2435,6 +2431,16 @@ export class Renderer {
                         // batch overlay paint pass doesn't iterate textured meshes,
                         // so applying the override here is what recolours them.
                         const txOverride = colorOverrides?.get(tm.expressId);
+                        // `world = origin + position`: the vertex buffer stores
+                        // positions in this mesh's per-element local frame, so the
+                        // model translation carries the world magnitude (#1973).
+                        // Per mesh, which also overwrites the column renderBatch
+                        // left set to the last opaque batch's origin. This used to
+                        // be hoisted out of the loop and hard-zeroed — right only
+                        // for the orphan type-geometry path (origin == 0), and it
+                        // drew every textured occurrence collapsed toward the
+                        // world origin.
+                        tpl[28] = tm.origin[0]; tpl[29] = tm.origin[1]; tpl[30] = tm.origin[2];
                         tpl[32] = txOverride ? txOverride[0] : tm.color[0];
                         tpl[33] = txOverride ? txOverride[1] : tm.color[1];
                         tpl[34] = txOverride ? txOverride[2] : tm.color[2];

--- a/packages/renderer/src/renderer-render-paths.test.ts
+++ b/packages/renderer/src/renderer-render-paths.test.ts
@@ -56,6 +56,8 @@ interface Harness {
         createdBuffers: FakeBuffer[];
         /** how many times a readback buffer was actually mapped */
         mapAsync: number;
+        /** every `queue.writeBuffer` payload, copied at call time */
+        writes: { buffer: unknown; floats: Float32Array }[];
     };
     knobs: {
         /** 'texture' = getCurrentTexture succeeds; 'null' = returns null */
@@ -88,7 +90,7 @@ interface Harness {
 }
 
 function makeHarness(): Harness {
-    const stats: Harness['stats'] = { push: 0, pop: 0, draws: [], createdBuffers: [], mapAsync: 0 };
+    const stats: Harness['stats'] = { push: 0, pop: 0, draws: [], createdBuffers: [], mapAsync: 0, writes: [] };
     const knobs: Harness['knobs'] = {
         textureMode: 'texture', encodeThrows: false, popRejects: false, gpuDead: false,
         deferMaps: false,
@@ -147,7 +149,17 @@ function makeHarness(): Harness {
     });
 
     const queue = {
-        writeBuffer() { /* no-op */ },
+        // Copied eagerly: the renderer reuses one scratch array for every
+        // per-mesh uniform, so holding the reference would read back only the
+        // LAST value written in the frame.
+        writeBuffer(buffer: unknown, _offset: number, data: ArrayBufferView | ArrayBuffer) {
+            const floats = ArrayBuffer.isView(data)
+                ? new Float32Array(data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength))
+                : new Float32Array(data.slice(0));
+            stats.writes.push({ buffer, floats });
+        },
+        writeTexture() { /* no-op */ },
+        copyExternalImageToTexture() { /* no-op */ },
         submit() { /* no-op */ },
         onSubmittedWorkDone() { return Promise.resolve(); },
     };
@@ -739,5 +751,88 @@ describe('pick path survives the device dying mid-readback (#1901)', () => {
         for (const buf of readbacks) {
             assert.ok(buf.destroyed > 0, 'a readback buffer survived the rethrow — leaked');
         }
+    });
+});
+
+/**
+ * #1973 — the textured sub-pass must carry each mesh's per-element `origin` as
+ * its model translation. It used to hoist `tpl[28..30] = 0` out of the loop,
+ * which was right only for the orphan type-geometry path (absolute positions,
+ * `origin == 0`) and drew every textured occurrence offset by `-origin`.
+ *
+ * The scene-side bookkeeping is covered in `scene-textured-origin.test.ts`;
+ * this asserts the value that actually reaches the GPU.
+ */
+function texturedTriangle(expressId: number, origin?: [number, number, number]): MeshData {
+    return {
+        expressId,
+        positions: new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]),
+        normals: new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]),
+        indices: new Uint32Array([0, 1, 2]),
+        color: [1, 1, 1, 1],
+        uvs: new Float32Array([0, 0, 1, 0, 0, 1]),
+        texture: { width: 1, height: 1, data: new Uint8Array([255, 255, 255, 255]) },
+        ...(origin ? { origin } : {}),
+    } as unknown as MeshData;
+}
+
+/** The model-matrix translation column of the uniform written for `tm`. */
+function translationFor(h: Harness, uniformBuffer: unknown): number[] | null {
+    for (let i = h.stats.writes.length - 1; i >= 0; i--) {
+        const w = h.stats.writes[i];
+        if (w.buffer === uniformBuffer && w.floats.length > 30) {
+            return [w.floats[28], w.floats[29], w.floats[30]];
+        }
+    }
+    return null;
+}
+
+describe('textured sub-pass carries the per-element origin (#1973)', () => {
+    const ORIGIN: [number, number, number] = [12.5, 10.5, -3.25];
+
+    function seedTextured(h: Harness, meshes: MeshData[]) {
+        const scene = h.renderer.getScene();
+        const device = h.renderer['device'].getDevice();
+        const pipeline = h.renderer['pipeline'] as never;
+        scene.appendToBatches(meshes, device, pipeline, false);
+        return scene.getTexturedMeshes();
+    }
+
+    it('writes the mesh origin into the model translation', () => {
+        const h = makeHarness();
+        const textured = seedTextured(h, [texturedTriangle(1, ORIGIN)]);
+        assert.strictEqual(textured.length, 1);
+
+        h.stats.writes.length = 0;
+        h.render();
+
+        assert.deepStrictEqual(translationFor(h, textured[0].uniformBuffer), ORIGIN);
+    });
+
+    it('writes zero for a mesh whose positions are already absolute', () => {
+        // The #961 orphan type-geometry path: `transform_mesh_local` leaves
+        // positions in world space and sets no origin.
+        const h = makeHarness();
+        const textured = seedTextured(h, [texturedTriangle(1)]);
+
+        h.stats.writes.length = 0;
+        h.render();
+
+        assert.deepStrictEqual(translationFor(h, textured[0].uniformBuffer), [0, 0, 0]);
+    });
+
+    it('gives each textured mesh its OWN origin, not the last one written', () => {
+        // The bug class this replaces was a single hoisted write shared by every
+        // mesh in the pass, so per-mesh divergence is the property that matters.
+        const h = makeHarness();
+        const other: [number, number, number] = [-4, 0.5, 88];
+        const textured = seedTextured(h, [texturedTriangle(1, ORIGIN), texturedTriangle(2, other)]);
+        assert.strictEqual(textured.length, 2);
+
+        h.stats.writes.length = 0;
+        h.render();
+
+        assert.deepStrictEqual(translationFor(h, textured[0].uniformBuffer), ORIGIN);
+        assert.deepStrictEqual(translationFor(h, textured[1].uniformBuffer), other);
     });
 });

--- a/packages/renderer/src/scene-textured-origin.test.ts
+++ b/packages/renderer/src/scene-textured-origin.test.ts
@@ -1,0 +1,156 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * #1973 — textured meshes must reconstruct `world = origin + position`.
+ *
+ * `transform_mesh_world_framed` (on by default for wasm) stores each element's
+ * vertices RELATIVE to a per-element `MeshData.origin` so the world magnitude
+ * stays out of f32. The batch path folds that origin into the shared frame; the
+ * textured sub-pass hard-zeroed its model translation, so every textured
+ * occurrence drew offset by `-origin` — collapsed toward the world origin,
+ * while CPU picking used the correctly placed geometry.
+ *
+ * The invariant asserted here is the one the issue asks for: a textured face
+ * set and its untextured twin land at the same world AABB. Buffer allocation
+ * and draws need a real GPUDevice, but the origin bookkeeping and the
+ * interleaved vertex data are GPU-agnostic, so a capturing stub suffices.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { Scene } from './scene.js';
+import { mergeGeometry } from './scene-geometry.js';
+import type { MeshData } from './types.js';
+
+// WebGPU enum globals used by Scene buffer/texture creation (not defined in
+// node) — same stub the other renderer tests install.
+(globalThis as Record<string, unknown>).GPUBufferUsage = {
+  MAP_READ: 1, MAP_WRITE: 2, COPY_SRC: 4, COPY_DST: 8, INDEX: 16,
+  VERTEX: 32, UNIFORM: 64, STORAGE: 128, INDIRECT: 256, QUERY_RESOLVE: 512,
+};
+(globalThis as Record<string, unknown>).GPUTextureUsage = {
+  COPY_SRC: 1, COPY_DST: 2, TEXTURE_BINDING: 4, STORAGE_BINDING: 8, RENDER_ATTACHMENT: 16,
+};
+
+/** Captures every `writeBuffer` payload so the interleaved vertices can be read back. */
+function fakeDevice(): { device: GPUDevice; writes: ArrayBuffer[] } {
+  const writes: ArrayBuffer[] = [];
+  const device = {
+    limits: { maxBufferSize: 1 << 30, maxStorageBufferBindingSize: 1 << 30 },
+    createBuffer: () => ({ destroy() {}, size: 0 }),
+    createTexture: () => ({ destroy() {}, createView: () => ({}) }),
+    createSampler: () => ({}),
+    queue: {
+      writeBuffer: (_b: unknown, _o: number, data: ArrayBuffer | ArrayBufferView) => {
+        writes.push(ArrayBuffer.isView(data) ? data.buffer as ArrayBuffer : data);
+      },
+      writeTexture: () => {},
+      copyExternalImageToTexture: () => {},
+    },
+  };
+  return { device: device as unknown as GPUDevice, writes };
+}
+
+const fakePipeline = {
+  createTexturedBindGroup: () => ({}),
+  createBindGroup: () => ({}),
+  getUniformBufferSize: () => 256,
+} as unknown as Parameters<Scene['appendToBatches']>[2];
+
+/** A unit triangle at the model origin, offset into world space by `origin`. */
+function meshData(expressId: number, origin: [number, number, number], textured: boolean): MeshData {
+  const base: Record<string, unknown> = {
+    expressId,
+    positions: new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]),
+    normals: new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]),
+    indices: new Uint32Array([0, 1, 2]),
+    color: [1, 1, 1, 1],
+    origin,
+  };
+  if (textured) {
+    base.uvs = new Float32Array([0, 0, 1, 0, 0, 1]);
+    base.texture = { width: 1, height: 1, data: new Uint8Array([255, 255, 255, 255]) };
+  }
+  return base as unknown as MeshData;
+}
+
+/** World-space AABB of `positions` once `origin` is folded back in. */
+function worldBounds(positions: ArrayLike<number>, origin: [number, number, number]) {
+  const min = [Infinity, Infinity, Infinity];
+  const max = [-Infinity, -Infinity, -Infinity];
+  for (let i = 0; i < positions.length; i += 3) {
+    for (let a = 0; a < 3; a++) {
+      const w = positions[i + a] + origin[a];
+      if (w < min[a]) min[a] = w;
+      if (w > max[a]) max[a] = w;
+    }
+  }
+  return { min, max };
+}
+
+/** Positions read out of the stride-36 interleaved textured vertex layout. */
+function texturedPositions(interleaved: ArrayBuffer, vertexCount: number): number[] {
+  const f = new Float32Array(interleaved);
+  const out: number[] = [];
+  for (let i = 0; i < vertexCount; i++) out.push(f[i * 9], f[i * 9 + 1], f[i * 9 + 2]);
+  return out;
+}
+
+// A real occurrence origin: SketchUp/BIM-Tools exports place elements via a
+// normal IfcLocalPlacement chain, so the elevation lives in `origin`.
+const ORIGIN: [number, number, number] = [12.5, 10.5, -3.25];
+
+describe('textured meshes carry their per-element origin (#1973)', () => {
+  it('records MeshData.origin on the TexturedMesh', () => {
+    const scene = new Scene();
+    const { device } = fakeDevice();
+
+    scene.appendToBatches([meshData(1, ORIGIN, true)], device, fakePipeline);
+
+    const textured = scene.getTexturedMeshes();
+    assert.strictEqual(textured.length, 1);
+    assert.deepStrictEqual([...textured[0].origin], ORIGIN);
+  });
+
+  it('lands at the same world AABB as an untextured twin', () => {
+    const scene = new Scene();
+    const { device, writes } = fakeDevice();
+
+    scene.appendToBatches([meshData(1, ORIGIN, true)], device, fakePipeline);
+
+    const textured = scene.getTexturedMeshes()[0];
+    // The vertex buffer is the first (and largest) write; positions must still
+    // be LOCAL — folding the world magnitude into f32 here would defeat the
+    // local frame the origin exists to provide.
+    const interleaved = writes.find((w) => w.byteLength === 3 * 36);
+    assert.ok(interleaved, 'interleaved vertex buffer was uploaded');
+    const positions = texturedPositions(interleaved, 3);
+    assert.deepStrictEqual(positions, [0, 0, 0, 1, 0, 0, 0, 1, 0]);
+
+    // The batch path is the reference: it reconstructs world = origin + position.
+    const merged = mergeGeometry([meshData(2, ORIGIN, false)]);
+
+    const texturedWorld = worldBounds(positions, [...textured.origin] as [number, number, number]);
+    assert.deepStrictEqual(texturedWorld.min, [...merged.bounds.min]);
+    assert.deepStrictEqual(texturedWorld.max, [...merged.bounds.max]);
+    // And it is genuinely offset from the model origin — a regression that
+    // dropped `origin` would put this AABB at [0,0,0]..[1,1,0] and still agree
+    // with itself.
+    assert.deepStrictEqual(texturedWorld.min, [12.5, 10.5, -3.25]);
+  });
+
+  it('keeps origin at zero for absolute-position meshes', () => {
+    // The #961 orphan type-geometry path runs `transform_mesh_local`, which
+    // leaves positions absolute and `origin` unset.
+    const scene = new Scene();
+    const { device } = fakeDevice();
+    const md = meshData(1, [0, 0, 0], true);
+    delete (md as unknown as Record<string, unknown>).origin;
+
+    scene.appendToBatches([md], device, fakePipeline);
+
+    assert.deepStrictEqual([...scene.getTexturedMeshes()[0].origin], [0, 0, 0]);
+  });
+});

--- a/packages/renderer/src/scene.ts
+++ b/packages/renderer/src/scene.ts
@@ -71,6 +71,23 @@ export interface TexturedMesh {
   bindGroup: GPUBindGroup;
   /** Authored tint (multiplies the sampled texel); white = texture passthrough. */
   color: [number, number, number, number];
+  /**
+   * The mesh's per-element local frame (`MeshData.origin`, already Y-up) — the
+   * renderer must reconstruct `world = origin + position`.
+   *
+   * The interleaved vertex buffer stores positions RELATIVE to this, which is
+   * the whole point of the local frame (#1114): keeping the world magnitude out
+   * of f32 so building-scale coordinates don't collapse adjacent vertices into
+   * degenerate fans. So it is applied as the draw's model translation, never
+   * folded back into the vertex data.
+   *
+   * `[0, 0, 0]` for the #961 orphan type-geometry path, whose positions are
+   * already absolute (`transform_mesh_local`); non-zero for the #1793
+   * occurrence path (`apply_submesh_placement` → `transform_mesh_world`), which
+   * is what real exporters write. Dropping it drew every textured occurrence
+   * collapsed toward the world origin (#1973).
+   */
+  origin: [number, number, number];
   /** Set when `texture` lives in the shared registry (#1781: one GPU texture
    *  per `IfcImageTexture`, sampled by many meshes) — released by refcount,
    *  never destroyed per-mesh. Undefined for per-mesh #961 blob/pixel uploads. */
@@ -3554,6 +3571,11 @@ export class Scene {
       sampler,
       bindGroup,
       color: meshData.color,
+      // `world = origin + position` (#1973). Absent on the orphan
+      // type-geometry path, whose positions are already absolute.
+      origin: meshData.origin
+        ? [meshData.origin[0], meshData.origin[1], meshData.origin[2]]
+        : [0, 0, 0],
       ...(sharedTextureKey !== undefined ? { sharedTextureKey } : {}),
     });
   }


### PR DESCRIPTION
Closes #1973.

The report's analysis is correct in full — I verified each claim against the code rather than taking it as given, and every one holds. Credit to @janbrouwer: the root cause, the two candidate fixes and the suggested regression test were all accurate.

## The bug

Local-frame meshes store vertices relative to a per-element `MeshData.origin` so the world magnitude stays out of f32 (#1114). The contract is `world = origin + position`.

| path | stored | model translation | world |
|---|---|---|---|
| batch (`mergeGeometry`) | `(origin − sharedOrigin) + position` | `translate(sharedOrigin)` | ✅ `origin + position` |
| textured (before) | `position` | `translate(0)` | ❌ `position` |

Off by exactly `−origin`. CPU picking uses the correctly placed geometry, so clicking a visible texture selected nothing.

The zeroing was right when written: the #961 orphan type-geometry path runs `transform_mesh_local`, leaving positions absolute with `origin == 0`. #1793 then added the occurrence path — a `Body` textured `IfcTriangulatedFaceSet`, which is what real exporters write — via `apply_submesh_placement` → `transform_mesh_world` → `transform_mesh_world_framed(relativize = local_frame_enabled())`, and `local_frame_enabled()` defaults **on for wasm**. So the viewer path produces a non-zero origin and this sub-pass was never updated.

This is the third instance of the same class (the void fast-path #1806/#1815 was the last): a world-space consumer that doesn't fold `MeshData.origin`.

## The fix

`TexturedMesh` carries `origin`; the draw sets the model translation from it per mesh. The loop already wrote `tpl` per mesh (per-mesh colour at `tpl[32..35]`), so this is a hoisted-constant becoming a per-mesh value — no restructuring.

**Interleaved positions deliberately stay local.** Folding the world magnitude back into the f32 vertex data is the obvious-looking alternative and it is wrong: it defeats the local frame this origin exists to provide and reintroduces the coordinate collapse on exactly the georeferenced models that need it. The test asserts the positions are still local.

I took the report's "small" option. The "bigger" one (put textured meshes on the batch frame) is a genuine improvement for keeping textured/opaque bit-coincident under `depthCompare:'equal'`, but it is not needed to fix this and is a larger change to the id/frame space.

Also checked, not assumed: the translate (`scene.ts:1489`) and rotate (`scene.ts:1682`) re-upload paths re-interleave from `meshData` and mutate only `positions` — rotation reads `meshData.origin` to fold the pivot but never writes it — so the cached `TexturedMesh.origin` stays valid across gizmo moves with no extra work. And leaving `tpl[28..30]` set no longer leaks: `renderBatch` always overwrites it from `batch.origin`, and the transparent passes overwrite the whole model matrix via `tpl.set(mesh.transform.m, 16)`.

## Verification on the reported model

`tests/models/textures/ifc-hbim-convento-textures.ifczip`, loaded in the WebGPU viewer. Read from the live store:

```
totalMeshes: 109,  textured: 107,  texturedWithNonZeroOrigin: 107
sample origins: [-19.03, 9.45, -12.79], [-19.22, 5.33, -14.84], [-19.13, 5.03, -14.11], …
```

Every textured mesh on this file was mis-drawn, by up to ~19 m.

Live A/B in the browser (the viewer aliases `@ifc-lite/renderer` to source, so reverting just the draw line gives a clean HMR comparison):

- **Before:** the model renders as a crushed heap of overlapping fragments collapsed around the origin.
- **After:** a coherent building — roof, courtyard and walls in their authored positions.

Screenshots are in the issue thread below.

## Tests

`packages/renderer/src/scene-textured-origin.test.ts` — the invariant the issue asks for, GPU-free via a capturing device stub:

1. `MeshData.origin` is recorded on the `TexturedMesh`.
2. A textured face set lands at the **same world AABB** as its untextured twin through `mergeGeometry` — and the interleaved positions are asserted still local, so a "bake the origin in" regression fails here too.
3. `origin` stays `[0,0,0]` for the absolute-position orphan path.

**Mutation-checked:** reverting `scene.ts` fails all three.

**Scope note, stated plainly:** these cover the scene-side bookkeeping and the reconstruction arithmetic. The one-line uniform write in `index.ts` is not unit-covered — the existing render-path harness stubs `writeBuffer` as a no-op and does not reach the textured sub-pass, and building a frame-level harness for one line was not worth it. That line is what the browser A/B above exercises directly. I also could not drive picking through synthetic pointer events in this harness, so I am *not* claiming to have verified the click-to-select half interactively; test 2 covers it by construction, since pick geometry is the batch-path world position the textured mesh now matches.

## Verification

- `packages/renderer`: 411 passed, 0 failed
- `pnpm typecheck`: 33/33
- Changeset included (`@ifc-lite/renderer` patch)