### PR TITLE
fix(diff): make the canonical sorts a total order, not a name-only one

### DIFF
--- a/.changeset/total-order-fingerprint.md
+++ b/.changeset/total-order-fingerprint.md
@@ -1,0 +1,9 @@
+---
+'@ifc-lite/diff': patch
+---
+
+**diff**: make the canonical sorts a total order, so `dataHash` cannot depend on the order an adapter walked its relationships.
+
+`sortedEntries`, `sortedPropertySets` and `sortedQuantitySets` ordered records by `name` alone. `Array.prototype.sort` is stable, so two records sharing a name kept their *input* order — and the sorted result is serialized and hashed, so the same content supplied in two orders produced two different fingerprints. Same-named property sets are an ordinary IFC arrangement (a type pset and an occurrence pset of one name), so this was reachable, not theoretical.
+
+Records now tiebreak on their own serialized content. Fingerprint values change only for entities that actually carry same-named collections; everything else is byte-identical.

--- a/docs/guide/model-diff.md
+++ b/docs/guide/model-diff.md
@@ -49,7 +49,7 @@ Each `EntityFingerprint` carries two independent hashes, so data and geometry ch
 - **every quantity set and its quantities** (quantities participate in the data fingerprint)
 - type assignments — **by the assigned type's name and IFC class only**
 
-Property sets, quantity sets, their members, and type assignments are all sorted before hashing, so collection ordering never produces a spurious "modified", and two semantically equal entities in the base and head hash identically.
+Property sets, quantity sets, their members, and type assignments are all sorted before hashing, so collection ordering never produces a spurious "modified", and two semantically equal entities in the base and head hash identically. The sort is **total**: records are ordered by name and then by their own serialized content, because sorting on name alone leaves same-named records in whatever order the adapter walked them (`Array.prototype.sort` is stable), which would put the adapter's iteration order into the hash. Same-named property sets are ordinary in IFC (a type pset and an occurrence pset of one name), so this is a reachable case rather than a theoretical one.
 
 !!! warning "The assigned type's `GlobalId` is not hashed"
     `TypeAssignmentInput` still has a `globalId` field and callers may keep

--- a/packages/diff/src/fingerprint.test.ts
+++ b/packages/diff/src/fingerprint.test.ts
@@ -333,3 +333,38 @@ describe('stableHash / buildDataFingerprint — locale independence', () => {
     expect(forward).toBe(reverse);
   });
 });
+
+describe('buildDataFingerprint — duplicate names cannot make the hash order-dependent', () => {
+  // Found via a CodeRabbit CLI review of the example's copy (#1998), then
+  // confirmed against the shipped package: sorting on `name` alone is not a
+  // total order, `Array.prototype.sort` is stable, so two same-named records
+  // kept their INPUT order and the hash moved with the adapter's walk order.
+  // The guide claims "collection ordering never produces a spurious modified";
+  // that was false for duplicates. Same-named psets are real here — type and
+  // occurrence psets of one name (#1913).
+  const wall = (sets: { name: string; v: number }[]) => ({
+    ifcType: 'IfcWall',
+    propertySets: sets.map((s) => ({ name: s.name, properties: [{ name: 'x', value: s.v }] })),
+  });
+
+  it('two same-named property sets hash the same whichever order they arrive in', () => {
+    const a = buildDataFingerprint(wall([{ name: 'P', v: 1 }, { name: 'P', v: 2 }]));
+    const b = buildDataFingerprint(wall([{ name: 'P', v: 2 }, { name: 'P', v: 1 }]));
+    expect(a).toBe(b);
+  });
+
+  it('still distinguishes genuinely different duplicate content', () => {
+    const a = buildDataFingerprint(wall([{ name: 'P', v: 1 }, { name: 'P', v: 2 }]));
+    const c = buildDataFingerprint(wall([{ name: 'P', v: 1 }, { name: 'P', v: 3 }]));
+    expect(a, 'the tiebreak must not collapse distinct content').not.toBe(c);
+  });
+
+  it('same-named quantity sets and same-named properties are order-stable too', () => {
+    const qs = (vals: number[]) => ({
+      ifcType: 'IfcWall',
+      quantitySets: vals.map((v) => ({ name: 'Q', quantities: [{ name: 'V', value: v }] })),
+      propertySets: [{ name: 'P', properties: vals.map((v) => ({ name: 'dup', value: v })) }],
+    });
+    expect(buildDataFingerprint(qs([1, 2]))).toBe(buildDataFingerprint(qs([2, 1])));
+  });
+});

--- a/packages/diff/src/fingerprint.ts
+++ b/packages/diff/src/fingerprint.ts
@@ -154,10 +154,29 @@ function compareCodeUnits(a: string, b: string): number {
   return a < b ? -1 : a > b ? 1 : 0;
 }
 
+/**
+ * Total order over already-normalized records: name first, then the record's
+ * own serialized content as a tiebreak.
+ *
+ * The name alone is NOT a total order. `Array.prototype.sort` is stable, so
+ * two entries sharing a name keep their INPUT order — and the sorted result is
+ * then `JSON.stringify`d and hashed, which makes `dataHash` depend on the order
+ * the adapter happened to walk its relationships in. Same content, two orders,
+ * two hashes. Same-named property sets are not hypothetical here: type and
+ * occurrence psets of one name are a normal IFC arrangement (#1913), and an
+ * adapter that supplies them unmerged hands us duplicates.
+ *
+ * Tiebreaking on the serialized content makes the order total and content-
+ * derived, so it cannot depend on input order at all.
+ */
+function byNameThenContent<T extends { name: string }>(a: T, b: T): number {
+  return compareCodeUnits(a.name, b.name) || compareCodeUnits(stableSerialize(a), stableSerialize(b));
+}
+
 function sortedEntries(entries: PropertyEntryInput[]): { name: string; value: string | number | boolean | null }[] {
   return entries
     .map((entry) => ({ name: entry.name, value: normalizeValue(entry.value) }))
-    .sort((a, b) => compareCodeUnits(a.name, b.name));
+    .sort(byNameThenContent);
 }
 
 /**
@@ -208,13 +227,13 @@ export function buildDataFingerprint(input: DataFingerprintInput): string {
 function sortedPropertySets(input: DataFingerprintInput) {
   return (input.propertySets ?? [])
     .map((set) => ({ name: set.name, properties: sortedEntries(set.properties) }))
-    .sort((a, b) => compareCodeUnits(a.name, b.name));
+    .sort(byNameThenContent);
 }
 
 function sortedQuantitySets(input: DataFingerprintInput) {
   return (input.quantitySets ?? [])
     .map((set) => ({ name: set.name, quantities: sortedEntries(set.quantities) }))
-    .sort((a, b) => compareCodeUnits(a.name, b.name));
+    .sort(byNameThenContent);
 }
 
 /**


### PR DESCRIPTION
## What and why

`sortedEntries`, `sortedPropertySets` and `sortedQuantitySets` ordered records by `name` alone. `Array.prototype.sort` is **stable**, so two records sharing a name kept their *input* order — and that sorted result is `JSON.stringify`d and hashed. Same content, two adapter walk orders, two `dataHash` values.

Confirmed against the shipped package before fixing anything:

```
A 2e607403b1ebbb7e   B 3bc705d1858f727c   ORDER-DEPENDENT
```

(one `IfcWall`, two property sets both named `P`, supplied in the two possible orders)

**Reachable, not theoretical.** A type pset and an occurrence pset of one name are an ordinary IFC arrangement (#1913), and an adapter that supplies them unmerged hands the fingerprint duplicates. `docs/guide/model-diff.md` claimed "collection ordering never produces a spurious modified" — false for exactly that case, and now corrected.

## The fix

Records tiebreak on their own serialized content, so the order is total and content-derived and input order cannot reach the hash.

Type assignments need no tiebreak and did not get one: their projection is `{name, type}` in full, so two records that tie on both are *identical objects* whose relative order cannot be observed. Adding a tiebreak there would be a guard no test could kill.

## How it was found

A CodeRabbit CLI review of #1998 flagged it against the **example's copy** of this code. Rather than fix only the copy, I checked whether the shipped package had the same hole. It did.

## Verification

169 tests (was 166) · typecheck 33/33 · docs-samples 255 clean · api-surface unchanged (internal only).

Mutation-checked against removing the tiebreak — i.e. reinstating the shipped bug:

```
--- MUTATION: drop the content tiebreak ---
  × two same-named property sets hash the same whichever order they arrive in
  × same-named quantity sets and same-named properties are order-stable too
  Tests  2 failed | 167 passed (169)
```

A companion test asserts the tiebreak does not collapse genuinely different duplicate content, so it cannot pass by over-merging.

Changeset: `@ifc-lite/diff` patch — values change only for entities that actually carry same-named collections; everything else is byte-identical.
