### PR TITLE
feat(viewer): render content matches in Compare, on by default (#1891)

### DIFF
--- a/apps/viewer/src/components/viewer/ComparePanel.tsx
+++ b/apps/viewer/src/components/viewer/ComparePanel.tsx
@@ -10,7 +10,7 @@
  */
 
 import { useEffect, useMemo } from 'react';
-import { GitCompareArrows, Loader2, Play, X, Trash2, Download, ChevronLeft } from 'lucide-react';
+import { GitCompareArrows, X, Trash2, Download, ChevronLeft } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 import { tourAnchor, TOUR_ANCHORS } from '@/lib/tours/anchors';
@@ -26,22 +26,14 @@ import { ChangeDetailView } from './compare/ChangeDetailView';
 import { BcfFromChange } from './compare/BcfFromChange';
 import { useBcfFromChange } from './compare/useBcfFromChange';
 import { CompareResultsList, CountBadge, LISTED_STATES, type CompareBucket } from './compare/CompareResultsList';
-import { CompareBlacklist } from './compare/CompareBlacklist';
-import { changedTypeCounts, type CompareRow } from './compare/changeRow';
-import type { DiffScope, DiffState, DiffEntry } from '@ifc-lite/diff';
+import { CompareRunControls } from './compare/CompareRunControls';
+import { changedTypeCounts, contentMatchRows, hasReportableChanges, MAX_ROWS_PER_GROUP, type CompareMatchRow, type CompareRow } from './compare/changeRow';
+import { contentMatchCounts, contentMatchingRan } from '@/lib/compare/contentMatches';
+import type { DiffState, DiffEntry } from '@ifc-lite/diff';
 
 interface ComparePanelProps {
   onClose?: () => void;
 }
-
-const SCOPES: { id: DiffScope; label: string }[] = [
-  { id: 'both', label: 'Both' },
-  { id: 'data', label: 'Data' },
-  { id: 'geometry', label: 'Geometry' },
-];
-
-/** Cap rows rendered per group so a huge diff can't stall the DOM. */
-const MAX_ROWS_PER_GROUP = 1000;
 
 /** The side actually drawn for an entry: base for deletions, head otherwise. */
 function renderRef(entry: DiffEntry<CompareRef>): CompareRef | undefined {
@@ -56,12 +48,14 @@ export function ComparePanel({ onClose }: ComparePanelProps) {
   const headModelId = useViewerStore((s) => s.compareHeadModelId);
   const scope = useViewerStore((s) => s.compareScope);
   const showUnchanged = useViewerStore((s) => s.compareShowUnchanged);
+  const matchByContent = useViewerStore((s) => s.compareMatchByContent);
   const excludedTypes = useViewerStore((s) => s.compareExcludedTypes);
   const selectedKey = useViewerStore((s) => s.compareSelectedKey);
   const setBaseModelId = useViewerStore((s) => s.setCompareBaseModelId);
   const setHeadModelId = useViewerStore((s) => s.setCompareHeadModelId);
   const setScope = useViewerStore((s) => s.setCompareScope);
   const setShowUnchanged = useViewerStore((s) => s.setCompareShowUnchanged);
+  const setMatchByContent = useViewerStore((s) => s.setCompareMatchByContent);
   const addExcludedType = useViewerStore((s) => s.addCompareExcludedType);
   const removeExcludedType = useViewerStore((s) => s.removeCompareExcludedType);
   const clearExcludedTypes = useViewerStore((s) => s.clearCompareExcludedTypes);
@@ -123,6 +117,18 @@ export function ComparePanel({ onClose }: ComparePanelProps) {
     return out;
   }, [result, models]);
 
+  // Content-match rows (#1891). They live on `diff.contentMatches`, NOT in
+  // `diff.entries` - a retiring match removed its entries outright - so this is
+  // separate plumbing rather than another bucket of `groups`.
+  const matchRows = useMemo<CompareMatchRow[]>(
+    () =>
+      contentMatchRows(result?.diff.contentMatches, (ref) =>
+        models.get(ref.modelId)?.ifcDataStore?.entities.getName(ref.localId) || '',
+      ),
+    [result, models],
+  );
+  const matchCounts = useMemo(() => contentMatchCounts(result?.diff.contentMatches), [result]);
+
   const counts = result?.diff.counts;
   const canRun = !!baseModelId && !!headModelId && baseModelId !== headModelId && !running;
 
@@ -177,6 +183,32 @@ export function ComparePanel({ onClose }: ComparePanelProps) {
     requestAnimationFrame(() => state.cameraCallbacks.frameSelection?.());
   };
 
+  /** Select the elements a content-match row stands for. Retiring matches
+   *  select their head copies (the base copies are hidden by the overlay);
+   *  review groups select every candidate on both sides. */
+  const focusMatch = (row: CompareMatchRow) => {
+    if (row.refs.length === 0) return;
+    const state = useViewerStore.getState();
+    state.clearEntitySelection();
+    state.setSelectedEntityIds(row.refs.map((r) => r.globalId));
+    state.addEntitiesToSelection(row.refs.map((r) => ({ modelId: r.modelId, expressId: r.localId })));
+    // A content match is not a `DiffEntry`, so it has no "what changed" detail
+    // and no BCF pre-fill yet - the row key still drives the list highlight.
+    state.setCompareSelectedKey(row.key);
+    requestAnimationFrame(() => state.cameraCallbacks.frameSelection?.());
+  };
+
+  const focusMatchGroup = (rows: CompareMatchRow[]) => {
+    const refs = rows.flatMap((row) => row.refs);
+    if (refs.length === 0) return;
+    const state = useViewerStore.getState();
+    state.clearEntitySelection();
+    state.setSelectedEntityIds(refs.map((r) => r.globalId));
+    state.addEntitiesToSelection(refs.map((r) => ({ modelId: r.modelId, expressId: r.localId })));
+    state.setCompareSelectedKey(null);
+    requestAnimationFrame(() => state.cameraCallbacks.frameSelection?.());
+  };
+
   const downloadReport = (format: 'csv' | 'json') => {
     if (!result) return;
     // Pass the blacklist in its original IFC casing so the report reads
@@ -228,98 +260,53 @@ export function ComparePanel({ onClose }: ComparePanelProps) {
               pre-filled form, so re-running / exports / browsing only get in the way. */}
           {!bcfComposing && (
             <>
-              {/* Run controls */}
-              <div className="p-3 space-y-3 border-b border-border">
-                <div className="grid grid-cols-[1.25rem_1fr] items-center gap-x-2 gap-y-2 text-xs" {...tourAnchor(TOUR_ANCHORS.compareAb)}>
-                  <span className="text-muted-foreground">A</span>
-                  <select
-                    value={baseModelId ?? ''}
-                    onChange={(e) => setBaseModelId(e.target.value)}
-                    className="w-full rounded border border-border bg-transparent px-2 py-1 text-foreground min-w-0"
-                  >
-                    {modelList.map((m) => (
-                      <option key={m.id} value={m.id}>{m.name}</option>
-                    ))}
-                  </select>
-                  <span className="text-muted-foreground">B</span>
-                  <select
-                    value={headModelId ?? ''}
-                    onChange={(e) => setHeadModelId(e.target.value)}
-                    className="w-full rounded border border-border bg-transparent px-2 py-1 text-foreground min-w-0"
-                  >
-                    {modelList.map((m) => (
-                      <option key={m.id} value={m.id}>{m.name}</option>
-                    ))}
-                  </select>
-                </div>
+              <CompareRunControls
+                models={modelList}
+                baseModelId={baseModelId}
+                headModelId={headModelId}
+                onBaseModelId={setBaseModelId}
+                onHeadModelId={setHeadModelId}
+                scope={scope}
+                onScope={setScope}
+                showUnchanged={showUnchanged}
+                onShowUnchanged={setShowUnchanged}
+                matchByContent={matchByContent}
+                onMatchByContent={setMatchByContent}
+                canRun={canRun}
+                running={running}
+                onRun={() => void runComparison()}
+                error={error}
+                geometryUnavailable={!!result?.geometryUnavailable}
+                excludedTypes={excludedTypes}
+                changedTypeCounts={typeCounts}
+                onAddExcludedType={addExcludedType}
+                onRemoveExcludedType={removeExcludedType}
+                onClearExcludedTypes={clearExcludedTypes}
+              />
 
-                {baseModelId === headModelId && (
-                  <p className="text-xs text-[#e0af68]">Pick two different models.</p>
-                )}
-
-                <div className="flex flex-wrap items-center gap-2">
-                  <div className="inline-flex rounded-md border border-border overflow-hidden text-xs shrink-0">
-                    {SCOPES.map((s) => (
-                      <button
-                        key={s.id}
-                        onClick={() => setScope(s.id)}
-                        className={cn(
-                          'px-2.5 py-1 transition-colors',
-                          scope === s.id ? 'bg-primary text-primary-foreground' : 'hover:bg-muted',
-                        )}
-                      >
-                        {s.label}
-                      </button>
-                    ))}
-                  </div>
-                  <label className="flex items-center gap-1.5 text-xs text-muted-foreground cursor-pointer select-none">
-                    <input
-                      type="checkbox"
-                      checked={showUnchanged}
-                      onChange={(e) => setShowUnchanged(e.target.checked)}
-                    />
-                    Show unchanged
-                  </label>
-                </div>
-
-                <Button size="sm" className="w-full gap-1.5" disabled={!canRun} onClick={() => void runComparison()} {...tourAnchor(TOUR_ANCHORS.compareRun)}>
-                  {running ? <Loader2 className="h-4 w-4 animate-spin" /> : <Play className="h-4 w-4" />}
-                  {running ? 'Comparing…' : 'Run comparison'}
-                </Button>
-
-                {error && <p className="text-xs text-[#f7768e]">{error}</p>}
-
-                {result?.geometryUnavailable && scope !== 'data' && (
-                  <p className="text-xs text-[#e0af68]">
-                    One model has no geometry fingerprints (loaded outside the WASM
-                    mesh path), so geometry changes can’t be detected. Data changes
-                    are still accurate — switch to the Data scope for reliable results.
-                  </p>
-                )}
-
-                {/* Ignored classes - blacklist noisy types out of the diff (#1470).
-                    Compact, in-line with the run controls; self-hides when empty. */}
-                <CompareBlacklist
-                  excludedTypes={excludedTypes}
-                  changedTypeCounts={typeCounts}
-                  onAdd={addExcludedType}
-                  onRemove={removeExcludedType}
-                  onClear={clearExcludedTypes}
-                />
-              </div>
-
-              {/* Counts */}
+              {/* Counts. The Matched badge appears when the content pass RAN, not
+                  when it found something (#1891) — added/deleted are lower BECAUSE
+                  of it, so the number explaining the drop sits next to them. */}
               {counts && (
-                <div className="grid grid-cols-4 gap-1 p-3 border-b border-border text-center" {...tourAnchor(TOUR_ANCHORS.compareCounts)}>
+                <div
+                  className={cn(
+                    'grid gap-1 p-3 border-b border-border text-center',
+                    contentMatchingRan(result?.diff.contentMatches) ? 'grid-cols-5' : 'grid-cols-4',
+                  )}
+                  {...tourAnchor(TOUR_ANCHORS.compareCounts)}
+                >
                   <CountBadge label="Changed" value={counts.modified} color={COMPARE_COLORS.modified} />
                   <CountBadge label="Added" value={counts.added} color={COMPARE_COLORS.added} />
                   <CountBadge label="Deleted" value={counts.deleted} color={COMPARE_COLORS.deleted} />
+                  {contentMatchingRan(result?.diff.contentMatches) && (
+                    <CountBadge label="Matched" value={matchCounts.matchedElements} color={COMPARE_COLORS.matched} />
+                  )}
                   <CountBadge label="Unchanged" value={counts.unchanged} color={COMPARE_COLORS.unchanged} />
                 </div>
               )}
 
-              {/* Export the full change report (#1202) */}
-              {result && counts && counts.added + counts.modified + counts.deleted > 0 && (
+              {/* Export the full change report (#1202) — exact negation of the results list's empty state. */}
+              {result && counts && hasReportableChanges(counts, matchRows) && (
                 <div className="flex items-center gap-2 px-3 py-2 border-b border-border text-xs">
                   <Download className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
                   <span className="text-muted-foreground">Download report</span>
@@ -339,9 +326,12 @@ export function ComparePanel({ onClose }: ComparePanelProps) {
                 result={result}
                 groups={groups}
                 counts={counts}
+                matchRows={matchRows}
                 selectedKey={selectedKey}
                 onFocus={focusEntry}
                 onFocusGroup={focusGroup}
+                onFocusMatch={focusMatch}
+                onFocusMatchGroup={focusMatchGroup}
               />
 
               {/* What-changed detail for the selected element */}

--- a/apps/viewer/src/components/viewer/compare/CompareMatchGroups.test.tsx
+++ b/apps/viewer/src/components/viewer/compare/CompareMatchGroups.test.tsx
@@ -1,0 +1,143 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Row cap on the content-match sections (#1891 review, Codex P1).
+ *
+ * The Added / Changed / Deleted buckets have been capped at
+ * `MAX_ROWS_PER_GROUP` since #924; the Matched / Needs review sections shipped
+ * uncapped. That is the worse place for it to be missing: content matching is
+ * ON by default and a from-scratch re-export produces roughly one match record
+ * per element, so the headline scenario - the one the whole feature exists for
+ * - is the one that pushes tens of thousands of buttons into the DOM and stalls
+ * the panel.
+ *
+ * The cap is display-only, and these tests pin all three halves of that: the
+ * button count, the reported overflow (a silently-shown subset would be worse
+ * than a slow one), and that the header count plus the header's "select all in
+ * 3D" action still cover the FULL set - matching how the other groups behave.
+ */
+
+import '@/test/setup-dom.js';
+import { afterEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { MAX_ROWS_PER_GROUP, type CompareMatchRow } from './changeRow.js';
+import { CompareMatchGroups } from './CompareMatchGroups.js';
+
+/** `retiring` picks the section: true -> Matched, false -> Needs review. */
+function rows(count: number, retiring: boolean): CompareMatchRow[] {
+  return Array.from({ length: count }, (_, i) => ({
+    key: `match:${i}`,
+    kind: retiring ? ('renamed' as const) : ('ambiguous' as const),
+    retiring,
+    ifcType: 'IfcWall',
+    name: `Wall ${i}`,
+    baseCount: 1,
+    headCount: 1,
+    refs: [{ modelId: 'B', localId: i, globalId: 1000 + i }],
+  }));
+}
+
+const mounted: Root[] = [];
+
+function render(matchRows: CompareMatchRow[], onFocusGroup: (r: CompareMatchRow[]) => void = () => {}) {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  mounted.push(root);
+  act(() => {
+    root.render(
+      <CompareMatchGroups
+        rows={matchRows}
+        selectedKey={null}
+        onFocus={() => {}}
+        onFocusGroup={onFocusGroup}
+      />,
+    );
+  });
+  return container;
+}
+
+afterEach(() => {
+  let root = mounted.pop();
+  while (root) {
+    const current = root;
+    act(() => current.unmount());
+    root = mounted.pop();
+  }
+});
+
+/** Section header + one button per listed row, so the row buttons are the
+ *  buttons after the header. */
+function rowButtons(container: HTMLElement): HTMLButtonElement[] {
+  return [...container.querySelectorAll('button')].slice(1) as HTMLButtonElement[];
+}
+
+describe('CompareMatchGroups - row cap (#1891 review)', () => {
+  it('renders every row when the group is under the cap', () => {
+    const container = render(rows(3, true));
+    assert.strictEqual(rowButtons(container).length, 3);
+    assert.ok(!container.textContent?.includes('more not shown'));
+  });
+
+  it('caps the rendered rows of a huge Matched group', () => {
+    // The default-on re-export case. Pre-fix this rendered one button per
+    // match, unbounded.
+    const container = render(rows(MAX_ROWS_PER_GROUP + 7, true));
+    assert.strictEqual(rowButtons(container).length, MAX_ROWS_PER_GROUP);
+  });
+
+  it('reports the truncated remainder rather than dropping it silently', () => {
+    const container = render(rows(MAX_ROWS_PER_GROUP + 7, true));
+    assert.ok(
+      container.textContent?.includes('+7 more not shown'),
+      'must use the same overflow wording as the Added/Changed/Deleted groups',
+    );
+  });
+
+  it('keeps the header count at the FULL group size, not the rendered size', () => {
+    const container = render(rows(MAX_ROWS_PER_GROUP + 7, true));
+    const header = container.querySelector('button');
+    assert.ok(header);
+    assert.ok(
+      header.textContent?.includes(`(${MAX_ROWS_PER_GROUP + 7})`),
+      `header read "${header.textContent}"`,
+    );
+  });
+
+  it('still selects every element in the group, including the unrendered ones', () => {
+    // The Added/Changed/Deleted headers select the full bucket rather than the
+    // capped rows; a capped match header that only selected what it drew would
+    // quietly disagree with its own count.
+    let selected: CompareMatchRow[] = [];
+    const container = render(rows(MAX_ROWS_PER_GROUP + 7, true), (r) => {
+      selected = r;
+    });
+    act(() => {
+      container.querySelector('button')!.click();
+    });
+    assert.strictEqual(selected.length, MAX_ROWS_PER_GROUP + 7);
+  });
+
+  it('caps the Needs review section too', () => {
+    // Unresolved groups retire nothing, so they are listed here AND under
+    // Added/Deleted - an uncapped section here doubles the flood.
+    const container = render(rows(MAX_ROWS_PER_GROUP + 4, false));
+    assert.strictEqual(rowButtons(container).length, MAX_ROWS_PER_GROUP);
+    assert.ok(container.textContent?.includes('+4 more not shown'));
+  });
+
+  it('caps the two sections independently', () => {
+    const container = render([
+      ...rows(MAX_ROWS_PER_GROUP + 2, true),
+      ...rows(MAX_ROWS_PER_GROUP + 5, false).map((r) => ({ ...r, key: `${r.key}:review` })),
+    ]);
+    // Two section headers + the capped rows of each.
+    assert.strictEqual(container.querySelectorAll('button').length, 2 + MAX_ROWS_PER_GROUP * 2);
+    assert.ok(container.textContent?.includes('+2 more not shown'));
+    assert.ok(container.textContent?.includes('+5 more not shown'));
+  });
+});

--- a/apps/viewer/src/components/viewer/compare/CompareMatchGroups.tsx
+++ b/apps/viewer/src/components/viewer/compare/CompareMatchGroups.tsx
@@ -1,0 +1,131 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The two content-matching sections of the compare results list (issue #1891),
+ * kept out of `CompareResultsList` so both stay under the module-size house
+ * rule (AGENTS.md).
+ *
+ * These rows do not come from `diff.entries` at all - they come from
+ * `diff.contentMatches`:
+ *
+ * - **Matched** (`renamed` / `moved` / `reshaped`): the engine retired these
+ *   elements' `added`/`deleted` entries. Without this section their counts drop
+ *   out of the panel with no row saying where they went.
+ * - **Needs review** (`duplicated` / `deduplicated` / `ambiguous`): the engine
+ *   retired nothing, so these elements are ALSO listed above under Added /
+ *   Deleted in their own colours. This section badges the grouping the engine
+ *   found without claiming a resolution it declined to make.
+ */
+
+import { Link2, TriangleAlert, MousePointerClick } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { COMPARE_COLORS, rgbaCss, type RGBA } from '@/lib/compare/overlay';
+import { MATCH_KIND_HINT, MATCH_KIND_LABEL } from '@/lib/compare/contentMatches';
+import { MAX_ROWS_PER_GROUP, type CompareMatchRow } from './changeRow';
+
+/** Amber, matching the panel's existing warning text colour (`#e0af68`). */
+const REVIEW_COLOR: RGBA = [0.878, 0.686, 0.408, 1];
+
+/** Right-hand summary for a row: the kind, plus the group shape when the match
+ *  is not a simple pair, plus the move distance when the engine measured one. */
+function matchRowSummary(row: CompareMatchRow): string {
+  const parts = [MATCH_KIND_LABEL[row.kind]];
+  if (row.baseCount !== 1 || row.headCount !== 1) parts.push(`${row.baseCount}:${row.headCount}`);
+  if (row.distance !== undefined && row.distance > 0) parts.push(`${row.distance.toFixed(3)} m`);
+  return parts.join(' · ');
+}
+
+interface MatchSectionProps {
+  rows: CompareMatchRow[];
+  selectedKey: string | null;
+  onFocus: (row: CompareMatchRow) => void;
+  onFocusGroup: (rows: CompareMatchRow[]) => void;
+}
+
+function MatchSection({
+  rows,
+  selectedKey,
+  onFocus,
+  onFocusGroup,
+  label,
+  title,
+  color,
+  Icon,
+}: MatchSectionProps & { label: string; title: string; color: RGBA; Icon: typeof Link2 }) {
+  if (rows.length === 0) return null;
+  // Same display cap as the Added/Changed/Deleted buckets. Content matching is
+  // on by default and a from-scratch re-export can produce one match record per
+  // element, so without this the default-on path is the one that floods the DOM.
+  // Header count and `onFocusGroup` keep the FULL set - only the buttons are
+  // capped, and the remainder is reported rather than silently dropped.
+  const shown = rows.length > MAX_ROWS_PER_GROUP ? rows.slice(0, MAX_ROWS_PER_GROUP) : rows;
+  const truncated = rows.length - shown.length;
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={() => onFocusGroup(rows)}
+        title={title}
+        className="group w-full flex items-center gap-1.5 px-1 py-1 text-xs font-medium rounded hover:bg-muted transition-colors"
+      >
+        <Icon className="h-3.5 w-3.5" style={{ color: rgbaCss(color) }} />
+        <span>{label}</span>
+        <span className="text-muted-foreground">({rows.length})</span>
+        <MousePointerClick className="h-3 w-3 ml-auto opacity-0 group-hover:opacity-60 transition-opacity" />
+      </button>
+      <div className="space-y-0.5">
+        {shown.map((row) => (
+          <button
+            key={row.key}
+            onClick={() => onFocus(row)}
+            title={MATCH_KIND_HINT[row.kind]}
+            className={cn(
+              'w-full text-left rounded px-2 py-1 flex items-center gap-2 hover:bg-muted transition-colors min-w-0',
+              selectedKey === row.key && 'bg-muted',
+            )}
+          >
+            <span className="h-2.5 w-2.5 rounded-sm shrink-0" style={{ backgroundColor: rgbaCss(color) }} />
+            <span className="min-w-0 flex-1 truncate text-xs">{row.name || row.ifcType}</span>
+            <span className="shrink-0 text-[10px] text-muted-foreground">{matchRowSummary(row)}</span>
+          </button>
+        ))}
+        {truncated > 0 && (
+          <p className="px-2 py-1 text-[10px] text-muted-foreground">
+            +{truncated} more not shown
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function CompareMatchGroups({ rows, selectedKey, onFocus, onFocusGroup }: MatchSectionProps) {
+  const matched = rows.filter((row) => row.retiring);
+  const review = rows.filter((row) => !row.retiring);
+  return (
+    <>
+      <MatchSection
+        rows={matched}
+        selectedKey={selectedKey}
+        onFocus={onFocus}
+        onFocusGroup={onFocusGroup}
+        label="Matched"
+        title="Select all content-matched elements in 3D"
+        color={COMPARE_COLORS.matched}
+        Icon={Link2}
+      />
+      <MatchSection
+        rows={review}
+        selectedKey={selectedKey}
+        onFocus={onFocus}
+        onFocusGroup={onFocusGroup}
+        label="Needs review"
+        title="Select every candidate in the unresolved match groups"
+        color={REVIEW_COLOR}
+        Icon={TriangleAlert}
+      />
+    </>
+  );
+}

--- a/apps/viewer/src/components/viewer/compare/CompareResultsList.tsx
+++ b/apps/viewer/src/components/viewer/compare/CompareResultsList.tsx
@@ -11,10 +11,11 @@ import { Plus, Minus, PencilLine, MousePointerClick } from 'lucide-react';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { cn } from '@/lib/utils';
 import { tourAnchor, TOUR_ANCHORS } from '@/lib/tours/anchors';
-import { COMPARE_COLORS, type RGBA } from '@/lib/compare/overlay';
+import { COMPARE_COLORS, rgbaCss, type RGBA } from '@/lib/compare/overlay';
 import type { DiffState } from '@ifc-lite/diff';
 import type { CompareResult } from '@/store/slices/compareSlice';
-import type { CompareRow } from './changeRow';
+import { hasReportableChanges, type CompareMatchRow, type CompareRow } from './changeRow';
+import { CompareMatchGroups } from './CompareMatchGroups';
 
 export interface CompareBucket {
   rows: CompareRow[];
@@ -27,10 +28,6 @@ export const LISTED_STATES: { state: Exclude<DiffState, 'unchanged'>; label: str
   { state: 'added', label: 'Added', color: COMPARE_COLORS.added, Icon: Plus },
   { state: 'deleted', label: 'Deleted', color: COMPARE_COLORS.deleted, Icon: Minus },
 ];
-
-export function rgbaCss([r, g, b, a]: RGBA): string {
-  return `rgba(${Math.round(r * 255)}, ${Math.round(g * 255)}, ${Math.round(b * 255)}, ${a})`;
-}
 
 export function CountBadge({ label, value, color }: { label: string; value: number; color: RGBA }) {
   return (
@@ -47,13 +44,27 @@ interface CompareResultsListProps {
   result: CompareResult | null;
   groups: Map<DiffState, CompareBucket>;
   counts: CompareResult['diff']['counts'] | undefined;
+  /** Content-match rows (#1891) - these live OUTSIDE `diff.entries`. */
+  matchRows: CompareMatchRow[];
   selectedKey: string | null;
   onFocus: (row: CompareRow) => void;
   /** Select every element in a state bucket at once (section-header click). */
   onFocusGroup: (state: DiffState) => void;
+  onFocusMatch: (row: CompareMatchRow) => void;
+  onFocusMatchGroup: (rows: CompareMatchRow[]) => void;
 }
 
-export function CompareResultsList({ result, groups, counts, selectedKey, onFocus, onFocusGroup }: CompareResultsListProps) {
+export function CompareResultsList({
+  result,
+  groups,
+  counts,
+  matchRows,
+  selectedKey,
+  onFocus,
+  onFocusGroup,
+  onFocusMatch,
+  onFocusMatchGroup,
+}: CompareResultsListProps) {
   return (
     <ScrollArea className="flex-1 min-h-0" {...tourAnchor(TOUR_ANCHORS.compareResults)}>
       {!result ? (
@@ -106,7 +117,16 @@ export function CompareResultsList({ result, groups, counts, selectedKey, onFocu
               </div>
             );
           })}
-          {counts && counts.added + counts.modified + counts.deleted === 0 && (
+          <CompareMatchGroups
+            rows={matchRows}
+            selectedKey={selectedKey}
+            onFocus={onFocusMatch}
+            onFocusGroup={onFocusMatchGroup}
+          />
+          {/* Exact negation of the panel's "Download report" bar, through the
+              same predicate - offering a report over "the models match" (or the
+              reverse) is precisely what two independent derivations produced. */}
+          {counts && !hasReportableChanges(counts, matchRows) && (
             <div className="p-3 text-sm text-muted-foreground">
               No differences in scope “{result.scope}”. The models match.
             </div>

--- a/apps/viewer/src/components/viewer/compare/CompareRunControls.tsx
+++ b/apps/viewer/src/components/viewer/compare/CompareRunControls.tsx
@@ -1,0 +1,186 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The Compare panel's run controls (issue #924): A/B model pickers, the
+ * data/geometry/both scope, the display + matching toggles, the run button and
+ * the in-line warnings. Extracted from `ComparePanel` so both stay under the
+ * module-size house rule (AGENTS.md) once content matching (#1891) added its
+ * own toggle here.
+ *
+ * Deliberately presentational - every piece of state is owned by the store and
+ * threaded in, so this file has no behaviour to test beyond wiring.
+ */
+
+import { Loader2, Play } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import { tourAnchor, TOUR_ANCHORS } from '@/lib/tours/anchors';
+import type { DiffScope } from '@ifc-lite/diff';
+import { CompareBlacklist } from './CompareBlacklist';
+import type { ChangedTypeCount } from './changeRow';
+
+const SCOPES: { id: DiffScope; label: string }[] = [
+  { id: 'both', label: 'Both' },
+  { id: 'data', label: 'Data' },
+  { id: 'geometry', label: 'Geometry' },
+];
+
+interface CompareRunControlsProps {
+  models: { id: string; name: string }[];
+  baseModelId: string | null;
+  headModelId: string | null;
+  onBaseModelId: (id: string) => void;
+  onHeadModelId: (id: string) => void;
+  scope: DiffScope;
+  onScope: (scope: DiffScope) => void;
+  showUnchanged: boolean;
+  onShowUnchanged: (show: boolean) => void;
+  matchByContent: boolean;
+  onMatchByContent: (enabled: boolean) => void;
+  canRun: boolean;
+  running: boolean;
+  onRun: () => void;
+  error: string | null;
+  /** Show the "no geometry fingerprints" warning (result-dependent). */
+  geometryUnavailable: boolean;
+  excludedTypes: string[];
+  changedTypeCounts: ChangedTypeCount[];
+  onAddExcludedType: (type: string) => void;
+  onRemoveExcludedType: (type: string) => void;
+  onClearExcludedTypes: () => void;
+}
+
+export function CompareRunControls({
+  models,
+  baseModelId,
+  headModelId,
+  onBaseModelId,
+  onHeadModelId,
+  scope,
+  onScope,
+  showUnchanged,
+  onShowUnchanged,
+  matchByContent,
+  onMatchByContent,
+  canRun,
+  running,
+  onRun,
+  error,
+  geometryUnavailable,
+  excludedTypes,
+  changedTypeCounts,
+  onAddExcludedType,
+  onRemoveExcludedType,
+  onClearExcludedTypes,
+}: CompareRunControlsProps) {
+  return (
+    <div className="p-3 space-y-3 border-b border-border">
+      <div
+        className="grid grid-cols-[1.25rem_1fr] items-center gap-x-2 gap-y-2 text-xs"
+        {...tourAnchor(TOUR_ANCHORS.compareAb)}
+      >
+        <span className="text-muted-foreground">A</span>
+        <select
+          value={baseModelId ?? ''}
+          onChange={(e) => onBaseModelId(e.target.value)}
+          className="w-full rounded border border-border bg-transparent px-2 py-1 text-foreground min-w-0"
+        >
+          {models.map((m) => (
+            <option key={m.id} value={m.id}>{m.name}</option>
+          ))}
+        </select>
+        <span className="text-muted-foreground">B</span>
+        <select
+          value={headModelId ?? ''}
+          onChange={(e) => onHeadModelId(e.target.value)}
+          className="w-full rounded border border-border bg-transparent px-2 py-1 text-foreground min-w-0"
+        >
+          {models.map((m) => (
+            <option key={m.id} value={m.id}>{m.name}</option>
+          ))}
+        </select>
+      </div>
+
+      {baseModelId === headModelId && (
+        <p className="text-xs text-[#e0af68]">Pick two different models.</p>
+      )}
+
+      <div className="flex flex-wrap items-center gap-2">
+        <div className="inline-flex rounded-md border border-border overflow-hidden text-xs shrink-0">
+          {SCOPES.map((s) => (
+            <button
+              key={s.id}
+              onClick={() => onScope(s.id)}
+              className={cn(
+                'px-2.5 py-1 transition-colors',
+                scope === s.id ? 'bg-primary text-primary-foreground' : 'hover:bg-muted',
+              )}
+            >
+              {s.label}
+            </button>
+          ))}
+        </div>
+        <label className="flex items-center gap-1.5 text-xs text-muted-foreground cursor-pointer select-none">
+          <input
+            type="checkbox"
+            checked={showUnchanged}
+            onChange={(e) => onShowUnchanged(e.target.checked)}
+          />
+          Show unchanged
+        </label>
+      </div>
+
+      {/* Content matching (#1891). On by default: without it a from-scratch
+          re-export reads as "everything deleted, everything added". Off is the
+          honest fallback when GlobalIds ARE stable and every match would be a
+          guess the user does not want. */}
+      <label className="flex items-start gap-1.5 text-xs text-muted-foreground cursor-pointer select-none">
+        <input
+          type="checkbox"
+          className="mt-0.5"
+          checked={matchByContent}
+          onChange={(e) => onMatchByContent(e.target.checked)}
+        />
+        <span>
+          Match re-exported elements by content
+          <span className="block text-[10px] opacity-70">
+            Re-pairs elements whose GlobalId changed but whose content did not.
+          </span>
+        </span>
+      </label>
+
+      <Button
+        size="sm"
+        className="w-full gap-1.5"
+        disabled={!canRun}
+        onClick={onRun}
+        {...tourAnchor(TOUR_ANCHORS.compareRun)}
+      >
+        {running ? <Loader2 className="h-4 w-4 animate-spin" /> : <Play className="h-4 w-4" />}
+        {running ? 'Comparing…' : 'Run comparison'}
+      </Button>
+
+      {error && <p className="text-xs text-[#f7768e]">{error}</p>}
+
+      {geometryUnavailable && scope !== 'data' && (
+        <p className="text-xs text-[#e0af68]">
+          One model has no geometry fingerprints (loaded outside the WASM
+          mesh path), so geometry changes can’t be detected. Data changes
+          are still accurate — switch to the Data scope for reliable results.
+        </p>
+      )}
+
+      {/* Ignored classes - blacklist noisy types out of the diff (#1470).
+          Compact, in-line with the run controls; self-hides when empty. */}
+      <CompareBlacklist
+        excludedTypes={excludedTypes}
+        changedTypeCounts={changedTypeCounts}
+        onAdd={onAddExcludedType}
+        onRemove={onRemoveExcludedType}
+        onClear={onClearExcludedTypes}
+      />
+    </div>
+  );
+}

--- a/apps/viewer/src/components/viewer/compare/changeRow.test.ts
+++ b/apps/viewer/src/components/viewer/compare/changeRow.test.ts
@@ -1,0 +1,116 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import type { ContentMatch, ContentMatchKind, DiffCounts } from '@ifc-lite/diff';
+import { contentMatchRows, hasReportableChanges } from './changeRow.js';
+import type { CompareRef } from '@/lib/compare/buildFingerprints';
+
+const fp = (modelId: string, globalId: number, ifcType = 'IfcWall') => ({
+  key: `k${globalId}`,
+  ifcType,
+  dataHash: 'd',
+  ref: { modelId, localId: globalId, globalId },
+});
+
+function match(
+  kind: ContentMatchKind,
+  base: number[],
+  head: number[],
+  distance?: number,
+): ContentMatch<CompareRef> {
+  return {
+    kind,
+    dataHash: 'd',
+    base: base.map((id) => fp('a', id)),
+    head: head.map((id) => fp('b', id)),
+    ...(distance === undefined ? {} : { distance }),
+  };
+}
+
+const nameOf = (ref: CompareRef): string => `name-${ref.globalId}`;
+
+describe('contentMatchRows (#1891)', () => {
+  it('returns nothing when the content pass did not run', () => {
+    assert.deepStrictEqual(contentMatchRows(undefined, nameOf), []);
+  });
+
+  it('builds a retiring row that selects only the surviving head copies', () => {
+    // The base copies are hidden by the overlay, so selecting them would frame
+    // the camera on geometry the user cannot see.
+    const [row] = contentMatchRows([match('renamed', [1, 2], [1001, 1002])], nameOf);
+    assert.strictEqual(row.retiring, true);
+    assert.deepStrictEqual(row.refs.map((r) => r.globalId), [1001, 1002]);
+    assert.deepStrictEqual([row.baseCount, row.headCount], [2, 2]);
+    assert.strictEqual(row.name, 'name-1001');
+    assert.strictEqual(row.ifcType, 'IfcWall');
+  });
+
+  it('builds a review row that selects every candidate on BOTH sides', () => {
+    const [row] = contentMatchRows([match('ambiguous', [1, 2], [1001])], nameOf);
+    assert.strictEqual(row.retiring, false);
+    assert.deepStrictEqual(row.refs.map((r) => r.globalId), [1, 2, 1001]);
+  });
+
+  it('carries the engine distance through', () => {
+    const [row] = contentMatchRows([match('moved', [1], [1001], 1.75)], nameOf);
+    assert.strictEqual(row.distance, 1.75);
+  });
+
+  it('leaves the distance undefined when the engine could not measure one', () => {
+    // Without an `aabb` on both sides the engine reports a bare `moved`; the
+    // row must not invent a 0 m displacement that reads as "did not move".
+    const [row] = contentMatchRows([match('moved', [1], [1001])], nameOf);
+    assert.strictEqual(row.distance, undefined);
+  });
+
+  it('gives every row a key that cannot collide with a DiffEntry key', () => {
+    // The panel stores the focused row in the single `compareSelectedKey`
+    // channel that also feeds `diff.byKey` lookups, so a collision would show
+    // the wrong element's detail.
+    const rows = contentMatchRows(
+      [match('renamed', [1], [1001]), match('ambiguous', [2], [1002])],
+      nameOf,
+    );
+    assert.deepStrictEqual(rows.map((r) => r.key), ['match:0', 'match:1']);
+    for (const row of rows) assert.ok(row.key.startsWith('match:'));
+  });
+
+  it('skips a match record that carries no entities at all', () => {
+    assert.deepStrictEqual(contentMatchRows([match('renamed', [], [])], nameOf), []);
+  });
+});
+
+describe('hasReportableChanges (#1891 review)', () => {
+  const counts = (added: number, modified: number, deleted: number): DiffCounts => ({
+    added,
+    modified,
+    deleted,
+    unchanged: 500,
+  });
+
+  it('is false when there is neither an entry nor a match row', () => {
+    // Drives BOTH the panel's "Download report" bar and the results list's "the
+    // models match" empty state, which are exact negations - so this false case
+    // is the one that must show the empty state and hide the export. The 500
+    // `unchanged` elements must not count: they are never listed or exported.
+    assert.strictEqual(hasReportableChanges(counts(0, 0, 0), []), false);
+  });
+
+  it('counts a comparison whose entries are all zero but has matches', () => {
+    // The headline #1891 case: a from-scratch re-export where the pass retired
+    // every added/deleted entry. `counts` alone reads as "the models match",
+    // which is exactly wrong - there is a full Matched section to list and a
+    // full CSV to export.
+    const [row] = contentMatchRows([match('renamed', [1], [1001])], nameOf);
+    assert.strictEqual(hasReportableChanges(counts(0, 0, 0), [row]), true);
+  });
+
+  it('counts each kind of entry on its own', () => {
+    assert.strictEqual(hasReportableChanges(counts(1, 0, 0), []), true);
+    assert.strictEqual(hasReportableChanges(counts(0, 1, 0), []), true);
+    assert.strictEqual(hasReportableChanges(counts(0, 0, 1), []), true);
+  });
+});

--- a/apps/viewer/src/components/viewer/compare/changeRow.ts
+++ b/apps/viewer/src/components/viewer/compare/changeRow.ts
@@ -9,8 +9,29 @@
  */
 
 import type { CompareRef } from '@/lib/compare/buildFingerprints';
+import { isRetiringMatch } from '@/lib/compare/contentMatches';
 import type { ChangeDetail } from '@/lib/compare/describeChange';
-import type { DiffEntry, DiffState } from '@ifc-lite/diff';
+import type {
+  ContentMatch,
+  ContentMatchKind,
+  DiffCounts,
+  DiffEntry,
+  DiffState,
+} from '@ifc-lite/diff';
+
+/**
+ * Cap rows RENDERED per group so a huge diff can't stall the DOM.
+ *
+ * Applies to the Added/Changed/Deleted buckets (`ComparePanel`) and, since
+ * #1891, to the Matched / Needs review sections (`CompareMatchGroups`) - the
+ * content pass is on by default and a from-scratch re-export can produce one
+ * match per element, so that list is the one most likely to be enormous.
+ *
+ * Display-only in both places: the group counts and the section-header "select
+ * all in 3D" action always cover the FULL set, and the overflow is reported as
+ * "+N more not shown" so a subset is never shown silently.
+ */
+export const MAX_ROWS_PER_GROUP = 1000;
 
 /** One row in the compare results list. */
 export interface CompareRow {
@@ -20,6 +41,97 @@ export interface CompareRow {
   state: DiffState;
   changeKinds: string[];
   ref: CompareRef;
+}
+
+/**
+ * One row in the compare panel's content-match lists (#1891).
+ *
+ * A content match is NOT a `DiffEntry`: it lives on `diff.contentMatches` and,
+ * for the retiring kinds, its entities were deliberately removed from
+ * `diff.entries`. So this is a separate row shape rather than a filter over
+ * {@link CompareRow} - there is nothing in `entries` left to filter.
+ */
+export interface CompareMatchRow {
+  /**
+   * Row identity. Prefixed so it can never collide with a `DiffEntry.key`
+   * (a GlobalId or a `missing:` synthetic), because the panel stores the
+   * focused row in the single `compareSelectedKey` channel that also feeds
+   * `diff.byKey` lookups.
+   */
+  key: string;
+  kind: ContentMatchKind;
+  /** Whether the engine retired this match's add/delete entries. */
+  retiring: boolean;
+  ifcType: string;
+  name: string;
+  /** How many entities the match holds per side (1 each for a simple pair). */
+  baseCount: number;
+  headCount: number;
+  /** Bounding-box-centre displacement, when the engine could compute one. */
+  distance?: number;
+  /** Federation global ids to select in 3D when the row is clicked. */
+  refs: CompareRef[];
+}
+
+/**
+ * Turn the engine's content matches into panel rows.
+ *
+ * `nameOf` resolves a display name from the per-model store (the engine result
+ * carries only type + key), kept as a callback so this module stays free of
+ * store imports and unit-testable.
+ *
+ * Retiring matches select their HEAD copies in 3D: the base copies are hidden
+ * by the overlay, so selecting them would frame the camera on nothing. Review
+ * groups select every candidate on both sides - the whole point of the group is
+ * that the user has to look at all of them to resolve it.
+ */
+export function contentMatchRows(
+  matches: readonly ContentMatch<CompareRef>[] | undefined,
+  nameOf: (ref: CompareRef) => string,
+): CompareMatchRow[] {
+  const rows: CompareMatchRow[] = [];
+  (matches ?? []).forEach((match, index) => {
+    const retiring = isRetiringMatch(match.kind);
+    const sample = match.head[0] ?? match.base[0];
+    if (!sample) return; // an empty match record carries nothing to show
+    const refs = retiring
+      ? match.head.map((f) => f.ref)
+      : [...match.base.map((f) => f.ref), ...match.head.map((f) => f.ref)];
+    rows.push({
+      key: `match:${index}`,
+      kind: match.kind,
+      retiring,
+      ifcType: sample.ifcType || 'IfcProduct',
+      name: nameOf(sample.ref),
+      baseCount: match.base.length,
+      headCount: match.head.length,
+      distance: match.distance,
+      refs,
+    });
+  });
+  return rows;
+}
+
+/**
+ * Does this comparison have anything to show? THE signal for that question, so
+ * the two places that ask it cannot drift apart: `ComparePanel`'s "Download
+ * report" bar renders when it is true, and `CompareResultsList`'s "the models
+ * match" empty state renders when it is false. They are exact negations of each
+ * other, and previously each derived that independently - one could offer a
+ * report over a panel claiming the models matched.
+ *
+ * Counts the content-match ROWS, not `contentMatchCounts(...).total`: rows are
+ * what the panel actually lists and what the report actually exports, and
+ * {@link contentMatchRows} drops a match record carrying no entities. Note that
+ * `counts` alone cannot answer this - a retiring match REMOVED its pair's
+ * `added`/`deleted` entries, so a comparison can be all-zero in `counts` and
+ * still be full of findings.
+ */
+export function hasReportableChanges(
+  counts: DiffCounts,
+  matchRows: readonly CompareMatchRow[],
+): boolean {
+  return counts.added + counts.modified + counts.deleted + matchRows.length > 0;
 }
 
 /** An IFC class present among the changes, with how many changes it drives -

--- a/apps/viewer/src/hooks/useCompare.test.tsx
+++ b/apps/viewer/src/hooks/useCompare.test.tsx
@@ -1,0 +1,264 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Mid-run option changes in `useCompare` (#1891 review, Greptile P1 + Codex P2).
+ *
+ * `runComparison` is async: it yields a frame so "Comparing…" paints, then
+ * awaits fingerprint extraction (which itself yields every 1500 entities). The
+ * scope / blacklist / content-matching controls stay live for that whole
+ * window. Reading the options BEFORE those awaits and publishing a result built
+ * from the captured values silently loses any change made in between - and the
+ * reconciliation effect cannot catch it, because it deliberately omits `result`
+ * from its deps: the option change already fired the effect (against a null or
+ * older result) and the stale result landing afterwards re-runs nothing.
+ *
+ * The user-visible symptom is the whole panel disagreeing with its own
+ * checkbox - counts, rows, overlay and exported CSV - until some other option
+ * moves or the comparison is re-run. So these tests assert the published
+ * COUNTS, not just a flag: with matching off the re-GUIDed wall is 1 added +
+ * 1 deleted, with it on it is 0/0 plus one content match.
+ *
+ * The fixture is two real parsed models holding the same wall under different
+ * GlobalIds - the from-scratch re-export the content pass exists for.
+ */
+
+import '@/test/setup-dom.js';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { IfcParser, type IfcDataStore } from '@ifc-lite/parser';
+import type { GeometryResult, MeshData } from '@ifc-lite/geometry';
+import type { DiffScope } from '@ifc-lite/diff';
+import { useViewerStore, type FederatedModel } from '@/store';
+import { useCompare } from './useCompare.js';
+
+// ─── Fixture: one wall, re-GUIDed between A and B ────────────────────────
+
+function ifc4(body: string): string {
+  return [
+    'ISO-10303-21;',
+    'HEADER;',
+    "FILE_DESCRIPTION((''),'2;1');",
+    "FILE_NAME('','',(''),(''),'','','');",
+    "FILE_SCHEMA(('IFC4'));",
+    'ENDSEC;',
+    'DATA;',
+    body,
+    'ENDSEC;',
+    'END-ISO-10303-21;',
+    '',
+  ].join('\n');
+}
+
+/** A wall plus its property set, all IfcRoot GlobalIds swapped per revision -
+ *  identical content, no shared key, which is exactly what the content pass is
+ *  meant to re-pair. */
+function wall(guid: string, psetGuid: string, relGuid: string): string {
+  return [
+    `#1=IFCWALL('${guid}',$,'Wall A',$,$,$,$,$,.STANDARD.);`,
+    `#2=IFCPROPERTYSINGLEVALUE('FireRating',$,IFCLABEL('60'),$);`,
+    `#3=IFCPROPERTYSET('${psetGuid}',$,'Pset_WallCommon',$,(#2));`,
+    `#4=IFCRELDEFINESBYPROPERTIES('${relGuid}',$,$,$,(#1),#3);`,
+  ].join('\n');
+}
+
+async function parse(body: string): Promise<IfcDataStore> {
+  const bytes = new TextEncoder().encode(ifc4(body));
+  // disableWorkerScan keeps the scan in-process (no Worker under node:test).
+  return new IfcParser().parseColumnar(bytes.buffer as ArrayBuffer, { disableWorkerScan: true });
+}
+
+function model(id: string, store: IfcDataStore, idOffset: number): FederatedModel {
+  // `buildEntityFingerprints` reads only the express id and the geometry hash
+  // off a mesh. Both sides carry the SAME hash, so the shapes agree and the
+  // content pass resolves the pair rather than handing it back for review.
+  const meshes = [{ expressId: 1 + idOffset, geometryHash: 42n } as unknown as MeshData];
+  return {
+    id,
+    name: id,
+    ifcDataStore: store,
+    geometryResult: { meshes } as unknown as GeometryResult,
+    idOffset,
+    maxExpressId: 4,
+  } as unknown as FederatedModel;
+}
+
+// ─── Harness ────────────────────────────────────────────────────────────
+
+let runComparison: (() => Promise<void>) | null = null;
+
+function Probe(): null {
+  runComparison = useCompare().runComparison;
+  return null;
+}
+
+let root: Root | null = null;
+
+async function seed(): Promise<void> {
+  const [a, b] = await Promise.all([
+    parse(wall('0aaaaaaaaaaaaaaaaaaaaa', '0bbbbbbbbbbbbbbbbbbbbb', '0ccccccccccccccccccccc')),
+    parse(wall('1zzzzzzzzzzzzzzzzzzzzz', '1yyyyyyyyyyyyyyyyyyyyy', '1xxxxxxxxxxxxxxxxxxxxx')),
+  ]);
+  useViewerStore.setState({
+    models: new Map([
+      ['A', model('A', a, 0)],
+      ['B', model('B', b, 1000)],
+    ]),
+    compareBaseModelId: 'A',
+    compareHeadModelId: 'B',
+    compareScope: 'both',
+    compareExcludedTypes: [],
+    compareResult: null,
+    compareError: null,
+    compareRunning: false,
+  });
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  await act(async () => {
+    root!.render(<Probe />);
+  });
+}
+
+/**
+ * Start a comparison, change an option while it is still in flight, then let it
+ * finish.
+ *
+ * The start and the mutation use the SYNCHRONOUS `act` deliberately: the run's
+ * first `await` is a `setTimeout(0)` macrotask, and the async form of `act`
+ * yields far enough for that timer to fire, which lets the whole run complete
+ * before the mutation and quietly turns the test into a no-op. With no `await`
+ * anywhere between `runComparison()` and `mutate()`, the interleaving the bug
+ * needs is guaranteed rather than raced for. The in-flight assertion below is
+ * the belt-and-braces check on exactly that (it is what caught the async
+ * version being flaky).
+ */
+async function runWithMidRunChange(mutate: () => void): Promise<void> {
+  let pending: Promise<void> | undefined;
+  act(() => {
+    pending = runComparison!();
+  });
+  assert.ok(pending, 'runComparison must have started');
+  assert.strictEqual(useViewerStore.getState().compareResult, null, 'run must still be in flight');
+  act(() => {
+    mutate();
+  });
+  await act(async () => {
+    await pending;
+  });
+}
+
+function published() {
+  const result = useViewerStore.getState().compareResult;
+  assert.ok(result, 'the comparison must have published a result');
+  return result;
+}
+
+beforeEach(async () => {
+  runComparison = null;
+  await seed();
+});
+
+afterEach(async () => {
+  const current = root;
+  root = null;
+  if (current) await act(async () => current.unmount());
+});
+
+describe('useCompare - an option changed mid-run wins (#1891 review)', () => {
+  it('publishes with content matching OFF when it was switched off during the run', async () => {
+    useViewerStore.setState({ compareMatchByContent: true });
+    await runWithMidRunChange(() => {
+      useViewerStore.getState().setCompareMatchByContent(false);
+    });
+
+    const result = published();
+    // Pre-fix this was the flag captured before the fingerprint yield (`true`),
+    // so the panel showed 0 added / 0 deleted / 1 match under an UNCHECKED box.
+    assert.strictEqual(result.diff.contentMatches, undefined, 'the pass must not have run');
+    assert.strictEqual(result.diff.counts.added, 1);
+    assert.strictEqual(result.diff.counts.deleted, 1);
+  });
+
+  it('publishes with content matching ON when it was switched on during the run', async () => {
+    useViewerStore.setState({ compareMatchByContent: false });
+    await runWithMidRunChange(() => {
+      useViewerStore.getState().setCompareMatchByContent(true);
+    });
+
+    const result = published();
+    assert.ok(result.diff.contentMatches, 'the pass must have run');
+    assert.strictEqual(result.diff.contentMatches.length, 1);
+    assert.strictEqual(result.diff.counts.added, 0);
+    assert.strictEqual(result.diff.counts.deleted, 0);
+  });
+
+  it('publishes the scope chosen during the run, not the one the run started with', async () => {
+    // The same hole, latent since #924: the scope buttons are not disabled
+    // while a comparison is running either. The publish-time read closes all
+    // three options at once, so this is the regression guard for the two the
+    // content checkbox merely got to first.
+    useViewerStore.setState({ compareMatchByContent: true });
+    await runWithMidRunChange(() => {
+      useViewerStore.getState().setCompareScope('data' satisfies DiffScope);
+    });
+
+    assert.strictEqual(published().scope, 'data');
+  });
+
+  it('publishes the blacklist chosen during the run, so the excluded class is gone', async () => {
+    useViewerStore.setState({ compareMatchByContent: false });
+    await runWithMidRunChange(() => {
+      useViewerStore.getState().addCompareExcludedType('IfcWall');
+    });
+
+    const result = published();
+    assert.deepStrictEqual(result.diff.excludedTypes, ['IFCWALL']);
+    // The only element in the fixture is the wall, so excluding it must empty
+    // the diff - not merely record the class on a result that still lists it.
+    assert.strictEqual(result.diff.counts.added, 0);
+    assert.strictEqual(result.diff.counts.deleted, 0);
+    assert.strictEqual(result.diff.entries.length, 0);
+  });
+
+  it('leaves the reconciliation effect a no-op, so publishing does not re-diff', async () => {
+    // Rejects the other candidate fix: publish the stale result anyway and add
+    // `result` to the effect's deps so the effect cleans it up afterwards. That
+    // converges too, so tests 1-4 cannot tell the two apart - but it does so by
+    // paying a second full diff and showing one wrong frame in between, and it
+    // arms exactly the setCompareResult -> re-render -> re-diff cycle the
+    // missing dep exists to prevent. `compareRunSeq` counts completed diffs, so
+    // 2 here means the stale result was published and then patched. Verified by
+    // mutation: this assertion reads 2 under that alternative.
+    useViewerStore.setState({ compareMatchByContent: true, compareRunSeq: 0 });
+    await runWithMidRunChange(() => {
+      useViewerStore.getState().setCompareMatchByContent(false);
+    });
+
+    assert.strictEqual(useViewerStore.getState().compareRunSeq, 1);
+  });
+
+  it('still reconciles a change made AFTER the result landed', async () => {
+    // The stale-publish fix must not cost the existing instant re-diff.
+    useViewerStore.setState({ compareMatchByContent: true });
+    let pending: Promise<void> | undefined;
+    await act(async () => {
+      pending = runComparison!();
+    });
+    await act(async () => {
+      await pending;
+    });
+    assert.ok(published().diff.contentMatches, 'baseline: the pass ran');
+
+    await act(async () => {
+      useViewerStore.getState().setCompareMatchByContent(false);
+    });
+    const result = published();
+    assert.strictEqual(result.diff.contentMatches, undefined);
+    assert.strictEqual(result.diff.counts.added, 1);
+    assert.strictEqual(result.diff.counts.deleted, 1);
+  });
+});

--- a/apps/viewer/src/hooks/useCompare.ts
+++ b/apps/viewer/src/hooks/useCompare.ts
@@ -26,17 +26,23 @@ import {
   hasGeometryHashes,
   type CompareRef,
 } from '@/lib/compare/buildFingerprints';
+import { contentMatchCounts, contentMatchingRan } from '@/lib/compare/contentMatches';
 
 type Side = EntityFingerprint<CompareRef>[];
 interface BuiltPair {
-  key: string;
+  baseModelId: string;
+  headModelId: string;
   baseName: string;
   headName: string;
   base: Side;
   head: Side;
 }
 
-const pairKey = (a: string, b: string): string => `${a} ${b}`;
+/** Are these fingerprints the ones for this A/B pair? (Compared field-wise
+ *  rather than through a joined key string, so two ids can never alias.) */
+function isPairOf(built: BuiltPair, baseModelId: string, headModelId: string): boolean {
+  return built.baseModelId === baseModelId && built.headModelId === headModelId;
+}
 
 /** Canonical, order-independent signature of a blacklist so a re-render with a
  *  fresh-but-equivalent array reference doesn't trigger a re-diff. Compared
@@ -72,24 +78,65 @@ function collectExcludedHiddenIds(built: BuiltPair, excludedTypes: string[]): Se
   return ids;
 }
 
-/** Run the (cheap) diff pass + derive the overlay's hidden set for one pair,
- *  scope and blacklist. Fingerprint extraction (the expensive part) already
- *  happened; this is safe to re-run on every scope / blacklist change. */
-function buildCompareResult(
-  built: BuiltPair,
-  baseModelId: string,
-  headModelId: string,
-  scope: CompareResult['scope'],
-  excludedTypes: string[],
-): CompareResult {
-  const diff = diffModels(built.base, built.head, { scope, excludeTypes: excludedTypes });
+/**
+ * Run the (cheap) diff pass for the cached fingerprints, derive the overlay's
+ * hidden set, and publish the whole comparison to the store. The single place a
+ * `CompareResult` is ever produced - both the Run button and the reconciliation
+ * effect below go through here.
+ *
+ * INVARIANT this function exists to protect (the #1891 P1 fix). The diff options
+ * are read HERE, and nothing may `await` between that read and
+ * `setCompareResult`:
+ *
+ * - **Read here, never in a caller.** The scope / blacklist / matching controls
+ *   stay live while a comparison is in flight, so a value captured before
+ *   `runComparison`'s awaits (the frame yield plus fingerprint extraction) can be
+ *   stale by the time the fingerprints land. Publishing such a value made the
+ *   panel disagree with its own controls - counts, rows, overlay and exported CSV
+ *   all - until the user moved some other option or re-ran. Latent since #924 for
+ *   scope + blacklist; the content-matching checkbox is merely the first of the
+ *   three a user reaches for mid-run.
+ * - **Stay synchronous.** With no `await` between the read and the publish, no
+ *   event handler can interleave, so the published result cannot be stale by even
+ *   one option change. Adding an `await` in here reintroduces the P1.
+ *
+ * Together those are what let the reconciliation effect below omit `result` from
+ * its deps: a published result always agrees with the store, so there is nothing
+ * for a `result`-triggered re-run to catch, and no `setCompareResult` ->
+ * re-render -> re-diff cycle.
+ *
+ * Fingerprint extraction (the expensive part) already happened, so this is cheap
+ * enough to re-run on every scope / blacklist / matching change.
+ *
+ * @returns the published result, plus the matching flag it ran with - telemetry
+ *   reports the OPTION, of which `diff.contentMatches` is only a derivation.
+ */
+function publishCompareResult(built: BuiltPair): {
+  result: CompareResult;
+  matchByContent: boolean;
+} {
+  const store = useViewerStore.getState();
+  const scope: CompareResult['scope'] = store.compareScope;
+  const excludedTypes = store.compareExcludedTypes;
+  const matchByContent = store.compareMatchByContent;
+
+  const diff = diffModels(built.base, built.head, {
+    scope,
+    excludeTypes: excludedTypes,
+    // #1891. On by default: a from-scratch re-export re-GUIDs every element,
+    // and a pure key diff then reports the entire model as deleted-and-added.
+    // No `aabb` is supplied yet (that needs the mesh-bounds plumbing), so a 1:1
+    // geometry mismatch degrades to a bare `moved` with no distance — the
+    // engine's documented fallback, not a silent wrong answer.
+    matchUnpairedByContent: matchByContent,
+  });
   // Geometry hashes are produced only on the WASM mesh path; if either side was
   // loaded without them (e.g. a huge native desktop load), geometry/both scopes
   // can't see shape changes - flag it so the panel can warn.
   const geometryUnavailable = !hasGeometryHashes(built.base) || !hasGeometryHashes(built.head);
-  return {
-    baseModelId,
-    headModelId,
+  const result: CompareResult = {
+    baseModelId: built.baseModelId,
+    headModelId: built.headModelId,
     baseName: built.baseName,
     headName: built.headName,
     scope,
@@ -97,6 +144,16 @@ function buildCompareResult(
     excludedHiddenIds: collectExcludedHiddenIds(built, excludedTypes),
     diff,
   };
+  store.setCompareResult(result);
+  // Completed-comparison signal for baseline consumers (compare tour). An
+  // option change re-diffing the cached fingerprints is a completed comparison
+  // too, so it bumps the same counter.
+  store.bumpCompareRunSeq();
+  // A retired pair's entries are gone, so a selection made under one setting can
+  // dangle under the other - drop it rather than leave a detail panel pointing
+  // at nothing.
+  store.setCompareSelectedKey(null);
+  return { result, matchByContent };
 }
 
 export function useCompare() {
@@ -104,6 +161,7 @@ export function useCompare() {
   const headModelId = useViewerStore((s) => s.compareHeadModelId);
   const scope = useViewerStore((s) => s.compareScope);
   const excludedTypes = useViewerStore((s) => s.compareExcludedTypes);
+  const matchByContent = useViewerStore((s) => s.compareMatchByContent);
   const running = useViewerStore((s) => s.compareRunning);
   const result = useViewerStore((s) => s.compareResult);
   const error = useViewerStore((s) => s.compareError);
@@ -116,8 +174,6 @@ export function useCompare() {
     const store = useViewerStore.getState();
     const baseId = store.compareBaseModelId;
     const headId = store.compareHeadModelId;
-    const activeScope = store.compareScope;
-    const activeExcluded = store.compareExcludedTypes;
 
     if (!baseId || !headId) {
       store.setCompareError('Select a model for both A and B.');
@@ -146,11 +202,11 @@ export function useCompare() {
     await new Promise((resolve) => setTimeout(resolve, 0));
 
     try {
-      const key = pairKey(baseId, headId);
       let built = builtRef.current;
-      if (!built || built.key !== key) {
+      if (!built || !isPairOf(built, baseId, headId)) {
         built = {
-          key,
+          baseModelId: baseId,
+          headModelId: headId,
           baseName: baseModel.name,
           headName: headModel.name,
           base: await buildEntityFingerprints({
@@ -171,16 +227,30 @@ export function useCompare() {
         builtRef.current = built;
       }
 
-      const payload = buildCompareResult(built, baseId, headId, activeScope, activeExcluded);
-      store.setCompareResult(payload);
-      // Completed-comparison signal for baseline consumers (compare tour).
-      store.bumpCompareRunSeq();
-      store.setCompareSelectedKey(null);
+      // The diff options are read inside `publishCompareResult`, AFTER every
+      // `await` above, and published atomically with it - see the invariant
+      // documented on that function. Nothing here may capture them earlier.
+      const { result: payload, matchByContent: ranMatchByContent } = publishCompareResult(built);
+
+      // Per-kind match counts are the default-on rollout's evidence (#1891):
+      // they say how often the pass fires in the field, and how much of what it
+      // finds it resolves versus hands back for review.
+      const matches = contentMatchCounts(payload.diff.contentMatches);
       posthog.capture('model_compare_run', {
-        scope: activeScope,
+        scope: payload.scope,
         changed_entity_count: payload.diff.entries.length,
         geometry_unavailable: payload.geometryUnavailable,
         excluded_type_count: payload.diff.excludedTypes.length,
+        content_matching: ranMatchByContent,
+        content_match_count: matches.total,
+        content_matched_elements: matches.matchedElements,
+        content_needs_review_elements: matches.needsReviewElements,
+        content_match_renamed: matches.renamed,
+        content_match_moved: matches.moved,
+        content_match_reshaped: matches.reshaped,
+        content_match_duplicated: matches.duplicated,
+        content_match_deduplicated: matches.deduplicated,
+        content_match_ambiguous: matches.ambiguous,
       });
     } catch (err) {
       console.error('[compare] comparison failed', err);
@@ -191,24 +261,35 @@ export function useCompare() {
     }
   }, []);
 
-  // Scope OR blacklist change with an existing result for the same pair ->
-  // re-diff from the cached fingerprints (instant). No-op when nothing has been
-  // compared yet, or when neither actually changed (equivalent array refs).
+  // Scope, blacklist OR content-matching change with an existing result for the
+  // same pair -> re-diff from the cached fingerprints (instant). No-op when
+  // nothing has been compared yet, or when none actually changed (equivalent
+  // array refs). `contentMatches`' PRESENCE is the result's record of the flag
+  // it ran with (see `contentMatchingRan`).
+  //
+  // This is only the change DETECTOR - the options it publishes are re-read from
+  // the store by `publishCompareResult`, which is what makes the published
+  // result agree with the store rather than with this render's props.
+  //
+  // `result` is deliberately NOT a dep - the effect writes it, so depending on
+  // it would be a re-render/re-diff cycle guarded only by the equality checks
+  // below. That omission is safe only because every publish reads these same
+  // options at publish time: a result can never land carrying options older than
+  // the ones this effect last saw, so there is nothing for a `result`-triggered
+  // re-run to catch.
   useEffect(() => {
     const built = builtRef.current;
     if (!result || !built) return;
-    if (built.key !== pairKey(result.baseModelId, result.headModelId)) return;
+    if (!isPairOf(built, result.baseModelId, result.headModelId)) return;
     const sameScope = result.scope === scope;
     const sameExcluded =
       excludedSignature(result.diff.excludedTypes) === excludedSignature(excludedTypes);
-    if (sameScope && sameExcluded) return;
+    const sameMatching = contentMatchingRan(result.diff.contentMatches) === matchByContent;
+    if (sameScope && sameExcluded && sameMatching) return;
 
-    const payload = buildCompareResult(built, result.baseModelId, result.headModelId, scope, excludedTypes);
-    useViewerStore.getState().setCompareResult(payload);
-    // A scope / blacklist re-diff is also a completed comparison - bump the run signal.
-    useViewerStore.getState().bumpCompareRunSeq();
+    publishCompareResult(built);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [scope, excludedTypes]);
+  }, [scope, excludedTypes, matchByContent]);
 
   return { baseModelId, headModelId, scope, running, result, error, runComparison };
 }

--- a/apps/viewer/src/lib/compare/buildFingerprints.test.ts
+++ b/apps/viewer/src/lib/compare/buildFingerprints.test.ts
@@ -1,0 +1,119 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { IfcParser, type IfcDataStore } from '@ifc-lite/parser';
+import type { MeshData } from '@ifc-lite/geometry';
+import { buildEntityFingerprints } from './buildFingerprints.js';
+
+/** Wrap a STEP body in a minimal IFC4 envelope (same helper shape as
+ *  describeChange.test.ts). */
+function ifc4(body: string): string {
+  return [
+    'ISO-10303-21;',
+    'HEADER;',
+    "FILE_DESCRIPTION((''),'2;1');",
+    "FILE_NAME('','',(''),(''),'','','');",
+    "FILE_SCHEMA(('IFC4'));",
+    'ENDSEC;',
+    'DATA;',
+    body,
+    'ENDSEC;',
+    'END-ISO-10303-21;',
+    '',
+  ].join('\n');
+}
+
+async function storeFromStep(body: string): Promise<IfcDataStore> {
+  const bytes = new TextEncoder().encode(ifc4(body));
+  const parser = new IfcParser();
+  // disableWorkerScan keeps the scan in-process (no Worker in node test).
+  return parser.parseColumnar(bytes.buffer as ArrayBuffer, { disableWorkerScan: true });
+}
+
+/** A wall carrying one property set. `guid`/`psetGuid` are the re-exported
+ *  identity; `fireRating` is the only piece of real content. */
+function wallWithPset(guid: string, psetGuid: string, relGuid: string, fireRating: string): string {
+  return [
+    `#1=IFCWALL('${guid}',$,'Wall A',$,$,$,$,$,.STANDARD.);`,
+    `#2=IFCPROPERTYSINGLEVALUE('FireRating',$,IFCLABEL('${fireRating}'),$);`,
+    `#3=IFCPROPERTYSET('${psetGuid}',$,'Pset_WallCommon',$,(#2));`,
+    `#4=IFCRELDEFINESBYPROPERTIES('${relGuid}',$,$,$,(#1),#3);`,
+  ].join('\n');
+}
+
+/** One mesh for express id 1 - the only thing `buildEntityFingerprints` reads
+ *  off a mesh is its express id and its geometry hash. */
+function meshes(expressId: number, geometryHash: bigint): readonly MeshData[] {
+  return [{ expressId, geometryHash } as unknown as MeshData];
+}
+
+async function fingerprintWall(step: string, modelId: string, geometryHash: bigint) {
+  const store = await storeFromStep(step);
+  const built = await buildEntityFingerprints({
+    modelId,
+    store,
+    meshes: meshes(1, geometryHash),
+    idOffset: 0,
+  });
+  const wall = built.find((f) => f.ifcType === 'IfcWall');
+  assert.ok(wall, `expected an IfcWall fingerprint in ${modelId}`);
+  return wall;
+}
+
+describe('buildEntityFingerprints - component sub-hashes (#1891)', () => {
+  it('populates components, so the content pass has its collision guard', async () => {
+    // Without `components` the viewer sits in the weakest row of the collision
+    // table in docs/guide/model-diff.md: only a differing ifcType can reject a
+    // colliding data hash, and the pass retires a real add+delete on it.
+    const wall = await fingerprintWall(
+      wallWithPset('0aaaaaaaaaaaaaaaaaaaaa', '0bbbbbbbbbbbbbbbbbbbbb', '0ccccccccccccccccccccc', '60'),
+      'A',
+      1n,
+    );
+    assert.ok(wall.components, 'components must be supplied');
+    assert.ok(wall.components!['attr:core'], 'attr:core sub-hash missing');
+    assert.ok(wall.components!['pset:Pset_WallCommon'], 'per-pset sub-hash missing');
+  });
+
+  it('is stable across a from-scratch re-export (new GlobalIds, same content)', async () => {
+    // This is the whole premise of the content pass: re-GUIDing every IfcRoot
+    // must leave the data hash AND every sub-hash untouched.
+    const a = await fingerprintWall(
+      wallWithPset('0aaaaaaaaaaaaaaaaaaaaa', '0bbbbbbbbbbbbbbbbbbbbb', '0ccccccccccccccccccccc', '60'),
+      'A',
+      1n,
+    );
+    const b = await fingerprintWall(
+      wallWithPset('1zzzzzzzzzzzzzzzzzzzzz', '1yyyyyyyyyyyyyyyyyyyyy', '1xxxxxxxxxxxxxxxxxxxxx', '60'),
+      'B',
+      1n,
+    );
+    assert.notStrictEqual(a.key, b.key, 'the fixture must actually re-GUID the wall');
+    assert.strictEqual(a.dataHash, b.dataHash);
+    assert.deepStrictEqual(a.components, b.components);
+  });
+
+  it('moves the differing sub-hash, and only that one, when a property changes', async () => {
+    // The guard only works if a sub-hash tracks the slice it names: a pset edit
+    // must move `pset:...` and leave `attr:core` alone.
+    const a = await fingerprintWall(
+      wallWithPset('0aaaaaaaaaaaaaaaaaaaaa', '0bbbbbbbbbbbbbbbbbbbbb', '0ccccccccccccccccccccc', '60'),
+      'A',
+      1n,
+    );
+    const b = await fingerprintWall(
+      wallWithPset('0aaaaaaaaaaaaaaaaaaaaa', '0bbbbbbbbbbbbbbbbbbbbb', '0ccccccccccccccccccccc', '90'),
+      'B',
+      1n,
+    );
+    assert.notStrictEqual(a.dataHash, b.dataHash, 'a property edit must change the data hash');
+    assert.strictEqual(a.components!['attr:core'], b.components!['attr:core']);
+    assert.notStrictEqual(
+      a.components!['pset:Pset_WallCommon'],
+      b.components!['pset:Pset_WallCommon'],
+    );
+  });
+});

--- a/apps/viewer/src/lib/compare/buildFingerprints.ts
+++ b/apps/viewer/src/lib/compare/buildFingerprints.ts
@@ -20,6 +20,7 @@
  */
 
 import {
+  buildComponentFingerprints,
   buildDataFingerprint,
   type DataFingerprintInput,
   type EntityFingerprint,
@@ -115,10 +116,20 @@ export async function buildEntityFingerprints(
     const globalId = store.entities.getGlobalId(localId);
     const key = globalId || `missing:${modelId}:${localId}`;
 
+    // One extraction, two fingerprints. `components` is the collision guard on
+    // content matching's destructive path (#1891): retiring a real add+delete
+    // in favour of one match record rests on `dataHash` equality meaning
+    // identity, and per-component sub-hashes catch a colliding pset/qset that
+    // the 64-bit data hash cannot. Both are computed from the SAME input
+    // object - a sub-hash over a different projection would stop being a
+    // collision guard and start rejecting genuine re-export matches.
+    const dataInput = buildDataInput(store, localId, ifcType);
+
     fingerprints.push({
       key,
       ifcType,
-      dataHash: buildDataFingerprint(buildDataInput(store, localId, ifcType)),
+      dataHash: buildDataFingerprint(dataInput),
+      components: buildComponentFingerprints(dataInput),
       geometryHash,
       ref: { modelId, localId, globalId: localId + idOffset },
     });

--- a/apps/viewer/src/lib/compare/contentMatches.test.ts
+++ b/apps/viewer/src/lib/compare/contentMatches.test.ts
@@ -1,0 +1,115 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import type { ContentMatch, ContentMatchKind } from '@ifc-lite/diff';
+import {
+  contentMatchCounts,
+  contentMatchingRan,
+  isRetiringMatch,
+  MATCH_KIND_HINT,
+  MATCH_KIND_LABEL,
+} from './contentMatches.js';
+import type { CompareRef } from './buildFingerprints.js';
+
+const ALL_KINDS: ContentMatchKind[] = [
+  'renamed',
+  'moved',
+  'reshaped',
+  'duplicated',
+  'deduplicated',
+  'ambiguous',
+];
+
+function match(kind: ContentMatchKind, base: number, head: number): ContentMatch<CompareRef> {
+  const fp = (globalId: number) => ({
+    key: `k${globalId}`,
+    ifcType: 'IfcWall',
+    dataHash: 'd',
+    ref: { modelId: 'm', localId: globalId, globalId },
+  });
+  return {
+    kind,
+    dataHash: 'd',
+    base: Array.from({ length: base }, (_, i) => fp(i + 1)),
+    head: Array.from({ length: head }, (_, i) => fp(1000 + i)),
+  };
+}
+
+describe('isRetiringMatch (#1891)', () => {
+  it('is true exactly for the kinds whose entries the engine removed', () => {
+    // The retiring/review split drives whether a consumer must supply the
+    // elements itself (retiring) or must NOT re-report them (review), so it is
+    // pinned per kind rather than inferred.
+    assert.deepStrictEqual(
+      ALL_KINDS.map(isRetiringMatch),
+      [true, true, true, false, false, false],
+    );
+  });
+});
+
+describe('contentMatchingRan (#1891)', () => {
+  it('separates "ran and found nothing" from "never ran"', () => {
+    // The whole reason this predicate exists rather than a truthiness check at
+    // each call site: `[]` means the pass looked and paired nothing, which the
+    // panel shows as a Matched badge reading 0. Collapsing it into "no matches"
+    // would hide the badge and drop the counts grid back to four columns,
+    // making a run that found nothing indistinguishable from one never asked -
+    // and it would also flip `useCompare`'s reconciliation gate into re-diffing
+    // for ever, because the result would deny the flag it actually ran with.
+    assert.strictEqual(contentMatchingRan([]), true);
+    assert.strictEqual(contentMatchingRan(undefined), false);
+  });
+
+  it('is true for a pass that did pair something', () => {
+    assert.strictEqual(contentMatchingRan([match('renamed', 1, 1)]), true);
+  });
+});
+
+describe('match kind vocabulary (#1891)', () => {
+  it('labels and hints every kind the engine can emit', () => {
+    for (const kind of ALL_KINDS) {
+      assert.ok(MATCH_KIND_LABEL[kind], `missing label for ${kind}`);
+      assert.ok(MATCH_KIND_HINT[kind], `missing hint for ${kind}`);
+    }
+  });
+});
+
+describe('contentMatchCounts (#1891)', () => {
+  it('tallies zero for a pass that did not run and for one that found nothing', () => {
+    for (const input of [undefined, []]) {
+      const counts = contentMatchCounts(input);
+      assert.strictEqual(counts.total, 0);
+      assert.strictEqual(counts.matchedElements, 0);
+      assert.strictEqual(counts.needsReviewElements, 0);
+    }
+  });
+
+  it('counts retired elements on the head side, one per surviving element', () => {
+    const counts = contentMatchCounts([match('renamed', 3, 3), match('moved', 1, 1)]);
+    assert.strictEqual(counts.renamed, 1);
+    assert.strictEqual(counts.moved, 1);
+    assert.strictEqual(counts.matchedElements, 4);
+    assert.strictEqual(counts.needsReviewElements, 0);
+  });
+
+  it('counts an unresolved group on BOTH sides - every candidate needs looking at', () => {
+    const counts = contentMatchCounts([match('ambiguous', 2, 3)]);
+    assert.strictEqual(counts.ambiguous, 1);
+    assert.strictEqual(counts.needsReviewElements, 5);
+    assert.strictEqual(counts.matchedElements, 0);
+  });
+
+  it('keeps the two families separate in a mixed result', () => {
+    const counts = contentMatchCounts([
+      match('reshaped', 1, 1),
+      match('duplicated', 1, 2),
+      match('deduplicated', 2, 1),
+    ]);
+    assert.strictEqual(counts.total, 3);
+    assert.strictEqual(counts.matchedElements, 1);
+    assert.strictEqual(counts.needsReviewElements, 6);
+  });
+});

--- a/apps/viewer/src/lib/compare/contentMatches.ts
+++ b/apps/viewer/src/lib/compare/contentMatches.ts
@@ -1,0 +1,117 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Viewer-side vocabulary for the diff engine's content-matching pass (issue
+ * #1891), shared by the overlay, the results list, the report export and
+ * telemetry so all four agree on what a match means.
+ *
+ * The engine splits its {@link ContentMatch} kinds into two families, and the
+ * difference is load-bearing for every consumer:
+ *
+ * - **retiring** (`renamed`, `moved`, `reshaped`) — the pass is confident, so
+ *   it REMOVES the corresponding `added`/`deleted` entries from
+ *   `ModelDiff.entries`. Anything reading only `entries` therefore loses these
+ *   elements entirely: the overlay would strand both copies at full material
+ *   colour, the list would show counts that dropped with no row explaining
+ *   where they went, and the report would silently omit them.
+ * - **review** (`duplicated`, `deduplicated`, `ambiguous`) — the pass refuses
+ *   to guess, so it retires NOTHING. Those entities keep their `added` /
+ *   `deleted` entries and their add/delete colours; the group is extra
+ *   information to badge, never a reason to recolour or re-count.
+ */
+
+import type { ContentMatch, ContentMatchKind } from '@ifc-lite/diff';
+import type { CompareRef } from './buildFingerprints.js';
+
+/** Kinds whose `added`/`deleted` entries the engine removed from the diff. */
+const RETIRING_KINDS: ReadonlySet<ContentMatchKind> = new Set<ContentMatchKind>([
+  'renamed',
+  'moved',
+  'reshaped',
+]);
+
+/** Did this match retire its entities' `added`/`deleted` entries? */
+export function isRetiringMatch(kind: ContentMatchKind): boolean {
+  return RETIRING_KINDS.has(kind);
+}
+
+/**
+ * Did the content-matching pass run for this comparison? THE signal for that
+ * question - the panel's Matched badge, its counts grid and `useCompare`'s
+ * reconciliation gate all read it here rather than each spelling out their own
+ * test.
+ *
+ * `undefined` (the flag was off, the pass never ran) and `[]` (it ran and found
+ * nothing to pair) are DIFFERENT states and the UI shows them differently: a
+ * Matched badge reading 0 says the pass looked and found nothing, a missing
+ * badge says it was never asked. So this tests PRESENCE, never
+ * `matches.length` - "are there matches" is a different question, and a
+ * consumer wanting that one should count the rows it is about to render.
+ */
+export function contentMatchingRan(
+  matches: readonly ContentMatch<CompareRef>[] | undefined,
+): boolean {
+  return matches !== undefined;
+}
+
+/** Short human labels, used verbatim in the panel and in the report's `change`
+ *  column so a CSV reader and a UI reader see the same word. */
+export const MATCH_KIND_LABEL: Record<ContentMatchKind, string> = {
+  renamed: 'Renamed',
+  moved: 'Moved',
+  reshaped: 'Reshaped',
+  duplicated: 'Duplicated',
+  deduplicated: 'Deduplicated',
+  ambiguous: 'Ambiguous',
+};
+
+/** One-line explanation per kind for the panel's row tooltips. */
+export const MATCH_KIND_HINT: Record<ContentMatchKind, string> = {
+  renamed: 'Same content in the same place under a new GlobalId (re-export).',
+  moved: 'Same content, different geometry hash - it looks relocated.',
+  reshaped: 'Same content, different geometry hash - its shape or tessellation changed.',
+  duplicated: 'One element in A matches several in B - it looks copied.',
+  deduplicated: 'Several elements in A match one in B - they look merged.',
+  ambiguous: 'Several candidates on both sides; no principled pairing.',
+};
+
+export interface ContentMatchCounts extends Record<ContentMatchKind, number> {
+  /** Element pairs the pass retired from `entries` (sum over retiring kinds,
+   *  counted on the head side - a group renamed N:N retires N pairs). */
+  matchedElements: number;
+  /** Entities sitting in an unresolved group, still present in `entries`. */
+  needsReviewElements: number;
+  /** Total match records, retiring and review alike. */
+  total: number;
+}
+
+/** Tally a comparison's content matches. `undefined` (the pass did not run)
+ *  and `[]` (it ran and found nothing) both tally to all-zero — the caller
+ *  distinguishes them by whether `contentMatches` exists, not by the counts. */
+export function contentMatchCounts(
+  matches: readonly ContentMatch<CompareRef>[] | undefined,
+): ContentMatchCounts {
+  const counts: ContentMatchCounts = {
+    renamed: 0,
+    moved: 0,
+    reshaped: 0,
+    duplicated: 0,
+    deduplicated: 0,
+    ambiguous: 0,
+    matchedElements: 0,
+    needsReviewElements: 0,
+    total: 0,
+  };
+  for (const match of matches ?? []) {
+    counts[match.kind] += 1;
+    counts.total += 1;
+    if (isRetiringMatch(match.kind)) {
+      counts.matchedElements += match.head.length;
+    } else {
+      counts.needsReviewElements += match.base.length + match.head.length;
+    }
+  }
+  return counts;
+}

--- a/apps/viewer/src/lib/compare/exportReport.test.ts
+++ b/apps/viewer/src/lib/compare/exportReport.test.ts
@@ -13,7 +13,7 @@ const report: CompareReport = {
   scope: 'both',
   generatedAt: '2026-06-18T00:00:00.000Z',
   excludedTypes: [],
-  counts: { added: 1, deleted: 1, modified: 1 },
+  counts: { added: 1, deleted: 1, modified: 1, matched: 0, needsReview: 0 },
   rows: [
     { globalId: '12SOM77Nv5ruUGky1rkC3a', name: 'Wall', ifcType: 'IfcWall', state: 'added', change: 'Added', movedDistance: 0, model: 'Project01 v2' },
     { globalId: '0v6FMURlDDD866oJ1s6pyr', name: 'Muro, "base"', ifcType: 'IfcWall', state: 'modified', change: 'Data changed', movedDistance: 0, model: 'Project01 v2' },
@@ -24,7 +24,7 @@ const report: CompareReport = {
 describe('reportToCsv (#1202)', () => {
   it('emits a header and one row per change', () => {
     const lines = reportToCsv(report).split('\r\n');
-    assert.strictEqual(lines[0], 'GlobalId,Name,IfcType,Change,MovedDistance_m,Model');
+    assert.strictEqual(lines[0], 'GlobalId,Name,IfcType,Change,MovedDistance_m,Model,Match,MatchedGlobalId');
     assert.strictEqual(lines.length, 1 + report.rows.length);
   });
 
@@ -36,7 +36,7 @@ describe('reportToCsv (#1202)', () => {
 
   it('formats the moved distance and leaves it blank when zero', () => {
     const lines = reportToCsv(report).split('\r\n');
-    assert.ok(lines[3].endsWith('Moved,1.2345,Project01 v2'));
+    assert.ok(lines[3].endsWith('Moved,1.2345,Project01 v2,,'));
     assert.ok(lines[1].includes(',Added,,'), 'zero move distance is blank');
   });
 
@@ -55,13 +55,13 @@ describe('reportToCsv (#1202)', () => {
     const withBlacklist: CompareReport = { ...report, excludedTypes: ['IfcOpeningElement'] };
     const lines = reportToCsv(withBlacklist).split('\r\n');
     assert.strictEqual(lines[0], '# Excluded classes (not compared): IfcOpeningElement');
-    assert.strictEqual(lines[1], 'GlobalId,Name,IfcType,Change,MovedDistance_m,Model');
+    assert.strictEqual(lines[1], 'GlobalId,Name,IfcType,Change,MovedDistance_m,Model,Match,MatchedGlobalId');
     assert.strictEqual(lines.length, 2 + report.rows.length);
   });
 
   it('omits the comment line entirely when nothing was excluded', () => {
     const lines = reportToCsv(report).split('\r\n');
-    assert.strictEqual(lines[0], 'GlobalId,Name,IfcType,Change,MovedDistance_m,Model');
+    assert.strictEqual(lines[0], 'GlobalId,Name,IfcType,Change,MovedDistance_m,Model,Match,MatchedGlobalId');
   });
 });
 
@@ -187,5 +187,196 @@ describe('buildCompareReport GlobalId under an identity map (#1891)', () => {
       },
     } as unknown as CompareResult;
     assert.strictEqual(buildCompareReport(missing, new Map()).rows[0].globalId, '');
+  });
+});
+
+describe('buildCompareReport content matches (#1891)', () => {
+  const ref = (modelId: string, id: number) => ({ modelId, localId: id, globalId: id });
+  const fingerprint = (modelId: string, key: string, id: number, ifcType = 'IfcWall') => ({
+    key,
+    ifcType,
+    dataHash: 'd',
+    ref: ref(modelId, id),
+  });
+
+  /** A result whose key pass found nothing and whose content pass found
+   *  `matches` - i.e. exactly the retired-pair case that used to vanish. */
+  const resultWith = (
+    matches: unknown[],
+    entries: unknown[] = [],
+    counts = { added: 0, modified: 0, deleted: 0, unchanged: 0 },
+  ) =>
+    ({
+      baseModelId: 'a',
+      headModelId: 'b',
+      baseName: 'A',
+      headName: 'B',
+      scope: 'both',
+      geometryUnavailable: false,
+      excludedHiddenIds: new Set<number>(),
+      diff: {
+        scope: 'both',
+        excludedTypes: [],
+        entries,
+        byKey: new Map(),
+        counts,
+        contentMatches: matches,
+      },
+    }) as unknown as CompareResult;
+
+  it('emits a row for a retired 1:1 rename, with the counterpart GlobalId', () => {
+    const report = buildCompareReport(
+      resultWith([
+        {
+          kind: 'renamed',
+          dataHash: 'd',
+          base: [fingerprint('a', 'OLD_GUID_AAAAAAAAAAAA', 1)],
+          head: [fingerprint('b', 'NEW_GUID_BBBBBBBBBBBB', 2)],
+        },
+      ]),
+      new Map(),
+    );
+    assert.strictEqual(report.rows.length, 1);
+    assert.deepStrictEqual(
+      [report.rows[0].globalId, report.rows[0].state, report.rows[0].change, report.rows[0].match],
+      ['NEW_GUID_BBBBBBBBBBBB', 'matched', 'Renamed', 'renamed'],
+    );
+    assert.strictEqual(report.rows[0].matchedGlobalId, 'OLD_GUID_AAAAAAAAAAAA');
+    assert.strictEqual(report.rows[0].model, 'B');
+  });
+
+  it('carries a moved match distance into the row', () => {
+    const report = buildCompareReport(
+      resultWith([
+        {
+          kind: 'moved',
+          dataHash: 'd',
+          base: [fingerprint('a', 'OLD_GUID_AAAAAAAAAAAA', 1)],
+          head: [fingerprint('b', 'NEW_GUID_BBBBBBBBBBBB', 2)],
+          distance: 2.5,
+        },
+      ]),
+      new Map(),
+    );
+    assert.strictEqual(report.rows[0].change, 'Moved');
+    assert.strictEqual(report.rows[0].movedDistance, 2.5);
+  });
+
+  it('emits one row per head entity of an N:N rename and blanks the counterpart', () => {
+    const report = buildCompareReport(
+      resultWith([
+        {
+          kind: 'renamed',
+          dataHash: 'd',
+          base: [fingerprint('a', 'OLD1AAAAAAAAAAAAAAAAAA', 1), fingerprint('a', 'OLD2AAAAAAAAAAAAAAAAAA', 2)],
+          head: [fingerprint('b', 'NEW1BBBBBBBBBBBBBBBBBB', 3), fingerprint('b', 'NEW2BBBBBBBBBBBBBBBBBB', 4)],
+        },
+      ]),
+      new Map(),
+    );
+    assert.strictEqual(report.rows.length, 2);
+    assert.deepStrictEqual(
+      report.rows.map((r) => r.globalId).sort(),
+      ['NEW1BBBBBBBBBBBBBBBBBB', 'NEW2BBBBBBBBBBBBBBBBBB'],
+    );
+    // No bijection is known, so claiming one would be a fabrication.
+    assert.deepStrictEqual(report.rows.map((r) => r.matchedGlobalId), ['', '']);
+  });
+
+  it('counts retired elements and review candidates separately', () => {
+    const report = buildCompareReport(
+      resultWith(
+        [
+          {
+            kind: 'reshaped',
+            dataHash: 'd',
+            base: [fingerprint('a', 'OLD_GUID_AAAAAAAAAAAA', 1)],
+            head: [fingerprint('b', 'NEW_GUID_BBBBBBBBBBBB', 2)],
+          },
+          {
+            kind: 'ambiguous',
+            dataHash: 'e',
+            base: [fingerprint('a', 'AMB1AAAAAAAAAAAAAAAAAA', 3), fingerprint('a', 'AMB2AAAAAAAAAAAAAAAAAA', 4)],
+            head: [fingerprint('b', 'AMB3BBBBBBBBBBBBBBBBBB', 5), fingerprint('b', 'AMB4BBBBBBBBBBBBBBBBBB', 6)],
+          },
+        ],
+        [],
+        { added: 2, modified: 0, deleted: 2, unchanged: 0 },
+      ),
+      new Map(),
+    );
+    assert.strictEqual(report.counts.matched, 1);
+    assert.strictEqual(report.counts.needsReview, 4);
+  });
+
+  it('annotates an unresolved group onto its existing add/delete rows instead of duplicating them', () => {
+    const report = buildCompareReport(
+      resultWith(
+        [
+          {
+            kind: 'duplicated',
+            dataHash: 'e',
+            base: [fingerprint('a', 'SRC_GUID_AAAAAAAAAAAA', 3)],
+            head: [fingerprint('b', 'CPY1BBBBBBBBBBBBBBBBBB', 5), fingerprint('b', 'CPY2BBBBBBBBBBBBBBBBBB', 6)],
+          },
+        ],
+        [
+          { key: 'SRC_GUID_AAAAAAAAAAAA', state: 'deleted', changeKinds: [], base: fingerprint('a', 'SRC_GUID_AAAAAAAAAAAA', 3) },
+          { key: 'CPY1BBBBBBBBBBBBBBBBBB', state: 'added', changeKinds: [], head: fingerprint('b', 'CPY1BBBBBBBBBBBBBBBBBB', 5) },
+          { key: 'CPY2BBBBBBBBBBBBBBBBBB', state: 'added', changeKinds: [], head: fingerprint('b', 'CPY2BBBBBBBBBBBBBBBBBB', 6) },
+        ],
+        { added: 2, modified: 0, deleted: 1, unchanged: 0 },
+      ),
+      new Map(),
+    );
+    // No extra rows: an unresolved group retires nothing, so its entities are
+    // already reported once each.
+    assert.strictEqual(report.rows.length, 3);
+    assert.deepStrictEqual(report.rows.map((r) => r.match), ['duplicated', 'duplicated', 'duplicated']);
+    assert.deepStrictEqual(report.rows.map((r) => r.state).sort(), ['added', 'added', 'deleted']);
+  });
+
+  it('leaves the report untouched when the content pass did not run', () => {
+    const noPass = {
+      baseModelId: 'a',
+      headModelId: 'b',
+      baseName: 'A',
+      headName: 'B',
+      scope: 'both',
+      geometryUnavailable: false,
+      excludedHiddenIds: new Set<number>(),
+      diff: {
+        scope: 'both',
+        excludedTypes: [],
+        entries: [
+          { key: 'ADDED_GUID_DDDDDDDDD', state: 'added', changeKinds: [], head: fingerprint('b', 'ADDED_GUID_DDDDDDDDD', 4) },
+        ],
+        byKey: new Map(),
+        counts: { added: 1, modified: 0, deleted: 0, unchanged: 0 },
+      },
+    } as unknown as CompareResult;
+    const report = buildCompareReport(noPass, new Map());
+    assert.strictEqual(report.rows.length, 1);
+    assert.strictEqual(report.rows[0].match, undefined);
+    assert.deepStrictEqual([report.counts.matched, report.counts.needsReview], [0, 0]);
+  });
+
+  it('serializes the match columns into the CSV', () => {
+    const report = buildCompareReport(
+      resultWith([
+        {
+          kind: 'renamed',
+          dataHash: 'd',
+          base: [fingerprint('a', 'OLD_GUID_AAAAAAAAAAAA', 1)],
+          head: [fingerprint('b', 'NEW_GUID_BBBBBBBBBBBB', 2)],
+        },
+      ]),
+      new Map(),
+    );
+    const lines = reportToCsv(report).split('\r\n');
+    assert.strictEqual(
+      lines[1],
+      'NEW_GUID_BBBBBBBBBBBB,,IfcWall,Renamed,,B,renamed,OLD_GUID_AAAAAAAAAAAA',
+    );
   });
 });

--- a/apps/viewer/src/lib/compare/exportReport.ts
+++ b/apps/viewer/src/lib/compare/exportReport.ts
@@ -20,24 +20,17 @@ import type { DiffEntry, DiffState } from '@ifc-lite/diff';
 import type { FederatedModel } from '../../store/types.js';
 import type { CompareResult } from '../../store/slices/compareSlice.js';
 import type { CompareRef } from './buildFingerprints.js';
+import { contentMatchCounts } from './contentMatches.js';
+import {
+  annotateReviewGroups,
+  contentMatchReportRows,
+  exportedGlobalId,
+  type CompareReportRow,
+} from './reportRows.js';
 import { summarizeGeometryChange, type Aabb } from './describeChange.js';
 import { downloadBlob, sanitizeFilename } from '../export/download.js';
 
-/** One row of the exported change report. */
-export interface CompareReportRow {
-  globalId: string;
-  name: string;
-  ifcType: string;
-  /** Raw diff state: added | deleted | modified. */
-  state: DiffState;
-  /** Human change label: "Added", "Deleted", "Moved", "Reshaped",
-   *  "Data changed", or a combination ("Moved, Data changed"). */
-  change: string;
-  /** AABB-centre displacement in metres (0 when not a move). */
-  movedDistance: number;
-  /** Which model this row's element lives in (head for add/modify, base for delete). */
-  model: string;
-}
+export type { CompareReportRow } from './reportRows.js';
 
 export interface CompareReport {
   baseModel: string;
@@ -47,7 +40,19 @@ export interface CompareReport {
   /** IFC classes excluded from the comparison (the blacklist, #1470). Empty when
    *  none were excluded. Recorded so a report reader knows what was ignored. */
   excludedTypes: string[];
-  counts: { added: number; deleted: number; modified: number };
+  /**
+   * `matched` counts elements the content pass retired out of `added`/`deleted`
+   * (#1891); `needsReview` counts entities left in an unresolved group. Both
+   * are 0 when the pass did not run. Without them a reader would take a lower
+   * added/deleted count at face value.
+   */
+  counts: {
+    added: number;
+    deleted: number;
+    modified: number;
+    matched: number;
+    needsReview: number;
+  };
   rows: CompareReportRow[];
 }
 
@@ -149,6 +154,9 @@ export function buildCompareReport(
   const headBounds = boundsIndex(headModel);
 
   const rows: CompareReportRow[] = [];
+  // Row → the federation global id it was built from, so the unresolved-group
+  // annotation can find its rows without re-deriving the ref.
+  const rowGlobalIds = new Map<CompareReportRow, number>();
   for (const entry of result.diff.entries) {
     if (entry.state === 'unchanged') continue;
     const ref = reportRef(entry);
@@ -158,8 +166,7 @@ export function buildCompareReport(
     const ifcType = (entry.head ?? entry.base)?.ifcType ?? 'IfcProduct';
     // The fingerprint key is the GlobalId; synthetic "missing:" keys (entities
     // without a resolvable GlobalId) export blank rather than the placeholder.
-    const rowKey = reportKey(entry);
-    const globalId = rowKey.startsWith('missing:') ? '' : rowKey;
+    const globalId = exportedGlobalId(reportKey(entry));
     const modelName = ref.modelId === result.headModelId ? result.headName : result.baseName;
 
     let change: string;
@@ -168,16 +175,34 @@ export function buildCompareReport(
     else if (entry.state === 'deleted') change = 'Deleted';
     else ({ change, movedDistance } = classifyModified(entry, baseBounds, headBounds));
 
-    rows.push({ globalId, name, ifcType, state: entry.state, change, movedDistance, model: modelName });
+    const row: CompareReportRow = { globalId, name, ifcType, state: entry.state, change, movedDistance, model: modelName };
+    rows.push(row);
+    rowGlobalIds.set(row, ref.globalId);
   }
 
-  // Stable order: added, then changed, then deleted; by type then name within.
-  const stateRank: Record<DiffState, number> = { added: 0, modified: 1, deleted: 2, unchanged: 3 };
+  // Content matches (#1891), added on top of the entry-derived rows rather than
+  // replacing anything: retiring matches contribute their own rows, unresolved
+  // groups annotate the add/delete rows that are already here.
+  const matches = result.diff.contentMatches ?? [];
+  rows.push(...contentMatchReportRows(matches, models, result.headName));
+  annotateReviewGroups(rows, matches, rowGlobalIds);
+
+  // Stable order: added, then changed, then matched, then deleted; by type then
+  // name within.
+  const stateRank: Record<DiffState | 'matched', number> = {
+    added: 0,
+    modified: 1,
+    matched: 2,
+    deleted: 3,
+    unchanged: 4,
+  };
   rows.sort((a, b) =>
     stateRank[a.state] - stateRank[b.state] ||
     a.ifcType.localeCompare(b.ifcType) ||
     a.name.localeCompare(b.name),
   );
+
+  const matchTally = contentMatchCounts(result.diff.contentMatches);
 
   return {
     baseModel: result.baseName,
@@ -190,6 +215,8 @@ export function buildCompareReport(
       added: result.diff.counts.added,
       deleted: result.diff.counts.deleted,
       modified: result.diff.counts.modified,
+      matched: matchTally.matchedElements,
+      needsReview: matchTally.needsReviewElements,
     },
     rows,
   };
@@ -207,7 +234,11 @@ function csvField(value: string | number): string {
 
 /** Serialize the report as RFC-4180 CSV (one element per row). */
 export function reportToCsv(report: CompareReport): string {
-  const header = ['GlobalId', 'Name', 'IfcType', 'Change', 'MovedDistance_m', 'Model'];
+  // `Match` / `MatchedGlobalId` are appended, never inserted: an existing
+  // consumer reading the first six columns positionally keeps working (#1891).
+  const header = [
+    'GlobalId', 'Name', 'IfcType', 'Change', 'MovedDistance_m', 'Model', 'Match', 'MatchedGlobalId',
+  ];
   const lines: string[] = [];
   // Provenance: a blacklist removes rows, so a CSV that looks "complete" would
   // mislead a coordinator (the ignored elements are simply gone). Lead with a
@@ -226,6 +257,8 @@ export function reportToCsv(report: CompareReport): string {
       csvField(r.change),
       csvField(r.movedDistance ? r.movedDistance.toFixed(4) : ''),
       csvField(r.model),
+      csvField(r.match ?? ''),
+      csvField(r.matchedGlobalId ?? ''),
     ].join(','));
   }
   return lines.join('\r\n');

--- a/apps/viewer/src/lib/compare/overlay.test.ts
+++ b/apps/viewer/src/lib/compare/overlay.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
-import type { DiffEntry, DiffState, ModelDiff } from '@ifc-lite/diff';
+import type { ContentMatch, ContentMatchKind, DiffEntry, DiffState, ModelDiff } from '@ifc-lite/diff';
 import { buildCompareOverlay, COMPARE_COLORS } from './overlay.js';
 import type { CompareRef } from './buildFingerprints.js';
 
@@ -26,9 +26,25 @@ function entry(
   };
 }
 
-function diffOf(entries: DiffEntry<CompareRef>[]): ModelDiff<CompareRef> {
-  // buildCompareOverlay only reads `entries`; the rest satisfies the type.
-  return { scope: 'both', excludedTypes: [], entries, byKey: new Map(), counts: { added: 0, modified: 0, deleted: 0, unchanged: 0 } };
+function diffOf(
+  entries: DiffEntry<CompareRef>[],
+  contentMatches?: ContentMatch<CompareRef>[],
+): ModelDiff<CompareRef> {
+  // buildCompareOverlay only reads `entries` + `contentMatches`; the rest
+  // satisfies the type.
+  return { scope: 'both', excludedTypes: [], entries, byKey: new Map(), counts: { added: 0, modified: 0, deleted: 0, unchanged: 0 }, contentMatches };
+}
+
+/** A content match over federation global ids. The engine retires a matched
+ *  pair's add/delete entries, so a match's entities are NOT in `entries` -
+ *  which is exactly why the overlay has to look at `contentMatches` too. */
+function match(
+  kind: ContentMatchKind,
+  base: number[],
+  head: number[],
+): ContentMatch<CompareRef> {
+  const fp = (globalId: number) => ({ key: `k${globalId}`, ifcType: 'IfcWall', dataHash: 'd', ref: ref(globalId) });
+  return { kind, dataHash: 'd', base: base.map(fp), head: head.map(fp) };
 }
 
 describe('buildCompareOverlay', () => {
@@ -117,5 +133,73 @@ describe('buildCompareOverlay', () => {
       new Set([9]),
     );
     assert.ok(hiddenIds.has(9), 'excluded id stays hidden regardless of showUnchanged');
+  });
+});
+
+describe('buildCompareOverlay - content matches (#1891)', () => {
+  for (const kind of ['renamed', 'moved', 'reshaped'] as const) {
+    it(`hides the A copy and gives the B copy the matched colour (${kind})`, () => {
+      const { colorOverrides, hiddenIds } = buildCompareOverlay(
+        diffOf([], [match(kind, [5], [1005])]),
+        false,
+      );
+      assert.deepStrictEqual(colorOverrides.get(1005), COMPARE_COLORS.matched);
+      assert.ok(!colorOverrides.has(5), 'the retired base copy is not coloured');
+      assert.ok(hiddenIds.has(5), 'the retired base copy must be hidden, not stranded at full colour');
+      assert.ok(!hiddenIds.has(1005), 'the surviving head copy stays visible');
+    });
+  }
+
+  it('handles an N:N renamed group, hiding every A copy', () => {
+    const { colorOverrides, hiddenIds } = buildCompareOverlay(
+      diffOf([], [match('renamed', [1, 2, 3], [1001, 1002, 1003])]),
+      false,
+    );
+    assert.deepStrictEqual([...hiddenIds].sort((a, b) => a - b), [1, 2, 3]);
+    for (const id of [1001, 1002, 1003]) {
+      assert.deepStrictEqual(colorOverrides.get(id), COMPARE_COLORS.matched);
+    }
+  });
+
+  for (const kind of ['ambiguous', 'duplicated', 'deduplicated'] as const) {
+    it(`leaves an unresolved group's add/delete colours alone (${kind})`, () => {
+      // These retire nothing, so their entries are still in `entries` with
+      // their own colours. Recolouring or hiding them here would claim a
+      // resolution the engine explicitly declined to make.
+      const { colorOverrides, hiddenIds } = buildCompareOverlay(
+        diffOf(
+          [entry('deleted', { base: 5 }), entry('added', { head: 1005 })],
+          [match(kind, [5], [1005])],
+        ),
+        false,
+      );
+      assert.deepStrictEqual(colorOverrides.get(5), COMPARE_COLORS.deleted);
+      assert.deepStrictEqual(colorOverrides.get(1005), COMPARE_COLORS.added);
+      assert.strictEqual(hiddenIds.size, 0);
+    });
+  }
+
+  it('composes matches with ordinary entries and the excluded set', () => {
+    const { colorOverrides, hiddenIds } = buildCompareOverlay(
+      diffOf(
+        [entry('added', { head: 1001 }), entry('modified', { base: 3, head: 1003 })],
+        [match('renamed', [5], [1005])],
+      ),
+      false,
+      new Set([7]),
+    );
+    assert.deepStrictEqual(colorOverrides.get(1001), COMPARE_COLORS.added);
+    assert.deepStrictEqual(colorOverrides.get(1003), COMPARE_COLORS.modified);
+    assert.deepStrictEqual(colorOverrides.get(1005), COMPARE_COLORS.matched);
+    assert.deepStrictEqual([...hiddenIds].sort((a, b) => a - b), [3, 5, 7]);
+  });
+
+  it('is a no-op when the content pass did not run', () => {
+    const { colorOverrides, hiddenIds } = buildCompareOverlay(
+      diffOf([entry('added', { head: 1001 })]),
+      false,
+    );
+    assert.strictEqual(colorOverrides.size, 1);
+    assert.strictEqual(hiddenIds.size, 0);
   });
 });

--- a/apps/viewer/src/lib/compare/overlay.ts
+++ b/apps/viewer/src/lib/compare/overlay.ts
@@ -17,6 +17,7 @@
  *   - deleted  (A only) → red     on A
  *   - unchanged          → ghost grey on B + hide A  (when "show unchanged"),
  *                          otherwise hide both
+ *   - content-matched    → blue    on B, **hide** the A copy (see below)
  *
  * Colours match the threejs compare example's palette. Keys are federation
  * **global** ids (`CompareRef.globalId`) — exactly what the renderer's
@@ -25,16 +26,29 @@
 
 import type { ModelDiff } from '@ifc-lite/diff';
 import type { CompareRef } from './buildFingerprints';
+import { isRetiringMatch } from './contentMatches';
 
 export type RGBA = [number, number, number, number];
 
-/** Diff-state colour conventions. `unchanged` is a translucent ghost. */
+/** Diff-state colour conventions. `unchanged` is a translucent ghost;
+ *  `matched` is the content-matching pass's own channel (#1891) — deliberately
+ *  a different hue from added/modified/deleted, because a match is not a
+ *  change the user asked about, it is the engine saying "these two are the
+ *  same element under a new GlobalId". */
 export const COMPARE_COLORS = {
   added: [0.22, 0.78, 0.44, 1] as RGBA,
   modified: [1.0, 0.6, 0.18, 1] as RGBA,
   deleted: [0.95, 0.3, 0.3, 1] as RGBA,
   unchanged: [0.45, 0.52, 0.58, 0.32] as RGBA,
+  matched: [0.36, 0.6, 0.95, 1] as RGBA,
 } as const;
+
+/** CSS `rgba(...)` for a compare colour — the panel's swatches and icons draw
+ *  from the same palette the 3D overlay does, so the legend cannot drift from
+ *  the scene. */
+export function rgbaCss([r, g, b, a]: RGBA): string {
+  return `rgba(${Math.round(r * 255)}, ${Math.round(g * 255)}, ${Math.round(b * 255)}, ${a})`;
+}
 
 export interface CompareOverlay {
   /** Per global-id colour override fed to `scene.setColorOverrides`. */
@@ -89,6 +103,25 @@ export function buildCompareOverlay(
           if (baseGlobal !== undefined) hiddenIds.add(baseGlobal);
         }
         break;
+    }
+  }
+
+  // Content matches (#1891). A retiring match (`renamed`/`moved`/`reshaped`)
+  // REMOVED its pair's `added`/`deleted` entries from `diff.entries`, so the
+  // loop above never saw them: without this both the A and the B copy would
+  // render at full material colour in a ghosted scene — the exact stranded-mesh
+  // class `excludedHiddenIds` exists to prevent. Treat them like `modified`
+  // (hide A, colour B) but in the match channel's own hue.
+  //
+  // Review kinds (`duplicated`/`deduplicated`/`ambiguous`) retire nothing, so
+  // their entries are still in `entries` with their add/delete colours. They
+  // are badged in the list, never recoloured here — recolouring would claim a
+  // resolution the engine explicitly declined to make.
+  for (const match of diff.contentMatches ?? []) {
+    if (!isRetiringMatch(match.kind)) continue;
+    for (const fingerprint of match.base) hiddenIds.add(fingerprint.ref.globalId);
+    for (const fingerprint of match.head) {
+      colorOverrides.set(fingerprint.ref.globalId, COMPARE_COLORS.matched);
     }
   }
 

--- a/apps/viewer/src/lib/compare/reportRows.ts
+++ b/apps/viewer/src/lib/compare/reportRows.ts
@@ -1,0 +1,117 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The change report's row shape, and the content-matching rows that do not
+ * come from `diff.entries` (issues #1202, #1891). Split out of
+ * `exportReport.ts` so both stay under the module-size house rule (AGENTS.md).
+ */
+
+import type { ContentMatch, ContentMatchKind, DiffState } from '@ifc-lite/diff';
+import type { FederatedModel } from '../../store/types.js';
+import type { CompareRef } from './buildFingerprints.js';
+import { isRetiringMatch, MATCH_KIND_LABEL } from './contentMatches.js';
+
+/** One row of the exported change report. */
+export interface CompareReportRow {
+  globalId: string;
+  name: string;
+  ifcType: string;
+  /**
+   * Raw diff state: added | deleted | modified, or `matched` for a row that
+   * came from `diff.contentMatches` rather than `diff.entries` (#1891). The
+   * engine deliberately invented no new `DiffState` for a content match, so
+   * this widening happens here, in the report's own vocabulary.
+   */
+  state: DiffState | 'matched';
+  /** Human change label: "Added", "Deleted", "Moved", "Reshaped",
+   *  "Data changed", "Renamed", or a combination ("Moved, Data changed"). */
+  change: string;
+  /** AABB-centre displacement in metres (0 when not a move). */
+  movedDistance: number;
+  /** Which model this row's element lives in (head for add/modify, base for delete). */
+  model: string;
+  /**
+   * The content-match kind this element participates in, when any (#1891).
+   * Set on `matched` rows, and also on the still-present `added`/`deleted`
+   * rows of an unresolved group (`duplicated`/`deduplicated`/`ambiguous`) -
+   * those retire nothing, so annotating them is how the grouping reaches the
+   * report without duplicating a GlobalId across two rows.
+   */
+  match?: ContentMatchKind;
+  /** The counterpart's GlobalId, for a content match that is exactly 1:1.
+   *  Blank for a group match: the engine reports the group precisely because
+   *  it has no evidence for which member pairs with which. */
+  matchedGlobalId?: string;
+}
+
+/** A GlobalId string for a report row: synthetic `missing:` keys (entities
+ *  without a resolvable GlobalId) export blank rather than the placeholder. */
+export function exportedGlobalId(key: string | undefined): string {
+  return !key || key.startsWith('missing:') ? '' : key;
+}
+
+/**
+ * Rows for the content-matching pass (#1891).
+ *
+ * A `renamed`/`moved`/`reshaped` match REMOVED its pair's `added` + `deleted`
+ * entries from `diff.entries`, so without this the elements simply vanish from
+ * a coordination CSV: the counts drop and no row says why. One row per head
+ * entity keeps the report's unit (one element per row) and keeps every
+ * GlobalId resolvable in the file it claims to describe.
+ *
+ * Unresolved groups (`duplicated`/`deduplicated`/`ambiguous`) retire nothing,
+ * so their entities are already present as `added`/`deleted` rows. They get an
+ * annotation on those rows instead ({@link annotateReviewGroups}) — emitting a
+ * second row would report one element twice.
+ */
+export function contentMatchReportRows(
+  matches: readonly ContentMatch<CompareRef>[],
+  models: ReadonlyMap<string, FederatedModel>,
+  headName: string,
+): CompareReportRow[] {
+  const rows: CompareReportRow[] = [];
+  for (const match of matches) {
+    if (!isRetiringMatch(match.kind)) continue;
+    const oneToOne = match.base.length === 1 && match.head.length === 1;
+    for (const fingerprint of match.head) {
+      const ref = fingerprint.ref;
+      rows.push({
+        globalId: exportedGlobalId(fingerprint.key),
+        name: models.get(ref.modelId)?.ifcDataStore?.entities.getName(ref.localId) || '',
+        ifcType: fingerprint.ifcType,
+        state: 'matched',
+        change: MATCH_KIND_LABEL[match.kind],
+        movedDistance: match.distance ?? 0,
+        model: headName,
+        match: match.kind,
+        matchedGlobalId: oneToOne ? exportedGlobalId(match.base[0]?.key) : '',
+      });
+    }
+  }
+  return rows;
+}
+
+/** Stamp the unresolved-group kind onto the `added`/`deleted` rows the engine
+ *  left in place, keyed by federation global id. */
+export function annotateReviewGroups(
+  rows: CompareReportRow[],
+  matches: readonly ContentMatch<CompareRef>[],
+  byGlobalId: ReadonlyMap<CompareReportRow, number>,
+): void {
+  const kindByGlobalId = new Map<number, ContentMatchKind>();
+  for (const match of matches) {
+    if (isRetiringMatch(match.kind)) continue;
+    for (const fingerprint of [...match.base, ...match.head]) {
+      kindByGlobalId.set(fingerprint.ref.globalId, match.kind);
+    }
+  }
+  if (kindByGlobalId.size === 0) return;
+  for (const row of rows) {
+    const globalId = byGlobalId.get(row);
+    if (globalId === undefined) continue;
+    const kind = kindByGlobalId.get(globalId);
+    if (kind) row.match = kind;
+  }
+}

--- a/apps/viewer/src/store/slices/compareSlice.test.ts
+++ b/apps/viewer/src/store/slices/compareSlice.test.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { describe, it, beforeEach } from 'node:test';
+import { describe, it, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert';
 import { createCompareSlice, type CompareSlice } from './compareSlice.js';
 
@@ -71,5 +71,78 @@ describe('CompareSlice - ignored-classes blacklist (#1470)', () => {
     state.setCompareExcludedTypes(['IfcSpace', 'IfcWall']);
     state.clearCompareExcludedTypes();
     assert.deepStrictEqual(state.compareExcludedTypes, []);
+  });
+});
+
+// The content-matching toggle persists through `window.localStorage`, and the
+// slice's persistence helpers early-return on `typeof window === 'undefined'`.
+// Without a window the default/load branches are never reached at all, so a
+// wrong default would sail through - these tests install a fake window so the
+// real branch is the one under test.
+describe('CompareSlice - content matching toggle (#1891)', () => {
+  const KEY = 'ifc-lite:compare-match-by-content-v1';
+  let storage: Map<string, string>;
+  let failReads = false;
+
+  function installWindow(): void {
+    storage = new Map<string, string>();
+    Reflect.set(globalThis, 'window', {
+      localStorage: {
+        getItem: (key: string) => {
+          if (failReads) throw new Error('denied');
+          return storage.get(key) ?? null;
+        },
+        setItem: (key: string, value: string) => {
+          storage.set(key, value);
+        },
+      },
+    });
+  }
+
+  function makeSlice(): CompareSlice {
+    let state: CompareSlice;
+    const setState = (partial: Partial<CompareSlice> | ((s: CompareSlice) => Partial<CompareSlice>)) => {
+      state = { ...state, ...(typeof partial === 'function' ? partial(state) : partial) };
+    };
+    state = createCompareSlice(setState, () => state, {} as never);
+    return new Proxy({} as CompareSlice, { get: (_t, prop) => state[prop as keyof CompareSlice] });
+  }
+
+  beforeEach(() => {
+    failReads = false;
+    installWindow();
+  });
+
+  afterEach(() => {
+    Reflect.deleteProperty(globalThis, 'window');
+  });
+
+  it('defaults ON - a re-export otherwise reads as "everything deleted, everything added"', () => {
+    assert.strictEqual(makeSlice().compareMatchByContent, true);
+  });
+
+  it('remembers an explicit opt-out', () => {
+    storage.set(KEY, 'false');
+    assert.strictEqual(makeSlice().compareMatchByContent, false);
+  });
+
+  it('remembers an explicit opt-in', () => {
+    storage.set(KEY, 'true');
+    assert.strictEqual(makeSlice().compareMatchByContent, true);
+  });
+
+  it('falls back to ON when the preference cannot be read', () => {
+    failReads = true;
+    assert.strictEqual(makeSlice().compareMatchByContent, true);
+  });
+
+  it('persists both directions through the setter', () => {
+    const state = makeSlice();
+    state.setCompareMatchByContent(false);
+    assert.strictEqual(state.compareMatchByContent, false);
+    assert.strictEqual(storage.get(KEY), 'false');
+    state.setCompareMatchByContent(true);
+    assert.strictEqual(state.compareMatchByContent, true);
+    assert.strictEqual(storage.get(KEY), 'true');
   });
 });

--- a/apps/viewer/src/store/slices/compareSlice.ts
+++ b/apps/viewer/src/store/slices/compareSlice.ts
@@ -44,6 +44,9 @@ export interface CompareResult {
 /** localStorage key for the cross-file compare blacklist (issue #1470). */
 const EXCLUDED_TYPES_STORAGE_KEY = 'ifc-lite:compare-excluded-types-v1';
 
+/** localStorage key for the content-matching toggle (issue #1891). */
+const MATCH_BY_CONTENT_STORAGE_KEY = 'ifc-lite:compare-match-by-content-v1';
+
 /** Case-insensitive de-dup while preserving the first-seen display casing (IFC
  *  PascalCase from the store, e.g. `IfcOpeningElement`). Trims and drops blanks. */
 function dedupeTypes(names: Iterable<string>): string[] {
@@ -84,6 +87,33 @@ function persistExcludedTypes(types: string[]): void {
   }
 }
 
+/** Read the persisted content-matching preference. Defaults to ON (#1891): a
+ *  from-scratch re-export re-GUIDs every element, and without this pass the
+ *  panel reports the whole model as deleted-and-added, which is the single
+ *  most common way Compare mode is wrong. `null` (never set) is the default,
+ *  so only an explicit opt-out is remembered. */
+function loadPersistedMatchByContent(): boolean {
+  if (typeof window === 'undefined') return true;
+  try {
+    const raw = window.localStorage.getItem(MATCH_BY_CONTENT_STORAGE_KEY);
+    if (raw === null) return true;
+    return raw !== 'false';
+  } catch (error) {
+    console.warn('[compare] ignoring unreadable content-matching preference:', error);
+    return true;
+  }
+}
+
+function persistMatchByContent(enabled: boolean): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(MATCH_BY_CONTENT_STORAGE_KEY, enabled ? 'true' : 'false');
+  } catch (error) {
+    // Quota / private mode - the preference just won't persist this session.
+    console.warn('[compare] failed to persist content-matching preference:', error);
+  }
+}
+
 export interface CompareSlice {
   comparePanelVisible: boolean;
   /** Selected base (A) / head (B) federation model ids. */
@@ -97,6 +127,13 @@ export interface CompareSlice {
    * Display casing is preserved; matching against entities is case-insensitive.
    */
   compareExcludedTypes: string[];
+  /**
+   * Whether the diff runs the content-matching pass (issue #1891) - the second
+   * pass that re-pairs entities the GlobalId diff left as `added`/`deleted`
+   * because the file was re-exported from scratch. Default ON; persisted the
+   * same way as {@link compareExcludedTypes} so an opt-out survives a reload.
+   */
+  compareMatchByContent: boolean;
   /** Whether unchanged elements are drawn (ghosted) or hidden. */
   compareShowUnchanged: boolean;
   /** Last comparison result (null when idle / not yet run). */
@@ -128,6 +165,8 @@ export interface CompareSlice {
   removeCompareExcludedType: (type: string) => void;
   /** Empty the blacklist. */
   clearCompareExcludedTypes: () => void;
+  /** Turn the content-matching pass on/off (persisted). */
+  setCompareMatchByContent: (enabled: boolean) => void;
   setCompareShowUnchanged: (show: boolean) => void;
   setCompareResult: (result: CompareResult | null) => void;
   bumpCompareRunSeq: () => void;
@@ -144,6 +183,7 @@ export const createCompareSlice: StateCreator<CompareSlice, [], [], CompareSlice
   compareHeadModelId: null,
   compareScope: 'both',
   compareExcludedTypes: loadPersistedExcludedTypes(),
+  compareMatchByContent: loadPersistedMatchByContent(),
   compareShowUnchanged: false,
   compareResult: null,
   compareRunSeq: 0,
@@ -184,6 +224,11 @@ export const createCompareSlice: StateCreator<CompareSlice, [], [], CompareSlice
   clearCompareExcludedTypes: () => {
     persistExcludedTypes([]);
     set({ compareExcludedTypes: [] });
+  },
+
+  setCompareMatchByContent: (compareMatchByContent) => {
+    persistMatchByContent(compareMatchByContent);
+    set({ compareMatchByContent });
   },
 
   setCompareShowUnchanged: (compareShowUnchanged) => set({ compareShowUnchanged }),

--- a/docs/guide/model-diff.md
+++ b/docs/guide/model-diff.md
@@ -407,6 +407,25 @@ The comparison covers every `IfcObjectDefinition` in the model, read through the
 
 ## Viewer Compare mode
 
-The viewer's Compare UI is a consumer of this engine. It extracts an `EntityFingerprint` per entity from each loaded revision, the data hash from the store and the geometry hash from the WASM mesh pass, and feeds both sides to `diffModels`. The result colours the 3D scene by state (added, modified, deleted), lets you scope the comparison to data, geometry, or both, and drives an inspect panel that reports which signals changed for a picked entity. The persisted type-exclusion list flows straight into `excludeTypes`, so classes the team does not care about stay out of the change set.
+The viewer's Compare UI is a consumer of this engine. It extracts an `EntityFingerprint` per entity from each loaded revision — the data hash and the per-component sub-hashes from the store, the geometry hash from the WASM mesh pass — and feeds both sides to `diffModels`. The result colours the 3D scene by state (added, modified, deleted), lets you scope the comparison to data, geometry, or both, and drives an inspect panel that reports which signals changed for a picked entity. The persisted type-exclusion list flows straight into `excludeTypes`, so classes the team does not care about stay out of the change set.
+
+### Content matching in the viewer
+
+Compare mode runs `matchUnpairedByContent` **on by default**, and the panel has a *Match re-exported elements by content* checkbox to turn it off. The preference persists across files and sessions, like the ignored-classes list. Toggling it re-runs the diff from the fingerprints already extracted, so it is instant — no re-extraction.
+
+Because both sides carry `components`, the viewer sits in the stronger row of the [collision table](#hash-collisions): a colliding data hash is additionally rejected when the pset/qset content disagrees.
+
+The viewer does **not** yet supply an `aabb`. Everything the pass needs to *pair* entities is present, but nothing can separate a move from a reshape or measure a displacement, so a 1:1 pair whose geometry hash differs is reported as a bare `moved` with no distance — the engine's documented fallback.
+
+What you see when a match is found:
+
+| where | retiring match (`renamed` / `moved` / `reshaped`) | unresolved group (`duplicated` / `deduplicated` / `ambiguous`) |
+| --- | --- | --- |
+| 3D | the A copy is hidden, the B copy is drawn blue in the match channel | untouched: the entities keep their green/red add and delete colours |
+| results list | a **Matched** group; clicking a row selects the surviving B copies | a **Needs review** group; clicking a row selects every candidate on both sides. The same entities are still listed under Added / Deleted |
+| counts | a **Matched** badge next to Added / Deleted, which are lower *because* of it | counted as added/deleted, as they are |
+| report (CSV/JSON) | one row per B element, `Change` = `Renamed` / `Moved` / `Reshaped`, with the counterpart's GlobalId in `MatchedGlobalId` when the match is exactly 1:1 | the existing add/delete rows gain the group kind in the `Match` column — no row is duplicated |
+
+The report's `counts` gained `matched` and `needsReview` for the same reason the badge exists: a retiring match lowers `added` and `deleted`, and a reader who cannot see why would take the lower numbers at face value. `Match` and `MatchedGlobalId` are appended after `Model`, so a consumer reading the first six CSV columns positionally is unaffected.
 
 For the full API, see the [`@ifc-lite/diff` README](https://github.com/LTplus-AG/ifc-lite/tree/main/packages/diff).


### PR DESCRIPTION
## What and why

Before this PR, `grep -rn "matchUnpairedByContent\|contentMatches" apps/` returned **zero hits**. The tiered content matcher merged in #1989 was exercised only by its own unit tests — no shipped surface reached it. This makes it reachable, and is therefore also its **first field test on real geometry**.

Default **ON**, with a visible toggle (*"Match re-exported elements by content"*) persisted like the ifcType blacklist. Only an explicit opt-out is remembered, so the default can move later without stale preferences pinning users to the old behaviour.

## Real-model verification, executed rather than asserted

`AC20-FZK-Haus.ifc` as A; B = the same file with every IfcRoot GlobalId regenerated (1322 rewrites), one wall translated +1 m, one property edited. Loaded as a federation in the running viewer, clicked **Run comparison**, drove the toggle, clicked a section header and a row, downloaded the CSV through the UI.

| | matching ON | matching OFF |
|---|---|---|
| added / deleted | **7 / 7** | 119 / 119 |
| content matches | 111 `renamed` + 1 `moved` | none |
| meshes hidden | 112 | 0 |
| meshes coloured | 126 (7 red, 7 green, **112 blue**) | 238 |
| **stranded** | **0** | **0** |
| CSV rows | 126 | 238 |

**The stranded-mesh risk was measured, not assumed.** With the overlay's content-match loop disabled, the same run leaves **224 of 238 meshed elements stranded at full material colour** in a ghosted scene. Retiring a pair removes its entries, and `overlay.ts` derived everything from `diff.entries` — so this is the exact failure `excludedHiddenIds` exists to prevent for #1470, and the counterfactual proves the new channel is load-bearing rather than decorative.

**An accidental control that held.** The 7 unmatched pairs are all `IfcSpace`, and they are *correct*: my fixture generator rewrote every 22-character GUID-shaped first string attribute, and `'SpaceTemperatureSummer'` / `'SpaceTemperatureWinter'` are exactly 22 characters in the IFC base64 alphabet — so those property **names** genuinely changed. The pass refused to pair 7 elements whose content really differs while pairing 112 that did not.

The single `moved` row is the wall I actually translated, with `MovedDistance_m` **blank** — the documented no-`aabb` fallback, which PR 2 fills in.

## The four surfaces

- **Overlay** — new `matched` channel: retiring kinds hide every A copy and colour B blue. Review kinds (ambiguous/duplicated/deduplicated) retire nothing, so they keep their add/delete colours and get badged instead.
- **Results list** — new **Matched** and **Needs review** groups from `diff.contentMatches`, with `match:<n>` row keys that cannot collide with a `DiffEntry` key.
- **Report** — one row per head entity of a retiring match, with `MatchedGlobalId` when 1:1 and **blank for a group**, because the engine has no bijection to claim there. Unresolved groups annotate their existing add/delete rows via a new `Match` column rather than duplicating a GlobalId. `counts` gains `matched` + `needsReview`; new CSV columns are appended.
- **Telemetry** — `model_compare_run` gains `content_matching` and per-kind counts. This is the default-on rollout's evidence.

`components` is now supplied, moving the viewer out of the weakest row of the collision table (previously `dataHash` only, so the guard protecting destructive retirement was inert).

## Mutation checks: 21 applied, 21 killed

**One survived first and was a masking fixture, not a redundant guard.** M17 (default OFF) passed because the test ran with no `window`, so `loadPersistedMatchByContent` early-returned at its `typeof window === 'undefined'` guard and the default branch was never reached — a test proving nothing about the headline default. Rewrote the suite with a fake `window.localStorage` so the real branch is under test, and added three more covering load/persist/error paths.

## Verification

viewer suite 2285 pass / 0 fail · typecheck 33/33 · docs-samples 255 clean · viewer build exit 0 · test-wiring clean. 0 console errors across every run.

`pnpm knip` exits 1 on unmodified `main` too; this branch reduces unused exports 363 → 362 and adds none.

## Known gaps, deliberate

A content-match row has no "what changed" detail and no BCF pre-fill — it is not a `DiffEntry`, and its key is namespaced so it can never resolve against `diff.byKey`. `useCompare.ts` has no unit test in this repo and still doesn't; the toggle wiring and re-diff guard are covered by the real-model drive rather than a killable unit test. A hook test is the follow-up if you want it locked down.

Toward #1891.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added content-based matching to model comparisons, enabled by default with a persistent opt-out setting.
  * Added Matched and Needs review result sections with focus actions, match details, counts, and overflow indicators.
  * Added matched-item visualization with dedicated coloring.
  * Comparison reports and CSV exports now include match statuses, matched IDs, and review counts.

* **Documentation**
  * Updated Compare mode guidance with matching behavior, visualization, and export details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->