### PR TITLE
chore(deps): bump server cargo-chef base to rust-1.97

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -81,3 +81,16 @@ updates:
         update-types:
           - minor
           - patch
+    ignore:
+      # tools/ifcopenshell_reference pins the parity reference engine, and
+      # requirements.lock rides the interpreter version: numpy/shapely ship
+      # cp-tagged wheels, so a python feature bump breaks `pip install`
+      # outright — 3.14 has no numpy 2.0.2 or shapely 2.0.7 wheel, and the
+      # slim image has no compiler to fall back on (see #2008). Moving this
+      # image means moving the lock and regenerating reference dumps, which
+      # requirements.lock already calls a reviewed change. Patch bumps
+      # (3.12.x) still flow.
+      - dependency-name: "python"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"

--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -2,10 +2,10 @@
 # Optimized multi-stage build for Railway deployment
 
 # Stage 1: Chef - prepare recipe for dependency caching.
-# Bumped from rust-1.88 → rust-1.95 because nalgebra 0.35.0 (PR #786) raised
-# its MSRV to 1.89.0. Pinning the bookworm variant so the build glibc lines
-# up with the bookworm-slim runtime stage below.
-FROM lukemathwalker/cargo-chef:latest-rust-1.95-bookworm AS chef
+# MSRV floor is 1.89.0 (nalgebra 0.35.0, PR #786). Pinning the bookworm
+# variant so the build glibc lines up with the bookworm-slim runtime stage
+# below.
+FROM lukemathwalker/cargo-chef:latest-rust-1.97-bookworm AS chef
 WORKDIR /app
 
 # Stage 2: Planner - create dependency recipe


### PR DESCRIPTION
Split out of dependabot #2008, which grouped this with a `python:3.12-slim` -> `3.14-slim` bump for the reference harness that cannot install its own `requirements.lock` (`numpy==2.0.2` has no cp313/cp314 wheel, `shapely==2.0.7` no cp314). This PR is the half that is actually safe.

Verified the base image from the registry rather than trusting the tag: `latest-rust-1.97-bookworm` ships `RUST_VERSION=1.97.1`, above the 1.89.0 MSRV floor.

Reworded the pin comment, which was tracking bump history that had gone stale.

Note `docker.yml` has no `pull_request` trigger, so PR CI does not build this image - it builds on push to main, where `apps/server/**` is in the path filter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the server’s build environment to use a newer Rust toolchain image.
  * Updated compatibility and image-alignment documentation.
  * Adjusted automated dependency updates to accept only compatible Python patch releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->