### PR TITLE
feat(diff): tiered content matching so repeated components pair (#1891)

### DIFF
--- a/.changeset/tiered-content-match.md
+++ b/.changeset/tiered-content-match.md
@@ -1,0 +1,26 @@
+---
+'@ifc-lite/diff': minor
+---
+
+**diff**: make `matchUnpairedByContent` work on models full of repeated components.
+
+Unpaired entities were bucketed by (`ifcType`, `dataHash`) and paired only when a bucket held exactly one entity per side. A real model is mostly repeated components, so that paired only the unique minority: three data-identical doors at three different unmoved positions, all re-GUIDed by a re-export, landed in one bucket, reported a single `ambiguous` group, and pairs nothing at all.
+
+Each bucket is now refined hierarchically from the inside. Geometry stays out of the *outer* bucket key on purpose — with it there, an element that genuinely moved would never meet its own previous revision and every real move would revert to add+delete noise.
+
+- entities carrying a `geometryHash` are sub-bucketed by it. One per side, or the same count `N` on both sides, retires as `renamed`. `undefined` hashes are excluded: `undefined` agreeing with `undefined` is vacuous, not evidence.
+- a 1:1 leftover pairs as `renamed`, `moved`, or the new `reshaped` kind.
+- an N:M leftover is paired by iterated mutual nearest neighbour under a distance cap — a base and a head pair only when each is the other's *unique* nearest — which abstains by construction on a symmetric layout instead of guessing. The collision guard is part of that pairing test, so a pair it rejects stays in the candidate pool and the later rounds still see it. Groups above 128 per side report as `ambiguous`.
+
+New API:
+
+- `EntityFingerprint.aabb?: { min, max }` — optional world-space bounding box, both revisions in the same frame and units. It separates `moved` from `reshaped`, carries `ContentMatch.distance`, and enables the positional pairing above. Without it the pass degrades to the previous behaviour: `moved` for a 1:1 leftover, `ambiguous` for a group.
+- `ContentMatchKind` gains `'reshaped'` — the bounding boxes changed size, or agreed entirely while the geometry hash changed (a re-tessellation). An axis-aligned box cannot separate a re-tessellation from a reshape confined to the interior, and this does not pretend it can.
+- `ContentMatch.distance?: number` — centre displacement in the caller's units, clamped to `0` below `moveTolerance`.
+- `DiffOptions.moveTolerance` (default `2e-3`), `reshapeTolerance` (default `1e-3`), `maxMoveDistance` (default `10`). The two tolerances are lifted from `MOVE_EPS`/`RESHAPE_EPS` in the viewer's `describeChange.ts`, which encode issue #1197 (a phantom "moved 1.09 m" on a wall that never moved).
+
+Also fixed, in **both** matching passes: when one revision was fingerprinted by a build that produces geometry hashes and the other by a build that does not, every one-sided `undefined` read as "the geometry differs". The content pass reported the whole model as `moved`; the key-based pass reported every key-matched entity as `modified` with `changeKinds: ['geometry']`, so two revisions that may be identical read as a wholly changed model. Neither pass now uses geometry to classify anything in that case — a capability difference between two fingerprinting runs is not a model change. Both derive the decision from one shared helper so they cannot drift apart. The abstention needs a *whole side* to carry no hashes: with both sides hashing, a single entity gaining or losing geometry is still a real change and is still reported, and `excludeTypes` is applied before the scan so a dropped entity is not evidence that its side hashes.
+
+**`DiffCounts` changes for that previously broken case, and only for it.** A mixed-capability comparison that used to return every matched entity as `modified`/`['geometry']` now returns them as `unchanged` (or `modified` on data alone under `scope: 'both'`/`'data'`): `counts.modified` falls and `counts.unchanged` rises by the same number. This is a false positive being replaced with the truth, not a lost signal, and it applies whether or not `matchUnpairedByContent` is set. The cost is the mirror case: a base revision that genuinely carries no geometry at all, compared against a head that added geometry to everything, is indistinguishable from a capability difference and now reports `unchanged`. `DiffState` and `DiffEntry` are unchanged in shape.
+
+Behaviour change for existing callers of `matchUnpairedByContent`: a bucket with `N` entities per side that agree on both the data hash and the world geometry hash now retires as one `renamed` match carrying all `N` per side, where it previously reported an `ambiguous` group and retired nothing. `renamed` therefore no longer implies exactly one entity per side; `moved`/`reshaped` still do. `DiffState`, `DiffEntry`, and `DiffCounts` are unchanged, so exhaustive switches over `DiffState` keep compiling.

--- a/docs/guide/model-diff.md
+++ b/docs/guide/model-diff.md
@@ -72,43 +72,101 @@ Property sets, quantity sets, their members, and type assignments are all sorted
     but never deduplicated, so an occurrence bound to two types still hashes
     differently from one bound to a single type.
 
-**Geometry hash** — an opaque fingerprint of the entity's mesh, supplied separately (a `bigint` from the WASM mesh pass, `MeshCollection.geometryHashValues`, or a string for callers that fingerprint geometry another way). Two entities are geometry-equal when both hashes are absent, or both are present and their normalized values match; one side missing means geometry was added or removed.
+**Geometry hash** — an opaque fingerprint of the entity's mesh, supplied separately (a `bigint` from the WASM mesh pass, `MeshCollection.geometryHashValues`, or a string for callers that fingerprint geometry another way). Two entities are geometry-equal when both hashes are absent, or both are present and their normalized values match; one side missing means geometry was added or removed - unless one whole revision carries no hashes while the other does, which is a difference between two fingerprinting runs rather than a model change and is handled by [capability abstention](#capability-abstention).
 
 !!! note "Geometry change is shape/placement, not centroid drift"
     The engine detects geometry change through the mesh hash, not by measuring
-    how far an element's bounding-box centre moved. A per-entity "moved by X
-    metres" metric is a separate viewer-level concern, not part of the diff
-    fingerprint.
+    how far an element's bounding-box centre moved. Content-keyed matching can
+    additionally report *how far* a matched element travelled, but only from an
+    optional bounding box the caller supplies alongside the hashes - see
+    [Content-keyed matching](#content-keyed-matching-unreliable-globalids).
 
 ## Content-keyed matching (unreliable GlobalIds)
 
-A model re-exported from scratch by another tool gets entirely new GlobalIds, so the key-based match above reports every element as deleted-and-added even when nothing substantive changed. Pass `matchUnpairedByContent: true` to run a second pass, after the normal key-based pass, that re-examines the entities that came out `added`/`deleted` and pairs them by content hash where the pairing is unambiguous:
+A model re-exported from scratch by another tool gets entirely new GlobalIds, so the key-based match above reports every element as deleted-and-added even when nothing substantive changed. Pass `matchUnpairedByContent: true` to run a second pass, after the normal key-based pass, that re-examines the entities that came out `added`/`deleted` and pairs them by content where the pairing is unambiguous:
 
 ```ts
 import { diffModels } from '@ifc-lite/diff';
 
-const diff = diffModels(baseFingerprints, headFingerprints, { matchUnpairedByContent: true });
+const diff = diffModels(baseFingerprints, headFingerprints, {
+  matchUnpairedByContent: true,
+});
 
 for (const match of diff.contentMatches ?? []) {
-  if (match.kind === 'renamed' || match.kind === 'moved') {
-    console.log(match.kind, match.base[0].key, '->', match.head[0].key);
-  } else {
-    console.log(match.kind, 'group:', match.base.length, 'base,', match.head.length, 'head');
+  switch (match.kind) {
+    case 'renamed':
+      // One entity per side, or a group of N identical ones.
+      console.log('renamed', match.base.map((entity) => entity.key));
+      break;
+    case 'moved':
+    case 'reshaped':
+      console.log(match.kind, match.base[0].key, '->', match.head[0].key, match.distance);
+      break;
+    default:
+      console.log(match.kind, 'group:', match.base.length, 'base,', match.head.length, 'head');
   }
 }
 ```
 
-- **`renamed`** — the base and head entity's data hash *and* geometry hash both agree; only the key (GlobalId) changed. The `added`/`deleted` pair is removed from `entries`/`byKey`/`counts` in favor of this single record. Under `scope: 'data'` geometry is excluded from the comparison, so every 1:1 match is reported as `renamed`.
-- **`moved`** — data hash agrees, geometry hash differs; the key changed and so did the entity's shape/placement. Also removed from `entries` in favor of the record.
-- **`duplicated`** — one base entity's content matches several head entities.
-- **`deduplicated`** — several base entities' content matches one head entity.
-- **`ambiguous`** — more than one entity on *both* sides shares the content hash.
+### How a bucket is refined
 
-For `duplicated`/`deduplicated`/`ambiguous`, there is no principled way to pick a 1:1 pairing, so the engine does not guess: the original `added`/`deleted` entries stay in `entries` untouched, and `match.base`/`match.head` list every candidate on each side for the caller to resolve.
+Unpaired entities are bucketed by (`ifcType`, `dataHash`). Geometry is deliberately **not** part of that key: an element that genuinely moved would then land in a different bucket from its own previous revision and could never be paired at all, so every real move would revert to add+delete noise. Instead each bucket is refined from the inside, which matters because a real model is mostly *repeated* components - three data-identical doors at three different places share one bucket.
+
+1. **World geometry hash.** Entities carrying a `geometryHash` are sub-bucketed by it. One per side, or the same count `N` on both sides, retires as a `renamed` match. `undefined` hashes are excluded: `undefined` agreeing with `undefined` is vacuous, not evidence. Uneven sub-buckets retire nothing and fall through to the next steps.
+2. **The 1:1 leftover.** One base and one head left in the bucket pair as `renamed`, `moved`, or `reshaped`.
+3. **The N:M leftover.** With an `aabb` on every remaining candidate, they are paired by *iterated mutual nearest neighbour*: a base and a head pair only when each is the other's unique nearest and they are no further apart than `maxMoveDistance`. Retiring a confident pair can disambiguate its neighbours, so this repeats to a fixpoint. The collision checks below are part of that pairing test rather than a filter over its result: a pair they reject leaves both candidates in the pool, so the following rounds pair the rest of the group against the real candidate set instead of one the rejected pair had already been removed from. Whatever is still unpaired is reported as a group.
+
+Mutual nearest neighbour is used rather than greedy nearest-centroid (order-dependent, commits to bad chains) or optimal assignment (minimises *total* distance, so it pairs everything it is given, including elements that genuinely appeared). It abstains by construction: a symmetric layout of identical elements that all moved has no unique nearest neighbour anywhere, and "ambiguous" is the correct answer there. Groups larger than 128 per side skip this step and report as ambiguous.
+
+### Match kinds
+
+- **`renamed`** - data hash *and* world geometry hash agree; only the key (GlobalId) changed. The `added`/`deleted` entries are removed from `entries`/`byKey`/`counts` in favour of this record. Under `scope: 'data'` geometry is excluded from the comparison, so every 1:1 match is reported as `renamed`. A `renamed` match holds one entity per side, except for a group of `N` per side that agreed on both hashes - there every bijection is identical in every field the engine can see, so the members are reported as a set rather than as a fabricated pairing.
+- **`moved`** - data hash agrees, geometry hash differs, and the bounding boxes are the same size while their centres are further apart than `moveTolerance`. Also what a geometry-hash difference reports when no bounding box is available, since nothing can then tell a move from a reshape. Retiring.
+- **`reshaped`** - data hash agrees, geometry hash differs, and the bounding boxes differ in size beyond `reshapeTolerance` - or agree entirely, which is what a re-tessellation looks like. An axis-aligned box genuinely cannot separate a re-tessellation from a reshape confined to the interior, and this kind does not pretend it can. Retiring.
+- **`duplicated`** - one base entity's content matches several head entities.
+- **`deduplicated`** - several base entities' content matches one head entity.
+- **`ambiguous`** - several candidates remain on both sides with no principled pairing: duplication could not be told from deduplication, positions were too symmetric for a unique nearest neighbour, or the only candidates were further apart than `maxMoveDistance`.
+
+For `duplicated`/`deduplicated`/`ambiguous` the engine does not guess: the original `added`/`deleted` entries stay in `entries` untouched, and `match.base`/`match.head` list every candidate on each side for the caller to resolve.
+
+### Bounding boxes and tolerances
+
+`EntityFingerprint.aabb` is optional. Supply it and the pass can separate a move from a reshape, report the displacement, and pair repeated components by position. Leave it out and a 1:1 leftover still pairs - as `renamed` when the geometry hashes agree, and as a bare `moved` with no `distance` when they differ, since nothing is then available to tell a move from a reshape - while a group is reported as `ambiguous`. Both revisions must express the box in the **same world frame and units** - the same contract the geometry hash already carries:
+
+```ts
+import type { EntityFingerprint } from '@ifc-lite/diff';
+
+const fingerprint: EntityFingerprint<number> = {
+  key: 'globalId',
+  ifcType: 'IfcDoor',
+  dataHash: 'a1b2c3d4e5f60718',
+  geometryHash: 1234567890n,
+  aabb: { min: [0, 0, 0], max: [0.9, 0.2, 2.1] },
+  ref: 42,
+};
+```
+
+| Option | Default | What it controls |
+| --- | --- | --- |
+| `moveTolerance` | `2e-3` | Centre displacement below which a pair counts as not moved; `distance` is reported as `0`. |
+| `reshapeTolerance` | `1e-3` | Per-axis size change above which a pair is `reshaped` rather than `moved`. |
+| `maxMoveDistance` | `10` | Furthest apart two same-content entities may be and still pair in the **N:M positional stage** (step 3 above). |
+
+The two tolerance defaults are lifted from `MOVE_EPS`/`RESHAPE_EPS` in the viewer's `describeChange.ts`, which encode issue #1197 - a phantom "moved 1.09 m" on a wall that never moved. The engine and the UI draw the move/reshape line in the same place on purpose. `moveTolerance` and `reshapeTolerance` apply wherever a pair is classified.
+
+`maxMoveDistance` does **not**. It is a pairing cap for the mutual-nearest-neighbour stage only, in the caller's units, so `10` is a building-scale relocation for a metre-scale model. Where that stage is doing the pairing, two candidates further apart than the cap are never each other's accepted nearest and stay in the `ambiguous` group rather than being asserted to be the same element. A 1:1 leftover (step 2) is a different situation: there is exactly one candidate on each side of the bucket, nothing to disambiguate, and the pair is classified as `moved` however far it travelled. Set the cap to bound *positional guessing among repeated components*, not to bound how far the engine will believe an element moved.
+
+### Capability abstention
+
+If one revision was fingerprinted by a build that produces geometry hashes and the other by a build that does not, every one-sided `undefined` would read as "the geometry differs" and the whole model would report as changed. When a whole side carries no geometry hashes at all while the other does, **neither** pass uses geometry to classify anything: the key-based pass reports matched entities as `unchanged` (or `modified` on data alone, never with `'geometry'` in `changeKinds`), and the content pass reports matches as `renamed`, as if `scope: 'data'` had been selected. That is a capability difference between two fingerprinting runs, not a model change.
+
+Only a *whole side* triggers it. If any participating entity on each side carries a hash, both sides are doing geometry hashing and one entity's one-sided `undefined` is a real change - geometry added or removed - which is still reported. `excludeTypes` is applied first, so an entity dropped from the comparison does not count as evidence that its side carries hashes.
+
+The cost, stated plainly: a base revision that genuinely carries no geometry at all, compared against a head that added geometry to everything, is indistinguishable from a capability difference and reports as `unchanged`. That case is rare and recoverable (the fingerprints are the caller's own); the false positive it prevents - two possibly identical revisions reading as a wholly changed model - is neither.
 
 ### Hash collisions
 
-`dataHash` is a 64-bit FNV-1a value. It was 32 bits until issue #1962: at that width collisions between plausible IFC content were findable by enumeration, and the package's tests pinned three real ones. 64 bits makes that class of collision vastly less likely - it does not remove it, and no finite hash could - and FNV-1a is a drift-catching hash rather than a cryptographic digest, and the exposure grows with the square of the number of distinct fingerprints compared — a from-scratch re-export leaves the whole model unpaired, which is the worst case. Only the 1:1 path is destructive — it retires a real `added` and a real `deleted` — so it still applies two checks that can never reject a genuine match:
+`dataHash` is a 64-bit FNV-1a value. It was 32 bits until issue #1962: at that width collisions between plausible IFC content were findable by enumeration, and the package's tests pinned three real ones. 64 bits makes that class of collision vastly less likely, but it does not remove it and no finite hash could, and FNV-1a is a drift-catching hash rather than a cryptographic digest; the exposure grows with the square of the number of distinct fingerprints compared, and a from-scratch re-export leaves the whole model unpaired, which is the worst case. Every path that retires entries (a geometry-hash sub-bucket, a 1:1 leftover, a mutual-nearest-neighbour pair) destroys a real `added` and a real `deleted` if the data hash collided, so all of them apply the same two checks, neither of which can reject a genuine match:
 
 - entities are bucketed by `ifcType` as well as `dataHash`. `buildDataFingerprint` already hashes `ifcType`, so identical content always agrees on it; a disagreement proves a collision.
 - when both sides carry `components` (from `buildComponentFingerprints`), every sub-hash must agree. This holds only because the sub-hashes are computed over exactly the projection `buildDataFingerprint` hashes, GlobalId-free `type-assignment` included. A sub-hash that saw something `dataHash` does not would stop being a collision guard and start being a filter: it would reject genuine re-export matches, which is the opposite of what this pass is for.
@@ -125,6 +183,8 @@ Neither makes the pass collision-proof, and widening did not change which collis
 `buildComponentFingerprints` takes the same `DataFingerprintInput` you already pass to `buildDataFingerprint`, so populating it is one extra call per entity. No finite hash eliminates the `attr:core` row: a wider hash lowers the probability of an accidental collision, and a cryptographic one additionally makes a deliberate collision hard to construct, but neither is a guarantee. Treat it as a residual rather than a bug.
 
 Ambiguous groups retire nothing, so a collision landing in one costs the caller an extra candidate to inspect rather than a lost entry.
+
+The residual concentrates in the **1:1 leftover**. Every other retiring path has corroboration beyond the data hash — an agreeing world geometry hash, or a mutual-nearest-neighbour agreement within the move cap — while the 1:1 leftover rests on the data hash, `ifcType`, and `components` alone. That is where a false pair would come from.
 
 Split and Merged (a *partial* geometric overlap between one entity and several others) are not implemented — they need a geometric-similarity threshold and a partial-overlap policy with no single correct answer.
 

--- a/packages/diff/src/content-match-position.test.ts
+++ b/packages/diff/src/content-match-position.test.ts
@@ -1,0 +1,273 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Position-based pairing of the N:M leftovers in a content bucket: iterated
+ * mutual nearest neighbour under a distance cap.
+ *
+ * The property under test is not "pairs as much as possible" but "pairs only
+ * where the evidence is unambiguous, and abstains otherwise" — a symmetric
+ * layout of identical elements that all moved genuinely *is* ambiguous.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { diffModels } from './diff.js';
+import { buildComponentFingerprints } from './fingerprint.js';
+import type { EntityAabb, EntityFingerprint } from './types.js';
+
+/** A box of `size` centred on `centre`. */
+function box(
+  centre: [number, number, number],
+  size: [number, number, number] = [1, 1, 1],
+): EntityAabb {
+  return {
+    min: [centre[0] - size[0] / 2, centre[1] - size[1] / 2, centre[2] - size[2] / 2],
+    max: [centre[0] + size[0] / 2, centre[1] + size[1] / 2, centre[2] + size[2] / 2],
+  };
+}
+
+/**
+ * Same-content door at a position. Every door gets its own geometry hash, so
+ * the geometry-hash tier resolves nothing and the whole bucket reaches the
+ * position pass.
+ */
+function door(
+  key: string,
+  centre: [number, number, number],
+  size: [number, number, number] = [1, 1, 1],
+): EntityFingerprint<number> {
+  return {
+    key,
+    ifcType: 'IfcDoor',
+    dataHash: 'd1',
+    geometryHash: `g@${key}`,
+    aabb: box(centre, size),
+    ref: 0,
+  };
+}
+
+const kinds = (diff: ReturnType<typeof diffModels>): string[] =>
+  (diff.contentMatches ?? []).map((m) => m.kind).sort();
+
+describe('content matching — mutual nearest neighbour (tier 3)', () => {
+  it('pairs a group of identical moved elements one-for-one', () => {
+    const base = [door('b1', [0, 0, 0]), door('b2', [10, 0, 0])];
+    const head = [door('h1', [0.5, 0, 0]), door('h2', [10.5, 0, 0])];
+
+    const diff = diffModels(base, head, { matchUnpairedByContent: true });
+
+    expect(diff.counts).toEqual({ added: 0, modified: 0, deleted: 0, unchanged: 0 });
+    const matches = diff.contentMatches ?? [];
+    expect(matches.map((m) => m.kind)).toEqual(['moved', 'moved']);
+    expect(matches.map((m) => [m.base[0].key, m.head[0].key])).toEqual([
+      ['b1', 'h1'],
+      ['b2', 'h2'],
+    ]);
+    for (const match of matches) expect(match.distance).toBeCloseTo(0.5, 10);
+  });
+
+  it('abstains on a symmetric layout where nothing has a unique nearest neighbour', () => {
+    // Every base is exactly equidistant from both heads. A total-distance
+    // optimiser would happily pair these; there is no evidence for either
+    // assignment, so the honest answer is "ambiguous".
+    const base = [door('b1', [-1, 0, 0]), door('b2', [1, 0, 0])];
+    const head = [door('h1', [0, -1, 0]), door('h2', [0, 1, 0])];
+
+    const diff = diffModels(base, head, { matchUnpairedByContent: true });
+
+    expect(diff.counts).toEqual({ added: 2, modified: 0, deleted: 2, unchanged: 0 });
+    expect(kinds(diff)).toEqual(['ambiguous']);
+    expect(diff.contentMatches?.[0]?.base.map((e) => e.key)).toEqual(['b1', 'b2']);
+  });
+
+  it('iterates to a fixpoint: retiring a confident pair unlocks a tied one', () => {
+    // h2 sits exactly between b1 and b2, so it has no unique nearest base in
+    // the first round. Once (b1, h1) retires, b2 is the only base left and h2
+    // becomes unambiguous.
+    const base = [door('b1', [0, 0, 0]), door('b2', [10, 0, 0])];
+    const head = [door('h1', [0.1, 0, 0]), door('h2', [5, 0, 0])];
+
+    const diff = diffModels(base, head, { matchUnpairedByContent: true });
+
+    expect(diff.counts).toEqual({ added: 0, modified: 0, deleted: 0, unchanged: 0 });
+    const matches = diff.contentMatches ?? [];
+    expect(matches.map((m) => [m.base[0].key, m.head[0].key])).toEqual([
+      ['b1', 'h1'],
+      ['b2', 'h2'],
+    ]);
+    expect(matches[1]?.distance).toBeCloseTo(5, 10);
+  });
+
+  it('classifies a positionally paired element that also changed size as reshaped', () => {
+    const base = [door('b1', [0, 0, 0]), door('b2', [10, 0, 0])];
+    const head = [door('h1', [0.5, 0, 0], [2, 1, 1]), door('h2', [10.5, 0, 0])];
+
+    const diff = diffModels(base, head, { matchUnpairedByContent: true });
+
+    const matches = diff.contentMatches ?? [];
+    expect(matches.map((m) => [m.base[0].key, m.kind])).toEqual([
+      ['b1', 'reshaped'],
+      ['b2', 'moved'],
+    ]);
+  });
+
+  it('refuses a pair beyond maxMoveDistance and leaves it ambiguous', () => {
+    const base = [door('b1', [0, 0, 0]), door('b2', [100, 0, 0])];
+    const head = [door('h1', [1, 0, 0]), door('h2', [1000, 0, 0])];
+
+    const diff = diffModels(base, head, { matchUnpairedByContent: true });
+
+    // Only the near pair retires; the teleport stays an unresolved candidate.
+    expect(diff.counts).toEqual({ added: 1, modified: 0, deleted: 1, unchanged: 0 });
+    expect(kinds(diff)).toEqual(['ambiguous', 'moved']);
+    const leftover = diff.contentMatches?.find((m) => m.kind === 'ambiguous');
+    expect(leftover?.base.map((e) => e.key)).toEqual(['b2']);
+    expect(leftover?.head.map((e) => e.key)).toEqual(['h2']);
+  });
+
+  it('honours a caller-supplied maxMoveDistance', () => {
+    const base = [door('b1', [0, 0, 0]), door('b2', [100, 0, 0])];
+    const head = [door('h1', [1, 0, 0]), door('h2', [1000, 0, 0])];
+
+    const diff = diffModels(base, head, {
+      matchUnpairedByContent: true,
+      maxMoveDistance: 1000,
+    });
+
+    expect(diff.counts).toEqual({ added: 0, modified: 0, deleted: 0, unchanged: 0 });
+    expect(kinds(diff)).toEqual(['moved', 'moved']);
+  });
+
+  it('does not pair positionally when a candidate has no bounding box', () => {
+    const base = [door('b1', [0, 0, 0]), door('b2', [10, 0, 0])];
+    const withoutBox: EntityFingerprint<number> = {
+      key: 'h1',
+      ifcType: 'IfcDoor',
+      dataHash: 'd1',
+      geometryHash: 'g@h1',
+      ref: 0,
+    };
+    const head = [withoutBox, door('h2', [10.5, 0, 0])];
+
+    const diff = diffModels(base, head, { matchUnpairedByContent: true });
+
+    expect(diff.counts).toEqual({ added: 2, modified: 0, deleted: 2, unchanged: 0 });
+    expect(kinds(diff)).toEqual(['ambiguous']);
+  });
+
+  const componentsFor = (reference: string) =>
+    buildComponentFingerprints({
+      ifcType: 'IfcDoor',
+      name: 'Door',
+      propertySets: [
+        { name: 'Pset_DoorCommon', properties: [{ name: 'Reference', value: reference }] },
+      ],
+    });
+  const withComponents = (
+    entity: EntityFingerprint<number>,
+    reference: string,
+  ): EntityFingerprint<number> => ({ ...entity, components: componentsFor(reference) });
+
+  it('keeps the componentsAgree guard on the positional path', () => {
+    const base = [
+      withComponents(door('b1', [0, 0, 0]), 'A'),
+      withComponents(door('b2', [10, 0, 0]), 'A'),
+    ];
+    const head = [
+      withComponents(door('h1', [0.5, 0, 0]), 'B'),
+      withComponents(door('h2', [10.5, 0, 0]), 'B'),
+    ];
+
+    const diff = diffModels(base, head, { matchUnpairedByContent: true });
+
+    // Position says these are the same doors; the component sub-hashes prove
+    // the shared data hash was a collision, and the guard wins.
+    expect(diff.counts).toEqual({ added: 2, modified: 0, deleted: 2, unchanged: 0 });
+    expect(kinds(diff)).toEqual(['ambiguous']);
+  });
+
+  it('leaves a guard-rejected pair in the pool instead of retiring a later round on it', () => {
+    // b1/h1 are each other's unique nearest, so the first round proposes them
+    // and the component sub-hashes reject the pair. b2's nearest head is h1
+    // (2.5) and not h2 (3), so (b2, h2) is NOT mutual nearest while b1 and h1
+    // are in the pool — it only becomes mutual once they are gone. Rejecting
+    // (b1, h1) *after* the fixpoint had already retired them therefore paired
+    // b2 with h2 on a pool that never existed, destroying a real added/deleted
+    // pair. The rejection has to be part of the pairing predicate.
+    const base = [
+      withComponents(door('b1', [0, 0, 0]), 'A'),
+      withComponents(door('b2', [3, 0, 0]), 'C'),
+    ];
+    const head = [
+      withComponents(door('h1', [0.5, 0, 0]), 'B'),
+      withComponents(door('h2', [6, 0, 0]), 'C'),
+    ];
+
+    const diff = diffModels(base, head, { matchUnpairedByContent: true });
+
+    expect(diff.counts).toEqual({ added: 2, modified: 0, deleted: 2, unchanged: 0 });
+    expect(kinds(diff)).toEqual(['ambiguous']);
+    const group = diff.contentMatches?.[0];
+    expect(group?.base.map((e) => e.key)).toEqual(['b1', 'b2']);
+    expect(group?.head.map((e) => e.key)).toEqual(['h1', 'h2']);
+  });
+
+  it('rejects the pair, not the round: an unrelated pair in the same round still retires', () => {
+    // The veto is local. (b2, h2) is mutual nearest with b1 and h1 present, so
+    // its basis is unaffected by their rejection and it retires as usual.
+    const base = [
+      withComponents(door('b1', [0, 0, 0]), 'A'),
+      withComponents(door('b2', [50, 0, 0]), 'C'),
+    ];
+    const head = [
+      withComponents(door('h1', [0.5, 0, 0]), 'B'),
+      withComponents(door('h2', [50.5, 0, 0]), 'C'),
+    ];
+
+    const diff = diffModels(base, head, { matchUnpairedByContent: true });
+
+    expect(diff.counts).toEqual({ added: 1, modified: 0, deleted: 1, unchanged: 0 });
+    expect(kinds(diff)).toEqual(['ambiguous', 'moved']);
+    const moved = diff.contentMatches?.find((m) => m.kind === 'moved');
+    expect([moved?.base[0]?.key, moved?.head[0]?.key]).toEqual(['b2', 'h2']);
+    const group = diff.contentMatches?.find((m) => m.kind === 'ambiguous');
+    expect([group?.base[0]?.key, group?.head[0]?.key]).toEqual(['b1', 'h1']);
+  });
+});
+
+describe('content matching — position pairing bails out on very large groups', () => {
+  /** `count` doors per side, each head 0.5 to the right of its base. */
+  function group(count: number): {
+    base: EntityFingerprint<number>[];
+    head: EntityFingerprint<number>[];
+  } {
+    const base: EntityFingerprint<number>[] = [];
+    const head: EntityFingerprint<number>[] = [];
+    for (let i = 0; i < count; i++) {
+      base.push(door(`b${i}`, [i * 5, 0, 0]));
+      head.push(door(`h${i}`, [i * 5 + 0.5, 0, 0]));
+    }
+    return { base, head };
+  }
+
+  it('pairs a group at the size limit', () => {
+    const { base, head } = group(128);
+
+    const diff = diffModels(base, head, { matchUnpairedByContent: true });
+
+    expect(diff.counts).toEqual({ added: 0, modified: 0, deleted: 0, unchanged: 0 });
+    expect(diff.contentMatches).toHaveLength(128);
+    expect(new Set(kinds(diff))).toEqual(new Set(['moved']));
+  });
+
+  it('reports a group above the size limit as ambiguous instead', () => {
+    const { base, head } = group(129);
+
+    const diff = diffModels(base, head, { matchUnpairedByContent: true });
+
+    expect(diff.counts).toEqual({ added: 129, modified: 0, deleted: 129, unchanged: 0 });
+    expect(kinds(diff)).toEqual(['ambiguous']);
+    expect(diff.contentMatches?.[0]?.base).toHaveLength(129);
+  });
+});

--- a/packages/diff/src/content-match-tiers.test.ts
+++ b/packages/diff/src/content-match-tiers.test.ts
@@ -1,0 +1,429 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Tiered content matching (the #1891 follow-up).
+ *
+ * A real model is mostly *repeated* components. Bucketing the unpaired
+ * entities by (`ifcType`, `dataHash`) alone therefore pairs only the unique
+ * minority: three data-identical doors at three different places all land in
+ * one bucket and nothing pairs. These tests cover the refinement inside a
+ * bucket — by world geometry hash first, then the leftover 1:1 — plus the
+ * capability abstention. Position-based pairing of an N:M leftover lives in
+ * content-match-position.test.ts.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { diffModels } from './diff.js';
+import { buildComponentFingerprints } from './fingerprint.js';
+import type { EntityAabb, EntityFingerprint } from './types.js';
+
+function fp(
+  key: string,
+  opts: Partial<Omit<EntityFingerprint<number>, 'key'>> = {},
+): EntityFingerprint<number> {
+  const entity: EntityFingerprint<number> = {
+    key,
+    ifcType: opts.ifcType ?? 'IfcDoor',
+    dataHash: opts.dataHash ?? 'd0',
+    geometryHash: opts.geometryHash,
+    ref: opts.ref ?? 0,
+  };
+  if (opts.components) entity.components = opts.components;
+  if (opts.aabb) entity.aabb = opts.aabb;
+  return entity;
+}
+
+/** A 1x1x1 box centred on (x, y, z), optionally scaled per axis. */
+function box(
+  [x, y, z]: [number, number, number],
+  size: [number, number, number] = [1, 1, 1],
+): EntityAabb {
+  return {
+    min: [x - size[0] / 2, y - size[1] / 2, z - size[2] / 2],
+    max: [x + size[0] / 2, y + size[1] / 2, z + size[2] / 2],
+  };
+}
+
+/** Three data-identical doors at three unmoved positions, all re-GUIDed. */
+const door = (key: string, geometryHash: string): EntityFingerprint<number> =>
+  fp(key, { ifcType: 'IfcDoor', dataHash: 'same-content-hash', geometryHash });
+
+describe('regression #1891: repeated identical components after a re-export', () => {
+  it('pairs three re-GUIDed unmoved doors one-for-one instead of reporting one ambiguous group', () => {
+    // The probe that motivated this work asserted the opposite: one
+    // `ambiguous` group, added=3, deleted=3, nothing paired. Geometry was not
+    // part of the bucket key, so the three doors could not be told apart.
+    const base = [door('OLD-A', 'g@x=0'), door('OLD-B', 'g@x=1'), door('OLD-C', 'g@x=2')];
+    const head = [door('NEW-A', 'g@x=0'), door('NEW-B', 'g@x=1'), door('NEW-C', 'g@x=2')];
+
+    const diff = diffModels(base, head, { matchUnpairedByContent: true });
+
+    expect(diff.counts).toEqual({ added: 0, modified: 0, deleted: 0, unchanged: 0 });
+    expect(diff.entries).toEqual([]);
+
+    const matches = diff.contentMatches ?? [];
+    expect(matches.map((m) => m.kind)).toEqual(['renamed', 'renamed', 'renamed']);
+    // Each door pairs with the door standing in its own place, not with an
+    // arbitrary member of the group.
+    expect(matches.map((m) => [m.base[0].key, m.head[0].key]).sort()).toEqual([
+      ['OLD-A', 'NEW-A'],
+      ['OLD-B', 'NEW-B'],
+      ['OLD-C', 'NEW-C'],
+    ]);
+  });
+
+  it('a single door still pairs as renamed (the 1:1 case that already worked)', () => {
+    const diff = diffModels([door('OLD-A', 'g@x=0')], [door('NEW-A', 'g@x=0')], {
+      matchUnpairedByContent: true,
+    });
+
+    expect(diff.counts.added).toBe(0);
+    expect(diff.counts.deleted).toBe(0);
+    expect(diff.contentMatches?.map((m) => m.kind)).toEqual(['renamed']);
+  });
+
+  it('pairs the doors that stayed and reports the one that moved, in one bucket', () => {
+    const base = [door('OLD-A', 'g@x=0'), door('OLD-B', 'g@x=1')];
+    const head = [door('NEW-A', 'g@x=0'), door('NEW-B', 'g@x=9')];
+
+    const diff = diffModels(base, head, { matchUnpairedByContent: true });
+
+    expect(diff.counts).toEqual({ added: 0, modified: 0, deleted: 0, unchanged: 0 });
+    const matches = diff.contentMatches ?? [];
+    expect(matches).toHaveLength(2);
+    const renamed = matches.find((m) => m.kind === 'renamed');
+    const moved = matches.find((m) => m.kind === 'moved');
+    expect(renamed?.base[0].key).toBe('OLD-A');
+    expect(moved?.base[0].key).toBe('OLD-B');
+    expect(moved?.head[0].key).toBe('NEW-B');
+    // No bounding boxes were supplied, so there is no distance to report.
+    expect(moved?.distance).toBeUndefined();
+  });
+
+  it('leaves the group ambiguous under scope: data, where the caller opted out of geometry', () => {
+    const base = [door('OLD-A', 'g@x=0'), door('OLD-B', 'g@x=1')];
+    const head = [door('NEW-A', 'g@x=0'), door('NEW-B', 'g@x=1')];
+
+    const diff = diffModels(base, head, { matchUnpairedByContent: true, scope: 'data' });
+
+    expect(diff.counts).toEqual({ added: 2, modified: 0, deleted: 2, unchanged: 0 });
+    expect(diff.contentMatches?.map((m) => m.kind)).toEqual(['ambiguous']);
+  });
+});
+
+describe('content matching — geometry-hash sub-buckets (tier 1)', () => {
+  it('retires an N:N sub-bucket as one renamed match carrying every member', () => {
+    // Both the data hash and the world geometry hash agree, twice over, on
+    // both sides. Every bijection is then identical in every field the engine
+    // can see, so the group retires without fabricating a specific pairing.
+    const base = [door('b1', 'g@same'), door('b2', 'g@same')];
+    const head = [door('h1', 'g@same'), door('h2', 'g@same')];
+
+    const diff = diffModels(base, head, { matchUnpairedByContent: true });
+
+    expect(diff.counts).toEqual({ added: 0, modified: 0, deleted: 0, unchanged: 0 });
+    expect(diff.entries).toEqual([]);
+    expect(diff.contentMatches).toHaveLength(1);
+    const match = diff.contentMatches?.[0];
+    expect(match?.kind).toBe('renamed');
+    expect(match?.base.map((e) => e.key)).toEqual(['b1', 'b2']);
+    expect(match?.head.map((e) => e.key)).toEqual(['h1', 'h2']);
+  });
+
+  it('does not retire an N:N sub-bucket whose component sub-hashes disagree', () => {
+    const componentsA = buildComponentFingerprints({
+      ifcType: 'IfcDoor',
+      name: 'Door',
+      propertySets: [{ name: 'Pset_DoorCommon', properties: [{ name: 'Reference', value: 'A' }] }],
+    });
+    const componentsB = buildComponentFingerprints({
+      ifcType: 'IfcDoor',
+      name: 'Door',
+      propertySets: [{ name: 'Pset_DoorCommon', properties: [{ name: 'Reference', value: 'B' }] }],
+    });
+    const base = [
+      fp('b1', { dataHash: 'd1', geometryHash: 'g', components: componentsA }),
+      fp('b2', { dataHash: 'd1', geometryHash: 'g', components: componentsA }),
+    ];
+    const head = [
+      fp('h1', { dataHash: 'd1', geometryHash: 'g', components: componentsB }),
+      fp('h2', { dataHash: 'd1', geometryHash: 'g', components: componentsB }),
+    ];
+
+    const diff = diffModels(base, head, { matchUnpairedByContent: true });
+
+    // The guard proves the shared data hash was a collision: nothing retires.
+    expect(diff.counts).toEqual({ added: 2, modified: 0, deleted: 2, unchanged: 0 });
+    expect(diff.contentMatches?.map((m) => m.kind)).toEqual(['ambiguous']);
+  });
+
+  it('does not treat undefined geometry hashes as agreement', () => {
+    // `undefined` matching `undefined` is vacuous, not evidence, so these do
+    // not get sub-bucketed into a 2:2 "renamed" group.
+    //
+    const base = [fp('b1', { dataHash: 'd1' }), fp('b2', { dataHash: 'd1' })];
+    const head = [fp('h1', { dataHash: 'd1' }), fp('h2', { dataHash: 'd1' })];
+
+    const diff = diffModels(base, head, { matchUnpairedByContent: true });
+
+    expect(diff.counts).toEqual({ added: 2, modified: 0, deleted: 2, unchanged: 0 });
+    expect(diff.contentMatches?.map((m) => m.kind)).toEqual(['ambiguous']);
+  });
+
+  it('still declines an undefined pair inside a model that does carry geometry', () => {
+    // The case above has NO geometry anywhere, which is parity rather than a
+    // capability mismatch (`baseHasGeometry === headHasGeometry` is true when
+    // both are false), so tier 1 does run there. This variant makes that
+    // independent of the abstention entirely: the `anchor` pair carries a
+    // geometry hash on both sides, so `useGeometry` is unambiguously true and
+    // tier 1 must decline the undefined pair on its own merits.
+    //
+    // Added after a review of #1992 argued the case above was unreachable. It
+    // is reachable — a mutation removing tier 1's undefined routing reds both
+    // — but the two fixtures pin the behaviour for different reasons and a
+    // realistic model looks like this one.
+    const anchor = (key: string) => fp(key, { dataHash: 'anchor', geometryHash: 'g@anchor' });
+    const base = [anchor('same'), fp('b1', { dataHash: 'd1' }), fp('b2', { dataHash: 'd1' })];
+    const head = [anchor('same'), fp('h1', { dataHash: 'd1' }), fp('h2', { dataHash: 'd1' })];
+
+    const diff = diffModels(base, head, { matchUnpairedByContent: true });
+
+    expect(diff.counts).toEqual({ added: 2, modified: 0, deleted: 2, unchanged: 1 });
+    expect(diff.contentMatches?.map((m) => m.kind)).toEqual(['ambiguous']);
+  });
+
+  it('retires nothing from an uneven sub-bucket and reports it as duplicated', () => {
+    const base = [door('b1', 'g@same')];
+    const head = [door('h1', 'g@same'), door('h2', 'g@same')];
+
+    const diff = diffModels(base, head, { matchUnpairedByContent: true });
+
+    expect(diff.counts).toEqual({ added: 2, modified: 0, deleted: 1, unchanged: 0 });
+    expect(diff.contentMatches?.map((m) => m.kind)).toEqual(['duplicated']);
+  });
+
+  it('keeps a unique element that genuinely moved pairable (geometry is not in the outer bucket key)', () => {
+    // The reason the tiers live inside the bucket: with geometry in the outer
+    // key these two would never meet and a real move would revert to
+    // add+delete noise.
+    const diff = diffModels([door('old', 'g@before')], [door('new', 'g@after')], {
+      matchUnpairedByContent: true,
+    });
+
+    expect(diff.counts).toEqual({ added: 0, modified: 0, deleted: 0, unchanged: 0 });
+    expect(diff.contentMatches?.map((m) => m.kind)).toEqual(['moved']);
+  });
+});
+
+describe('content matching — moved vs reshaped from the bounding box (tier 2)', () => {
+  const movedPair = (baseAabb: EntityAabb, headAabb: EntityAabb) => ({
+    base: [fp('old', { dataHash: 'd1', geometryHash: 'g1', aabb: baseAabb })],
+    head: [fp('new', { dataHash: 'd1', geometryHash: 'g2', aabb: headAabb })],
+  });
+
+  it('reports a same-size box whose centre travelled as moved, with the distance', () => {
+    const { base, head } = movedPair(box([0, 0, 0]), box([3, 4, 0]));
+
+    const diff = diffModels(base, head, { matchUnpairedByContent: true });
+
+    expect(diff.contentMatches).toHaveLength(1);
+    expect(diff.contentMatches?.[0]?.kind).toBe('moved');
+    expect(diff.contentMatches?.[0]?.distance).toBeCloseTo(5, 10);
+    expect(diff.counts).toEqual({ added: 0, modified: 0, deleted: 0, unchanged: 0 });
+  });
+
+  it('reports a box that changed size as reshaped, not moved', () => {
+    const { base, head } = movedPair(box([0, 0, 0]), box([3, 0, 0], [2, 1, 1]));
+
+    const diff = diffModels(base, head, { matchUnpairedByContent: true });
+
+    expect(diff.contentMatches?.[0]?.kind).toBe('reshaped');
+    expect(diff.contentMatches?.[0]?.distance).toBeCloseTo(3, 10);
+  });
+
+  it('reports an unmoved box whose geometry hash changed as reshaped with distance 0', () => {
+    // Same size, same centre, different hash: a re-tessellation looks exactly
+    // like a reshape confined to the interior of the box, and the AABB cannot
+    // separate them.
+    const { base, head } = movedPair(box([0, 0, 0]), box([0, 0, 0]));
+
+    const diff = diffModels(base, head, { matchUnpairedByContent: true });
+
+    expect(diff.contentMatches?.[0]?.kind).toBe('reshaped');
+    expect(diff.contentMatches?.[0]?.distance).toBe(0);
+  });
+
+  it('treats a sub-tolerance centre shift as no move at all (#1197)', () => {
+    const { base, head } = movedPair(box([0, 0, 0]), box([1e-4, 0, 0]));
+
+    const diff = diffModels(base, head, { matchUnpairedByContent: true });
+
+    expect(diff.contentMatches?.[0]?.kind).toBe('reshaped');
+    expect(diff.contentMatches?.[0]?.distance).toBe(0);
+  });
+
+  it('honours a caller-supplied moveTolerance', () => {
+    const { base, head } = movedPair(box([0, 0, 0]), box([0.5, 0, 0]));
+
+    const strict = diffModels(base, head, { matchUnpairedByContent: true });
+    expect(strict.contentMatches?.[0]?.kind).toBe('moved');
+    expect(strict.contentMatches?.[0]?.distance).toBeCloseTo(0.5, 10);
+
+    const loose = diffModels(base, head, { matchUnpairedByContent: true, moveTolerance: 1 });
+    expect(loose.contentMatches?.[0]?.kind).toBe('reshaped');
+    expect(loose.contentMatches?.[0]?.distance).toBe(0);
+  });
+
+  it('honours a caller-supplied reshapeTolerance', () => {
+    const { base, head } = movedPair(box([0, 0, 0]), box([3, 0, 0], [1.05, 1, 1]));
+
+    const strict = diffModels(base, head, { matchUnpairedByContent: true });
+    expect(strict.contentMatches?.[0]?.kind).toBe('reshaped');
+
+    const loose = diffModels(base, head, { matchUnpairedByContent: true, reshapeTolerance: 0.1 });
+    expect(loose.contentMatches?.[0]?.kind).toBe('moved');
+  });
+
+  it('falls back to a bare moved when only one side carries a box', () => {
+    const base = [fp('old', { dataHash: 'd1', geometryHash: 'g1', aabb: box([0, 0, 0]) })];
+    const head = [fp('new', { dataHash: 'd1', geometryHash: 'g2' })];
+
+    const diff = diffModels(base, head, { matchUnpairedByContent: true });
+
+    expect(diff.contentMatches?.[0]?.kind).toBe('moved');
+    expect(diff.contentMatches?.[0]?.distance).toBeUndefined();
+  });
+
+  it('ignores a box with a non-finite coordinate rather than propagating NaN', () => {
+    const broken: EntityAabb = { min: [0, 0, Number.NaN], max: [1, 1, 1] };
+    const { base, head } = movedPair(box([0, 0, 0]), broken);
+
+    const diff = diffModels(base, head, { matchUnpairedByContent: true });
+
+    expect(diff.contentMatches?.[0]?.kind).toBe('moved');
+    expect(diff.contentMatches?.[0]?.distance).toBeUndefined();
+  });
+});
+
+describe('content matching — abstains when only one side was fingerprinted with geometry', () => {
+  it('reports renamed, not moved, when the head revision carries no geometry hashes at all', () => {
+    // A capability difference between two fingerprinting runs (hashing on in
+    // one build, off in the other) is not a model change. Without the
+    // abstention every one-sided `undefined` reads as "geometry differs" and
+    // the whole model reports as moved.
+    const base = [
+      fp('kept', { dataHash: 'd0', geometryHash: 'g0' }),
+      fp('old', { dataHash: 'd1', geometryHash: 'g1' }),
+    ];
+    const head = [fp('kept', { dataHash: 'd0' }), fp('new', { dataHash: 'd1' })];
+
+    const diff = diffModels(base, head, { matchUnpairedByContent: true });
+
+    expect(diff.contentMatches).toHaveLength(1);
+    expect(diff.contentMatches?.[0]?.kind).toBe('renamed');
+    expect(diff.contentMatches?.[0]?.distance).toBeUndefined();
+  });
+
+  it('abstains in the other direction too (base has no hashes, head does)', () => {
+    const base = [fp('old', { dataHash: 'd1' })];
+    const head = [fp('new', { dataHash: 'd1', geometryHash: 'g1' })];
+
+    const diff = diffModels(base, head, { matchUnpairedByContent: true });
+
+    expect(diff.contentMatches?.[0]?.kind).toBe('renamed');
+  });
+
+  it('still reports moved when both sides carry hashes and only one entity lacks one', () => {
+    // Not a capability difference: this revision really did lose the
+    // entity's geometry, so the abstention must not swallow it.
+    const base = [
+      fp('other', { dataHash: 'd0', geometryHash: 'g0' }),
+      fp('old', { dataHash: 'd1', geometryHash: 'g1' }),
+    ];
+    const head = [fp('other', { dataHash: 'd0', geometryHash: 'g0' }), fp('new', { dataHash: 'd1' })];
+
+    const diff = diffModels(base, head, { matchUnpairedByContent: true });
+
+    expect(diff.contentMatches).toHaveLength(1);
+    expect(diff.contentMatches?.[0]?.kind).toBe('moved');
+  });
+});
+
+describe('diffModels — geometry hash representation is the caller\'s contract', () => {
+  // Raised by a CodeRabbit CLI review of this branch. Equality is
+  // `String(a) === String(b)`, which is fine for the documented pairing
+  // (a wasm `bigint` and its own decimal string) but means a differently
+  // *rendered* value is a different fingerprint. Pinned rather than
+  // "fixed": canonicalizing numeric-looking strings would collide an
+  // opaque caller token with an unrelated bigint. Tier 1 sub-buckets on
+  // `String(hash)`, so a mismatch costs the pair its `renamed` and drops it
+  // to the residue — where it can still pair, as the spurious geometry
+  // change the second test pins. Worth a test either way.
+  it('pairs a bigint hash with its own decimal string form', () => {
+    const base = [fp('old', { dataHash: 'd1', geometryHash: 42n })];
+    const head = [fp('new', { dataHash: 'd1', geometryHash: '42' })];
+
+    const diff = diffModels(base, head, { matchUnpairedByContent: true });
+
+    expect(diff.contentMatches?.[0]?.kind).toBe('renamed');
+  });
+
+  it('treats a differently-rendered hash as a different fingerprint, not an equal one', () => {
+    const base = [fp('old', { dataHash: 'd1', geometryHash: 42n })];
+    const head = [fp('new', { dataHash: 'd1', geometryHash: '0x2a' })];
+
+    const diff = diffModels(base, head, { matchUnpairedByContent: true });
+
+    // Same content bucket, different geometry sub-bucket → tier 1 cannot
+    // pair them, so they fall to tier 2 and read as a geometry change.
+    expect(diff.contentMatches?.[0]?.kind).toBe('moved');
+  });
+});
+
+describe('diffModels — a one-sided leftover is not dressed up as a group', () => {
+  // Raised Medium by Cursor Bugbot on #1989: when a tier resolves every
+  // candidate on one side, the driver `continue`s and emits no group, where
+  // the pre-tier pass would have reported the whole bucket as `duplicated`.
+  //
+  // Declined deliberately, and pinned here so the change is visible rather
+  // than accidental. A `ContentMatch` whose `base` is empty asserts that some
+  // head entities are ambiguous against *nothing*, which `groupKind(0, n)`
+  // would label `ambiguous` — a strictly less honest description of an entity
+  // that is simply added. The leftover stays in `entries` as `added` and
+  // carries its own `dataHash`, so a caller that wants the grouping can still
+  // reconstruct it; nothing is lost that was not recoverable.
+  //
+  // What the caller gains instead is the definite answer tier 1 found.
+  //
+  // Mutation note, recorded because it is not the tidy result: TWO redundant
+  // guards suppress the one-sided group (`content-match.ts`, once right after
+  // tier 1 and again after the positional pass). Mutating either ALONE leaves
+  // the other catching it, so neither line is individually pinned; mutating
+  // both together reds the first test below. The redundancy is defence in
+  // depth rather than dead code, and this is what it costs to verify.
+  it('reports the exact pair as renamed and leaves the odd one out as a plain add', () => {
+    const base = [door('b1', 'g@A')];
+    const head = [door('h1', 'g@A'), door('h2', 'g@B')];
+
+    const diff = diffModels(base, head, { matchUnpairedByContent: true });
+
+    // Pre-tier this bucket reported one `duplicated` group of 1 base + 2 head
+    // and retired nothing. Now b1 -> h1 is settled and h2 is what it is.
+    expect(diff.contentMatches?.map((m) => m.kind)).toEqual(['renamed']);
+    expect(diff.contentMatches?.[0]?.base[0]?.key).toBe('b1');
+    expect(diff.contentMatches?.[0]?.head[0]?.key).toBe('h1');
+    expect(diff.counts).toEqual({ added: 1, modified: 0, deleted: 0, unchanged: 0 });
+    expect(diff.entries.filter((e) => e.state === 'added').map((e) => e.key)).toEqual(['h2']);
+  });
+
+  it('still reports the group when BOTH sides have leftovers', () => {
+    const base = [door('b1', 'g@A'), door('b2', 'g@X')];
+    const head = [door('h1', 'g@A'), door('h2', 'g@Y')];
+
+    const diff = diffModels(base, head, { matchUnpairedByContent: true });
+
+    expect(diff.contentMatches?.map((m) => m.kind).sort()).toEqual(['moved', 'renamed']);
+  });
+});

--- a/packages/diff/src/content-match.test.ts
+++ b/packages/diff/src/content-match.test.ts
@@ -132,15 +132,19 @@ describe('diffModels — matchUnpairedByContent: renamed / moved', () => {
 
 describe('diffModels — matchUnpairedByContent: ambiguous groups', () => {
   it('reports a many-to-many content match as a group, not a guessed pairing (regression: #1923-style silent pick)', () => {
-    // Two base entities and two head entities all share content hash 'd1':
-    // there is no principled 1:1 pairing.
+    // Two base and two head entities share content hash 'd1' and carry no
+    // geometry hash at all, so nothing beyond the data hash distinguishes
+    // them: there is no principled 1:1 pairing. (When they *do* agree on a
+    // world geometry hash on both sides the group retires instead — see
+    // content-match-tiers.test.ts; that is a decision about observational
+    // identity, not a guess about which one became which.)
     const base = [
-      fp('b1', { dataHash: 'd1', geometryHash: 100n, ref: 1 }),
-      fp('b2', { dataHash: 'd1', geometryHash: 100n, ref: 2 }),
+      fp('b1', { dataHash: 'd1', ref: 1 }),
+      fp('b2', { dataHash: 'd1', ref: 2 }),
     ];
     const head = [
-      fp('h1', { dataHash: 'd1', geometryHash: 100n, ref: 11 }),
-      fp('h2', { dataHash: 'd1', geometryHash: 100n, ref: 12 }),
+      fp('h1', { dataHash: 'd1', ref: 11 }),
+      fp('h2', { dataHash: 'd1', ref: 12 }),
     ];
 
     const diff = diffModels(base, head, { matchUnpairedByContent: true });

--- a/packages/diff/src/content-match.ts
+++ b/packages/diff/src/content-match.ts
@@ -1,0 +1,215 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The content-keyed matching pass (issue #1891): pair up the entities the
+ * key-based pass in `diff.ts` classified as `added`/`deleted`, for the case
+ * where GlobalIds are unreliable (a from-scratch re-export re-GUIDs
+ * everything).
+ *
+ * Entities are bucketed by (`ifcType`, `dataHash`) and then refined
+ * *hierarchically inside* each bucket. The outer key deliberately does not
+ * include geometry: an element that genuinely moved would then land in a
+ * different bucket from its own previous revision and could never be paired at
+ * all, so every real move would revert to add+delete noise. Geometry is a
+ * local decision within the bucket.
+ */
+
+import {
+  classifyPair,
+  componentsAgree,
+  fingerprintsOf,
+  groupKind,
+  pairByPosition,
+  refineByGeometryHash,
+  type Candidate,
+} from './content-tiers.js';
+import type { GeometryTolerances } from './geometry-compare.js';
+import type {
+  ContentMatch,
+  ContentMatchKind,
+  DiffCounts,
+  DiffEntry,
+  EntityFingerprint,
+} from './types.js';
+
+/**
+ * Bucket key for the content pass.
+ *
+ * {@link EntityFingerprint.dataHash} alone is a 64-bit FNV-1a hex string
+ * (`stableHash`, widened from 32 bits in issue #1962). It is a drift-catching
+ * hash, not a cryptographic one, and the exposure grows with the square of the
+ * number of distinct fingerprints compared — a from-scratch re-export leaves
+ * the whole model unpaired. Pairing on `dataHash` alone would retire a real
+ * `added` and a real `deleted` entry in favour of a fabricated match.
+ *
+ * Folding `ifcType` in as plaintext costs nothing and cannot reject a real
+ * match: `buildDataFingerprint` already hashes `ifcType` as part of its
+ * payload, so equal content implies equal `ifcType`. A disagreement therefore
+ * *proves* the shared `dataHash` was a collision.
+ */
+function contentBucketKey<TRef>(entity: EntityFingerprint<TRef>): string {
+  // NUL separator: `ifcType` is an IFC class name and never contains one, so
+  // no ifcType/dataHash pair can be confused with another.
+  return `${entity.ifcType}\u0000${entity.dataHash}`;
+}
+
+function bucketCandidates<TRef>(
+  entries: readonly DiffEntry<TRef>[],
+): {
+  addedByBucket: Map<string, Candidate<TRef>[]>;
+  deletedByBucket: Map<string, Candidate<TRef>[]>;
+} {
+  const addedByBucket = new Map<string, Candidate<TRef>[]>();
+  const deletedByBucket = new Map<string, Candidate<TRef>[]>();
+
+  const push = (map: Map<string, Candidate<TRef>[]>, candidate: Candidate<TRef>): void => {
+    const key = contentBucketKey(candidate.fingerprint);
+    const list = map.get(key);
+    if (list) list.push(candidate);
+    else map.set(key, [candidate]);
+  };
+
+  for (const entry of entries) {
+    if (entry.state === 'added' && entry.head) {
+      push(addedByBucket, { entry, fingerprint: entry.head });
+    } else if (entry.state === 'deleted' && entry.base) {
+      push(deletedByBucket, { entry, fingerprint: entry.base });
+    }
+  }
+
+  return { addedByBucket, deletedByBucket };
+}
+
+/**
+ * Content-keyed matching over the leftover `added`/`deleted` entries.
+ *
+ * `useGeometry` is resolved once by `diff.ts` and shared with the key-based
+ * pass (`resolveUseGeometry`). It is false under `scope: 'data'`, where geometry
+ * is excluded from the comparison, and false when the two revisions disagree on
+ * whether they carry geometry hashes at all. Either way no geometry
+ * sub-bucketing happens and every 1:1 match reports as `renamed` — a
+ * geometry-derived `moved` would report a difference the caller either opted out
+ * of seeing or that the fingerprints cannot support.
+ *
+ * `DiffState`/`DiffEntry` are never widened by this pass: it only removes
+ * entries or leaves them alone, so downstream code that exhaustively switches
+ * over `DiffState` needs no changes.
+ *
+ * Pure: never mutates its inputs.
+ */
+export function applyContentMatching<TRef>(
+  entries: DiffEntry<TRef>[],
+  counts: DiffCounts,
+  useGeometry: boolean,
+  tolerances: GeometryTolerances,
+): { entries: DiffEntry<TRef>[]; counts: DiffCounts; contentMatches: ContentMatch<TRef>[] } {
+  const { addedByBucket, deletedByBucket } = bucketCandidates(entries);
+
+  const retired = new Set<DiffEntry<TRef>>();
+  const contentMatches: ContentMatch<TRef>[] = [];
+  let removedAdded = 0;
+  let removedDeleted = 0;
+
+  const retire = (
+    bases: readonly Candidate<TRef>[],
+    heads: readonly Candidate<TRef>[],
+    dataHash: string,
+    kind: ContentMatchKind,
+    distance?: number,
+  ): void => {
+    for (const candidate of bases) {
+      retired.add(candidate.entry);
+      removedDeleted++;
+    }
+    for (const candidate of heads) {
+      retired.add(candidate.entry);
+      removedAdded++;
+    }
+    const match: ContentMatch<TRef> = {
+      kind,
+      dataHash,
+      base: bases.map((candidate) => candidate.fingerprint),
+      head: heads.map((candidate) => candidate.fingerprint),
+    };
+    if (distance !== undefined) match.distance = distance;
+    contentMatches.push(match);
+  };
+
+  for (const [bucketKey, headGroup] of addedByBucket) {
+    const baseGroup = deletedByBucket.get(bucketKey);
+    if (!baseGroup || baseGroup.length === 0) continue;
+    const dataHash = headGroup[0]?.fingerprint.dataHash;
+    if (dataHash === undefined) continue;
+
+    let residueBase: readonly Candidate<TRef>[] = baseGroup;
+    let residueHead: readonly Candidate<TRef>[] = headGroup;
+
+    if (useGeometry) {
+      const refined = refineByGeometryHash(baseGroup, headGroup);
+      for (const group of refined.resolved) {
+        retire(group.bases, group.heads, dataHash, 'renamed');
+      }
+      residueBase = refined.residueBase;
+      residueHead = refined.residueHead;
+    }
+
+    if (residueBase.length === 0 || residueHead.length === 0) continue;
+
+    if (residueBase.length === 1 && residueHead.length === 1) {
+      // TIER 2. This is the one destructive path resting on the data hash
+      // alone — no geometry hash agreed, so `componentsAgree` and the bucket's
+      // `ifcType` are all that stand between a genuine re-GUID and a retired
+      // pair of unrelated entities. The false-positive budget of the whole
+      // feature concentrates here; every other retiring path also had a world
+      // geometry hash or a mutual-nearest-neighbour agreement behind it.
+      const base = residueBase[0];
+      const head = residueHead[0];
+      if (componentsAgree([base.fingerprint, head.fingerprint])) {
+        const { kind, distance } = classifyPair(
+          base.fingerprint,
+          head.fingerprint,
+          useGeometry,
+          tolerances,
+        );
+        retire([base], [head], dataHash, kind, distance);
+      }
+      // Guard rejected: a proven collision. Report nothing rather than a match.
+      continue;
+    }
+
+    const positioned = pairByPosition(residueBase, residueHead, useGeometry, tolerances);
+    for (const [base, head] of positioned.pairs) {
+      const { kind, distance } = classifyPair(
+        base.fingerprint,
+        head.fingerprint,
+        useGeometry,
+        tolerances,
+      );
+      retire([base], [head], dataHash, kind, distance);
+    }
+
+    const { leftoverBase, leftoverHead } = positioned;
+    if (leftoverBase.length === 0 || leftoverHead.length === 0) continue;
+    contentMatches.push({
+      kind: groupKind(leftoverBase.length, leftoverHead.length),
+      dataHash,
+      base: fingerprintsOf(leftoverBase),
+      head: fingerprintsOf(leftoverHead),
+    });
+  }
+
+  if (retired.size === 0) {
+    return { entries, counts, contentMatches };
+  }
+
+  const nextEntries = entries.filter((entry) => !retired.has(entry));
+  const nextCounts: DiffCounts = {
+    ...counts,
+    added: counts.added - removedAdded,
+    deleted: counts.deleted - removedDeleted,
+  };
+
+  return { entries: nextEntries, counts: nextCounts, contentMatches };
+}

--- a/packages/diff/src/content-tiers.ts
+++ b/packages/diff/src/content-tiers.ts
@@ -1,0 +1,258 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The refinement tiers inside one content bucket (issue #1891 follow-up), and
+ * the guards every destructive path shares.
+ *
+ * `content-match.ts` owns the bucketing and the driver loop; this module owns
+ * what happens *within* a single (`ifcType`, `dataHash`) bucket: sub-bucketing
+ * by world geometry hash, classifying a pair, and pairing a leftover group by
+ * position.
+ */
+
+import {
+  classifyGeometryChange,
+  geometryEqual,
+  isUsableAabb,
+  aabbCentre,
+  type GeometryTolerances,
+  type Vec3,
+} from './geometry-compare.js';
+import { mutualNearestPairs } from './mutual-nearest.js';
+import type { ContentMatchKind, DiffEntry, EntityFingerprint } from './types.js';
+
+/**
+ * Largest leftover group the position-based pass will look at, per side.
+ *
+ * Mutual nearest neighbour is O(n·m) per round, and a bucket this large is a
+ * mass of identical components where positional pairing is guesswork anyway.
+ * Above it the group is reported as ambiguous, which is both cheaper and more
+ * honest.
+ */
+export const MAX_POSITION_MATCH_GROUP = 128;
+
+/** One `added`/`deleted` entry paired with the fingerprint its state implies. */
+export interface Candidate<TRef> {
+  entry: DiffEntry<TRef>;
+  fingerprint: EntityFingerprint<TRef>;
+}
+
+/** Order-independent canonical form of a component sub-hash map. */
+function componentSignature(components: Record<string, string>): string {
+  let signature = '';
+  for (const key of Object.keys(components).sort()) {
+    signature += `${key}\u0000${components[key]}\u0001`;
+  }
+  return signature;
+}
+
+/**
+ * Whether every supplied entity's component sub-hashes agree.
+ *
+ * Like the `ifcType` half of the bucket key in `content-match.ts`, this cannot reject a
+ * real match — {@link EntityFingerprint.components} hashes slices of the same
+ * content `dataHash` hashes whole — so a disagreement proves a collision.
+ *
+ * It does *not* make the pass collision-proof, and the asymmetry is worth
+ * knowing: FNV-1a's per-character update is a bijection on its state at any
+ * width, so two entities differing only inside `attr:core` (a different
+ * `Name`, all else equal) hash their whole payloads as `prefix + name +
+ * identical suffix` — a `dataHash` collision there *implies* an `attr:core`
+ * collision, and this check abstains. It bites when the differing content
+ * lands in a pset/qset slice, whose sub-hash is computed over an unrelated
+ * string. Widening `stableHash` to 64 bits (issue #1962) made the premise far
+ * less likely without removing the implication.
+ *
+ * Entities without components contribute nothing: components are opt-in, and a
+ * caller may supply them for one revision only, so their absence is not
+ * evidence either way (this mirrors the `changedComponents` guard in the
+ * key-based pass, which also abstains).
+ */
+export function componentsAgree<TRef>(entities: readonly EntityFingerprint<TRef>[]): boolean {
+  let signature: string | undefined;
+  for (const entity of entities) {
+    if (!entity.components) continue;
+    const current = componentSignature(entity.components);
+    if (signature === undefined) signature = current;
+    else if (current !== signature) return false;
+  }
+  return true;
+}
+
+export function fingerprintsOf<TRef>(
+  ...groups: readonly (readonly Candidate<TRef>[])[]
+): EntityFingerprint<TRef>[] {
+  const all: EntityFingerprint<TRef>[] = [];
+  for (const group of groups) for (const candidate of group) all.push(candidate.fingerprint);
+  return all;
+}
+
+/** Kind for a group that retires nothing. Total over the counts that reach it:
+ *  a leftover 1:1 only occurs after the position pass refused to pair it, and
+ *  "we could not tell" is exactly `ambiguous`. */
+export function groupKind(baseCount: number, headCount: number): ContentMatchKind {
+  if (baseCount === 1 && headCount === 1) return 'ambiguous';
+  if (baseCount === 1) return 'duplicated';
+  if (headCount === 1) return 'deduplicated';
+  return 'ambiguous';
+}
+
+/**
+ * Classify a pair the pass has decided is the same element.
+ *
+ * Equal (or out-of-scope) geometry means only the key changed: `renamed`.
+ * Otherwise the bounding boxes, when present, separate a move from a reshape.
+ */
+export function classifyPair<TRef>(
+  base: EntityFingerprint<TRef>,
+  head: EntityFingerprint<TRef>,
+  useGeometry: boolean,
+  tolerances: GeometryTolerances,
+): { kind: ContentMatchKind; distance?: number } {
+  if (!useGeometry || geometryEqual(base.geometryHash, head.geometryHash)) {
+    return { kind: 'renamed' };
+  }
+  return classifyGeometryChange(base.aabb, head.aabb, tolerances);
+}
+
+/** TIER 1 result: what the geometry-hash sub-buckets resolved, and what is left. */
+export interface GeometryRefinement<TRef> {
+  /** Sub-buckets that agreed on both sides, N per side. Retiring. */
+  resolved: { bases: Candidate<TRef>[]; heads: Candidate<TRef>[] }[];
+  residueBase: Candidate<TRef>[];
+  residueHead: Candidate<TRef>[];
+}
+
+/**
+ * TIER 1 — sub-bucket a (`ifcType`, `dataHash`) bucket by world geometry hash.
+ *
+ * This is what makes the pass work on a real model: buildings are mostly
+ * repeated components, so three data-identical doors at three different places
+ * used to land in one bucket, report a single `ambiguous` group, and pair
+ * nothing at all. Sub-bucketing pairs each door with the door that is still in
+ * its place.
+ *
+ * Entities whose `geometryHash` is `undefined` are excluded: `undefined`
+ * matching `undefined` is vacuous agreement, not evidence, so they go to the
+ * residue where the later tiers can weigh what is actually known about them.
+ *
+ * A sub-bucket with `N` entities on both sides retires as one group. Both the
+ * data hash and the world-space geometry hash agree `N` times over, so every
+ * bijection between the two sides is identical in every field the engine can
+ * see; there is nothing left to guess, and no specific pairing is fabricated
+ * (the match carries all `N` per side). A sub-bucket with different counts
+ * retires nothing and falls to the residue, where it can still be reported as
+ * duplicated/deduplicated/ambiguous, or paired positionally against entities
+ * from the *other* sub-buckets — which is the point of not resolving it here.
+ */
+export function refineByGeometryHash<TRef>(
+  bases: readonly Candidate<TRef>[],
+  heads: readonly Candidate<TRef>[],
+): GeometryRefinement<TRef> {
+  const subBuckets = new Map<string, { bases: Candidate<TRef>[]; heads: Candidate<TRef>[] }>();
+  const residueBase: Candidate<TRef>[] = [];
+  const residueHead: Candidate<TRef>[] = [];
+
+  const bucketFor = (hash: string) => {
+    const existing = subBuckets.get(hash);
+    if (existing) return existing;
+    const created = { bases: [] as Candidate<TRef>[], heads: [] as Candidate<TRef>[] };
+    subBuckets.set(hash, created);
+    return created;
+  };
+
+  for (const candidate of bases) {
+    const hash = candidate.fingerprint.geometryHash;
+    if (hash === undefined) residueBase.push(candidate);
+    else bucketFor(String(hash)).bases.push(candidate);
+  }
+  for (const candidate of heads) {
+    const hash = candidate.fingerprint.geometryHash;
+    if (hash === undefined) residueHead.push(candidate);
+    else bucketFor(String(hash)).heads.push(candidate);
+  }
+
+  const resolved: GeometryRefinement<TRef>['resolved'] = [];
+  for (const group of subBuckets.values()) {
+    const pairable =
+      group.bases.length > 0 &&
+      group.bases.length === group.heads.length &&
+      // The guard stays on every destructive path, tier 1 included: it cannot
+      // reject a genuine match and it is cheap.
+      componentsAgree(fingerprintsOf(group.bases, group.heads));
+    if (pairable) {
+      resolved.push(group);
+      continue;
+    }
+    residueBase.push(...group.bases);
+    residueHead.push(...group.heads);
+  }
+
+  return { resolved, residueBase, residueHead };
+}
+
+/** Centres for a group, or `null` when any member lacks a usable box. */
+function centresOf<TRef>(group: readonly Candidate<TRef>[]): Vec3[] | null {
+  const centres: Vec3[] = [];
+  for (const candidate of group) {
+    const aabb = candidate.fingerprint.aabb;
+    if (!isUsableAabb(aabb)) return null;
+    centres.push(aabbCentre(aabb));
+  }
+  return centres;
+}
+
+/**
+ * TIER 3 — pair an N:M leftover group by position.
+ *
+ * Returns the accepted pairs and whatever stayed unpaired. Degrades to "no
+ * pairs, everything left over" — today's `ambiguous` — when geometry is out of
+ * scope, when any candidate lacks a bounding box, or when the group is larger
+ * than {@link MAX_POSITION_MATCH_GROUP}.
+ */
+export function pairByPosition<TRef>(
+  bases: readonly Candidate<TRef>[],
+  heads: readonly Candidate<TRef>[],
+  useGeometry: boolean,
+  tolerances: GeometryTolerances,
+): { pairs: [Candidate<TRef>, Candidate<TRef>][]; leftoverBase: Candidate<TRef>[]; leftoverHead: Candidate<TRef>[] } {
+  const nothing = { pairs: [], leftoverBase: [...bases], leftoverHead: [...heads] };
+  if (!useGeometry) return nothing;
+  if (bases.length > MAX_POSITION_MATCH_GROUP || heads.length > MAX_POSITION_MATCH_GROUP) {
+    return nothing;
+  }
+  const baseCentres = centresOf(bases);
+  const headCentres = centresOf(heads);
+  if (!baseCentres || !headCentres) return nothing;
+
+  const pairs: [Candidate<TRef>, Candidate<TRef>][] = [];
+  const pairedBase = new Set<number>();
+  const pairedHead = new Set<number>();
+  // Same guard as every other destructive path, handed to the pairing itself
+  // rather than applied to its output: the fixpoint computes each round as if
+  // every pair it already accepted were gone, so a pair discarded afterwards
+  // would leave the following rounds pairing against a pool that never
+  // existed. As a veto, a rejected pair keeps both candidates available for
+  // the rounds that follow.
+  const accept = (baseIndex: number, headIndex: number): boolean =>
+    componentsAgree([bases[baseIndex].fingerprint, heads[headIndex].fingerprint]);
+  for (const pair of mutualNearestPairs(
+    baseCentres,
+    headCentres,
+    tolerances.maxMoveDistance,
+    accept,
+  )) {
+    pairedBase.add(pair.base);
+    pairedHead.add(pair.head);
+    pairs.push([bases[pair.base], heads[pair.head]]);
+  }
+
+  return {
+    pairs,
+    leftoverBase: bases.filter((_, index) => !pairedBase.has(index)),
+    leftoverHead: heads.filter((_, index) => !pairedHead.has(index)),
+  };
+}
+

--- a/packages/diff/src/diff.test.ts
+++ b/packages/diff/src/diff.test.ts
@@ -102,16 +102,132 @@ describe('diffModels — type & geometry edge cases', () => {
   });
 
   it('geometry appearing or disappearing counts as a change', () => {
+    // `anchor` carries a hash in BOTH revisions, so both sides demonstrably do
+    // geometry hashing and the capability abstention (see the suite below)
+    // stays out of the way. `e` gaining or losing geometry is then a real
+    // change, and must still read as one.
+    const anchor = fp('anchor', { geometryHash: 9n });
     expect(
-      diffModels([fp('e')], [fp('e', { geometryHash: 1n })], { scope: 'geometry' }).byKey.get('e')?.state,
+      diffModels([anchor, fp('e')], [anchor, fp('e', { geometryHash: 1n })], {
+        scope: 'geometry',
+      }).byKey.get('e')?.state,
     ).toBe('modified');
     expect(
-      diffModels([fp('e', { geometryHash: 1n })], [fp('e')], { scope: 'geometry' }).byKey.get('e')?.state,
+      diffModels([anchor, fp('e', { geometryHash: 1n })], [anchor, fp('e')], {
+        scope: 'geometry',
+      }).byKey.get('e')?.state,
     ).toBe('modified');
     // Both sides geometry-less → unchanged.
     expect(
       diffModels([fp('e')], [fp('e')], { scope: 'geometry' }).byKey.get('e')?.state,
     ).toBe('unchanged');
+  });
+});
+
+describe('diffModels — mixed-capability revisions (key-based pass)', () => {
+  // Raised MAJOR by a CodeRabbit CLI review of #1989: the content-keyed pass
+  // gained a capability abstention while the key-based pass kept calling
+  // `geometryEqual` unconditionally. `geometryEqual` reads a one-sided
+  // `undefined` as "the geometry differs", so a revision fingerprinted with
+  // geometry hashing ON compared against one fingerprinted with it OFF
+  // reported EVERY key-matched entity as `modified` / `['geometry']` — two
+  // possibly identical revisions read as a wholly changed model.
+
+  it('reports no geometry change when only the base side carries hashes', () => {
+    const base = [
+      fp('a', { geometryHash: 1n }),
+      fp('b', { geometryHash: 2n }),
+      fp('c', { geometryHash: 3n }),
+    ];
+    const head = [fp('a'), fp('b'), fp('c')];
+
+    const diff = diffModels(base, head);
+
+    expect(diff.counts).toEqual({ added: 0, modified: 0, deleted: 0, unchanged: 3 });
+    for (const entry of diff.entries) expect(entry.changeKinds).toEqual([]);
+  });
+
+  it('reports no geometry change when only the head side carries hashes', () => {
+    const base = [fp('a'), fp('b')];
+    const head = [fp('a', { geometryHash: 1n }), fp('b', { geometryHash: 2n })];
+
+    const diff = diffModels(base, head);
+
+    expect(diff.counts).toEqual({ added: 0, modified: 0, deleted: 0, unchanged: 2 });
+  });
+
+  it('still reports the data half of a mixed-capability comparison', () => {
+    // Abstaining on geometry must not blind the data channel.
+    const base = [fp('a', { geometryHash: 1n }), fp('b', { geometryHash: 2n })];
+    const head = [fp('a', { dataHash: 'd1' }), fp('b')];
+
+    const diff = diffModels(base, head);
+
+    expect(diff.byKey.get('a')?.state).toBe('modified');
+    expect(diff.byKey.get('a')?.changeKinds).toEqual(['data']);
+    expect(diff.byKey.get('b')?.state).toBe('unchanged');
+  });
+
+  it('abstains under scope geometry too, rather than reporting a phantom model-wide change', () => {
+    const base = [fp('a', { geometryHash: 1n }), fp('b', { geometryHash: 2n })];
+    const head = [fp('a'), fp('b')];
+
+    const diff = diffModels(base, head, { scope: 'geometry' });
+
+    expect(diff.counts.modified).toBe(0);
+  });
+
+  it('does not abstain when both sides carry hashes and one entity lost its geometry', () => {
+    // The mirror of the abstention: a single entity losing geometry while its
+    // side still does hashing is a real change, not a capability difference.
+    const base = [fp('a', { geometryHash: 1n }), fp('b', { geometryHash: 2n })];
+    const head = [fp('a', { geometryHash: 1n }), fp('b')];
+
+    const diff = diffModels(base, head);
+
+    expect(diff.byKey.get('a')?.state).toBe('unchanged');
+    expect(diff.byKey.get('b')?.state).toBe('modified');
+    expect(diff.byKey.get('b')?.changeKinds).toEqual(['geometry']);
+  });
+
+  it('reads capability from participating entities only, so excludeTypes can trigger it', () => {
+    // The only base entity carrying a hash is an excluded class, so it does not
+    // participate: the base side effectively carries no geometry hashes and the
+    // abstention must fire. Scanning the raw input instead would miss this and
+    // report the surviving wall as `modified`/`['geometry']`.
+    //
+    // `void` is present in the BASE only, deliberately: with a counterpart in
+    // head the pair would also be dropped by the counterpart check below, and
+    // this test would not isolate the entity's own exclusion (a mutation
+    // dropping that check survived until the fixture was narrowed this way).
+    const base = [
+      fp('void', { ifcType: 'IfcOpeningElement', geometryHash: 7n }),
+      fp('w', { ifcType: 'IfcWall' }),
+    ];
+    const head = [fp('w', { ifcType: 'IfcWall', geometryHash: 8n })];
+
+    const diff = diffModels(base, head, { excludeTypes: ['IfcOpeningElement'] });
+
+    expect(diff.byKey.has('void')).toBe(false);
+    expect(diff.byKey.get('w')?.state).toBe('unchanged');
+  });
+
+  it('does not let an excluded counterpart hide a participating hash', () => {
+    // `w` is excluded in HEAD only, so the pair drops from the comparison in
+    // both revisions — its base hash must not count as base capability either.
+    const base = [
+      fp('w', { ifcType: 'IfcWall', geometryHash: 5n }),
+      fp('s', { ifcType: 'IfcSlab' }),
+    ];
+    const head = [
+      fp('w', { ifcType: 'IfcWallStandardCase' }),
+      fp('s', { ifcType: 'IfcSlab', geometryHash: 6n }),
+    ];
+
+    const diff = diffModels(base, head, { excludeTypes: ['IfcWallStandardCase'] });
+
+    expect(diff.byKey.has('w')).toBe(false);
+    expect(diff.byKey.get('s')?.state).toBe('unchanged');
   });
 });
 

--- a/packages/diff/src/diff.ts
+++ b/packages/diff/src/diff.ts
@@ -2,34 +2,17 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+import { applyContentMatching } from './content-match.js';
+import { geometryEqual, resolveTolerances, resolveUseGeometry } from './geometry-compare.js';
 import type {
-  ContentMatch,
-  ContentMatchKind,
   DiffChangeKind,
   DiffCounts,
   DiffEntry,
   DiffScope,
   EntityFingerprint,
-  GeometryHash,
   ModelDiff,
   DiffOptions,
 } from './types.js';
-
-/**
- * Compare two geometry fingerprints.
- *
- * - both `undefined`  → equal (neither side has geometry)
- * - one `undefined`   → changed (geometry added or removed)
- * - both present      → equal iff the normalized hashes match
- *
- * `bigint` and `string` hashes are normalized to strings so a `bigint` from
- * the WASM `BigUint64Array` compares equal to its string form.
- */
-function geometryEqual(a: GeometryHash | undefined, b: GeometryHash | undefined): boolean {
-  if (a === undefined && b === undefined) return true;
-  if (a === undefined || b === undefined) return false;
-  return String(a) === String(b);
-}
 
 /** Canonical form for exclude-set membership: trimmed + upper-cased so a
  *  hand-typed `ifcopeningelement ` still matches the store's `IfcOpeningElement`. */
@@ -68,6 +51,34 @@ function changedComponentKeys(
   return changed.sort();
 }
 
+/**
+ * Does `side` carry *any* geometry hash among the entities that actually
+ * participate in the comparison? Feeds {@link resolveUseGeometry}.
+ *
+ * `excludeTypes` drops an entity from the diff entirely — in either revision —
+ * so an excluded entity's hash is no evidence that its side "has geometry":
+ * excluding the only class that happened to carry hashes leaves that side with
+ * none, and the abstention must see that. The participation rule is exactly the
+ * one the classification walk below applies.
+ *
+ * Early-exits on the first hit and allocates nothing; a side that really does
+ * carry hashes usually stops on its first entity.
+ */
+function sideHasGeometryHash<TRef>(
+  side: Map<string, EntityFingerprint<TRef>>,
+  otherSide: Map<string, EntityFingerprint<TRef>>,
+  isExcluded: (entity: EntityFingerprint<TRef>) => boolean,
+): boolean {
+  for (const [key, entity] of side) {
+    if (entity.geometryHash === undefined) continue;
+    if (isExcluded(entity)) continue;
+    const counterpart = otherSide.get(key);
+    if (counterpart !== undefined && isExcluded(counterpart)) continue;
+    return true;
+  }
+  return false;
+}
+
 function indexByKey<TRef>(
   entities: Iterable<EntityFingerprint<TRef>>,
 ): Map<string, EntityFingerprint<TRef>> {
@@ -82,186 +93,6 @@ function indexByKey<TRef>(
 }
 
 /**
- * Bucket key for the content pass.
- *
- * {@link EntityFingerprint.dataHash} alone is a 64-bit FNV-1a hex string
- * (`stableHash`, widened from 32 bits in issue #1962). It is a drift-catching
- * hash, not a cryptographic one, and the exposure grows with the square of the
- * number of distinct fingerprints compared — a from-scratch re-export leaves
- * the whole model unpaired. Pairing on `dataHash` alone would retire a real
- * `added` and a real `deleted` entry in favour of a fabricated
- * `renamed`/`moved`.
- *
- * Folding `ifcType` in as plaintext costs nothing and cannot reject a real
- * match: `buildDataFingerprint` already hashes `ifcType` as part of its
- * payload, so equal content implies equal `ifcType`. A disagreement therefore
- * *proves* the shared `dataHash` was a collision.
- */
-function contentBucketKey<TRef>(entity: EntityFingerprint<TRef>): string {
-  // NUL separator: `ifcType` is an IFC class name and never contains one, so
-  // no ifcType/dataHash pair can be confused with another.
-  return `${entity.ifcType}\u0000${entity.dataHash}`;
-}
-
-/**
- * Whether the two sides' component sub-hashes agree.
- *
- * Like the `ifcType` check in {@link contentBucketKey}, this cannot reject a
- * real match — {@link EntityFingerprint.components} hashes slices of the same
- * content `dataHash` hashes whole — so a disagreement proves a collision.
- *
- * It does *not* make the pass collision-proof, and the asymmetry is worth
- * knowing: FNV-1a's per-character update is a bijection on its state at any
- * width, so two entities differing only inside `attr:core` (a different
- * `Name`, all else equal) hash their whole payloads as `prefix + name +
- * identical suffix` — a `dataHash` collision there *implies* an `attr:core`
- * collision, and this check abstains. It bites when the differing content
- * lands in a pset/qset slice, whose sub-hash is computed over an unrelated
- * string. Widening `stableHash` to 64 bits (issue #1962) made the premise far
- * less likely without removing the implication.
- *
- * One side missing them is not evidence either way (components are opt-in, and
- * a caller may supply them for one revision only), so this mirrors the
- * `changedComponents` guard in the key-based pass and abstains.
- */
-function componentsAgree(
-  base: Record<string, string> | undefined,
-  head: Record<string, string> | undefined,
-): boolean {
-  if (!base || !head) return true;
-  const baseKeys = Object.keys(base);
-  if (baseKeys.length !== Object.keys(head).length) return false;
-  for (const key of baseKeys) {
-    if (base[key] !== head[key]) return false;
-  }
-  return true;
-}
-
-function pushTo<TRef>(map: Map<string, DiffEntry<TRef>[]>, key: string, entry: DiffEntry<TRef>): void {
-  const list = map.get(key);
-  if (list) {
-    list.push(entry);
-  } else {
-    map.set(key, [entry]);
-  }
-}
-
-/**
- * Second matching pass for issue #1891: content-keyed matching of the
- * entities the key-based pass classified as `added`/`deleted`.
- *
- * Buckets leftover `added`/`deleted` entries by {@link contentBucketKey}
- * (`ifcType` + {@link EntityFingerprint.dataHash}).
- *
- * - A bucket with exactly one entity on each side is an unambiguous content
- *   match: `renamed` (geometry hash also agrees, or geometry is out of scope)
- *   or `moved` (it doesn't). The `added`/`deleted` pair is removed from
- *   `entries`/`counts` in favor of a single {@link ContentMatch} — but only
- *   once {@link componentsAgree} has ruled out a `dataHash` collision, since
- *   this is the one destructive path in the pass.
- * - A bucket with more than one entity on either side is ambiguous — no
- *   principled 1:1 pairing exists (see #1923 for what silently guessing looks
- *   like) — so it is left untouched in `entries` and reported *only* as a
- *   {@link ContentMatch} group for the caller to resolve. Nothing is retired
- *   there, so a collision that lands in such a bucket costs the caller an
- *   extra candidate to look at rather than a lost entry.
- *
- * `considerGeometry` is the caller's {@link DiffScope} choice: under
- * `scope: 'data'` geometry is excluded from the comparison, so a
- * geometry-derived `moved` would report a difference the caller explicitly
- * opted out of seeing, and every 1:1 match is reported as `renamed`.
- *
- * `DiffState`/`DiffEntry` are never widened by this pass: it only removes
- * entries or leaves them alone, so downstream code that exhaustively
- * switches over `DiffState` needs no changes.
- *
- * Pure: never mutates its inputs.
- */
-function applyContentMatching<TRef>(
-  entries: DiffEntry<TRef>[],
-  counts: DiffCounts,
-  considerGeometry: boolean,
-): { entries: DiffEntry<TRef>[]; counts: DiffCounts; contentMatches: ContentMatch<TRef>[] } {
-  const addedByHash = new Map<string, DiffEntry<TRef>[]>();
-  const deletedByHash = new Map<string, DiffEntry<TRef>[]>();
-
-  for (const entry of entries) {
-    if (entry.state === 'added' && entry.head) {
-      pushTo(addedByHash, contentBucketKey(entry.head), entry);
-    } else if (entry.state === 'deleted' && entry.base) {
-      pushTo(deletedByHash, contentBucketKey(entry.base), entry);
-    }
-  }
-
-  const toRemove = new Set<DiffEntry<TRef>>();
-  const contentMatches: ContentMatch<TRef>[] = [];
-  let removedAdded = 0;
-  let removedDeleted = 0;
-
-  for (const [bucketKey, headGroup] of addedByHash) {
-    const baseGroup = deletedByHash.get(bucketKey);
-    if (!baseGroup || baseGroup.length === 0) continue;
-
-    // Every entry in these buckets carries the fingerprint its state implies
-    // (added ⇒ `head`, deleted ⇒ `base`), so this reads the bucket's shared
-    // `dataHash` off the first head entity rather than re-deriving it.
-    const dataHash = headGroup[0]?.head?.dataHash;
-    if (dataHash === undefined) continue;
-
-    if (baseGroup.length === 1 && headGroup.length === 1) {
-      const baseEntry = baseGroup[0];
-      const headEntry = headGroup[0];
-      const baseFp = baseEntry.base;
-      const headFp = headEntry.head;
-      // Guaranteed by the state check above (added always carries `head`,
-      // deleted always carries `base`); guard anyway rather than asserting.
-      if (!baseFp || !headFp) continue;
-
-      // Retiring the pair destroys a real `added` and a real `deleted` if the
-      // `dataHash` collided. Component sub-hashes, when the caller
-      // supplied them, catch part of that — see {@link componentsAgree} for
-      // which part, and which it provably cannot.
-      if (!componentsAgree(baseFp.components, headFp.components)) continue;
-
-      toRemove.add(baseEntry);
-      toRemove.add(headEntry);
-      removedAdded++;
-      removedDeleted++;
-
-      const kind: ContentMatchKind =
-        !considerGeometry || geometryEqual(baseFp.geometryHash, headFp.geometryHash)
-          ? 'renamed'
-          : 'moved';
-      contentMatches.push({ kind, dataHash, base: [baseFp], head: [headFp] });
-      continue;
-    }
-
-    // Ambiguous: more than one candidate on at least one side. Report the
-    // group; the original added/deleted entries stay as-is.
-    const kind: ContentMatchKind =
-      baseGroup.length === 1 ? 'duplicated' : headGroup.length === 1 ? 'deduplicated' : 'ambiguous';
-    const base: EntityFingerprint<TRef>[] = [];
-    for (const entry of baseGroup) if (entry.base) base.push(entry.base);
-    const head: EntityFingerprint<TRef>[] = [];
-    for (const entry of headGroup) if (entry.head) head.push(entry.head);
-    contentMatches.push({ kind, dataHash, base, head });
-  }
-
-  if (toRemove.size === 0) {
-    return { entries, counts, contentMatches };
-  }
-
-  const nextEntries = entries.filter((entry) => !toRemove.has(entry));
-  const nextCounts: DiffCounts = {
-    ...counts,
-    added: counts.added - removedAdded,
-    deleted: counts.deleted - removedDeleted,
-  };
-
-  return { entries: nextEntries, counts: nextCounts, contentMatches };
-}
-
-/**
  * Diff two model revisions, classifying every entity (matched by
  * {@link EntityFingerprint.key}, typically the IFC `GlobalId`) as
  * added / modified / deleted / unchanged.
@@ -269,7 +100,9 @@ function applyContentMatching<TRef>(
  * Pure and store-agnostic: the caller supplies fingerprints (data hash from
  * `buildDataFingerprint`, geometry hash from the WASM mesh pass). The `scope`
  * option selects whether data differences, geometry differences, or both count
- * as a modification — the "compare data, geometry, or both" toggle.
+ * as a modification — the "compare data, geometry, or both" toggle. Geometry is
+ * additionally skipped when the two revisions disagree on whether they carry
+ * geometry hashes at all (see {@link resolveUseGeometry}).
  */
 export function diffModels<TRef = unknown>(
   base: Iterable<EntityFingerprint<TRef>>,
@@ -291,6 +124,17 @@ export function diffModels<TRef = unknown>(
 
   const baseByKey = indexByKey(base);
   const headByKey = indexByKey(head);
+
+  // Resolve the geometry abstention BEFORE classifying anything: a revision
+  // fingerprinted with geometry hashing on, compared against one fingerprinted
+  // with it off, would otherwise report every key-matched entity as
+  // `modified` / `['geometry']` — the whole model "changed" on a difference
+  // between two fingerprinting runs. See `resolveUseGeometry`.
+  const useGeometry = resolveUseGeometry(
+    considerGeometry,
+    sideHasGeometryHash(baseByKey, headByKey, isExcluded),
+    sideHasGeometryHash(headByKey, baseByKey, isExcluded),
+  );
 
   const entries: DiffEntry<TRef>[] = [];
   const byKey = new Map<string, DiffEntry<TRef>>();
@@ -321,7 +165,7 @@ export function diffModels<TRef = unknown>(
     ) {
       changeKinds.push('data');
     }
-    if (considerGeometry && !geometryEqual(baseEntity.geometryHash, headEntity.geometryHash)) {
+    if (useGeometry && !geometryEqual(baseEntity.geometryHash, headEntity.geometryHash)) {
       changeKinds.push('geometry');
     }
 
@@ -350,7 +194,10 @@ export function diffModels<TRef = unknown>(
     return { scope, excludedTypes: excluded ? [...excluded].sort() : [], entries, byKey, counts };
   }
 
-  const matched = applyContentMatching(entries, counts, considerGeometry);
+  // The content pass inherits the same resolved answer rather than re-deriving
+  // one, so a mixed-capability comparison cannot abstain in one pass and not
+  // the other.
+  const matched = applyContentMatching(entries, counts, useGeometry, resolveTolerances(options));
   const matchedByKey = new Map<string, DiffEntry<TRef>>();
   for (const entry of matched.entries) matchedByKey.set(entry.key, entry);
 

--- a/packages/diff/src/geometry-compare.ts
+++ b/packages/diff/src/geometry-compare.ts
@@ -1,0 +1,192 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Geometry comparison primitives shared by the key-based pass (`diff.ts`) and
+ * the content-keyed matching pass (`content-match.ts`).
+ *
+ * Everything here is bounding-box or hash arithmetic on the caller's own
+ * numbers — no IFC knowledge, no store access.
+ */
+
+import type { EntityAabb, GeometryHash } from './types.js';
+
+/**
+ * A centre shift below this counts as tessellation / float noise, not a move.
+ *
+ * Deliberately the same value as `MOVE_EPS` in the viewer's
+ * `apps/viewer/src/lib/compare/describeChange.ts`: it encodes issue #1197,
+ * where a re-cut wall that never moved reported a phantom "moved 1.09 m". The
+ * engine and the UI must draw that line in the same place, so the shared
+ * origin is written down rather than left to coincidence.
+ */
+export const DEFAULT_MOVE_TOLERANCE = 2e-3;
+
+/**
+ * A per-axis bounding-box size change above this counts as a reshape.
+ * Same origin as {@link DEFAULT_MOVE_TOLERANCE}: `RESHAPE_EPS` in
+ * `describeChange.ts`.
+ */
+export const DEFAULT_RESHAPE_TOLERANCE = 1e-3;
+
+/**
+ * Maximum centre displacement at which two same-content entities may be paired
+ * by position. Metres for a metre-scale model: a building-scale relocation
+ * pairs, a cross-site teleport does not.
+ */
+export const DEFAULT_MAX_MOVE_DISTANCE = 10;
+
+/** Resolved {@link DEFAULT_MOVE_TOLERANCE} & friends for one diff run. */
+export interface GeometryTolerances {
+  moveTolerance: number;
+  reshapeTolerance: number;
+  maxMoveDistance: number;
+}
+
+/** Non-finite or negative input falls back to the default rather than poisoning
+ *  every comparison with `NaN` (an untyped JS caller can pass anything). */
+function positiveOr(value: number | undefined, fallback: number): number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 ? value : fallback;
+}
+
+export function resolveTolerances(options: {
+  moveTolerance?: number;
+  reshapeTolerance?: number;
+  maxMoveDistance?: number;
+}): GeometryTolerances {
+  return {
+    moveTolerance: positiveOr(options.moveTolerance, DEFAULT_MOVE_TOLERANCE),
+    reshapeTolerance: positiveOr(options.reshapeTolerance, DEFAULT_RESHAPE_TOLERANCE),
+    maxMoveDistance: positiveOr(options.maxMoveDistance, DEFAULT_MAX_MOVE_DISTANCE),
+  };
+}
+
+/**
+ * Compare two geometry fingerprints.
+ *
+ * - both `undefined`  → equal (neither side has geometry)
+ * - one `undefined`   → changed (geometry added or removed)
+ * - both present      → equal iff the normalized hashes match
+ *
+ * `bigint` and `string` hashes are normalized to strings so a `bigint` from
+ * the WASM `BigUint64Array` compares equal to its string form.
+ */
+export function geometryEqual(
+  a: GeometryHash | undefined,
+  b: GeometryHash | undefined,
+): boolean {
+  if (a === undefined && b === undefined) return true;
+  if (a === undefined || b === undefined) return false;
+  return String(a) === String(b);
+}
+
+/**
+ * ABSTENTION — may geometry be used to classify anything in this diff?
+ *
+ * One revision fingerprinted by a build with geometry hashing on and the other
+ * by a build with it off is a *capability* difference between two fingerprinting
+ * runs, not a model change. {@link geometryEqual} reads every one-sided
+ * `undefined` as "the geometry differs", so believing it would report the entire
+ * model as changed: `modified`/`['geometry']` in the key-based pass, `moved` in
+ * the content-keyed pass. When a whole side carries no geometry hashes at all
+ * while the other does, neither pass uses geometry to classify anything.
+ *
+ * Both passes route through here so they cannot drift apart — a mixed-capability
+ * pair of revisions must read the same way whichever pass sees the entity. (The
+ * viewer keeps a `hasGeometryHashes` helper for the same reason.)
+ *
+ * A side "has geometry" if *any* participating entity carries a hash, so this
+ * never fires on a model where only some entities are geometric: a single
+ * entity that lost its geometry is still a real change, and stays one.
+ */
+export function resolveUseGeometry(
+  considerGeometry: boolean,
+  baseHasGeometry: boolean,
+  headHasGeometry: boolean,
+): boolean {
+  return considerGeometry && baseHasGeometry === headHasGeometry;
+}
+
+/** A box is usable only if all six coordinates are real numbers; a box with a
+ *  `NaN` in it would silently answer "different size" to every question. */
+export function isUsableAabb(aabb: EntityAabb | undefined): aabb is EntityAabb {
+  if (!aabb) return false;
+  for (let axis = 0; axis < 3; axis++) {
+    if (!Number.isFinite(aabb.min[axis]) || !Number.isFinite(aabb.max[axis])) return false;
+  }
+  return true;
+}
+
+export type Vec3 = readonly [number, number, number];
+
+export function aabbCentre(aabb: EntityAabb): Vec3 {
+  return [
+    (aabb.min[0] + aabb.max[0]) / 2,
+    (aabb.min[1] + aabb.max[1]) / 2,
+    (aabb.min[2] + aabb.max[2]) / 2,
+  ];
+}
+
+export function centreDistance(a: Vec3, b: Vec3): number {
+  const dx = b[0] - a[0];
+  const dy = b[1] - a[1];
+  const dz = b[2] - a[2];
+  return Math.sqrt(dx * dx + dy * dy + dz * dz);
+}
+
+/** True when the two boxes have the same extent on every axis within `tolerance`. */
+export function sizeAgrees(a: EntityAabb, b: EntityAabb, tolerance: number): boolean {
+  for (let axis = 0; axis < 3; axis++) {
+    const sizeA = a.max[axis] - a.min[axis];
+    const sizeB = b.max[axis] - b.min[axis];
+    if (Math.abs(sizeA - sizeB) > tolerance) return false;
+  }
+  return true;
+}
+
+/** How a pair whose geometry hash differs is described. */
+export interface GeometryChange {
+  kind: 'moved' | 'reshaped';
+  /** Centre displacement, clamped to 0 below the move tolerance. Absent when
+   *  no bounding box was available on one of the sides. */
+  distance?: number;
+}
+
+/**
+ * Classify a geometry-hash difference between two entities that content
+ * matching has already decided are the same element.
+ *
+ * Without a bounding box on both sides there is nothing to reason with, so the
+ * answer is the pre-#1891-follow-up one: `moved`, no distance.
+ *
+ * With boxes:
+ * - different size on any axis → `reshaped` (a pure rigid move cannot change
+ *   the axis-aligned extent... except by rotating it, which is why the
+ *   distance still travels with the record for the caller to judge).
+ * - same size, centre beyond `moveTolerance` → `moved`.
+ * - same size and same centre, yet the hash differs → `reshaped` with distance
+ *   0. This is what a re-tessellation looks like, and it is also what a
+ *   reshape confined to the interior of the box looks like. An axis-aligned
+ *   bounding box genuinely cannot separate those two, so this does not claim
+ *   to: it reports the honest "the shape changed, it did not move".
+ */
+export function classifyGeometryChange(
+  baseAabb: EntityAabb | undefined,
+  headAabb: EntityAabb | undefined,
+  tolerances: GeometryTolerances,
+): GeometryChange {
+  if (!isUsableAabb(baseAabb) || !isUsableAabb(headAabb)) return { kind: 'moved' };
+
+  const rawDistance = centreDistance(aabbCentre(baseAabb), aabbCentre(headAabb));
+  // Clamp sub-tolerance jitter to exactly 0, the way `describeChange.ts` does
+  // for the key-matched path (issue #1197: "moved 1.09 m" on a wall that never
+  // moved). A caller comparing `distance > 0` must not see float noise.
+  const distance = rawDistance > tolerances.moveTolerance ? rawDistance : 0;
+
+  if (!sizeAgrees(baseAabb, headAabb, tolerances.reshapeTolerance)) {
+    return { kind: 'reshaped', distance };
+  }
+  if (distance > 0) return { kind: 'moved', distance };
+  return { kind: 'reshaped', distance: 0 };
+}

--- a/packages/diff/src/index.ts
+++ b/packages/diff/src/index.ts
@@ -30,6 +30,7 @@ export type {
 export type {
   ContentMatch,
   ContentMatchKind,
+  EntityAabb,
   DiffChangeKind,
   DiffCounts,
   DiffEntry,

--- a/packages/diff/src/mutual-nearest.ts
+++ b/packages/diff/src/mutual-nearest.ts
@@ -1,0 +1,147 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Iterated mutual-nearest-neighbour pairing between two sets of points.
+ *
+ * Used by the content-keyed matching pass for the leftover N:M candidates in a
+ * bucket: entities that already agree on `ifcType` and `dataHash`, so the only
+ * open question is which one became which.
+ *
+ * Two alternatives were rejected on purpose:
+ *
+ * - **Greedy nearest-centroid** is order-dependent — the answer changes with
+ *   the order the caller happened to enumerate entities in — and it commits to
+ *   a bad chain: one early pairing at the cap edge can displace every later
+ *   one.
+ * - **Hungarian / optimal assignment** minimises the *total* distance, which
+ *   is the wrong objective here. It pairs everything it is given, including
+ *   elements that genuinely appeared or disappeared, and it will accept a pair
+ *   sitting at the distance cap to buy a shorter pairing elsewhere. A global
+ *   optimum over the candidates is not evidence that two entities are the same
+ *   entity.
+ *
+ * Mutual nearest neighbour is deterministic, order-independent, and abstains
+ * by construction: a symmetric layout of identical elements that all moved has
+ * no unique nearest neighbour anywhere, and reporting that as ambiguous is the
+ * correct answer, not a failure.
+ */
+
+import { centreDistance, type Vec3 } from './geometry-compare.js';
+
+export interface NearestPair {
+  /** Index into the `base` array passed to {@link mutualNearestPairs}. */
+  base: number;
+  /** Index into the `head` array passed to {@link mutualNearestPairs}. */
+  head: number;
+  /** Centre distance between the two, unclamped. */
+  distance: number;
+}
+
+/**
+ * For every unretired point in `from`, the index of its *unique* nearest
+ * unretired point in `to`, or -1 when there is none or the nearest is tied.
+ *
+ * A tie is an abstention, not a coin flip: two candidates equidistant from the
+ * same element carry no information about which one it became.
+ */
+function uniqueNearest(
+  from: readonly Vec3[],
+  to: readonly Vec3[],
+  retiredFrom: ReadonlySet<number>,
+  retiredTo: ReadonlySet<number>,
+): Int32Array {
+  const nearest = new Int32Array(from.length).fill(-1);
+  for (let i = 0; i < from.length; i++) {
+    if (retiredFrom.has(i)) continue;
+    let bestIndex = -1;
+    let best = Infinity;
+    let second = Infinity;
+    for (let j = 0; j < to.length; j++) {
+      if (retiredTo.has(j)) continue;
+      const distance = centreDistance(from[i], to[j]);
+      if (distance < best) {
+        second = best;
+        best = distance;
+        bestIndex = j;
+      } else if (distance < second) {
+        second = distance;
+      }
+    }
+    // `best < second` strictly: an equidistant runner-up means the nearest
+    // neighbour is not unique, so this element abstains.
+    nearest[i] = bestIndex >= 0 && best < second ? bestIndex : -1;
+  }
+  return nearest;
+}
+
+/**
+ * Pair points from `base` and `head` by iterated mutual nearest neighbour
+ * under `maxDistance`.
+ *
+ * A pair `(b, h)` is accepted only when `h` is `b`'s unique nearest unretired
+ * head, `b` is `h`'s unique nearest unretired base, their distance is within
+ * `maxDistance`, and `accept(b, h)` agrees. Accepted pairs are retired and the
+ * search repeats until a round accepts nothing — retiring a confident pair can
+ * make its neighbours unambiguous, which is why this iterates instead of
+ * running once.
+ *
+ * `accept` is a *veto inside the pairing predicate*, not a filter over the
+ * result, and the difference is load-bearing. Every round computes its mutual
+ * nearest neighbours as if every previously accepted pair were gone, so a pair
+ * discarded afterwards would leave later rounds resting on a pool that never
+ * existed: a base whose true nearest head is the rejected one would be paired
+ * with its runner-up instead. Vetoing here keeps both points in the pool for
+ * every later round, so the rest of the group is paired against the real
+ * candidate set.
+ *
+ * Termination does not depend on `accept`: a round that accepts nothing ends
+ * the loop, and a round that accepts anything retires at least one point per
+ * side, so there are at most `min(base.length, head.length)` rounds. A vetoed
+ * pair is simply re-proposed and re-vetoed in the round that ends the loop —
+ * it cannot spin, and it cannot pair either point with anyone else, because
+ * being mutually nearest means neither has a closer partner and retirement
+ * only ever removes candidates.
+ *
+ * Pairs are returned in ascending `base` index order so the result does not
+ * depend on iteration order anywhere.
+ */
+export function mutualNearestPairs(
+  base: readonly Vec3[],
+  head: readonly Vec3[],
+  maxDistance: number,
+  accept: (baseIndex: number, headIndex: number) => boolean,
+): NearestPair[] {
+  const pairs: NearestPair[] = [];
+  const retiredBase = new Set<number>();
+  const retiredHead = new Set<number>();
+
+  while (retiredBase.size < base.length && retiredHead.size < head.length) {
+    const nearestHead = uniqueNearest(base, head, retiredBase, retiredHead);
+    const nearestBase = uniqueNearest(head, base, retiredHead, retiredBase);
+
+    // Mutual pairs within one round are necessarily disjoint (each head has at
+    // most one unique nearest base), so they can all be accepted together.
+    const round: NearestPair[] = [];
+    for (let b = 0; b < base.length; b++) {
+      if (retiredBase.has(b)) continue;
+      const h = nearestHead[b];
+      if (h < 0 || nearestBase[h] !== b) continue;
+      const distance = centreDistance(base[b], head[h]);
+      if (!(distance <= maxDistance)) continue;
+      if (!accept(b, h)) continue;
+      round.push({ base: b, head: h, distance });
+    }
+    if (round.length === 0) break;
+
+    for (const pair of round) {
+      retiredBase.add(pair.base);
+      retiredHead.add(pair.head);
+      pairs.push(pair);
+    }
+  }
+
+  pairs.sort((a, b) => a.base - b.base);
+  return pairs;
+}

--- a/packages/diff/src/types.ts
+++ b/packages/diff/src/types.ts
@@ -23,6 +23,14 @@ export type DiffChangeKind = 'data' | 'geometry';
  * - `both`     — either (default)
  *
  * This is the user-facing "compare data, geometry, or both" toggle.
+ *
+ * Selecting geometry is a request, not a guarantee: when one revision carries
+ * geometry hashes and the other carries none at all, geometry classifies
+ * nothing regardless of scope. Every entity's one-sided `undefined` would
+ * otherwise read as a difference and the whole model would report as changed on
+ * what is a difference between two fingerprinting runs. Under `'geometry'` that
+ * abstention leaves every matched entity `unchanged`; under `'both'` the data
+ * channel is unaffected.
  */
 export type DiffScope = 'data' | 'geometry' | 'both';
 
@@ -31,8 +39,40 @@ export type DiffScope = 'data' | 'geometry' | 'both';
  * (`MeshCollection.geometryHashValues` is a `BigUint64Array`); strings are
  * accepted for callers that fingerprint geometry another way. `undefined`
  * means the entity carries no geometry.
+ *
+ * **Both revisions must use the same representation.** Equality is `String(a)
+ * === String(b)`, so a `bigint` matches its own decimal string form (`42n` and
+ * `'42'`) but nothing else: `'0x2a'` is a *different* fingerprint from `42n`.
+ * The engine deliberately does not try to parse or canonicalize string forms,
+ * because a string hash is an opaque token from the caller's own scheme and
+ * reinterpreting one that happens to look numeric would collide it with an
+ * unrelated `bigint`.
+ *
+ * Content matching's first tier sub-buckets on `String(hash)`, which is where
+ * mixing representations costs the most: `42n` and `'42'` land in one
+ * sub-bucket and retire as `renamed`, while `42n` and `'0x2a'` land in two, so
+ * that tier resolves neither. They are not lost — they fall to the bucket's
+ * residue, where a 1:1 leftover still pairs and {@link ContentMatchKind}s as
+ * `moved`/`reshaped`, and a larger residue can end up an `ambiguous` group. So
+ * the cost of mixing is a missed `renamed` and a spurious geometry difference,
+ * not an unpairable entity.
  */
 export type GeometryHash = bigint | string;
+
+/**
+ * An axis-aligned bounding box in **world space**, in the caller's units.
+ *
+ * Same contract as {@link EntityFingerprint.geometryHash}: both revisions must
+ * be expressed in the *same* frame. The engine compares base and head boxes
+ * numerically and never re-projects them, so a base fingerprinted in a
+ * georeferenced frame and a head fingerprinted in a local one produce
+ * meaningless displacements rather than an error. Feed both sides from the
+ * same pipeline.
+ */
+export interface EntityAabb {
+  readonly min: readonly [number, number, number];
+  readonly max: readonly [number, number, number];
+}
 
 /**
  * One entity's identity + fingerprints within a single model, as supplied by
@@ -53,8 +93,25 @@ export interface EntityFingerprint<TRef = unknown> {
    * quantity sets + type assignments). Build with `buildDataFingerprint`.
    */
   dataHash: string;
-  /** Geometry fingerprint, or `undefined` when the entity has no geometry. */
+  /**
+   * Geometry fingerprint, or `undefined` when the entity has no geometry.
+   *
+   * A one-sided `undefined` on a matched entity is a geometry change (geometry
+   * added or removed) — *unless* one whole revision carries no geometry hashes
+   * at all while the other does, which is a capability difference between two
+   * fingerprinting runs rather than a model change. Geometry then classifies
+   * nothing, in both matching passes; see {@link DiffScope}.
+   */
   geometryHash?: GeometryHash;
+  /**
+   * Optional world-space bounding box, in the caller's units and frame (see
+   * {@link EntityAabb}). Used only by the content-keyed matching pass
+   * ({@link DiffOptions.matchUnpairedByContent}), where it separates a move
+   * from a reshape and lets a group of same-content entities be paired by
+   * position. Absent on either side, that pass falls back to reporting a
+   * geometry-hash difference as a bare `moved`.
+   */
+  aabb?: EntityAabb;
   /**
    * Opt-in per-componentKey sub-hashes (`attr:core`, `pset:<Name>`,
    * `qset:<Name>`, `type-assignment`). Build with
@@ -92,18 +149,43 @@ export interface DiffOptions {
    * nothing substantive changed.
    *
    * When `true`, after the normal key-based pass, entities that came out
-   * `added` or `deleted` are bucketed by {@link EntityFingerprint.dataHash}
-   * and re-examined:
+   * `added` or `deleted` are bucketed by ({@link EntityFingerprint.ifcType},
+   * {@link EntityFingerprint.dataHash}) and re-examined. Within one bucket the
+   * pass refines hierarchically — a real model is mostly *repeated*
+   * components, so a bucket routinely holds many same-content entities that
+   * differ only in where they sit:
    *
-   * - a bucket with exactly one leftover base entity and one leftover head
-   *   entity is an unambiguous content match: the two `added`/`deleted`
+   * - **by world geometry hash.** Entities carrying a
+   *   {@link EntityFingerprint.geometryHash} are sub-bucketed by it. A
+   *   sub-bucket with one entity per side, or with the same count `N > 1` on
+   *   both sides, is an unambiguous content match: the `added`/`deleted`
    *   entries are removed from {@link ModelDiff.entries} / `byKey` / `counts`
    *   (so they no longer read as a spurious add+delete) and reported instead
-   *   as a single `renamed`/`moved` {@link ContentMatch} in
-   *   {@link ModelDiff.contentMatches} — `renamed` if the geometry hash also
-   *   agrees (only the identity changed), `moved` if it differs. Under
-   *   {@link DiffScope} `'data'` geometry is out of the comparison, so every
-   *   1:1 match is reported as `renamed`.
+   *   as a single `renamed` {@link ContentMatch} in
+   *   {@link ModelDiff.contentMatches}. For `N > 1`, every bijection is
+   *   observationally identical in every field the engine can see, so the
+   *   match carries all `N` entities per side rather than a guessed pairing.
+   *   Geometry is not part of the *outer* bucket key: an entity that genuinely
+   *   moved must still meet its counterpart.
+   * - **1:1 leftover.** One base and one head left over in a bucket pair as
+   *   `renamed` (geometry agrees, or geometry is out of scope), `moved`, or
+   *   `reshaped` — see {@link ContentMatchKind} and {@link moveTolerance} /
+   *   {@link reshapeTolerance} for how an {@link EntityFingerprint.aabb}
+   *   separates the last two.
+   * - **N:M leftover.** With an `aabb` on every candidate, leftovers are
+   *   paired by *iterated mutual nearest neighbour* under
+   *   {@link maxMoveDistance}: a base and a head pair only when each is the
+   *   other's unique nearest, which abstains by construction on a symmetric
+   *   layout rather than guessing. Whatever is still unpaired stays a
+   *   reported group (below).
+   *
+   * Under {@link DiffScope} `'data'` geometry is out of the comparison
+   * entirely, so no geometry sub-bucketing happens and every 1:1 match is
+   * reported as `renamed`. The same applies under the capability abstention
+   * described on {@link DiffScope}, which this pass shares with the key-based
+   * one: when one revision carries geometry hashes and the other carries none
+   * at all, geometry classifies nothing and every 1:1 match is `renamed` rather
+   * than a model-wide sweep of `moved`.
    *
    *   Because this is the pass's only destructive path and `dataHash` is a
    *   64-bit FNV-1a value rather than a cryptographic digest, a pair is
@@ -136,6 +218,35 @@ export interface DiffOptions {
    * results.
    */
   matchUnpairedByContent?: boolean;
+  /**
+   * Bounding-box-centre displacement (in the caller's units) below which a
+   * content-matched pair counts as *not* moved. Default `2e-3`.
+   *
+   * Lifted deliberately from `MOVE_EPS` in the viewer's
+   * `apps/viewer/src/lib/compare/describeChange.ts`, which encodes issue
+   * #1197: a re-cut/re-tessellated wall that never moved reported a phantom
+   * "moved 1.09 m". Below this, {@link ContentMatch.distance} is reported as
+   * `0`, exactly as `describeChange` clamps it. Only used when both sides
+   * carry an {@link EntityFingerprint.aabb}.
+   */
+  moveTolerance?: number;
+  /**
+   * Per-axis bounding-box *size* change (caller's units) above which a
+   * content-matched pair counts as `reshaped` rather than `moved`. Default
+   * `1e-3` — the same `RESHAPE_EPS` the viewer's `describeChange.ts` uses, so
+   * the engine and the UI draw the move/reshape line in the same place. Only
+   * used when both sides carry an {@link EntityFingerprint.aabb}.
+   */
+  reshapeTolerance?: number;
+  /**
+   * Maximum bounding-box-centre displacement (caller's units, so metres for a
+   * metre-scale model) at which the mutual-nearest-neighbour pass will pair
+   * two same-content entities. Default `10`: a building-scale relocation
+   * pairs, a cross-site teleport stays `ambiguous` rather than being asserted
+   * to be the same element. Only used when both sides carry an
+   * {@link EntityFingerprint.aabb}.
+   */
+  maxMoveDistance?: number;
 }
 
 export interface DiffEntry<TRef = unknown> {
@@ -171,29 +282,55 @@ export interface DiffCounts {
  * How a {@link ContentMatch} relates its `base` and `head` members (issue
  * #1891, `DiffOptions.matchUnpairedByContent`):
  *
- * - `renamed`      — exactly one base and one head entity share a data hash
- *   AND a geometry hash: same content, different key (re-GUID/rename).
- * - `moved`        — exactly one base and one head entity share a data hash
- *   but NOT a geometry hash: same content, different key, and it moved.
+ * - `renamed`      — the base and head members share a data hash AND a world
+ *   geometry hash: same content, same place, different key (re-GUID/rename).
+ *   Usually one entity per side; a group of `N` per side is reported as one
+ *   `renamed` match when both sides agree on both hashes `N` times over,
+ *   because every bijection between them is then indistinguishable.
+ * - `moved`        — one base and one head entity share a data hash but not a
+ *   geometry hash, and their bounding boxes are the same size in every axis
+ *   while their centres are further apart than `DiffOptions.moveTolerance`.
+ *   Without an {@link EntityFingerprint.aabb} on both sides this is also what
+ *   a bare geometry-hash difference reports, since nothing can tell a move
+ *   from a reshape.
+ * - `reshaped`     — one base and one head entity share a data hash but not a
+ *   geometry hash, and their bounding boxes differ in size beyond
+ *   `DiffOptions.reshapeTolerance` — or agree entirely, which is what a
+ *   re-tessellation looks like. A bounding box genuinely cannot separate a
+ *   re-tessellation from a reshape confined to the interior, and this kind
+ *   does not pretend otherwise.
  * - `duplicated`   — one base entity's content matches several head entities
  *   (it looks like it was copied).
  * - `deduplicated` — several base entities' content matches one head entity
  *   (they look like they were merged into one).
- * - `ambiguous`    — more than one entity on *both* sides shares the content
- *   hash; there is no principled way to tell duplication from deduplication,
- *   let alone which specific base entity corresponds to which head entity.
+ * - `ambiguous`    — several candidates remain on both sides with no
+ *   principled pairing: the engine could not tell duplication from
+ *   deduplication, or positions were symmetric enough that no base was any
+ *   head's unique nearest neighbour, or the only candidates were further apart
+ *   than `DiffOptions.maxMoveDistance`.
  */
-export type ContentMatchKind = 'renamed' | 'moved' | 'duplicated' | 'deduplicated' | 'ambiguous';
+export type ContentMatchKind =
+  | 'renamed'
+  | 'moved'
+  | 'reshaped'
+  | 'duplicated'
+  | 'deduplicated'
+  | 'ambiguous';
 
 /**
  * A content-hash-based match (or ambiguous match group) among entities the
- * key-based pass classified as `added`/`deleted` (issue #1891). For `renamed`
- * and `moved`, `base`/`head` each hold exactly one entity, and the
- * corresponding `added`/`deleted` {@link DiffEntry} pair is removed from
- * {@link ModelDiff.entries} in favor of this record. For `duplicated`,
- * `deduplicated`, and `ambiguous`, `base`/`head` hold every entity in the
- * bucket, and those entities' `added`/`deleted` entries are left in
- * {@link ModelDiff.entries} untouched — the engine reports the grouping
+ * key-based pass classified as `added`/`deleted` (issue #1891).
+ *
+ * `renamed`, `moved`, and `reshaped` are *retiring* kinds: the corresponding
+ * `added`/`deleted` {@link DiffEntry} pairs are removed from
+ * {@link ModelDiff.entries} in favour of this record. `moved` and `reshaped`
+ * always hold exactly one entity per side; `renamed` holds one per side except
+ * for the same-data-and-geometry group described in {@link ContentMatchKind},
+ * where it holds `N` per side.
+ *
+ * For `duplicated`, `deduplicated`, and `ambiguous`, `base`/`head` hold every
+ * unresolved candidate, and those entities' `added`/`deleted` entries are left
+ * in {@link ModelDiff.entries} untouched — the engine reports the grouping
  * instead of guessing a 1:1 pairing (see #1923).
  */
 export interface ContentMatch<TRef = unknown> {
@@ -204,6 +341,16 @@ export interface ContentMatch<TRef = unknown> {
   base: EntityFingerprint<TRef>[];
   /** Head-revision entities in this match/group. */
   head: EntityFingerprint<TRef>[];
+  /**
+   * Bounding-box-centre displacement base→head, in the caller's units.
+   *
+   * Present only on `moved`/`reshaped` matches whose two entities both carried
+   * an {@link EntityFingerprint.aabb}. Reported as `0` below
+   * {@link DiffOptions.moveTolerance}, mirroring the viewer's
+   * `describeChange.ts` clamp (issue #1197): sub-tolerance jitter is
+   * tessellation noise, not a move.
+   */
+  distance?: number;
 }
 
 export interface ModelDiff<TRef = unknown> {

--- a/scripts/api-surface.json
+++ b/scripts/api-surface.json
@@ -1025,6 +1025,7 @@
     "DiffOptions: interface",
     "DiffScope: type",
     "DiffState: type",
+    "EntityAabb: interface",
     "EntityFingerprint: interface",
     "GeometryHash: type",
     "ModelDiff: interface",


### PR DESCRIPTION
> **Stacked on #1987** (`feat/1962-widen-stablehash`). Review that one first; this branch contains its commit. Base moves to `main` once #1987 lands.

## The defect, verified

#1961 shipped content-keyed matching, but `contentBucketKey` is `ifcType + NUL + dataHash` — geometry is consulted *after* pairing and never used to separate candidates. So:

**Three data-identical doors at three different unmoved positions, all re-GUIDed, reported one `ambiguous` group and paired nothing** (`counts.added` stayed 3, `deleted` 3). One door on its own paired fine. Since a real model is mostly repeated components, the feature paired only the unique minority — the headline behaviour, not an edge case.

## The fix: refine inside the bucket, do not change the bucket key

Putting `geometryHash` into the outer key would **regress** the case that works today: a unique element that genuinely moved would land in a different bucket from its own base and never meet it, reverting every real move to add+delete noise. So the outer key is unchanged (it is also the load-bearing collision defence) and the tiers are local to each bucket:

- **Tier 1** — sub-bucket by geometry hash. `undefined` hashes go to the residue (undefined matching undefined is vacuous, not evidence). Equal non-zero counts on both sides retire as one `renamed` match. This alone fixes the three doors.
- **Tier 2** — 1:1 residue. `reshaped` if per-axis AABB size differs, `moved` if size agrees and the centre moved, `reshaped` at distance 0 if both agree but the hash differs (the re-tessellation case; the AABB genuinely cannot separate that from an interior reshape, and the comment says so). No AABB → today's bare `moved`.
- **Tier 3** — N:M residue via **iterated mutual-nearest-neighbour** under a distance cap. Not greedy (order-dependent, commits to bad chains) and not Hungarian (minimising *total* distance forces pairings at the cap edge; a global optimum is not evidence of identity). Mutual-NN is deterministic, order-independent, and **abstains on ties** — a symmetric layout of identical doors that all moved genuinely is ambiguous.

`componentsAgree` guards every retiring path. Tolerances default to `moveTolerance` 2e-3 / `reshapeTolerance` 1e-3, lifted deliberately from `describeChange.ts`'s `MOVE_EPS`/`RESHAPE_EPS` so the #1197 lesson (a phantom "moved 1.09 m" on a wall that never moved) is shared rather than re-learned; `maxMoveDistance` 10 m.

## A pre-existing bug fixed here

`geometryEqual` treats one-side-`undefined` as "geometry differs", so a capability mismatch (one revision fingerprinted with hashing on, the other off) fabricated `moved` for an entire model. There is now an explicit per-side abstention: if one side carries no geometry hashes at all, geometry classifies nothing. The same exposure exists on the **key-based** pass, but fixing it there would change `DiffState`/`DiffCounts` for every existing caller — out of scope here, worth its own issue.

## Three judgement calls for your review

1. **Uneven (N≠M) tier-1 sub-buckets fall to the residue** rather than reporting per-sub-bucket. Reporting them would be worse: base `{g1,g1}` / head `{g1,g2}` (one door stayed, one moved) would read "deduplicated", whereas the residue lets tier 3 pair them correctly.
2. **A tier-3 leftover of exactly 1+1 reports `ambiguous`, not `duplicated`** — it only exists because the cap or a tie refused it, and "we could not tell" is `ambiguous`.
3. **`renamed` no longer implies `base.length === 1`**, because of the N:N group case. Nothing consumes `contentMatches` yet, so no consumer breaks, but it is a real contract change and is called out in the changeset and docs.

`DiffState` and `DiffEntry` remain byte-identical, so the exhaustive `Record<DiffState, number>` in the viewer's `exportReport.ts` still compiles untouched.

## Module split

`diff.ts` 365 → 173. New: `content-match.ts` (233), `content-tiers.ts` (249), `geometry-compare.ts` (165), `mutual-nearest.ts` (127). All under the ~400 house limit.

## Verification

88 tests pass (was 58) · `pnpm typecheck` 33/33 · `docs:check-samples` 252 snippets clean · `check:api-surface` matches after `api-surface:update` (one additive line, `EntityAabb`) · `check-test-wiring` clean.

**One pre-existing test legitimately changed meaning** and is not quietly edited: the #1923 many-to-many group test used a 2:2 group sharing both `dataHash` *and* `geometryHash`, which is now exactly the N:N retire case. Its #1923 intent is preserved by removing the geometry hashes (2:2 with no geometry evidence still abstains and retires nothing); the N:N retirement is added as a separate, explicitly argued test.

18 mutations run. One of them came back green and turned out to be an incomplete mutation on my side rather than a missing test; re-run correctly, it reds two tests. All 18 confirmed, source restored.

Addresses the core of #1891 (@bruadam).
