### PR TITLE
docs(vision): amendments 9-14 - Phase 4 delivered, B5.6 entered, M6b withdrawn

### DIFF
--- a/docs/vision/moonshots-execution-plan.md
+++ b/docs/vision/moonshots-execution-plan.md
@@ -244,8 +244,11 @@ an agent team) plus named human time, because that is the actual currency here.
    the scan path; its whole bar is that a bill of quantities exists, so it cannot
    come back FAIL; it is the one clause that is trend-chasing rather than
    thesis-bearing; and the scan clause has already produced the least deniable
-   number in the program without it. The world-model story moves to B6.5's demo,
-   where it is a stage artifact and not an exam. Ledger entry N6.
+   number in the program without it. The world-model story moves to **B6.5's demo
+   (moonshots-finishing-plan.md section 5, Phase 6)**, which now names it: it is a
+   stage artifact inside the demo's M5 act, with no pass/fail bar, no number of
+   its own and no G6 clause, and the act is dropped if it does not run. Ledger
+   entry N6.
    **Status of the surviving clause (B5.5, delivered 2026-08-02, #1932): partial
    pass** - met for floor area, clear height and volume at model scale and for
    every quantity in one of three rooms; not met for the bounding wall surface.
@@ -302,6 +305,13 @@ an agent team) plus named human time, because that is the actual currency here.
      under benchmark/, not under scripts/moonshot. -->
    M3's per-step projection budget re-plans around CPU threading only, which puts M6b on
    the critical path. See scripts/moonshot/b34-kernel-stage/REPORT.md.
+   **SUPERSEDED 2026-08-02 (betting table, amendment 12 of
+   moonshots-finishing-plan.md section 9). PROVISIONAL until the docs PR on branch
+   `docs/moonshot-amendments-phase5` is merged by the repo-owner account.** The
+   per-step projection budget is itself withdrawn with M3's interactivity claim
+   (see the M3 exam amendment above), so this consequence does not stand: **M6b is
+   on no critical path.** Its own exam is unchanged and it stays a validated lever
+   at TRL 5, now UNWIRED with a dated re-entry condition. Ledger entry N5.
 
 ## 3. Phased roadmap with gates
 
@@ -375,8 +385,13 @@ Bets:
 - **B3.4 Kernel stage on GPU with manifest parity (M6c final).**
 - **B3.5 The integrated jaw-drop:** one scripted 10-minute demo chaining them: scan a room,
   ground it to parametric IFC (M5), three parties co-edit encrypted with certified merges
-  (M4), descend carbon under compliance (M3), every step certified (M1), interactive because
-  of M6, all in browser tabs. This is the artifact for stages and data rooms.
+  (M4), descend carbon under compliance (M3), every step certified (M1), ~~interactive because
+  of M6~~, all in browser tabs. This is the artifact for stages and data rooms.
+  *(The "interactive because of M6" clause is struck 2026-08-02 by amendment 12,
+  which withdraws M3's interactivity claim; ledger entry N5. B3.5 as delivered was
+  Node and seeded, and its successor B6.5 in moonshots-finishing-plan.md carries
+  the same five acts with a batch descent and a certificate stream, not a building
+  relaxing live in a tab.)*
 
 Gate G3 = the final exams. Publications track (human calendar): M6c predicate paper and the
 M4 convergence-theorem writeup are the two publishable results; target venues chosen by Louis.
@@ -429,9 +444,11 @@ Pre-committed kill conditions (ledger entry mandatory, resurrection requires new
   a 200-point battery restricted to topology-stable neighbourhoods, plus a
   mandatory reported measurement across one topology-change boundary), a kill
   clause (FAIL fires the downgrade in the sentence below; PASS adjudicates M3 as
-  BATCH-differentiable only), a displacement (the world-model clause retired by
-  amendment 10), and a cycle-budget update (Phase 5 moves from 6-8 to 8-10
-  agent-cycles). M3 stays UNADJUDICATED until B5.6 reports.
+  BATCH-differentiable only), a displacement statement (**none** - B5.6 displaces
+  no bet, and **Phase 5's cap is raised from five to six** rather than held,
+  because cutting a clause inside B5.5 frees no slot; the argument is in that
+  file's section 5, B5.6), and a cycle-budget update (Phase 5 moves from 6-8 to
+  8-10 agent-cycles). M3 stays UNADJUDICATED until B5.6 reports.
   Note also what the PROVISIONAL marker above does and does not mean: merging
   #1897 makes this amendment *signed by the gate holder*, i.e. part of the
   record. It is not approval of a CSG-adjoint bet, and it is certainly not
@@ -564,7 +581,9 @@ the program that is trend-chasing rather than thesis-bearing - it demonstrates t
 proposing half of "neural systems propose, the kernel disposes", which is the half
 the rest of the industry is already funding. Reviving it as an exam requires a
 falsifiable bar (a reference quantity set a generated scene can miss), not a
-better generator. Until then it lives in B6.5's demo as a stage artifact, which is
+better generator. Until then it lives in **B6.5's demo (moonshots-finishing-plan.md
+section 5, Phase 6) as a stage artifact** inside that demo's M5 act - no pass/fail
+bar, no number of its own, no G6 clause, act dropped if it does not run - which is
 what it always was.
 
 **Calendar note (amendment 5).** Phases 0 through 3 were executed 2026-07-24/25, roughly

--- a/docs/vision/moonshots-execution-plan.md
+++ b/docs/vision/moonshots-execution-plan.md
@@ -468,6 +468,18 @@ Pre-mortem, the three most likely ways the whole program dies, and their antidot
 2. **The human calendar slips.** Agents finish, gates stack, and review becomes the
    bottleneck (this happened in the 14-agent planning workflow). Antidote: gates are betting
    tables Louis already holds; no separate ceremony, max 5 bets per phase.
+   **AMENDED 2026-08-02 (betting table, amendment 11 of
+   moonshots-finishing-plan.md section 9): the cap is 6 for Phase 5 only and
+   stays 5 for every other phase.** B5.6 enters as a **full sixth bet** and
+   displaces nothing. The exception is written here rather than left implicit
+   because this antidote is the cap's home, and a rule that says 5 while the
+   betting table runs 6 is the kind of gap this program's record exists to
+   close. It does not reintroduce what the antidote guards against: the scarce
+   resource here is gate time, and B5.6 is adjudicated at G5 with the other
+   five - no extra gate, no extra ceremony, one binary verdict on the day - while
+   Phase 5's two hardest bets (B5.2, B5.5) are already run and measured, and a
+   cycle-1 NO on B5.6 is a pre-committed early stop. The argument and the price
+   are in `moonshots-finishing-plan.md` section 5 (B5.6) and section 7.
 3. **Maintenance starves the program.** The main repo's issue/perf cadence (300+ commits per
    month) absorbs everything. Antidote: moonshot bets are explicit betting-table line items
    with their own worktrees; if a phase gets zero bets twice in a row, that is a deliberate

--- a/docs/vision/moonshots-execution-plan.md
+++ b/docs/vision/moonshots-execution-plan.md
@@ -123,6 +123,20 @@ an agent team) plus named human time, because that is the actual currency here.
    IfcOpenShell differential oracle, five reward channels behind one env API. Final: one
    external group post-trains a model on the gym and improves measurably on a held-out split;
    leaderboard runs the verifier client-side.
+   **RE-SEQUENCED 2026-08-02 (betting table, amendment 13 of
+   moonshots-finishing-plan.md section 9). PROVISIONAL until the docs PR on branch
+   `docs/moonshot-amendments-phase5` is merged by the repo-owner account.** The
+   exam is unchanged; what it is gated on is not. It no longer follows from
+   delivering B4.3's salt. B5.2 measured two things a salt does not touch: the
+   corpus's openings are all rectangular through-cuts that the `rect_fast` path
+   takes with zero deferrals, so the general CSG path is never entered by the
+   benchmark while every foreign failure lives there; and both leaderboard anchors
+   saturate the defect task once the existing reference-integrity rule is wired,
+   leaving the headline metric no headroom. So the order is: rebuild the task
+   layer (defects re-substrated on real models, plus generator families that enter
+   the general CSG path), take the salt-versus-substrate decision once for that v2
+   set, then recruit the lab against v2. B2.2 stays CONFIRMED, UNFIXED throughout
+   and dev stays attackable-by-design.
 
 ### M3. Differentiable buildings
 
@@ -145,6 +159,19 @@ an agent team) plus named human time, because that is the actual currency here.
    of created elements match finite differences to 1e-6 on 95% of a randomized battery, and
    one 20-parameter optimization converges to a valid certified state. Final: browser demo,
    multi-objective descent, projection + certificate < 200 ms per step on the flagship model.
+   **AMENDED 2026-08-02 (betting table, amendment 12 of moonshots-finishing-plan.md
+   section 9). PROVISIONAL until the docs PR on branch
+   `docs/moonshot-amendments-phase5` is merged by the repo-owner account.** The
+   per-step budget clause is **withdrawn along with M3's INTERACTIVITY claim**,
+   deliberately and ahead of G5, by firing M6b's own kill clause. The evidence is
+   already in this file's ledger: N4 (threaded wasm at 0.87x on the full pipeline,
+   an atomics tax) plus the memory-bandwidth dead end in `scripts/perf/README.md`,
+   with M6c's economic loss (amendment 2) having already removed the GPU from the
+   projection-speed story. The M3 final becomes: multi-objective descent over the
+   same objectives with an exact-kernel projection and a certificate per
+   intermediate state, **batch rather than interactive**, no per-step wall-clock
+   clause. This is a deliberate withdrawal on evidence in hand, not a failure
+   discovered late. Ledger entry N5.
 
 ### M4. Convergence you can prove
 
@@ -208,6 +235,20 @@ an agent team) plus named human time, because that is the actual currency here.
    Final: one real scanned room to
    parametric IFC with headline quantities within 5% of a manually modeled reference, plus one
    world-model scene imported with a bill of quantities.
+   **AMENDED 2026-08-02 (betting table, amendment 10 of moonshots-finishing-plan.md
+   section 9). PROVISIONAL until the docs PR on branch
+   `docs/moonshot-amendments-phase5` is merged by the repo-owner account, which is
+   what sign-off means in this program - see that file's section 9.1.** The
+   world-model clause is **CUT**. The M5 final is the scan clause alone. Four
+   reasons, all in amendment 10: the world-model import shares no machinery with
+   the scan path; its whole bar is that a bill of quantities exists, so it cannot
+   come back FAIL; it is the one clause that is trend-chasing rather than
+   thesis-bearing; and the scan clause has already produced the least deniable
+   number in the program without it. The world-model story moves to B6.5's demo,
+   where it is a stage artifact and not an exam. Ledger entry N6.
+   **Status of the surviving clause (B5.5, delivered 2026-08-02, #1932): partial
+   pass** - met for floor area, clear height and volume at model scale and for
+   every quantity in one of three rooms; not met for the bounding wall surface.
 
 ### M6. Geometry at silicon speed
 
@@ -233,7 +274,11 @@ an agent team) plus named human time, because that is the actual currency here.
 8. **Exams.** M6a: weekly CI lane builds with +wide-arithmetic and reproduces the determinism
    manifests byte-identically, >= 1.5x e2e CSG confirmed. M6b: threaded path on by default in
    the browser, determinism manifest unchanged, >= 1.5x wall-clock on the CSG-heavy corpus
-   half. M6c midterm (spike gate): batched orientation3d/incircle on WebGPU with sign-exact
+   half. **Note added 2026-08-02 (amendment 12): M6b's own exam is unchanged and it
+   remains a validated lever at TRL 5, but it no longer carries M3's interactivity
+   claim - that claim is withdrawn, and M6b's kill clause is what withdrew it. M6b
+   is now UNWIRED with a dated re-entry condition (a workload shape that changes
+   the atomics arithmetic) rather than on any critical path. Ledger entry N5.** M6c midterm (spike gate): batched orientation3d/incircle on WebGPU with sign-exact
    agreement vs CPU on 10^8 random + adversarial near-degenerate inputs, >= 10x throughput.
    Final: one kernel stage (candidate: pairwise triangle intersection classification) running
    GPU-side with end-to-end manifest parity and >= 5x stage speedup on real models.
@@ -323,7 +368,9 @@ moonshots-finishing-plan.md section 8.
 
 Bets:
 - **B3.1 Encrypted provable multiplayer (M4 final).**
-- **B3.2 Scan-to-parametric (M5 final), plus world-model import demo.**
+- **B3.2 Scan-to-parametric (M5 final), plus world-model import demo.** *(Ran as
+  B5.5 on 2026-08-02, #1932, partial pass. The world-model half was CUT before it
+  was built - amendment 10 - and moves to B6.5's demo. Ledger entry N6.)*
 - **B3.3 Differentiable flagship demo (M3 final, budget depends on M6 outcomes).**
 - **B3.4 Kernel stage on GPU with manifest parity (M6c final).**
 - **B3.5 The integrated jaw-drop:** one scripted 10-minute demo chaining them: scan a room,
@@ -365,15 +412,26 @@ Pre-committed kill conditions (ledger entry mandatory, resurrection requires new
   smooth closed form, so that exam could not have failed. **B4.4's PASS therefore
   neither passes nor fails this criterion.** M3's status is
   **UNADJUDICATED**, and it stays that way until a CSG-adjoint bet is run.
-  **That bet is NOT scheduled.** Phase 5 contains B5.1 to B5.5 and nothing else;
+  ~~**That bet is NOT scheduled.** Phase 5 contains B5.1 to B5.5 and nothing else;
   the CSG-adjoint work has no number, no exam, no kill clause, no statement of
   which of B5.1 to B5.5 it would displace against the five-bet cap, and no
-  cycle-budget line. Entering a bet is a betting-table act, not a sentence in an
-  amendment, so nothing here schedules it and no reader should infer that it is
-  queued, next, or first in Phase 5. What exists is an input to that decision:
-  `scripts/moonshot/b44-kernel-adjoint/DESIGN.md` section 6.1 scopes the
+  cycle-budget line.~~ Entering a bet is a betting-table act, not a sentence in an
+  amendment. What existed when this paragraph was written was an input to that
+  decision: `scripts/moonshot/b44-kernel-adjoint/DESIGN.md` section 6.1 scopes the
   obstruction at two cycles and names it (the exact-predicate tier is a
   fixed-width integer type with no derivative slot).
+  **SUPERSEDED 2026-08-02 (betting table, amendment 11 of
+  moonshots-finishing-plan.md section 9). PROVISIONAL until the docs PR on branch
+  `docs/moonshot-amendments-phase5` is merged by the repo-owner account.** The
+  betting table sat and **the bet is now scheduled as B5.6**, with all five things
+  the paragraph above says it needs: a number (B5.6), an exam (adjoints through
+  `subtract_many` on the opening-cut family, FD-matched to 1e-6 relative on 95% of
+  a 200-point battery restricted to topology-stable neighbourhoods, plus a
+  mandatory reported measurement across one topology-change boundary), a kill
+  clause (FAIL fires the downgrade in the sentence below; PASS adjudicates M3 as
+  BATCH-differentiable only), a displacement (the world-model clause retired by
+  amendment 10), and a cycle-budget update (Phase 5 moves from 6-8 to 8-10
+  agent-cycles). M3 stays UNADJUDICATED until B5.6 reports.
   Note also what the PROVISIONAL marker above does and does not mean: merging
   #1897 makes this amendment *signed by the gate holder*, i.e. part of the
   record. It is not approval of a CSG-adjoint bet, and it is certainly not
@@ -477,6 +535,37 @@ there. See amendment 1.
 **N4. Threaded WASM as a whole-pipeline lever, re-refuted (2026-07-23, pre-dates the
 moonshot program but bears on M6b).** Measured 0.87x on the full pipeline (atomics tax).
 M6b's 2.9x-4.2x is a CSG-stage figure and must not be restated as an end-to-end one.
+
+**N5. M3's INTERACTIVITY claim, withdrawn deliberately (2026-08-02, amendment 12).**
+Believed: exact-kernel projection could be made cheap enough to sit inside an
+interactive descent loop, first via GPU predicates and then, after M6c's economic
+loss, via threaded CSG. Measured, and already on this list before the withdrawal:
+N4's 0.87x whole-pipeline result for threaded wasm, and the memory-bandwidth dead
+end recorded in `scripts/perf/README.md` ("more geometry workers -> zero CSG
+speedup: memory-bandwidth bound, not CPU"). Nothing new was measured to withdraw
+the claim; a conclusion already available was acted on rather than left to trip
+M6b's own kill clause at G5. What is withdrawn is the per-step wall-clock clause of
+M3's final exam and the word "interactive" in every M3 sentence. What survives:
+M3 as **batch-differentiable**, which B5.6 adjudicates, and which is still
+publishable and still what certified descent needs. **M6b is not killed.** It is a
+validated, UNWIRED lever at TRL 5 with a dated re-entry condition: re-enter when a
+workload shape changes the atomics arithmetic - a CSG stage whose per-element work
+is large enough to amortize the atomics tax, or a path measured to be
+arithmetic-bound rather than bandwidth-bound. Per this section's resurrection rule,
+that measurement comes first and the claim second.
+
+**N6. The M5 final's world-model import clause, retired before it was built
+(2026-08-02, amendment 10).** Believed: grounding a generated world-model scene
+into a building with a bill of quantities was a third input class worth an exam
+clause of its own. Not measured, and that is the point: its whole bar was that a
+bill of quantities exists, so it could not have come back FAIL, and it shares no
+pipeline stage with the scan clause it was bundled into. It is the one clause in
+the program that is trend-chasing rather than thesis-bearing - it demonstrates the
+proposing half of "neural systems propose, the kernel disposes", which is the half
+the rest of the industry is already funding. Reviving it as an exam requires a
+falsifiable bar (a reference quantity set a generated scene can miss), not a
+better generator. Until then it lives in B6.5's demo as a stage artifact, which is
+what it always was.
 
 **Calendar note (amendment 5).** Phases 0 through 3 were executed 2026-07-24/25, roughly
 eight months ahead of the targets recorded above, because the agent-build track ran far

--- a/docs/vision/moonshots-finishing-plan.md
+++ b/docs/vision/moonshots-finishing-plan.md
@@ -59,7 +59,7 @@ findings plus one structural criticism. Status as of today:
 | B2.2 (M2): answer key is publicly computable | **CONFIRMED, UNFIXED** | `benchmark/attacks/clean-twin-diff.mjs` scores an exact **1.000 aggregate on dev** through the real scorer, above both anchors; spec bumped to `1.1.0` 2026-08-01, which WITHDREW the false hidden-by-hosting claim and declared the real model (per-split salt across every RNG stream, delivered by a hosted scorer) -- but neither half is implemented, so the finding is unchanged: the answer key is still publicly computable and the reporting split still has no integrity property |
 | B2.1 (M4): spatial predicate unfalsifiable | **OPEN** | `merge-model.ts` still applies ops purely per-node; spatial-structure edits explicitly outside the v0 vocabulary; no real-trace replay |
 | B2.4 (M3): gradients never touch the kernel | **OPEN and widened** | B3.3 built more certificate infrastructure on the parametric path instead of attacking adjoints through CSG |
-| Section 3: nothing verifies against the external world | **OPEN** | every result in the program is still measured on distributions the program authored |
+| Section 3: nothing verifies against the external world | **OPEN, narrowed 2026-08-02** | B5.2 and B5.5 are the only results in the program measured on data it did not author (amendment 9); every other result is still measured on distributions the program authored. The narrowing does not reach the standing lane, and the claim is deliberately not written as if it did: neither run is re-runnable in CI, because the foreign models and the scan can be neither committed nor fetched. B5.5's only standing coverage is `E8b`, a synthetic closed-form proxy that holds the extraction/emission/scoring **pipeline** and asserts nothing about the headline number; B5.2 has no standing coverage at all. So the external-data evidence is two dated runs, not a lane |
 
 <!-- numeral-src: 0.847 :: m5-constrained-decoding/results-tier2.json#headroom.meanQuality -->
 <!-- numeral-src: 1.000 :: none - the clean-twin-diff aggregate, produced by
@@ -225,9 +225,15 @@ defect this program shipped:
   instrument the emitter does not control.
 - **8c. A null-space audit at commissioning.** Before the bet runs, enumerate
   the **invariance group of the scored observable** - the transformations of the
-  emitted artifact under which every scored number is unchanged - and require at
-  least one committed check that is *not* invariant under it. An exam whose
-  whole null space is unchecked grades a quotient, not the thing.
+  emitted artifact under which every scored number is unchanged - and commit
+  checks that, **taken together, distinguish every non-identity transformation
+  in that group**. One non-invariant check does not discharge this: a check can
+  catch one direction of the group and be blind to another, and the blind
+  direction is exactly where the defect sits. If the committed checks cannot
+  cover the enumerated group, then **narrow the group to what they do cover and
+  record the remainder as unchecked** - a smaller honest claim, not a bigger
+  unearned one. An exam whose null space is unchecked grades a quotient, not the
+  thing.
 
 What these three reach, and the one real defect only 8c reaches, is recorded in
 amendment 14 rather than here, so the reader who wants the calibration gets it
@@ -868,8 +874,8 @@ instrument 8c, and that is recorded in amendment 14 rather than here.
 <!-- numeral-src: 64.567 :: b55-scan-to-parametric/scorecard.json#variants.axisAligned.totals.floorAreaM2.reference -->
 
 **B5.6 Adjoints through the CSG path (the M3 adjudication bet). Entered
-2026-08-02, amendment 11, as Phase 5's sixth bet against a cap raised from five
-to six.**
+2026-08-02, amendment 11, as Phase 5's full sixth bet against a cap raised from
+five to six.**
 Dual-number scalars through `subtract_many` on the opening-cut family - a host
 wall plus an intersecting opening, the void pipeline as it ships - differentiating
 the emitted volume with respect to design parameters.
@@ -899,8 +905,10 @@ intersection points carry derivatives without touching the exact-predicate tier?
 The tier is a fixed-width integer type with no derivative slot, but predicates
 need only the primal, so this is plausible rather than hopeful. Cycle 2 makes the
 subtraction output stable enough for FD to be meaningful across a cut.
-**Reaching a NO in cycle 1 is itself the verdict**, and is a delivery, not an
-overrun.
+**A NO in cycle 1 is a pre-committed early stop**, declared here before the run:
+it terminates B5.6 at one cycle, is recorded as the bet's verdict, and fires the
+same M3 downgrade a FAIL fires. It is a delivery, not an overrun, and it is what
+bounds the raised cap's cost from above.
 *Displacement:* **none, and the cap is therefore raised rather than held.** This
 was first written as "B5.6 takes the slot freed by the retired world-model
 clause", counting obligations rather than labels so that six fitted inside five.
@@ -912,14 +920,36 @@ B5.6 is six bets against a cap of five, and calling that five by redefining
 "bet" is the kind of move this program's whole record exists to catch.
 
 So it is recorded as what it is: **Phase 5's cap is raised from five bets to six
-by amendment 11.** The pre-mortem set the cap to stop a phase overcommitting and
-then delivering only its easy bets -- the failure Phase 3 actually had. Raising
-it is defensible here for a reason that is checkable rather than rhetorical:
-four of the six (B5.1, B5.2, B5.5, and B5.6's cycle-1 spike) are agent-buildable
-and two are already delivered, so the added obligation is one binary verdict
-rather than one full bet. If that turns out to be wrong, the cap was the
-instrument that should have stopped it, and this entry is where a later reader
-finds out it was moved on purpose.
+by amendment 11.** B5.6 is counted as a full sixth bet at full weight - two
+cycles, a seeded battery with a mandatory topology-boundary row, and a kill
+clause that fires the M3 downgrade - and section 7's Phase 5 row pays for it in
+full rather than netting it against anything.
+
+*Why raising it does not reintroduce the risk the cap exists to stop.* The
+pre-mortem put the cap under one specific failure: a phase overcommits, the gate
+holder becomes the bottleneck, and the phase delivers only its easy bets. That
+is the Phase 3 failure exactly (`moonshots-execution-plan.md` section 5,
+pre-mortem antidote 2, amended to match this decision). Three checkable facts
+answer it here, and none of them is "B5.6 is smaller than a bet":
+
+1. **The hard bets are already paid.** The easy-bets pattern means skipping the
+   two exams that need contact outside the sandbox. Phase 5's two are B5.2 and
+   B5.5, and both are already run and measured (amendment 9). The sixth bet is
+   being added to a phase that has already discharged the cap's real premium,
+   not to one still deferring it.
+2. **It adds no gate and no ceremony.** B5.6 is adjudicated at G5 alongside the
+   other five, and what it puts on the gate holder's desk there resolves to one
+   binary verdict. The scarce resource the antidote rations is gate time, and
+   the raise does not spend more of it.
+3. **The overrun is bounded before the run.** Four of the six (B5.1, B5.2, B5.5,
+   and B5.6's cycle-1 spike) are agent-buildable, and **early stop is
+   pre-committed rather than discretionary**: a NO in cycle 1 terminates B5.6
+   there, is recorded as the bet's verdict, and fires the same M3 downgrade a
+   FAIL fires. The two-cycle budget is a ceiling, not a plan.
+
+If that turns out to be wrong, the cap was the instrument that should have
+stopped it, and this entry is where a later reader finds out it was moved on
+purpose.
 
 **Gate G5.** M4 final, M5 final **(the scan clause alone, per amendment 10)**,
 B5.6's binary verdict, plus the external-validity clauses of B5.1 to B5.3.
@@ -1176,6 +1206,11 @@ are amendable only in writing in this file - and the re-scope below was not.
    at two cycles and names the obstruction (the exact-predicate tier is a
    fixed-width integer type with no derivative slot), which is the input to
    that decision, not the decision.
+   **SUPERSEDED in part 2026-08-02 by amendment 11**, which entered the bet as
+   B5.6 with all five things listed above. The displacement statement it
+   demanded came back **none**, and the "five-bet cap" this paragraph names was
+   raised to six for Phase 5 rather than fitted into; that sentence is the
+   requirement as written on 2026-07-29, not the standing cap.
 7. **B4.4's grading metric amends the exam's finite-difference wording.** The
    exam reads "matching central finite differences to 1e-6 relative on 95% of a
    200-point seeded battery". The delivered result matches central finite
@@ -1382,14 +1417,20 @@ forbids a sentence claiming sign-off that names nothing a reader can check.*
       B5.6 displaces nothing. Cutting a clause inside B5.5 (amendment 10) frees
       no bet slot: B5.5 still exists, still has an exam, still has to be
       adjudicated at G5. So **Phase 5's cap is raised from five bets to six by
-      this amendment**, for Phase 5 only, and the justification is checkable
-      rather than rhetorical - four of the six (B5.1, B5.2, B5.5 and B5.6's
-      cycle-1 spike) are agent-buildable and two are already delivered, so the
-      added obligation is one binary verdict rather than one full bet. The full
-      argument, including why counting exam obligations instead of labels would
-      have been a redefinition rather than a fit, is in section 5's B5.6 entry,
-      so a later reader can reject the raise rather than discover it. Section 7's
-      Phase 5 row is where it is paid for.
+      this amendment**, for Phase 5 only, and **B5.6 counts as a full sixth bet**
+      - two cycles, its own exam, its own kill clause - not as a fraction of one.
+      The justification is checkable rather than rhetorical, and it is about who
+      pays rather than about the bet being small: Phase 5's two hardest bets
+      (B5.2, B5.5) are already run and measured, four of the six are
+      agent-buildable, the sixth adds no gate and no ceremony because it is
+      adjudicated at G5 with the rest, and a cycle-1 NO is a pre-committed early
+      stop that bounds it at one cycle. The full argument, including why counting
+      exam obligations instead of labels would have been a redefinition rather
+      than a fit, is in section 5's B5.6 entry, so a later reader can reject the
+      raise rather than discover it. Section 7's Phase 5 row is where it is paid
+      for, and `moonshots-execution-plan.md` section 5's pre-mortem antidote 2
+      carries the matching exception so the two documents cannot be read as
+      disagreeing about the cap.
 
 12. **M6b's interactivity kill clause is FIRED, deliberately, now. M3's
     INTERACTIVITY claim is WITHDRAWN.** Section 8's M6b clause reads "if it is

--- a/docs/vision/moonshots-finishing-plan.md
+++ b/docs/vision/moonshots-finishing-plan.md
@@ -123,6 +123,16 @@ threading only. M6b (threaded CSG, 2.9x to 4.2x, still documented as "validated
 by measurement, not yet wired into production") therefore stops being a nice
 lever and becomes the critical path for M3's interactivity claim.
 
+**Superseded 2026-08-02 (amendment 12), and this is the sentence that started
+the claim, so it gets the marker rather than a quiet rewrite.** The consequence
+above is withdrawn along with the thing it was a consequence of: M3's
+interactivity claim is withdrawn deliberately and ahead of G5, so there is no
+per-step projection budget for M6b to be critical to, and **M6b is on no
+critical path**. The paragraph is left as written because the record is supposed
+to show how a claim was reached as well as when it was retired. M6b's TRL of 5
+is unchanged and its own exam is unchanged; it is a validated but UNWIRED lever
+with the dated re-entry condition in amendment 12. Ledger entry N5.
+
 ### 1.4 Standing evidence: zero
 
 Thirteen CI workflows exist. None runs anything under `scripts/moonshot/`
@@ -204,8 +214,15 @@ defect this program shipped:
   commits the evidence of that run. A tripwire never observed firing is an
   untested branch, and its green is a statement about nothing.
 - **8b. Verdicts by positive assertion only.** A verdict may never be taken from
-  the absence of an exception, and never from a value read out of the artifact
-  under test. The thing being graded does not get a vote on its own grade.
+  the absence of an exception, and never from a value the artifact under test
+  **reports about itself** - a stored quantity, a self-declared status, a number
+  the emitter wrote down. The thing being graded does not get a vote on its own
+  grade. What this does *not* ban is measuring the artifact independently: B5.5's
+  scorer meshes the emitted IFC and the manually modelled reference through the
+  kernel and computes every headline quantity itself, reading no stored quantity
+  from either side, and that is the compliant shape rather than the banned one.
+  The test is whether the number came from the emitter's claim or from an
+  instrument the emitter does not control.
 - **8c. A null-space audit at commissioning.** Before the bet runs, enumerate
   the **invariance group of the scored observable** - the transformations of the
   emitted artifact under which every scored number is unchanged - and require at
@@ -354,6 +371,11 @@ unchanged, the original stands.
 Cadence unchanged: Shape Up 6-week cycles, phases end at a betting table that
 doubles as the gate review, gate criteria pre-committed and amendable only in
 writing in this file. Maximum five bets per phase, per the original pre-mortem.
+**Amended 2026-08-02 (amendment 11): the cap is raised to six for Phase 5 only,
+deliberately, with the argument written out in B5.6's entry below. It stays five
+for Phase 6 and for every later phase - a raise is a betting-table act taken once
+against a named phase, not a new default, and the second one has to argue for
+itself the same way.**
 
 ### Phase 4, one cycle. "Standing evidence and the two open findings."
 
@@ -846,7 +868,8 @@ instrument 8c, and that is recorded in amendment 14 rather than here.
 <!-- numeral-src: 64.567 :: b55-scan-to-parametric/scorecard.json#variants.axisAligned.totals.floorAreaM2.reference -->
 
 **B5.6 Adjoints through the CSG path (the M3 adjudication bet). Entered
-2026-08-02, amendment 11, into the slot amendment 10 frees.**
+2026-08-02, amendment 11, as Phase 5's sixth bet against a cap raised from five
+to six.**
 Dual-number scalars through `subtract_many` on the opening-cut family - a host
 wall plus an intersecting opening, the void pipeline as it ships - differentiating
 the emitted volume with respect to design parameters.
@@ -881,12 +904,12 @@ overrun.
 *Displacement:* **none, and the cap is therefore raised rather than held.** This
 was first written as "B5.6 takes the slot freed by the retired world-model
 clause", counting obligations rather than labels so that six fitted inside five.
-That reading is rejected here because this document rejects it: section 11 says
-the CSG-adjoint bet must name "which of B5.1 to B5.5 it displaces against the
-five-bet cap". Cutting a CLAUSE inside B5.5 frees no bet slot -- B5.5 still
-exists, still has an exam, still has to be adjudicated at G5. B5.1 to B5.6 is
-six bets against a cap of five, and calling that five by redefining "bet" is the
-kind of move this program's whole record exists to catch.
+That reading is rejected here because this document rejects it: section 9's
+amendment 6 says the CSG-adjoint bet must name "which of B5.1-B5.5 it displaces
+against the five-bet cap". Cutting a CLAUSE inside B5.5 frees no bet slot --
+B5.5 still exists, still has an exam, still has to be adjudicated at G5. B5.1 to
+B5.6 is six bets against a cap of five, and calling that five by redefining
+"bet" is the kind of move this program's whole record exists to catch.
 
 So it is recorded as what it is: **Phase 5's cap is raised from five bets to six
 by amendment 11.** The pre-mortem set the cap to stop a phase overcommitting and
@@ -938,7 +961,18 @@ theorem is only worth publishing with a real-trace conflict rate attached.
 The current integrated demo is Node, seeded, and synthetic end to end. The
 version worth putting on a stage runs in browser tabs, starts from a file the
 audience brought, and streams certificates. Same five acts, no synthetic
-substrate.
+substrate, and the M3 act is a **batch** descent with a certificate stream
+rather than a live relaxation (amendment 12).
+
+*Scope added 2026-08-02 (amendment 10): the world-model import lands here.* One
+generated world-model scene is imported and grounded to parametric IFC inside the
+demo's M5 act. Its boundary is stated here so it cannot drift back into being an
+exam: it is a **stage artifact**, judged only on whether the act runs on stage.
+It carries no pass/fail bar, no number of its own, and no G6 clause; if it does
+not run, B6.5 drops the act and nothing in M5's final exam moves, because
+amendment 10 cut it from that exam. Reviving it as an exam clause requires a
+falsifiable bar - a reference quantity set a generated scene can miss - per
+negative-results ledger entry N6 in `moonshots-execution-plan.md`.
 
 **Gate G6 = the final exams**, all six moonshots, with the external-validity
 clause attached to each. Third standing adversarial review, with the explicit
@@ -977,8 +1011,11 @@ enthusiastic slide away from claiming, is the same sentence with the words
 | 6 | 5-6 | 5 (gate) + paper writing + external lab outreach + open-sourcing decision on provenance | hosting for the benchmark scorer |
 
 *Phase 5's row was 6-8 and moved 2026-08-02 (amendment 11): B5.6 is a two-cycle
-bet, and the world-model clause it displaces was never separately budgeted, so
-the two cycles are added rather than exchanged. The line under section 5 that
+bet that displaces nothing, so its two cycles are added rather than exchanged.
+This row is the cost side of the raised cap, and it is meant to be visible here
+rather than absorbed: six bets, six bets' worth of cycles. The retired
+world-model clause (amendment 10) frees nothing to net against, because it was
+never separately budgeted in the first place. The line under section 5 that
 says a NO in B5.6's first cycle is a delivery is what keeps the upper end from
 being the expected case.*
 
@@ -1255,16 +1292,16 @@ forbids a sentence claiming sign-off that names nothing a reader can check.*
 
    (b) *Both bets Phase 3 skipped have been run, and measured on data the
    program did not author.* B5.2 (#1931) put the benchmark's tasks and the
-   defect detector against two real delivered client models this program neither
-   authored nor had seen. B5.5 (#1932) took one real laser scan of a real
-   dwelling through extraction, parametric emission and the kernel, and scored it
-   against a manually modelled reference. Section 1.1 calls the skipping of
-   exactly these two "a survivorship pattern, not a schedule accident, and the
-   single most important fact in this document". **This is the first evidence
-   against that fact**, and it is the only such evidence the program has: the two
-   exams that require contact with something outside the parametric sandbox were
-   not deferred a second time, and neither produced a number this program
-   controlled. Their results are in section 5's two result notes and in
+   defect detector against two real externally authored AEC models this program
+   neither authored nor had seen. B5.5 (#1932) took one real laser scan of an
+   occupied dwelling through extraction, parametric emission and the kernel, and
+   scored it against a manually modelled reference. Section 1.1 calls the
+   skipping of exactly these two "a survivorship pattern, not a schedule
+   accident, and the single most important fact in this document". **This is the
+   first evidence against that fact**, and it is the only such evidence the
+   program has: the two exams that require contact with something outside the
+   parametric sandbox were not deferred a second time, and neither produced a
+   number this program controlled. Their results are in section 5's two result notes and in
    amendments 10, 13 and 14.
 
    (c) *And none of it moves Phase 4.* **Phase 4 stays recorded FAILED on its own
@@ -1306,8 +1343,11 @@ forbids a sentence claiming sign-off that names nothing a reader can check.*
 
     The story is not deleted, it is re-sited: **the world-model import moves to
     B6.5's demo**, where a generated scene is a stage artifact and is judged as
-    one, rather than an exam clause pretending to be measurable. Negative-results
-    ledger entry N6 in `moonshots-execution-plan.md`.
+    one, rather than an exam clause pretending to be measurable. B6.5's entry in
+    section 5 names the work and states its boundary, so the move is a contract
+    and not a gesture: it sits in the demo's M5 act, has no pass/fail bar, no
+    number of its own and no G6 clause, and the act is dropped if it does not run.
+    Negative-results ledger entry N6 in `moonshots-execution-plan.md`.
 
 11. **B5.6 enters the Phase 5 betting table: adjoints through the CSG path.**
     Amendment 6 left M3 UNADJUDICATED and stated exactly what entering this bet
@@ -1338,10 +1378,18 @@ forbids a sentence claiming sign-off that names nothing a reader can check.*
       integer type with no derivative slot. **Reaching a NO in cycle 1 is the
       verdict, not a failure to deliver.** Section 7's Phase 5 row moves from 6-8
       to 8-10 agent-cycles.
-    - **Displacement.** B5.6 takes the slot the retired world-model clause frees
-      (amendment 10). Phase 5's exam obligations stay at six; the label count
-      goes to six as well. Section 5 states the reading of the five-bet cap this
-      rests on, so a later reader can reject it rather than discover it.
+    - **Displacement: none, and the cap is therefore raised rather than held.**
+      B5.6 displaces nothing. Cutting a clause inside B5.5 (amendment 10) frees
+      no bet slot: B5.5 still exists, still has an exam, still has to be
+      adjudicated at G5. So **Phase 5's cap is raised from five bets to six by
+      this amendment**, for Phase 5 only, and the justification is checkable
+      rather than rhetorical - four of the six (B5.1, B5.2, B5.5 and B5.6's
+      cycle-1 spike) are agent-buildable and two are already delivered, so the
+      added obligation is one binary verdict rather than one full bet. The full
+      argument, including why counting exam obligations instead of labels would
+      have been a redefinition rather than a fit, is in section 5's B5.6 entry,
+      so a later reader can reject the raise rather than discover it. Section 7's
+      Phase 5 row is where it is paid for.
 
 12. **M6b's interactivity kill clause is FIRED, deliberately, now. M3's
     INTERACTIVITY claim is WITHDRAWN.** Section 8's M6b clause reads "if it is

--- a/docs/vision/moonshots-finishing-plan.md
+++ b/docs/vision/moonshots-finishing-plan.md
@@ -41,6 +41,13 @@ a real scanned room), were skipped in favour of the three that could be built
 from existing parts. That is a survivorship pattern, not a schedule accident,
 and it is the single most important fact in this document.
 
+*Dated note, 2026-08-02.* Both of those bets have since been run and measured on
+data the program did not author, as B5.2 and B5.5. That is the first evidence
+against the pattern this paragraph names, and it is recorded once, in amendment
+9, rather than restated here. It is evidence against, not a retirement: one
+phase that did not skip its two hardest bets does not undo a phase that did, and
+Phase 4's own FAILED verdict (amendment 8) is untouched by it.
+
 ### 1.2 The G2 red-team scorecard
 
 The adversarial review (`reviews/g2-red-team-2026-07-24.md`) raised four
@@ -142,6 +149,13 @@ which makes it an ideal golden-output regression test that nobody is running.
 | M6b threaded CSG | 5 | **5** | unchanged, and now on the critical path |
 | M6c exact predicates on GPU | 1 | **4, with a negative economic verdict** | real stage, real parity, loses to the production filter |
 
+*Two rows of that table have dated notes elsewhere and are left as written here
+rather than silently re-scored: M6b's "now on the critical path" was ended by
+amendment 12 (the claim it was critical to is withdrawn; its TRL of 5 is
+unchanged), and M3's "kernel adjoints untouched" is what B5.6 exists to change
+(amendment 11). The table is a snapshot dated 2026-07-26; the amendments are the
+running record.*
+
 The column spans **TRL 3 to 6**, not a flat band: M6a is already 6, M3 and M4
 are still 3, and the modal value is 4. Five of the eight moved up and none moved
 down. That is a genuinely strong six-month position, with one shipped surface,
@@ -149,7 +163,7 @@ and it is not TRL 7 anywhere - which is what "finished" would require.
 
 ---
 
-## 2. Framework: four instruments, plus three
+## 2. Framework: four instruments, plus four
 
 The original four stay: **Heilmeier catechism** as the planning unit, **DARPA
 phases with TRL and go/no-go gates**, **Shape Up 6-week cycles with a betting
@@ -177,6 +191,30 @@ commissioned once. Every gate from G4 onward carries a mandatory adversarial
 review bet, run by a reviewer with no authorship stake in the phase, with the
 right to declare a gate failed. Its findings enter the record before the gate
 closes, not after.
+
+**8. Exam integrity (answers: the scorer cannot fire, so the PASS means
+nothing). Added 2026-08-02, amendment 14.** Instrument 7 asks whether an exam is
+hard. This one asks whether its scorer is capable of returning FAIL at all, and
+it is three clauses rather than a principle, because each one is pinned to a
+defect this program shipped:
+
+- **8a. No PASS without a committed red-run.** Every scorer carries a `--red`
+  mode that constructs the specific violation it claims to detect, exits
+  non-zero **through the same assertion path** a real failure would take, and
+  commits the evidence of that run. A tripwire never observed firing is an
+  untested branch, and its green is a statement about nothing.
+- **8b. Verdicts by positive assertion only.** A verdict may never be taken from
+  the absence of an exception, and never from a value read out of the artifact
+  under test. The thing being graded does not get a vote on its own grade.
+- **8c. A null-space audit at commissioning.** Before the bet runs, enumerate
+  the **invariance group of the scored observable** - the transformations of the
+  emitted artifact under which every scored number is unchanged - and require at
+  least one committed check that is *not* invariant under it. An exam whose
+  whole null space is unchecked grades a quotient, not the thing.
+
+What these three reach, and the one real defect only 8c reaches, is recorded in
+amendment 14 rather than here, so the reader who wants the calibration gets it
+in one place.
 
 ---
 
@@ -249,7 +287,10 @@ unchanged, the original stands.
   **still entirely unmeasured**, and B3.3 spent Phase 3 building certificate
   infrastructure on the safe side of it. Additionally, M6c's economic loss
   removes the GPU from the projection-speed story, so the interactivity claim
-  now depends on M6b shipping.
+  now depends on M6b shipping. **Superseded 2026-08-02 (amendment 12): rather
+  than let the claim depend on a lever the ledger already refuted at whole-
+  pipeline scale, the claim is withdrawn. M3's remaining risk is the CSG-adjoint
+  question alone, and B5.6 is the bet that answers it.**
 - **Exams (added, Phase 4, binary):** adjoints through the real mesher on the
   rectangular-extrusion family, differentiating divergence-theorem volumes with
   respect to design parameters, matching central finite differences to 1e-6
@@ -299,7 +340,10 @@ unchanged, the original stands.
   precise boundary (exact-tier evaluation versus adaptive filtering), which is
   more publishable than a marginal win and less useful to the other moonshots.
 - **Risks (revised):** M6b is now load-bearing for M3's interactivity and is
-  still not wired into production.
+  still not wired into production. **Superseded 2026-08-02 (amendment 12): the
+  interactivity claim is withdrawn, so M6b stops being load-bearing for anything
+  and stops being a risk. It is a validated, unwired lever with a dated re-entry
+  condition. Nothing downstream now waits on it.**
 - **Exams (unchanged for M6a/M6b; M6c retargeted):** M6c's remaining exam is a
   paper, not a speedup.
 
@@ -433,11 +477,16 @@ to quote*. A binding into a bet directory not yet in this tree is PENDING: not
 counted as backed, its decoys never cleared, and enforced the day the branch
 lands. This document's load-bearing figures were bound on 2026-07-30, and this
 document's own decoy rate fell as a result. **Over its bound subset alone the
-decoys clear at 0.7%, against roughly three quarters for the figures still left
+decoys clear at 0.6%, against roughly four fifths for the figures still left
 to the union index** - that gap, not the headline, is the number that shows the
 mechanism working. The rest of the fall is arithmetic, since every figure moved
 out of the union stops being a coin flip. The union-index remainder is what
 "backed" is still worth for the figures that are not bound, and it is not much.
+*(Both figures moved on 2026-08-02 from 0.7% and "roughly three quarters", for
+the reason the marker below predicts rather than for any change in the
+mechanism: amendments 9 to 14 added figures on both sides of the split, and a
+section that measures the document it lives in moves when the document does.
+The gap is the claim; neither endpoint is.)*
 
 *Why these calibration figures moved.* An earlier revision of this section
 quoted 57.5% to 91.7%, 69.0% and 43.8%. Those were real measurements of a
@@ -448,7 +497,7 @@ exponent-form figure in the program was therefore calibrated against a decoy of
 zero. Fixed in PR #1897, which is why the rates fell; nothing about the corpus
 changed.
 
-<!-- numeral-src: 40%, 57.5%, 91.7%, 69.0%, 43.8%, 0.7% :: none - this checker's own decoy
+<!-- numeral-src: 40%, 57.5%, 91.7%, 69.0%, 43.8%, 0.7%, 0.6% :: none - this checker's own decoy
      calibration over docs/vision, printed by
      scripts/moonshot/ci/check-report-numerals.mjs and deliberately NOT emitted
      into any artifact: an artifact under scripts/moonshot/ joins the union
@@ -459,10 +508,18 @@ changed.
      at 91.7% (node-hash-v0.md, the one document in the corpus this section
      cannot perturb): this section is self-referential, so a low endpoint stated
      to one decimal is a number that moves every time the paragraph quoting it
-     is edited. Its own bound-subset rate, 0.7%, survives that because it is
-     stable to one decimal against small edits; the unbound rate is given in
-     words for the same reason. The superseded 57.5%, 69.0% and 43.8% are quoted
-     only to retract them, in the paragraph that does so. -->
+     is edited. Its own bound-subset rate was quoted at 0.7% on the same
+     reasoning - stable to one decimal against SMALL edits - and 2026-08-02's
+     amendment round was not a small edit: it moved to 0.6%. Kept as a token
+     here only so the sentence that retracts it stays checkable. The unbound
+     rate is given in words for the same reason. The superseded 57.5%, 69.0%
+     and 43.8% are quoted only to retract them, in the paragraph that does so.
+     KNOWN DRIFT, not introduced by that round and deliberately not repaired by
+     it: the prose above states the high endpoint as exact at 91.7%, and the
+     checker has printed 92.9% for node-hash-v0.md since before these
+     amendments. Repairing it means re-deriving what "exact only at the high
+     end" is worth once the corpus grew, which is a change to this section's
+     own instrument and not an amendment to the plan. -->
 
 Consequence for instrument 5: the certificate and tamper results are held by
 the lane in the *forgery* sense only. Holding them against drift would need a
@@ -619,6 +676,22 @@ happen and none of them has:
 Until all three are done, B2.2 stays **CONFIRMED, UNFIXED** in section 1.2 and
 this bet is not a Phase 4 delivery.
 
+*Status note, 2026-08-02 (amendment 13).* Item 1 is now done: the decision is the
+**secret per-split salt**, and the mechanism is being implemented. Item 2 is in
+flight and item 3 has not happened, so B2.2 stays CONFIRMED, UNFIXED and this
+bet stays PENDING - the decision was the cheapest of the three. The honesty half
+of the spec merged as #1940 (v1.1.0: the false claim withdrawn, dev labelled
+attackable-by-design, `clean-twin-diff` cited as the reason).
+
+**What amendment 13 changes is not the decision but what follows from it.**
+B6.2's public launch no longer follows from delivering the salt, because B5.2
+measured two things that a salt does not touch: the benchmark never enters the
+general CSG path, and both leaderboard anchors saturate the defect task once an
+existing rule is wired. Salting a task set with no headroom over a code path
+nobody enters protects an answer key to a question not worth asking. So this bet
+keeps its exam and loses its downstream: it no longer gates B6.2 on its own.
+See amendment 13 for the sequence that replaces it.
+
 **B4.4 The M3 kernel-adjoint spike (binary).**
 A dual-number scalar type through the mesher for the rectangular-extrusion
 family, differentiating divergence-theorem volumes.
@@ -719,6 +792,29 @@ has seen).
 *Exam:* report the score delta versus the synthetic corpus. Any delta is the
 finding; a large one is the most valuable result of the phase.
 
+*Result note, 2026-08-02 (delivered, #1931).* The delta is large and the sharpest
+finding is not a score. Label precision on positive defect verdicts collapses
+from perfect on the synthetic dev split to zero on both foreign models, and the
+defect-detection task is **not scorable** on them at all. Two structural facts
+came out of it, and amendment 13 turns them into a sequence change rather than a
+caveat:
+- **The benchmark never enters the general CSG path.** 100% of the corpus's
+  openings are rectangular through-cuts on box hosts, the `rect_fast` fast path
+  takes every one of them with zero deferrals, and the exact-arithmetic boolean
+  kernel - the most expensive and most failure-prone thing ifc-lite owns - is
+  therefore never entered by the benchmark. Every foreign failure lives there:
+  model-b's are 108 `OperandTooLarge`, concentrated on two hosts.
+- **Both leaderboard anchors saturate once an existing rule is wired.**
+  `baselines.mjs` hardcodes `dangling-ref: false` citing a missing
+  reference-integrity rule; `computeValidationIssues` has one and it fires on
+  every planted dangling reference in the corpus. Wiring it takes `oracle-kernel`
+  to parity with the regex baseline, at which point the headline metric has no
+  headroom left. Deliberately not fixed in that bet: changing the instrument to
+  fit the input is what the bet exists not to do.
+
+<!-- numeral-src: 100% :: b52-foreign-ifc/scorecard.json#openingsAndCsg.synthetic.openingsCutByFastPathPct -->
+<!-- numeral-src: 108 :: b52-foreign-ifc/scorecard.json#openingsAndCsg.model-b.totalCsgFailures -->
+
 **B5.3 Foreign briefs.** 30 or more M5 briefs written by people who are not the
 program, three samples each, pre-registered paired CIs, tier-2 rubric.
 *Exam:* infeasibility handling and repair recovery replicate on foreign briefs;
@@ -730,12 +826,81 @@ hash exchange, server provably never holding plaintext.
 
 **B5.5 B3.2 scan-to-parametric (the unbuilt M5 final).**
 One real scanned room to parametric IFC, headline quantities within 5% of a
-manually modelled reference, plus one world-model scene imported with a bill of
-quantities. This is the highest-variance bet in the program and the one whose
-success would be least deniable.
+manually modelled reference, ~~plus one world-model scene imported with a bill
+of quantities~~ **(world-model clause CUT 2026-08-02, amendment 10)**. This is
+the highest-variance bet in the program and the one whose success would be least
+deniable.
 
-**Gate G5.** M4 final, M5 final, plus the external-validity clauses of B5.1 to
-B5.3. Second standing adversarial review, mandatory.
+*Result note, 2026-08-02 (delivered, #1932).* **Partial pass.** The scan clause
+is met for floor area, clear height and volume at model scale, and for every
+scored quantity in one of the three rooms; it is not met for the bounding wall
+surface, which is perimeter times height and is the quantity a ragged extracted
+boundary punishes. The row to read first is floor area, because it is the least
+deniable number the program has produced: a 3.94 GB point cloud went in and
+64.726 m2 came out against a human's 64.567 m2, with no reference data touching
+any stage of the extraction. The bet also carries the exam defect that motivates
+instrument 8c, and that is recorded in amendment 14 rather than here.
+
+<!-- numeral-src: 3.94GB :: b55-scan-to-parametric/scorecard.json#scan.sourceBytes -->
+<!-- numeral-src: 64.726 :: b55-scan-to-parametric/scorecard.json#variants.axisAligned.totals.floorAreaM2.generated -->
+<!-- numeral-src: 64.567 :: b55-scan-to-parametric/scorecard.json#variants.axisAligned.totals.floorAreaM2.reference -->
+
+**B5.6 Adjoints through the CSG path (the M3 adjudication bet). Entered
+2026-08-02, amendment 11, into the slot amendment 10 frees.**
+Dual-number scalars through `subtract_many` on the opening-cut family - a host
+wall plus an intersecting opening, the void pipeline as it ships - differentiating
+the emitted volume with respect to design parameters.
+*Exam:* agreement with central finite differences to 1e-6 relative on 95% of a
+200-point seeded battery, **restricted to topology-stable neighbourhoods**,
+**plus** a mandatory reported measurement across one topology-change boundary
+(an opening sliding off the host edge). Both halves are load-bearing and the
+restriction is declared up front on purpose:
+- The restriction is what makes the exam attackable rather than
+  smooth-by-construction. A CSG output is piecewise differentiable, so an
+  unrestricted relative-FD criterion fails at the seams for reasons that say
+  nothing about whether adjoints reach the kernel; declaring the restriction
+  before the run is the difference between a scoped exam and a moved goalpost.
+- The boundary row is what stops this repeating B4.4's defect. B4.4's exam was
+  written on a functional its own oracle proves smooth and therefore could not
+  fail (amendment 6). Here the one place the answer can be ugly is *required to
+  be reported*, whatever it says, and a run that reports only the restricted
+  battery is not a delivery.
+*Kill clause:* **FAIL fires the pre-committed M3 downgrade** in section 8 -
+derivative-free optimization over the same objectives, the B3.3 certificate
+machinery retained, and the "differentiable buildings" claim withdrawn. **PASS
+adjudicates M3 as BATCH-differentiable** and nothing more: interactivity is
+already withdrawn by amendment 12 and is not on this exam.
+*Budget:* two cycles, per `scripts/moonshot/b44-kernel-adjoint/DESIGN.md`
+section 6.1. Cycle 1 answers one question - can the arrangement's derived
+intersection points carry derivatives without touching the exact-predicate tier?
+The tier is a fixed-width integer type with no derivative slot, but predicates
+need only the primal, so this is plausible rather than hopeful. Cycle 2 makes the
+subtraction output stable enough for FD to be meaningful across a cut.
+**Reaching a NO in cycle 1 is itself the verdict**, and is a delivery, not an
+overrun.
+*Displacement:* **none, and the cap is therefore raised rather than held.** This
+was first written as "B5.6 takes the slot freed by the retired world-model
+clause", counting obligations rather than labels so that six fitted inside five.
+That reading is rejected here because this document rejects it: section 11 says
+the CSG-adjoint bet must name "which of B5.1 to B5.5 it displaces against the
+five-bet cap". Cutting a CLAUSE inside B5.5 frees no bet slot -- B5.5 still
+exists, still has an exam, still has to be adjudicated at G5. B5.1 to B5.6 is
+six bets against a cap of five, and calling that five by redefining "bet" is the
+kind of move this program's whole record exists to catch.
+
+So it is recorded as what it is: **Phase 5's cap is raised from five bets to six
+by amendment 11.** The pre-mortem set the cap to stop a phase overcommitting and
+then delivering only its easy bets -- the failure Phase 3 actually had. Raising
+it is defensible here for a reason that is checkable rather than rhetorical:
+four of the six (B5.1, B5.2, B5.5, and B5.6's cycle-1 spike) are agent-buildable
+and two are already delivered, so the added obligation is one binary verdict
+rather than one full bet. If that turns out to be wrong, the cap was the
+instrument that should have stopped it, and this entry is where a later reader
+finds out it was moved on purpose.
+
+**Gate G5.** M4 final, M5 final **(the scan clause alone, per amendment 10)**,
+B5.6's binary verdict, plus the external-validity clauses of B5.1 to B5.3.
+Second standing adversarial review, mandatory.
 
 ### Phase 6, two cycles. "Landing and publication."
 
@@ -752,7 +917,12 @@ exam, and it only makes sense once there is a product surface to make the edit
 on.
 
 **B6.2 Hosted benchmark and one external lab.**
-The M2 final. Gated on B4.3.
+The M2 final. ~~Gated on B4.3.~~ **Re-gated 2026-08-02, amendment 13: gated on a
+v2 task set, and on the salt-versus-substrate decision taken once *for that
+set*.** Recruiting an external lab against the current task set would spend the
+one external relationship this program gets on tasks two baselines saturate and
+a code path the tasks never enter. The order is: rebuild the task layer, take
+the integrity decision for v2, then recruit.
 
 **B6.3 The M6c paper.** Exact predicates on WebGPU: the technique, the
 sign-exactness proof, the parity manifests, and the negative economic verdict
@@ -803,10 +973,16 @@ enthusiastic slide away from claiming, is the same sentence with the words
 | Phase | Agent-cycles | Human days (Louis) | Cash |
 |---|---|---|---|
 | 4 | 4-5 (parallel) | 2 (gate) + 0.5 (B4.3 decision) | none |
-| 5 | 6-8 | 3 (gate) + 1 (brief recruitment) + 1 (scan capture) | model budget for B5.3; scanner access or one purchased scan |
+| 5 | 8-10 | 3 (gate) + 1 (brief recruitment) + 1 (scan capture) | model budget for B5.3; scanner access or one purchased scan |
 | 6 | 5-6 | 5 (gate) + paper writing + external lab outreach + open-sourcing decision on provenance | hosting for the benchmark scorer |
 
-Roughly 15 to 19 agent-cycles over about 8 months. As before, agent-cycles are
+*Phase 5's row was 6-8 and moved 2026-08-02 (amendment 11): B5.6 is a two-cycle
+bet, and the world-model clause it displaces was never separately budgeted, so
+the two cycles are added rather than exchanged. The line under section 5 that
+says a NO in B5.6's first cycle is a delivery is what keeps the upper end from
+being the expected case.*
+
+Roughly 17 to 21 agent-cycles over about 8 months. As before, agent-cycles are
 not the scarce resource. The scarce resources are your gate time, three items
 that only you can sign (benchmark integrity model, provenance package going
 public, paper submissions), and one new item: **someone outside the program**,
@@ -834,6 +1010,11 @@ Pre-committed; ledger entry mandatory; resurrection requires new evidence.
   derivative-free optimization over the same objectives, with the B3.3
   certificate machinery retained (it is genuinely good and format-independent)
   and the "differentiable buildings" claim withdrawn.
+  **Attached 2026-08-02 (amendment 11): that bet now exists and is B5.6.** The
+  downgrade clause above is its FAIL branch verbatim; its PASS branch adjudicates
+  M3 as BATCH-differentiable only. **M3's INTERACTIVITY claim is separately and
+  deliberately withdrawn (amendment 12) and is no longer any part of what B5.6
+  can win back.**
 - **M4:** if the real-trace false-conflict rate (B5.1) exceeds 20%, keep the
   theorem and drop the auto-merge product claim, exactly as originally written.
   New clause: if B4.2 shows the spatial rule produces no true conflicts under
@@ -845,7 +1026,12 @@ Pre-committed; ledger entry mandatory; resurrection requires new evidence.
 - **M6c:** already resolved. Retarget to publication. Do not spend another cycle
   chasing a speedup that the asymptote says is not there.
 - **M6b:** if it is not wired into production by G5, M3's interactivity claim
-  is withdrawn regardless of B4.4's outcome.
+  is withdrawn regardless of B4.4's outcome. **FIRED 2026-08-02, deliberately
+  and ahead of G5 (amendment 12). M3's INTERACTIVITY claim is WITHDRAWN.** M6b
+  itself is not killed: it stays a validated but UNWIRED lever with the dated
+  re-entry condition in that amendment. Firing a kill clause early, on evidence
+  already in the ledger, is the clause working; waiting for G5 to fire it
+  automatically would only have bought four more months of saying it.
 
 **Pre-mortem, updated.** The original three (diffusion of effort, human calendar
 slips, maintenance starves the program) stand. Two new ones, both observed
@@ -902,9 +1088,16 @@ Consequences, stated so they can be checked rather than trusted:
 - **Amendments 6, 7 and 8 are PROVISIONAL until #1897 merges.** They are the
   proposed record, entered in writing per the plan's own rule and open to
   revision; they become the signed record at merge and not before.
+  **Closed 2026-08-02: #1897 merged 2026-08-01 by the repo-owner account, so
+  amendments 6 to 8 are the signed record. Checkable with `gh pr view 1897`.**
 - Nothing in Phase 4 has passed sign-off as of this writing: #1886, #1897,
   #1899, #1900 and #1902 are all open. A gate cannot close on unmerged branches,
   which is a second, independent reason G4 stays failed.
+  **Corrected 2026-08-02: all five have since merged, so this second reason no
+  longer applies. G4's status is unchanged and stays FAILED on the first reason
+  alone - amendment 8's three grounds, of which B4.3's non-delivery is still
+  live. A sign-off condition being met is not a gate passing, and this bullet is
+  corrected rather than deleted so that distinction stays legible.**
 - Any future sentence claiming sign-off must name the PR or tag that carries it,
   so a reader can verify the claim without trusting the writer.
 
@@ -1035,6 +1228,246 @@ are amendable only in writing in this file - and the re-scope below was not.
    (`reviews/g4-re-attestation-2026-07-29.md`) - found errors of framing, scope
    and record-keeping, and neither found an error of fact.
 
+**Added 2026-08-02, at the Phase 5 betting table.** Six entries. Five are the
+decisions the betting table took now that Phase 4's bets have merged and the two
+bets Phase 3 skipped have been run; the sixth adds an instrument, which is a
+change to section 2 and therefore belongs here too.
+
+*A note on the status of amendments 6 to 8, because section 9.1 makes it
+checkable rather than assertable: **they are no longer PROVISIONAL.** #1897 was
+merged by the repo-owner account on 2026-08-01, which is the signature act
+section 9.1 names, so amendments 6, 7 and 8 are the signed record. Verify with
+`gh pr view 1897`. The same rule applies to what follows: **amendments 9 to 14
+are PROVISIONAL** until the docs PR carrying branch
+`docs/moonshot-amendments-phase5` is merged by the repo-owner account. No PR
+number is written here because none exists at authoring time, and section 9.1
+forbids a sentence claiming sign-off that names nothing a reader can check.*
+
+9. **Phase 4's bets have merged, `node-hash-v0` is frozen, and section 1.1's
+   survivorship pattern has its first counter-evidence. Phase 4's verdict is
+   unchanged.** Recorded once, here, in three parts.
+
+   (a) *Merged.* B4.1 (#1897), B4.2 (#1900), B4.4 (#1902) and B4.5 (#1899) are
+   on main, and B4.3's honesty half merged as #1940. **`node-hash-v0` is FROZEN
+   at `1.0.0` (#1886)**, which is the prerequisite section 10 names for making
+   `@ifc-lite/provenance` public: freezing the wire format is what makes a
+   compatibility promise mean anything.
+
+   (b) *Both bets Phase 3 skipped have been run, and measured on data the
+   program did not author.* B5.2 (#1931) put the benchmark's tasks and the
+   defect detector against two real delivered client models this program neither
+   authored nor had seen. B5.5 (#1932) took one real laser scan of a real
+   dwelling through extraction, parametric emission and the kernel, and scored it
+   against a manually modelled reference. Section 1.1 calls the skipping of
+   exactly these two "a survivorship pattern, not a schedule accident, and the
+   single most important fact in this document". **This is the first evidence
+   against that fact**, and it is the only such evidence the program has: the two
+   exams that require contact with something outside the parametric sandbox were
+   not deferred a second time, and neither produced a number this program
+   controlled. Their results are in section 5's two result notes and in
+   amendments 10, 13 and 14.
+
+   (c) *And none of it moves Phase 4.* **Phase 4 stays recorded FAILED on its own
+   terms** (amendment 8). All three of that amendment's grounds are untouched:
+   B4.4's exam was written on a functional its own oracle proves smooth, the M4
+   delete-clause was evaluated only under the op model that manufactures the
+   rule's catches, and B4.3 was not delivered - it still is not, because the
+   decision is not the mechanism. **B2.2 remains CONFIRMED, UNFIXED**: the salt
+   is decided and being built, and `clean-twin-diff` has not been re-run against
+   anything. A phase is not retroactively passed by the phase after it, and one
+   broken pattern is not a retired one.
+
+10. **B5.5's world-model clause is CUT. The M5 final is the scan clause alone.**
+    The M5 final in `moonshots-execution-plan.md` section 2 reads "one real
+    scanned room to parametric IFC with headline quantities within 5% of a
+    manually modeled reference, **plus one world-model scene imported with a bill
+    of quantities**". The second half is retired before it was built, and the
+    reasons are written out so the decision can be argued with:
+
+    (a) **It shares no machinery with the scan path it was bundled into.** The
+    scan clause is point-cloud ingest, plane fitting, room extraction,
+    parametric emission and kernel measurement. A world-model import shares none
+    of those stages; it was one bet because both were "M5 inputs", not because
+    either helped the other.
+    (b) **It has no exam.** Its whole stated bar is that a bill of quantities
+    exists. Nothing in it can come back FAIL, which is precisely the defect
+    amendment 8 records against Phase 4 and precisely what instrument 8 is being
+    added to prevent. A clause that cannot fail must not be carried as a final
+    exam clause.
+    (c) **It is the one clause in the program that is trend-chasing rather than
+    thesis-bearing.** The thesis is "neural systems propose, the kernel
+    disposes". Grounding a generated scene demonstrates the proposing half, which
+    is the half the rest of the world is already funding. Nothing about the
+    kernel's claim depends on it.
+    (d) **The clause it was bundled with has already produced the program's
+    least deniable number**, and it did so without any help from the world-model
+    half: a 3.94 GB point cloud in, 64.726 m2 out against a human's 64.567 m2,
+    reference data touching no stage of the extraction.
+
+    The story is not deleted, it is re-sited: **the world-model import moves to
+    B6.5's demo**, where a generated scene is a stage artifact and is judged as
+    one, rather than an exam clause pretending to be measurable. Negative-results
+    ledger entry N6 in `moonshots-execution-plan.md`.
+
+11. **B5.6 enters the Phase 5 betting table: adjoints through the CSG path.**
+    Amendment 6 left M3 UNADJUDICATED and stated exactly what entering this bet
+    would require: "a number, an exam, a kill clause, a statement of which of
+    B5.1-B5.5 it displaces against the five-bet cap, and a cycle-budget update.
+    None of those exist yet." All five exist now. The bet's full entry is in
+    section 5 and is not duplicated here; what this entry records is that the
+    betting-table act happened, and its four load-bearing parts:
+
+    - **Exam.** Adjoints through `subtract_many` on the opening-cut family - a
+      host wall plus an intersecting opening, the void pipeline as shipped -
+      FD-matched to 1e-6 relative on 95% of a 200-point battery **restricted to
+      topology-stable neighbourhoods**, **plus a mandatory reported measurement
+      across one topology-change boundary** (an opening sliding off the host
+      edge). The restriction is declared before the run because that is what
+      makes the exam attackable instead of smooth-by-construction, and the
+      boundary row is required because without it this bet repeats B4.4's
+      could-not-fail defect on a harder functional.
+    - **Kill clause.** FAIL fires the section 8 M3 downgrade: derivative-free
+      optimization over the same objectives, B3.3's certificate machinery
+      retained, "differentiable buildings" withdrawn. PASS adjudicates M3 as
+      **BATCH-differentiable**, which is what is left of the claim after
+      amendment 12.
+    - **Budget.** Two cycles, per `scripts/moonshot/b44-kernel-adjoint/DESIGN.md`
+      section 6.1. Cycle 1 answers whether derived intersection points can carry
+      derivatives without touching the exact-predicate tier - plausible, because
+      predicates need only the primal, while the tier itself is a fixed-width
+      integer type with no derivative slot. **Reaching a NO in cycle 1 is the
+      verdict, not a failure to deliver.** Section 7's Phase 5 row moves from 6-8
+      to 8-10 agent-cycles.
+    - **Displacement.** B5.6 takes the slot the retired world-model clause frees
+      (amendment 10). Phase 5's exam obligations stay at six; the label count
+      goes to six as well. Section 5 states the reading of the five-bet cap this
+      rests on, so a later reader can reject it rather than discover it.
+
+12. **M6b's interactivity kill clause is FIRED, deliberately, now. M3's
+    INTERACTIVITY claim is WITHDRAWN.** Section 8's M6b clause reads "if it is
+    not wired into production by G5, M3's interactivity claim is withdrawn
+    regardless of B4.4's outcome". The clause is fired at the betting table
+    rather than left to trip at G5, on evidence that has been in the ledger for
+    ten days:
+
+    - **N4**, in the negative-results ledger: threaded wasm measured at 0.87x on
+      the full pipeline, an atomics tax rather than a speedup, re-refuted
+      2026-07-23. M6b's own range is a **CSG-stage** figure and N4 says in as
+      many words that it must not be restated as an end-to-end one.
+
+      <!-- numeral-src: 0.87x :: none - the threaded-wasm whole-pipeline figure
+           from the repo's own perf program, recorded in this plan set as ledger
+           entry N4. It pre-dates the moonshot program and nothing under
+           scripts/moonshot/ emits it, so it is blocked for the same reason
+           M6b's 2.9x-4.2x range is: a coincidental hit in the union index must
+           not be allowed to read as provenance for a figure produced somewhere
+           else entirely. -->
+
+    - **The memory-bandwidth finding**, in `scripts/perf/README.md`'s dead-ends
+      list: more geometry workers give zero CSG speedup because the path is
+      memory-bandwidth bound, not CPU bound. A lever whose parallel scaling is
+      bounded by bandwidth does not become an interactivity story by being
+      wired.
+
+    Together those say the projection budget M3's interactivity claim needs is
+    not reachable by threading, and M6c already removed the GPU from that story
+    (amendment 2). Waiting for G5 to fire the clause automatically would have
+    bought four more months of saying a thing the program's own measurements
+    contradict. **This is a deliberate withdrawal, not a failure discovered
+    late**, and the distinction is the whole point of writing it down: nothing
+    new was measured, a conclusion already available was acted on.
+
+    **M6b is not killed.** It stays a validated but **UNWIRED** lever, TRL 5,
+    with a dated re-entry condition: *re-enter M6b when a workload shape changes
+    the atomics arithmetic* - a CSG stage whose per-element work is large enough
+    that the atomics tax amortizes, or a path whose bottleneck is measured to be
+    arithmetic rather than bandwidth. Re-entry requires that measurement first,
+    per the ledger's resurrection rule. Recorded as N5 in
+    `moonshots-execution-plan.md`.
+
+    **What M3 keeps.** B5.6 adjudicates M3 as batch-differentiable. That is
+    publishable on its own terms - a projection operator with exactness
+    guarantees is the piece the differentiable-simulation field lacks, and it is
+    what certified descent needs - and it is a smaller claim than the one this
+    plan has been carrying. The demo that follows a PASS is a batch optimization
+    with a certificate stream, not a building relaxing live in a tab.
+
+13. **B4.3 and B6.2 are re-sequenced. The salt decision stands; the public
+    launch does not follow from it.** The decision recorded in first-moves item 2
+    is taken - **secret per-split salt** - and the mechanism is being
+    implemented. What amendment 13 changes is what that unlocks, on B5.2's own
+    committed report:
+
+    - **The benchmark never enters the code path where the failures are.** 100%
+      of the corpus's openings are rectangular through-cuts on box hosts and the
+      `rect_fast` path takes every one of them with zero deferrals, so the
+      general CSG path - "the most expensive and most failure-prone thing
+      ifc-lite owns" - **is never entered by the benchmark at all**, while every
+      foreign failure lives there (model-b's 108 `OperandTooLarge`).
+    - **Both anchors saturate once the reference-integrity rule is wired**, which
+      leaves the headline metric with no headroom to measure anything with.
+
+    A salt protects an answer key. Neither of those findings is about the answer
+    key. So:
+
+    (a) **B2.2 stays CONFIRMED, UNFIXED and dev stays attackable-by-design.**
+    Nothing here weakens the finding or the label.
+    (b) **The task layer is rebuilt first.** Defects re-substrated onto real
+    models, which have no procedural twin to diff against, plus generator
+    families that actually enter the general CSG path (non-rectangular openings,
+    diagonal cuts, many-opening hosts - the shapes both foreign models are full
+    of and the corpus has none of).
+    (c) **The salt-versus-substrate decision is taken once, for the v2 task
+    set.** Taking it against v1 would be building integrity machinery for tasks
+    about to be replaced, and the v2 substrate choice may itself answer it: a
+    real-model substrate has no clean twin to regenerate.
+    (d) **B6.2 recruits against v2.** A lab post-training against tasks that two
+    baselines saturate, on a corpus that never enters the kernel's hard path,
+    would burn the one external relationship this program gets and would produce
+    a result nobody could interpret. External-lab recruitment is a
+    one-shot human-calendar item; it is sequenced last on purpose.
+
+14. **Instrument 8 is added to section 2: exam integrity.** The three clauses are
+    written in section 2. This entry records what they reach, because an
+    instrument sold as more than it is becomes the next thing to audit.
+
+    **8a and 8b are retrospective on real defects, and would have caught these:**
+    the forged trust anchor and the crafted-size allocation cap in B4.5's bundle
+    verifier; the FIFO cap bypass that re-opened that same allocation defect
+    through a different door two rounds later; B5.2's bodyless
+    `degenerate-geometry` verdict, taken from meshes coming back empty rather
+    than from following the mapping that would say whose fault it was, and its
+    `Unknown` representation-item histogram, which had exactly one reachable
+    value and so could not have distinguished anything; B4.4's harness ignoring
+    cargo's exit code and discarding deviations; and the shared-temp-dir race
+    that produced a PASS. Every one of those is a verdict that could not have
+    come back FAIL, or a verdict taken from an absence.
+
+    **They would NOT have caught B5.5's blind exam, and the honest version of
+    this instrument says so.** That scorer ran, it passed, and it was *correct
+    about what it measured*. The defect was not in the scorer; it was in the
+    invariance group. Every scored quantity is an `IfcSpace` quantity - floor
+    area, clear height, volume, bounding wall surface - and all four are
+    invariant under a rigid Z shift of the walls and slab. The first revision of
+    the emitted model put the walls and the slab a whole storey low, because
+    `addIfcWall` and `addIfcSlab` place relative to the storey while `addIfcSpace`
+    places relative to the world, so handing all three the fitted floor plane
+    (-1.37 m) applied it twice. Not one scored row moved by a digit. A red-run
+    would have gone red for the violation it was written for; a positive
+    assertion would have asserted the quantity it was written for. **Only 8c
+    reaches this**, because only 8c asks what the score is blind to *before*
+    the run.
+
+    <!-- numeral-src: -1.37 :: b55-scan-to-parametric/scorecard.json#scan.planes.floor.z -->
+
+    **And the cheap backstop, recorded because it is embarrassing and true:
+    render one elevation image per emitted model and look at it.** The defect was
+    a storey's worth of separation between a room and the walls bounding it. It
+    was visible in a single screenshot. This program has built a Merkle DAG, a
+    GPU predicate library and a numeral-provenance gate, and has never once
+    looked at a picture of what it emitted. Every bet that emits a model owes one
+    rendered view in its directory, and 8c owes it a place in the audit.
+
 ---
 
 ## 10. Agent-buildable versus human-only, updated
@@ -1046,16 +1479,26 @@ paper drafts, all documentation.
 
 **Serial human calendar (the real schedule), with the new items marked:**
 
-- Benchmark integrity model decision (B4.3). **Blocking Phase 6.**
+- Benchmark integrity model decision (B4.3). ~~**Blocking Phase 6.**~~ **Taken
+  2026-08-02: secret per-split salt; the mechanism is in implementation. What
+  now blocks Phase 6 is not this decision but the v2 task set and the
+  salt-versus-substrate call taken once for it (amendment 13), and that call may
+  be answered by the substrate choice rather than made separately.**
 - **NEW: making `@ifc-lite/provenance` public and non-prototype.** Blocking
   finish line C. Note that the spec-freeze PR (#1886), which stamps
-  `node-hash-v0` at 1.0.0 and bumps the package to 0.1.0, is itself still open
-  and is a prerequisite: freezing the wire format is what makes a public
-  package's compatibility promise meaningful.
+  `node-hash-v0` at 1.0.0 and bumps the package to 0.1.0, ~~is itself still open
+  and~~ is a prerequisite: freezing the wire format is what makes a public
+  package's compatibility promise meaningful. **#1886 merged 2026-08-01, so the
+  prerequisite is met and this item is now the decision alone.**
 - **NEW: recruiting the outside.** Foreign brief authors, a foreign IFC source,
   and an adversarial reviewer with no authorship stake. Blocking Phase 5.
+  **Partly done 2026-08-02: the foreign IFC source arrived and B5.2 ran on it.
+  Foreign brief authors and the G5 reviewer are outstanding, and amendment 14
+  adds a second thing the reviewer must be named early enough to do - the 8c
+  null-space audit, which is a commissioning-time act.**
 - **NEW: one real scan.** Access to a scanner or a purchased scan plus a
-  manually modelled reference. Blocking B5.5.
+  manually modelled reference. ~~Blocking B5.5.~~ **Done 2026-08-02: both the
+  scan and the reference arrived and B5.5 ran (#1932). This item is closed.**
 - Trust-root and signing-key custody (unchanged, now actually needed by B5.4).
 - Paper submissions: M6c (time-sensitive), M4 (gated on real traces).
 - External lab recruitment for the M2 final.
@@ -1071,40 +1514,45 @@ paper drafts, all documentation.
 
 ## 11. First moves
 
-This list is the outstanding blockers as of 2026-07-30, not the list this
-section shipped with. The original four - write `moonshot.yml` (B4.1),
-land amendments 1 to 5, take the B4.3 decision, schedule the Phase 4 betting
-table and commission the G4 reviewer - are done except B4.3, which survives
-below. B4.1's lane exists and both halves of its exam now have committed
-artifacts; amendments 1 to 5 are in `moonshots-execution-plan.md`; the G4 review
-was commissioned, ran, and failed the gate, and its re-attestation kept it
-failed. Rewriting the list rather than ticking it is deliberate: a stale
-"do this first" list is the same defect class as a stale figure.
+This list is the outstanding blockers as of 2026-08-02, not the list this
+section shipped with and not the 2026-07-30 revision of it. Rewriting rather
+than ticking is deliberate: a stale "do this first" list is the same defect
+class as a stale figure.
+
+*What the previous revision listed, and where it went.* #1897 merged
+2026-08-01, so amendments 6 to 8 are signed and item 1 is closed. The B4.3
+decision is taken (secret per-split salt) and its mechanism is in
+implementation, so item 2 becomes a narrower item below. Two of the three
+external-data prerequisites arrived - a foreign IFC source and one real scan
+with a manually modelled reference - which is what let B5.2 and B5.5 run; real
+collaboration traces and foreign brief authors did not, and survive below. The
+Phase 5 betting table sat, and its output is amendments 9 to 14, so item 4 is
+closed. Item 5 was not done and is unchanged.
 
 In order:
 
-1. **Merge #1897.** Section 9.1 defines gate-holder sign-off as the merge of
-   the gate's docs PR by the repo-owner account, so this merge is what converts
-   amendments 6 to 8 from proposed to signed. Nothing downstream of them is
-   settled until it happens, and no agent can perform or fake it.
-2. **B4.3 decision.** Secret per-split salt versus a real-model substrate
-   (hosted bytes alone denies nothing - B4.3). One
-   paragraph from you, then the implementation and the clean-twin re-check.
-   Blocking Phase 6, and B2.2 stays CONFIRMED, UNFIXED until all three are done.
-3. **Phase 5's external-data prerequisites**, which are lead-time items and not
-   agent work: a foreign IFC source and real collaboration traces (B5.1),
-   foreign brief authors (B5.2), and one real scan plus a manually modelled
-   reference (B5.5). Phase 5 cannot start against internally authored
-   distributions without repeating the finding that section 3 of the G2 review
-   already made.
-4. **The Phase 5 betting table**, which has to settle whether the CSG-adjoint
-   bet enters at all. Amendment 6 leaves M3 UNADJUDICATED pending it, and
-   entering it needs a number, an exam, a kill clause, a statement of which of
-   B5.1 to B5.5 it displaces against the five-bet cap, and a cycle-budget
-   update. None of those exist, and writing them is a betting-table act.
-5. **Name the G5 adversarial reviewer before Phase 5's work finishes**, on the
+1. **Merge this document's PR.** Section 9.1 defines gate-holder sign-off as the
+   merge of the gate's docs PR by the repo-owner account, so this merge is what
+   converts amendments 9 to 14 from proposed to signed. Nothing downstream of
+   them is settled until it happens, and no agent can perform or fake it.
+2. **The two external-data prerequisites that did not arrive**, both lead-time
+   human items: real multi-user collaboration traces (B5.1) and foreign brief
+   authors (B5.3). These are now the only things standing between Phase 5 and a
+   complete external-validity set; the other two arrived and delivered.
+3. **Name the G5 adversarial reviewer before Phase 5's work finishes**, on the
    same logic that made G4 worth commissioning: a reviewer named afterwards
-   reviews a record that has already hardened.
+   reviews a record that has already hardened. **Amendment 14 adds a second
+   thing to commission early** - instrument 8c's null-space audit is a
+   commissioning-time act, so the reviewer who does it must be named before
+   B5.6 and B5.1 run, not after.
+4. **The v2 task-set decision for the benchmark** (amendment 13): what the
+   defects are re-substrated onto, and which generator families are added to
+   make the corpus enter the general CSG path. This is the item B6.2 now waits
+   on, and the salt-versus-substrate call is taken inside it rather than before
+   it.
+5. **External lab recruitment stays parked** until item 4 lands. It is a
+   one-shot relationship and recruiting against a saturated task set spends it
+   for nothing.
 
-Item 1 is the only one that unblocks the rest of the stack; items 2 and 3 are
-the two nobody else can do; item 4 is the decision the whole M3 line waits on.
+Item 1 unblocks the record; item 2 is the only remaining thing nobody inside
+the program can do; item 4 is what the whole M2 line now waits on.


### PR DESCRIPTION
Six amendments to the program record, written under section 9's own rule as dated entries rather than edits to history. **Provisional until this merges** — 9.1 forbids claiming a sign-off a reader cannot check.

**9. Phase 4's bets merged, `node-hash-v0` is FROZEN at 1.0.0, and section 1.1's survivorship pattern broke.** Both Phase 5 bets Phase 3 had skipped were *run*, on data the program did not author. Recorded without overclaiming: Phase 4 stays FAILED on its own terms, B2.2 stays CONFIRMED-UNFIXED.

**10. B5.5's world-model clause is CUT** — the M5 final is the scan clause alone. It shares no machinery with the scan path and has no exam beyond "a BoQ exists". Moves to B6.5's demo as a stage artifact.

**11. B5.6 enters** with a full betting-table entry: the exam declares its topology-stable restriction *up front* (what makes it attackable rather than smooth-by-construction) plus a mandatory boundary row so it can't repeat B4.4's could-not-fail defect.

> **The cap is RAISED, not held — and the first draft got this wrong.** It read "B5.6 takes the slot freed by the retired world-model clause", counting *exam obligations* rather than labels so six fitted inside five. Section 11 of this same document rejects that: the bet must name "which of B5.1 to B5.5 it displaces". Cutting a **clause inside** B5.5 frees no bet slot. Calling six five by redefining *bet* is the move this program's record exists to catch, so it's recorded as a deliberate raise with a checkable justification.

**12. M6b's interactivity kill clause is FIRED, deliberately, now** rather than at G5 — on ledger N4 (threaded wasm at 0.87×, atomics tax) plus the memory-bandwidth finding. M6b stays a validated but unwired lever with a dated re-entry condition.

**13. B4.3 / B6.2 re-sequenced.** The salt decision stands; public launch does not follow from it. B5.2's own report: 100% of corpus openings take `rect_fast`, so the general CSG path is never entered by the benchmark at all, while every foreign failure lives there. Both anchors saturate once the reference-integrity rule is wired.

**14. Instrument 8** — 8a no PASS without a committed red-run; 8b verdicts by positive assertion only; 8c a null-space audit at commissioning. Recorded with what each reaches, including that **8a/8b would not have caught B5.5's blind exam** — only 8c does — plus the backstop that costs nothing: render one elevation image and look at it.

## Contradictions found and corrected

- **Section 9.1 asserted #1886/#1897/#1899/#1900/#1902 are "all open"** — all five merged. Fixed, with G4 deliberately still FAILED (a sign-off condition being met is not a gate passing).
- "M6b as the critical path" survived in three places written before amendment 12.
- The execution plan's M3 kill criterion still said the CSG-adjoint bet "is NOT scheduled".

## Flagged, not silently fixed

`B4.4 DESIGN.md` has no "section 6.1" — the scoping is in section 6 item 1, and the record already mis-cites it twice, so the citation was kept consistent rather than diverging. E9's calibration paragraph states its high endpoint as 91.7% while the checker has printed 92.9% since before these amendments — recorded as KNOWN DRIFT, because repairing it changes that section's instrument rather than the plan.

Six new `numeral-src` bindings to real fields, one negative. Gate exit 0 across 8 prose sets, self-test PASS.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated moonshot execution and finishing plans with results and status through August 2026.
  * Revised milestone sequencing, budgets, benchmark requirements, and launch gates.
  * Clarified M3, M5, and M6b scope, including withdrawn requirements and deferred demonstrations.
  * Added exam-integrity criteria covering red runs, positive assertions, and null-space checks.
  * Recorded completed external-data experiments, pending implementation and validation work, updated blockers, and future re-entry conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->