### PR TITLE
fix(collab-server): move the image to Node 24 LTS, widen engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "typescript": "^6.0.3"
   },
   "engines": {
-    "node": "22.x",
+    "node": "22.x || 24.x",
     "pnpm": ">=8.0.0"
   },
   "dependencies": {

--- a/packages/collab-server/Dockerfile
+++ b/packages/collab-server/Dockerfile
@@ -1,12 +1,12 @@
 # Reference image for @ifc-lite/collab-server — the real-time collaboration
 # sync server. Build context is the repo root (see railway.toml's
-# dockerfilePath). Node 22 LTS; pnpm via corepack.
+# dockerfilePath). Node 24 LTS; pnpm via corepack.
 #
 # This is intentionally simple (single stage). It installs + builds ONLY the
 # collab-server's dependency subgraph (`...`), so it stays off the heavy
 # viewer/wasm toolchain. Slim it with a separate runtime stage + `pnpm deploy`
 # if image size matters.
-FROM node:22-slim AS app
+FROM node:24-slim AS app
 WORKDIR /app
 
 RUN corepack enable


### PR DESCRIPTION
Replaces dependabot #2009 (Node 22 -> 26).

Node 26 does not reach LTS until **2026-10-28**, and this image is the Railway prod deploy for the collab sync server - that would have put a live service on a Current-line runtime for three months. Node 24 has been LTS since 2025-10-28 (maintenance 2026-10-20, EOL 2028-04-30).

Also fixed two things #2009 left inconsistent:

- root `engines.node` was `22.x` while the image would run 26. Widened to `22.x || 24.x` rather than `24.x`, because CI pins node 22 across `test.yml`/`determinism.yml`/`parity`/etc - a bare `24.x` would put every CI job in violation of the declared engine.
- the Dockerfile header still read "Node 22 LTS".

**Verification gap, stated plainly:** nothing in CI builds this Dockerfile. `docker.yml` has no `pull_request` trigger and its `paths` do not cover `packages/collab-server`. I could not build it locally either (no local Node 24, Docker daemon down), so the Railway build is the first real exercise of this change. Node 22 is supported until 2027-04-30, so there is no urgency here if you would rather sit on it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added support for running the package with Node.js 24.x.
  * Updated the collaboration server’s container environment to Node.js 24 LTS.
  * Updated related documentation to reflect the supported Node.js version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->