### PR TITLE
fix(cli): compare object identities in --by-entity, not positional Name slots (#1891)

### DIFF
--- a/.changeset/by-entity-shared-scope.md
+++ b/.changeset/by-entity-shared-scope.md
@@ -1,0 +1,18 @@
+---
+'@ifc-lite/cli': minor
+---
+
+**diff**: `ifc-lite diff --by-entity` now compares the same entities as `--by-content` — every `IfcObjectDefinition`, decided from the schema inheritance chain — instead of asking every row of the entity index for a GlobalId (issue [#1891](https://github.com/LTplus-AG/ifc-lite/issues/1891)).
+
+**The reported numbers change, on every model.** `Common`, `Added` and `Removed` are now counts of objects, so they get much smaller: on the bundled sample models the key set goes 132 → 40 (`building-architecture.ifc`), 133 → 40 (`-rev-b`), 232 → 96 (`infra-bridge.ifc`) and 39 → 12 (`hello-wall.ifc`); on a 209k-entity model it goes 41,100 → 3,780. What left the count is entities whose identity was never their own:
+
+- **Relationships and property sets.** An `IfcRelDefinesByProperties` is identified by its endpoints, and a property set's contents already travel with the element that owns it, so counting them reported every edited property twice and turned a re-GUIDed relationship into churn. They are the large majority of the old key set — 14,701 `IfcRelDefinesByProperties` and 14,432 `IfcPropertySet` on the 209k model alone — and the churn is not hypothetical: on a real re-export pair the flag reported 183 added and 179 removed entities where **every single one** was a property set or a relationship the exporter had re-GUIDed. It now reports 118 common, 0 added, 0 removed, which is what happened.
+- **Entities keyed by their Name.** The columnar parser fills its GlobalId column positionally, and slot 0 of an `IfcMaterial`, `IfcSurfaceStyle`, `IfcClassification` or `IfcProjectedCRS` is a *Name*. Those entities were compared under that name — and two of them sharing a name collided into one key, so they were compared as a single entity. Every sample model had collisions: 8 (`building-architecture.ifc`), 9 (`-rev-b`), 7 (`infra-bridge.ifc`), 4 (`hello-wall.ifc`), and 12 on the 209k model.
+
+The chain is read across every bundled schema (IFC2X3 + IFC4 + IFC4X3), not from the parser's IFC4 codegen pin, which matters most on IFC2X3. IFC4 dropped 23 `IfcObjectDefinition` classes that IFC2X3 files still carry — `IfcMove`, `IfcOrderAction`, `IfcScheduleTimeControl`, `IfcSpaceProgram`, `IfcServiceLife`, `IfcTimeSeriesSchedule`, … — and the pin alone has nothing to say about any of them: the ones the parser's entity table does not hold would have gone uncompared even though their STEP records carry a GlobalId, and the IFC2X3-only *resource* classes it does hold (an `IfcSymbolStyle`, taken in because the name ends in `STYLE`) would still have been keyed on the Name in slot 0. The bundled sample models are unaffected — 132 → 40, 133 → 40, 232 → 96 and 39 → 12 as above, and 118 common / 0 added / 0 removed on the re-export pair.
+
+Two smaller consequences. A vendor-specific `IfcRoot` subtype that no IFC schema declares is no longer compared unless its class name ends in `Type`: with no inheritance chain there is nothing to prove it is an object rather than a resource, and guessing would mean reading a STEP record for every row of every unrecognised type in the file. And the flag is much cheaper — the old walk re-read 205,435 STEP records on that 209k-entity model to ask each one for a GlobalId; classifying once per type dismisses the geometry buckets without touching a row.
+
+If you were reading the added/removed counts as a proxy for "a property set appeared", that signal moved rather than vanished: the same command's type-difference table still reports `IfcPropertySet` and `IfcRel…` count deltas, and `--by-content` reports an edited property as a change to the element that owns it.
+
+`--by-content`, the type-count output, and the JSON shape are unchanged.

--- a/.changeset/inheritance-chain-across-schemas.md
+++ b/.changeset/inheritance-chain-across-schemas.md
@@ -1,0 +1,9 @@
+---
+'@ifc-lite/parser': minor
+---
+
+**schema**: export `getInheritanceChainAcrossSchemas(type)` — the inheritance chain resolved against every bundled IFC schema (IFC2X3 + IFC4 + IFC4X3), leaf → root.
+
+The already-exported `getInheritanceChainForEntity` comes from the generated registry, which is pinned to IFC4_ADD2_TC1, so it answers an empty chain for any class that pin does not carry: 23 `IfcObjectDefinition` classes IFC4 dropped from IFC2X3 (`IfcMove`, `IfcOrderAction`, `IfcScheduleTimeControl`, `IfcSpaceProgram`, …) and 77 IFC4X3 additions (`IfcRoad`, `IfcBridge`, `IfcAlignment`, `IfcCourse`, …). Code that decides *what kind of thing* an entity is — as `ifc-lite diff` does — reads an empty chain as "unknown" and gets those classes wrong on schemas that are still very common in the wild.
+
+This is the counterpart of the existing `getAttributeNamesAcrossSchemas`, and is the same function the columnar parser has always used internally to categorize entities. For classes the pin does know, both functions agree on every ancestor that matters; note that the two return their chains in opposite order, so pick the leaf by name rather than by position.

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -764,11 +764,13 @@ Reports:
 
 | Flag | Description |
 |------|-------------|
-| `--by-entity` | Compare entities by GlobalId |
+| `--by-entity` | Compare every `IfcObjectDefinition` by GlobalId (added / removed / common) |
 | `--by-content` | Per-entity comparison via the `@ifc-lite/diff` engine, pairing re-GUIDed elements by content |
 | `--identity-out <file>` | Write the accepted matches to an identity-map sidecar (implies `--by-content`) |
 | `--identity-in <file>` | Replay a sidecar's claims so those elements are matched by key (implies `--by-content`) |
 | `--json` | JSON output |
+
+Both comparison modes cover the same entities: every `IfcObjectDefinition` in the file. See [what gets compared](#what-gets-compared) below.
 
 #### Re-GUIDed models: `--by-content` and the identity map
 
@@ -784,7 +786,13 @@ ifc-lite diff model-v1.ifc model-v2.ifc --identity-in renames.json
 
 The sidecar pins the SHA-256 of both files, and `--identity-in` refuses a map that was verified against a different pair. Nothing in the files is ever rewritten: an identity map is a reviewable claim alongside the models, not an edit to them. This path compares **data only** — the CLI has no geometry pipeline — so every unambiguous match reports as `renamed`. See [Model Diff](model-diff.md#identity-maps) for the full semantics.
 
-`--by-content` compares every `IfcObjectDefinition` in the file — every `IfcObject` (products, but also tasks, actors, controls, resources and groups), plus `IfcTypeObject` and `IfcProject`. The other two `IfcRoot` branches are left out on purpose: an `IfcRelationship` is identified by its endpoints rather than in its own right, and a property set's contents are already part of its owner's comparison, so including it would report every edited property twice. `--identity-out` refuses to write over either input model.
+`--identity-out` refuses to write over either input model.
+
+#### What gets compared
+
+Both `--by-entity` and `--by-content` compare every `IfcObjectDefinition` in the file — every `IfcObject` (products, but also tasks, actors, controls, resources and groups), plus `IfcTypeObject` and `IfcProject`. The other two `IfcRoot` branches are left out on purpose: an `IfcRelationship` is identified by its endpoints rather than in its own right, and a property set's contents are already part of its owner's comparison, so including it would report every edited property twice.
+
+Membership comes from the schema inheritance chain, so an entity that is not an `IfcRoot` at all — a material, a surface style, a classification, a projected CRS — is not compared under its name, and a schedule task or actor is compared even though it carries no geometry. The chain is read from every schema ifc-lite bundles (IFC2X3, IFC4 and IFC4X3), so a class that only one of them declares — `IfcMove` and `IfcSpaceProgram` in IFC2X3, `IfcRoad` and `IfcAlignment` in IFC4X3 — is classified as what it is, not as an unknown. One consequence is deliberate: a vendor-specific `IfcRoot` subtype that no IFC schema declares is not compared unless its class name ends in `Type`, because there is no chain to prove it is an object rather than a resource.
 
 ---
 

--- a/docs/guide/model-diff.md
+++ b/docs/guide/model-diff.md
@@ -318,13 +318,15 @@ ifc-lite diff model-v1.ifc model-v2.ifc --json
 
 | Flag | Description |
 |------|-------------|
-| `--by-entity` | Compare entities by GlobalId (added / removed / common) |
+| `--by-entity` | Compare every `IfcObjectDefinition` by GlobalId (added / removed / common) |
 | `--by-content` | Run the `@ifc-lite/diff` engine with content-keyed matching |
 | `--identity-out <file>` | Write the accepted matches to an identity-map sidecar (implies `--by-content`) |
 | `--identity-in <file>` | Replay a sidecar's claims as key aliases (implies `--by-content`) |
 | `--json` | JSON output |
 
 Without `--by-entity`, the command reports the schema, entity count, entity-count delta, and the per-type differences (sorted by the size of the delta). With `--by-entity` it adds the count of GlobalIds added, removed, and common between the two files.
+
+Those GlobalIds are the same set `--by-content` fingerprints: every `IfcObjectDefinition` in the file, decided from the inheritance chain of whichever bundled schema declares the class (IFC2X3, IFC4 or IFC4X3). Relationships and property sets are left out — a relationship's identity is its endpoints, and a property set's contents already travel with its owner — and so is anything that is not an `IfcRoot` at all. That last exclusion matters more than it sounds: the columnar parser fills its GlobalId column positionally, and slot 0 of a material, a surface style or a classification is a *Name*, so those entities used to be compared under their name and two of them sharing one collapsed into a single key.
 
 ### `--by-content` and the identity map
 

--- a/packages/cli/src/commands/diff-by-entity.test.ts
+++ b/packages/cli/src/commands/diff-by-entity.test.ts
@@ -1,0 +1,217 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `ifc-lite diff --by-entity` and the comparison scope it now shares with
+ * `--by-content` (issue #1891).
+ *
+ * The flag used to ask every row of the entity index for a GlobalId, which is
+ * two different wrong questions at once: a resource entity answered with its
+ * *Name*, and relationships and property sets answered with a GlobalId whose
+ * identity is not their own. Both are pinned below.
+ */
+
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { comparableEntities, comparableGlobalIds } from './diff-scope.js';
+import { diffCommand } from './diff.js';
+import { loadIfcBytes } from '../loader.js';
+import { guid, legacyScheduleModel, scheduleModel } from './diff-test-helpers.js';
+
+async function scheduleStore(taskGuid: string): Promise<Awaited<ReturnType<typeof loadIfcBytes>>> {
+  return loadIfcBytes(new TextEncoder().encode(scheduleModel(taskGuid)), 'model');
+}
+
+async function legacyStore(moveGuid: string): Promise<Awaited<ReturnType<typeof loadIfcBytes>>> {
+  return loadIfcBytes(new TextEncoder().encode(legacyScheduleModel(moveGuid)), 'model');
+}
+
+describe('comparableGlobalIds', () => {
+  it('keys every IfcObjectDefinition, and nothing that is not one', async () => {
+    const keys = comparableGlobalIds(await scheduleStore(guid('OLDT')));
+
+    expect([...keys].sort()).toEqual(
+      [guid('PROJ'), guid('STOR'), guid('WALL'), guid('OLDT'), guid('ACTR'), guid('VTYP')].sort(),
+    );
+  }, 30_000);
+
+  it('does not key an IfcMaterial by its Name', async () => {
+    // The parser fills the EntityTable's GlobalId column positionally, and slot
+    // 0 of an IfcMaterial is its Name — so `brick` used to enter the comparison
+    // as an entity key. Two resource entities sharing a name then collided into
+    // one key and were compared as one entity; on the bundled sample models
+    // that was 4 to 9 collisions per file.
+    const keys = comparableGlobalIds(await scheduleStore(guid('OLDT')));
+
+    expect(keys.has('brick')).toBe(false);
+    // Nothing else slipped in under a non-GlobalId either: every key is the
+    // 22 characters an IFC GlobalId has.
+    expect([...keys].every((key) => key.length === 22)).toBe(true);
+  }, 30_000);
+
+  it('leaves out the two dependent IfcRoot branches', async () => {
+    // A relationship is identified by its endpoints and a property set travels
+    // with its owner, so counting either reports churn that is not a change to
+    // any thing in the model. On a real model these are most of the key set.
+    const keys = comparableGlobalIds(await scheduleStore(guid('OLDT')));
+
+    expect(keys.has(guid('RELP'))).toBe(false);
+    expect(keys.has(guid('RELC'))).toBe(false);
+    expect(keys.has(guid('PSET'))).toBe(false);
+    // Including an unrecognised `IfcRel…` class, which the parser's name-based
+    // branch does put in its table: the relationship branch is shut by name
+    // when the registry cannot confirm it.
+    expect(keys.has(guid('VREL'))).toBe(false);
+  }, 30_000);
+
+  it('reaches an IfcTask and an IfcActor, which the EntityTable does not hold', async () => {
+    const store = await scheduleStore(guid('OLDT'));
+
+    // Not a regression pin on the old flag — that path reached these too, via
+    // the on-demand fallback in EntityNode — but on the shared walk, which
+    // reads the STEP record only for the object types the table declines.
+    expect(store.entities.getGlobalId(store.entityIndex.byType.get('IFCTASK')![0])).toBe('');
+    expect(comparableGlobalIds(store).has(guid('OLDT'))).toBe(true);
+    expect(comparableGlobalIds(store).has(guid('ACTR'))).toBe(true);
+  }, 30_000);
+
+  it('keeps a vendor class to exactly the reach the EntityTable gives it', async () => {
+    const keys = comparableGlobalIds(await scheduleStore(guid('OLDT')));
+
+    // A class no schema registry knows has no chain to judge, so it is not read
+    // from source: doing that would cost one STEP extraction per row of every
+    // unrecognised bucket in the file, on every file, to reach entities almost
+    // no file has. The deliberate price is that a vendor IfcRoot subtype goes
+    // uncompared — narrower than the old flag, which read slot 0 positionally
+    // and so happened to see this one (while reading a Name for every vendor
+    // class that is not an IfcRoot).
+    expect(keys.has(guid('VEND'))).toBe(false);
+    // Except where the table already reaches it: the parser's type-object
+    // branch is name-based, so an unrecognised `…Type` class is in the table
+    // with a real GlobalId and keeps being compared.
+    expect(keys.has(guid('VTYP'))).toBe(true);
+  }, 30_000);
+
+  it('keys an IFC2X3 object class the IFC4 codegen pin does not carry', async () => {
+    // The parser's generated registry is pinned to IFC4_ADD2_TC1, so it answers
+    // an empty chain for the 23 IFC2X3 IfcObjectDefinition classes IFC4 dropped.
+    // Judging those `unknown` left every one the EntityTable does not hold out
+    // of the comparison entirely, silently, on a schema most files in the wild
+    // still use. The chain has to come from every bundled schema.
+    const store = await legacyStore(guid('MOVE'));
+
+    expect(store.entities.getGlobalId(store.entityIndex.byType.get('IFCMOVE')![0])).toBe('');
+    const keys = comparableGlobalIds(store);
+    expect(keys.has(guid('MOVE'))).toBe(true);
+    expect(keys.has(guid('SPGM'))).toBe(true);
+    // Read from the STEP record under its own class name, not 'Unknown': the
+    // content path hashes `ifcType` into the fingerprint and cross-checks it on
+    // every match.
+    const move = [...comparableEntities(store)].find((e) => e.globalId === guid('MOVE'));
+    expect(move?.ifcType).toBe('IfcMove');
+  }, 30_000);
+
+  it('does not key an IFC2X3 resource entity by its Name', async () => {
+    // The other half of the same defect. `IfcSymbolStyle` is a resource with a
+    // Name in slot 0 and no GlobalId, but its class name ends in STYLE, so the
+    // parser's name-based branch puts it in the EntityTable with `hatch` in the
+    // GlobalId column. Without an IFC2X3 chain to prove it is not an IfcRoot,
+    // `hatch` was an entity key.
+    const store = await legacyStore(guid('MOVE'));
+
+    expect(store.entities.getGlobalId(store.entityIndex.byType.get('IFCSYMBOLSTYLE')![0])).toBe(
+      'hatch',
+    );
+    const keys = comparableGlobalIds(store);
+    expect(keys.has('hatch')).toBe(false);
+    // The IFC2X3 type object next to it is a real IfcTypeObject and stays in.
+    expect(keys.has(guid('GTTY'))).toBe(true);
+    expect([...keys].sort()).toEqual(
+      [guid('PROJ'), guid('STOR'), guid('WALL'), guid('MOVE'), guid('SPGM'), guid('GTTY')].sort(),
+    );
+  }, 30_000);
+});
+
+describe('ifc-lite diff --by-entity', () => {
+  let dir: string;
+  let basePath: string;
+  let headPath: string;
+  let stdoutSpy: ReturnType<typeof vi.spyOn>;
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'ifclite-by-entity-'));
+    basePath = join(dir, 'v1.ifc');
+    headPath = join(dir, 'v2.ifc');
+    stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    stdoutSpy.mockRestore();
+    stderrSpy.mockRestore();
+  });
+
+  function stdout(): string {
+    return stdoutSpy.mock.calls.map((call) => String(call[0])).join('');
+  }
+
+  it('counts the re-GUIDed task, and only the entities a diff can speak for', async () => {
+    await writeFile(basePath, scheduleModel(guid('OLDT')), 'utf-8');
+    await writeFile(headPath, scheduleModel(guid('NEWT')), 'utf-8');
+
+    await diffCommand([basePath, headPath, '--by-entity', '--json']);
+    const result = JSON.parse(stdout());
+
+    // Project, storey, wall, actor and the vendor type are common; the task's
+    // GlobalId changed. The old scope answered 12 keys here — the five above
+    // plus the task, plus a property set, two relationships, an unrecognised
+    // relationship, a vendor class and the string `brick`.
+    expect(result.entityDiff).toEqual({
+      added: [guid('NEWT')],
+      removed: [guid('OLDT')],
+      common: 5,
+    });
+  }, 60_000);
+
+  it('says which entities the count is about', async () => {
+    await writeFile(basePath, scheduleModel(guid('OLDT')), 'utf-8');
+    await writeFile(headPath, scheduleModel(guid('NEWT')), 'utf-8');
+
+    await diffCommand([basePath, headPath, '--by-entity']);
+    const text = stdout();
+
+    expect(text).toContain('Entity comparison (by GlobalId, every IfcObjectDefinition)');
+    expect(text).toContain('Common:  5');
+    expect(text).toContain('Added:   1');
+    expect(text).toContain('Removed: 1');
+  }, 60_000);
+
+  it('counts a re-GUIDed IFC2X3 object the IFC4 pin does not know', async () => {
+    await writeFile(basePath, legacyScheduleModel(guid('OLDM')), 'utf-8');
+    await writeFile(headPath, legacyScheduleModel(guid('NEWM')), 'utf-8');
+
+    await diffCommand([basePath, headPath, '--by-entity', '--json']);
+    const result = JSON.parse(stdout());
+
+    // The IfcMove moved; project, storey, wall, space program and gas terminal
+    // type did not. Nothing here is keyed on the IfcSymbolStyle's name.
+    expect(result.entityDiff).toEqual({
+      added: [guid('NEWM')],
+      removed: [guid('OLDM')],
+      common: 5,
+    });
+  }, 60_000);
+
+  it('reports no entity comparison at all without the flag', async () => {
+    await writeFile(basePath, scheduleModel(guid('OLDT')), 'utf-8');
+    await writeFile(headPath, scheduleModel(guid('NEWT')), 'utf-8');
+
+    await diffCommand([basePath, headPath, '--json']);
+
+    expect(JSON.parse(stdout()).entityDiff).toBeUndefined();
+  }, 60_000);
+});

--- a/packages/cli/src/commands/diff-engine.ts
+++ b/packages/cli/src/commands/diff-engine.ts
@@ -20,37 +20,11 @@
  * `renamed` and reports every genuinely ambiguous group as a group, exactly as
  * it does for a viewer session whose geometry hashing was unavailable.
  *
- * **Scope of the comparison: every `IfcObjectDefinition` in the file.** IFC's
- * three `IfcRoot` branches are not equally comparable. An `IfcObjectDefinition`
- * (every `IfcObject` — product, task, actor, control, resource, group — plus
- * `IfcTypeObject` and `IfcContext`) is an independently identifiable thing, and
- * is precisely what an identity map can make a claim about. The other two
- * branches are dependent and stay out:
- *
- * - `IfcRelationship`: its identity is its endpoints. Re-GUIDing an
- *   `IfcRelAggregates` while both ends are untouched is not a change anyone
- *   wants reported, and a rename claim about one would be a claim about nothing.
- * - `IfcPropertyDefinition`: a property set's content is already folded into its
- *   owner's `dataHash`, so comparing it again would double-report every edited
- *   property — once on the element, once on the pset.
- *
- * Membership is decided from the schema registry's inheritance chain, not from
- * whether the columnar parser happened to put the entity in its `EntityTable`.
- * That distinction is the whole fix for a class of silent drop-outs: the table
- * only holds the categories the viewer renders, so `IfcTask`, `IfcActor`,
- * `IfcWorkPlan` and every other non-product `IfcObject` reported an empty
- * GlobalId and vanished from the comparison entirely, even though their STEP
- * records carry one. Those are read straight from the source record instead.
- * (The parser's own `--by-entity` path still asks the table and so still misses
- * them; that is pre-existing behaviour of a different flag, untouched here.)
- *
- * The same distinction closes the drop-out's mirror image. The parser fills the
- * table's GlobalId column positionally, and for a resource entity slot 0 is not
- * a GlobalId: an `IfcMaterial`, `IfcSurfaceStyle`, `IfcClassification` or
- * `IfcProjectedCRS` was being compared under its *Name*. On the bundled sample
- * models that put 7-9 colliding keys into every comparison — a material and a
- * surface style of the same name arriving as one entity. None of them is an
- * `IfcRoot`, so the chain check leaves them out and the key set is unique again.
+ * **Scope of the comparison: every `IfcObjectDefinition` in the file**, decided
+ * from the schema registry's inheritance chain rather than from what the
+ * columnar parser put in its `EntityTable`. That walk is `diff-scope.ts`, which
+ * documents the rule and the two silent defects it fixes; `--by-entity` runs on
+ * the same walk, so both modes of the command answer about the same entities.
  */
 
 import { createHash } from 'node:crypto';
@@ -63,14 +37,12 @@ import {
 } from '@ifc-lite/diff';
 import { RelationshipType } from '@ifc-lite/data';
 import {
-  EntityExtractor,
   extractAllEntityAttributes,
   extractPropertiesOnDemand,
   extractQuantitiesOnDemand,
-  extractRootAttributesFromEntity,
-  getInheritanceChainForEntity,
   type IfcDataStore,
 } from '@ifc-lite/parser';
+import { comparableEntities, type RootAttributes } from './diff-scope.js';
 
 /** Adapter handle threaded through the diff: the entity's express id. */
 export type DiffRef = number;
@@ -87,47 +59,6 @@ export function modelIdentityOf(path: string, bytes: Uint8Array): ModelIdentity 
   return { hash: `sha256:${digest}`, path };
 }
 
-/** The IfcRoot-family attributes a fingerprint needs when the columnar
- *  `EntityTable` does not hold the entity. */
-type RootAttributes = ReturnType<typeof extractRootAttributesFromEntity>;
-
-/** How an uppercase STEP type participates in the comparison. `name` is the
- *  registry's PascalCase spelling, used instead of the `EntityTable`'s
- *  `'Unknown'` for entities the table never took in. */
-interface TypeRole {
-  role: 'independent' | 'dependent' | 'unknown';
-  name: string;
-}
-
-/**
- * Classify one STEP type against the three `IfcRoot` branches.
- *
- * `unknown` is not `dependent`: a vendor extension or a schema leaf outside the
- * codegen pin has no inheritance chain to judge, so it keeps exactly the reach
- * the `EntityTable` already gave it — which for a `…TYPE` class is a genuine
- * GlobalId, since the parser's type-object branch is name-based and takes those
- * in. Guessing that an unrecognised class is an `IfcObject` and reading its
- * source record instead would cost one STEP extraction per row of every
- * unrecognised bucket in the file, on every file, to reach entities almost no
- * file has.
- *
- * The one name the chain is not needed for is `IFCREL…`: that prefix is the
- * parser's own rule for taking an unrecognised relationship into the table, and
- * a relationship is excluded here whether the registry can confirm it or not.
- * Without this, an unrecognised `IfcRelXxx` would be the single class of entity
- * that got in through the relationship branch the comparison deliberately shuts.
- */
-function classifyType(typeKey: string): TypeRole {
-  const upper = typeKey.toUpperCase();
-  const chain = getInheritanceChainForEntity(upper);
-  if (chain.length === 0) {
-    return { role: upper.startsWith('IFCREL') ? 'dependent' : 'unknown', name: typeKey };
-  }
-  const name = chain[chain.length - 1];
-  if (!chain.includes('IfcRoot')) return { role: 'dependent', name };
-  return { role: chain.includes('IfcObjectDefinition') ? 'independent' : 'dependent', name };
-}
-
 /**
  * Build one {@link EntityFingerprint} per `IfcObjectDefinition` in a store.
  *
@@ -139,66 +70,17 @@ function classifyType(typeKey: string): TypeRole {
  */
 export function buildFileFingerprints(store: IfcDataStore): EntityFingerprint<DiffRef>[] {
   const fingerprints: EntityFingerprint<DiffRef>[] = [];
-  const seen = new Set<number>();
-  // One extractor for the whole file: it holds a buffer reference, and the
-  // source read below only fires for the (small) set of object types the
-  // EntityTable declines to hold.
-  const extractor = new EntityExtractor(store.source);
-
-  for (const [typeKey, ids] of store.entityIndex.byType) {
-    // Classified once per type rather than once per entity — the geometry
-    // buckets (IfcCartesianPoint, IfcPolyLoop, …) are the bulk of a real file
-    // and are dismissed here without touching a single row.
-    const type = classifyType(typeKey);
-    if (type.role === 'dependent') continue;
-
-    for (const expressId of ids) {
-      if (seen.has(expressId)) continue;
-      seen.add(expressId);
-
-      let globalId = store.entities.getGlobalId(expressId);
-      let source: RootAttributes | undefined;
-      if (!globalId && type.role === 'independent') {
-        // In the file but not in the table: a schedule task, an actor, a work
-        // plan. Its GlobalId is in the STEP record, so read it there.
-        source = readRootAttributes(extractor, store, expressId);
-        globalId = source?.globalId ?? '';
-      }
-      // Still nothing: the entity is not an IfcRoot at all (a placement, a
-      // profile, a representation item), so it has no cross-file identity.
-      if (!globalId) continue;
-
-      const tableType = store.entities.getTypeName(expressId);
-      // `getTypeName` answers 'Unknown' for a row the table never took in. The
-      // registry's own spelling is the honest answer, and it has to be a real
-      // type name: `ifcType` is hashed into the fingerprint and cross-checked
-      // on every content match, so 'Unknown' would pair a task with an actor.
-      const ifcType = source && (!tableType || tableType === 'Unknown') ? type.name : tableType;
-      const input = buildDataInput(store, expressId, ifcType, source);
-      fingerprints.push({
-        key: globalId,
-        ifcType,
-        dataHash: buildDataFingerprint(input),
-        components: buildComponentFingerprints(input),
-        ref: expressId,
-      });
-    }
+  for (const { expressId, globalId, ifcType, source } of comparableEntities(store)) {
+    const input = buildDataInput(store, expressId, ifcType, source);
+    fingerprints.push({
+      key: globalId,
+      ifcType,
+      dataHash: buildDataFingerprint(input),
+      components: buildComponentFingerprints(input),
+      ref: expressId,
+    });
   }
-
   return fingerprints;
-}
-
-/** IfcRoot attributes straight from the entity's STEP record, for the rows the
- *  columnar `EntityTable` never took in. */
-function readRootAttributes(
-  extractor: EntityExtractor,
-  store: IfcDataStore,
-  expressId: number,
-): RootAttributes | undefined {
-  const ref = store.entityIndex.byId.get(expressId);
-  if (!ref) return undefined;
-  const entity = extractor.extractEntity(ref);
-  return entity ? extractRootAttributesFromEntity(entity) : undefined;
 }
 
 /**

--- a/packages/cli/src/commands/diff-scope.ts
+++ b/packages/cli/src/commands/diff-scope.ts
@@ -1,0 +1,188 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Which entities of a file take part in an `ifc-lite diff`, and under what key
+ * (issue #1891).
+ *
+ * One answer for both comparison modes: `--by-entity`, which reports GlobalIds
+ * added / removed / common, and `--by-content`, which fingerprints the same
+ * entities for the `@ifc-lite/diff` engine (see `diff-engine.ts`). They were
+ * two answers, and the older one was wrong in ways the user could not see.
+ *
+ * **Scope: every `IfcObjectDefinition` in the file.** IFC's three `IfcRoot`
+ * branches are not equally comparable. An `IfcObjectDefinition` (every
+ * `IfcObject` — product, task, actor, control, resource, group — plus
+ * `IfcTypeObject` and `IfcContext`) is an independently identifiable thing, and
+ * is precisely what a diff can make a claim about. The other two branches are
+ * dependent and stay out:
+ *
+ * - `IfcRelationship`: its identity is its endpoints. Re-GUIDing an
+ *   `IfcRelAggregates` while both ends are untouched is not a change anyone
+ *   wants reported, and on a re-export it is most of the reported churn.
+ * - `IfcPropertyDefinition`: a property set's content already travels with its
+ *   owner, so comparing it again double-reports every edited property — once on
+ *   the element, once on the pset.
+ *
+ * **Membership is decided from the inheritance chain of every bundled schema**
+ * (IFC2X3 + IFC4 + IFC4X3), not from what the columnar parser happened to put
+ * in its `EntityTable`, not from whichever attribute sits in slot 0 of a STEP
+ * record, and not from the IFC4 codegen pin alone. That is the whole fix for
+ * two silent defects:
+ *
+ * 1. The parser fills the table's GlobalId column positionally, and slot 0 of a
+ *    resource entity is a **Name**. An `IfcMaterial`, `IfcSurfaceStyle`,
+ *    `IfcClassification` or `IfcProjectedCRS` was therefore compared under its
+ *    name — and two of them sharing a name arrived as one entity. On the four
+ *    bundled sample models that was 4-9 colliding keys and 16-25 non-`IfcRoot`
+ *    entries per file. None of them is an `IfcRoot`, so the chain check leaves
+ *    them out and the key set is unique again.
+ * 2. The `EntityTable` only holds the categories the viewer renders, so
+ *    `IfcTask`, `IfcActor`, `IfcWorkPlan` and every other non-product
+ *    `IfcObject` answer '' from `getGlobalId` even though their STEP records
+ *    carry one. Those are read straight from the source record here.
+ *
+ * Classification happens once per *type*, so the geometry buckets — which are
+ * the bulk of a real file — are dismissed without touching a single row.
+ */
+
+import {
+  EntityExtractor,
+  extractRootAttributesFromEntity,
+  getInheritanceChainAcrossSchemas,
+  type IfcDataStore,
+} from '@ifc-lite/parser';
+
+/** The IfcRoot-family attributes read from a STEP record when the columnar
+ *  `EntityTable` does not hold the entity. */
+export type RootAttributes = ReturnType<typeof extractRootAttributesFromEntity>;
+
+/** One entity that takes part in the comparison. */
+export interface ComparableEntity {
+  expressId: number;
+  /** Non-empty by construction: an entity without one has no cross-file
+   *  identity and is not yielded at all. */
+  globalId: string;
+  /** The registry's PascalCase spelling where the `EntityTable` has no row (and
+   *  so answers `'Unknown'`), the table's own type name otherwise. */
+  ifcType: string;
+  /** Set only when the entity is absent from the `EntityTable`, whose display
+   *  accessors then answer '' for every attribute. */
+  source: RootAttributes | undefined;
+}
+
+/** How an uppercase STEP type participates in the comparison. `name` is the
+ *  registry's PascalCase spelling. */
+interface TypeRole {
+  role: 'independent' | 'dependent' | 'unknown';
+  name: string;
+}
+
+/**
+ * Classify one STEP type against the three `IfcRoot` branches.
+ *
+ * The chain has to come from **every bundled schema**, not from the parser's
+ * IFC4 codegen pin. `getInheritanceChainForEntity` answers an empty chain for
+ * any class the pin does not carry, and that is not a rare corner: IFC2X3 alone
+ * puts 23 `IfcObjectDefinition` classes there (`IfcMove`, `IfcOrderAction`,
+ * `IfcScheduleTimeControl`, `IfcSpaceProgram`, `IfcServiceLife`, …) and IFC4X3
+ * another 77. Judging those as `unknown` dropped the ones the `EntityTable`
+ * does not hold — real objects with real GlobalIds, which the walk this
+ * replaced did compare — and let through the IFC2X3-only *resource* classes it
+ * does hold under a `…STYLE` name, keyed on the Name in slot 0. Both are wrong
+ * answers about an IFC2X3 file, which is still most of what is in the wild.
+ *
+ * `unknown` is still not `dependent`: a vendor extension no schema declares has
+ * no chain to judge, so it keeps exactly the reach the `EntityTable` gives it —
+ * which for a `…TYPE` class is a genuine GlobalId, since the parser's
+ * type-object branch is name-based and takes those in. Guessing that an
+ * unrecognised class is an `IfcObject` and reading its source record instead
+ * would cost one STEP extraction per row of every unrecognised bucket in the
+ * file, on every file, to reach entities almost no file has. The price of that
+ * choice is that a vendor `IfcRoot` subtype whose name does not end in `TYPE`
+ * stays uncompared.
+ *
+ * The one name the chain is not needed for is `IFCREL…`: that prefix is the
+ * parser's own rule for taking an unrecognised relationship into the table, and
+ * a relationship is excluded here whether any schema can confirm it or not.
+ * Without this, an unrecognised `IfcRelXxx` would be the single class of entity
+ * that got in through the relationship branch the comparison deliberately shuts.
+ */
+function classifyType(typeKey: string): TypeRole {
+  const upper = typeKey.toUpperCase();
+  const chain = getInheritanceChainAcrossSchemas(upper);
+  if (chain.length === 0) {
+    return { role: upper.startsWith('IFCREL') ? 'dependent' : 'unknown', name: typeKey };
+  }
+  // The chain holds the class itself plus its supertypes; which end the leaf
+  // sits at is the schema source's business, so find it by name.
+  const name = chain.find((ancestor) => ancestor.toUpperCase() === upper) ?? typeKey;
+  if (!chain.includes('IfcRoot')) return { role: 'dependent', name };
+  return { role: chain.includes('IfcObjectDefinition') ? 'independent' : 'dependent', name };
+}
+
+/**
+ * Walk a store's entity index and yield every entity the comparison covers.
+ *
+ * Lazy on purpose: `--by-entity` only needs the keys, and a generator lets it
+ * collect them without materialising a second array per file.
+ */
+export function* comparableEntities(store: IfcDataStore): Generator<ComparableEntity> {
+  const seen = new Set<number>();
+  // One extractor for the whole file: it holds a buffer reference, and the
+  // source read below only fires for the (small) set of object types the
+  // EntityTable declines to hold.
+  const extractor = new EntityExtractor(store.source);
+
+  for (const [typeKey, ids] of store.entityIndex.byType) {
+    const type = classifyType(typeKey);
+    if (type.role === 'dependent') continue;
+
+    for (const expressId of ids) {
+      if (seen.has(expressId)) continue;
+      seen.add(expressId);
+
+      let globalId = store.entities.getGlobalId(expressId);
+      let source: RootAttributes | undefined;
+      if (!globalId && type.role === 'independent') {
+        // In the file but not in the table: a schedule task, an actor, a work
+        // plan. Its GlobalId is in the STEP record, so read it there.
+        source = readRootAttributes(extractor, store, expressId);
+        globalId = source?.globalId ?? '';
+      }
+      // Still nothing: the entity is not an IfcRoot at all (a placement, a
+      // profile, a representation item), so it has no cross-file identity.
+      if (!globalId) continue;
+
+      const tableType = store.entities.getTypeName(expressId);
+      // `getTypeName` answers 'Unknown' for a row the table never took in. The
+      // registry's own spelling is the honest answer, and on the content path
+      // it has to be a real type name: `ifcType` is hashed into the fingerprint
+      // and cross-checked on every match, so 'Unknown' would pair a task with
+      // an actor.
+      const ifcType = source && (!tableType || tableType === 'Unknown') ? type.name : tableType;
+      yield { expressId, globalId, ifcType, source };
+    }
+  }
+}
+
+/** The comparison's key set for one file: every covered entity's GlobalId. */
+export function comparableGlobalIds(store: IfcDataStore): Set<string> {
+  const keys = new Set<string>();
+  for (const entity of comparableEntities(store)) keys.add(entity.globalId);
+  return keys;
+}
+
+/** IfcRoot attributes straight from the entity's STEP record, for the rows the
+ *  columnar `EntityTable` never took in. */
+function readRootAttributes(
+  extractor: EntityExtractor,
+  store: IfcDataStore,
+  expressId: number,
+): RootAttributes | undefined {
+  const ref = store.entityIndex.byId.get(expressId);
+  if (!ref) return undefined;
+  const entity = extractor.extractEntity(ref);
+  return entity ? extractRootAttributesFromEntity(entity) : undefined;
+}

--- a/packages/cli/src/commands/diff-test-helpers.ts
+++ b/packages/cli/src/commands/diff-test-helpers.ts
@@ -90,6 +90,49 @@ END-ISO-10303-21;
 `;
 }
 
+/**
+ * An IFC2X3 file whose objects are classes IFC4 dropped, so the parser's IFC4
+ * codegen pin knows none of them.
+ *
+ * - `IfcMove` (an `IfcTask` subtype) and `IfcSpaceProgram` (an `IfcControl`)
+ *   are `IfcObjectDefinition`s with real GlobalIds in slot 0, and are not
+ *   `IfcProduct`s, so the `EntityTable` does not hold them.
+ * - `IfcSymbolStyle` is a *resource*: no GlobalId at all, a Name in slot 0. Its
+ *   class name ends in `STYLE`, which is one of the parser's two name-based
+ *   branches, so the table does hold it — with `hatch` in the GlobalId column.
+ * - `IfcGasTerminalType` is a real `IfcTypeObject`, reached through the other
+ *   name-based branch (`…TYPE`).
+ *
+ * Deciding membership from the IFC4 pin alone gets all three wrong at once.
+ */
+export function legacyScheduleModel(moveGuid: string): string {
+  return `ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''),'2;1');
+FILE_NAME('m','2026',(''),(''),'','','');
+FILE_SCHEMA(('IFC2X3'));
+ENDSEC;
+DATA;
+#1= IFCPROJECT('${guid('PROJ')}',$,'Proj',$,$,$,$,(#20),#30);
+#20= IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.E-5,#21,$);
+#21= IFCAXIS2PLACEMENT3D(#22,$,$);
+#22= IFCCARTESIANPOINT((0.,0.,0.));
+#30= IFCUNITASSIGNMENT((#31));
+#31= IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+#40= IFCLOCALPLACEMENT($,#21);
+#41= IFCBUILDINGSTOREY('${guid('STOR')}',$,'L01',$,$,#40,$,$,.ELEMENT.,0.);
+#70= IFCWALLSTANDARDCASE('${guid('WALL')}',$,'Wall A',$,$,#40,$,'tagA');
+#90= IFCMOVE('${moveGuid}',$,'Move A',$,$,'ID1',$,$,.F.,$,#41,#41,$);
+#91= IFCSPACEPROGRAM('${guid('SPGM')}',$,'Program A',$,$,'SP1',$,$,$,$);
+#92= IFCSYMBOLSTYLE('hatch',#93);
+#93= IFCDEFINEDSYMBOL($,$);
+#94= IFCGASTERMINALTYPE('${guid('GTTY')}',$,'GT',$,$,$,$,$,$,.GASAPPLIANCE.);
+#96= IFCRELCONTAINEDINSPATIALSTRUCTURE('${guid('RELC')}',$,$,$,(#70),#41);
+ENDSEC;
+END-ISO-10303-21;
+`;
+}
+
 export const BASE_MODEL = model(guid('OLDA'), guid('OLDB'));
 /** Same building, re-exported: the two walls carry brand-new GlobalIds. */
 export const HEAD_MODEL = model(guid('NEWA'), guid('NEWB'));

--- a/packages/cli/src/commands/diff.ts
+++ b/packages/cli/src/commands/diff.ts
@@ -8,15 +8,20 @@
  * Compare two IFC files and report differences in entity counts,
  * types, and optionally property values.
  *
+ * `--by-entity` adds a GlobalId-level added/removed/common count over the
+ * entities `diff-scope.ts` decides are comparable, which is the same set
+ * `--by-content` fingerprints — one answer about which entities a diff is
+ * about, for both modes of the command.
+ *
  * `--by-content` switches to the `@ifc-lite/diff` engine with content-keyed
  * matching and the identity-map sidecar (issue #1891) — see `diff-content.ts`.
  */
 
 import { loadIfcFile } from '../loader.js';
 import { hasFlag, getFlag, fatal, printJson, formatTable } from '../output.js';
-import { EntityNode } from '@ifc-lite/query';
 import { IFC_ENTITY_NAMES } from '@ifc-lite/data';
 import { contentDiffCommand } from './diff-content.js';
+import { comparableGlobalIds } from './diff-scope.js';
 
 const USAGE =
   'Usage: ifc-lite diff <file1.ifc> <file2.ifc> [--json] [--by-entity]\n' +
@@ -104,25 +109,16 @@ export async function diffCommand(args: string[]): Promise<void> {
   }
   typeDiffs.sort((a, b) => Math.abs(b.delta) - Math.abs(a.delta));
 
-  // Entity-level comparison by GlobalId
+  // Entity-level comparison by GlobalId, over the entities `diff-scope.ts`
+  // says are comparable at all. Asking every row of the entity index for a
+  // GlobalId instead — which is what this did — answered with a *Name* for
+  // every resource entity whose STEP record starts with one, so two materials
+  // sharing a name were compared as one entity, and it counted relationships
+  // and property sets whose identity belongs to the things they connect.
   let entityDiff: { added: string[]; removed: string[]; common: number } | undefined;
   if (byEntity) {
-    const globalIds1 = new Set<string>();
-    const globalIds2 = new Set<string>();
-    for (const [, ids] of store1.entityIndex.byType) {
-      for (const id of ids) {
-        const node = new EntityNode(store1, id);
-        const gid = node.globalId;
-        if (gid) globalIds1.add(gid);
-      }
-    }
-    for (const [, ids] of store2.entityIndex.byType) {
-      for (const id of ids) {
-        const node = new EntityNode(store2, id);
-        const gid = node.globalId;
-        if (gid) globalIds2.add(gid);
-      }
-    }
+    const globalIds1 = comparableGlobalIds(store1);
+    const globalIds2 = comparableGlobalIds(store2);
 
     const added = [...globalIds2].filter(g => !globalIds1.has(g));
     const removed = [...globalIds1].filter(g => !globalIds2.has(g));
@@ -163,7 +159,7 @@ export async function diffCommand(args: string[]): Promise<void> {
   }
 
   if (entityDiff) {
-    process.stdout.write(`\n  Entity comparison (by GlobalId):\n`);
+    process.stdout.write(`\n  Entity comparison (by GlobalId, every IfcObjectDefinition):\n`);
     process.stdout.write(`    Common:  ${entityDiff.common}\n`);
     process.stdout.write(`    Added:   ${entityDiff.added.length}\n`);
     process.stdout.write(`    Removed: ${entityDiff.removed.length}\n`);

--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -124,7 +124,13 @@ export {
 } from './generated/serializers.js';
 
 export * from './types.js';
-export { getAttributeNames, getAttributeNamesAcrossSchemas, getAttributeNameAt, isKnownType, normalizeIfcTypeName } from './ifc-schema.js';
+// `getInheritanceChainAcrossSchemas` is the counterpart of
+// `getAttributeNamesAcrossSchemas`: it answers for every bundled schema
+// (IFC2X3 + IFC4 + IFC4X3), where the generated `getInheritanceChainForEntity`
+// above only knows the codegen pin (IFC4_ADD2_TC1) and returns an empty chain
+// for a class the pin does not carry — `IfcMove`, `IfcSpaceProgram`, `IfcRoad`.
+// Anything that decides *what kind of thing* an entity is must use this one.
+export { getAttributeNames, getAttributeNamesAcrossSchemas, getAttributeNameAt, isKnownType, normalizeIfcTypeName, getInheritanceChain as getInheritanceChainAcrossSchemas } from './ifc-schema.js';
 
 import type { IfcEntity, ParseResult } from './types.js';
 import { EntityIndexBuilder } from './entity-index.js';

--- a/scripts/api-surface.json
+++ b/scripts/api-surface.json
@@ -3476,6 +3476,7 @@
     "getClassificationsForElement: function",
     "getCoordinateSystemDescription: function",
     "getEntityMetadata: function",
+    "getInheritanceChainAcrossSchemas: function",
     "getInheritanceChainForEntity: function",
     "getMaterialDisplay: function",
     "getMaterialForElement: function",


### PR DESCRIPTION
## What and why

`--by-entity` compared GlobalIds read from the `EntityTable`. The parser fills that table's GlobalId column **positionally**, and slot 0 of a resource entity is a **Name** — so the flag was silently comparing materials and surface styles under their names, and colliding them with each other.

Measured before changing anything, replaying the old loop against the chain-checked walk:

| model | old keys | dup keys | non-`IfcRoot` | new keys | dup | non-`IfcRoot` |
|---|---|---|---|---|---|---|
| `hello-wall.ifc` | 39 | 4 | 18 | 12 | 0 | 0 |
| `building-architecture.ifc` | 132 | 8 | 23 | 40 | 0 | 0 |
| `building-architecture-rev-b.ifc` | 133 | 9 | 25 | 40 | 0 | 0 |
| `infra-bridge.ifc` | 232 | 7 | 16 | 96 | 0 | 0 |
| `ara3d/dental_clinic.ifc` (209k) | 41,100 | 12 | 44 | 3,780 | 0 | 0 |

The non-`IfcRoot` entries were `IfcMaterial`, `IfcSurfaceStyle`, `IfcClassification`, `IfcProjectedCRS` and geometric subcontexts.

## Two corrections to the premise I was given

**The "silent drop-out" claim does not hold for this flag.** It is true of the pre-fix `--by-content` path (which read `store.entities.getGlobalId` only), but `--by-entity` went through `EntityNode.globalId`, which falls back to `extractRootAttributesFromEntity` on the STEP record. Measured on `856_wall_decode_failed.ifc`: `IFCTASK` count 8, table GlobalIds 0, `EntityNode` GlobalIds **8**. Tasks and work schedules were already compared; "gained keys" was 0 on every model probed. The fix keeps them, and the test says explicitly that this is not a regression pin on the old flag.

**A third defect, larger than either, surfaced from the probe: scope.** Relationships and property sets dominated the old key set (14,701 `IfcRelDefinesByProperties` + 14,432 `IfcPropertySet` on the 209k model). On a real re-export pair:

```
BEFORE                          AFTER
Added:   183                    Added:   0
Removed: 179                    Removed: 0
```

Every one of those 362 was a re-GUIDed pset or relationship. **Not one object identity had changed.** Anyone reading that output as "183 things were added" was reading noise.

## The fix

Membership now comes from the schema registry inheritance chain, shared with `--by-content`: every `IfcObjectDefinition` in, `IfcRelationship` and `IfcPropertyDefinition` out by rule, classified once per *type* so geometry buckets are dismissed without touching a row.

`classifyType`, the per-type dismissal, the source read and the `ifcType` resolution moved verbatim out of `diff-engine.ts` into a shared `diff-scope.ts` (174 lines) with no logic change — `diff-engine.ts` drops 263 → 145 lines and its 8 existing tests pass untouched.

The vendor gap is inherited, not widened: `IFCVENDORTASK` stays uncompared, `IFCVENDORWALLTYPE` stays compared, pinned with reasoning — including the note that this is *narrower* than the old flag, which saw vendor roots via the positional slot-0 fallback at the cost of reading a Name for every vendor non-root.

## Verification

`@ifc-lite/cli` 241 tests (19 files) · typecheck 33/33 · docs-samples 255 clean · generated regions up to date · api-surface matches · `tsc --noEmit` on the package directly.

That last one matters: **`pnpm typecheck` does not cover `packages/cli`** — it has no `typecheck` script, so the package is only typechecked by its build. Same class of gap as #1998 found in the examples. Flagging rather than fixing here, since it belongs in its own change.

8 mutations, all killed, every one of the 8 new tests killed by at least one — including reverting `--by-entity` to the old `EntityNode` walk.

Changeset (`@ifc-lite/cli` minor) states plainly that **the reported numbers change on every model**, with before/after counts, and points anyone who read added/removed as a "pset appeared" proxy at the type-difference table and `--by-content`.

Toward #1891.
