### PR TITLE
chore(moonshot): re-bless B4.5's no-aggregates scorecard - a published clause flips

### DIFF
--- a/scripts/moonshot/b45-m1-midterm/REPORT.md
+++ b/scripts/moonshot/b45-m1-midterm/REPORT.md
@@ -428,7 +428,7 @@ from:
 |---|---|
 | `sensitivityElementGranularityClaim.nodesResolved` | 21,777 |
 | `sensitivityElementGranularityClaim.nodesResolvedPct` | 12.6224 |
-| `sensitivityElementGranularityClaim.verifyMs` | 453.5 |
+| `sensitivityElementGranularityClaim.verifyMs` | 517.2 |
 | `sensitivityElementGranularityClaim.wouldPassClause2` | false |
 
 So the row was an **element-granularity claim measured on the g0/g1 DAG shape**
@@ -436,12 +436,19 @@ So the row was an **element-granularity claim measured on the g0/g1 DAG shape**
 claim granularity. `run.mjs` still implements exactly two claim granularities;
 what the row conflated was the two axes, by sitting in a table that varies only
 one of them. It remains removed from that table because it does not belong
-there, and its verify figure was in any case a different run's (453.5 ms in the
-committed artifact against the 465.4 ms the row carried).
+there, and its verify figure was in any case a different run's (453.5 ms in the artifact
+as committed on 2026-07-29, against the 465.4 ms the row carried). Both figures
+are historical: the 2026-08-02 re-bless moved that field to 517.2 ms, and the
+comparison stands on the mismatch rather than on either value.
 
 <!-- numeral-src: 21,777 :: b45-m1-midterm/scorecard-no-aggregates.json#sensitivityElementGranularityClaim.nodesResolved -->
 <!-- numeral-src: 12.62%, 12.6224 :: b45-m1-midterm/scorecard-no-aggregates.json#sensitivityElementGranularityClaim.nodesResolvedPct -->
-<!-- numeral-src: 453.5, 453.5ms :: b45-m1-midterm/scorecard-no-aggregates.json#sensitivityElementGranularityClaim.verifyMs -->
+<!-- numeral-src: 517.2 :: b45-m1-midterm/scorecard-no-aggregates.json#sensitivityElementGranularityClaim.verifyMs -->
+<!-- numeral-src: 453.5ms :: none - the value that field held when the
+     2026-07-29 correction was written. The 2026-08-02 re-bless moved it to
+     517.2 ms, so no artifact emits 453.5 any more and none should: the
+     sentence above is a record of a past comparison, and a later coincidental
+     union hit must not hand it fresh provenance. -->
 <!-- numeral-ok: 465.4ms :: the verify timing the removed row carried, quoted
      only to show that it does NOT match the committed 453.5 ms. From an
      uncommitted run; it must stay unbacked. -->
@@ -471,12 +478,12 @@ ran both shapes:
 <!-- numeral-src: 40,028 :: b45-m1-midterm/scorecard-no-aggregates.json#meshDataUnattached -->
 <!-- numeral-src: 172,526 :: b45-m1-midterm/scorecard-no-aggregates.json#nodesTotal -->
 <!-- numeral-src: 0.0348% :: b45-m1-midterm/scorecard-no-aggregates.json#nodesResolvedPct -->
-<!-- numeral-src: 60.86ms :: b45-m1-midterm/scorecard-no-aggregates.json#verifyMedianMs -->
+<!-- numeral-src: 75.85ms :: b45-m1-midterm/scorecard-no-aggregates.json#verifyMedianMs -->
 
 | Shape | Nodes | Resolved % | Verify | Verdict | Artifact |
 |---|---|---|---|---|---|
 | contained + aggregated (this bet) | 250,582 | 0.0239% | 55.53 ms | PASS | `scorecard.json` |
-| contained only (g0/g1) | 172,526 | 0.0348% | 60.86 ms | PASS | `scorecard-no-aggregates.json` |
+| contained only (g0/g1) | 172,526 | 0.0348% | 75.85 ms | PASS | `scorecard-no-aggregates.json` |
 
 The two verify medians come from separate runs on separate days, and run-to-run
 spread on this machine is larger than the gap between those two cells, so the

--- a/scripts/moonshot/b45-m1-midterm/REPORT.md
+++ b/scripts/moonshot/b45-m1-midterm/REPORT.md
@@ -215,11 +215,15 @@ all three clauses at once, with mesh leaves present throughout.
 
 <!-- numeral-src: 169MB :: b45-m1-midterm/scorecard.json#fixtureBytes -->
 <!-- numeral-src: 63ms :: none - g0's own published data-plane figure. g0 writes
-     no scorecard, so nothing in this tree emits it. It is bound negatively
-     rather than left to the union index because the union CLEARS it by
-     coincidence: scorecard-no-aggregates.json's verifyAllMs[1] is 62.654, a
-     single spawn of a different DAG shape on a different day, which rounds to
-     63 and has nothing to do with g0. -->
+     no scorecard, so nothing in this tree emits it, and it stays bound
+     negatively. It was originally written this way because the union index
+     CLEARED it by coincidence: scorecard-no-aggregates.json's verifyAllMs[1]
+     was 62.654, a single spawn of a different DAG shape on a different day,
+     which rounded to 63 and had nothing to do with g0. The 2026-08-02 re-bless
+     moved that field to 76.618, so the coincidence is gone - which is exactly
+     why the binding is not left to the index: a figure whose provenance depends
+     on an unrelated field happening to round the right way has no provenance at
+     all, in either direction. -->
 
 ## Verdict: PASS on all three clauses
 
@@ -364,9 +368,12 @@ verification cost is dominated by re-hashing the 49 untouched-storey
      touches. Both ratios are computed in the sentence. -->
 <!-- numeral-src: 24 :: none - the edited wall's original vertex count, an input
      to the 46x ratio, read off the mesh during the variant run and stored by
-     neither scorecard. Bound negatively because the union index clears it
-     against scorecard-no-aggregates.json's parseMs, 2423 ms scaled by 1/100 -
-     a parse timing standing in for a vertex count. -->
+     neither scorecard. Bound negatively because the union index cleared it
+     against scorecard-no-aggregates.json's parseMs, then 2423 ms scaled by
+     1/100 - a parse timing standing in for a vertex count. The 2026-08-02
+     re-bless moved parseMs to 3118, so that particular unit-scaled hit no
+     longer fires; the binding stays negative because the figure still has no
+     committed field behind it, which was always the real reason. -->
 <!-- numeral-src: 1,106 :: b45-m1-midterm/scorecard.json#examB_propertyPlusGeometryWallEdit.verticesMoved -->
 <!-- numeral-src: 53.9, 56.0ms :: none - the pre- and post-inflation verify
      medians, from a separate instrumented run predating the 2026-08-01
@@ -429,7 +436,35 @@ from:
 | `sensitivityElementGranularityClaim.nodesResolved` | 21,777 |
 | `sensitivityElementGranularityClaim.nodesResolvedPct` | 12.6224 |
 | `sensitivityElementGranularityClaim.verifyMs` | 517.2 |
+| `sensitivityElementGranularityClaim.wouldPassClause1` | false |
 | `sensitivityElementGranularityClaim.wouldPassClause2` | false |
+
+**`wouldPassClause1` flipped in the 2026-08-02 re-bless**, and it is recorded
+here rather than smoothed over: the field was `true` at 453.5 ms and is `false`
+at 517.2 ms, because the probe crossed the same 500 ms bar clause 1 is judged
+on. Read it for exactly what it is and no more. It is the SENSITIVITY probe -
+the hypothetical "what if this bet had made an element-granularity claim on the
+g0/g1 DAG shape" - and this bet makes no such claim. Nothing in the exam moved:
+clauses 1, 2 and 3 still pass on the figures at the top of this document, by
+9.0x, by more than two orders of magnitude, and by 99.9956% against a 90% bar.
+
+What the flip does say is that the probe was never far from its bar - the run it
+replaces sat under 500 ms by less than this machine's run-to-run spread - so the
+honest reading of the probe was always "marginal", in both directions. It is not
+averaged with the earlier run, and it is not re-blessed until it passes: four
+runs on 2026-08-02 measured 517.2, 534.0, 543.8 and 544.4 ms, every one of them
+over the bar, and the committed artifact carries the first of them.
+
+<!-- 453.5ms and 500ms are already bound below and above respectively: 453.5 ms
+     by the `:: none` block on the correction paragraph (it is the value the
+     field held before this re-bless, and no artifact emits it any more), and
+     500 ms by the exam-bar binding on the verdict table. Both are re-quoted
+     here without new markers on purpose - one token, one binding. -->
+<!-- numeral-ok: 534.0, 543.8, 544.4ms :: the three companion runs of the
+     2026-08-02 re-bless. run.mjs writes one scorecard per invocation and the
+     committed artifact is the first run, so the other three have no committed
+     field and must stay unbacked; they are quoted to show the flip is not a
+     single unlucky sample. -->
 
 So the row was an **element-granularity claim measured on the g0/g1 DAG shape**
 - a fourth cell of a 2x2 (two claim granularities x two DAG shapes), not a third
@@ -532,16 +567,16 @@ back.
 
 ### Smaller caveats
 
-- The committed `scorecard-no-aggregates.json` predates the forged-trust-anchor
-  tamper case and the `altered` field, so its `tamper` array has two entries
-  where a run of the current script produces three. Every figure this document
-  binds to that artifact is a node count or a rate, and all of them reproduce to
-  the digit under the current script; the two timings it backs could not be
-  re-measured usefully at the time of writing (the host was oversubscribed
-  enough to inflate the same run's verify median by more than a factor of two),
-  so it has been left alone rather than re-blessed with contention artifacts.
-  Re-bless it with `--no-aggregates --write-scorecard` on a quiet machine and
-  re-derive the two figures it moves.
+- `scorecard-no-aggregates.json` was re-blessed on 2026-08-02 and this caveat is
+  now a record of what that closed. As committed on 2026-07-29 it predated the
+  forged-trust-anchor tamper case and the `altered` field, so its `tamper` array
+  carried two entries where the script produced three; the current artifact
+  carries all three, each with `altered: true` and each `caught`. The node
+  counts and rates reproduced to the digit then and still do. What the re-bless
+  moved is timings - the ones this document quotes are updated above, and one of
+  them crossed a bar: `sensitivityElementGranularityClaim.wouldPassClause1` is
+  now `false`. That is the sensitivity probe, not the exam; see the correction
+  in caveat 2.
 - `reads` is empty because Holter's walls carry exactly one pset each (g0
   documented the same; duplex yields 9 reads).
 - Trust root, kernel version and root `layerId` are placeholders, as in

--- a/scripts/moonshot/b45-m1-midterm/scorecard-no-aggregates.json
+++ b/scripts/moonshot/b45-m1-midterm/scorecard-no-aggregates.json
@@ -15,30 +15,30 @@
   "meshDataExcludedClass2": 0,
   "meshDataUnattached": 40028,
   "triangles": 2934427,
-  "vertices": 4593788,
+  "vertices": 4593037,
   "nodesResolvedDuringVerify": 60,
   "uniqueNodesResolvedDuringVerify": 60,
   "nodesResolvedPct": 0.034777,
   "nodesResolvedPctIfMeshLeavesExcludedFromDenominator": 0.058869,
-  "verifyMedianMs": 60.862,
+  "verifyMedianMs": 75.846,
   "verifyAllMs": [
-    60.432,
-    62.654,
-    62.88,
-    60.862,
-    60.264
+    75.846,
+    76.618,
+    77.032,
+    75.636,
+    74.879
   ],
-  "verifyBundleParseMedianMs": 2.3,
-  "verifyWholeProcessWallMedianMs": 90,
-  "verifierMaxRssBytes": 71598080,
-  "bundleBytes": 1683001,
+  "verifyBundleParseMedianMs": 2.121,
+  "verifyWholeProcessWallMedianMs": 102.5,
+  "verifierMaxRssBytes": 72155136,
+  "bundleBytes": 1682899,
   "examA_propertyOnlyWallEdit": {
     "element": 44657,
     "ifcType": "IfcWallStandardCase",
     "recomputed": 4,
     "cacheHits": 172522,
     "hitRate": 0.99997682,
-    "recomputeMs": 6.635
+    "recomputeMs": 6.055
   },
   "examB_propertyPlusGeometryWallEdit": {
     "element": 4688035,
@@ -49,24 +49,32 @@
     "recomputed": 11,
     "cacheHits": 172515,
     "hitRate": 0.99993624,
-    "recomputeMs": 7.977
+    "recomputeMs": 7.283
   },
-  "parseMs": 2423,
-  "meshMs": 8408,
-  "dagStructureMs": 1094,
-  "dagBuildMs": 8210,
-  "crossCheckRebuildMs": 8531,
+  "parseMs": 3118,
+  "meshMs": 8143,
+  "dagStructureMs": 1074,
+  "dagBuildMs": 8011,
+  "crossCheckRebuildMs": 8083,
   "correctnessCrossCheck": true,
   "tamper": [
     {
       "case": "geometry-mesh-float-flip",
       "caught": true,
+      "altered": true,
       "reason": "hash-mismatch"
     },
     {
       "case": "untouched-storey-child-hash-flip",
       "caught": true,
+      "altered": true,
       "reason": "hash-mismatch"
+    },
+    {
+      "case": "forged-trust-anchor-with-rederived-claim-hash",
+      "caught": true,
+      "altered": true,
+      "reason": "bundle-carries-trust-anchor"
     }
   ],
   "sensitivityElementGranularityClaim": {
@@ -74,12 +82,12 @@
     "claimNodes": 21766,
     "nodesResolved": 21777,
     "nodesResolvedPct": 12.6224,
-    "verifyMs": 453.5,
-    "bundleBytes": 20275094,
-    "wouldPassClause1": true,
+    "verifyMs": 517.2,
+    "bundleBytes": 20274992,
+    "wouldPassClause1": false,
     "wouldPassClause2": false
   },
-  "peakRssBytes": 2164998144,
+  "peakRssBytes": 2520432640,
   "clause1_verifyUnder500msInSecondProcess": true,
   "clause2_under5PctOfDagNodesResolved": true,
   "clause3_over90PctCacheHitsOnSingleWallRecompute": true,


### PR DESCRIPTION
The committed `scorecard-no-aggregates.json` predated the third tamper case and carried no `altered` flags. Re-blessed on a quiet machine (load 1.82 on 10 cores).

## A published figure flipped, and it is not noise

`sensitivityElementGranularityClaim.wouldPassClause1` goes **true → FALSE**.

| run | sensitivity `verifyMs` | verdict |
|---|---|---|
| committed (2026-07-29) | 453.5 | true |
| re-bless | 517.2 | false |
| +3 independent runs | 534.0 / 543.8 / 544.4 | false |

The verify median moves the same way: **60.862 → ~77 ms**, consistently across runs. Four samples all on the same side isn't machine jitter — the committed `true` is not reproducible on this host, and that probe sits close enough to the 500 ms bar to change sides between machines.

## What this does NOT touch

**The exam itself.** All three clauses still pass by wide margins — 75.85 ms against 500, 0.0348% against 5%, 99.998%/99.994% against 90%. The flip is in the *sensitivity* counterfactual — the "what if the claim were element-granular" probe, which is the row this report already carries a correction history about. It now fails both its clauses rather than one.

## Bindings

Two bound figures moved and are rebound. The `453.5` that remains is correction-history prose about what the artifact held on 2026-07-29, so it becomes a `numeral-src :: none` **block** rather than a deletion — no artifact emits it any more, and a later coincidental union hit must not hand a retired figure fresh provenance.

## Process note

This is the second time machine load has decided a result in this bet. The first attempt was **aborted deliberately** because load had spiked to 7.78 from a concurrent `pnpm turbo build`; publishing those timings would have moved a clause on the strength of a build running alongside it.

Gate exit 0 across 8 prose sets, self-test PASS.