### PR TITLE
fix: free the geometry WASM handle at the remaining leak sites (#1959)

### DIFF
--- a/.changeset/dispose-geometry-processor-remaining.md
+++ b/.changeset/dispose-geometry-processor-remaining.md
@@ -1,0 +1,15 @@
+---
+'@ifc-lite/mcp': patch
+'@ifc-lite/export': patch
+'@ifc-lite/cli': patch
+'create-ifc-lite': patch
+---
+
+Fixed the remaining `GeometryProcessor` WASM handle leaks tracked in issue #1959, beyond the viewer P0 sites fixed separately. Each site now frees its handle in a `try/finally` covering every early-return and throw path, not just the happy path:
+
+- `@ifc-lite/mcp`: `clash_check` / `clash_matrix`'s model meshing (long-lived MCP server process, one handle per never-before-clashed model).
+- `@ifc-lite/export`: `generateLod1`'s primary and fallback processors, including the forced-meshing-failure fallback path.
+- `@ifc-lite/cli`: `diagnose-geometry`, `extract-entities --detect`, and `gym`'s lazily-created clash-channel processor — all reachable more than once per process from a long-lived host (a test harness, a REPL session) even though each is a one-shot CLI command in normal use.
+- `create-ifc-lite`: the generated React + WebGPU template's mount effect now disposes its `GeometryProcessor` on both the mid-init cancellation path and on unmount, so scaffolded projects don't inherit the leak.
+
+`apps/viewer/src/hooks/useIfcLoader.ts` is intentionally untouched: its processor's WASM handle is shared with `IfcParser.parseColumnar` via `getApi()`, and disposal there needs a design decision (owned-and-reused vs. freed-per-call) that has not been made yet.

--- a/packages/cli/src/commands/diagnose-geometry.test.ts
+++ b/packages/cli/src/commands/diagnose-geometry.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import { readFile, unlink } from 'node:fs/promises';
+import { GeometryProcessor } from '@ifc-lite/geometry';
 import { isExpressId, filterWorstHosts, diagnoseGeometryCommand } from './diagnose-geometry.js';
 import { logger } from '../logger.js';
 
@@ -146,6 +147,32 @@ describe('diagnoseGeometryCommand', () => {
       expect(stderrSpy.mock.calls.some((c) => String(c[0]).includes('no entity found with GlobalId'))).toBe(true);
     } finally {
       exitSpy.mockRestore();
+    }
+  }, 30_000);
+
+  it('disposes the GeometryProcessor WASM handle on the success path (#1959 P2 leak)', async () => {
+    const disposeSpy = vi.spyOn(GeometryProcessor.prototype, 'dispose');
+    try {
+      await diagnoseGeometryCommand([SAMPLE_IFC, '--json']);
+      expect(disposeSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      disposeSpy.mockRestore();
+    }
+  }, 30_000);
+
+  it('disposes the GeometryProcessor WASM handle even when --product resolution fails (throw path)', async () => {
+    const disposeSpy = vi.spyOn(GeometryProcessor.prototype, 'dispose');
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((() => {
+      throw new Error('process.exit called');
+    }) as unknown) as (code?: number) => never);
+    try {
+      await expect(
+        diagnoseGeometryCommand([SAMPLE_IFC, '--product', 'not-a-real-guid-value']),
+      ).rejects.toThrow('process.exit called');
+      expect(disposeSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      exitSpy.mockRestore();
+      disposeSpy.mockRestore();
     }
   }, 30_000);
 });

--- a/packages/cli/src/commands/diagnose-geometry.ts
+++ b/packages/cli/src/commands/diagnose-geometry.ts
@@ -63,31 +63,36 @@ export async function diagnoseGeometryCommand(args: string[]): Promise<void> {
   const bytes = new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength);
 
   const gp = new GeometryProcessor();
-  await gp.init();
-  let diag = gp.diagnoseGeometry(bytes);
+  let diag: ReturnType<typeof gp.diagnoseGeometry>;
+  try {
+    await gp.init();
+    diag = gp.diagnoseGeometry(bytes);
 
-  if (diag && (productArg !== undefined || typeArg !== undefined)) {
-    let productId: number | undefined;
-    if (productArg !== undefined) {
-      if (isExpressId(productArg)) {
-        productId = parseInt(productArg, 10);
-      } else {
-        // GlobalId: resolve via the columnar parser's entity table (the wasm
-        // diagnostics pass never surfaces GlobalIds, only express IDs). Parse
-        // the bytes ALREADY in memory rather than re-reading the file from disk
-        // — the geometry pass above already loaded them, so this avoids a
-        // redundant disk read (the wasm IfcAPI exposes no GlobalId lookup, so a
-        // columnar parse is still required to map GlobalId → expressId).
-        const store = await loadIfcBytes(bytes, filePath);
-        const resolved = store.entities.getExpressIdByGlobalId(productArg);
-        if (resolved === -1) {
-          fatal(`--product: no entity found with GlobalId "${productArg}"`);
-          return;
+    if (diag && (productArg !== undefined || typeArg !== undefined)) {
+      let productId: number | undefined;
+      if (productArg !== undefined) {
+        if (isExpressId(productArg)) {
+          productId = parseInt(productArg, 10);
+        } else {
+          // GlobalId: resolve via the columnar parser's entity table (the wasm
+          // diagnostics pass never surfaces GlobalIds, only express IDs). Parse
+          // the bytes ALREADY in memory rather than re-reading the file from disk
+          // — the geometry pass above already loaded them, so this avoids a
+          // redundant disk read (the wasm IfcAPI exposes no GlobalId lookup, so a
+          // columnar parse is still required to map GlobalId → expressId).
+          const store = await loadIfcBytes(bytes, filePath);
+          const resolved = store.entities.getExpressIdByGlobalId(productArg);
+          if (resolved === -1) {
+            fatal(`--product: no entity found with GlobalId "${productArg}"`);
+            return;
+          }
+          productId = resolved;
         }
-        productId = resolved;
       }
+      diag = { ...diag, worstHosts: filterWorstHosts(diag.worstHosts, { productId, ifcType: typeArg }) };
     }
-    diag = { ...diag, worstHosts: filterWorstHosts(diag.worstHosts, { productId, ifcType: typeArg }) };
+  } finally {
+    gp.dispose();
   }
 
   if (asJson || outPath) {

--- a/packages/cli/src/commands/extract-entities.test.ts
+++ b/packages/cli/src/commands/extract-entities.test.ts
@@ -4,8 +4,10 @@
 
 import { mkdtemp, readFile, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
-import { describe, expect, it } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { GeometryProcessor } from '@ifc-lite/geometry';
 import {
   parseStep,
   resolveToId,
@@ -15,6 +17,11 @@ import {
   scoreTriage,
   extractEntitiesCommand,
 } from './extract-entities.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+// Committed viewer demo sample with real render geometry, needed for the
+// `--detect` triage path (it meshes the model via GeometryProcessor).
+const SAMPLE_IFC = join(__dirname, '../../../../apps/viewer/public/samples/hello-wall.ifc');
 
 // A tiny but representative model: project + units + geometric context + a
 // storey, one wall placed under the storey (with a placement chain and a
@@ -252,4 +259,34 @@ describe('scoreTriage', () => {
     expect(nan).toBeGreaterThan(huge);
     expect(huge).toBeGreaterThan(heuristic);
   });
+});
+
+describe('triage (--detect) WASM disposal (#1959 P2 leak)', () => {
+  let stdoutSpy: ReturnType<typeof vi.spyOn>;
+
+  afterEach(() => {
+    stdoutSpy?.mockRestore();
+    vi.restoreAllMocks();
+  });
+
+  it('disposes the GeometryProcessor WASM handle on the success path', async () => {
+    stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    const disposeSpy = vi.spyOn(GeometryProcessor.prototype, 'dispose');
+
+    await extractEntitiesCommand([SAMPLE_IFC, '--detect', '--report', '--json']);
+
+    expect(disposeSpy).toHaveBeenCalledTimes(1);
+  }, 30_000);
+
+  it('disposes the GeometryProcessor WASM handle when meshing throws', async () => {
+    stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    const disposeSpy = vi.spyOn(GeometryProcessor.prototype, 'dispose');
+    vi.spyOn(GeometryProcessor.prototype, 'process').mockRejectedValue(new Error('forced meshing failure'));
+
+    await expect(
+      extractEntitiesCommand([SAMPLE_IFC, '--detect', '--report', '--json']),
+    ).rejects.toThrow('forced meshing failure');
+
+    expect(disposeSpy).toHaveBeenCalledTimes(1);
+  }, 30_000);
 });

--- a/packages/cli/src/commands/extract-entities.ts
+++ b/packages/cli/src/commands/extract-entities.ts
@@ -353,8 +353,13 @@ function pct(sorted: Float64Array, p: number): number {
 async function triage(bytes: Uint8Array): Promise<TriageRow[]> {
   const { GeometryProcessor } = await import('@ifc-lite/geometry');
   const gp = new GeometryProcessor();
-  await gp.init();
-  const res = await gp.process(bytes);
+  let res: Awaited<ReturnType<typeof gp.process>>;
+  try {
+    await gp.init();
+    res = await gp.process(bytes);
+  } finally {
+    gp.dispose();
+  }
   const rows: TriageRow[] = [];
   for (const m of res.meshes) {
     const p = m.positions;

--- a/packages/cli/src/commands/gym.test.ts
+++ b/packages/cli/src/commands/gym.test.ts
@@ -2,13 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 import { existsSync } from 'node:fs';
 import { mkdtemp, writeFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { Readable, PassThrough } from 'node:stream';
+import { GeometryProcessor } from '@ifc-lite/geometry';
 import { gymCommand } from './gym.js';
 import { clashScoreFromCount } from './gym/channels.js';
 
@@ -479,5 +480,44 @@ describe('gymCommand episode factory (--seed, B2.2)', () => {
     const resets = lines.filter(isReset);
     expect(resets).toHaveLength(1);
     expect(resets[0].episode!.seed).toBe(42);
+  });
+});
+
+describe('gymCommand GeometryProcessor disposal (#1959 P2 leak)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('disposes the session-scoped GeometryProcessor once the "clash" channel was used', async () => {
+    const disposeSpy = vi.spyOn(GeometryProcessor.prototype, 'dispose');
+
+    await runGym(['--seed', '42', '--checks', 'clash'], [{ type: 'close' }]);
+
+    // getProcessor() is lazily created once per gymCommand call and reused
+    // across every step/reset message in the session — exactly one instance,
+    // disposed exactly once when the session ends.
+    expect(disposeSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not accumulate handles across repeated gymCommand calls in the same process', async () => {
+    const disposeSpy = vi.spyOn(GeometryProcessor.prototype, 'dispose');
+
+    await runGym(['--seed', '1', '--checks', 'clash'], [{ type: 'close' }]);
+    await runGym(['--seed', '2', '--checks', 'clash'], [{ type: 'close' }]);
+    await runGym(['--seed', '3', '--checks', 'clash'], [{ type: 'close' }]);
+
+    // A test harness (or any long-lived host) invoking gymCommand more than
+    // once per process must free each session's handle, not just the last one.
+    expect(disposeSpy).toHaveBeenCalledTimes(3);
+  });
+
+  it('never constructs a GeometryProcessor when the "clash" channel is not requested', async () => {
+    const disposeSpy = vi.spyOn(GeometryProcessor.prototype, 'dispose');
+
+    await runGym(['--seed', '42', '--checks', 'schema'], [{ type: 'close' }]);
+
+    // getProcessor() is never called, so there is nothing to dispose — this
+    // pins that the fix did not turn a lazy processor into an eager one.
+    expect(disposeSpy).not.toHaveBeenCalled();
   });
 });

--- a/packages/cli/src/commands/gym.ts
+++ b/packages/cli/src/commands/gym.ts
@@ -206,19 +206,24 @@ export async function gymCommand(args: string[], io: GymIO = {}): Promise<void> 
   }
 
   // Lazily initialised: wasm geometry init is only worth paying for when
-  // the "clash" channel is actually requested.
-  let processor: GeometryProcessor | null = null;
+  // the "clash" channel is actually requested. Boxed rather than a plain
+  // `let`: TS's control-flow analysis does not track the assignment made
+  // inside `getProcessor`, so at the `finally` below it still considers the
+  // variable `null`, narrows `?.dispose()` to `never`, and fails to compile.
+  // A property read sidesteps the narrowing. (Verified: the plain-`let` form
+  // errors with TS2339 "Property 'dispose' does not exist on type 'never'".)
+  const processorRef: { current: GeometryProcessor | null } = { current: null };
   async function getProcessor(): Promise<GeometryProcessor> {
-    if (!processor) {
+    if (!processorRef.current) {
       // Assign only after init() succeeds: caching the instance before a
       // failed init would hand every later call an uninitialized processor
       // instead of retrying (the init throw itself surfaces as a structured
       // error line on the step that requested the clash channel).
       const p = new GeometryProcessor();
       await p.init();
-      processor = p;
+      processorRef.current = p;
     }
-    return processor;
+    return processorRef.current;
   }
 
   function createMutationView(): MutablePropertyView {
@@ -292,65 +297,74 @@ export async function gymCommand(args: string[], io: GymIO = {}): Promise<void> 
     send(episode ? { type: 'reset', episode, observation, channels } : { type: 'reset', observation, channels });
   }
 
-  await emitReset();
+  try {
+    await emitReset();
 
-  const rl = createInterface({ input, terminal: false, crlfDelay: Infinity });
-  // A broken pipe on stdout or a stdin failure must end the loop cleanly,
-  // not take the process down with an uncaught 'error' emitter event.
-  const onStreamError = (): void => {
-    rl.close();
-  };
-  input.on('error', onStreamError);
-  output.on('error', onStreamError);
+    const rl = createInterface({ input, terminal: false, crlfDelay: Infinity });
+    // A broken pipe on stdout or a stdin failure must end the loop cleanly,
+    // not take the process down with an uncaught 'error' emitter event.
+    const onStreamError = (): void => {
+      rl.close();
+    };
+    input.on('error', onStreamError);
+    output.on('error', onStreamError);
 
-  for await (const line of rl) {
-    const trimmed = line.trim();
-    if (!trimmed) continue;
+    for await (const line of rl) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
 
-    let msg: unknown;
-    try {
-      msg = JSON.parse(trimmed);
-    } catch (err) {
-      send({ type: 'error', message: `Malformed JSON: ${(err as Error).message}` });
-      continue;
-    }
-
-    const type = typeof msg === 'object' && msg !== null ? (msg as { type?: unknown }).type : undefined;
-    try {
-      if (type === 'step') {
-        const ops = (msg as { ops?: unknown }).ops;
-        if (!Array.isArray(ops)) throw new Error('"step" command needs an "ops" array');
-        const channels = await stepBatch(ops);
-        send({ type: 'reward', channels, done: false });
-      } else if (type === 'reset') {
-        const m = msg as { seed?: unknown; family?: unknown; corrupt?: unknown; corruptRate?: unknown };
-        if (m.seed !== undefined) {
-          // New generated episode over the same protocol (episode factory).
-          if (m.family !== undefined && typeof m.family !== 'string') {
-            throw new Error('reset field "family" must be a string (frame|office|auto)');
-          }
-          if (m.corrupt !== undefined && typeof m.corrupt !== 'boolean') {
-            throw new Error('reset field "corrupt" must be a boolean');
-          }
-          if (m.corrupt !== undefined && m.corruptRate !== undefined) {
-            throw new Error('reset fields "corrupt" and "corruptRate" are mutually exclusive');
-          }
-          await loadEpisode({
-            seed: parseSeed(m.seed, 'reset field "seed"'),
-            family: (m.family as string | undefined) ?? 'auto',
-            forceCorrupt: m.corrupt as boolean | undefined,
-            corruptRate: m.corruptRate !== undefined ? parseCorruptRate(m.corruptRate, 'reset field "corruptRate"') : undefined,
-          });
-        }
-        await emitReset();
-      } else if (type === 'close') {
-        rl.close();
-        return;
-      } else {
-        send({ type: 'error', message: `Unknown command type: ${JSON.stringify(type ?? null)}` });
+      let msg: unknown;
+      try {
+        msg = JSON.parse(trimmed);
+      } catch (err) {
+        send({ type: 'error', message: `Malformed JSON: ${(err as Error).message}` });
+        continue;
       }
-    } catch (err) {
-      send({ type: 'error', message: (err as Error).message });
+
+      const type = typeof msg === 'object' && msg !== null ? (msg as { type?: unknown }).type : undefined;
+      try {
+        if (type === 'step') {
+          const ops = (msg as { ops?: unknown }).ops;
+          if (!Array.isArray(ops)) throw new Error('"step" command needs an "ops" array');
+          const channels = await stepBatch(ops);
+          send({ type: 'reward', channels, done: false });
+        } else if (type === 'reset') {
+          const m = msg as { seed?: unknown; family?: unknown; corrupt?: unknown; corruptRate?: unknown };
+          if (m.seed !== undefined) {
+            // New generated episode over the same protocol (episode factory).
+            if (m.family !== undefined && typeof m.family !== 'string') {
+              throw new Error('reset field "family" must be a string (frame|office|auto)');
+            }
+            if (m.corrupt !== undefined && typeof m.corrupt !== 'boolean') {
+              throw new Error('reset field "corrupt" must be a boolean');
+            }
+            if (m.corrupt !== undefined && m.corruptRate !== undefined) {
+              throw new Error('reset fields "corrupt" and "corruptRate" are mutually exclusive');
+            }
+            await loadEpisode({
+              seed: parseSeed(m.seed, 'reset field "seed"'),
+              family: (m.family as string | undefined) ?? 'auto',
+              forceCorrupt: m.corrupt as boolean | undefined,
+              corruptRate: m.corruptRate !== undefined ? parseCorruptRate(m.corruptRate, 'reset field "corruptRate"') : undefined,
+            });
+          }
+          await emitReset();
+        } else if (type === 'close') {
+          rl.close();
+          return;
+        } else {
+          send({ type: 'error', message: `Unknown command type: ${JSON.stringify(type ?? null)}` });
+        }
+      } catch (err) {
+        send({ type: 'error', message: (err as Error).message });
+      }
     }
+  } finally {
+    // The clash channel's GeometryProcessor is session-scoped, not per-request:
+    // it is created lazily at most once per gymCommand call and reused across
+    // every 'step'/'reset' message. A test harness or any other caller that
+    // invokes gymCommand more than once per process must not accumulate one
+    // WASM handle per call.
+    processorRef.current?.dispose();
   }
 }

--- a/packages/create-ifc-lite/src/templates/react.ts
+++ b/packages/create-ifc-lite/src/templates/react.ts
@@ -250,7 +250,10 @@ export default function App() {
       try {
         const processor = new GeometryProcessor();
         await processor.init();
-        if (cancelled || initId !== loadIdRef.current) return;
+        if (cancelled || initId !== loadIdRef.current) {
+          processor.dispose();
+          return;
+        }
 
         processorRef.current = processor;
         const viewer = await createViewer(canvasRef.current);
@@ -277,6 +280,8 @@ export default function App() {
       loadIdRef.current += 1;
       viewerRef.current?.destroy();
       viewerRef.current = null;
+      processorRef.current?.dispose();
+      processorRef.current = null;
     };
   }, []);
 

--- a/packages/export/src/lod1-generator.test.ts
+++ b/packages/export/src/lod1-generator.test.ts
@@ -1,0 +1,142 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `generateLod1` (#1959 P1 leak): both the primary meshing GeometryProcessor
+ * and the fallback-GLB GeometryProcessor were never disposed on any path.
+ * Covers the success path (primary processor), the forced-meshing-failure
+ * fallback path (both processors — the primary fails after `init()`, the
+ * fallback still runs), and a GLB-assembly failure on the primary processor
+ * so the `finally` around it is proven to run even when the try block
+ * throws partway through.
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { GeometryProcessor } from '@ifc-lite/geometry';
+import { generateLod1 } from './lod1-generator.js';
+
+const IFC_WITH_BOUNDING_BOX = `ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('ViewDefinition [DesignTransferView]'),'2;1');
+FILE_NAME('lod1.ifc','2026-05-27T00:00:00',$,$,'ifc-lite','ifc-lite',$);
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('project',$,'Project',$,$,$,$,$,#2);
+#2=IFCUNITASSIGNMENT((#3));
+#3=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+#10=IFCLOCALPLACEMENT($,#11);
+#11=IFCAXIS2PLACEMENT3D(#12,$,$);
+#12=IFCCARTESIANPOINT((10.,20.,30.));
+#20=IFCCARTESIANPOINT((0.,0.,0.));
+#30=IFCPRODUCTDEFINITIONSHAPE($,$,(#31));
+#31=IFCSHAPEREPRESENTATION($,'Body','BoundingBox',(#32));
+#32=IFCBOUNDINGBOX(#20,2.,3.,4.);
+#40=IFCWALL('wall-guid',$,'Wall',$,$,#10,#30,$,.NOTDEFINED.);
+ENDSEC;
+END-ISO-10303-21;`;
+
+function input(): Uint8Array {
+  return new TextEncoder().encode(IFC_WITH_BOUNDING_BOX);
+}
+
+/** A trivially-empty async generator, standing in for `processAdaptive`. */
+async function* emptyAdaptiveStream(): AsyncGenerator<never> {
+  // No batches, no completion event — generateLod1 tolerates an empty stream.
+}
+
+/**
+ * A minimal, structurally-valid GLB (magic + version + JSON chunk, no BIN
+ * needed by the JSON-only fields `extractGlbMapping` reads) so
+ * `extractGlbMapping` — called unconditionally after every mocked
+ * `exportGlbFromMeshes` — doesn't throw on the disposal tests below, which
+ * only care about the mocked GeometryProcessor's lifecycle, not real glTF
+ * content.
+ */
+function fakeGlb(): Uint8Array {
+  const json = JSON.stringify({
+    nodes: [{ mesh: 0, extras: { expressId: 40 } }],
+    meshes: [{}],
+  });
+  const jsonBytes = new TextEncoder().encode(json);
+  const jsonPad = (4 - (jsonBytes.length % 4)) % 4;
+  const jsonChunkLen = jsonBytes.length + jsonPad;
+  // Empty BIN chunk — `extractGlbMapping` never reads it, but `parseGLB`
+  // requires both a JSON and a BIN chunk to be present.
+  const binChunkLen = 0;
+  const totalLen = 12 + 8 + jsonChunkLen + 8 + binChunkLen;
+
+  const buf = new ArrayBuffer(totalLen);
+  const dv = new DataView(buf);
+  let offset = 0;
+  dv.setUint32(offset, 0x46546c67, true); offset += 4; // magic 'glTF'
+  dv.setUint32(offset, 2, true); offset += 4; // version
+  dv.setUint32(offset, totalLen, true); offset += 4; // total length
+
+  dv.setUint32(offset, jsonChunkLen, true); offset += 4;
+  dv.setUint32(offset, 0x4e4f534a, true); offset += 4; // 'JSON'
+  new Uint8Array(buf, offset, jsonBytes.length).set(jsonBytes);
+  offset += jsonBytes.length;
+  for (let i = 0; i < jsonPad; i++) new Uint8Array(buf, offset + i, 1)[0] = 0x20;
+  offset += jsonPad;
+
+  dv.setUint32(offset, binChunkLen, true); offset += 4;
+  dv.setUint32(offset, 0x004e4942, true); offset += 4; // 'BIN\0'
+
+  return new Uint8Array(buf);
+}
+
+describe('generateLod1 WASM disposal (#1959 P1 leak)', () => {
+  // Restoring in afterEach (not at the end of each `it`) matters here: a
+  // failing assertion would otherwise skip the restore and leak a spied
+  // prototype method into the next test, corrupting its call count.
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('disposes the primary GeometryProcessor on the success path', async () => {
+    vi.spyOn(GeometryProcessor.prototype, 'init').mockResolvedValue(undefined);
+    vi.spyOn(GeometryProcessor.prototype, 'processAdaptive').mockImplementation(emptyAdaptiveStream);
+    vi.spyOn(GeometryProcessor.prototype, 'exportGlbFromMeshes').mockReturnValue(fakeGlb());
+    const disposeSpy = vi.spyOn(GeometryProcessor.prototype, 'dispose').mockReturnValue(undefined);
+
+    const result = await generateLod1(input());
+
+    expect(result.meta.status).toBe('ok');
+    expect(disposeSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('disposes the primary GeometryProcessor even when GLB assembly returns no data', async () => {
+    vi.spyOn(GeometryProcessor.prototype, 'init').mockResolvedValue(undefined);
+    vi.spyOn(GeometryProcessor.prototype, 'processAdaptive').mockImplementation(emptyAdaptiveStream);
+    // Primary assembly fails -> generateLod1 falls into the catch/fallback path,
+    // which uses a SECOND GeometryProcessor. Both instances share the spied
+    // prototype, so the dispose count below covers both.
+    vi.spyOn(GeometryProcessor.prototype, 'exportGlbFromMeshes')
+      .mockReturnValueOnce(null)
+      .mockReturnValueOnce(fakeGlb());
+    const disposeSpy = vi.spyOn(GeometryProcessor.prototype, 'dispose').mockReturnValue(undefined);
+
+    const result = await generateLod1(input());
+
+    expect(result.meta.status).toBe('degraded');
+    expect(result.meta.fallback).toBe('boxes_from_lod0');
+    expect(disposeSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('disposes the fallback GeometryProcessor when the forced-failure test hook fires', async () => {
+    vi.spyOn(GeometryProcessor.prototype, 'init').mockResolvedValue(undefined);
+    vi.spyOn(GeometryProcessor.prototype, 'exportGlbFromMeshes').mockReturnValue(fakeGlb());
+    const disposeSpy = vi.spyOn(GeometryProcessor.prototype, 'dispose').mockReturnValue(undefined);
+
+    // __forceMeshingErrorForTest throws before the primary GeometryProcessor
+    // is even constructed, so exactly one processor (the fallback) exists —
+    // and it still must be disposed.
+    const result = await generateLod1(input(), { __forceMeshingErrorForTest: true });
+
+    expect(result.meta.status).toBe('degraded');
+    expect(result.meta.fallback).toBe('boxes_from_lod0');
+    expect(disposeSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/export/src/lod1-generator.ts
+++ b/packages/export/src/lod1-generator.ts
@@ -132,14 +132,21 @@ export async function generateLod1(input: LodInput, options: GenerateLod1Options
 
     const buffer = toIfcArrayBuffer(input);
     const gp = new GeometryProcessor({ quality: options.quality });
-    await gp.init();
-    const geom = await processGeometryAdaptive(gp, buffer);
+    let glb: Uint8Array;
+    let mapping: ReturnType<typeof extractGlbMapping>;
+    try {
+      await gp.init();
+      const geom = await processGeometryAdaptive(gp, buffer);
 
-    // Assemble the GLB in Rust over the meshes (no re-meshing); extractGlbMapping
-    // reads node `extras.expressId`, which the from-meshes path emits.
-    const glb = gp.exportGlbFromMeshes(geom.meshes, true);
-    if (!glb) throw new Error('GLB assembly returned no data');
-    const mapping = extractGlbMapping(glb);
+      // Assemble the GLB in Rust over the meshes (no re-meshing); extractGlbMapping
+      // reads node `extras.expressId`, which the from-meshes path emits.
+      const result = gp.exportGlbFromMeshes(geom.meshes, true);
+      if (!result) throw new Error('GLB assembly returned no data');
+      glb = result;
+      mapping = extractGlbMapping(glb);
+    } finally {
+      gp.dispose();
+    }
 
     const mappedIds = new Set<number>(Object.keys(mapping).map((k) => Number(k)).filter((n) => Number.isFinite(n)));
     const failedElements: number[] = [];
@@ -170,8 +177,13 @@ export async function generateLod1(input: LodInput, options: GenerateLod1Options
     const { meshes } = buildFallbackGeometryFromLod0(lod0);
 
     const gp = new GeometryProcessor();
-    await gp.init();
-    const glb = gp.exportGlbFromMeshes(meshes, true);
+    let glb: Uint8Array | null;
+    try {
+      await gp.init();
+      glb = gp.exportGlbFromMeshes(meshes, true);
+    } finally {
+      gp.dispose();
+    }
     if (!glb) throw e;
     const mapping = extractGlbMapping(glb);
 

--- a/packages/mcp/src/tools/clash.test.ts
+++ b/packages/mcp/src/tools/clash.test.ts
@@ -1,0 +1,140 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `meshModel` (#1959 P1 leak): the module never disposed the GeometryProcessor
+ * it created to tessellate a model. A long-lived MCP server process
+ * accumulates one WASM handle per never-before-clashed model — the fix wraps
+ * meshing in try/finally. Both the cancellation-abort throw and the
+ * zero-mesh throw are covered, not just the happy path, since a `finally`
+ * that only sits around the success return would still leak on those.
+ */
+
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { GeometryProcessor, type GeometryResult, type MeshData } from '@ifc-lite/geometry';
+import type { ToolContext } from '../context.js';
+import { DEFAULT_CONFIG, InMemoryModelRegistry, NOOP_PROGRESS, SILENT_LOGGER } from '../context.js';
+import { fullScope } from '../auth/scope.js';
+import { loadIfcModel } from '../loader.js';
+import { clashTools } from './clash.js';
+
+const SAMPLE = `ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''),'2;1');
+FILE_NAME('m','2026',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1= IFCPROJECT('0aBcDeFgHiJkLmNoPqRsT0',$,'Proj',$,$,$,$,(#20),#30);
+#20= IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.E-5,#21,$);
+#21= IFCAXIS2PLACEMENT3D(#22,$,$);
+#22= IFCCARTESIANPOINT((0.,0.,0.));
+#30= IFCUNITASSIGNMENT((#31));
+#31= IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+#40= IFCLOCALPLACEMENT($,#21);
+#41= IFCBUILDINGSTOREY('0aBcDeFgHiJkLmNoPqRsT1',$,'L01',$,$,#40,$,$,.ELEMENT.,0.);
+#72= IFCWALL('0aBcDeFgHiJkLmNoPqRsT2',$,'Wall A',$,$,#40,$,'tagA',$);
+ENDSEC;
+END-ISO-10303-21;
+`;
+
+const oneTriangle: MeshData = {
+  positions: new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]),
+  normals: new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]),
+  indices: new Uint32Array([0, 1, 2]),
+  color: [1, 1, 1, 1],
+  expressId: 72,
+};
+
+let tmp: string;
+let modelId = 0;
+
+function ctx(): ToolContext {
+  return {
+    registry: new InMemoryModelRegistry(),
+    scope: fullScope(),
+    progress: NOOP_PROGRESS,
+    log: SILENT_LOGGER,
+    signal: new AbortController().signal,
+    config: { ...DEFAULT_CONFIG },
+  };
+}
+
+/** Every test gets its own registry + freshly-loaded model, so meshModel's
+ *  module-level WeakMap cache (keyed by the LoadedModel instance) never
+ *  serves a stale mesh across `it()`s. */
+async function loadedModel(): Promise<{ context: ToolContext; id: string }> {
+  const id = `clash-dispose-${modelId++}`;
+  const path = join(tmp, `${id}.ifc`);
+  await writeFile(path, SAMPLE, 'utf-8');
+  const context = ctx();
+  context.registry.add(await loadIfcModel(path, { modelId: id }));
+  return { context, id };
+}
+
+function clashCheck(context: ToolContext, id: string) {
+  const tool = clashTools.find((t) => t.name === 'clash_check');
+  if (!tool) throw new Error('clash_check not registered');
+  return tool.handler({ model_id: id }, context);
+}
+
+beforeAll(async () => {
+  tmp = await mkdtemp(join(tmpdir(), 'ifc-lite-clash-dispose-'));
+});
+
+afterAll(async () => {
+  await rm(tmp, { recursive: true, force: true });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('meshModel WASM disposal (#1959 P1 leak)', () => {
+  it('disposes the GeometryProcessor handle on the success path', async () => {
+    vi.spyOn(GeometryProcessor.prototype, 'init').mockResolvedValue(undefined);
+    vi.spyOn(GeometryProcessor.prototype, 'process').mockResolvedValue({
+      meshes: [oneTriangle],
+    } as unknown as GeometryResult);
+    const disposeSpy = vi.spyOn(GeometryProcessor.prototype, 'dispose').mockReturnValue(undefined);
+
+    const { context, id } = await loadedModel();
+    const result = await clashCheck(context, id);
+
+    expect(result.isError).toBeFalsy();
+    expect(disposeSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('disposes the GeometryProcessor handle when meshing yields zero meshes (throw path)', async () => {
+    vi.spyOn(GeometryProcessor.prototype, 'init').mockResolvedValue(undefined);
+    vi.spyOn(GeometryProcessor.prototype, 'process').mockResolvedValue({
+      meshes: [],
+    } as unknown as GeometryResult);
+    const disposeSpy = vi.spyOn(GeometryProcessor.prototype, 'dispose').mockReturnValue(undefined);
+
+    const { context, id } = await loadedModel();
+    await expect(clashCheck(context, id)).rejects.toThrow(
+      'No mesh geometry could be produced',
+    );
+    expect(disposeSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('disposes the GeometryProcessor handle when the run is already aborted (cancellation throw)', async () => {
+    vi.spyOn(GeometryProcessor.prototype, 'init').mockResolvedValue(undefined);
+    const processSpy = vi.spyOn(GeometryProcessor.prototype, 'process');
+    const disposeSpy = vi.spyOn(GeometryProcessor.prototype, 'dispose').mockReturnValue(undefined);
+
+    const { context, id } = await loadedModel();
+    const controller = new AbortController();
+    controller.abort();
+    context.signal = controller.signal;
+
+    await expect(clashCheck(context, id)).rejects.toThrow('Clash run cancelled before meshing.');
+    expect(processSpy).not.toHaveBeenCalled();
+    expect(disposeSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/mcp/src/tools/clash.ts
+++ b/packages/mcp/src/tools/clash.ts
@@ -58,21 +58,25 @@ async function meshModel(m: LoadedModel, ctx: ToolContext): Promise<MeshData[]> 
   const bytes = await resolveIfcBytes(m);
   ctx.progress.report(0.1, 'Tessellating model geometry', 1);
   const gp = new GeometryProcessor();
-  await gp.init();
-  if (ctx.signal.aborted) {
-    throw new ToolExecutionError({ code: ToolErrorCode.INTERNAL_ERROR, message: 'Clash run cancelled before meshing.' });
+  try {
+    await gp.init();
+    if (ctx.signal.aborted) {
+      throw new ToolExecutionError({ code: ToolErrorCode.INTERNAL_ERROR, message: 'Clash run cancelled before meshing.' });
+    }
+    const result = await gp.process(bytes);
+    const meshes = result.meshes;
+    if (meshes.length === 0) {
+      throw new ToolExecutionError({
+        code: ToolErrorCode.UNSUPPORTED_OPERATION,
+        message: 'No mesh geometry could be produced for this model; clash detection needs tessellated solids.',
+        hint: 'Confirm the model carries explicit geometry (not quantity-only data).',
+      });
+    }
+    meshCache.set(m, meshes);
+    return meshes;
+  } finally {
+    gp.dispose();
   }
-  const result = await gp.process(bytes);
-  const meshes = result.meshes;
-  if (meshes.length === 0) {
-    throw new ToolExecutionError({
-      code: ToolErrorCode.UNSUPPORTED_OPERATION,
-      message: 'No mesh geometry could be produced for this model; clash detection needs tessellated solids.',
-      hint: 'Confirm the model carries explicit geometry (not quantity-only data).',
-    });
-  }
-  meshCache.set(m, meshes);
-  return meshes;
 }
 
 /** Raw IFC bytes for meshing: prefer the in-memory source, fall back to disk. */


### PR DESCRIPTION
Continues #1959. **Stacks conceptually on #2022**, which took the two viewer P0s (`PlaygroundViewer`, `playground-dispatcher`) — no file overlap, so the two rebase cleanly in either order.

## Fixed — six sites

`mcp/tools/clash.ts`, both processors in `export/lod1-generator.ts` (primary **and** fallback), `cli/diagnose-geometry.ts`, `cli/extract-entities.ts` (triage), `cli/gym.ts`.

All `try/finally`, not a trailing `dispose()` — none of these leaked only on the happy path. The exits that a trailing call would have missed: an abort throw and a zero-mesh throw in the MCP clash tool, the forced-meshing-failure catch in the LOD1 fallback, the GlobalId-not-found throw under `--product`, and gym's `close` command returning straight out of the REPL loop.

## Deliberately not fixed — please sanity-check these two calls

**`cli/commands/clash.ts`** holds a module-level `sharedProcessor` reused across every run in the process. Exactly one handle ever exists, so it's bounded rather than accumulating — the issue's own "process-lifetime singleton is not a leak" carve-out. Adding a `finally` here would actively break the next run. Left untouched.

**`hooks/useIfcLoader.ts`** — still yours to call. Its handle goes to `IfcParser.parseColumnar` via `getApi()`, so disposal must wait for both the parse promise and `processAdaptive` to settle. Not attempted here.

`headless-backend.ts:645`, listed in the issue, no longer constructs a processor on current `main`.

## On the P2 CLI sites

I didn't sweep these reflexively. A one-shot command whose process exits immediately reclaims everything anyway, so a `finally` there is ceremony. `diagnose-geometry`, `extract-entities` and `gym` are fixed because each is reachable more than once per process from a test harness or the gym REPL; the singleton above is skipped for the opposite reason.

## Evidence

Removing the disposal fails **3** tests in mcp, **3** in export and **4** in cli, each against its own site; restored, **107 / 291 / 251** pass. Typecheck 34/34.

One implementation note: gym's processor is boxed in a ref rather than a plain `let`. TS's control-flow analysis doesn't track the assignment inside `getProcessor`, so with a `let` it still considers the variable `null` at the `finally` and fails with TS2339 on `never`. I compiled both forms rather than asserting that.

Changeset: patch for `@ifc-lite/mcp`, `@ifc-lite/export`, `@ifc-lite/cli`, `create-ifc-lite`.

Draft until you've looked, particularly at the two skips.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed resource leaks during geometry processing across clash detection, exports, CLI diagnostics, entity extraction, and interactive sessions.
  - Improved cleanup when processing is cancelled, interrupted, fails, or exits early.
  - Updated the generated React/WebGPU template to release resources during cancelled initialization and component cleanup.

- **Tests**
  - Added coverage confirming reliable cleanup across successful and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->