### PR TITLE
fix(changeset): version the packages that re-expose the breaking IfcCreator (#1986)

### DIFF
--- a/.changeset/uniform-storey-placement.md
+++ b/.changeset/uniform-storey-placement.md
@@ -52,7 +52,7 @@ Thirteen constructors that carried no `llmSemantics` at all — `addIfcRamp`, `a
 
 ## Downstream packages carrying the break
 
-The behaviour change is not confined to `@ifc-lite/create`: three packages re-expose `IfcCreator` and therefore ship it to their own consumers. Each is versioned to say so, rather than letting a caller pick the change up through a range they believed was compatible.
+The behaviour change is not confined to `@ifc-lite/create`: four packages re-expose `IfcCreator` and therefore ship it to their own consumers. Each is versioned to say so, rather than letting a caller pick the change up through a range they believed was compatible.
 
 - **`@ifc-lite/sdk` (major)** — re-exports the class directly (`packages/sdk/src/index.ts`: `export { IfcCreator } from '@ifc-lite/create'`). Without a major, a consumer on `^1.21` accepts the release and gets storey-relative placement with no signal.
 - **`@ifc-lite/sandbox` (major, was minor)** — `buildCreateMethods()` auto-discovers `IfcCreator.prototype` and dispatches to it, so every affected constructor is reachable from sandbox scripts. A script passing absolute coordinates against a non-zero-elevation storey now emits geometry one elevation off. That is breaking for the script author even though the sandbox's own surface is unchanged.

--- a/.changeset/uniform-storey-placement.md
+++ b/.changeset/uniform-storey-placement.md
@@ -1,6 +1,8 @@
 ---
 '@ifc-lite/create': major
-'@ifc-lite/sandbox': minor
+'@ifc-lite/sdk': major
+'@ifc-lite/sandbox': major
+'@ifc-lite/cli': minor
 ---
 
 **BREAKING:** every `IfcCreator` element constructor now places its product relative to the storey it is added to. Element coordinates are storey-relative across the whole API.
@@ -46,3 +48,13 @@ Also in this release: `getStoreyPlacement` throws `Unknown storeyId #N` instead 
 The `llmSemantics.placement` metadata in `NAMESPACE_SCHEMAS` is corrected to match: the seven methods previously tagged `'world'` (`addIfcMember`, `addIfcPlate`, `addIfcCurtainWall`, `addIfcRailing`, `addIfcDoor`, `addIfcWindow`, `addAxisElement`) are now `'storey-relative'`, and the `useWhen`/`cautions` prose that described them as world-placement is rewritten. The `MethodPlacementKind` union is unchanged and no export was added or removed. Consumers that read `placement` to generate guidance will see different values for those seven methods — which is the point: the old values now describe behaviour that no longer exists.
 
 Thirteen constructors that carried no `llmSemantics` at all — `addIfcRamp`, `addIfcFooting`, `addIfcPile`, `addIfcSpace`, `addIfcFurnishingElement`, `addIfcBuildingElementProxy`, `addIfcCircularColumn`, `addIfcHollowCircularColumn`, `addIfcIShapeBeam`, `addIfcLShapeMember`, `addIfcTShapeMember`, `addIfcUShapeMember`, `addIfcRectangleHollowBeam` — now declare `placement: 'storey-relative'` with their coordinate keys. They were invisible to every consumer that groups methods by placement frame, so nothing generated from this schema said which datum their coordinates were in. `NAMESPACE_SCHEMAS.create` now tags all 30 coordinate-taking constructors (27 storey-relative, `addElement` explicit-placement, and the two wall-local hosted inserts).
+
+## Downstream packages carrying the break
+
+The behaviour change is not confined to `@ifc-lite/create`: three packages re-expose `IfcCreator` and therefore ship it to their own consumers. Each is versioned to say so, rather than letting a caller pick the change up through a range they believed was compatible.
+
+- **`@ifc-lite/sdk` (major)** — re-exports the class directly (`packages/sdk/src/index.ts`: `export { IfcCreator } from '@ifc-lite/create'`). Without a major, a consumer on `^1.21` accepts the release and gets storey-relative placement with no signal.
+- **`@ifc-lite/sandbox` (major, was minor)** — `buildCreateMethods()` auto-discovers `IfcCreator.prototype` and dispatches to it, so every affected constructor is reachable from sandbox scripts. A script passing absolute coordinates against a non-zero-elevation storey now emits geometry one elevation off. That is breaking for the script author even though the sandbox's own surface is unchanged.
+- **`@ifc-lite/cli` (minor)** — `create` constructs `IfcCreator` and passes `--elevation` straight through, so the same shift reaches CLI users following the previous absolute-coordinate convention. Minor rather than major because the package is pre-1.0, where the house rule maps a breaking change to a minor bump.
+
+`@ifc-lite/wasm`, `@ifc-lite/mcp` and the viewer apps are unaffected: none of them constructs or re-exports `IfcCreator`.

--- a/.changeset/uniform-storey-placement.md
+++ b/.changeset/uniform-storey-placement.md
@@ -3,6 +3,7 @@
 '@ifc-lite/sdk': major
 '@ifc-lite/sandbox': major
 '@ifc-lite/cli': minor
+'@ifc-lite/mcp': minor
 ---
 
 **BREAKING:** every `IfcCreator` element constructor now places its product relative to the storey it is added to. Element coordinates are storey-relative across the whole API.
@@ -56,5 +57,6 @@ The behaviour change is not confined to `@ifc-lite/create`: three packages re-ex
 - **`@ifc-lite/sdk` (major)** — re-exports the class directly (`packages/sdk/src/index.ts`: `export { IfcCreator } from '@ifc-lite/create'`). Without a major, a consumer on `^1.21` accepts the release and gets storey-relative placement with no signal.
 - **`@ifc-lite/sandbox` (major, was minor)** — `buildCreateMethods()` auto-discovers `IfcCreator.prototype` and dispatches to it, so every affected constructor is reachable from sandbox scripts. A script passing absolute coordinates against a non-zero-elevation storey now emits geometry one elevation off. That is breaking for the script author even though the sandbox's own surface is unchanged.
 - **`@ifc-lite/cli` (minor)** — `create` constructs `IfcCreator` and passes `--elevation` straight through, so the same shift reaches CLI users following the previous absolute-coordinate convention. Minor rather than major because the package is pre-1.0, where the house rule maps a breaking change to a minor bump.
+- **`@ifc-lite/mcp` (minor)** — exposure is indirect but real: `loadIfcModel()` (`src/index.ts`) returns a `LoadedModel` carrying `bim: BimContext` (`src/loader.ts`), whose `create` namespace constructs the class (`@ifc-lite/sdk` `namespaces/create.ts`: `project()` returns `new IfcCreator(params)`, `building()` takes a `StoreyElevation`). A library consumer calling `model.bim.create.building({ StoreyElevation })` gets the new datum. Minor for the same pre-1.0 reason as the CLI.
 
-`@ifc-lite/wasm`, `@ifc-lite/mcp` and the viewer apps are unaffected: none of them constructs or re-exports `IfcCreator`.
+`@ifc-lite/wasm` is unaffected — it neither constructs nor re-exports `IfcCreator`, directly or through a namespace. The viewer apps are private and unpublished.


### PR DESCRIPTION
Fixes the three Codex P1 threads on #1986. The fix belongs here rather than on the release PR — #1986 is regenerated from `.changeset/*.md`, so edits to its `package.json`/CHANGELOG would be overwritten on the next run.

## The problem

`uniform-storey-placement.md` correctly declares `@ifc-lite/create: major`, but three packages re-expose `IfcCreator` and were left on compatible bumps:

| package | current | #1986 proposes | correct |
|---|---|---|---|
| `@ifc-lite/create` | 1.17.0 | **2.0.0** ✅ | 2.0.0 |
| `@ifc-lite/sdk` | 1.21.4 | 1.21.5 (patch) ❌ | **2.0.0** |
| `@ifc-lite/sandbox` | 1.16.4 | 1.17.0 (minor) ❌ | **2.0.0** |
| `@ifc-lite/cli` | 0.21.1 | 0.21.2 (patch) ❌ | **0.22.0** |

A consumer on `@ifc-lite/sdk@^1.21` accepts 1.21.5 and receives storey-relative placement with nothing in the range to warn them. On a non-zero-elevation storey their elements move by one elevation, silently — which is the exact failure the `create` major exists to announce.

## Verified, not inferred from the dependency graph

Being depended-on isn't enough to justify a major; I checked that each package actually re-exposes the changed surface:

- **sdk** — `packages/sdk/src/index.ts:222`: `export { IfcCreator } from '@ifc-lite/create';` — the class itself, directly.
- **sandbox** — `packages/sandbox/src/bridge-create.ts:13` imports `IfcCreator` and `buildCreateMethods()` auto-discovers `IfcCreator.prototype`, so every affected constructor is reachable from a sandbox script. Breaking for the script author even though the sandbox's own export surface is unchanged — which is why minor was wrong.
- **cli** — `packages/cli/src/commands/create.ts:21` constructs it and `:50` reads `--elevation`, passing it straight through.

`@ifc-lite/wasm`, `@ifc-lite/mcp` and the viewer apps neither construct nor re-export it, so they keep their dependency-only bumps.

**cli takes a minor, not a major**, because it is pre-1.0 — AGENTS.md maps a breaking change to `minor` for a 0.x package. That matches Codex's own recommendation of a 0.22 release.

## Verified output

Ran `changeset version` on this branch and reverted the result, so only the changeset is committed here:

```
@ifc-lite/create   2.0.0
@ifc-lite/sdk      2.0.0
@ifc-lite/sandbox  2.0.0
@ifc-lite/cli      0.22.0
@ifc-lite/mcp      0.9.3   (unchanged bump)
@ifc-lite/wasm     4.2.3   (unchanged bump)
```

## What happens on merge

The changesets action regenerates #1986 with the corrected versions and the added changelog section, which explains to each downstream consumer why *their* package went major. Nothing needs doing to #1986 by hand.

One file changed, +13/-1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Storey-relative placement behavior has been updated across the SDK, creation tools, and sandbox.
  * Applications may need migration updates to align with the new placement model.
  * Unknown storeys now produce clear errors instead of being silently accepted.

* **Bug Fixes**
  * Corrected placement metadata in the sandbox.

* **Documentation**
  * Added placement metadata guidance for 13 constructors.
  * Documented migration steps and package release impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->