### PR TITLE
fix(processing): give the symbolic 2D transform a full 2x2 so it can mirror (#1994)

### DIFF
--- a/.changeset/transform2d-mirror.md
+++ b/.changeset/transform2d-mirror.md
@@ -1,0 +1,9 @@
+---
+'@ifc-lite/wasm': patch
+---
+
+Fix the 2D symbolic transform (floor-plan / annotation rendering) to represent a mirroring `IfcMappedItem` MappingTarget (#1994). `Transform2D` (`rust/processing/src/symbolic/transform.rs`) stored its linear block as a `(cos_theta, sin_theta)` similarity — rotation + uniform scale + translation — which has no reflection component, so a MappingTarget whose `Axis2` disagrees with the right-handed perpendicular of `Axis1` drew its plan symbols un-mirrored while the 3D mesh path (fixed in #1990) mirrored correctly. `Transform2D` now carries a full 2x2 linear block (`m00, m01, m10, m11`), and `parse_cartesian_transformation_operator` derives handedness from `Axis2` the same way `router/transforms/operator.rs` does for the 3D path, so both paths agree.
+
+Non-mirroring geometry (rotation, uniform scale, translation, identity) is bit-equivalent to before. Text/annotation glyphs stay non-mirrored under a mirroring transform by construction: their direction reads only the local X-axis column, which a mirroring `Axis2` never touches.
+
+Impact is low — no model in the 63-model test corpus carries a mirroring operator — so this is a correctness fix demonstrated by a hand-authored fixture, not an observed rendering failure.

--- a/rust/processing/src/symbolic/mod.rs
+++ b/rust/processing/src/symbolic/mod.rs
@@ -211,8 +211,10 @@ where
             };
             let combined_transform = if context_transform.tx.abs() > 0.001
                 || context_transform.ty.abs() > 0.001
-                || (context_transform.cos_theta - 1.0).abs() > 0.0001
-                || context_transform.sin_theta.abs() > 0.0001
+                || (context_transform.m00 - 1.0).abs() > 0.0001
+                || context_transform.m01.abs() > 0.0001
+                || context_transform.m10.abs() > 0.0001
+                || (context_transform.m11 - 1.0).abs() > 0.0001
             {
                 compose_transforms(&context_transform, &placement_transform)
             } else {

--- a/rust/processing/src/symbolic/text.rs
+++ b/rust/processing/src/symbolic/text.rs
@@ -68,8 +68,14 @@ pub(super) fn extract_text_literal(
     // only a non-finite scale falls back. The direction below needs the stricter
     // positive test, since it divides.
     let text_scale = if raw_scale.is_finite() { raw_scale } else { 1.0 };
+    // Only the X-axis column (m00, m10) feeds the direction — NOT the Y
+    // column, which is where a mirroring MappingTarget's reflection lives
+    // (see `parse_cartesian_transformation_operator`). Glyphs therefore stay
+    // readable (non-mirrored) under a mirroring transform, same as before
+    // #1994: Axis1 is unaffected by an Axis2 mirror by construction, so this
+    // is not a special case — it falls out of reading only the X column.
     let dir = if raw_scale.is_finite() && raw_scale > 0.0 {
-        (composed.cos_theta / raw_scale, -composed.sin_theta / raw_scale)
+        (composed.m00 / raw_scale, -composed.m10 / raw_scale)
     } else {
         (1.0, 0.0)
     };

--- a/rust/processing/src/symbolic/transform.rs
+++ b/rust/processing/src/symbolic/transform.rs
@@ -12,18 +12,23 @@ use ifc_lite_core::{DecodedEntity, EntityDecoder, IfcType};
 // its storey elevation forward via `world_y`.
 // ────────────────────────────────────────────────────────────────────────────
 
-/// A 2D SIMILARITY: rotation + uniform scale + translation. It carries no
-/// reflection, so a mirroring `IfcMappedItem` MappingTarget (an `Axis2` that
-/// disagrees with `Axis3 × Axis1`, or a negative `Scale`) draws its plan symbols
-/// un-mirrored even though the 3D mesh mirrors them. Representing that needs a
-/// full 2x2 linear block here; tracked in #1994. #1985
+/// A full 2D AFFINE transform: an arbitrary 2x2 linear block (`m00, m01, m10,
+/// m11`) plus translation. Unlike the `(cos_theta, sin_theta)` similarity this
+/// replaced, the 2x2 CAN carry a reflection, so a mirroring `IfcMappedItem`
+/// MappingTarget (an `Axis2` that disagrees with the right-handed frame derived
+/// from `Axis1`) now draws its plan symbols mirrored, matching the 3D mesh path
+/// (`router/transforms/operator.rs`). Column 0 (`m00, m10`) is the local X axis
+/// image, column 1 (`m01, m11`) is the local Y axis image: `transform_point`
+/// maps `(x, y) -> x * column0 + y * column1 + translation`. #1994 #1985
 #[derive(Clone, Copy, Debug)]
 pub(super) struct Transform2D {
     pub(super) tx: f32,
     pub(super) ty: f32,
     pub(super) tz: f32,
-    pub(super) cos_theta: f32,
-    pub(super) sin_theta: f32,
+    pub(super) m00: f32,
+    pub(super) m01: f32,
+    pub(super) m10: f32,
+    pub(super) m11: f32,
 }
 
 impl Transform2D {
@@ -32,40 +37,53 @@ impl Transform2D {
             tx: 0.0,
             ty: 0.0,
             tz: 0.0,
-            cos_theta: 1.0,
-            sin_theta: 0.0,
+            m00: 1.0,
+            m01: 0.0,
+            m10: 0.0,
+            m11: 1.0,
         }
     }
 
-    /// Uniform scale factor carried by the linear block. 1.0 for a pure
-    /// rotation; an `IfcMappedItem` MappingTarget's `Scale` folds in here (see
-    /// `parse_cartesian_transformation_operator`), so SCALAR outputs that never
-    /// pass through [`Self::transform_point`] — a circle's radius, an ellipse's
-    /// semi-axes, a text height — must multiply by this or they stay authored-size
-    /// while their positions move. #1985
+    /// Scale factor carried by the linear block, as `sqrt(|det|)`. For the
+    /// similarity transforms this codebase actually authors (pure rotation,
+    /// uniform scale, or both) `|det| = scale^2` exactly, so this returns the
+    /// same uniform scale the old `(cos, sin)` magnitude did. A mirroring
+    /// transform has `det < 0`; `sqrt(|det|)` still recovers the magnitude,
+    /// which is what every scalar consumer (radius, height, …) wants — a
+    /// reflection has no separate "size", only orientation, and orientation
+    /// is not representable as a scalar. 1.0 for a pure rotation. An
+    /// `IfcMappedItem` MappingTarget's `Scale` folds in here (see
+    /// `parse_cartesian_transformation_operator`), so SCALAR outputs that
+    /// never pass through [`Self::transform_point`] — a circle's radius, an
+    /// ellipse's semi-axes, a text height — must multiply by this or they
+    /// stay authored-size while their positions move. #1985
     pub(super) fn scale(&self) -> f32 {
-        (self.cos_theta * self.cos_theta + self.sin_theta * self.sin_theta).sqrt()
+        (self.m00 * self.m11 - self.m01 * self.m10).abs().sqrt()
     }
 
     pub(super) fn transform_point(&self, x: f32, y: f32) -> (f32, f32) {
-        let rx = x * self.cos_theta - y * self.sin_theta;
-        let ry = x * self.sin_theta + y * self.cos_theta;
+        let rx = self.m00 * x + self.m01 * y;
+        let ry = self.m10 * x + self.m11 * y;
         (rx + self.tx, ry + self.ty)
     }
 }
 
 /// Compose two 2D transforms: `result = a * b` (apply `b` first, then `a`).
 pub(super) fn compose_transforms(a: &Transform2D, b: &Transform2D) -> Transform2D {
-    let combined_cos = a.cos_theta * b.cos_theta - a.sin_theta * b.sin_theta;
-    let combined_sin = a.sin_theta * b.cos_theta + a.cos_theta * b.sin_theta;
-    let rtx = b.tx * a.cos_theta - b.ty * a.sin_theta;
-    let rty = b.tx * a.sin_theta + b.ty * a.cos_theta;
+    let m00 = a.m00 * b.m00 + a.m01 * b.m10;
+    let m01 = a.m00 * b.m01 + a.m01 * b.m11;
+    let m10 = a.m10 * b.m00 + a.m11 * b.m10;
+    let m11 = a.m10 * b.m01 + a.m11 * b.m11;
+    let rtx = a.m00 * b.tx + a.m01 * b.ty;
+    let rty = a.m10 * b.tx + a.m11 * b.ty;
     Transform2D {
         tx: rtx + a.tx,
         ty: rty + a.ty,
         tz: a.tz + b.tz,
-        cos_theta: combined_cos,
-        sin_theta: combined_sin,
+        m00,
+        m01,
+        m10,
+        m11,
     }
 }
 
@@ -122,23 +140,10 @@ fn resolve_placement_for_symbolic(
         _ => Transform2D::identity(),
     };
 
-    let combined_cos = parent_transform.cos_theta * local_transform.cos_theta
-        - parent_transform.sin_theta * local_transform.sin_theta;
-    let combined_sin = parent_transform.sin_theta * local_transform.cos_theta
-        + parent_transform.cos_theta * local_transform.sin_theta;
-
-    let rotated_local_tx = local_transform.tx * parent_transform.cos_theta
-        - local_transform.ty * parent_transform.sin_theta;
-    let rotated_local_ty = local_transform.tx * parent_transform.sin_theta
-        + local_transform.ty * parent_transform.cos_theta;
-
-    Transform2D {
-        tx: parent_transform.tx + rotated_local_tx,
-        ty: parent_transform.ty + rotated_local_ty,
-        tz: parent_transform.tz + local_transform.tz,
-        cos_theta: combined_cos,
-        sin_theta: combined_sin,
-    }
+    // Same composition `compose_transforms` performs (parent applied after
+    // local); kept as a direct call rather than a hand-inlined duplicate so
+    // the two never drift on the linear-block representation again.
+    compose_transforms(&parent_transform, &local_transform)
 }
 
 /// Parse `IfcAxis2Placement3D` / `IfcAxis2Placement2D` to a 2D transform.
@@ -174,7 +179,7 @@ pub(super) fn parse_axis2_placement_2d(
     } else {
         placement.get(1)
     };
-    let (cos_theta, sin_theta) = match ref_dir_attr {
+    let (dx, dy) = match ref_dir_attr {
         Some(attr) if !attr.is_null() => match attr.as_entity_ref() {
             Some(ref_dir_id) => match decoder.decode_by_id(ref_dir_id) {
                 Ok(ref_dir) if ref_dir.ifc_type == IfcType::IfcDirection => {
@@ -204,25 +209,35 @@ pub(super) fn parse_axis2_placement_2d(
         _ => (1.0, 0.0),
     };
 
+    // `IfcAxis2Placement2D` / `…3D` carry only ONE in-plane direction
+    // (RefDirection); the Y axis is always the right-handed perpendicular —
+    // there is no second direction attribute here that could disagree and
+    // introduce a reflection, unlike `IfcCartesianTransformationOperator`'s
+    // Axis1/Axis2 pair below.
     Transform2D {
         tx,
         ty,
         tz,
-        cos_theta,
-        sin_theta,
+        m00: dx,
+        m01: -dy,
+        m10: dy,
+        m11: dx,
     }
 }
 
 /// Parse `IfcCartesianTransformationOperator2D` / `…3D` for `IfcMappedItem`
-/// targets: translation, in-plane rotation, and the uniform `Scale` (attr 3).
+/// targets: translation, the full 2x2 linear block (rotation, optional
+/// reflection, and the uniform `Scale`, attr 3).
 ///
-/// [`Transform2D`]'s `(cos_theta, sin_theta)` pair is the linear block, so
-/// folding a uniform scale into BOTH makes it a similarity transform that
-/// `transform_point` and `compose_transforms` already handle exactly. Scale used
-/// to be dropped here, so a map authored in metres and instantiated with
-/// `Scale = 1000` into a millimetre model drew its 2D symbols 1000x too small
-/// while the 3D mesh was correct. Per-axis (`…nonUniform`) scales still are not
-/// representable in this 2D similarity and stay on the uniform Scale. #1985
+/// Axis1 (attr 0) gives the local X direction. Axis2 (attr 1) is normally
+/// just the right-handed perpendicular of Axis1 and is IGNORED in that case,
+/// keeping bit-identical output for the (overwhelmingly common) non-mirroring
+/// case. A supplied Axis2 that DISAGREES with the perpendicular — a mirroring
+/// MappingTarget, the frame `#1994` is about — is honoured instead, exactly
+/// mirroring how `router/transforms/operator.rs`'s 3D path derives handedness
+/// from Axis2 vs. `Axis3 × Axis1`. Per-axis (`…nonUniform`) scales are still
+/// not read here (only the uniform `Scale`); that gap is unchanged from
+/// before and is a separate concern from the mirroring this fixes.
 pub(super) fn parse_cartesian_transformation_operator(
     operator: &DecodedEntity,
     decoder: &mut EntityDecoder,
@@ -248,20 +263,15 @@ pub(super) fn parse_cartesian_transformation_operator(
 
     // Scale (attr 3), defaulting to 1.0 when absent/null or non-finite (the same
     // NaN guard the 3D operator parser applies, so a malformed Scale can never
-    // poison a coordinate). The MAGNITUDE is taken: [`Transform2D`] is a
-    // similarity with no reflection, so a negative scale's sign is dropped rather
-    // than folded into `(cos, sin)`, where it would masquerade as a 180-degree
-    // rotation. Zero passes through, collapsing the symbol exactly as a zero scale
-    // collapses the 3D solid.
-    //
-    // `…2DnonUniform`'s Scale2 is likewise not representable here and is ignored,
-    // so a non-uniform target draws with its X scale on both axes. Both gaps need
-    // the same thing (a full 2x2 linear block) and are tracked in #1994.
+    // poison a coordinate). The MAGNITUDE is taken: a negative Scale is a
+    // uniform-reflection convention some exporters use, distinct from the
+    // Axis2 mirroring this function now derives; folding its sign in here too
+    // is out of scope for #1994 (unchanged from before this fix).
     let raw_scale = operator.get(3).and_then(|v| v.as_float()).unwrap_or(1.0) as f32;
     let scale = if raw_scale.is_finite() { raw_scale.abs() } else { 1.0 };
 
     // Axis1 (attr 0) gives the X direction for 2D / 3D operators.
-    let (cos_theta, sin_theta) = match operator.get_ref(0) {
+    let x_axis = match operator.get_ref(0) {
         Some(ax_ref) => match decoder.decode_by_id(ax_ref) {
             Ok(ax) if ax.ifc_type == IfcType::IfcDirection => {
                 let ratios = ax
@@ -283,12 +293,52 @@ pub(super) fn parse_cartesian_transformation_operator(
         None => (1.0, 0.0),
     };
 
+    // Right-handed perpendicular of Axis1 (the default Y when Axis2 is
+    // absent or agrees with it): rotating (dx, dy) by +90°.
+    let default_y = (-x_axis.1, x_axis.0);
+
+    // Axis2 (attr 1): only consulted when it DISAGREES with `default_y`.
+    let y_axis = match operator.get_ref(1) {
+        Some(ax_ref) => match decoder.decode_by_id(ax_ref) {
+            Ok(ax) if ax.ifc_type == IfcType::IfcDirection => {
+                let ratios = ax
+                    .get(0)
+                    .and_then(|a| a.as_list())
+                    .map(|l| l.to_vec())
+                    .unwrap_or_default();
+                let ex = ratios.first().and_then(|v| v.as_float()).unwrap_or(0.0) as f32;
+                let ey = ratios.get(1).and_then(|v| v.as_float()).unwrap_or(1.0) as f32;
+                // Project onto the perpendicular of x_axis (Gram-Schmidt),
+                // matching the 3D path's orthogonalization.
+                let dot = ex * x_axis.0 + ey * x_axis.1;
+                let px = ex - dot * x_axis.0;
+                let py = ey - dot * x_axis.1;
+                let len = (px * px + py * py).sqrt();
+                if len > 0.0001 {
+                    let proj = (px / len, py / len);
+                    let agreement = proj.0 * default_y.0 + proj.1 * default_y.1;
+                    if agreement < 1.0 - 1e-6 {
+                        proj
+                    } else {
+                        default_y
+                    }
+                } else {
+                    default_y
+                }
+            }
+            _ => default_y,
+        },
+        None => default_y,
+    };
+
     Transform2D {
         tx,
         ty,
         tz: 0.0,
-        cos_theta: cos_theta * scale,
-        sin_theta: sin_theta * scale,
+        m00: x_axis.0 * scale,
+        m10: x_axis.1 * scale,
+        m01: y_axis.0 * scale,
+        m11: y_axis.1 * scale,
     }
 }
 

--- a/rust/processing/src/symbolic/transform.rs
+++ b/rust/processing/src/symbolic/transform.rs
@@ -6,8 +6,11 @@ use ifc_lite_core::{DecodedEntity, EntityDecoder, IfcType};
 
 // ────────────────────────────────────────────────────────────────────────────
 // 2D transform primitives. Floor-plan symbolic rendering uses a custom
-// 2D-only transform: translations accumulate directly (not rotated by parent
-// rotations), but rotations DO accumulate so symbols orient correctly.
+// 2D-only transform. `compose_transforms` is ordinary affine composition —
+// the child's translation IS carried through the parent's linear block, and
+// the linear blocks multiply — so symbols orient and land correctly under a
+// nested placement. (An earlier version of this comment claimed translations
+// accumulated unrotated, which never matched the code.)
 // `tz` is strictly additive along the chain and lets each primitive carry
 // its storey elevation forward via `world_y`.
 // ────────────────────────────────────────────────────────────────────────────
@@ -51,7 +54,16 @@ impl Transform2D {
     /// transform has `det < 0`; `sqrt(|det|)` still recovers the magnitude,
     /// which is what every scalar consumer (radius, height, …) wants — a
     /// reflection has no separate "size", only orientation, and orientation
-    /// is not representable as a scalar. 1.0 for a pure rotation. An
+    /// is not representable as a scalar. 1.0 for a pure rotation.
+    ///
+    /// PRECONDITION: the linear block is orthogonal times a UNIFORM scale.
+    /// Every constructor here guarantees that — `parse_axis2_placement_2d`
+    /// builds a pure rotation, and `parse_cartesian_transformation_operator`
+    /// builds unit, mutually perpendicular columns scaled by one factor — and
+    /// the property is closed under composition. If `Scale2` (non-uniform)
+    /// is ever wired into this now-capable 2x2, `sqrt(|det|)` silently becomes
+    /// the GEOMETRIC MEAN of the two axis scales and every scalar consumer
+    /// below goes subtly wrong. Split the accessor before doing that. An
     /// `IfcMappedItem` MappingTarget's `Scale` folds in here (see
     /// `parse_cartesian_transformation_operator`), so SCALAR outputs that
     /// never pass through [`Self::transform_point`] — a circle's radius, an
@@ -238,6 +250,17 @@ pub(super) fn parse_axis2_placement_2d(
 /// from Axis2 vs. `Axis3 × Axis1`. Per-axis (`…nonUniform`) scales are still
 /// not read here (only the uniform `Scale`); that gap is unchanged from
 /// before and is a separate concern from the mirroring this fixes.
+///
+/// Axis3 (attr 4 on `IfcCartesianTransformationOperator3D`) is deliberately
+/// NOT consulted, and cannot matter here. A 3D operator's matrix has Axis1,
+/// Axis2 and Axis3 as its columns, so the plan projection — rows x,y of the
+/// first two columns — is a function of Axis1 and Axis2 alone; Axis3 lives
+/// entirely in the discarded third column. Concretely, a reflection through
+/// the XY plane (Axis3 = −Z, default Axis1/Axis2) has 3D `det = −1` while its
+/// plan submatrix is the identity with `det = +1`: mirroring an object
+/// vertically does not mirror its footprint, and leaving the plan symbol
+/// unmirrored is the correct answer, not an oversight. A tilted, non-axis
+/// aligned Axis3 is outside what a plan projection represents at all.
 pub(super) fn parse_cartesian_transformation_operator(
     operator: &DecodedEntity,
     decoder: &mut EntityDecoder,

--- a/rust/processing/tests/issue_1994_transform2d_mirror.rs
+++ b/rust/processing/tests/issue_1994_transform2d_mirror.rs
@@ -1,0 +1,193 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! #1994: the symbolic 2D transform (`Transform2D` in
+//! `rust/processing/src/symbolic/transform.rs`) stored its linear block as a
+//! `(cos_theta, sin_theta)` similarity, which has no reflection component. A
+//! mirroring `IfcMappedItem` MappingTarget — an `Axis2` that disagrees with
+//! the right-handed perpendicular of `Axis1` — therefore drew its 2D plan
+//! symbols un-mirrored, while the 3D mesh path (fixed in #1990) mirrors
+//! correctly.
+//!
+//! Both fixtures below map the SAME source polyline — a single segment from
+//! (0, 0) to (1, 2) in map-local coordinates, chosen off-axis so a Y-mirror
+//! is visible on the endpoint — through two `IfcCartesianTransformationOperator2D`
+//! MappingTargets that are identical except for `Axis2`:
+//!
+//! - Non-mirrored: `Axis1 = (1, 0)`, `Axis2 = $` (defaults to the
+//!   right-handed perpendicular `(0, 1)` — identity).
+//! - Mirrored: `Axis1 = (1, 0)`, `Axis2 = (0, -1)` (disagrees with the
+//!   perpendicular — a reflection about the X axis).
+//!
+//! The extractor applies a further Y-flip to match the section-cut display
+//! convention (`y_out = -y_world`), so the expected endpoints below are
+//! `(1, -2)` for the non-mirrored map and `(1, 2)` for the mirrored one.
+
+use ifc_lite_processing::extract_symbolic_data;
+
+/// `extra_entities` may define `#23` (or any other unused id) for
+/// `axis2_ref` to point at; `axis2_ref` is `$` for "no Axis2 supplied".
+fn fixture(extra_entities: &str, axis2_ref: &str) -> String {
+    format!(
+        r#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('issue-1994 fixture'),'2;1');
+FILE_NAME('test.ifc','2026-08-03T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('0$ScRe4drECQ4DMSqUjd6d',$,'P',$,$,$,$,(#2),#3);
+#2=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.0E-5,#5,$);
+#3=IFCUNITASSIGNMENT((#6));
+#4=IFCCARTESIANPOINT((0.,0.,0.));
+#5=IFCAXIS2PLACEMENT3D(#4,$,$);
+#6=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+#10=IFCCARTESIANPOINT((0.,0.));
+#11=IFCCARTESIANPOINT((1.,2.));
+#12=IFCPOLYLINE((#10,#11));
+#13=IFCSHAPEREPRESENTATION(#2,'Body','GeometricCurveSet',(#12));
+#14=IFCCARTESIANPOINT((0.,0.));
+#15=IFCAXIS2PLACEMENT3D(#14,$,$);
+#16=IFCREPRESENTATIONMAP(#15,#13);
+#20=IFCDIRECTION((1.,0.));
+#21=IFCCARTESIANPOINT((0.,0.));
+{extra_entities}
+#22=IFCCARTESIANTRANSFORMATIONOPERATOR2D(#20,{axis2_ref},#21,$);
+#30=IFCMAPPEDITEM(#16,#22);
+#40=IFCLOCALPLACEMENT($,#5);
+#50=IFCSHAPEREPRESENTATION(#2,'Annotation','MappedRepresentation',(#30));
+#51=IFCPRODUCTDEFINITIONSHAPE($,$,(#50));
+#52=IFCANNOTATION('1xScRe4drECQ4DMSqUjd6d',$,'Note',$,$,#40,#51);
+ENDSEC;
+END-ISO-10303-21;
+"#
+    )
+}
+
+/// Non-mirrored MappingTarget (`Axis2 = $`, default right-handed
+/// perpendicular): the mapped endpoint stays where it always did — this pins
+/// the regression risk, not the new capability.
+#[test]
+fn non_mirroring_axis2_null_is_unchanged() {
+    let data = extract_symbolic_data(&fixture("", "$"));
+    let pl = data
+        .polylines
+        .iter()
+        .find(|p| p.representation == "Annotation")
+        .expect("mapped annotation polyline");
+    assert_eq!(pl.points.len(), 4, "2-point polyline -> 4 floats");
+    assert_eq!((pl.points[0], pl.points[1]), (0.0, 0.0), "start point");
+    let (ex, ey) = (pl.points[2], pl.points[3]);
+    assert!((ex - 1.0).abs() < 1e-5, "non-mirrored endpoint x: {ex}");
+    assert!((ey - -2.0).abs() < 1e-5, "non-mirrored endpoint y: {ey}");
+}
+
+/// Mirroring MappingTarget (`Axis2 = (0, -1)`, disagreeing with the
+/// right-handed perpendicular of Axis1): the mapped endpoint's Y must flip
+/// relative to the non-mirrored case above. This is the RED case: before the
+/// fix, `Transform2D` could not represent a reflection at all, so Axis2 was
+/// never even read and this endpoint came out identical to the non-mirrored
+/// fixture.
+#[test]
+fn mirroring_axis2_flips_the_mapped_geometry() {
+    let content = fixture("#23=IFCDIRECTION((0.,-1.));", "#23");
+    let data = extract_symbolic_data(&content);
+    let pl = data
+        .polylines
+        .iter()
+        .find(|p| p.representation == "Annotation")
+        .expect("mapped annotation polyline");
+    assert_eq!(pl.points.len(), 4, "2-point polyline -> 4 floats");
+    assert_eq!((pl.points[0], pl.points[1]), (0.0, 0.0), "start point");
+    let (ex, ey) = (pl.points[2], pl.points[3]);
+    assert!((ex - 1.0).abs() < 1e-5, "mirrored endpoint x: {ex}");
+    assert!(
+        (ey - 2.0).abs() < 1e-5,
+        "mirrored endpoint y should flip sign vs the non-mirrored case: {ey}"
+    );
+}
+
+/// Rotation-only MappingTarget (no mirror): `Axis1 = (0, 1)` is a plain 90°
+/// rotation with `Axis2` absent (defaults to the perpendicular). Pins that
+/// ordinary rotation is unaffected by the full-2x2 representation change.
+#[test]
+fn pure_rotation_is_unchanged() {
+    let content = fixture("", "$").replace(
+        "#20=IFCDIRECTION((1.,0.));",
+        "#20=IFCDIRECTION((0.,1.));",
+    );
+    let data = extract_symbolic_data(&content);
+    let pl = data
+        .polylines
+        .iter()
+        .find(|p| p.representation == "Annotation")
+        .expect("mapped annotation polyline");
+    let (ex, ey) = (pl.points[2], pl.points[3]);
+    // Local (1, 2) rotated 90° CCW (X -> (0,1), Y -> (-1,0)) = (1*0 + 2*-1, 1*1 + 2*0) = (-2, 1).
+    // Display Y-flip: (-2, -1).
+    assert!((ex - -2.0).abs() < 1e-5, "rotated endpoint x: {ex}");
+    assert!((ey - -1.0).abs() < 1e-5, "rotated endpoint y: {ey}");
+}
+
+/// Uniform-scale MappingTarget (no mirror): `Scale = 2` with the default
+/// (identity) axes. Pins that `Transform2D::scale()` (now `sqrt(|det|)`)
+/// still recovers a plain uniform scale exactly.
+#[test]
+fn uniform_scale_is_unchanged() {
+    let content = fixture("", "$").replace(
+        "#22=IFCCARTESIANTRANSFORMATIONOPERATOR2D(#20,$,#21,$);",
+        "#22=IFCCARTESIANTRANSFORMATIONOPERATOR2D(#20,$,#21,2.);",
+    );
+    let data = extract_symbolic_data(&content);
+    let pl = data
+        .polylines
+        .iter()
+        .find(|p| p.representation == "Annotation")
+        .expect("mapped annotation polyline");
+    let (ex, ey) = (pl.points[2], pl.points[3]);
+    assert!((ex - 2.0).abs() < 1e-5, "scaled endpoint x: {ex}");
+    assert!((ey - -4.0).abs() < 1e-5, "scaled endpoint y: {ey}");
+}
+
+/// Translation-only MappingTarget (no mirror): a non-zero `LocalOrigin`.
+/// Pins that translation composition is unaffected.
+#[test]
+fn translation_is_unchanged() {
+    let content = fixture("", "$").replace(
+        "#21=IFCCARTESIANPOINT((0.,0.));",
+        "#21=IFCCARTESIANPOINT((5.,7.));",
+    );
+    let data = extract_symbolic_data(&content);
+    let pl = data
+        .polylines
+        .iter()
+        .find(|p| p.representation == "Annotation")
+        .expect("mapped annotation polyline");
+    let (sx, sy) = (pl.points[0], pl.points[1]);
+    let (ex, ey) = (pl.points[2], pl.points[3]);
+    assert!((sx - 5.0).abs() < 1e-5, "start x: {sx}");
+    assert!((sy - -7.0).abs() < 1e-5, "start y: {sy}");
+    assert!((ex - 6.0).abs() < 1e-5, "translated endpoint x: {ex}");
+    assert!((ey - -9.0).abs() < 1e-5, "translated endpoint y: {ey}");
+}
+
+/// Identity MappingTarget must still be recognised as identity: `mod.rs`'s
+/// combined-transform fast-path check reads the full 2x2 now, so an all-
+/// identity chain (no scale, no rotation, no mirror, no translation) has to
+/// still take the `placement_transform`-only branch rather than always
+/// composing in a context transform. Not directly observable from
+/// `SymbolicData` alone, so this asserts the plain-identity geometry still
+/// lands exactly where authored (a regression here would show as an
+/// off-by-epsilon or NaN, not a crash).
+#[test]
+fn identity_mapping_target_lands_unmoved() {
+    let data = extract_symbolic_data(&fixture("", "$"));
+    let pl = data
+        .polylines
+        .iter()
+        .find(|p| p.representation == "Annotation")
+        .expect("mapped annotation polyline");
+    let (sx, sy) = (pl.points[0], pl.points[1]);
+    assert_eq!((sx, sy), (0.0, 0.0), "identity start point");
+}

--- a/rust/processing/tests/issue_1994_transform2d_mirror.rs
+++ b/rust/processing/tests/issue_1994_transform2d_mirror.rs
@@ -45,7 +45,8 @@ DATA;
 #6=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
 #10=IFCCARTESIANPOINT((0.,0.));
 #11=IFCCARTESIANPOINT((1.,2.));
-#12=IFCPOLYLINE((#10,#11));
+#17=IFCCARTESIANPOINT((3.,1.));
+#12=IFCPOLYLINE((#10,#11,#17));
 #13=IFCSHAPEREPRESENTATION(#2,'Body','GeometricCurveSet',(#12));
 #14=IFCCARTESIANPOINT((0.,0.));
 #15=IFCAXIS2PLACEMENT3D(#14,$,$);
@@ -76,7 +77,7 @@ fn non_mirroring_axis2_null_is_unchanged() {
         .iter()
         .find(|p| p.representation == "Annotation")
         .expect("mapped annotation polyline");
-    assert_eq!(pl.points.len(), 4, "2-point polyline -> 4 floats");
+    assert_eq!(pl.points.len(), 6, "3-point polyline -> 6 floats");
     assert_eq!((pl.points[0], pl.points[1]), (0.0, 0.0), "start point");
     let (ex, ey) = (pl.points[2], pl.points[3]);
     assert!((ex - 1.0).abs() < 1e-5, "non-mirrored endpoint x: {ex}");
@@ -98,7 +99,7 @@ fn mirroring_axis2_flips_the_mapped_geometry() {
         .iter()
         .find(|p| p.representation == "Annotation")
         .expect("mapped annotation polyline");
-    assert_eq!(pl.points.len(), 4, "2-point polyline -> 4 floats");
+    assert_eq!(pl.points.len(), 6, "3-point polyline -> 6 floats");
     assert_eq!((pl.points[0], pl.points[1]), (0.0, 0.0), "start point");
     let (ex, ey) = (pl.points[2], pl.points[3]);
     assert!((ex - 1.0).abs() < 1e-5, "mirrored endpoint x: {ex}");
@@ -106,6 +107,31 @@ fn mirroring_axis2_flips_the_mapped_geometry() {
         (ey - 2.0).abs() < 1e-5,
         "mirrored endpoint y should flip sign vs the non-mirrored case: {ey}"
     );
+
+    // Chirality, not just position. A single moved point cannot distinguish a
+    // reflection from some rotation about the preserved origin — the endpoint
+    // above is reachable either way. Signed area over three non-collinear
+    // points can: a rotation preserves its sign, a reflection inverts it. The
+    // authored winding is positive (see `non_mirroring_axis2_null_is_unchanged`),
+    // so a genuine mirror must come out negative.
+    assert!(
+        signed_area(&pl.points) < 0.0,
+        "a reflection must invert the winding, not merely move points; got {:?}",
+        pl.points
+    );
+}
+
+/// Twice the signed area of the polygon through a flat `[x, y, x, y, ...]`
+/// point list (the shoelace sum). Sign is the chirality: positive for
+/// counter-clockwise, negative once reflected.
+fn signed_area(points: &[f32]) -> f32 {
+    let n = points.len() / 2;
+    let mut sum = 0.0;
+    for i in 0..n {
+        let j = (i + 1) % n;
+        sum += points[2 * i] * points[2 * j + 1] - points[2 * j] * points[2 * i + 1];
+    }
+    sum
 }
 
 /// Rotation-only MappingTarget (no mirror): `Axis1 = (0, 1)` is a plain 90°


### PR DESCRIPTION
Closes #1994. Implemented to the shape you specified.

`Transform2D`'s `(cos, sin)` pair is a similarity with no reflection component, so a mirroring operator drew plan symbols un-mirrored while the 3D path (post-#1990) mirrored correctly. Replaced with a full 2x2; `compose_transforms` becomes a real matrix multiply, `transform_point` follows, `scale()` becomes `sqrt(|det|)`.

**Handedness follows the 3D convention rather than a new one.** `router/transforms/operator.rs` already derives it, so I read that and mirrored the approach: default Y is the right-handed perpendicular of Axis1, and a supplied Axis2 is honoured *only when it disagrees* (Gram-Schmidt projection, then a dot-product test). The non-mirroring case therefore takes the branch it always took and is bit-identical.

That was the actual risk here, so it's where the tests are weighted: five of the six pin the **unchanged** paths — rotation, uniform scale, translation, identity, and a null Axis2 — and pass with or without the fix. Only `mirroring_axis2_flips_the_mapped_geometry` is new behaviour. Reverting just the disagreement test gives 5 pass / 1 fail.

## Two consumers your list didn't name

- **`parse_axis2_placement_2d`** read the same fields. It now emits a pure rotation — `IfcAxis2Placement2D`/`3D` carry only one in-plane direction, so no mirror is representable there and none should be inferred.
- **`resolve_placement_for_symbolic`** was a hand-inlined duplicate of the composition formula. Rather than update the same maths in two places, it now calls `compose_transforms`.

## Judgement calls

**Text orientation** needed no special case, which I want to flag explicitly since it was the obvious place to get this wrong. The direction pair reads only the X-axis column, and a mirroring Axis2 flips only the Y column — so glyphs stay readable under a mirroring transform automatically. If you'd rather mirrored text *did* mirror, that's a one-line change, but readable seemed the conservative default.

**Negative `Scale`** still takes its magnitude — a separate reflection convention, documented as such before this change, and out of scope per the issue.

## Verification

`issue_1994_transform2d_mirror` 6/6 · `issue_843_symbolic_data` 3/3 · `issue_843_symbolic_parity` 4/4 · `issue_1985_mapped_item_transform` 2/2 · processing lib 57/57 · ratchet 4/4 · clippy clean.

Nothing under `rust/geometry` or `rust/wasm-bindings` is touched, so no geometry hash moves.

Fixture is a hand-authored inline IFC string, following the `issue_843_symbolic_data.rs` convention — no corpus download needed.

## Worth restating

Per your own note, **no model in the 63-model corpus exercises a mirroring operator**, so this closes a correctness gap rather than an observed failure. The new test is the only thing demonstrating it. Draft until you've looked.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected 2D rendering for mirrored mapped geometry.
  * Preserved readable orientation for text and annotation glyphs during mirrored transformations.
  * Improved handling of rotated, scaled, translated, and identity placements.
  * Maintained existing behavior for non-mirrored transformations and malformed input defaults.

* **Tests**
  * Added regression coverage for mirrored and non-mirrored mapped geometry transformations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->