### PR TITLE
feat(geometry): expose a per-entity world AABB from the geometry hash pass (#1891)

### DIFF
--- a/.changeset/geometry-world-aabb-wasm-surface.md
+++ b/.changeset/geometry-world-aabb-wasm-surface.md
@@ -1,0 +1,15 @@
+---
+'@ifc-lite/wasm': minor
+---
+
+`MeshCollection.geometryAabbValues`: per-entity world bounding boxes from the geometry-hash pass.
+
+A new read-only member on the committed type surface (`packages/wasm/pkg/ifc-lite.d.ts`), so this is additive public API. Nothing was removed or renamed.
+
+Six `f64` per entry, `[minX, minY, minZ, maxX, maxY, maxZ]`, in `geometryHashIds` order — entry `i` occupies `[6*i, 6*i+6)`, so the array is always exactly `6 * geometryHashCount` long. An entity with a hash but no box reserves its six slots as `NaN` rather than shortening the array, which would mis-attribute every later entry. Populated only when `IfcAPI.setComputeGeometryHashes()` is on, the same switch that gates the hashes; empty otherwise, so nothing is computed when the diff feature is off.
+
+The box is in the WebGL Y-up frame, like every other box, position, origin and placement crossing this boundary. It carries absolute world coordinates (the file's RTC folded back in) while `positions` are RTC-relative, so a consumer comparing the two folds `rtcOffset*` in. See `docs/api/wasm.md`.
+
+Why: a changed geometry hash conflates *moved*, *reshaped* and *re-tessellated* into one bit, which is what makes the diff engine's `moved` match kind a guess. The box separates them — same extent at a new centre is a move, a different extent is a reshape, an identical box with a different hash is retriangulation.
+
+No companion volume is exposed. A divergence-theorem volume needs a closed, consistently wound surface, and 14.7% of the mesh segments reaching this pass are open or non-manifold, where that sum is arbitrary rather than approximate — and looks like an ordinary positive number from the outside.

--- a/docs/api/wasm.md
+++ b/docs/api/wasm.md
@@ -268,8 +268,41 @@ class MeshCollection {
   readonly geometryHashIds: Uint32Array;
   readonly geometryHashValues: BigUint64Array;
   readonly geometryHashCount: number;
+  readonly geometryAabbValues: Float64Array;  // 6 per id, see below
 }
 ```
+
+#### geometryAabbValues
+
+Per-entity world bounding boxes from the same pass as the hashes, gated by the
+same `setComputeGeometryHashes()` switch — empty when geometry hashing is off.
+
+Six `f64` per entry, `[minX, minY, minZ, maxX, maxY, maxZ]`, in
+`geometryHashIds` order: entry `i` occupies `[6*i, 6*i+6)`, so
+`geometryAabbValues.length === 6 * geometryHashCount` always. An entity that
+produced a hash but no box reserves its six slots as `NaN` rather than
+shortening the array, which would mis-attribute every later entry.
+
+The box is in the **WebGL Y-up frame**, like `positions`, `origin` and
+`localBounds` — not the IFC Z-up frame the hasher accumulates in. It holds
+absolute world coordinates while `positions` are RTC-relative, so fold the
+collection's RTC offset in (itself Y-up-swapped) before comparing the two:
+
+```js
+const world = [
+  origin[0] + positions[3 * v + 0] + collection.rtcOffsetX,
+  origin[1] + positions[3 * v + 1] + collection.rtcOffsetZ,
+  origin[2] + positions[3 * v + 2] - collection.rtcOffsetY,
+];
+```
+
+Why it exists: a changed geometry hash conflates *moved*, *reshaped* and
+*re-tessellated* into one bit. The box separates them — same extent at a new
+centre is a move, a different extent is a reshape, an identical box with a
+different hash is retriangulation. No companion volume is exposed: a
+divergence-theorem volume needs a closed, consistently wound surface, and a
+sizeable share of the mesh segments reaching this pass are open or
+non-manifold, where that sum is arbitrary rather than approximate.
 
 ### MeshDataJs
 

--- a/packages/wasm/pkg/ifc-lite.d.ts
+++ b/packages/wasm/pkg/ifc-lite.d.ts
@@ -790,6 +790,24 @@ export class MeshCollection {
      */
     readonly diagnostics: any;
     /**
+     * Per-entity world-space AABBs as a `Float64Array`, SIX values per entry
+     * (`minx, miny, minz, maxx, maxy, maxz`), in the same order as
+     * [`Self::geometry_hash_ids`] — entry `i` spans `[6*i, 6*i+6)`. Empty
+     * unless geometry hashing was enabled; the same
+     * `IfcAPI.setComputeGeometryHashes` switch gates both, so nothing is
+     * computed when the diff feature is off.
+     *
+     * Unquantized world `f64` (the file's RTC folded back in), so two
+     * revisions that chose different RTC offsets report the same box. This is
+     * what lets a consumer say "MOVED" honestly instead of inferring it from a
+     * changed hash, which also fires on reshape and on retriangulation.
+     *
+     * No companion volume ships: see `GeometryHasher::world_aabb` — 14.7% of
+     * the mesh segments feeding this pass are open or non-manifold, and a
+     * divergence-theorem volume over those is arbitrary, not approximate.
+     */
+    readonly geometryAabbValues: Float64Array;
+    /**
      * Number of per-entity geometry fingerprints recorded.
      */
     readonly geometryHashCount: number;
@@ -1620,6 +1638,7 @@ export interface InitOutput {
     readonly meshOutline2d: (a: number, b: number, c: number, d: number, e: number, f: number) => number;
     readonly meshcollection_buildingRotation: (a: number, b: number) => void;
     readonly meshcollection_diagnostics: (a: number) => number;
+    readonly meshcollection_geometryAabbValues: (a: number) => number;
     readonly meshcollection_geometryHashCount: (a: number) => number;
     readonly meshcollection_geometryHashIds: (a: number) => number;
     readonly meshcollection_geometryHashValues: (a: number) => number;

--- a/packages/wasm/pkg/ifc-lite.d.ts
+++ b/packages/wasm/pkg/ifc-lite.d.ts
@@ -802,6 +802,14 @@ export class MeshCollection {
      * what lets a consumer say "MOVED" honestly instead of inferring it from a
      * changed hash, which also fires on reshape and on retriangulation.
      *
+     * **Frame: WebGL Y-up**, like every other box, position, origin and
+     * placement that crosses this boundary (see `MeshDataJs::local_bounds`).
+     * The hasher accumulates in the producer's IFC Z-up frame, so the swap
+     * `(x,y,z) -> (x,z,-y)` is applied here, on the way out. Unconverted, the
+     * boxes would not enclose the very meshes `processGeometryBatch` returns
+     * alongside them. Positions are RTC-relative and this box is absolute, so
+     * a consumer comparing the two folds `rtcOffset*` in — itself Y-up-swapped.
+     *
      * No companion volume ships: see `GeometryHasher::world_aabb` — 14.7% of
      * the mesh segments feeding this pass are open or non-manifold, and a
      * divergence-theorem volume over those is arbitrary, not approximate.

--- a/rust/geometry/src/geom_hash.rs
+++ b/rust/geometry/src/geom_hash.rs
@@ -93,7 +93,9 @@ pub struct GeometryHasher {
     triangle_accum: u64,
     triangle_count: u64,
     /// Unquantized `f64` world bounds over every in-range triangle corner.
-    /// `min[0] > max[0]` marks "nothing accumulated yet".
+    /// An axis still holding its `INFINITY..NEG_INFINITY` sentinel never
+    /// accumulated; axes can diverge here, so [`Self::world_aabb`] tests all
+    /// three rather than assuming they move together.
     min: [f64; 3],
     max: [f64; 3],
 }
@@ -260,7 +262,37 @@ impl GeometryHasher {
     }
 
     /// The entity's world-space AABB as `[minx, miny, minz, maxx, maxy, maxz]`,
-    /// or `None` if no in-range triangle corner was ever seen.
+    /// or `None` if the box is not well-formed on all three axes — which
+    /// covers both "no in-range triangle corner was ever seen" and the
+    /// partial-accumulation case below.
+    ///
+    /// ### Why all three axes are tested, not just one
+    ///
+    /// The axes look like they must accumulate together — `extend_bounds` runs
+    /// the same loop over all three for every corner — but they do not, because
+    /// that loop is `f64::min`/`f64::max`, which DROP a NaN operand. A position
+    /// buffer carrying NaN on one axis and finite values on the others leaves
+    /// that axis at its `INFINITY..NEG_INFINITY` sentinel while its neighbours
+    /// hold real bounds. Testing only axis 0 then returns
+    /// `Some([x0, inf, z0, x1, -inf, z1])` — an inverted, infinite axis
+    /// presented as a measured box, which downstream differences to NaN.
+    /// Requiring every axis to be finite and ordered turns that into `None`,
+    /// which the wire format already reserves NaN slots for
+    /// (`MeshCollection::push_geometry_hash`).
+    ///
+    /// The hash makes no such promise: NaN quantizes to 0, so a NaN-carrying
+    /// entity still produces a fingerprint. `Some(hash)` with `None` box is
+    /// therefore a REACHABLE pair, not a structural impossibility, and
+    /// `produce_element_meshes` keeps the hash when it happens rather than
+    /// discarding both. The fingerprint is the diff engine's primary signal and
+    /// is well-defined here; dropping it would remove the element from the
+    /// comparison in exchange for nothing, and it cannot desynchronize the
+    /// parallel FFI arrays because `push_geometry_hash` writes six NaNs for a
+    /// missing box instead of shortening the array (pinned by
+    /// `a_missing_box_reserves_its_slots_instead_of_shifting_the_array`).
+    ///
+    /// The converse stays impossible: a `Some` box needs an accumulated corner,
+    /// which needs a triangle, which `is_empty()` already gates on.
     ///
     /// UNQUANTIZED `f64` world coordinates, not grid indices: the box is meant
     /// to be read as a length, so snapping it to the hash tolerance would put a
@@ -288,7 +320,10 @@ impl GeometryHasher {
     /// downstream split/merge detector reading them would make confident false
     /// claims, so the number is not shipped at all.
     pub fn world_aabb(&self) -> Option<[f64; 6]> {
-        if self.min[0] > self.max[0] {
+        let well_formed = (0..3).all(|k| {
+            self.min[k].is_finite() && self.max[k].is_finite() && self.min[k] <= self.max[k]
+        });
+        if !well_formed {
             return None;
         }
         Some([

--- a/rust/geometry/src/geom_hash.rs
+++ b/rust/geometry/src/geom_hash.rs
@@ -36,6 +36,20 @@
 //! scaled to metres, and either both pre- or both post- any axis convention
 //! swap). The caller is responsible for feeding `positions` and `rtc_offset`
 //! in the same frame.
+//!
+//! ## World AABB (#1891 follow-on)
+//!
+//! The same pass also accumulates an UNQUANTIZED `f64` world axis-aligned
+//! bounding box ([`GeometryHasher::world_aabb`]). The hash alone cannot say
+//! WHY two revisions differ — "hash changed" conflates moved, reshaped and
+//! re-tessellated — so the diff engine needs a second, interpretable signal.
+//! The box is free here: `add_mesh_with_origin` already reconstructs the exact
+//! `f64` world coordinate of every triangle corner in order to quantize it.
+//!
+//! Deliberately NOT shipped alongside it: a volume. See
+//! [`GeometryHasher::world_aabb`] for the measurement — a divergence-theorem
+//! volume needs a closed, consistently wound surface, and 14% of the segments
+//! that reach this hasher are neither.
 
 /// Default quantization grid in metres (1 mm). Chosen as a starting point near
 /// the `f32` precision floor of RTC-local coordinates; tune empirically with
@@ -78,6 +92,10 @@ pub struct GeometryHasher {
     /// Commutative running sum of per-triangle hashes.
     triangle_accum: u64,
     triangle_count: u64,
+    /// Unquantized `f64` world bounds over every in-range triangle corner.
+    /// `min[0] > max[0]` marks "nothing accumulated yet".
+    min: [f64; 3],
+    max: [f64; 3],
 }
 
 impl GeometryHasher {
@@ -94,20 +112,44 @@ impl GeometryHasher {
             rtc: rtc_offset,
             triangle_accum: 0,
             triangle_count: 0,
+            min: [f64::INFINITY; 3],
+            max: [f64::NEG_INFINITY; 3],
         }
     }
 
-    /// Hash the quantized world position of one vertex into a per-corner value.
-    /// `origin` is the per-mesh local-frame origin (`world = origin + position`);
-    /// pass `[0.0; 3]` for absolute-coordinate positions.
+    /// Reconstruct the full `f64` WORLD coordinate of one vertex. `origin` is
+    /// the per-mesh local-frame origin (`world = origin + position`); pass
+    /// `[0.0; 3]` for absolute-coordinate positions.
     #[inline]
-    fn corner(&self, positions: &[f32], vi: usize, origin: &[f64; 3]) -> [i64; 3] {
+    fn world(&self, positions: &[f32], vi: usize, origin: &[f64; 3]) -> [f64; 3] {
         let base = vi * 3;
         [
-            quantize(positions[base] as f64 + origin[0] + self.rtc[0], self.inv_tol),
-            quantize(positions[base + 1] as f64 + origin[1] + self.rtc[1], self.inv_tol),
-            quantize(positions[base + 2] as f64 + origin[2] + self.rtc[2], self.inv_tol),
+            positions[base] as f64 + origin[0] + self.rtc[0],
+            positions[base + 1] as f64 + origin[1] + self.rtc[1],
+            positions[base + 2] as f64 + origin[2] + self.rtc[2],
         ]
+    }
+
+    /// Snap a reconstructed world corner to the quantization grid.
+    #[inline]
+    fn quantize_corner(&self, world: &[f64; 3]) -> [i64; 3] {
+        [
+            quantize(world[0], self.inv_tol),
+            quantize(world[1], self.inv_tol),
+            quantize(world[2], self.inv_tol),
+        ]
+    }
+
+    /// Grow the world AABB by one reconstructed corner.
+    ///
+    /// `f64::min`/`f64::max` return the non-NaN operand, so a NaN coordinate
+    /// (a malformed position buffer) is skipped rather than poisoning the box.
+    #[inline]
+    fn extend_bounds(&mut self, world: &[f64; 3]) {
+        for k in 0..3 {
+            self.min[k] = self.min[k].min(world[k]);
+            self.max[k] = self.max[k].max(world[k]);
+        }
     }
 
     /// Add one mesh segment (a flat `[x,y,z, ...]` position buffer and a
@@ -135,13 +177,28 @@ impl GeometryHasher {
                 continue;
             }
 
+            let world = [
+                self.world(positions, i0, &origin),
+                self.world(positions, i1, &origin),
+                self.world(positions, i2, &origin),
+            ];
+
+            // Bounds take EVERY in-range corner, including those of triangles
+            // the hash rejects as post-quantization degenerate below. A sliver
+            // or zero-area face carries no shape signal for the fingerprint,
+            // but its corners are real geometry and do contribute extent —
+            // dropping them would under-report the element's box.
+            for corner in &world {
+                self.extend_bounds(corner);
+            }
+
             // Sort the three quantized corners so triangle winding and the
             // starting vertex don't affect the hash — only the (multiset of)
             // positions and their adjacency as a triangle.
             let mut tri = [
-                self.corner(positions, i0, &origin),
-                self.corner(positions, i1, &origin),
-                self.corner(positions, i2, &origin),
+                self.quantize_corner(&world[0]),
+                self.quantize_corner(&world[1]),
+                self.quantize_corner(&world[2]),
             ];
             tri.sort_unstable();
 
@@ -201,6 +258,43 @@ impl GeometryHasher {
         h = fold_i64(h, self.triangle_count as i64);
         mix64(h)
     }
+
+    /// The entity's world-space AABB as `[minx, miny, minz, maxx, maxy, maxz]`,
+    /// or `None` if no in-range triangle corner was ever seen.
+    ///
+    /// UNQUANTIZED `f64` world coordinates, not grid indices: the box is meant
+    /// to be read as a length, so snapping it to the hash tolerance would put a
+    /// millimetre of noise on every face for no benefit. It is RTC-invariant
+    /// for the same reason the hash is — both are built from the reconstructed
+    /// world coordinate.
+    ///
+    /// This is the diff engine's "did it MOVE?" signal. The hash answers only
+    /// "is it different"; comparing two boxes separates a translation (same
+    /// extent, shifted centre) from a reshape (different extent) from pure
+    /// re-tessellation (identical box, different hash).
+    ///
+    /// ### Why there is no matching `volume()`
+    ///
+    /// A divergence-theorem volume is only defined for a closed, consistently
+    /// wound surface; for an open one the sum is not merely inaccurate, it is
+    /// arbitrary — it depends on the reference point through the boundary flux.
+    /// Measured over the fixture corpus at exactly this granularity (one
+    /// [`crate::orient_mesh_outward`]-ed submesh per `add_mesh*` call, which is
+    /// what the mesh producer feeds in): 14.7% of segments are open or
+    /// non-manifold, and for those, moving the reference point by one bounding
+    /// -box extent changes the result by more than 1% on 1511 segments, with a
+    /// p90 of 75% and a maximum of 2e10 relative. There is no way to tell those
+    /// apart from the outside — they look like ordinary positive numbers. A
+    /// downstream split/merge detector reading them would make confident false
+    /// claims, so the number is not shipped at all.
+    pub fn world_aabb(&self) -> Option<[f64; 6]> {
+        if self.min[0] > self.max[0] {
+            return None;
+        }
+        Some([
+            self.min[0], self.min[1], self.min[2], self.max[0], self.max[1], self.max[2],
+        ])
+    }
 }
 
 /// Convenience: hash a single-segment entity in one call.
@@ -216,195 +310,5 @@ pub fn hash_mesh_world(
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    /// A unit cube (8 verts, 12 triangles) centred near `origin` in world
-    /// coordinates. Returns positions already in world space.
-    fn cube(origin: [f32; 3]) -> (Vec<f32>, Vec<u32>) {
-        let [ox, oy, oz] = origin;
-        let mut positions = Vec::with_capacity(8 * 3);
-        for &x in &[0.0_f32, 1.0] {
-            for &y in &[0.0_f32, 1.0] {
-                for &z in &[0.0_f32, 1.0] {
-                    positions.extend_from_slice(&[ox + x, oy + y, oz + z]);
-                }
-            }
-        }
-        // 12 triangles over the 8 corners (not a watertight ordering — only
-        // needs to be a deterministic, non-degenerate triangle soup).
-        let indices = vec![
-            0, 1, 3, 0, 3, 2, 4, 6, 7, 4, 7, 5, 0, 4, 5, 0, 5, 1, 2, 3, 7, 2, 7, 6, 0, 2, 6, 0, 6,
-            4, 1, 5, 7, 1, 7, 3,
-        ];
-        (positions, indices)
-    }
-
-    const TOL: f64 = 1.0e-3;
-
-    #[test]
-    fn rtc_invariance_same_world_geometry() {
-        // Same wall at world position (1_000_000, 0, 0), expressed two ways:
-        //   file A: local = world,            rtc = [0,0,0]
-        //   file B: local = world - 999_000,  rtc = [999_000,0,0]
-        // f32 can't hold 1e6 + sub-metre detail, so build the geometry at a
-        // realistic magnitude where the two encodings reconstruct the same
-        // world coords within f32 precision.
-        let world_origin = [1234.5_f32, -67.25, 8.5];
-        let (pos_a, idx) = cube(world_origin);
-        let a = hash_mesh_world(&pos_a, &idx, [0.0, 0.0, 0.0], TOL);
-
-        let shift = [999_000.0_f64, -2_000.0, 5_000.0];
-        let pos_b: Vec<f32> = pos_a
-            .chunks_exact(3)
-            .flat_map(|c| {
-                [
-                    (c[0] as f64 - shift[0]) as f32,
-                    (c[1] as f64 - shift[1]) as f32,
-                    (c[2] as f64 - shift[2]) as f32,
-                ]
-            })
-            .collect();
-        let b = hash_mesh_world(&pos_b, &idx, shift, TOL);
-
-        assert_eq!(a, b, "RTC offset must not change the geometry hash");
-    }
-
-    #[test]
-    fn translation_is_detected() {
-        let (pos, idx) = cube([0.0, 0.0, 0.0]);
-        let moved: Vec<f32> = pos.chunks_exact(3).flat_map(|c| [c[0] + 1.0, c[1], c[2]]).collect();
-        assert_ne!(
-            hash_mesh_world(&pos, &idx, [0.0; 3], TOL),
-            hash_mesh_world(&moved, &idx, [0.0; 3], TOL),
-            "a 1 m move must change the hash"
-        );
-    }
-
-    #[test]
-    fn degenerate_triangles_do_not_affect_hash() {
-        let (pos, idx) = cube([0.0, 0.0, 0.0]);
-        let base = hash_mesh_world(&pos, &idx, [0.0; 3], TOL);
-
-        // Append zero-area triangles (repeated/coincident corners) — the kind
-        // of triangulation noise that must not move the fingerprint.
-        let mut noisy = idx.clone();
-        noisy.extend_from_slice(&[0, 0, 1]);
-        noisy.extend_from_slice(&[2, 2, 2]);
-        let with_noise = hash_mesh_world(&pos, &noisy, [0.0; 3], TOL);
-
-        assert_eq!(base, with_noise, "zero-area triangles must not change the hash");
-    }
-
-    #[test]
-    fn sub_tolerance_jitter_is_ignored() {
-        // `round(v/tol)` puts cell *centres* at integer multiples of `tol` and
-        // cell *boundaries* at the half-grid `(k+0.5)*tol`. Place verts at
-        // centres (here `10*tol` apart, well clear of boundaries) so a jitter
-        // below half a cell stays inside the same quantization cell.
-        let cell = TOL * 10.0;
-        let base: Vec<f32> = (0..24).map(|i| (i as f32) * (cell as f32)).collect();
-        let idx: Vec<u32> = (0..(base.len() as u32 / 3) - 2)
-            .flat_map(|i| [i, i + 1, i + 2])
-            .collect();
-
-        let jitter = (TOL as f32) * 0.1;
-        let perturbed: Vec<f32> = base.iter().map(|v| v + jitter).collect();
-
-        assert_eq!(
-            hash_mesh_world(&base, &idx, [0.0; 3], TOL),
-            hash_mesh_world(&perturbed, &idx, [0.0; 3], TOL),
-            "jitter below the quantization grid must not change the hash"
-        );
-    }
-
-    #[test]
-    fn triangle_and_vertex_order_invariant() {
-        let (pos, idx) = cube([3.0, 3.0, 3.0]);
-        let canonical = hash_mesh_world(&pos, &idx, [0.0; 3], TOL);
-
-        // Reverse triangle order and rotate each triangle's corners.
-        let mut shuffled = Vec::with_capacity(idx.len());
-        for tri in idx.chunks_exact(3).rev() {
-            shuffled.extend_from_slice(&[tri[1], tri[2], tri[0]]);
-        }
-        assert_eq!(
-            canonical,
-            hash_mesh_world(&pos, &shuffled, [0.0; 3], TOL),
-            "reordering triangles / rotating corners must not change the hash"
-        );
-    }
-
-    #[test]
-    fn winding_invariant() {
-        let (pos, idx) = cube([0.0, 0.0, 0.0]);
-        let canonical = hash_mesh_world(&pos, &idx, [0.0; 3], TOL);
-        let flipped: Vec<u32> =
-            idx.chunks_exact(3).flat_map(|t| [t[0], t[2], t[1]]).collect();
-        assert_eq!(
-            canonical,
-            hash_mesh_world(&pos, &flipped, [0.0; 3], TOL),
-            "reversing winding must not change the hash"
-        );
-    }
-
-    #[test]
-    fn segment_split_matches_single_segment() {
-        // Hashing an entity as one 12-triangle mesh must equal hashing it as
-        // two 6-triangle segments (entities arrive split across submeshes).
-        let (pos, idx) = cube([10.0, 0.0, -4.0]);
-        let single = hash_mesh_world(&pos, &idx, [0.0; 3], TOL);
-
-        let (first, second) = idx.split_at(idx.len() / 2);
-        let mut hasher = GeometryHasher::new(TOL, [0.0; 3]);
-        hasher.add_mesh(&pos, first);
-        hasher.add_mesh(&pos, second);
-        assert_eq!(single, hasher.finish(), "split segments must match a single mesh");
-    }
-
-    #[test]
-    fn distinct_shapes_differ() {
-        let (cube_pos, cube_idx) = cube([0.0, 0.0, 0.0]);
-        let (big_pos, big_idx) = cube([0.0, 0.0, 0.0]);
-        let scaled: Vec<f32> = big_pos.iter().map(|v| v * 2.0).collect();
-        assert_ne!(
-            hash_mesh_world(&cube_pos, &cube_idx, [0.0; 3], TOL),
-            hash_mesh_world(&scaled, &big_idx, [0.0; 3], TOL),
-            "a 2x-scaled cube must hash differently"
-        );
-    }
-
-    /// Documents the tolerance trade-off empirically: a move of exactly one
-    /// grid cell is always detected; the same geometry under pure
-    /// reconstruction noise stays stable. This is the harness to extend with
-    /// real revision pairs when tuning `DEFAULT_GEOM_HASH_TOLERANCE`.
-    #[test]
-    fn tolerance_sweep_sensitivity() {
-        let (pos, idx) = cube([100.0, 50.0, 25.0]);
-        for &tol in &[1.0e-4_f64, 1.0e-3, 1.0e-2, 1.0e-1] {
-            let baseline = hash_mesh_world(&pos, &idx, [0.0; 3], tol);
-
-            // A move of one full grid cell must always register as changed.
-            let one_cell = tol as f32;
-            let moved: Vec<f32> =
-                pos.chunks_exact(3).flat_map(|c| [c[0] + one_cell, c[1], c[2]]).collect();
-            assert_ne!(
-                baseline,
-                hash_mesh_world(&moved, &idx, [0.0; 3], tol),
-                "tol={tol}: a one-cell move must be detected"
-            );
-
-            // A move of one thousandth of a cell must be absorbed. The cube
-            // sits at integer coords; for every tolerance here those land on
-            // cell centres (integer multiples of `tol`), so a tiny nudge stays
-            // in-cell.
-            let tiny = (tol as f32) * 1.0e-3;
-            let nudged: Vec<f32> = pos.iter().map(|v| v + tiny).collect();
-            assert_eq!(
-                baseline,
-                hash_mesh_world(&nudged, &idx, [0.0; 3], tol),
-                "tol={tol}: sub-grid jitter must be absorbed"
-            );
-        }
-    }
-}
+#[path = "geom_hash_tests.rs"]
+mod tests;

--- a/rust/geometry/src/geom_hash_tests.rs
+++ b/rust/geometry/src/geom_hash_tests.rs
@@ -1,0 +1,325 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Tests for [`super`] — split out of `geom_hash.rs` so the module stays under
+//! the house 400-line rule (test files are ratchet-exempt).
+
+use super::*;
+
+/// A unit cube (8 verts, 12 triangles) centred near `origin` in world
+/// coordinates. Returns positions already in world space.
+fn cube(origin: [f32; 3]) -> (Vec<f32>, Vec<u32>) {
+    let [ox, oy, oz] = origin;
+    let mut positions = Vec::with_capacity(8 * 3);
+    for &x in &[0.0_f32, 1.0] {
+        for &y in &[0.0_f32, 1.0] {
+            for &z in &[0.0_f32, 1.0] {
+                positions.extend_from_slice(&[ox + x, oy + y, oz + z]);
+            }
+        }
+    }
+    // 12 triangles over the 8 corners (not a watertight ordering — only
+    // needs to be a deterministic, non-degenerate triangle soup).
+    let indices = vec![
+        0, 1, 3, 0, 3, 2, 4, 6, 7, 4, 7, 5, 0, 4, 5, 0, 5, 1, 2, 3, 7, 2, 7, 6, 0, 2, 6, 0, 6,
+        4, 1, 5, 7, 1, 7, 3,
+    ];
+    (positions, indices)
+}
+
+const TOL: f64 = 1.0e-3;
+
+#[test]
+fn rtc_invariance_same_world_geometry() {
+    // Same wall at world position (1_000_000, 0, 0), expressed two ways:
+    //   file A: local = world,            rtc = [0,0,0]
+    //   file B: local = world - 999_000,  rtc = [999_000,0,0]
+    // f32 can't hold 1e6 + sub-metre detail, so build the geometry at a
+    // realistic magnitude where the two encodings reconstruct the same
+    // world coords within f32 precision.
+    let world_origin = [1234.5_f32, -67.25, 8.5];
+    let (pos_a, idx) = cube(world_origin);
+    let a = hash_mesh_world(&pos_a, &idx, [0.0, 0.0, 0.0], TOL);
+
+    let shift = [999_000.0_f64, -2_000.0, 5_000.0];
+    let pos_b: Vec<f32> = pos_a
+        .chunks_exact(3)
+        .flat_map(|c| {
+            [
+                (c[0] as f64 - shift[0]) as f32,
+                (c[1] as f64 - shift[1]) as f32,
+                (c[2] as f64 - shift[2]) as f32,
+            ]
+        })
+        .collect();
+    let b = hash_mesh_world(&pos_b, &idx, shift, TOL);
+
+    assert_eq!(a, b, "RTC offset must not change the geometry hash");
+}
+
+#[test]
+fn translation_is_detected() {
+    let (pos, idx) = cube([0.0, 0.0, 0.0]);
+    let moved: Vec<f32> = pos.chunks_exact(3).flat_map(|c| [c[0] + 1.0, c[1], c[2]]).collect();
+    assert_ne!(
+        hash_mesh_world(&pos, &idx, [0.0; 3], TOL),
+        hash_mesh_world(&moved, &idx, [0.0; 3], TOL),
+        "a 1 m move must change the hash"
+    );
+}
+
+#[test]
+fn degenerate_triangles_do_not_affect_hash() {
+    let (pos, idx) = cube([0.0, 0.0, 0.0]);
+    let base = hash_mesh_world(&pos, &idx, [0.0; 3], TOL);
+
+    // Append zero-area triangles (repeated/coincident corners) — the kind
+    // of triangulation noise that must not move the fingerprint.
+    let mut noisy = idx.clone();
+    noisy.extend_from_slice(&[0, 0, 1]);
+    noisy.extend_from_slice(&[2, 2, 2]);
+    let with_noise = hash_mesh_world(&pos, &noisy, [0.0; 3], TOL);
+
+    assert_eq!(base, with_noise, "zero-area triangles must not change the hash");
+}
+
+#[test]
+fn sub_tolerance_jitter_is_ignored() {
+    // `round(v/tol)` puts cell *centres* at integer multiples of `tol` and
+    // cell *boundaries* at the half-grid `(k+0.5)*tol`. Place verts at
+    // centres (here `10*tol` apart, well clear of boundaries) so a jitter
+    // below half a cell stays inside the same quantization cell.
+    let cell = TOL * 10.0;
+    let base: Vec<f32> = (0..24).map(|i| (i as f32) * (cell as f32)).collect();
+    let idx: Vec<u32> = (0..(base.len() as u32 / 3) - 2)
+        .flat_map(|i| [i, i + 1, i + 2])
+        .collect();
+
+    let jitter = (TOL as f32) * 0.1;
+    let perturbed: Vec<f32> = base.iter().map(|v| v + jitter).collect();
+
+    assert_eq!(
+        hash_mesh_world(&base, &idx, [0.0; 3], TOL),
+        hash_mesh_world(&perturbed, &idx, [0.0; 3], TOL),
+        "jitter below the quantization grid must not change the hash"
+    );
+}
+
+#[test]
+fn triangle_and_vertex_order_invariant() {
+    let (pos, idx) = cube([3.0, 3.0, 3.0]);
+    let canonical = hash_mesh_world(&pos, &idx, [0.0; 3], TOL);
+
+    // Reverse triangle order and rotate each triangle's corners.
+    let mut shuffled = Vec::with_capacity(idx.len());
+    for tri in idx.chunks_exact(3).rev() {
+        shuffled.extend_from_slice(&[tri[1], tri[2], tri[0]]);
+    }
+    assert_eq!(
+        canonical,
+        hash_mesh_world(&pos, &shuffled, [0.0; 3], TOL),
+        "reordering triangles / rotating corners must not change the hash"
+    );
+}
+
+#[test]
+fn winding_invariant() {
+    let (pos, idx) = cube([0.0, 0.0, 0.0]);
+    let canonical = hash_mesh_world(&pos, &idx, [0.0; 3], TOL);
+    let flipped: Vec<u32> =
+        idx.chunks_exact(3).flat_map(|t| [t[0], t[2], t[1]]).collect();
+    assert_eq!(
+        canonical,
+        hash_mesh_world(&pos, &flipped, [0.0; 3], TOL),
+        "reversing winding must not change the hash"
+    );
+}
+
+#[test]
+fn segment_split_matches_single_segment() {
+    // Hashing an entity as one 12-triangle mesh must equal hashing it as
+    // two 6-triangle segments (entities arrive split across submeshes).
+    let (pos, idx) = cube([10.0, 0.0, -4.0]);
+    let single = hash_mesh_world(&pos, &idx, [0.0; 3], TOL);
+
+    let (first, second) = idx.split_at(idx.len() / 2);
+    let mut hasher = GeometryHasher::new(TOL, [0.0; 3]);
+    hasher.add_mesh(&pos, first);
+    hasher.add_mesh(&pos, second);
+    assert_eq!(single, hasher.finish(), "split segments must match a single mesh");
+}
+
+#[test]
+fn distinct_shapes_differ() {
+    let (cube_pos, cube_idx) = cube([0.0, 0.0, 0.0]);
+    let (big_pos, big_idx) = cube([0.0, 0.0, 0.0]);
+    let scaled: Vec<f32> = big_pos.iter().map(|v| v * 2.0).collect();
+    assert_ne!(
+        hash_mesh_world(&cube_pos, &cube_idx, [0.0; 3], TOL),
+        hash_mesh_world(&scaled, &big_idx, [0.0; 3], TOL),
+        "a 2x-scaled cube must hash differently"
+    );
+}
+
+/// Documents the tolerance trade-off empirically: a move of exactly one
+/// grid cell is always detected; the same geometry under pure
+/// reconstruction noise stays stable. This is the harness to extend with
+/// real revision pairs when tuning `DEFAULT_GEOM_HASH_TOLERANCE`.
+#[test]
+fn tolerance_sweep_sensitivity() {
+    let (pos, idx) = cube([100.0, 50.0, 25.0]);
+    for &tol in &[1.0e-4_f64, 1.0e-3, 1.0e-2, 1.0e-1] {
+        let baseline = hash_mesh_world(&pos, &idx, [0.0; 3], tol);
+
+        // A move of one full grid cell must always register as changed.
+        let one_cell = tol as f32;
+        let moved: Vec<f32> =
+            pos.chunks_exact(3).flat_map(|c| [c[0] + one_cell, c[1], c[2]]).collect();
+        assert_ne!(
+            baseline,
+            hash_mesh_world(&moved, &idx, [0.0; 3], tol),
+            "tol={tol}: a one-cell move must be detected"
+        );
+
+        // A move of one thousandth of a cell must be absorbed. The cube
+        // sits at integer coords; for every tolerance here those land on
+        // cell centres (integer multiples of `tol`), so a tiny nudge stays
+        // in-cell.
+        let tiny = (tol as f32) * 1.0e-3;
+        let nudged: Vec<f32> = pos.iter().map(|v| v + tiny).collect();
+        assert_eq!(
+            baseline,
+            hash_mesh_world(&nudged, &idx, [0.0; 3], tol),
+            "tol={tol}: sub-grid jitter must be absorbed"
+        );
+    }
+}
+
+// --- world AABB (#1891 follow-on) ---------------------------------------
+
+/// The box must be the exact `f64` world extent, NOT the quantization grid.
+#[test]
+fn world_aabb_is_the_exact_unquantized_extent() {
+    let (pos, idx) = cube([2.5, -7.0, 0.25]);
+    let mut h = GeometryHasher::new(TOL, [0.0; 3]);
+    h.add_mesh(&pos, &idx);
+    let aabb = h.world_aabb().expect("cube produced corners");
+    assert_eq!(aabb, [2.5, -7.0, 0.25, 3.5, -6.0, 1.25]);
+}
+
+/// RTC is folded back exactly as it is for the hash, so two files that picked
+/// different offsets report the SAME world box.
+#[test]
+fn world_aabb_is_rtc_invariant() {
+    let world_origin = [1234.5_f32, -67.25, 8.5];
+    let (pos_a, idx) = cube(world_origin);
+    let mut a = GeometryHasher::new(TOL, [0.0; 3]);
+    a.add_mesh(&pos_a, &idx);
+
+    let shift = [999_000.0_f64, -2_000.0, 5_000.0];
+    let pos_b: Vec<f32> = pos_a
+        .chunks_exact(3)
+        .flat_map(|c| {
+            [
+                (c[0] as f64 - shift[0]) as f32,
+                (c[1] as f64 - shift[1]) as f32,
+                (c[2] as f64 - shift[2]) as f32,
+            ]
+        })
+        .collect();
+    let mut b = GeometryHasher::new(TOL, shift);
+    b.add_mesh(&pos_b, &idx);
+
+    assert_eq!(
+        a.world_aabb(),
+        b.world_aabb(),
+        "the file's RTC choice must not move the reported world box"
+    );
+}
+
+/// `origin` (the per-mesh local frame) is folded back, and boxes union across
+/// the segments of one entity.
+#[test]
+fn world_aabb_folds_origin_and_unions_segments() {
+    let (pos, idx) = cube([0.0, 0.0, 0.0]);
+    let mut h = GeometryHasher::new(TOL, [0.0; 3]);
+    h.add_mesh_with_origin(&pos, &idx, [10.0, 0.0, 0.0]);
+    h.add_mesh_with_origin(&pos, &idx, [-4.0, 2.0, 0.0]);
+    assert_eq!(
+        h.world_aabb().expect("two segments"),
+        [-4.0, 0.0, 0.0, 11.0, 3.0, 1.0]
+    );
+}
+
+/// A triangle the HASH rejects as post-quantization degenerate still carries
+/// real extent, so its corners must reach the box. Otherwise an element whose
+/// outermost face happens to be a sliver reports a box that is too small.
+#[test]
+fn world_aabb_includes_hash_skipped_degenerate_triangles() {
+    let (mut pos, mut idx) = cube([0.0, 0.0, 0.0]);
+    let base = (pos.len() / 3) as u32;
+    // A zero-area triangle (two coincident corners) reaching out to x = 40.
+    pos.extend_from_slice(&[40.0, 0.0, 0.0, 40.0, 0.0, 0.0, 40.0, 1.0, 0.0]);
+    idx.extend_from_slice(&[base, base + 1, base + 2]);
+
+    let mut h = GeometryHasher::new(TOL, [0.0; 3]);
+    h.add_mesh(&pos, &idx);
+    assert_eq!(
+        h.world_aabb().expect("cube + sliver"),
+        [0.0, 0.0, 0.0, 40.0, 1.0, 1.0],
+        "a degenerate triangle contributes extent even though it carries no hash"
+    );
+    // ...and it still must not move the fingerprint.
+    assert_eq!(
+        h.finish(),
+        hash_mesh_world(&pos, &{ idx[..idx.len() - 3].to_vec() }, [0.0; 3], TOL),
+        "the degenerate triangle must stay out of the hash"
+    );
+}
+
+/// Out-of-range indices are skipped defensively by the hash; the box must skip
+/// them too rather than read past the buffer.
+#[test]
+fn world_aabb_skips_out_of_range_triangles() {
+    let (pos, idx) = cube([0.0, 0.0, 0.0]);
+    let mut noisy = idx.clone();
+    noisy.extend_from_slice(&[0, 1, 9999]);
+    let mut h = GeometryHasher::new(TOL, [0.0; 3]);
+    h.add_mesh(&pos, &noisy);
+    assert_eq!(h.world_aabb().expect("cube"), [0.0, 0.0, 0.0, 1.0, 1.0, 1.0]);
+}
+
+/// Nothing accumulated ⇒ no box (never a degenerate INFINITY..-INFINITY one).
+#[test]
+fn world_aabb_is_none_without_geometry() {
+    let h = GeometryHasher::new(TOL, [0.0; 3]);
+    assert_eq!(h.world_aabb(), None);
+    let mut empty = GeometryHasher::new(TOL, [0.0; 3]);
+    empty.add_mesh(&[], &[]);
+    assert_eq!(empty.world_aabb(), None);
+}
+
+/// The AABB work must not perturb a single existing fingerprint. These are the
+/// hash values produced by `geom_hash.rs` BEFORE this change; they are pinned
+/// literals, not recomputed, so a future refactor of the corner reconstruction
+/// cannot silently re-key every stored diff.
+#[test]
+fn hash_values_are_byte_identical_to_the_pre_aabb_implementation() {
+    let (pos, idx) = cube([0.0, 0.0, 0.0]);
+    assert_eq!(
+        hash_mesh_world(&pos, &idx, [0.0; 3], TOL),
+        9_804_297_170_738_711_971
+    );
+
+    let (pos, idx) = cube([1234.5, -67.25, 8.5]);
+    assert_eq!(
+        hash_mesh_world(&pos, &idx, [999_000.0, -2_000.0, 5_000.0], TOL),
+        16_570_244_528_967_140_961
+    );
+
+    let mut h = GeometryHasher::new(1.0e-2, [3.0, -1.0, 0.5]);
+    let (pos, idx) = cube([10.0, 0.0, -4.0]);
+    h.add_mesh_with_origin(&pos, &idx, [0.125, 0.25, -0.5]);
+    assert_eq!(h.finish(), 7_301_177_935_129_768_504);
+}

--- a/rust/geometry/src/geom_hash_tests.rs
+++ b/rust/geometry/src/geom_hash_tests.rs
@@ -300,6 +300,62 @@ fn world_aabb_is_none_without_geometry() {
     assert_eq!(empty.world_aabb(), None);
 }
 
+/// A triangle whose corners carry NaN on ONE axis leaves that axis at its
+/// sentinel while the other two hold real bounds — the three axes really can
+/// diverge, because `extend_bounds` uses `f64::min`/`f64::max`, which drop NaN.
+///
+/// Testing only axis 0 shipped whichever of these two the NaN happened to miss:
+/// NaN on x looked like "no geometry", NaN on y returned a box whose y span was
+/// `inf .. -inf` labelled as a measurement. Neither is a box, so both are
+/// `None`.
+#[test]
+fn world_aabb_is_none_when_any_single_axis_never_accumulated() {
+    // Corners differ in y and z, so the triangle is NOT degenerate after
+    // quantization (NaN quantizes to 0) and DOES reach the fingerprint.
+    let nan_on = |axis: usize| {
+        let mut pos: Vec<f32> = vec![0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 0.0, 1.0];
+        for v in 0..3 {
+            pos[v * 3 + axis] = f32::NAN;
+        }
+        let mut h = GeometryHasher::new(TOL, [0.0; 3]);
+        h.add_mesh(&pos, &[0, 1, 2]);
+        h
+    };
+
+    for axis in 0..3 {
+        let h = nan_on(axis);
+        assert!(
+            !h.is_empty(),
+            "axis {axis}: the triangle must still hash — otherwise this test is not \
+             exercising the divergence it claims to"
+        );
+        assert_eq!(
+            h.world_aabb(),
+            None,
+            "axis {axis}: an axis that never accumulated must suppress the whole box, \
+             not be reported as an inverted/infinite span"
+        );
+    }
+}
+
+/// The two emit gates are independent, and `produce_element_meshes` relies on
+/// exactly this: a fingerprint can exist with no box, so it must not collapse
+/// the pair to `(None, None)` and throw the fingerprint away.
+#[test]
+fn a_hash_without_a_box_is_reachable() {
+    let mut h = GeometryHasher::new(TOL, [0.0; 3]);
+    h.add_mesh(
+        &[f32::NAN, 0.0, 0.0, f32::NAN, 1.0, 0.0, f32::NAN, 0.0, 1.0],
+        &[0, 1, 2],
+    );
+    assert!(!h.is_empty(), "the NaN-x triangle still carries a fingerprint");
+    assert_eq!(h.world_aabb(), None, "...and no box");
+    // The converse must stay unreachable: a box implies an accumulated corner,
+    // which implies a triangle, which is what `is_empty()` already gates on.
+    let empty = GeometryHasher::new(TOL, [0.0; 3]);
+    assert!(empty.is_empty() && empty.world_aabb().is_none());
+}
+
 /// The AABB work must not perturb a single existing fingerprint. These are the
 /// hash values produced by `geom_hash.rs` BEFORE this change; they are pinned
 /// literals, not recomputed, so a future refactor of the corner reconstruction

--- a/rust/processing/src/element.rs
+++ b/rust/processing/src/element.rs
@@ -175,6 +175,17 @@ pub struct ProducedElementMeshes {
     /// `None` when hashing is off, nothing was produced, or the job is a
     /// TypeProduct.
     pub geometry_hash: Option<u64>,
+    /// The same pass's world-space AABB, `[minx, miny, minz, maxx, maxy, maxz]`
+    /// in unquantized `f64` world coordinates (the file's RTC folded back in),
+    /// over every triangle corner the hasher saw. `Some` exactly when
+    /// [`Self::geometry_hash`] is `Some`, so the two stay index-parallel at the
+    /// FFI boundary.
+    ///
+    /// Why the diff engine needs it: the hash conflates moved / reshaped /
+    /// re-tessellated into one "different" bit. The box separates them — same
+    /// extent at a new centre is a MOVE, a different extent is a reshape, an
+    /// identical box with a different hash is retriangulation.
+    pub geometry_aabb: Option<[f64; 6]>,
     /// CSG diagnostics recorded while producing THIS element, attributed by
     /// product id. The router is fully drained on return, so a warm router
     /// reused across a batch never leaks one element's failures into the
@@ -235,7 +246,13 @@ pub fn produce_element_meshes(
     // a warm (batch-reused) router starts the next element clean.
     let csg_failures = router.take_csg_failures();
 
-    let geometry_hash = hasher.and_then(|h| if h.is_empty() { None } else { Some(h.finish()) });
+    // The fingerprint and the box are emitted together or not at all: the wasm
+    // boundary exposes them as arrays indexed in lockstep, so a hash without a
+    // box (or the reverse) would silently misalign every id past that element.
+    let (geometry_hash, geometry_aabb) = match hasher {
+        Some(h) if !h.is_empty() => (Some(h.finish()), h.world_aabb()),
+        _ => (None, None),
+    };
 
     let degenerate_triangles_dropped = DEGENERATE_DROPPED.with(|c| c.get());
 
@@ -243,6 +260,7 @@ pub fn produce_element_meshes(
         meshes,
         instance_occurrences,
         geometry_hash,
+        geometry_aabb,
         csg_failures,
         degenerate_triangles_dropped,
     }

--- a/rust/processing/src/element.rs
+++ b/rust/processing/src/element.rs
@@ -246,9 +246,9 @@ pub fn produce_element_meshes(
     // a warm (batch-reused) router starts the next element clean.
     let csg_failures = router.take_csg_failures();
 
-    // The fingerprint and the box are emitted together or not at all: the wasm
-    // boundary exposes them as arrays indexed in lockstep, so a hash without a
-    // box (or the reverse) would silently misalign every id past that element.
+    // A hash with NO box is reachable and deliberately KEPT (a NaN axis hashes
+    // but never accumulates); `push_geometry_hash` reserves NaN slots so the FFI
+    // arrays still cannot misalign. Box-without-hash is impossible. See `world_aabb`.
     let (geometry_hash, geometry_aabb) = match hasher {
         Some(h) if !h.is_empty() => (Some(h.finish()), h.world_aabb()),
         _ => (None, None),

--- a/rust/processing/tests/geometry_hash_world_aabb.rs
+++ b/rust/processing/tests/geometry_hash_world_aabb.rs
@@ -1,0 +1,242 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! `produce_element_meshes` must hand back, alongside the #924 fingerprint, the
+//! WORLD AABB of the geometry that fingerprint covers (#1891 follow-on).
+//!
+//! The diff engine's content matcher calls two content-identical entities
+//! `moved` whenever their geometry hashes differ — but the hash conflates
+//! moved, reshaped and re-tessellated, so that label is a guess. The box is the
+//! signal that makes it checkable, which only works if it is (a) actually the
+//! extent of the produced meshes, (b) in WORLD coordinates with the file's RTC
+//! folded back in, and (c) gated by the same switch as the hash.
+//!
+//! Run against real fixture geometry, not a synthetic cube: the production path
+//! reaches the hasher through `emit_sub_meshes` (many segments per element,
+//! each in its own local frame with its own `origin`), which a single-mesh unit
+//! test cannot exercise.
+
+use ifc_lite_core::{build_entity_index, has_geometry_by_name, EntityDecoder, EntityScanner};
+use ifc_lite_geometry::GeometryRouter;
+use ifc_lite_processing::element::{
+    produce_element_meshes, ElementJobKind, ElementMeshJob, GeometryHashConfig,
+    MeshProductionContext, MeshProductionOptions, ProducedElementMeshes,
+};
+use rustc_hash::FxHashMap;
+use std::sync::Arc;
+
+const FIXTURE: &str = "../../tests/models/ara3d/AC20-FZK-Haus.ifc";
+
+fn read_fixture() -> Option<Vec<u8>> {
+    match std::fs::read(FIXTURE) {
+        Ok(b) => Some(b),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            eprintln!(
+                "skipping geometry-hash AABB test: fixture missing at {FIXTURE} — \
+                 run `pnpm fixtures` (sha256 in tests/models/manifest.json)"
+            );
+            None
+        }
+        Err(e) => panic!("failed to read fixture {FIXTURE}: {e}"),
+    }
+}
+
+/// Produce every geometry element, with hashing configured as `hash`.
+fn produce_all(
+    content: &[u8],
+    index: &Arc<ifc_lite_core::EntityIndex>,
+    hash: Option<GeometryHashConfig>,
+) -> Vec<(u32, ProducedElementMeshes)> {
+    let router = GeometryRouter::with_scale(1.0);
+    let mut decoder = EntityDecoder::with_arc_index(content, index.clone());
+    decoder.seed_unit_scales(router.unit_scale(), 1.0);
+
+    let void_index = FxHashMap::default();
+    let geometry_style_index = FxHashMap::default();
+    let indexed_colour_full = FxHashMap::default();
+    let element_material_colors = FxHashMap::default();
+    let texture_index = FxHashMap::default();
+    let ctx = MeshProductionContext {
+        void_index: &void_index,
+        geometry_style_index: &geometry_style_index,
+        indexed_colour_full: &indexed_colour_full,
+        element_material_colors: &element_material_colors,
+        texture_index: &texture_index,
+        site_local_rotation: None,
+    };
+    let opts = MeshProductionOptions { geometry_hash: hash };
+
+    let mut jobs: Vec<(u32, usize, usize)> = Vec::new();
+    let mut scanner = EntityScanner::new(content);
+    while let Some((id, type_name, start, end)) = scanner.next_entity() {
+        if has_geometry_by_name(type_name) {
+            jobs.push((id, start, end));
+        }
+    }
+
+    let mut out = Vec::new();
+    for (id, start, end) in jobs {
+        let Ok(entity) = decoder.decode_at_with_id(id, start, end) else {
+            continue;
+        };
+        let ifc_type = entity.ifc_type;
+        let produced = produce_element_meshes(
+            &ElementMeshJob {
+                id,
+                ifc_type,
+                entity: &entity,
+                kind: ElementJobKind::Product,
+                element_color: None,
+                metadata: None,
+            },
+            &ctx,
+            &opts,
+            &mut decoder,
+            &router,
+        );
+        out.push((id, produced));
+    }
+    out
+}
+
+fn cfg(rtc: [f64; 3]) -> Option<GeometryHashConfig> {
+    Some(GeometryHashConfig {
+        tolerance: ifc_lite_geometry::DEFAULT_GEOM_HASH_TOLERANCE,
+        world_rtc: rtc,
+    })
+}
+
+/// The reported box must contain every produced world vertex, and must be tight
+/// against them on both ends of every axis.
+///
+/// A slack bound would pass on a box that is merely "big enough" — including
+/// one accumulated from a wrong frame that happens to be larger. The tolerance
+/// here is the `f32` storage step at this model's magnitude, nothing more: the
+/// hasher reads pre-weld positions and `build_mesh_data` may drop degenerate
+/// triangles afterwards, so the box may legitimately be a hair LARGER than the
+/// surviving mesh, never smaller.
+#[test]
+fn reported_aabb_is_the_tight_world_extent_of_the_produced_meshes() {
+    let Some(content) = read_fixture() else { return };
+    let index = Arc::new(build_entity_index(&content));
+
+    let mut checked = 0usize;
+    for (id, produced) in produce_all(&content, &index, cfg([0.0; 3])) {
+        let Some(aabb) = produced.geometry_aabb else {
+            continue;
+        };
+        assert!(
+            produced.geometry_hash.is_some(),
+            "#{id}: a box without a fingerprint would misalign the parallel FFI arrays"
+        );
+
+        let mut mn = [f64::INFINITY; 3];
+        let mut mx = [f64::NEG_INFINITY; 3];
+        let mut verts = 0usize;
+        for m in &produced.meshes {
+            for v in m.positions.chunks_exact(3) {
+                verts += 1;
+                for k in 0..3 {
+                    let w = v[k] as f64 + m.origin[k];
+                    mn[k] = mn[k].min(w);
+                    mx[k] = mx[k].max(w);
+                }
+            }
+        }
+        if verts == 0 {
+            continue;
+        }
+
+        // 1e-3 m: comfortably above the f32 step at this model's ~100 m scale
+        // (~8e-6 m) and below any real geometric difference.
+        const TOL: f64 = 1.0e-3;
+        for k in 0..3 {
+            assert!(
+                aabb[k] <= mn[k] + TOL,
+                "#{id} axis {k}: reported min {} is INSIDE the mesh min {} — the box \
+                 would clip real geometry",
+                aabb[k],
+                mn[k]
+            );
+            assert!(
+                aabb[k] >= mn[k] - TOL,
+                "#{id} axis {k}: reported min {} is far below the mesh min {} — the box \
+                 is not tight, so a move of that size would read as no move",
+                aabb[k],
+                mn[k]
+            );
+            assert!(
+                aabb[3 + k] >= mx[k] - TOL,
+                "#{id} axis {k}: reported max {} is INSIDE the mesh max {}",
+                aabb[3 + k],
+                mx[k]
+            );
+            assert!(
+                aabb[3 + k] <= mx[k] + TOL,
+                "#{id} axis {k}: reported max {} is far above the mesh max {}",
+                aabb[3 + k],
+                mx[k]
+            );
+        }
+        checked += 1;
+    }
+
+    assert!(
+        checked > 100,
+        "only {checked} elements carried a box — the fixture or the hashing switch \
+         regressed, so the bounds assertions above proved nothing"
+    );
+}
+
+/// The box is in WORLD coordinates: a file that shifted its geometry by an RTC
+/// offset and reports that offset must produce the SAME box as the unshifted
+/// file. Without the fold-back, the diff engine would read every element of a
+/// georeferenced revision as moved by the whole RTC.
+#[test]
+fn reported_aabb_is_rtc_invariant() {
+    let Some(content) = read_fixture() else { return };
+    let index = Arc::new(build_entity_index(&content));
+
+    let plain: FxHashMap<u32, [f64; 6]> = produce_all(&content, &index, cfg([0.0; 3]))
+        .into_iter()
+        .filter_map(|(id, p)| p.geometry_aabb.map(|a| (id, a)))
+        .collect();
+    let shift = [1234.5_f64, -678.25, 90.125];
+    let shifted: FxHashMap<u32, [f64; 6]> = produce_all(&content, &index, cfg(shift))
+        .into_iter()
+        .filter_map(|(id, p)| p.geometry_aabb.map(|a| (id, a)))
+        .collect();
+
+    assert!(plain.len() > 100, "expected the fixture's elements, got {}", plain.len());
+    assert_eq!(plain.len(), shifted.len(), "the RTC must not change WHICH elements report");
+
+    for (id, a) in &plain {
+        let b = shifted.get(id).unwrap_or_else(|| panic!("#{id} missing from the shifted run"));
+        for k in 0..3 {
+            assert!(
+                (b[k] - (a[k] + shift[k])).abs() < 1.0e-6
+                    && (b[3 + k] - (a[3 + k] + shift[k])).abs() < 1.0e-6,
+                "#{id} axis {k}: box {b:?} is not the plain box {a:?} shifted by {shift:?} — \
+                 the RTC offset is not being folded back into world space"
+            );
+        }
+    }
+}
+
+/// The box rides the SAME switch as the fingerprint: with hashing off, nothing
+/// is accumulated. Compare mode already costs GPU instancing (see
+/// `gpu_meshes/batch.rs`), so this pass must not run when the feature is off.
+#[test]
+fn no_aabb_when_hashing_is_off() {
+    let Some(content) = read_fixture() else { return };
+    let index = Arc::new(build_entity_index(&content));
+    let produced = produce_all(&content, &index, None);
+    assert!(!produced.is_empty(), "fixture produced no elements");
+    for (id, p) in produced {
+        assert!(
+            p.geometry_aabb.is_none() && p.geometry_hash.is_none(),
+            "#{id}: hashing is off, so neither fingerprint nor box may be computed"
+        );
+    }
+}

--- a/rust/processing/tests/geometry_hash_world_aabb.rs
+++ b/rust/processing/tests/geometry_hash_world_aabb.rs
@@ -43,12 +43,20 @@ fn read_fixture() -> Option<Vec<u8>> {
 }
 
 /// Produce every geometry element, with hashing configured as `hash`.
+///
+/// `router_rtc` is the offset the MESH pipeline shifts by (every produced
+/// vertex comes back as `world - router_rtc`); `hash.world_rtc` is the offset
+/// the HASHER folds back on. They are two independent knobs and a caller that
+/// sets only one is not modelling a georeferenced file at all — see
+/// [`reported_aabb_is_rtc_invariant`].
 fn produce_all(
     content: &[u8],
     index: &Arc<ifc_lite_core::EntityIndex>,
     hash: Option<GeometryHashConfig>,
+    router_rtc: [f64; 3],
 ) -> Vec<(u32, ProducedElementMeshes)> {
-    let router = GeometryRouter::with_scale(1.0);
+    let mut router = GeometryRouter::with_scale(1.0);
+    router.set_rtc_offset((router_rtc[0], router_rtc[1], router_rtc[2]));
     let mut decoder = EntityDecoder::with_arc_index(content, index.clone());
     decoder.seed_unit_scales(router.unit_scale(), 1.0);
 
@@ -122,7 +130,7 @@ fn reported_aabb_is_the_tight_world_extent_of_the_produced_meshes() {
     let index = Arc::new(build_entity_index(&content));
 
     let mut checked = 0usize;
-    for (id, produced) in produce_all(&content, &index, cfg([0.0; 3])) {
+    for (id, produced) in produce_all(&content, &index, cfg([0.0; 3]), [0.0; 3]) {
         let Some(aabb) = produced.geometry_aabb else {
             continue;
         };
@@ -193,17 +201,27 @@ fn reported_aabb_is_the_tight_world_extent_of_the_produced_meshes() {
 /// offset and reports that offset must produce the SAME box as the unshifted
 /// file. Without the fold-back, the diff engine would read every element of a
 /// georeferenced revision as moved by the whole RTC.
+///
+/// RTC is TWO cooperating halves and the invariant is that they cancel:
+/// `GeometryRouter::set_rtc_offset` makes the pipeline emit `world - rtc`, and
+/// `GeometryHashConfig::world_rtc` makes the hasher add `rtc` back. Configuring
+/// only the hasher (as the first version of this test did) leaves the geometry
+/// standing still and reduces the assertion to "adding rtc adds rtc" — it
+/// survives deleting the pipeline half outright, which is exactly the shape of
+/// a test that cannot fail. Both knobs are set here, so the shifted run must
+/// reproduce the unshifted box, and killing EITHER half moves every box by the
+/// whole offset.
 #[test]
 fn reported_aabb_is_rtc_invariant() {
     let Some(content) = read_fixture() else { return };
     let index = Arc::new(build_entity_index(&content));
 
-    let plain: FxHashMap<u32, [f64; 6]> = produce_all(&content, &index, cfg([0.0; 3]))
+    let plain: FxHashMap<u32, [f64; 6]> = produce_all(&content, &index, cfg([0.0; 3]), [0.0; 3])
         .into_iter()
         .filter_map(|(id, p)| p.geometry_aabb.map(|a| (id, a)))
         .collect();
     let shift = [1234.5_f64, -678.25, 90.125];
-    let shifted: FxHashMap<u32, [f64; 6]> = produce_all(&content, &index, cfg(shift))
+    let shifted: FxHashMap<u32, [f64; 6]> = produce_all(&content, &index, cfg(shift), shift)
         .into_iter()
         .filter_map(|(id, p)| p.geometry_aabb.map(|a| (id, a)))
         .collect();
@@ -211,14 +229,19 @@ fn reported_aabb_is_rtc_invariant() {
     assert!(plain.len() > 100, "expected the fixture's elements, got {}", plain.len());
     assert_eq!(plain.len(), shifted.len(), "the RTC must not change WHICH elements report");
 
+    // The shifted run stores its vertices as `f32` around a ~1300 m world
+    // magnitude, where one ULP is ~1.2e-4 m; the unshifted run sits at ~100 m.
+    // 1e-3 m is that storage step with headroom and nothing more — a dropped
+    // fold-back would miss by the offset itself (hundreds of metres).
+    const TOL: f64 = 1.0e-3;
     for (id, a) in &plain {
         let b = shifted.get(id).unwrap_or_else(|| panic!("#{id} missing from the shifted run"));
         for k in 0..3 {
             assert!(
-                (b[k] - (a[k] + shift[k])).abs() < 1.0e-6
-                    && (b[3 + k] - (a[3 + k] + shift[k])).abs() < 1.0e-6,
-                "#{id} axis {k}: box {b:?} is not the plain box {a:?} shifted by {shift:?} — \
-                 the RTC offset is not being folded back into world space"
+                (b[k] - a[k]).abs() < TOL && (b[3 + k] - a[3 + k]).abs() < TOL,
+                "#{id} axis {k}: RTC-shifted box {b:?} is not the unshifted box {a:?} — \
+                 the file's RTC choice leaked into the reported WORLD box, so every \
+                 element of a georeferenced revision would read as moved by {shift:?}"
             );
         }
     }
@@ -231,7 +254,7 @@ fn reported_aabb_is_rtc_invariant() {
 fn no_aabb_when_hashing_is_off() {
     let Some(content) = read_fixture() else { return };
     let index = Arc::new(build_entity_index(&content));
-    let produced = produce_all(&content, &index, None);
+    let produced = produce_all(&content, &index, None, [0.0; 3]);
     assert!(!produced.is_empty(), "fixture produced no elements");
     for (id, p) in produced {
         assert!(

--- a/rust/processing/tests/module_size_allowlist.txt
+++ b/rust/processing/tests/module_size_allowlist.txt
@@ -56,8 +56,6 @@
 # canonical scan would refine. Plus the #[cfg(test)] include for facet_weld_scoped_tests.rs
 # (the test file itself is ratchet-exempt).
           952 rust/geometry/src/facet_weld.rs
-# +2: mix64 made pub(crate); doc-comment noting the shared use by router::content_hash.
-     410 rust/geometry/src/geom_hash.rs
      633 rust/geometry/src/kernel/arrangement/classify.rs
      566 rust/geometry/src/kernel/fixed.rs
 # NEW (#1655): register-resident FixedInt<K> newtype backing the exact predicate cascade; large because it is a drop-in for bnum's I512 and must carry the full num_traits + std::ops trait surface (16 impls) the fixed_impl! macro binds. Its differential fuzz is split into the sibling tests.rs, kept under budget.
@@ -192,7 +190,8 @@
      499 rust/processing/src/determinism.rs
 # +48: #1623 Phase 2 don't-bake — ProducedElementMeshes.instance_occurrences + threading it through produce_inner (tuple returns), and emit_sub_meshes converting empty-with-InstanceMeta placeholders into RawInstanceOccurrences.
 # +19: #1781 textured occurrence sub-meshes — emit_sub_meshes attaches UVs+texture (length-guarded) and the non-void path calls the texture-aware router entry.
-     879 rust/processing/src/element.rs
+# +18: #1891 follow-on — ProducedElementMeshes.geometry_aabb (the world box from the SAME hashing pass) plus the emit-together match that keeps it index-parallel with geometry_hash at the FFI boundary.
+     897 rust/processing/src/element.rs
      468 rust/processing/src/georeferencing.rs
      772 rust/processing/src/prepass.rs
 # +24: build the entity index INLINE in the scan loop instead of a separate build_entity_index pass (perf/single-scan; one file walk instead of two).
@@ -208,7 +207,8 @@
 # +6: wire per-batch point-cache hit/miss stats into record_pipeline_batch (perf/brep-point-cache-instrumentation).
 # +13: attach the per-worker shared IfcMappedItem source cache to each batch router, mirroring the item-dedup attach (#1623).
 # +155: #1623 Phase 3 browser don't-bake — produce_batch gains arm_instancing (batch-local plan arm + occurrence collection + finalize call/return-tuple change) and the partitioned path folds the kept occurrences into the IFNS shard as empty-geometry refs; the finalize + recovery bodies were extracted to gpu_meshes/instancing.rs (new, ~165 lines) to hold the net down.
-     941 rust/wasm-bindings/src/api/gpu_meshes/batch.rs
+# +4: #1891 follow-on — carry ProducedElementMeshes.geometry_aabb through ElementMeshOutput to push_geometry_hash on both the flat and partitioned paths.
+     945 rust/wasm-bindings/src/api/gpu_meshes/batch.rs
 # +108: build the referenced-repmaps + instantiated-type-id sets and the material-layer index ONCE in the streaming pre-pass (from spans this scan already collected) and emit them as a `prepass-columns` event, so every geometry worker skips its own full-file walk on the first batch (perf/single-scan #957/#563).
 # +14: #1623 Phase 3 — tally the don't-bake MappedInstancePlan from the same IfcMappedItem spans and emit it on the prepass-columns event (mirrors the referenced-repmaps ship).
 # +9: cap the entity-index up-front reservation (PREPASS_INDEX_RESERVE_CAP) so a ~4GB file does not reserve ~1GB of slots on top of the resident file and abort the wasm32 4GB address space before the scan (huge-file graceful-4gb).
@@ -221,6 +221,7 @@
 # +65: #1623 Phase 3 — cached_mapped_instance_plan field (doc + init + clear on clearPrePassCache/setEntityIndex) + setMappedInstancePlan wasm setter + mapped_instance_plan accessor (mirrors setReferencedRepmaps).
      1088 rust/wasm-bindings/src/api/mod.rs
 # +61: #1781 external image textures — textureId/textureUrl fields + getters, set_texture_ref, and the get/takeMesh/Clone field threading.
-     753 rust/wasm-bindings/src/zero_copy/mesh.rs
+# +39: #1891 follow-on — geometry_aabb_values field + geometryAabbValues getter (the doc carries the no-volume rationale so a future reader does not re-derive it), the four constructor/Clone initializers, and the #[cfg(test)] include for mesh_tests.rs (the test file itself is ratchet-exempt).
+     792 rust/wasm-bindings/src/zero_copy/mesh.rs
      743 rust/wasm-bindings/src/zero_copy/symbolic.rs
      440 rust/wasm-bindings/src/api/styling/prepass.rs

--- a/rust/processing/tests/module_size_allowlist.txt
+++ b/rust/processing/tests/module_size_allowlist.txt
@@ -221,7 +221,7 @@
 # +65: #1623 Phase 3 — cached_mapped_instance_plan field (doc + init + clear on clearPrePassCache/setEntityIndex) + setMappedInstancePlan wasm setter + mapped_instance_plan accessor (mirrors setReferencedRepmaps).
      1088 rust/wasm-bindings/src/api/mod.rs
 # +61: #1781 external image textures — textureId/textureUrl fields + getters, set_texture_ref, and the get/takeMesh/Clone field threading.
-# +39: #1891 follow-on — geometry_aabb_values field + geometryAabbValues getter (the doc carries the no-volume rationale so a future reader does not re-derive it), the four constructor/Clone initializers, and the #[cfg(test)] include for mesh_tests.rs (the test file itself is ratchet-exempt).
-     792 rust/wasm-bindings/src/zero_copy/mesh.rs
+# +17: #1891 follow-on — geometry_aabb_values field + geometryAabbValues getter (the doc carries the Y-up frame contract and the no-volume rationale so a future reader does not re-derive them), the four constructor/Clone initializers, and the #[cfg(test)] include for mesh_tests.rs (the test file itself is ratchet-exempt). Net +17 and not +56, because the two Z-up→Y-up conversion helpers moved out to a new sibling frame_swap.rs (107 lines, under the house limit, no row): the box swap is now shared by the f32 local bounds and the f64 world AABB, so the min/max reversal lives in exactly one place.
+     770 rust/wasm-bindings/src/zero_copy/mesh.rs
      743 rust/wasm-bindings/src/zero_copy/symbolic.rs
      440 rust/wasm-bindings/src/api/styling/prepass.rs

--- a/rust/wasm-bindings/src/api/gpu_meshes/batch.rs
+++ b/rust/wasm-bindings/src/api/gpu_meshes/batch.rs
@@ -9,12 +9,16 @@ use wasm_bindgen::prelude::*;
 
 /// Per-element output of [`IfcAPI::produce_batch`] — the canonical producer's
 /// meshes (with `instance` metadata intact, BEFORE the MeshDataJs Z-up→Y-up
-/// swap) plus the element's geometry hash. The flat path converts each to
-/// MeshDataJs; the instanced path collates them into an IFNS shard.
+/// swap) plus the element's geometry hash and world AABB. The flat path
+/// converts each to MeshDataJs; the instanced path collates them into an IFNS
+/// shard.
 struct ElementMeshOutput {
     id: u32,
     meshes: Vec<ifc_lite_processing::MeshData>,
     geometry_hash: Option<u64>,
+    /// World AABB from the same hashing pass, `Some` exactly when
+    /// `geometry_hash` is (see `ProducedElementMeshes::geometry_aabb`).
+    geometry_aabb: Option<[f64; 6]>,
 }
 
 /// Session-constant style lookups shared across batches: colour map plus
@@ -453,6 +457,7 @@ impl IfcAPI {
                 id,
                 meshes: produced.meshes,
                 geometry_hash: produced.geometry_hash,
+                geometry_aabb: produced.geometry_aabb,
             });
         }
 
@@ -546,6 +551,7 @@ impl IfcAPI {
                     id,
                     meshes: vec![m],
                     geometry_hash: None,
+                    geometry_aabb: None,
                 });
             }
             shard
@@ -625,7 +631,7 @@ impl IfcAPI {
                 mesh_collection.add(MeshDataJs::from_mesh_data(mesh_data));
             }
             if let Some(hash) = out.geometry_hash {
-                mesh_collection.push_geometry_hash(out.id, hash);
+                mesh_collection.push_geometry_hash(out.id, hash, out.geometry_aabb);
             }
         }
         mesh_collection.set_diagnostics(csg_diag);
@@ -799,7 +805,7 @@ impl IfcAPI {
             // The element-level geometry-diff hash is path-independent metadata;
             // keep it on the collection regardless of which path the meshes took.
             if let Some(hash) = out.geometry_hash {
-                mesh_collection.push_geometry_hash(out.id, hash);
+                mesh_collection.push_geometry_hash(out.id, hash, out.geometry_aabb);
             }
         }
         // #1623 Phase 3: fold the kept don't-bake occurrence counts into the per-rep

--- a/rust/wasm-bindings/src/zero_copy/frame_swap.rs
+++ b/rust/wasm-bindings/src/zero_copy/frame_swap.rs
@@ -1,0 +1,107 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! The IFC Z-up → WebGL Y-up conversion, in one place.
+//!
+//! Everything the producer emits is in the IFC frame; everything that crosses
+//! the JS boundary is in the viewer's. Positions, normals and origins are a
+//! plain per-component `(x,y,z) -> (x,z,-y)`, applied inline where they are
+//! copied. Boxes and matrices are NOT: each needs a correction that is easy to
+//! get subtly wrong and impossible to notice from the shape of the output, so
+//! both live here with the reasoning stated once.
+
+/// Swap an axis-aligned box's corners from IFC Z-up to WebGL Y-up
+/// (`(x,y,z) -> (x,z,-y)`). A per-component swap of `min`/`max` independently
+/// is WRONG: negating the Y axis flips which corner is the min/max along the
+/// new Z, so the new Z range is `[-maxY, -minY]`, not `[-minY, -maxY]`.
+///
+/// Generic over the component type so the two boxes that cross this boundary
+/// share ONE copy of that reversal and cannot drift apart: `MeshDataJs`'s
+/// `f32` local bounds and `MeshCollection`'s `f64` world AABBs. The world box
+/// must stay `f64` — it carries absolute world coordinates that can sit
+/// kilometres from the origin, which is exactly the precision an `f32` helper
+/// would throw away.
+pub(super) fn swap_zup_to_yup_aabb<T: Copy + std::ops::Neg<Output = T>>(b: [T; 6]) -> [T; 6] {
+    let [min_x, min_y, min_z, max_x, max_y, max_z] = b;
+    [min_x, min_z, -max_y, max_x, max_z, -min_y]
+}
+
+/// Conjugate a row-major 4×4 matrix by the fixed IFC Z-up → WebGL Y-up swap
+/// `S`: `(x,y,z,w) -> (x,z,-y,w)`, so a placement/rotation matrix expressed in
+/// the IFC frame becomes valid in the Y-up frame the renderer uses:
+/// `M' = S · M · Sᵀ` (S is orthogonal, so `S⁻¹ = Sᵀ`).
+pub(super) fn swap_zup_to_yup_mat4(m: &[f64; 16]) -> [f64; 16] {
+    #[rustfmt::skip]
+    const S: [f64; 16] = [
+        1.0, 0.0, 0.0, 0.0,
+        0.0, 0.0, 1.0, 0.0,
+        0.0, -1.0, 0.0, 0.0,
+        0.0, 0.0, 0.0, 1.0,
+    ];
+    #[rustfmt::skip]
+    const ST: [f64; 16] = [
+        1.0, 0.0, 0.0, 0.0,
+        0.0, 0.0, -1.0, 0.0,
+        0.0, 1.0, 0.0, 0.0,
+        0.0, 0.0, 0.0, 1.0,
+    ];
+    fn matmul(a: &[f64; 16], b: &[f64; 16]) -> [f64; 16] {
+        let mut out = [0.0; 16];
+        for r in 0..4 {
+            for c in 0..4 {
+                let mut sum = 0.0;
+                for k in 0..4 {
+                    sum += a[r * 4 + k] * b[k * 4 + c];
+                }
+                out[r * 4 + c] = sum;
+            }
+        }
+        out
+    }
+    matmul(&matmul(&S, m), &ST)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The stored world boxes are IFC Z-up and JS is Y-up, so the
+    /// `geometryAabbValues` getter runs this on the way out — and it is NOT a
+    /// component-wise swap: negating Y flips which corner is the min along the
+    /// new Z. The getter itself needs a JS realm, so the shared helper is
+    /// pinned here for both component types it serves.
+    #[test]
+    fn zup_to_yup_reverses_min_max_on_the_negated_axis() {
+        // y spans [2, 5] in IFC ⇒ the new z spans [-5, -2], not [-2, -5].
+        let world = swap_zup_to_yup_aabb([1.0f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
+        assert_eq!(world, [1.0, 3.0, -5.0, 4.0, 6.0, -2.0]);
+        assert!(world[2] <= world[5], "min must stay <= max on the negated axis");
+
+        // MeshDataJs's f32 local bounds take the identical path.
+        let local = swap_zup_to_yup_aabb([1.0f32, 2.0, 3.0, 4.0, 5.0, 6.0]);
+        assert_eq!(local, [1.0, 3.0, -5.0, 4.0, 6.0, -2.0]);
+    }
+
+    /// The world box is `f64` precisely so a box at national-grid coordinates
+    /// keeps sub-millimetre resolution — finer than the 1 mm grid the companion
+    /// geometry hash quantizes on. Routing it through an `f32` helper would
+    /// destroy that, so the conversion must be exact.
+    #[test]
+    fn the_world_box_survives_the_swap_at_national_grid_coordinates() {
+        let ifc = [
+            2_600_000.000_5_f64,
+            1_200_000.000_5,
+            0.0,
+            2_600_001.000_5,
+            1_200_001.000_5,
+            3.0,
+        ];
+        let out = swap_zup_to_yup_aabb(ifc);
+        assert_eq!(out, [ifc[0], ifc[2], -ifc[4], ifc[3], ifc[5], -ifc[1]]);
+        assert_ne!(
+            out[2], out[2] as f32 as f64,
+            "the fixture must be one an f32 round-trip would visibly move"
+        );
+    }
+}

--- a/rust/wasm-bindings/src/zero_copy/mesh.rs
+++ b/rust/wasm-bindings/src/zero_copy/mesh.rs
@@ -444,6 +444,10 @@ pub struct MeshCollection {
     /// its fingerprint (see `ifc_lite_geometry::geom_hash`). Empty otherwise.
     geometry_hash_ids: Vec<u32>,
     geometry_hash_values: Vec<u64>,
+    /// World-space AABBs from the SAME pass, 6 `f64` per entry
+    /// (minx,miny,minz,maxx,maxy,maxz) in `geometry_hash_ids` order. Populated
+    /// and emptied in lockstep with the two arrays above.
+    geometry_aabb_values: Vec<f64>,
     /// Typed CSG / opening diagnostics for the batch that produced this collection
     /// (the public `GeometryDiagnostics` contract). The worker merges these across
     /// batches and the loader across workers, surfacing one per-load `diagnostics`
@@ -582,6 +586,26 @@ impl MeshCollection {
         js_sys::BigUint64Array::from(&self.geometry_hash_values[..])
     }
 
+    /// Per-entity world-space AABBs as a `Float64Array`, SIX values per entry
+    /// (`minx, miny, minz, maxx, maxy, maxz`), in the same order as
+    /// [`Self::geometry_hash_ids`] — entry `i` spans `[6*i, 6*i+6)`. Empty
+    /// unless geometry hashing was enabled; the same
+    /// `IfcAPI.setComputeGeometryHashes` switch gates both, so nothing is
+    /// computed when the diff feature is off.
+    ///
+    /// Unquantized world `f64` (the file's RTC folded back in), so two
+    /// revisions that chose different RTC offsets report the same box. This is
+    /// what lets a consumer say "MOVED" honestly instead of inferring it from a
+    /// changed hash, which also fires on reshape and on retriangulation.
+    ///
+    /// No companion volume ships: see `GeometryHasher::world_aabb` — 14.7% of
+    /// the mesh segments feeding this pass are open or non-manifold, and a
+    /// divergence-theorem volume over those is arbitrary, not approximate.
+    #[wasm_bindgen(getter, js_name = geometryAabbValues)]
+    pub fn geometry_aabb_values(&self) -> js_sys::Float64Array {
+        js_sys::Float64Array::from(&self.geometry_aabb_values[..])
+    }
+
     /// Number of per-entity geometry fingerprints recorded.
     #[wasm_bindgen(getter, js_name = geometryHashCount)]
     pub fn geometry_hash_count(&self) -> usize {
@@ -612,6 +636,7 @@ impl MeshCollection {
             building_rotation: None,
             geometry_hash_ids: Vec::new(),
             geometry_hash_values: Vec::new(),
+            geometry_aabb_values: Vec::new(),
             diagnostics: None,
         }
     }
@@ -626,6 +651,7 @@ impl MeshCollection {
             building_rotation: None,
             geometry_hash_ids: Vec::new(),
             geometry_hash_values: Vec::new(),
+            geometry_aabb_values: Vec::new(),
             diagnostics: None,
         }
     }
@@ -636,11 +662,18 @@ impl MeshCollection {
         self.meshes.push(mesh);
     }
 
-    /// Record a per-entity geometry fingerprint (for revision diffing).
+    /// Record a per-entity geometry fingerprint + world AABB (for revision
+    /// diffing). Both arrive from the one hashing pass, so they are pushed
+    /// together and the three arrays stay index-parallel. `aabb` is
+    /// `[minx, miny, minz, maxx, maxy, maxz]`; a producer that somehow has a
+    /// hash but no box writes NaNs rather than shortening the array, which
+    /// would misalign every later entry.
     #[inline]
-    pub fn push_geometry_hash(&mut self, express_id: u32, hash: u64) {
+    pub fn push_geometry_hash(&mut self, express_id: u32, hash: u64, aabb: Option<[f64; 6]>) {
         self.geometry_hash_ids.push(express_id);
         self.geometry_hash_values.push(hash);
+        self.geometry_aabb_values
+            .extend_from_slice(&aabb.unwrap_or([f64::NAN; 6]));
     }
 
     /// Attach the batch's typed CSG / opening diagnostics (the public
@@ -665,6 +698,7 @@ impl MeshCollection {
             building_rotation: None,
             geometry_hash_ids: Vec::new(),
             geometry_hash_values: Vec::new(),
+            geometry_aabb_values: Vec::new(),
             diagnostics: None,
         }
     }
@@ -741,6 +775,7 @@ impl Clone for MeshCollection {
             building_rotation: self.building_rotation,
             geometry_hash_ids: self.geometry_hash_ids.clone(),
             geometry_hash_values: self.geometry_hash_values.clone(),
+            geometry_aabb_values: self.geometry_aabb_values.clone(),
             diagnostics: self.diagnostics.clone(),
         }
     }
@@ -751,3 +786,7 @@ impl Default for MeshCollection {
         Self::new()
     }
 }
+
+#[cfg(test)]
+#[path = "mesh_tests.rs"]
+mod tests;

--- a/rust/wasm-bindings/src/zero_copy/mesh.rs
+++ b/rust/wasm-bindings/src/zero_copy/mesh.rs
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use super::frame_swap::{swap_zup_to_yup_aabb, swap_zup_to_yup_mat4};
 use ifc_lite_geometry::Mesh;
 use wasm_bindgen::prelude::*;
 
@@ -209,50 +210,6 @@ impl MeshDataJs {
     }
 }
 
-/// Swap an axis-aligned box's corners from IFC Z-up to WebGL Y-up
-/// (`(x,y,z) -> (x,z,-y)`). A per-component swap of `min`/`max` independently
-/// is WRONG: negating the Y axis flips which corner is the min/max along the
-/// new Z, so the new Z range is `[-maxY, -minY]`, not `[-minY, -maxY]`.
-fn swap_zup_to_yup_aabb(b: [f32; 6]) -> [f32; 6] {
-    let [min_x, min_y, min_z, max_x, max_y, max_z] = b;
-    [min_x, min_z, -max_y, max_x, max_z, -min_y]
-}
-
-/// Conjugate a row-major 4×4 matrix by the fixed IFC Z-up → WebGL Y-up swap
-/// `S`: `(x,y,z,w) -> (x,z,-y,w)`, so a placement/rotation matrix expressed in
-/// the IFC frame becomes valid in the Y-up frame the renderer uses:
-/// `M' = S · M · Sᵀ` (S is orthogonal, so `S⁻¹ = Sᵀ`).
-fn swap_zup_to_yup_mat4(m: &[f64; 16]) -> [f64; 16] {
-    #[rustfmt::skip]
-    const S: [f64; 16] = [
-        1.0, 0.0, 0.0, 0.0,
-        0.0, 0.0, 1.0, 0.0,
-        0.0, -1.0, 0.0, 0.0,
-        0.0, 0.0, 0.0, 1.0,
-    ];
-    #[rustfmt::skip]
-    const ST: [f64; 16] = [
-        1.0, 0.0, 0.0, 0.0,
-        0.0, 0.0, -1.0, 0.0,
-        0.0, 1.0, 0.0, 0.0,
-        0.0, 0.0, 0.0, 1.0,
-    ];
-    fn matmul(a: &[f64; 16], b: &[f64; 16]) -> [f64; 16] {
-        let mut out = [0.0; 16];
-        for r in 0..4 {
-            for c in 0..4 {
-                let mut sum = 0.0;
-                for k in 0..4 {
-                    sum += a[r * 4 + k] * b[k * 4 + c];
-                }
-                out[r * 4 + c] = sum;
-            }
-        }
-        out
-    }
-    matmul(&matmul(&S, m), &ST)
-}
-
 impl MeshDataJs {
     /// Create new mesh data with IFC Z-up to WebGL Y-up conversion.
     ///
@@ -447,6 +404,10 @@ pub struct MeshCollection {
     /// World-space AABBs from the SAME pass, 6 `f64` per entry
     /// (minx,miny,minz,maxx,maxy,maxz) in `geometry_hash_ids` order. Populated
     /// and emptied in lockstep with the two arrays above.
+    ///
+    /// Stored in the producer's IFC **Z-up** frame, the frame the hasher
+    /// reconstructed them in. The Z-up→Y-up swap happens once, in the
+    /// `geometryAabbValues` getter — the single point where these reach JS.
     geometry_aabb_values: Vec<f64>,
     /// Typed CSG / opening diagnostics for the batch that produced this collection
     /// (the public `GeometryDiagnostics` contract). The worker merges these across
@@ -598,12 +559,28 @@ impl MeshCollection {
     /// what lets a consumer say "MOVED" honestly instead of inferring it from a
     /// changed hash, which also fires on reshape and on retriangulation.
     ///
+    /// **Frame: WebGL Y-up**, like every other box, position, origin and
+    /// placement that crosses this boundary (see `MeshDataJs::local_bounds`).
+    /// The hasher accumulates in the producer's IFC Z-up frame, so the swap
+    /// `(x,y,z) -> (x,z,-y)` is applied here, on the way out. Unconverted, the
+    /// boxes would not enclose the very meshes `processGeometryBatch` returns
+    /// alongside them. Positions are RTC-relative and this box is absolute, so
+    /// a consumer comparing the two folds `rtcOffset*` in — itself Y-up-swapped.
+    ///
     /// No companion volume ships: see `GeometryHasher::world_aabb` — 14.7% of
     /// the mesh segments feeding this pass are open or non-manifold, and a
     /// divergence-theorem volume over those is arbitrary, not approximate.
     #[wasm_bindgen(getter, js_name = geometryAabbValues)]
     pub fn geometry_aabb_values(&self) -> js_sys::Float64Array {
-        js_sys::Float64Array::from(&self.geometry_aabb_values[..])
+        // `push_geometry_hash` is the only writer and always extends by exactly
+        // six, so `chunks_exact` drops nothing. NaN placeholders (hash without a
+        // box) survive the swap as NaN, since `-NaN` is NaN.
+        let y_up: Vec<f64> = self
+            .geometry_aabb_values
+            .chunks_exact(6)
+            .flat_map(|b| swap_zup_to_yup_aabb([b[0], b[1], b[2], b[3], b[4], b[5]]))
+            .collect();
+        js_sys::Float64Array::from(&y_up[..])
     }
 
     /// Number of per-entity geometry fingerprints recorded.
@@ -667,7 +644,8 @@ impl MeshCollection {
     /// together and the three arrays stay index-parallel. `aabb` is
     /// `[minx, miny, minz, maxx, maxy, maxz]`; a producer that somehow has a
     /// hash but no box writes NaNs rather than shortening the array, which
-    /// would misalign every later entry.
+    /// would misalign every later entry. `aabb` stays in the producer's IFC
+    /// Z-up frame; the getter converts (see `geometry_aabb_values`).
     #[inline]
     pub fn push_geometry_hash(&mut self, express_id: u32, hash: u64, aabb: Option<[f64; 6]>) {
         self.geometry_hash_ids.push(express_id);

--- a/rust/wasm-bindings/src/zero_copy/mesh_tests.rs
+++ b/rust/wasm-bindings/src/zero_copy/mesh_tests.rs
@@ -1,0 +1,65 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Native unit tests for `mesh.rs`. The `js_sys` typed-array GETTERS need a JS
+//! environment, so these exercise the backing buffers directly — which is where
+//! the contract that matters lives: the three geometry-diff arrays are read by
+//! index, so any length skew mis-attributes every entry after it.
+
+use super::MeshCollection;
+
+#[test]
+fn geometry_diff_arrays_stay_index_parallel() {
+    let mut c = MeshCollection::new();
+    c.push_geometry_hash(7, 111, Some([0.0, 1.0, 2.0, 3.0, 4.0, 5.0]));
+    c.push_geometry_hash(9, 222, Some([-1.0, -2.0, -3.0, 10.0, 20.0, 30.0]));
+
+    assert_eq!(c.geometry_hash_ids, vec![7, 9]);
+    assert_eq!(c.geometry_hash_values, vec![111, 222]);
+    assert_eq!(c.geometry_aabb_values.len(), 2 * 6);
+    assert_eq!(&c.geometry_aabb_values[6..], &[-1.0, -2.0, -3.0, 10.0, 20.0, 30.0]);
+}
+
+/// A hash with no box must still occupy its six slots. Shortening the array
+/// instead would silently shift every LATER entity's box onto the wrong id —
+/// the failure mode is wrong answers, not a crash, so it is pinned here.
+#[test]
+fn a_missing_box_reserves_its_slots_instead_of_shifting_the_array() {
+    let mut c = MeshCollection::new();
+    c.push_geometry_hash(1, 10, None);
+    c.push_geometry_hash(2, 20, Some([1.0, 2.0, 3.0, 4.0, 5.0, 6.0]));
+
+    assert_eq!(c.geometry_aabb_values.len(), 12, "one 6-slot span per id");
+    assert!(
+        c.geometry_aabb_values[..6].iter().all(|v| v.is_nan()),
+        "the absent box must read as NaN, not as a box at the origin"
+    );
+    assert_eq!(&c.geometry_aabb_values[6..], &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+}
+
+/// Every constructor starts empty, so a collection that never hashed exposes no
+/// stale spans.
+#[test]
+fn constructors_start_with_no_geometry_diff_data() {
+    for c in [
+        MeshCollection::new(),
+        MeshCollection::with_capacity(4),
+        MeshCollection::from_vec(Vec::new()),
+    ] {
+        assert!(c.geometry_hash_ids.is_empty());
+        assert!(c.geometry_hash_values.is_empty());
+        assert!(c.geometry_aabb_values.is_empty());
+    }
+}
+
+/// `Clone` is how a batch hands its results on; the boxes must ride with the
+/// ids rather than being dropped.
+#[test]
+fn clone_carries_the_boxes() {
+    let mut c = MeshCollection::new();
+    c.push_geometry_hash(5, 55, Some([0.5; 6]));
+    let cloned = c.clone();
+    assert_eq!(cloned.geometry_hash_ids, vec![5]);
+    assert_eq!(cloned.geometry_aabb_values, vec![0.5; 6]);
+}

--- a/rust/wasm-bindings/src/zero_copy/mod.rs
+++ b/rust/wasm-bindings/src/zero_copy/mod.rs
@@ -8,6 +8,7 @@
 
 use wasm_bindgen::prelude::*;
 
+mod frame_swap;
 mod mesh;
 mod symbolic;
 

--- a/scripts/test-wasm-contract.mjs
+++ b/scripts/test-wasm-contract.mjs
@@ -845,6 +845,147 @@ test('setEntityIndex resets pipeline diagnostics like a fresh load, and installs
   }
 });
 
+// ===== geometry-diff hashes + world AABB (issue #1891) =====
+// Mocked-wasm tests cannot see any of this: the JS member name, the typed-array
+// type, the 6-per-id stride, and above all the COORDINATE FRAME are all facts
+// about the real binding. The hasher accumulates in the producer's IFC Z-up
+// frame while every mesh crossing this boundary is Y-up, so a box that skipped
+// the swap would look perfectly well-formed and simply fail to contain its own
+// element's vertices.
+console.log('\n📋 geometry-diff hashes + world AABB');
+
+/**
+ * Run one hashed batch over `content` and hand the caller the live collection.
+ * `tolerance` is the geometry-hash quantization grid in metres; passing null
+ * disables hashing (which is what makes the "off ⇒ empty" case testable).
+ */
+function withHashedBatch(content, tolerance, fn) {
+  const hashApi = new IfcAPI();
+  hashApi.setComputeGeometryHashes(tolerance);
+  const bytes = new TextEncoder().encode(content);
+  const pre = hashApi.buildPrePassOnce(bytes);
+  try {
+    assert.ok(pre.totalJobs > 0, 'fixture must produce geometry jobs');
+    const col = hashApi.processGeometryBatch(
+      bytes, pre.jobs, pre.unitScale,
+      pre.rtcOffset[0], pre.rtcOffset[1], pre.rtcOffset[2], pre.needsShift,
+      pre.voidKeys, pre.voidCounts, pre.voidValues, pre.styleIds, pre.styleColors,
+    );
+    try {
+      return fn(col);
+    } finally {
+      col.free();
+    }
+  } finally {
+    hashApi.clearPrePassCache();
+  }
+}
+
+test('geometryAabbValues is a Float64Array of exactly 6 values per hashed id', () => {
+  withHashedBatch(columnContent, 1e-3, (col) => {
+    const ids = col.geometryHashIds;
+    assert.ok(ids.length > 0, 'hashing on must fingerprint at least one entity');
+    assert.equal(col.geometryHashCount, ids.length, 'count must match the id array');
+
+    const aabb = col.geometryAabbValues;
+    assert.ok(aabb instanceof Float64Array,
+      `geometryAabbValues must be a Float64Array, got ${aabb && aabb.constructor && aabb.constructor.name}`);
+    assert.equal(aabb.length, 6 * col.geometryHashCount,
+      'six values per hashed id — a shorter array would mis-attribute every later box');
+    assert.ok(aabb.every(Number.isFinite),
+      'every hashed entity in this fixture produced real geometry, so no NaN spans');
+    for (let i = 0; i < col.geometryHashCount; i++) {
+      for (let k = 0; k < 3; k++) {
+        assert.ok(aabb[6 * i + k] <= aabb[6 * i + 3 + k],
+          `box ${i} axis ${k}: min ${aabb[6 * i + k]} must not exceed max ${aabb[6 * i + 3 + k]}`);
+      }
+    }
+  });
+});
+
+// THE frame assertion. The exposed box is absolute world in the viewer's Y-up
+// frame; mesh positions are RTC-relative and local-frame-relative in that same
+// frame. So world = origin + position + S(rtcOffset), where S is the same
+// Z-up→Y-up swap (x, y, z) -> (x, z, -y) the RTC offset itself has NOT had
+// applied (it is reported in the IFC frame, see coordinate-handler.ts).
+// Skipping the swap on the box makes this fail: a Z-up box has the element's
+// height on its Z axis while the Y-up mesh carries it on Y.
+test('geometryAabbValues is in the viewer frame and encloses its own meshes', () => {
+  withHashedBatch(columnContent, 1e-3, (col) => {
+    const ids = col.geometryHashIds;
+    const aabb = col.geometryAabbValues;
+    assert.ok(ids.length > 0, 'need at least one hashed entity to compare against');
+
+    // Y-up RTC: the collection reports it in IFC Z-up, like the mesher consumed it.
+    const rtc = [col.rtcOffsetX, col.rtcOffsetZ, -col.rtcOffsetY];
+
+    // Measured extent of every mesh, per express id, in world Y-up.
+    const measured = new Map();
+    for (let i = 0; i < col.length; i++) {
+      const mesh = col.get(i);
+      if (!mesh) continue;
+      try {
+        const o = mesh.origin;
+        const p = mesh.positions;
+        let box = measured.get(mesh.expressId);
+        if (!box) {
+          box = [Infinity, Infinity, Infinity, -Infinity, -Infinity, -Infinity];
+          measured.set(mesh.expressId, box);
+        }
+        // Only INDEXED vertices, because that is exactly the corner set the
+        // hasher walked (it iterates triangles, not the position buffer).
+        for (const vi of mesh.indices) {
+          const base = vi * 3;
+          if (base + 2 >= p.length) continue;
+          for (let k = 0; k < 3; k++) {
+            const w = p[base + k] + (o ? o[k] : 0) + rtc[k];
+            if (w < box[k]) box[k] = w;
+            if (w > box[3 + k]) box[3 + k] = w;
+          }
+        }
+      } finally {
+        mesh.free();
+      }
+    }
+
+    let compared = 0;
+    for (let i = 0; i < ids.length; i++) {
+      const box = measured.get(ids[i]);
+      if (!box) continue; // hashed but not in this collection's flat meshes
+      compared++;
+      const extent = Math.max(
+        box[3] - box[0], box[4] - box[1], box[5] - box[2], 1,
+      );
+      // f32 vertices reconstructed to f64 by both sides with the same terms, so
+      // the only slack is f64 summation order.
+      const eps = 1e-6 * extent;
+      for (let k = 0; k < 3; k++) {
+        assert.ok(aabb[6 * i + k] <= box[k] + eps,
+          `id ${ids[i]} axis ${k}: exposed min ${aabb[6 * i + k]} must not cut into the mesh min ${box[k]}`);
+        assert.ok(aabb[6 * i + 3 + k] >= box[3 + k] - eps,
+          `id ${ids[i]} axis ${k}: exposed max ${aabb[6 * i + 3 + k]} must not cut into the mesh max ${box[3 + k]}`);
+      }
+      // Tight, not merely enclosing: the hasher sees exactly these vertices, so
+      // a box inflated by a bad conversion (or by mixing frames) is also wrong.
+      for (let k = 0; k < 3; k++) {
+        assert.ok(Math.abs(aabb[6 * i + k] - box[k]) <= eps,
+          `id ${ids[i]} axis ${k}: exposed min ${aabb[6 * i + k]} must equal the mesh min ${box[k]}`);
+        assert.ok(Math.abs(aabb[6 * i + 3 + k] - box[3 + k]) <= eps,
+          `id ${ids[i]} axis ${k}: exposed max ${aabb[6 * i + 3 + k]} must equal the mesh max ${box[3 + k]}`);
+      }
+    }
+    assert.ok(compared > 0, 'at least one hashed id must have meshes in the collection to compare');
+  });
+});
+
+test('geometryAabbValues is empty when setComputeGeometryHashes is off', () => {
+  withHashedBatch(columnContent, null, (col) => {
+    assert.equal(col.geometryHashCount, 0, 'hashing off ⇒ no fingerprints');
+    assert.equal(col.geometryAabbValues.length, 0,
+      'the box rides the same switch — nothing is computed when the diff feature is off');
+  });
+});
+
 // ===== 2D boolean contour sets (issue #1863) =====
 console.log('\n📋 2D boolean contour sets');
 

--- a/scripts/test-wasm-contract.mjs
+++ b/scripts/test-wasm-contract.mjs
@@ -359,6 +359,7 @@ test('processGeometryBatchFromSource returns empty when no source is installed (
     }
   } finally {
     freshApi.clearPrePassCache();
+    freshApi.free();
   }
 });
 
@@ -770,6 +771,7 @@ test('getPipelineDiagnostics: undefined before load, accumulates across batches,
       'a new load (buildPrePassOnce) resets the accumulator until its first batch');
   } finally {
     diagApi.clearPrePassCache();
+    diagApi.free();
   }
 });
 
@@ -842,6 +844,7 @@ test('setEntityIndex resets pipeline diagnostics like a fresh load, and installs
       'the post-setEntityIndex batch must start a fresh accumulator at 1, not accumulate onto the prior load');
   } finally {
     entityIdxApi.clearPrePassCache();
+    entityIdxApi.free();
   }
 });
 
@@ -877,7 +880,11 @@ function withHashedBatch(content, tolerance, fn) {
       col.free();
     }
   } finally {
+    // clearPrePassCache drops the load-scoped caches; free() drops the wasm
+    // instance itself. Only the second one reclaims the linear-memory the
+    // IfcAPI holds, and this helper builds a fresh one per invocation.
     hashApi.clearPrePassCache();
+    hashApi.free();
   }
 }
 


### PR DESCRIPTION
## What and why

The content matcher (#1961) reports `moved` whenever two content-identical entities have different geometry hashes. That is a lie in several of its causes: the hash (`rust/geometry/src/geom_hash.rs`) is a world-space quantized triangle multiset, so "hash differs" conflates moved, reshaped and re-tessellated. A truthful `moved` needs a placement, and split/merge detection will need extent.

This exposes a per-entity **world AABB** from the same hashing pass. `corner()` already reconstructs the full f64 world coordinate of every triangle corner, so the box is close to free: no second pass, no extra traversal.

Surfaced as `MeshCollection.geometryAabbValues` (`Float64Array`, 6 per id, in `geometryHashIds` order), behind the same `setComputeGeometryHashes` gate. Nothing is computed when the diff feature is off. **The consuming diff-engine change is #1989; this PR ships only the data.**

Two details are mutation-pinned because both are easy to get subtly wrong: bounds take the **unquantized** f64 world coordinate, and they include corners of triangles the hash skips as post-quantization degenerate (a degenerate triangle still contributes real extent).

## Volume: measured, and deliberately not shipped

The obvious companion is a divergence-theorem volume. I built a harness running the **real** production path at the hasher's own granularity over the fixture corpus (17,919 elements / 55,427 segments) before deciding:

```
segments closed + consistently wound : 47277 (85.3%)
elements where ALL segments closed   : 15400 (85.9%)
elements with negative summed volume                : 62
elements whose volume exceeds its own AABB volume   : 73

reference-point invariance of the divergence sum
  CLOSED segments  : mean rel change 1.9e-9, max 7.3e-6
  OPEN/non-manifold: p50 7.6e-9   p90 7.5e-1   p99 2.6e8
```

The reference-point column is decisive. For an open surface the divergence sum is not inaccurate, it is **arbitrary** — the boundary flux scales with distance to the reference point. Closed segments are invariant to 2e-9 as theory demands; open ones move by 75% at p90.

This is not a corpus quirk. `rust/geometry/src/mesh_orient.rs:244-246` deliberately leaves open and non-orientable components as authored (`// open / non-orientable — leave winding as authored`), and `rust/processing/src/element.rs:311` records that since #1311 material-layer wall slices are **OPEN bands** whose union is the watertight skin — so their per-slice sum is not the wall's volume.

The reason to refuse rather than ship-with-caveats: only 135 of 17,919 elements produce a *detectably* wrong number (negative, or exceeding their own AABB). The rest look like ordinary plausible volumes. A split/merge detector fed those would emit confident false claims, which is worse than not having the feature.

**To do it properly** needs (a) a per-element closedness verdict carried out of the mesher — `orient_mesh_outward` already computes `closed` per component and discards it, so this is cheap — and (b) a defined answer for the multi-segment sum, since 3,205 elements are multi-segment and summing overlapping submeshes over-counts. Both belong in their own PR. The rationale is written into `GeometryHasher::world_aabb`'s doc comment so a future reader does not re-derive it.

I did reuse rather than reinvent: `rust/geometry/src/kernel/signed_volume.rs` already exists. Note that `tests/cdt_volume_watertight_verify.rs`'s `roof_1112` case computes a "volume" of 179.98 for a surface it documents as having 37 legitimate open edges, used purely as a self-consistency baseline. That is the trap in miniature.

## No geometry output changed

The geometry hash is byte-identical before and after, pinned by a test whose literals were taken from the **pre-change** implementation (checked out `HEAD:geom_hash.rs`, printed the values, restored, confirmed the new code reproduces them).

## Module-size ratchet

`geom_hash.rs` sat at exactly its recorded 410 budget, so it was **split, not allowlisted**: tests moved to `geom_hash_tests.rs` (ratchet-exempt) and the file is now 314 lines, so its allowlist row is **deleted**. Three rows grew, each with a written justification.

## Verification

`cargo clippy --workspace --exclude ifc-lite-wasm --all-targets -- -D warnings` clean · `cargo test --workspace --no-fail-fast` exit 0, 138 test binaries, zero failures · `module_size_ratchet` 4/4.

`packages/wasm/pkg/ifc-lite.d.ts` regenerated via `scripts/build-wasm.sh` and committed (additive: `readonly geometryAabbValues: Float64Array`); the `pkg/README.md` / `pkg/package.json` churn was reverted.

15 mutations run, each confirmed to red the intended test then restored — including storing quantized indices instead of world coordinates, accumulating after the degenerate `continue`, and subtracting RTC back out.

Toward #1891.
