### PR TITLE
fix(viewer): restore the anchor on re-align, and the local-frame origin with it (#2007)

### DIFF
--- a/apps/viewer/src/components/viewer/BasepointOverlay.tsx
+++ b/apps/viewer/src/components/viewer/BasepointOverlay.tsx
@@ -85,7 +85,7 @@ export function BasepointOverlay() {
         mapConversion: selection.eff.mapConversion,
         projectedCRS: selection.eff.projectedCRS,
         lengthUnitScale: selection.eff.lengthUnitScale,
-        preAlignmentCoordinateInfo: model?.preAlignmentCoordinateInfo,
+        preAlignmentCoordinateInfo: model?.preAlignment?.coordinateInfo,
       },
     };
   }, [models, anchorModelIdOverride, georefMutations]);
@@ -116,7 +116,7 @@ export function BasepointOverlay() {
           mapConversion: eff?.mapConversion,
           projectedCRS: eff?.projectedCRS,
           lengthUnitScale: eff?.lengthUnitScale,
-          preAlignmentCoordinateInfo: model.preAlignmentCoordinateInfo,
+          preAlignmentCoordinateInfo: model.preAlignment?.coordinateInfo,
         };
         const anchorIsThis = anchorInput.id === modelId;
         const placement = await computeIfcOriginViewerPosition(

--- a/apps/viewer/src/hooks/ingest/federationRealign.test.ts
+++ b/apps/viewer/src/hooks/ingest/federationRealign.test.ts
@@ -1,0 +1,562 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Switching the federation anchor twice must leave the model that started as
+ * the anchor exactly as it was loaded (#2007).
+ *
+ * The old loop `continue`d past the anchor before the restore step, so X → A →
+ * X left X's vertices baked into A's frame while X defined the federation
+ * frame. Asserting "no alignment ran on the final pass" would have passed on
+ * that code — the assertions here are byte-level identity against the original
+ * geometry, and identity of the OTHER model against the frame it landed in the
+ * first time X was the anchor.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+
+import type { MapConversion, ProjectedCRS } from '@ifc-lite/parser';
+import type { CoordinateInfo, EntityWorldAabb, GeometryResult, MeshData } from '@ifc-lite/geometry';
+import type { ModelGeoref } from './federationAlign.js';
+import {
+  capturePreAlignment,
+  realignFederationModels,
+  restorePreAlignment,
+  type RealignableModel,
+} from './federationRealign.js';
+
+function coordinateInfo(over?: Partial<CoordinateInfo>): CoordinateInfo {
+  return {
+    originShift: { x: 0, y: 0, z: 0 },
+    originalBounds: { min: { x: 0, y: 0, z: 0 }, max: { x: 1, y: 1, z: 1 } },
+    shiftedBounds: { min: { x: 0, y: 0, z: 0 }, max: { x: 1, y: 1, z: 1 } },
+    hasLargeCoordinates: false,
+    ...over,
+  };
+}
+
+function georef(
+  conversion: Partial<MapConversion>,
+  crsName = 'EPSG:2056',
+): Omit<ModelGeoref, 'coordinateInfo'> {
+  return {
+    mapConversion: {
+      id: 1,
+      sourceCRS: 2,
+      targetCRS: 3,
+      eastings: 0,
+      northings: 0,
+      orthogonalHeight: 0,
+      xAxisAbscissa: 1,
+      xAxisOrdinate: 0,
+      scale: 1,
+      ...conversion,
+    },
+    projectedCRS: { id: 4, name: crsName, mapUnitScale: 1 } as ProjectedCRS,
+    lengthUnitScale: 1,
+  };
+}
+
+/**
+ * A box mesh with REAL unit normals. Zero-length normals survive the alignment
+ * untouched (the rotation short-circuits on them), so a fixture built with
+ * zeroed normals could not tell a restored normal from an unrestored one.
+ */
+function boxMesh(
+  expressId: number,
+  place: [number, number, number],
+  localOrigin?: [number, number, number],
+): MeshData {
+  const positions: number[] = [];
+  const normals: number[] = [];
+  const o = localOrigin ?? [0, 0, 0];
+  for (const x of [0, 4]) {
+    for (const y of [0, 1]) {
+      for (const z of [0, 2]) {
+        // Local-frame vertices: world = origin + position, exactly as the wasm
+        // pipeline emits them. Alignment folds the origin in and zeroes it, so a
+        // fixture without origins cannot tell a complete restore from a partial one.
+        positions.push(x + place[0] - o[0], y + place[1] - o[1], z + place[2] - o[2]);
+        const len = Math.sqrt(3);
+        normals.push(
+          (x === 0 ? -1 : 1) / len,
+          (y === 0 ? -1 : 1) / len,
+          (z === 0 ? -1 : 1) / len,
+        );
+      }
+    }
+  }
+  return {
+    expressId,
+    positions: new Float32Array(positions),
+    normals: new Float32Array(normals),
+    indices: new Uint32Array([0, 1, 2]),
+    color: [1, 1, 1, 1],
+    geometryHash: 7n,
+    ...(localOrigin ? { origin: [...localOrigin] as [number, number, number] } : {}),
+    geometryAabb: {
+      min: [place[0], place[1], place[2]],
+      max: [place[0] + 4, place[1] + 1, place[2] + 2],
+    },
+  } as MeshData;
+}
+
+interface TestModel extends RealignableModel {
+  /** The model's own georef, minus the coordinateInfo the resolver supplies. */
+  ownGeoref: Omit<ModelGeoref, 'coordinateInfo'>;
+}
+
+function model(
+  meshes: MeshData[],
+  info: CoordinateInfo,
+  ownGeoref: Omit<ModelGeoref, 'coordinateInfo'>,
+  instanced?: Map<number, EntityWorldAabb>,
+): TestModel {
+  const geometryResult: GeometryResult = {
+    meshes,
+    totalTriangles: meshes.length,
+    totalVertices: meshes.reduce((n, m) => n + m.positions.length / 3, 0),
+    coordinateInfo: info,
+    ...(instanced ? { instancedGeometryAabbs: instanced } : {}),
+  };
+  return { geometryResult, ownGeoref, federationAlignmentStatus: 'none' };
+}
+
+/**
+ * Exactly what `extractModelGeoref` does for the fields that matter here: the
+ * MapConversion and CRS come from the file, the `coordinateInfo` is whatever
+ * the model's geometry carries AT THE MOMENT OF THE CALL. That last part is
+ * what makes reading the anchor's frame before restoring it observable.
+ */
+function resolveGeoref(_modelId: string, m: TestModel): ModelGeoref {
+  return { ...m.ownGeoref, coordinateInfo: m.geometryResult?.coordinateInfo };
+}
+
+function applyPatch(models: Map<string, TestModel>) {
+  return (modelId: string, patch: Partial<RealignableModel>): void => {
+    const target = models.get(modelId);
+    if (!target) throw new Error(`updateModel called for unknown model ${modelId}`);
+    Object.assign(target, patch);
+  };
+}
+
+async function realign(models: Map<string, TestModel>, anchorModelId: string) {
+  const anchor = models.get(anchorModelId);
+  if (!anchor) throw new Error(`no such anchor ${anchorModelId}`);
+  return realignFederationModels<TestModel>({
+    models: Array.from(models.entries()),
+    anchorModelId,
+    // Resolved BEFORE the call, exactly as `findReferenceGeorefModel` does it —
+    // so this georef carries the anchor's frame as it stands pre-restore.
+    anchorGeoref: resolveGeoref(anchorModelId, anchor),
+    resolveGeoref,
+    updateModel: applyPatch(models),
+  });
+}
+
+/**
+ * `world = origin + position` — what the renderer, the spatial index and every
+ * bounds query actually see. Asserting on this rather than on whether `origin`
+ * is present is what catches the failure mode this repo keeps hitting: a
+ * world-space consumer that drops the folded origin misplaces geometry by
+ * exactly that offset, and it reads as a rendering glitch rather than a data bug.
+ */
+function worldPositionsOf(mesh: MeshData): Float32Array {
+  const o = mesh.origin ?? [0, 0, 0];
+  const out = new Float32Array(mesh.positions.length);
+  for (let i = 0; i < mesh.positions.length; i += 3) {
+    out[i] = mesh.positions[i] + o[0];
+    out[i + 1] = mesh.positions[i + 1] + o[1];
+    out[i + 2] = mesh.positions[i + 2] + o[2];
+  }
+  return out;
+}
+
+function bytesOf(array: Float32Array): Uint8Array {
+  return new Uint8Array(array.buffer.slice(array.byteOffset, array.byteOffset + array.byteLength));
+}
+
+function assertBytesEqual(actual: Float32Array, expected: Float32Array, label: string): void {
+  assert.deepStrictEqual(
+    Buffer.from(bytesOf(actual)).toString('hex'),
+    Buffer.from(bytesOf(expected)).toString('hex'),
+    label,
+  );
+}
+
+function assertBytesDiffer(actual: Float32Array, expected: Float32Array, label: string): void {
+  assert.notDeepStrictEqual(
+    Buffer.from(bytesOf(actual)).toString('hex'),
+    Buffer.from(bytesOf(expected)).toString('hex'),
+    label,
+  );
+}
+
+/** X and A: same projected CRS, 2500 m apart, 30° between their grid norths,
+ *  and different RTC choices so the two frames really are two frames. */
+function federation(): { models: Map<string, TestModel>; x: TestModel; a: TestModel } {
+  const theta = Math.PI / 6;
+  const x = model(
+    // Two meshes: one on the wasm local-frame path (an origin), one without.
+    // Absent must stay absent — a restore that hands out a [0,0,0] origin gives
+    // the renderer a local frame the mesh never had.
+    [boxMesh(11, [0, 0, 0], [3, 0, -2]), boxMesh(12, [10, 0, 5])],
+    coordinateInfo({ wasmRtcOffset: { x: 1000, y: 500, z: 0 } }),
+    georef({ eastings: 2500, xAxisAbscissa: Math.cos(theta), xAxisOrdinate: Math.sin(theta) }),
+    new Map<number, EntityWorldAabb>([[99, { min: [0, 0, 0], max: [2, 2, 2] }]]),
+  );
+  const a = model(
+    [boxMesh(21, [7, 0, -3], [-1, 0, 4])],
+    coordinateInfo({ originShift: { x: 20, y: 0, z: -5 } }),
+    georef({ eastings: 0, northings: 800 }),
+  );
+  const models = new Map<string, TestModel>([['X', x], ['A', a]]);
+  return { models, x, a };
+}
+
+describe('realignFederationModels — switching the anchor back restores it (#2007)', () => {
+  it('leaves X byte-identical to its original geometry after X → A → X', async () => {
+    const { models, x, a } = federation();
+    const xMesh = x.geometryResult!.meshes[0];
+    const aMesh = a.geometryResult!.meshes[0];
+    const xOriginalPositions = new Float32Array(xMesh.positions);
+    const xOriginalNormals = new Float32Array(xMesh.normals!);
+    // Cloned, not referenced. A baseline that aliases the live object cannot
+    // fail: the restore would be compared against whatever the restore itself
+    // produced.
+    const xOriginalInfo = structuredClone(x.geometryResult!.coordinateInfo);
+    const xOriginalBox = structuredClone(xMesh.geometryAabb!);
+    const xOriginalOrigin = [...xMesh.origin!] as [number, number, number];
+    const xOriginalWorld = worldPositionsOf(xMesh);
+    const aOriginalWorldOfSecondMesh = worldPositionsOf(x.geometryResult!.meshes[1]);
+    const xOriginalInstanced = structuredClone(x.geometryResult!.instancedGeometryAabbs!);
+
+    // Round 1 — X anchors. A is baked into X's frame; X is untouched.
+    await realign(models, 'X');
+    assertBytesEqual(xMesh.positions, xOriginalPositions, 'the anchor must not move on its own pass');
+    const aPositionsUnderX = new Float32Array(aMesh.positions);
+    const aNormalsUnderX = new Float32Array(aMesh.normals!);
+    const aBoxUnderX = aMesh.geometryAabb!;
+
+    // Round 2 — A anchors. X is now a non-anchor and gets baked into A's frame.
+    await realign(models, 'A');
+    assertBytesDiffer(xMesh.positions, xOriginalPositions, 'fixture: X must really leave its own frame');
+    assert.ok(x.preAlignment, 'X must have been snapshotted when it was aligned');
+
+    // Round 3 — X anchors again. This is the defect: the old loop skipped the
+    // restore along with the alignment.
+    const third = await realign(models, 'X');
+
+    assertBytesEqual(xMesh.positions, xOriginalPositions, 'X positions must be byte-identical again');
+    assertBytesEqual(xMesh.normals!, xOriginalNormals, 'X normals must be byte-identical again');
+    assert.deepStrictEqual(xMesh.geometryAabb, xOriginalBox, 'X world box must be its original');
+    // The consequence, not the mechanism: alignment folds the origin into the
+    // vertices and zeroes it, so a restore that puts the local-frame positions
+    // back without the origin leaves the mesh sitting at `position` instead of
+    // `origin + position` — displaced by exactly the folded offset.
+    assertBytesEqual(
+      worldPositionsOf(xMesh),
+      xOriginalWorld,
+      'X must sit at the same WORLD coordinates it loaded at',
+    );
+    assertBytesEqual(
+      worldPositionsOf(x.geometryResult!.meshes[1]),
+      aOriginalWorldOfSecondMesh,
+      'the origin-less mesh must sit where it loaded too',
+    );
+    assert.deepStrictEqual(
+      xMesh.origin,
+      xOriginalOrigin,
+      'and by the right mechanism: the local-frame origin itself is back',
+    );
+    // Numerically inert (a [0,0,0] origin adds nothing) but structurally wrong:
+    // capture and restore must round-trip, and inventing a channel the capture
+    // never saw is the defect `federationAlign.test.ts` pins for the instanced
+    // boxes. Downstream code reads presence as "this mesh is on the local-frame
+    // path".
+    assert.equal(
+      x.geometryResult!.meshes[1].origin,
+      undefined,
+      'a mesh that never had an origin must not be given one',
+    );
+    assert.deepStrictEqual(
+      x.geometryResult!.instancedGeometryAabbs,
+      xOriginalInstanced,
+      'X instanced-only boxes must be their originals',
+    );
+    assert.deepStrictEqual(
+      x.geometryResult!.coordinateInfo,
+      xOriginalInfo,
+      'X must be back on its own RTC/shift frame',
+    );
+    assert.deepStrictEqual(
+      [...third.movedModelIds].sort(),
+      ['A', 'X'],
+      'the caller has to learn the anchor geometry changed, or the GPU buffers and '
+      + 'the spatial index both keep describing the old frame',
+    );
+    assert.equal(x.federationAlignmentStatus, 'anchor');
+
+    // And the frame the rest of the federation was aligned INTO is X's own
+    // again: A lands exactly where it landed the first time X anchored. This is
+    // the half that restoring the anchor too late would still get wrong — the
+    // anchor georef would carry A's coordinateInfo.
+    assertBytesEqual(aMesh.positions, aPositionsUnderX, 'A must land in the same frame as in round 1');
+    assertBytesEqual(aMesh.normals!, aNormalsUnderX, 'A normals must match round 1');
+    assert.deepStrictEqual(aMesh.geometryAabb, aBoxUnderX, 'A world box must match round 1');
+    assert.deepStrictEqual(aMesh.origin, [0, 0, 0], 'A was aligned, so its origin is folded in again');
+    assert.equal(third.counts.aligned, 1);
+    assert.equal(third.counts.skipped, 0);
+    assert.equal(third.counts.failed, 0);
+  });
+
+  it('snapshots the coordinate frame by value, so a later in-place edit cannot rewrite it', () => {
+    // Positions, normals and origins are copied into the snapshot; the FRAME
+    // they are relative to has to be copied too. Holding the live object means
+    // anything that edits it in place — `useIfcLoader.ts` does exactly that to
+    // `wasmRtcOffset` on the streaming path — silently rewrites the baseline,
+    // and the restore then puts the model back into the edited frame instead of
+    // its own, with nothing to notice because snapshot and geometry are one
+    // value.
+    const geometry = federation().x.geometryResult!;
+    const before = structuredClone(geometry.coordinateInfo);
+
+    const snapshot = capturePreAlignment(geometry);
+
+    // Every depth the frame has: a scalar, a nested vector, and a bounds corner
+    // two levels down. The corner is the one that catches a copy that stopped a
+    // level too early — `restorePreAlignment` spreads `originalBounds` and
+    // `shiftedBounds` one level, which does NOT copy their `min`/`max`.
+    geometry.coordinateInfo.hasLargeCoordinates = !geometry.coordinateInfo.hasLargeCoordinates;
+    geometry.coordinateInfo.originShift.x += 137;
+    geometry.coordinateInfo.originalBounds.min.x -= 42;
+    geometry.coordinateInfo.shiftedBounds.max.z += 7;
+    geometry.coordinateInfo.wasmRtcOffset = { x: 4, y: 5, z: 6 };
+
+    restorePreAlignment(geometry, snapshot);
+
+    assert.deepStrictEqual(
+      geometry.coordinateInfo,
+      before,
+      'the restored frame must be the captured one, not the edited one',
+    );
+  });
+
+  it('snapshots the instanced-only box channel by value too', () => {
+    const geometry = federation().x.geometryResult!;
+    const before = structuredClone(geometry.instancedGeometryAabbs!);
+
+    const snapshot = capturePreAlignment(geometry);
+
+    geometry.instancedGeometryAabbs!.set(1234, { min: [0, 0, 0], max: [1, 1, 1] });
+    geometry.instancedGeometryAabbs!.delete(99);
+
+    restorePreAlignment(geometry, snapshot);
+
+    assert.deepStrictEqual(
+      geometry.instancedGeometryAabbs,
+      before,
+      'the restored channel must be the captured one, not the edited one',
+    );
+  });
+
+  it('hands the restore its own copy, so editing the restored frame cannot corrupt the snapshot', () => {
+    // The mirror of the capture case, and just as silent: if the restore hands
+    // the geometry the snapshot's own nested objects, the next in-place edit of
+    // the live frame rewrites the baseline that the NEXT re-align will restore
+    // from. `{ ...coordinateInfo, originalBounds: { ...originalBounds } }` looks
+    // deep enough and is not — `min`/`max` are still shared.
+    const geometry = federation().x.geometryResult!;
+    const before = structuredClone(geometry.coordinateInfo);
+    const beforeInstanced = structuredClone(geometry.instancedGeometryAabbs!);
+    const snapshot = capturePreAlignment(geometry);
+
+    restorePreAlignment(geometry, snapshot);
+    geometry.coordinateInfo.originalBounds.min.x -= 42;
+    geometry.coordinateInfo.originShift.y += 9;
+    geometry.instancedGeometryAabbs!.delete(99);
+    // A second re-align restores from the same snapshot.
+    restorePreAlignment(geometry, snapshot);
+
+    assert.deepStrictEqual(
+      geometry.coordinateInfo,
+      before,
+      'the second restore must still produce the captured frame',
+    );
+    assert.deepStrictEqual(
+      geometry.instancedGeometryAabbs,
+      beforeInstanced,
+      'the second restore must still produce the captured channel',
+    );
+  });
+
+  it('clears the restored anchor\'s snapshots so nothing stale can be re-applied', async () => {
+    const { models, x } = federation();
+    await realign(models, 'X');
+    await realign(models, 'A');
+    assert.ok(x.preAlignment, 'fixture: X must be carrying a snapshot before the switch back');
+
+    await realign(models, 'X');
+
+    // One field, so there is no way to clear four channels and forget the fifth
+    // — which is the same reason "positions but no origins" is now unrepresentable.
+    assert.equal(x.preAlignment, undefined, 'the whole snapshot must be cleared');
+  });
+
+  it('places a model the same way no matter which anchor came before', async () => {
+    // Switching TO an anchor must give what loading with that anchor from the
+    // start would: the frame X lands in is A's OWN frame, not whatever frame A
+    // was last baked into. This is where reading the anchor's `coordinateInfo`
+    // before restoring it shows up — and it is invisible in a bare X → A → X
+    // round trip, because two models converge on the first anchor's frame and
+    // the two errors then cancel on the way back.
+    const direct = federation();
+    await realign(direct.models, 'A');
+    const directX = direct.x.geometryResult!.meshes[0].positions;
+
+    const viaX = federation();
+    await realign(viaX.models, 'X');
+    await realign(viaX.models, 'A');
+
+    assertBytesDiffer(
+      directX,
+      new Float32Array(federation().x.geometryResult!.meshes[0].positions),
+      'fixture: anchoring on A must really move X',
+    );
+    assertBytesEqual(
+      viaX.x.geometryResult!.meshes[0].positions,
+      directX,
+      'X under anchor A must not depend on X having anchored first',
+    );
+    assertBytesEqual(
+      viaX.a.geometryResult!.meshes[0].positions,
+      direct.a.geometryResult!.meshes[0].positions,
+      'the anchor itself must come back to the same frame either way',
+    );
+  });
+
+  it('re-aligns repeatedly without drift once the anchor stays put', async () => {
+    // Three passes on the same anchor must be idempotent: the restore is what
+    // makes pass N start from the same geometry pass 1 did.
+    const { models, a } = federation();
+    const aMesh = a.geometryResult!.meshes[0];
+    await realign(models, 'X');
+    const first = new Float32Array(aMesh.positions);
+    const firstNormals = new Float32Array(aMesh.normals!);
+    await realign(models, 'X');
+    await realign(models, 'X');
+    assertBytesEqual(aMesh.positions, first, 'repeated re-aligns must not compound');
+    assertBytesEqual(aMesh.normals!, firstNormals, 'repeated re-aligns must not compound on normals');
+  });
+
+  it('restores a model with no georeference and reports it as skipped', async () => {
+    const { models, a } = federation();
+    const aMesh = a.geometryResult!.meshes[0];
+    const aOriginal = new Float32Array(aMesh.positions);
+    await realign(models, 'X');
+    assertBytesDiffer(aMesh.positions, aOriginal, 'fixture: A must really have been aligned');
+
+    // A loses its georef (the user cleared the edit, say). It has to go back to
+    // its own frame rather than stay baked into the anchor's.
+    const anchor = models.get('X')!;
+    const result = await realignFederationModels<TestModel>({
+      models: Array.from(models.entries()),
+      anchorModelId: 'X',
+      anchorGeoref: resolveGeoref('X', anchor),
+      resolveGeoref: (modelId, m) => (modelId === 'A' ? null : resolveGeoref(modelId, m)),
+      updateModel: applyPatch(models),
+    });
+
+    assertBytesEqual(aMesh.positions, aOriginal, 'A must be back in its own frame');
+    assert.equal(a.federationAlignmentStatus, 'none');
+    assert.equal(result.counts.skipped, 1);
+    assert.equal(result.counts.aligned, 0);
+    // Skipped by the alignment but still MOVED by the restore. Anything keyed
+    // on the align count — the GPU content version, the spatial index — misses
+    // exactly this model (#2013).
+    assert.deepStrictEqual(result.movedModelIds, ['A'], 'a restored-then-skipped model still moved');
+  });
+
+  it('clears the status of a model with no geometry instead of leaving it stale', async () => {
+    // A model that cannot participate at all — no `geometryResult` — used to be
+    // counted as skipped without being written to, so it kept the badge from the
+    // PREVIOUS anchor. The models panel and BasepointOverlay would then show
+    // `Aligned` for a model nothing in this pass aligned.
+    const { models } = federation();
+    await realign(models, 'X');
+    const a = models.get('A')!;
+    assert.equal(a.federationAlignmentStatus, 'same-crs', 'fixture: A must carry a stale-able status');
+
+    a.geometryResult = undefined;
+    const second = await realign(models, 'X');
+
+    assert.equal(
+      a.federationAlignmentStatus,
+      'none',
+      'a model that could not be aligned must not keep claiming it was',
+    );
+    assert.equal(second.counts.skipped, 1);
+    assert.deepStrictEqual(second.movedModelIds, [], 'nothing moved: there was no geometry to move');
+  });
+
+  it('reports only what moved when the anchor never left its own frame', async () => {
+    const { models } = federation();
+    const first = await realign(models, 'X');
+    assert.deepStrictEqual(
+      first.movedModelIds,
+      ['A'],
+      'a never-aligned anchor has nothing to restore, so only the aligned model moved',
+    );
+  });
+
+  it('reports a model the restore moved even when its new alignment is identity', async () => {
+    // A is baked into X's frame, then the anchor moves to B — and B's georef is
+    // A's own, so A's new alignment is `identity` and moves nothing. The RESTORE
+    // is what put A back. A moved-set keyed on the alignment status alone would
+    // leave A's GPU buffers and its spatial index describing X's frame while the
+    // geometry sits in A's.
+    const shared = georef({ eastings: 0, northings: 800 });
+    const theta = Math.PI / 6;
+    const models = new Map<string, TestModel>([
+      ['X', model(
+        [boxMesh(41, [0, 0, 0])],
+        coordinateInfo(),
+        georef({ eastings: 2500, xAxisAbscissa: Math.cos(theta), xAxisOrdinate: Math.sin(theta) }),
+      )],
+      ['A', model([boxMesh(42, [7, 0, -3])], coordinateInfo(), shared)],
+      ['B', model([boxMesh(43, [1, 0, 9])], coordinateInfo(), shared)],
+    ]);
+    const a = models.get('A')!;
+    const aMesh = a.geometryResult!.meshes[0];
+    const aOriginal = new Float32Array(aMesh.positions);
+
+    await realign(models, 'X');
+    assertBytesDiffer(aMesh.positions, aOriginal, 'fixture: A must really be baked into X\'s frame');
+
+    const second = await realign(models, 'B');
+
+    assert.equal(a.federationAlignmentStatus, 'identity', 'fixture: the new alignment must be a no-op');
+    assertBytesEqual(aMesh.positions, aOriginal, 'the restore put A back in its own frame');
+    assert.ok(
+      second.movedModelIds.includes('A'),
+      `the restore moved A even though the alignment did not — got ${JSON.stringify(second.movedModelIds)}`,
+    );
+  });
+
+  it('reports nothing moved when every model is already where it belongs', async () => {
+    // Anchor with no georef difference to anyone: the alignment is `identity`
+    // and no snapshot exists, so nothing is rewritten and nothing downstream
+    // needs invalidating. Over-reporting here would rebuild every BVH and
+    // re-upload every GPU buffer on each click of Re-align.
+    const same = georef({ eastings: 0 });
+    const models = new Map<string, TestModel>([
+      ['X', model([boxMesh(31, [0, 0, 0])], coordinateInfo(), same)],
+      ['A', model([boxMesh(32, [5, 0, 5])], coordinateInfo(), same)],
+    ]);
+    const result = await realign(models, 'X');
+    assert.deepStrictEqual(result.movedModelIds, [], 'an identity alignment moves nothing');
+    assert.equal(result.counts.aligned, 1, 'it still counts as handled');
+  });
+});

--- a/apps/viewer/src/hooks/ingest/federationRealign.ts
+++ b/apps/viewer/src/hooks/ingest/federationRealign.ts
@@ -1,0 +1,293 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Re-baking an already-loaded federation against the current anchor.
+ *
+ * `realignFederation` (useIfcFederation.ts) is the caller; the loop lives here
+ * so it can be driven without a React store, and because federationAlign.ts is
+ * already over the module-size guideline.
+ *
+ * Two rules this module exists to keep:
+ *
+ *  1. **"Do not align" is not "do not restore".** The anchor must never be
+ *     ALIGNED — it defines the frame — but it must be RESTORED if it was ever
+ *     aligned as a non-anchor. Switching the anchor X → A bakes X's geometry
+ *     into A's frame; switching back to X used to `continue` past X before the
+ *     restore step, leaving X defining a frame its own vertices are not in and
+ *     every other model aligned to a frame X had left (#2007).
+ *
+ *  2. **The anchor is restored BEFORE anything is aligned into it.** The frame
+ *     a model lands in is the anchor's `CoordinateInfo` (its RTC/shift choice),
+ *     and alignment REPLACES that field on the model it re-bakes. So an anchor
+ *     still carrying the previous anchor's `CoordinateInfo` hands every other
+ *     model the wrong destination — restoring the anchor's vertices but reading
+ *     its frame first fixes half the bug and hides the other half.
+ *
+ * The restore covers the whole set alignment touches: positions, normals,
+ * per-mesh local-frame origins, coordinateInfo, per-entity world boxes and the
+ * instanced-only world boxes. #2005 fixed two cases of a restore path covering
+ * less than the alignment wrote and the origins were a third (found by running
+ * the real `Building-Architecture.ifc` + `Infra-Bridge.ifc` federation through
+ * two anchor switches), so capture and restore are defined next to each other
+ * here and cannot answer different questions.
+ */
+
+import type { FederatedModel, PreAlignmentSnapshot } from '../../store/index.js';
+import { alignGeometryToReference, type ModelGeoref } from './federationAlign.js';
+
+type AlignableGeometry = NonNullable<FederatedModel['geometryResult']>;
+
+/** The part of a federated model this module reads and writes. */
+export interface RealignableModel {
+  geometryResult?: AlignableGeometry | null;
+  preAlignment?: PreAlignmentSnapshot;
+  federationAlignmentStatus?: FederatedModel['federationAlignmentStatus'];
+}
+
+/**
+ * Snapshot a geometry result's current state as its pre-alignment state.
+ *
+ * The snapshot owns everything it can be asked to put back: positions, normals
+ * and origins are copied, the coordinate frame is deep-copied, and the
+ * instanced-box Map is copied. The only things shared with the live geometry
+ * are the world-box OBJECTS, which is sound because alignment replaces boxes
+ * rather than mutating them — pinned by `federationAlign.test.ts`.
+ *
+ * The rule is that a snapshot and the geometry it came from are never one
+ * value. Otherwise an in-place edit of the live geometry silently rewrites the
+ * baseline, the restore becomes a no-op, and no assertion comparing the two can
+ * see it.
+ */
+export function capturePreAlignment(geometry: AlignableGeometry): PreAlignmentSnapshot {
+  return {
+    positions: geometry.meshes.map((mesh) => new Float32Array(mesh.positions)),
+    normals: geometry.meshes.map((mesh) => (
+      mesh.normals && mesh.normals.length > 0 ? new Float32Array(mesh.normals) : undefined
+    )),
+    // Copied, not held: alignment replaces the array (`mesh.origin = [0,0,0]`)
+    // today, but a copy costs three numbers and cannot be undone by a future
+    // in-place writer.
+    origins: geometry.meshes.map((mesh) => (mesh.origin ? [...mesh.origin] : undefined)),
+    // Deep-copied, and by `structuredClone` rather than by hand: the frame is
+    // nested three levels (`originalBounds.min.x`), so neither a spread nor a
+    // spread-plus-one-level-of-bounds reaches the corners, and a hand-written
+    // copy would silently stop covering a field added later. Holding the live
+    // object instead would let anything that edits it in place (useIfcLoader
+    // does exactly that to `wasmRtcOffset` on the streaming path) rewrite the
+    // baseline, which turns the restore into a no-op that cannot be detected,
+    // because the snapshot and the geometry would be one value.
+    coordinateInfo: structuredClone(geometry.coordinateInfo),
+    geometryAabbs: geometry.meshes.map((mesh) => mesh.geometryAabb),
+    // The Map is copied so the snapshot owns its own entry set. The boxes
+    // inside stay shared, at the same depth as the per-mesh `geometryAabbs`
+    // above: alignment REPLACES box objects rather than mutating them, which is
+    // pinned by `federationAlign.test.ts`.
+    instancedGeometryAabbs: geometry.instancedGeometryAabbs
+      ? new Map(geometry.instancedGeometryAabbs)
+      : undefined,
+  };
+}
+
+/**
+ * Put a geometry result back exactly as the snapshot found it, undoing whatever
+ * alignment baked into it.
+ *
+ * Normals are restored because alignment rotates them in place, so repeated
+ * re-bakes would compound the rotation and drift the shading. The world boxes
+ * are restored because alignment re-frames them too: re-aligning an already
+ * aligned box while the vertices restart from the snapshot leaves the box in a
+ * frame of its own, and compare then reports a plausible wrong distance (#2005).
+ *
+ * A mesh whose snapshot slot holds no box LOSES its box rather than keeping the
+ * aligned one: an unknown pre-alignment box is the engine's documented "no box"
+ * state (compare degrades to a bare `moved`), whereas a kept one asserts a
+ * position in the previous anchor's frame.
+ */
+export function restorePreAlignment(
+  geometry: AlignableGeometry,
+  snapshot: PreAlignmentSnapshot,
+): void {
+  const meshes = geometry.meshes;
+  const restoreCount = Math.min(meshes.length, snapshot.positions.length);
+  for (let i = 0; i < restoreCount; i += 1) {
+    meshes[i].positions = new Float32Array(snapshot.positions[i]);
+    const normals = snapshot.normals[i];
+    if (normals) meshes[i].normals = new Float32Array(normals);
+    // The origin the alignment folded in and zeroed. Absent stays absent: a
+    // mesh that never had one must not gain a [0,0,0] the renderer would then
+    // treat as a local frame.
+    const origin = snapshot.origins[i];
+    if (origin) meshes[i].origin = [...origin];
+    else delete meshes[i].origin;
+    const box = snapshot.geometryAabbs[i];
+    if (box) meshes[i].geometryAabb = box;
+    else delete meshes[i].geometryAabb;
+  }
+  // Copies out, for the mirror of the reason the capture copies in: hand the
+  // geometry the snapshot's own objects and the next in-place edit of the live
+  // frame rewrites the baseline the NEXT restore reads. The spread this
+  // replaced looked deep enough and was not — it copied the two bounds objects
+  // but left their `min`/`max` shared.
+  geometry.coordinateInfo = structuredClone(snapshot.coordinateInfo);
+  geometry.instancedGeometryAabbs = snapshot.instancedGeometryAabbs
+    ? new Map(snapshot.instancedGeometryAabbs)
+    : undefined;
+}
+
+/** How each model fared, for the caller's summary toast. */
+export interface RealignCounts {
+  aligned: number;
+  reprojected: number;
+  skipped: number;
+  failed: number;
+}
+
+export interface RealignFederationParams<M extends RealignableModel> {
+  /** Every model in the federation, `[modelId, model]`, anchor included. */
+  models: ReadonlyArray<readonly [string, M]>;
+  anchorModelId: string;
+  /**
+   * The anchor's georeference as the caller resolved it. Its `coordinateInfo`
+   * is re-pointed at the anchor's restored frame before anything is aligned —
+   * see {@link RealignFederationResult.anchorGeoref}.
+   */
+  anchorGeoref: ModelGeoref;
+  /**
+   * A non-anchor model's OWN georeference, or null when it has none (the model
+   * is then left in its own frame and counted as skipped). Called after the
+   * model has been restored, because the georef reads its `coordinateInfo`.
+   */
+  resolveGeoref: (modelId: string, model: M) => ModelGeoref | null;
+  updateModel: (modelId: string, patch: Partial<RealignableModel>) => void;
+}
+
+export interface RealignFederationResult {
+  counts: RealignCounts;
+  /**
+   * The georeference every non-anchor model was actually aligned to: the
+   * caller's anchor georef with its `coordinateInfo` re-pointed at the anchor's
+   * restored frame. Reported so the caller names the right CRS in its summary.
+   */
+  anchorGeoref: ModelGeoref;
+  /**
+   * Every model whose geometry this pass actually MOVED: the anchor when it was
+   * restored, plus each non-anchor that was restored out of a previous anchor's
+   * frame and/or re-baked into this one. A model that was only re-written with
+   * the values it already had (never aligned, or an `identity`/`failed`
+   * alignment) is not in here.
+   *
+   * Two things must be keyed on this rather than on the align counts, because a
+   * model can move without being "aligned" — a restored anchor (#2007), or a
+   * model restored and then skipped for having no georef:
+   *
+   *  - `bumpGeometryContentVersion`, or the GPU keeps the old vertex buffers.
+   *  - the per-model spatial index (`IfcDataStore.spatialIndex`), a BVH of
+   *    WORLD-space mesh bounds that backs `queryByBounds`/`raycast`/
+   *    `queryFrustum`. Alignment has never rebuilt it — the loader builds it
+   *    once, after load-time alignment — so re-aligning has always left it
+   *    describing the previous frame: measured on the real
+   *    `Building-Architecture.ifc` + `Infra-Bridge.ifc` federation, a re-align
+   *    left the index finding 7 of 78 meshes inside the model's own bounds
+   *    (#2013). The caller owns the rebuild because the index hangs off the
+   *    data store, which this module deliberately knows nothing about.
+   */
+  movedModelIds: string[];
+}
+
+/**
+ * Restore every model to its own frame and re-bake the non-anchors into the
+ * anchor's. See the module header for the two ordering rules.
+ */
+export async function realignFederationModels<M extends RealignableModel>(
+  params: RealignFederationParams<M>,
+): Promise<RealignFederationResult> {
+  const { models, anchorModelId, resolveGeoref, updateModel } = params;
+  const counts: RealignCounts = { aligned: 0, reprojected: 0, skipped: 0, failed: 0 };
+  const movedModelIds: string[] = [];
+
+  // The anchor FIRST, and restored rather than skipped (#2007).
+  const anchorModel = models.find(([modelId]) => modelId === anchorModelId)?.[1];
+  const anchorGeometry = anchorModel?.geometryResult;
+  if (anchorModel) {
+    if (anchorGeometry) {
+      const snapshot = anchorModel.preAlignment;
+      if (snapshot) {
+        restorePreAlignment(anchorGeometry, snapshot);
+        movedModelIds.push(anchorModelId);
+      }
+    }
+    // Snapshots CLEARED, not kept: a restored anchor is its own pre-alignment
+    // state, so a surviving snapshot is a second, stale copy of it — which is
+    // how every previous defect in this path started. Clearing also restores
+    // the invariant the loader documents ("undefined for the anchor itself")
+    // and drops the geometry-sized copies.
+    updateModel(anchorModelId, {
+      preAlignment: undefined,
+      federationAlignmentStatus: 'anchor',
+    });
+  }
+
+  // The frame the rest of the federation lands in is the anchor's
+  // `coordinateInfo` as it stands AFTER the restore. Everything else in a
+  // ModelGeoref — mapConversion, projectedCRS, lengthUnitScale — comes from the
+  // data store and the user's georef edits, which a restore cannot touch
+  // (`getEffectiveGeoreference` passes `coordinateInfo` straight through), so
+  // re-pointing that one field is exactly what re-extracting would produce.
+  const anchorGeoref: ModelGeoref = anchorGeometry
+    ? { ...params.anchorGeoref, coordinateInfo: anchorGeometry.coordinateInfo }
+    : params.anchorGeoref;
+
+  for (const [modelId, model] of models) {
+    if (modelId === anchorModelId) continue;
+    const geometry = model.geometryResult;
+    if (!geometry) {
+      // Say so, rather than leaving the badge from the PREVIOUS anchor. A model
+      // with no geometry cannot be aligned against anything, and a stale
+      // `same-crs` here reads in the models panel and the basepoint overlay as
+      // "aligned to the current anchor" — a claim nothing in this pass made.
+      updateModel(modelId, { federationAlignmentStatus: 'none' });
+      counts.skipped += 1;
+      continue;
+    }
+
+    // Lazy-snapshot: a model that joined before federation existed (or as the
+    // anchor of a previous federation) was never re-baked, so its current
+    // vertices ARE its pre-alignment positions — and restoring one of those is
+    // a no-op that moves nothing.
+    const stored = model.preAlignment;
+    const snapshot = stored ?? capturePreAlignment(geometry);
+    restorePreAlignment(geometry, snapshot);
+    const restoredFromSnapshot = stored !== undefined;
+
+    // AFTER the restore: the model's georef reads its `coordinateInfo`, and the
+    // one that matters is its own, not the frame it was last baked into.
+    const georef = resolveGeoref(modelId, model);
+    if (!georef) {
+      updateModel(modelId, {
+        preAlignment: snapshot,
+        federationAlignmentStatus: 'none',
+      });
+      // Skipped by the ALIGNMENT, but the restore above still moved it out of
+      // the previous anchor's frame.
+      if (restoredFromSnapshot) movedModelIds.push(modelId);
+      counts.skipped += 1;
+      continue;
+    }
+
+    const status = await alignGeometryToReference(geometry, georef, anchorGeoref);
+    updateModel(modelId, {
+      preAlignment: snapshot,
+      federationAlignmentStatus: status,
+    });
+    if (restoredFromSnapshot || status === 'same-crs' || status === 'reprojected') {
+      movedModelIds.push(modelId);
+    }
+    if (status === 'reprojected') counts.reprojected += 1;
+    else if (status === 'failed') counts.failed += 1;
+    else counts.aligned += 1;
+  }
+
+  return { counts, anchorGeoref, movedModelIds };
+}

--- a/apps/viewer/src/hooks/useIfcFederation.ts
+++ b/apps/viewer/src/hooks/useIfcFederation.ts
@@ -20,16 +20,17 @@ import {
   type IfcDataStore,
   type FederatedIfcxParseResult,
 } from '@ifc-lite/parser';
-import type { CoordinateInfo, MeshData } from '@ifc-lite/geometry';
+import type { MeshData } from '@ifc-lite/geometry';
 import { IfcQuery } from '@ifc-lite/query';
-import { buildSpatialIndexGuarded } from '../utils/loadingUtils.js';
+import { buildSpatialIndexGuarded, buildSpatialIndexForModel } from '../utils/loadingUtils.js';
 import { getDynamicBatchConfig } from '../utils/ifcConfig.js';
 import { calculateMeshBounds, createCoordinateInfo } from '../utils/localParsingUtils.js';
 import {
   buildIfcxDataStore,
   convertIfcxMeshes,
 } from './ingest/viewerModelIngest.js';
-import { extractModelGeoref, alignGeometryToReference, findReferenceGeorefModel } from './ingest/federationAlign.js';
+import { extractModelGeoref, findReferenceGeorefModel } from './ingest/federationAlign.js';
+import { realignFederationModels } from './ingest/federationRealign.js';
 import { toast } from '../components/ui/toast.js';
 import { acquireFederationLoadSlot, releaseFederationLoadSlot } from './federationLoadGate.js';
 
@@ -208,11 +209,15 @@ export function useIfcFederation(
    * Re-apply federation alignment using the currently selected anchor
    * (`anchorModelIdOverride` from the store, falling back to earliest-loaded).
    *
-   * Restores each non-anchor model's geometry from its `preAlignmentPositions`
-   * snapshot, then re-runs alignment against the new anchor. Skips models that
-   * have no snapshot — those were loaded standalone and would need a reload to
-   * participate in re-alignment. Updates `federationAlignmentStatus` on every
-   * touched model so the UI badges reflect the new state.
+   * Restores every model's geometry from its pre-alignment snapshot — the
+   * anchor included, because it may have been aligned under a previous anchor
+   * (#2007) — then re-runs alignment on the non-anchors. Models with no
+   * geometry or no georeference are left in their own frame and counted as
+   * skipped. Updates `federationAlignmentStatus` on every touched model so the
+   * UI badges reflect the new state.
+   *
+   * The mechanics live in `ingest/federationRealign.ts`; what stays here is the
+   * store and toast wiring.
    *
    * Per user preference: this is an explicit operation, not auto-triggered by
    * remove/reorder/anchor-change. Wire it to a "Re-align federation" button.
@@ -230,132 +235,78 @@ export function useIfcFederation(
       toast.error('Cannot re-align: no model with valid georeferencing.');
       return;
     }
-    const { modelId: anchorModelId, georef: anchorGeoref } = referenceSelection;
 
-    let aligned = 0;
-    let reprojected = 0;
-    let skipped = 0;
-    let failed = 0;
+    // ONE snapshot of the user's georef edits for the whole pass, on purpose.
+    // `findReferenceGeorefModel()` just read them to build the anchor's georef
+    // and every `resolveGeoref` below reads the same Map, with no await in
+    // between, so every model in the federation is placed from one consistent
+    // set of inputs.
+    //
+    // The cross-CRS path awaits `resolveProjection`, which can load a precision
+    // grid or fetch a definition — a real window in which the georeferencing
+    // panel (the Re-align button's `busy` flag disables only itself) can commit
+    // an edit. Re-reading the store per callback would then place the models
+    // handled after that edit from different inputs than the ones before it AND
+    // than the anchor, whose georef is necessarily resolved up front — the
+    // anchor's frame has to be read before the restores run (#2007), so it
+    // cannot be refreshed mid-pass without reintroducing that bug. The result
+    // would be a federation aligned half to one frame and half to another, with
+    // nothing in the UI saying so. A uniformly one-edit-stale result is the
+    // better failure: it is what the user asked for when they clicked, and the
+    // next Re-align picks the edit up.
+    const georefMutations = state.georefMutations;
 
-    const updateModel = state.updateModel;
+    const { counts, anchorGeoref, movedModelIds } = await realignFederationModels({
+      models: allModels,
+      anchorModelId: referenceSelection.modelId,
+      anchorGeoref: referenceSelection.georef,
+      resolveGeoref: (modelId, model) => (
+        model.ifcDataStore && model.geometryResult
+          ? extractModelGeoref(
+            model.ifcDataStore,
+            model.geometryResult.coordinateInfo,
+            georefMutations.get(modelId),
+          )
+          : null
+      ),
+      updateModel: state.updateModel,
+    });
 
-    for (const [modelId, model] of allModels) {
-      if (modelId === anchorModelId) {
-        if (model.federationAlignmentStatus !== 'anchor') {
-          updateModel(modelId, { federationAlignmentStatus: 'anchor' });
-        }
-        continue;
-      }
-      if (!model.geometryResult || !model.ifcDataStore) {
-        skipped += 1;
-        continue;
-      }
-
-      // Lazy-snapshot: a model that joined before federation existed (or as
-      // the original anchor of a previous federation) was never re-baked, so
-      // its current vertices ARE its pre-alignment positions. Take a snapshot
-      // before we mutate them so subsequent re-aligns can restore.
-      let snapshots = model.preAlignmentPositions;
-      let normalSnapshots = model.preAlignmentNormals;
-      let snapshotInfo = model.preAlignmentCoordinateInfo;
-      let aabbSnapshots = model.preAlignmentGeometryAabbs;
-      let instancedAabbSnapshot = model.preAlignmentInstancedGeometryAabbs;
-      if (!snapshots || !snapshotInfo) {
-        snapshots = model.geometryResult.meshes.map((m) => new Float32Array(m.positions));
-        normalSnapshots = model.geometryResult.meshes.map((m) =>
-          m.normals && m.normals.length > 0 ? new Float32Array(m.normals) : undefined,
-        );
-        snapshotInfo = model.geometryResult.coordinateInfo;
-        aabbSnapshots = model.geometryResult.meshes.map((m) => m.geometryAabb);
-        instancedAabbSnapshot = model.geometryResult.instancedGeometryAabbs;
-      }
-
-      // Restore vertices, normals and world boxes to pre-alignment state.
-      // Normals must be restored because applyAlignmentTransformAndUpdateBounds
-      // rotates them in place — without restoring, repeated re-aligns would
-      // compound rotations and drift lighting/shading. The per-entity world
-      // boxes (#1891) are re-framed by the same pass and need it for the same
-      // reason: re-aligning an already-aligned box while the vertices restart
-      // from the snapshot would leave the box in a frame of its own, and
-      // compare would report a plausible but wrong move distance.
-      const meshes = model.geometryResult.meshes;
-      const restoreCount = Math.min(meshes.length, snapshots.length);
-      for (let i = 0; i < restoreCount; i += 1) {
-        meshes[i].positions = new Float32Array(snapshots[i]);
-        if (normalSnapshots) {
-          const snap = normalSnapshots[i];
-          if (snap) {
-            meshes[i].normals = new Float32Array(snap);
-          }
-        }
-        if (aabbSnapshots) {
-          const box = aabbSnapshots[i];
-          if (box) meshes[i].geometryAabb = box;
-          else delete meshes[i].geometryAabb;
-        }
-      }
-      // Unconditional: the snapshot's value IS the pre-alignment state, and
-      // `undefined` — this model had no instanced-only boxes — is a state worth
-      // restoring like any other. Gating the restore on the snapshot being
-      // truthy would make the capture and the restore answer two different
-      // questions ("was there a snapshot?" vs "was there a channel?"), which is
-      // how a box survives a re-align in the previous anchor's frame and gets
-      // transformed a second time.
-      model.geometryResult.instancedGeometryAabbs = instancedAabbSnapshot;
-      model.geometryResult.coordinateInfo = {
-        ...snapshotInfo,
-        originalBounds: { ...snapshotInfo.originalBounds },
-        shiftedBounds: { ...snapshotInfo.shiftedBounds },
-      };
-
-      const parsedGeoref = extractModelGeoref(
-        model.ifcDataStore,
-        model.geometryResult.coordinateInfo,
-        state.georefMutations.get(modelId),
-      );
-      if (!parsedGeoref) {
-        updateModel(modelId, {
-          preAlignmentPositions: snapshots,
-          preAlignmentNormals: normalSnapshots,
-          preAlignmentCoordinateInfo: snapshotInfo,
-          preAlignmentGeometryAabbs: aabbSnapshots,
-          preAlignmentInstancedGeometryAabbs: instancedAabbSnapshot,
-          federationAlignmentStatus: 'none',
-        });
-        skipped += 1;
-        continue;
-      }
-
-      const status = await alignGeometryToReference(model.geometryResult, parsedGeoref, anchorGeoref);
-      updateModel(modelId, {
-        preAlignmentPositions: snapshots,
-        preAlignmentNormals: normalSnapshots,
-        preAlignmentCoordinateInfo: snapshotInfo,
-        preAlignmentGeometryAabbs: aabbSnapshots,
-        preAlignmentInstancedGeometryAabbs: instancedAabbSnapshot,
-        federationAlignmentStatus: status,
-      });
-      if (status === 'reprojected') reprojected += 1;
-      else if (status === 'failed') failed += 1;
-      else aligned += 1;
-    }
-
-    // Signal that mesh content was mutated in place — forces the merged-mesh
-    // cache in ViewportContainer to rebuild AND the streaming hook to clear
-    // the WebGPU scene and re-upload buffers. Without this, the success toast
-    // fires but the visible model doesn't move because the GPU still has the
-    // old vertex positions cached.
-    if (aligned + reprojected > 0) {
+    // Everything keyed on "whose geometry actually moved", not on the align
+    // count — a restored anchor (#2007) and a restored-then-skipped model both
+    // move without being aligned.
+    if (movedModelIds.length > 0) {
+      // Signal that mesh content was mutated in place — forces the merged-mesh
+      // cache in ViewportContainer to rebuild AND the streaming hook to clear
+      // the WebGPU scene and re-upload buffers. Without this, the success toast
+      // fires but the visible model doesn't move because the GPU still has the
+      // old vertex positions cached.
       useViewerStore.getState().bumpGeometryContentVersion();
+
+      // Re-index. `IfcDataStore.spatialIndex` is a BVH of WORLD-space mesh
+      // bounds backing queryByBounds/raycast/queryFrustum; the loader builds it
+      // once, after load-time alignment, and re-aligning has never rebuilt it
+      // (#2013). Measured on the real Building-Architecture + Infra-Bridge
+      // federation, one re-align left the index finding 7 of 78 meshes inside
+      // the model's own bounds. Runs after the whole pass so no build races the
+      // geometry it is measuring, and `buildSpatialIndexForModel` drops its
+      // result if the model or its store went away meanwhile.
+      const models = useViewerStore.getState().models;
+      for (const modelId of movedModelIds) {
+        const moved = models.get(modelId) as FederatedModel | undefined;
+        if (moved?.ifcDataStore && moved.geometryResult) {
+          buildSpatialIndexForModel(moved.geometryResult.meshes, modelId, moved.ifcDataStore);
+        }
+      }
     }
 
     const messageParts: string[] = [];
-    if (aligned > 0) messageParts.push(`${aligned} aligned`);
-    if (reprojected > 0) messageParts.push(`${reprojected} reprojected`);
-    if (skipped > 0) messageParts.push(`${skipped} skipped`);
-    if (failed > 0) messageParts.push(`${failed} failed`);
+    if (counts.aligned > 0) messageParts.push(`${counts.aligned} aligned`);
+    if (counts.reprojected > 0) messageParts.push(`${counts.reprojected} reprojected`);
+    if (counts.skipped > 0) messageParts.push(`${counts.skipped} skipped`);
+    if (counts.failed > 0) messageParts.push(`${counts.failed} failed`);
     const summary = messageParts.length > 0 ? messageParts.join(', ') : 'no changes needed';
-    if (failed > 0) {
+    if (counts.failed > 0) {
       toast.error(`Federation re-aligned against "${anchorGeoref.projectedCRS.name}": ${summary}.`);
     } else {
       toast.success(`Federation re-aligned against "${anchorGeoref.projectedCRS.name}": ${summary}.`);

--- a/apps/viewer/src/hooks/useIfcLoader.ts
+++ b/apps/viewer/src/hooks/useIfcLoader.ts
@@ -60,6 +60,8 @@ import { detectPointCloudFormat, ingestPointCloud } from './ingest/pointCloudIng
 import { removePointCloudScanCache } from './ingest/pointCloudScanCache.js';
 import { getGlobalRenderer } from './useBCF.js';
 import { extractModelGeoref, alignGeometryToReference, findReferenceGeorefModel } from './ingest/federationAlign.js';
+import { capturePreAlignment } from './ingest/federationRealign.js';
+import type { PreAlignmentSnapshot } from '../store/index.js';
 import { computePointCloudAlignment, unregisterPointCloudAlignment, hasRegisteredPointCloudAlignment } from './ingest/pointCloudAlignment.js';
 import { toast } from '../components/ui/toast.js';
 import { posthog } from '../lib/analytics.js';
@@ -466,26 +468,17 @@ export function useIfcLoader() {
           const referenceGeoref = findReferenceGeorefModel()?.georef ?? null;
           const parsedGeorefMutations = useViewerStore.getState().georefMutations.get(modelId);
           const parsedGeoref = extractModelGeoref(dataStore, geometryResult.coordinateInfo, parsedGeorefMutations);
-          let preAlignmentPositions: Float32Array[] | undefined;
-          let preAlignmentNormals: (Float32Array | undefined)[] | undefined;
-          let preAlignmentCoordinateInfo: CoordinateInfo | undefined;
-          let preAlignmentGeometryAabbs: (EntityWorldAabb | undefined)[] | undefined;
-          let preAlignmentInstancedGeometryAabbs: Map<number, EntityWorldAabb> | undefined;
+          // The snapshot `realignFederation` later restores from. Captured by
+          // the same function that restores it (ingest/federationRealign.ts) so
+          // the two cannot cover different fields — #1891's world boxes are
+          // re-framed by the alignment exactly like the positions and normals,
+          // and a snapshot that misses one lets a later re-align transform it a
+          // second time.
+          let preAlignment: PreAlignmentSnapshot | undefined;
           let federationAlignmentStatus: FederatedModel['federationAlignmentStatus'] = 'none';
           if (referenceGeoref && parsedGeoref) {
             setProgress({ phase: 'Aligning georeferenced model', percent: 90 });
-            preAlignmentPositions = geometryResult.meshes.map((mesh) => new Float32Array(mesh.positions));
-            preAlignmentNormals = geometryResult.meshes.map((mesh) =>
-              mesh.normals && mesh.normals.length > 0 ? new Float32Array(mesh.normals) : undefined,
-            );
-            preAlignmentCoordinateInfo = geometryResult.coordinateInfo;
-            // #1891: the world boxes are re-framed by the alignment too, so
-            // they need the same snapshot the positions and normals get —
-            // otherwise a later re-align transforms them a second time.
-            // Alignment replaces box objects rather than mutating them, so
-            // holding the references is enough.
-            preAlignmentGeometryAabbs = geometryResult.meshes.map((mesh) => mesh.geometryAabb);
-            preAlignmentInstancedGeometryAabbs = geometryResult.instancedGeometryAabbs;
+            preAlignment = capturePreAlignment(geometryResult);
             const status = await alignGeometryToReference(geometryResult, parsedGeoref, referenceGeoref);
             federationAlignmentStatus = status;
             if (status === 'reprojected') {
@@ -542,11 +535,7 @@ export function useIfcLoader() {
             idOffset,
             maxExpressId,
             pointCloudHandleId: patch?.pointCloudHandleId,
-            preAlignmentPositions,
-            preAlignmentNormals,
-            preAlignmentCoordinateInfo,
-            preAlignmentGeometryAabbs,
-            preAlignmentInstancedGeometryAabbs,
+            preAlignment,
             federationAlignmentStatus,
           };
           useViewerStore.getState().addModel(federatedModel);

--- a/apps/viewer/src/store/types.ts
+++ b/apps/viewer/src/store/types.ts
@@ -326,6 +326,56 @@ export type MetadataLoadState =
 export type ModelSourceFile = File;
 
 /** Complete model container for federation */
+/**
+ * A federated model's geometry as it stood before alignment re-baked it.
+ *
+ * The whole set of channels `federationAlign.ts` overwrites — anything it
+ * writes has to be in here or the restore is incomplete. Captured and restored
+ * by the one pair of functions in `hooks/ingest/federationRealign.ts`.
+ */
+export interface PreAlignmentSnapshot {
+  /** One Float32Array per mesh, in `geometryResult.meshes` order. */
+  positions: Float32Array[];
+  /** Per mesh, sparse: `undefined` where the mesh carried no normals. Restored
+   *  because alignment rotates normals in place, so repeated re-bakes would
+   *  compound the rotation and drift the shading. */
+  normals: (Float32Array | undefined)[];
+  /**
+   * Per mesh, sparse: the local-frame origin (`world = origin + position`),
+   * `undefined` where the mesh carried none.
+   *
+   * Alignment folds each origin into the vertices and then ZEROES it — it does
+   * not remove it — so there is no safe "leave the origin alone" reading of a
+   * restore: leaving the zero misplaces the mesh by exactly the offset that was
+   * folded in, which is the same damage as deleting it. Only putting the true
+   * value back is correct. Measured at up to 54 m of displacement on the second
+   * re-align of `Infra-Bridge.ifc`, and every model off the wasm local-frame
+   * path carries origins.
+   */
+  origins: ([number, number, number] | undefined)[];
+  /** The RTC/shift frame the positions are relative to, recovered before the
+   *  new alignment is applied. */
+  coordinateInfo: CoordinateInfo;
+  /**
+   * Per mesh, sparse: the per-entity world box (#1891), `undefined` where the
+   * mesh carried none. Alignment REPLACES each box with one in the anchor's
+   * frame, so a re-align run against already-aligned boxes would transform them
+   * twice while the vertices started over from the snapshot — the box and its
+   * mesh would part company again, silently.
+   *
+   * References, not copies: alignment never mutates a box in place, so the
+   * snapshotted objects stay valid pre-alignment values.
+   */
+  geometryAabbs: (EntityWorldAabb | undefined)[];
+  /**
+   * `geometryResult.instancedGeometryAabbs`, where `undefined` is a VALUE — the
+   * model had no instanced-only channel — and not a missing snapshot. Restoring
+   * it unconditionally is what keeps capture and restore asking the same
+   * question (#2005).
+   */
+  instancedGeometryAabbs: Map<number, EntityWorldAabb> | undefined;
+}
+
 export interface FederatedModel {
   /** Unique identifier (UUID generated on load) */
   id: string;
@@ -387,48 +437,20 @@ export interface FederatedModel {
    */
   pointCloudHandleId?: number;
   /**
-   * Snapshot of mesh positions before federation alignment ran (one Float32Array
-   * per mesh, indexed in `geometryResult.meshes` order). Populated when this
-   * model joined an existing federation and its geometry was re-baked into the
-   * anchor's viewer frame. Used by `realignFederation()` to re-apply alignment
-   * against a different anchor without re-parsing the source file.
+   * This model's geometry as it stood before federation alignment re-baked it
+   * into the anchor's viewer frame, or `undefined` when no alignment is applied
+   * — a single-model load, the federation anchor itself, or a model that was
+   * restored back into its own frame.
    *
-   * Stays `undefined` for single-model loads and the federation anchor itself
-   * (which has no alignment applied).
+   * ONE object rather than a field per channel, on purpose. Every channel here
+   * is something the alignment overwrites, and a restore that puts back some of
+   * them and not others is the defect this whole path keeps producing (#2005
+   * lost the world boxes, #2007 the anchor, and the local-frame origins were
+   * never captured at all). Grouping them makes "positions but no origins"
+   * unrepresentable instead of merely unreachable: capture and restore cannot
+   * drift apart, because there is one value to write and one to read.
    */
-  preAlignmentPositions?: Float32Array[];
-  /**
-   * Snapshot of mesh normals before federation alignment ran (one Float32Array
-   * per mesh, sparse — empty slot when a mesh had no normals). Restored
-   * alongside `preAlignmentPositions` on re-alignment so repeated re-bakes
-   * don't accumulate rotation drift on the normals (lighting/shading bug).
-   */
-  preAlignmentNormals?: (Float32Array | undefined)[];
-  /**
-   * CoordinateInfo at the time `preAlignmentPositions` was taken. Restored
-   * together with the positions on re-alignment so the source's RTC/shift
-   * frame is recovered before applying the new alignment.
-   */
-  preAlignmentCoordinateInfo?: CoordinateInfo;
-  /**
-   * Snapshot of the per-entity world boxes (#1891) before federation alignment
-   * ran, one slot per mesh in `geometryResult.meshes` order (empty slot when
-   * that mesh carried no box). Restored alongside `preAlignmentPositions` for
-   * the same reason the normals are: alignment REPLACES each box with one in
-   * the anchor's frame, so a second re-align run against already-aligned boxes
-   * would transform them twice while the vertices started over from the
-   * snapshot — the box and its mesh would part company again, silently.
-   *
-   * References, not copies: alignment never mutates a box in place, so the
-   * snapshotted objects stay valid pre-alignment values.
-   */
-  preAlignmentGeometryAabbs?: (EntityWorldAabb | undefined)[];
-  /**
-   * Snapshot of `geometryResult.instancedGeometryAabbs` before alignment, for
-   * the same reason as `preAlignmentGeometryAabbs`. Absent when the model
-   * carried no instanced-only boxes.
-   */
-  preAlignmentInstancedGeometryAabbs?: Map<number, EntityWorldAabb>;
+  preAlignment?: PreAlignmentSnapshot;
   /**
    * How this model was placed in the current federation:
    *   - `'anchor'`       — this model drives the world frame, no alignment
@@ -438,7 +460,9 @@ export interface FederatedModel {
    *   - `'failed'`       — alignment could not be computed; model rendered in
    *                        its own local frame and likely at the wrong real
    *                        world position
-   *   - `'none'`         — single-model load or first georeferenced model
+   *   - `'none'`         — single-model load, first georeferenced model, or a
+   *                        model that could not take part in the last
+   *                        federation re-align (no geometry, or no georeference)
    */
   federationAlignmentStatus?: 'anchor' | 'same-crs' | 'reprojected' | 'identity' | 'failed' | 'none';
 }


### PR DESCRIPTION
Closes #2007.

## The reported bug

`realignFederation` skipped the anchor with `continue` **before** the restore step, so switching the anchor X → A → X left X defining the federation frame while its geometry stayed baked into A's. "Do not align" and "do not restore" are now separate concerns.

**Ordering matters as much as the restore.** The frame every other model lands in is the anchor's `CoordinateInfo`, and alignment *overwrites* that field on whatever it re-bakes. An anchor still carrying the previous anchor's `CoordinateInfo` hands every other model the wrong destination — so the anchor is restored before its georef is read.

`anchorRestored` also feeds `bumpGeometryContentVersion`: the anchor's vertices move without anything being "aligned", and the old `aligned + reprojected > 0` condition would have left the GPU on stale buffers.

**Snapshots are cleared on the restored anchor.** Once restored it is unaligned, so a surviving snapshot is a stale second copy of state it already holds — the shape of every previous defect in this function.

## A second, larger defect found while driving it

**Alignment folds each mesh's local-frame `origin` into its vertices and then zeroes it, and no `preAlignment*` field ever captured it.** Restoring positions without the origin silently drops that translation — measured at **up to 54 m** on `Infra-Bridge.ifc`, on every model off the wasm local-frame path, which is the default.

This is the same family as the three fixed during #2005 (restore paths not covering everything alignment touches), and it is why the brief's "restore all five fields" was wrong — it was six. Capture now lives next to restore in one function the loader also uses, so the two cannot diverge again. Absent stays absent: a mesh that never had an origin must not gain a `[0,0,0]` the renderer would read as a local frame.

## Real-model evidence

`Building-Architecture.ifc` + `Infra-Bridge.ifc` — real parse, real wasm geometry, real georefs (both EPSG:32760, axes `(0.500, 0.866)` vs `(1, 0)`, the 60° grid-north difference), driven through the product's own `realignFederationModels`:

```
round 1 (anchor X):  X untouched: true     A moved by up to 34.466 m
round 2 (anchor A):  A restored: true      X moved by up to 44.025 m
round 3 (anchor X):  X byte-identical to original: true   residual 0.000000 m
                     A byte-identical to round 1:  true   residual 0.000000 m
                     X snapshots cleared: true
                     (pre-fix, X would have stayed 44.025 m out)
```

Before the origin fix, that same run reported `A byte-identical: false, residual 54.201523 m`. **That is how the origin gap was found** — the harness caught it, not reasoning.

**Stated plainly: the browser UI was not driven.** There is no store/debug global to read geometry back from, so a browser run could only have given a visual impression rather than a measurement. The evidence is the node harness plus unit tests; the React/toast wiring and the GPU re-upload path are covered by reasoning and typecheck only.

## Two mutation survivors, both fixture defects

- **A two-model X → A → X fixture cannot detect the ordering half of the bug.** With two models the frames converge on the first anchor's, so reading the anchor's pre-restore `coordinateInfo` is wrong twice and the errors *cancel on the way back*. M2 survived until a path-independence test was added (`realign(A)` alone versus `realign(X); realign(A)`).
- M13 (restoring an absent origin as `[0,0,0]`) survived until an origin-less mesh joined the fixture.

Fixture normals are deliberately real unit vectors: zero-length normals short-circuit the rotation and could not discriminate a restored normal from an unrestored one — the same class of trap as a 90° rotation mapping a box onto a box.

The headline test asserts X is **byte-identical** (hex of the raw buffers) to its original positions and normals, plus deep-equality of origin, world box, instanced boxes and `coordinateInfo` — not merely that no alignment ran, which the old code also satisfies.

13 mutations, 13 killed.

## Structure

New sibling module `federationRealign.ts` (316 lines) owns capture/restore/re-align; `useIfcFederation.ts` keeps only store and toast wiring, dropping 701 → 614 lines. `federationAlign.ts` untouched.

## Verification

viewer **2339 pass / 0 fail** · typecheck 34/34 · docs-samples clean · viewer build exit 0 · test-wiring clean. Viewer-only, so no changeset.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved federation anchor switching by restoring models to their original state before realignment.
  * Preserved model geometry, placement, normals, origins, coordinate metadata, and bounds during alignment.
  * Added handling and reporting for models missing required geometry or georeferencing.
  * Rebuilt spatial data for models whose geometry moved.

* **Bug Fixes**
  * Prevented cumulative placement drift and ensured consistent results regardless of anchor selection.
  * Improved alignment consistency across repeated realignment operations.
  * Improved restoration of model state after anchor changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->