### PR TITLE
fix(viewer): free the geometry WASM handle on every exit path (#1959)

### DIFF
--- a/apps/viewer/src/components/mcp/PlaygroundViewer.test.ts
+++ b/apps/viewer/src/components/mcp/PlaygroundViewer.test.ts
@@ -1,0 +1,136 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `loadPlaygroundGeometry` (#1959 P0 leak) creates a GeometryProcessor per
+ * call and, before the fix, never disposed it — including the `cancelled`
+ * bail-out that fires on every model swap (the effect's cleanup flips
+ * `cancelled` and a fresh IIFE starts for the new model, so a busy playground
+ * session leaked one WASM handle per swap).
+ *
+ * This exercises the extracted loader function directly rather than
+ * mounting `<PlaygroundViewer>`: mounting pulls in the "mount Three.js once"
+ * effect, which constructs a real `THREE.WebGLRenderer` — happy-dom's
+ * `canvas.getContext('webgl')` returns `null`, so that effect throws before
+ * the geometry-loading effect under test ever gets to run, and there is no
+ * existing pattern in this repo for stubbing a WebGL context convincingly
+ * enough for `WebGLRenderer`'s capability-detection calls (`getParameter`,
+ * `getExtension`, ...). Testing the disposal contract through the standalone
+ * function is the proportionate alternative to building that stub.
+ */
+
+import { describe, it, mock } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { GeometryProcessor, type GeometryResult, type MeshData } from '@ifc-lite/geometry';
+import { loadPlaygroundGeometry } from './PlaygroundViewer.js';
+import { parsePlaygroundModel, type LoadedPlaygroundModel } from './playground-dispatcher.js';
+
+function ifc4(body: string): string {
+  return [
+    'ISO-10303-21;', 'HEADER;', "FILE_DESCRIPTION((''),'2;1');",
+    "FILE_NAME('','',(''),(''),'','','');", "FILE_SCHEMA(('IFC4'));", 'ENDSEC;',
+    'DATA;', body, 'ENDSEC;', 'END-ISO-10303-21;', '',
+  ].join('\n');
+}
+
+async function schemaOnlyModel(globalId: string): Promise<LoadedPlaygroundModel> {
+  const bytes = new TextEncoder().encode(
+    ifc4(`#1=IFCWALL('${globalId}',$,'Wall A',$,$,$,$,$,.STANDARD.);`),
+  );
+  return parsePlaygroundModel(bytes.buffer as ArrayBuffer, `${globalId}.ifc`);
+}
+
+/** A promise plus its resolver, so the test controls exactly when
+ *  `processor.process()` settles relative to flipping `cancelled`. */
+function deferred<T>(): { promise: Promise<T>; resolve: (v: T) => void } {
+  let resolve!: (v: T) => void;
+  const promise = new Promise<T>((res) => { resolve = res; });
+  return { promise, resolve };
+}
+
+describe('loadPlaygroundGeometry WASM disposal (#1959 P0 leak)', () => {
+  it('disposes the GeometryProcessor handle when the caller cancels mid-flight', async () => {
+    const gate = deferred<GeometryResult>();
+    const initMock = mock.method(GeometryProcessor.prototype, 'init', async () => undefined);
+    const processMock = mock.method(GeometryProcessor.prototype, 'process', () => gate.promise);
+    const disposeMock = mock.method(GeometryProcessor.prototype, 'dispose', () => undefined);
+    const onMeshes = mock.fn((_meshes: MeshData[]) => undefined);
+    try {
+      let cancelled = false;
+      const run = loadPlaygroundGeometry(await schemaOnlyModel('0aBcDeFgHiJkLmNoPqRsT3'), {
+        isCancelled: () => cancelled,
+        setPhase: () => undefined,
+        setPhaseMsg: () => undefined,
+        onMeshes,
+      });
+
+      // Mirrors the effect's cleanup: the model changed (or the component
+      // unmounted) while `processor.process()` was still in flight.
+      cancelled = true;
+      gate.resolve({ meshes: [{ expressId: 1 }] } as unknown as GeometryResult);
+      await run;
+
+      assert.equal(disposeMock.mock.callCount(), 1, 'dispose runs exactly once on the cancelled bail-out');
+      assert.equal(onMeshes.mock.callCount(), 0, 'the cancelled result must never reach the scene');
+    } finally {
+      initMock.mock.restore();
+      processMock.mock.restore();
+      disposeMock.mock.restore();
+    }
+  });
+
+  it('disposes the GeometryProcessor handle on the empty-mesh branch', async () => {
+    const initMock = mock.method(GeometryProcessor.prototype, 'init', async () => undefined);
+    const processMock = mock.method(GeometryProcessor.prototype, 'process', async () =>
+      ({ meshes: [] }) as unknown as GeometryResult,
+    );
+    const disposeMock = mock.method(GeometryProcessor.prototype, 'dispose', () => undefined);
+    const phases: string[] = [];
+    try {
+      await loadPlaygroundGeometry(await schemaOnlyModel('0aBcDeFgHiJkLmNoPqRsT4'), {
+        isCancelled: () => false,
+        setPhase: (p) => phases.push(p),
+        setPhaseMsg: () => undefined,
+        onMeshes: () => assert.fail('onMeshes must not fire for an empty mesh list'),
+      });
+      assert.deepEqual(phases, ['processing', 'error']);
+      assert.equal(disposeMock.mock.callCount(), 1, 'dispose runs exactly once on the empty-mesh branch');
+    } finally {
+      initMock.mock.restore();
+      processMock.mock.restore();
+      disposeMock.mock.restore();
+    }
+  });
+
+  it('disposes the GeometryProcessor handle on the success path', async () => {
+    const oneTriangle = {
+      positions: new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]),
+      normals: new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]),
+      indices: new Uint32Array([0, 1, 2]),
+      color: [1, 1, 1, 1] as [number, number, number, number],
+      expressId: 1,
+    };
+    const initMock = mock.method(GeometryProcessor.prototype, 'init', async () => undefined);
+    const processMock = mock.method(GeometryProcessor.prototype, 'process', async () =>
+      ({ meshes: [oneTriangle] }) as unknown as GeometryResult,
+    );
+    const disposeMock = mock.method(GeometryProcessor.prototype, 'dispose', () => undefined);
+    const onMeshes = mock.fn((_meshes: MeshData[]) => undefined);
+    try {
+      await loadPlaygroundGeometry(await schemaOnlyModel('0aBcDeFgHiJkLmNoPqRsT5'), {
+        isCancelled: () => false,
+        setPhase: () => undefined,
+        setPhaseMsg: () => undefined,
+        onMeshes,
+      });
+      assert.equal(onMeshes.mock.callCount(), 1);
+      assert.equal(disposeMock.mock.callCount(), 1, 'dispose runs exactly once on the success path');
+    } finally {
+      initMock.mock.restore();
+      processMock.mock.restore();
+      disposeMock.mock.restore();
+    }
+  });
+});

--- a/apps/viewer/src/components/mcp/PlaygroundViewer.tsx
+++ b/apps/viewer/src/components/mcp/PlaygroundViewer.tsx
@@ -81,6 +81,79 @@ export interface ViewerController {
   subscribeSelection(handler: (hits: SelectionHit[]) => void): () => void;
 }
 
+// ── geometry loading (extracted for direct testing — see
+//    PlaygroundViewer.test.ts; mounting the component pulls in
+//    THREE.WebGLRenderer, which needs a real WebGL context happy-dom can't
+//    provide) ──────────────────────────────────────────────────────────────
+
+interface GeometryLoadCallbacks {
+  /** Read fresh each await boundary — the caller's effect-cleanup flips this
+   *  when the model changes or the component unmounts mid-flight. */
+  isCancelled: () => boolean;
+  setPhase: (phase: 'processing' | 'ready' | 'error') => void;
+  setPhaseMsg: (msg: string) => void;
+  /** Fired once with the non-empty mesh list on the success path. */
+  onMeshes: (meshes: MeshData[]) => void;
+  onReady?: () => void;
+}
+
+/**
+ * Boots a `GeometryProcessor`, tessellates `model`, and reports the result
+ * via `cb`. The processor's WASM handle is always freed before this
+ * resolves — on the happy path, the `cancelled` bail-out, the empty-mesh
+ * branch, and any thrown error — because the inner `try/finally` wraps every
+ * one of those exits. `result.meshes` is already copied out into plain JS
+ * `MeshData` (positions/indices as fresh typed arrays), so nothing
+ * downstream holds onto the handle being freed.
+ */
+export async function loadPlaygroundGeometry(
+  model: LoadedPlaygroundModel,
+  cb: GeometryLoadCallbacks,
+): Promise<void> {
+  cb.setPhase('processing');
+  cb.setPhaseMsg('booting geometry pipeline…');
+  try {
+    // Construction can't throw synchronously here (no wasm work happens
+    // until init()), so once we're past this line `processor` is a real
+    // object the finally below must dispose.
+    const processor = new GeometryProcessor({ preferNative: false });
+    try {
+      await processor.init();
+      cb.setPhaseMsg('extracting geometry…');
+      // Use our owning byte snapshot — store.source can be a sub-view that
+      // the parser detached internally on big files.
+      const result = await processor.process(
+        model.bytes,
+        model.store.entityIndex.byId as unknown as Map<number, unknown>,
+      );
+      if (cb.isCancelled()) return;
+      const meshes = result.meshes ?? [];
+      // eslint-disable-next-line no-console
+      console.log('[playground-viewer] geometry result:', {
+        meshCount: meshes.length,
+        firstMeshVerts: meshes[0]?.positions?.length,
+        coordinateInfo: result.coordinateInfo,
+      });
+      if (meshes.length === 0) {
+        cb.setPhase('error');
+        cb.setPhaseMsg('No drawable geometry — model may be schema-only.');
+        return;
+      }
+      cb.onMeshes(meshes);
+      cb.setPhase('ready');
+      cb.onReady?.();
+    } finally {
+      processor.dispose();
+    }
+  } catch (err) {
+    if (cb.isCancelled()) return;
+    // eslint-disable-next-line no-console
+    console.error('[playground-viewer] geometry processing failed', err);
+    cb.setPhase('error');
+    cb.setPhaseMsg(err instanceof Error ? err.message : String(err));
+  }
+}
+
 // ── component ──────────────────────────────────────────────────────────────
 
 export interface PlaygroundViewerProps {
@@ -156,44 +229,16 @@ export const PlaygroundViewer = forwardRef<ViewerController, PlaygroundViewerPro
       setMeshCount(0);
       return;
     }
-    void (async () => {
-      setPhase('processing');
-      setPhaseMsg('booting geometry pipeline…');
-      try {
-        const processor = new GeometryProcessor({ preferNative: false });
-        await processor.init();
-        setPhaseMsg('extracting geometry…');
-        // Use our owning byte snapshot — store.source can be a sub-view that
-        // the parser detached internally on big files.
-        const result = await processor.process(
-          model.bytes,
-          model.store.entityIndex.byId as unknown as Map<number, unknown>,
-        );
-        if (cancelled) return;
-        const meshes = result.meshes ?? [];
-        // eslint-disable-next-line no-console
-        console.log('[playground-viewer] geometry result:', {
-          meshCount: meshes.length,
-          firstMeshVerts: meshes[0]?.positions?.length,
-          coordinateInfo: result.coordinateInfo,
-        });
-        if (meshes.length === 0) {
-          setPhase('error');
-          setPhaseMsg('No drawable geometry — model may be schema-only.');
-          return;
-        }
+    void loadPlaygroundGeometry(model, {
+      isCancelled: () => cancelled,
+      setPhase,
+      setPhaseMsg,
+      onMeshes: (meshes) => {
         sceneHandleRef.current?.loadMeshes(meshes, model);
         setMeshCount(meshes.length);
-        setPhase('ready');
-        onReady?.();
-      } catch (err) {
-        if (cancelled) return;
-        // eslint-disable-next-line no-console
-        console.error('[playground-viewer] geometry processing failed', err);
-        setPhase('error');
-        setPhaseMsg(err instanceof Error ? err.message : String(err));
-      }
-    })();
+      },
+      onReady,
+    });
     return () => { cancelled = true; };
   }, [model, onReady]);
 

--- a/apps/viewer/src/components/mcp/playground-dispatcher.test.ts
+++ b/apps/viewer/src/components/mcp/playground-dispatcher.test.ts
@@ -1,0 +1,85 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * meshForClash (#1959 P0 leak) creates a GeometryProcessor per call and never
+ * disposed it — not on the happy path, and not on the `throw` it emits when
+ * a model has no drawable geometry. That throw path is the one worth
+ * covering: a `try { ... } finally { dispose() }` that only wraps the
+ * success return would still leak on every schema-only model clashed
+ * against.
+ */
+
+import { describe, it, mock } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { GeometryProcessor, type GeometryResult } from '@ifc-lite/geometry';
+import { ToolErrorCode } from '@ifc-lite/mcp/browser';
+import { dispatch, parsePlaygroundModel, type LoadedPlaygroundModel } from './playground-dispatcher.js';
+
+function ifc4(body: string): string {
+  return [
+    'ISO-10303-21;', 'HEADER;', "FILE_DESCRIPTION((''),'2;1');",
+    "FILE_NAME('','',(''),(''),'','','');", "FILE_SCHEMA(('IFC4'));", 'ENDSEC;',
+    'DATA;', body, 'ENDSEC;', 'END-ISO-10303-21;', '',
+  ].join('\n');
+}
+
+/** A schema-only model (no geometry entity) — same shape meshForClash sees
+ *  in production when a model carries no drawable geometry. Each call gets
+ *  a unique GlobalId so its `id:fileSize` cache key never collides with a
+ *  sibling test's — meshForClash's module-level LRU cache would otherwise
+ *  serve a stale (or throw-skipped) result across `it()`s. */
+async function schemaOnlyModel(globalId: string): Promise<LoadedPlaygroundModel> {
+  const bytes = new TextEncoder().encode(
+    ifc4(`#1=IFCWALL('${globalId}',$,'Wall A',$,$,$,$,$,.STANDARD.);`),
+  );
+  return parsePlaygroundModel(bytes.buffer as ArrayBuffer, `${globalId}.ifc`);
+}
+
+describe('meshForClash WASM disposal (#1959 P0 leak)', () => {
+  it('disposes the GeometryProcessor handle when it throws UNSUPPORTED_OPERATION on empty meshes', async () => {
+    const initMock = mock.method(GeometryProcessor.prototype, 'init', async () => undefined);
+    const processMock = mock.method(GeometryProcessor.prototype, 'process', async () =>
+      ({ meshes: [] }) as unknown as GeometryResult,
+    );
+    const disposeMock = mock.method(GeometryProcessor.prototype, 'dispose', () => undefined);
+    try {
+      const model = await schemaOnlyModel('0aBcDeFgHiJkLmNoPqRsT1');
+      const result = await dispatch(model, 'clash_check', {});
+      assert.equal(result.isError, true);
+      assert.equal(result.errorCode, ToolErrorCode.UNSUPPORTED_OPERATION);
+      assert.equal(disposeMock.mock.callCount(), 1, 'dispose runs exactly once even though meshForClash threw');
+    } finally {
+      initMock.mock.restore();
+      processMock.mock.restore();
+      disposeMock.mock.restore();
+    }
+  });
+
+  it('disposes the GeometryProcessor handle on the success path too', async () => {
+    const oneTriangle = {
+      positions: new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]),
+      normals: new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]),
+      indices: new Uint32Array([0, 1, 2]),
+      color: [1, 1, 1, 1] as [number, number, number, number],
+      expressId: 1,
+    };
+    const initMock = mock.method(GeometryProcessor.prototype, 'init', async () => undefined);
+    const processMock = mock.method(GeometryProcessor.prototype, 'process', async () =>
+      ({ meshes: [oneTriangle] }) as unknown as GeometryResult,
+    );
+    const disposeMock = mock.method(GeometryProcessor.prototype, 'dispose', () => undefined);
+    try {
+      const model = await schemaOnlyModel('0aBcDeFgHiJkLmNoPqRsT2');
+      const result = await dispatch(model, 'clash_check', {});
+      assert.equal(result.isError, false);
+      assert.equal(disposeMock.mock.callCount(), 1, 'dispose runs exactly once on the success path');
+    } finally {
+      initMock.mock.restore();
+      processMock.mock.restore();
+      disposeMock.mock.restore();
+    }
+  });
+});

--- a/apps/viewer/src/components/mcp/playground-dispatcher.ts
+++ b/apps/viewer/src/components/mcp/playground-dispatcher.ts
@@ -333,23 +333,35 @@ async function meshForClash(m: LoadedPlaygroundModel): Promise<MeshData[]> {
   const cached = getCachedMeshes(key);
   if (cached) return cached;
 
+  // Construction can't throw synchronously here (no wasm work happens until
+  // init()), so once we're past this line `processor` is a real object the
+  // finally below must dispose — on every exit, including the throw for
+  // empty meshes below.
   const processor = new GeometryProcessor({ preferNative: false });
-  await processor.init();
-  // Use our owning byte snapshot — store.source can be a detached sub-view.
-  const result = await processor.process(
-    m.bytes,
-    m.store.entityIndex.byId as unknown as Map<number, unknown>,
-  );
-  const meshes = result.meshes ?? [];
-  if (meshes.length === 0) {
-    throw new ToolExecutionError({
-      code: ToolErrorCode.UNSUPPORTED_OPERATION,
-      message: 'No mesh geometry could be produced for this model; clash detection needs tessellated solids.',
-      hint: 'Confirm the model carries explicit geometry (not schema/quantity-only data).',
-    });
+  try {
+    await processor.init();
+    // Use our owning byte snapshot — store.source can be a detached sub-view.
+    const result = await processor.process(
+      m.bytes,
+      m.store.entityIndex.byId as unknown as Map<number, unknown>,
+    );
+    const meshes = result.meshes ?? [];
+    if (meshes.length === 0) {
+      throw new ToolExecutionError({
+        code: ToolErrorCode.UNSUPPORTED_OPERATION,
+        message: 'No mesh geometry could be produced for this model; clash detection needs tessellated solids.',
+        hint: 'Confirm the model carries explicit geometry (not schema/quantity-only data).',
+      });
+    }
+    setCachedMeshes(key, meshes);
+    return meshes;
+  } finally {
+    // `result.meshes` is already copied out into plain JS MeshData — nothing
+    // downstream (the mesh cache, the clash engine) holds onto the WASM
+    // handle, so freeing it here is safe on every path above, including the
+    // throw.
+    processor.dispose();
   }
-  setCachedMeshes(key, meshes);
-  return meshes;
 }
 
 /**


### PR DESCRIPTION
Partial fix for #1959 — the two P0 sites that have no design question attached.

## What leaked

Both sites construct a `GeometryProcessor`, run it, and never dispose it. Both re-fire per model: `PlaygroundViewer`'s effect on every model swap, `meshForClash` once per clash-checked model.

Neither leaked only on the happy path, which is the part worth noting — a `dispose()` appended after the last statement would have fixed neither:

- `PlaygroundViewer` escapes early via the `cancelled` check immediately after `process()`, and again on the empty-mesh branch.
- `meshForClash` **throws** `UNSUPPORTED_OPERATION` when a model yields no meshes.

So both are `try/finally`, and the tests assert disposal on *every* exit rather than just success.

## Verified before freeing

Neither call site calls `processor.getApi()` — that is internal to `process()` — and the returned `MeshData` is already copied out into plain JS typed arrays, so nothing downstream (mesh cache, clash engine) holds a reference into WASM memory. Freeing at these two points is safe.

## One structural change, and why

`PlaygroundViewer`'s loader is extracted into `loadPlaygroundGeometry`. Mounting the component runs a sibling effect that constructs a real `THREE.WebGLRenderer`; happy-dom returns `null` from `canvas.getContext('webgl')`, and the renderer can't be stubbed either — `mock.method` on the frozen ES-module namespace throws `Cannot redefine property`. No existing pattern in the repo fakes a WebGL context.

Extracting the loader was the proportionate way to get the paths under test. Building a WebGL-context Proxy to verify a `dispose()` call was not. Happy to revert the extraction if you'd rather keep the component intact and take the fix untested there.

## Evidence

Removing both `dispose()` calls fails all five new tests (**2333 pass / 5 fail**); restored, **2338 pass / 0 fail**. Typecheck 34/34.

## Deliberately not fixed

`useIfcLoader.ts` — the canonical load path, and the biggest of the leaks. Its processor's handle is handed to `IfcParser.parseColumnar` via `getApi()`, so disposal has to wait for both the parse promise and `processAdaptive` to settle. You flagged that as needing a design decision and I don't think it should be made inside this PR. The P1/P2 sites from the issue are also untouched.

Draft until you've looked.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model geometry loading and clash checking reliability.
  * Ensured processing resources are consistently released after successful, cancelled, empty, or failed operations.
  * Prevented callbacks from running when processing is cancelled or produces no usable geometry.
  * Preserved mesh caching and successful mesh generation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->