### PR TITLE
fix(sdk,parser): let addEntity author IFC2X3 and IFC4X3 classes (#2003)

### DIFF
--- a/.changeset/known-type-across-schemas.md
+++ b/.changeset/known-type-across-schemas.md
@@ -1,0 +1,16 @@
+---
+'@ifc-lite/parser': minor
+'@ifc-lite/data': minor
+---
+
+**schema**: `isKnownType` and `normalizeIfcTypeName` now answer for every bundled IFC schema (IFC2X3 + IFC4 + IFC4X3), not just the IFC4_ADD2_TC1 codegen pin (issue [#2003](https://github.com/LTplus-AG/ifc-lite/issues/2003)).
+
+Both read `isKnownEntity` / `getEntityMetadata`, which are generated from the pin and answer "unknown" for any class it does not carry. Measured on the bundled tables: 251 real classes, including 100 `IfcObjectDefinition` ones — the IFC2X3 classes IFC4 dropped (`IfcMove`, `IfcScheduleTimeControl`, `IfcSpaceProgram`, `IfcServiceLife`, `IfcOrderAction`, …) and the IFC4X3 infrastructure classes it never had (`IfcRoad`, `IfcSignal`, `IfcAlignment`, `IfcRailway`, `IfcMarineFacility`, …). `normalizeIfcTypeName` had the same blind spot from the other side: it fell through to "preserve as-is", so `'IFCROAD'` stayed `'IFCROAD'` instead of canonicalizing to `'IfcRoad'`.
+
+Both now resolve against the schema union first and fall back to the pin, the same order `getInheritanceChainAcrossSchemas` uses.
+
+`isKnownType` is still a guard, not a pass-through. Typos (`IfcWal`, `IfcRoadd`), vendor extensions, and the 138 EXPRESS *defined types* the upstream SchemaInfo tables carry as entity rows are all still rejected — 132 named by the cross-schema `IFC_DATA_TYPES` table (`IfcLengthMeasure`, `IfcBoolean`, `IfcCountMeasure`, …) and 6 more that only the pin's own `SCHEMA_REGISTRY.types` map names (`IfcBinary`, `IfcArcIndex`, `IfcLineIndex`, `IfcComplexNumber`, `IfcCompoundPlaneAngleMeasure`, `IfcPropertySetDefinitionSet`). None of the 776 pinned classes appears in either table, so no IFC4 answer changes.
+
+It answers known-ness, not instantiability: abstract supertypes (`IfcProduct`, `IfcRoot`) are real IFC classes and still answer `true`, exactly as they did before. Rejecting those is a separate, pre-existing question — `main` already accepts 123 of them — tracked in [#2035](https://github.com/LTplus-AG/ifc-lite/issues/2035).
+
+**data**: exports `IFC_DATA_TYPES`, the raw bundled defined-type table, for the same reason the `ENTITIES_*` tables are exported: a synchronous guard deciding "is this a class I may instantiate?" has to subtract the defined types, and the existing `findDataType` is async.

--- a/.changeset/sdk-add-entity-across-schemas.md
+++ b/.changeset/sdk-add-entity-across-schemas.md
@@ -1,0 +1,9 @@
+---
+'@ifc-lite/sdk': minor
+---
+
+**store**: `bim.store.addEntity` can author IFC2X3-only and IFC4X3-only classes (issue [#2003](https://github.com/LTplus-AG/ifc-lite/issues/2003)).
+
+The SDK gates `addEntity` on the parser's `isKnownType` and registers the same check as `@ifc-lite/mutations`' entity-type normalizer, so while that check answered from the IFC4 codegen pin alone the guard did not degrade — it refused outright. `bim.store.addEntity('arch', { type: 'IfcRoad', … })` threw `unknown IFC type 'IfcRoad'` for roughly 251 perfectly valid classes, and the SDK could not author them at all.
+
+Nothing changes for the IFC4 classes the pin carries, and the guard still rejects what it was written to reject: `IfcWal` still throws.

--- a/docs/api/typescript.md
+++ b/docs/api/typescript.md
@@ -241,6 +241,8 @@ class RelationshipGraphBuilder { /* build(): RelationshipGraph */ }
 
 Each table type also has `fromColumns` / `toColumns` helpers for structured-clone transfer across workers (`entityTableFromColumns`, `propertyTableToColumns`, ...). Shared enums and types live here too: `IfcTypeEnum`, `PropertyValueType`, `QuantityType`, `RelationshipType`, `SpatialHierarchy`, `IfcStoreBase`, the generated entity-name lists (`ENTITIES_IFC2X3` / `IFC4` / `IFC4X3`), plus utilities like `safeUtf8Decode` and `createLogger`.
 
+`IFC_DATA_TYPES` sits alongside those entity lists: the raw, read-only table of EXPRESS **defined types** (`IfcLengthMeasure`, `IfcBoolean`, `IfcTextAlignment`, ...) across all three schemas. The upstream data the `ENTITIES_*` lists come from carries defined types as entity rows, so any synchronous consumer deciding "is this name a class I may instantiate?" has to subtract this table — that is what `@ifc-lite/parser`'s `isKnownType` does. Prefer the async `findDataType(version, name)` when you only need a single lookup and are not inside a synchronous guard.
+
 ---
 
 ## @ifc-lite/query

--- a/packages/data/src/index.ts
+++ b/packages/data/src/index.ts
@@ -99,6 +99,14 @@ export {
 export { ENTITIES_IFC2X3 } from './ifc-schema/generated/entities-ifc2x3.js';
 export { ENTITIES_IFC4 } from './ifc-schema/generated/entities-ifc4.js';
 export { ENTITIES_IFC4X3 } from './ifc-schema/generated/entities-ifc4x3.js';
+// The upstream SchemaInfo tables the `ENTITIES_*` lists come from also carry
+// EXPRESS *defined types* (`IfcLengthMeasure`, `IfcBoolean`, `IfcTextAlignment`,
+// …) as rows, because IDS needs their names. They are not instantiable
+// entities, so a synchronous consumer deciding "is this a class I may create?"
+// has to subtract them, and this is the authoritative list to subtract.
+// Raw and read-only for the same reason as the entity tables above; the async
+// `findDataType` cannot answer inside a synchronous guard.
+export { IFC_DATA_TYPES } from './ifc-schema/generated/data-types.js';
 export type {
   IfcAttributeInfo,
   IfcDataTypeInfo,

--- a/packages/parser/src/ifc-schema.ts
+++ b/packages/parser/src/ifc-schema.ts
@@ -9,8 +9,8 @@
  * Do NOT hardcode entity types or attributes here; regenerate instead.
  */
 
-import { getAllAttributesForEntity, isKnownEntity, getInheritanceChainForEntity, getEntityMetadata } from './generated/schema-registry.js';
-import { ENTITIES_IFC2X3, ENTITIES_IFC4, ENTITIES_IFC4X3, type IfcEntityInfo } from '@ifc-lite/data';
+import { SCHEMA_REGISTRY, getAllAttributesForEntity, isKnownEntity, getInheritanceChainForEntity, getEntityMetadata } from './generated/schema-registry.js';
+import { ENTITIES_IFC2X3, ENTITIES_IFC4, ENTITIES_IFC4X3, IFC_DATA_TYPES, type IfcEntityInfo } from '@ifc-lite/data';
 
 // Union map across every bundled IFC schema (2X3 + 4 + 4X3). The parser
 // has to categorize entities from ANY schema the user loads — so the
@@ -57,6 +57,52 @@ const ENTITY_NAME_ALIASES: Record<string, string> = {
  */
 export function resolveEntityNameAlias(type: string): string {
     return ENTITY_NAME_ALIASES[type.toUpperCase()] ?? type;
+}
+
+// The bundled `ENTITIES_*` tables are generated from buildingSMART's
+// SchemaInfo dumps, which list EXPRESS *defined types* (IfcLengthMeasure,
+// IfcBoolean, IfcCountMeasure, …) alongside real ENTITY declarations. Those
+// are not instantiable, so an "is this a class?" predicate has to subtract
+// them or it would start answering yes for `IfcLengthMeasure`, which the IFC4
+// codegen pin has always answered no for.
+//
+// Two authoritative tables say which names are not ENTITY declarations, and
+// both are needed — measured over the 1159 union rows:
+//   - `IFC_DATA_TYPES` (cross-schema, IDS-derived): 132 rows.
+//   - `SCHEMA_REGISTRY.types` (the pin's own EXPRESS TYPE map): 6 more that
+//     the IDS table omits — IfcBinary, IfcArcIndex, IfcLineIndex,
+//     IfcComplexNumber, IfcCompoundPlaneAngleMeasure, IfcPropertySetDefinitionSet.
+// `.enums` and `.selects` subtract nothing today and are folded in because the
+// question is "does the pin classify this name as a non-ENTITY declaration",
+// and answering it from two thirds of the pin's own classification would be
+// the arbitrary choice. Asserted in `known-type-across-schemas.test.ts`.
+//
+// None of the pin's 776 ENTITY names appears in any of these tables, so the
+// subtraction cannot change an IFC4 answer — and could not reject a pinned
+// class even if it did, because `isKnownType` falls back to `isKnownEntity`.
+const NON_ENTITY_NAMES_UPPER: ReadonlySet<string> = new Set([
+    ...IFC_DATA_TYPES.map(t => t.name.toUpperCase()),
+    ...Object.keys(SCHEMA_REGISTRY.types).map(n => n.toUpperCase()),
+    ...Object.keys(SCHEMA_REGISTRY.enums).map(n => n.toUpperCase()),
+    ...Object.keys(SCHEMA_REGISTRY.selects).map(n => n.toUpperCase()),
+]);
+
+/**
+ * Entity-metadata lookup across the bundled schema union (2X3 + 4 + 4X3) —
+ * the counterpart of the generated `getEntityMetadata`, which only knows the
+ * IFC4_ADD2_TC1 codegen pin and so answers `undefined` for the 251 classes
+ * outside it (`IfcMove`, `IfcScheduleTimeControl`, `IfcRoad`, `IfcSignal`, …).
+ *
+ * Deliberately does NOT resolve {@link ENTITY_NAME_ALIASES}: an alias maps a
+ * leaf to its nearest schema-known *supertype*, which is what an inheritance
+ * walk wants and the opposite of what a name-canonicalizer wants — resolving
+ * it here would turn `normalizeIfcTypeName('IfcSolidStratum')` into
+ * `'IfcGeotechnicalStratum'`, silently changing the caller's class.
+ */
+function getEntityInfoAcrossSchemas(type: string): IfcEntityInfo | undefined {
+    const upper = type.toUpperCase();
+    if (NON_ENTITY_NAMES_UPPER.has(upper)) return undefined;
+    return ENTITY_INFO_BY_UPPER.get(upper);
 }
 
 function getInheritanceChainFromSchemaUnion(type: string): string[] | null {
@@ -107,9 +153,27 @@ export function getAttributeNamesAcrossSchemas(type: string): string[] {
 }
 
 /**
- * Check if a type is known in the IFC schema.
+ * Check if a type is a real IFC entity class in any bundled schema.
+ *
+ * Answers for the union of every bundled IFC schema (2X3 + 4 + 4X3), falling
+ * back to the parser's IFC4_ADD2_TC1 codegen pin — the same union-first,
+ * pin-second order as {@link getInheritanceChain}. Answering from the pin alone
+ * rejected roughly 251 perfectly valid classes: the IFC2X3 ones IFC4 dropped
+ * (`IfcMove`, `IfcScheduleTimeControl`, `IfcSpaceProgram`, …) and the IFC4X3
+ * infrastructure ones it never had (`IfcRoad`, `IfcSignal`, `IfcAlignment`, …).
+ * That made `@ifc-lite/sdk`'s `addEntity` refuse to author them at all (#2003).
+ *
+ * Still a real guard, not a pass-through: a typo (`IfcWal`), a vendor extension
+ * and an EXPRESS defined type (`IfcLengthMeasure`, `IfcArcIndex`) are all
+ * rejected.
+ *
+ * Known-ness, not instantiability: abstract supertypes (`IfcProduct`,
+ * `IfcRoot`) answer `true`, as they always have. Rejecting those is a separate,
+ * pre-existing question tracked in #2035 — it is a different predicate and it
+ * belongs at the authoring boundary, not in a name-registry check.
  */
 export function isKnownType(type: string): boolean {
+    if (getEntityInfoAcrossSchemas(type)) return true;
     return isKnownEntity(type);
 }
 
@@ -144,13 +208,22 @@ export function getAttributeNameAt(type: string, index: number): string | null {
  *
  * - `'IFCWALL'` → `'IfcWall'`
  * - `'IfcWall'` → `'IfcWall'` (unchanged)
+ * - `'IFCROAD'` → `'IfcRoad'` (IFC4X3, outside the codegen pin)
+ * - `'ifcmove'` → `'IfcMove'` (IFC2X3, dropped in IFC4)
  * - `'IfcVendorExtensionFoo'` → `'IfcVendorExtensionFoo'` (unchanged — unknown to registry)
+ *
+ * Resolves against the bundled schema union first and the IFC4_ADD2_TC1 pin
+ * second, matching {@link isKnownType} — the pin alone left every class outside
+ * it falling through to "preserve as-is", so an IFC4X3 class kept whatever
+ * casing the caller happened to type instead of being canonicalized (#2003).
  *
  * Used at user-facing API boundaries to keep the public contract on
  * canonical PascalCase regardless of how the caller spells the type.
  */
 export function normalizeIfcTypeName(type: string): string {
     if (typeof type !== 'string' || type.length === 0) return type;
+    const info = getEntityInfoAcrossSchemas(type);
+    if (info) return info.name;
     const metadata = getEntityMetadata(type);
     if (metadata) return metadata.name;
     // Unknown to registry — preserve as-is (could be a vendor extension).

--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -130,6 +130,17 @@ export * from './types.js';
 // above only knows the codegen pin (IFC4_ADD2_TC1) and returns an empty chain
 // for a class the pin does not carry — `IfcMove`, `IfcSpaceProgram`, `IfcRoad`.
 // Anything that decides *what kind of thing* an entity is must use this one.
+// `isKnownType` and `normalizeIfcTypeName` are cross-schema too, despite the
+// unqualified names — they were pin-only until #2003.
+//
+// NAMING FOOTGUN, recorded rather than fixed here: the pinned helper has the
+// shorter, more obvious name (`getInheritanceChainForEntity`) and the correct
+// one carries the qualifier, so reaching for the wrong one is the path of least
+// resistance — five call sites have now been fixed after the fact (#2001, #2003,
+// #2014, this one). The qualifier belongs on the *pinned* function
+// (`…ForEntityInIfc4Pin`), leaving the union walker the plain name, so the easy
+// choice is the safe one. That is a rename across every consumer and does not
+// belong in a fix PR; it needs its own.
 export { getAttributeNames, getAttributeNamesAcrossSchemas, getAttributeNameAt, isKnownType, normalizeIfcTypeName, resolveEntityNameAlias, getInheritanceChain as getInheritanceChainAcrossSchemas } from './ifc-schema.js';
 
 import type { IfcEntity, ParseResult } from './types.js';

--- a/packages/parser/test/known-type-across-schemas.test.ts
+++ b/packages/parser/test/known-type-across-schemas.test.ts
@@ -1,0 +1,253 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `isKnownType` / `normalizeIfcTypeName` answer for every bundled IFC schema,
+ * not just the IFC4_ADD2_TC1 codegen pin (#2003).
+ *
+ * These two were the last surface still reading the pin alone after #2001 and
+ * #2014 fixed `diff`, `validate` and the MCP tools. `@ifc-lite/sdk` registers
+ * them as the entity-type normalizer for `@ifc-lite/mutations`, so a `false`
+ * here is not a degraded answer — it is `addEntity` refusing to author the
+ * class at all. On main that rejected roughly 251 real classes: the IFC2X3
+ * ones IFC4 dropped (`IfcMove`, `IfcScheduleTimeControl`) and the IFC4X3
+ * infrastructure ones it never had (`IfcRoad`, `IfcSignal`).
+ *
+ * The guard still has to reject typos — that is the reason it exists — so both
+ * directions are asserted here, and widening it to "accept anything" fails.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { ENTITIES_IFC2X3, ENTITIES_IFC4, ENTITIES_IFC4X3, IFC_DATA_TYPES } from '@ifc-lite/data';
+import { SCHEMA_REGISTRY, getEntityMetadata } from '../src/generated/schema-registry.js';
+import { isKnownType, normalizeIfcTypeName } from '../src/ifc-schema.js';
+
+/**
+ * The six EXPRESS TYPEs the IDS-derived `IFC_DATA_TYPES` table omits but the
+ * pin's own `SCHEMA_REGISTRY.types` map carries. They ride along in the bundled
+ * `ENTITIES_*` tables as if they were classes.
+ */
+const TYPES_ONLY_IN_THE_PIN = [
+  'IfcBinary',
+  'IfcArcIndex',
+  'IfcLineIndex',
+  'IfcComplexNumber',
+  'IfcCompoundPlaneAngleMeasure',
+  'IfcPropertySetDefinitionSet',
+];
+
+/** Classes that exist only in IFC2X3 — dropped by IFC4, so absent from the pin. */
+const IFC2X3_ONLY = [
+  'IfcMove',
+  'IfcOrderAction',
+  'IfcScheduleTimeControl',
+  'IfcSpaceProgram',
+  'IfcServiceLife',
+  'IfcTimeSeriesSchedule',
+  'IfcConditionCriterion',
+];
+
+/** IFC4X3 infrastructure classes the IFC4 pin never had. */
+const IFC4X3_ONLY = [
+  'IfcRoad',
+  'IfcSignal',
+  'IfcAlignment',
+  'IfcRailway',
+  'IfcMarineFacility',
+  'IfcCourse',
+  'IfcPavement',
+];
+
+const PINNED: string[] = Object.keys(SCHEMA_REGISTRY.entities);
+
+const UNION_NAMES: string[] = [
+  ...new Map(
+    [ENTITIES_IFC2X3, ENTITIES_IFC4, ENTITIES_IFC4X3]
+      .flatMap((list) => list.map((entity) => [entity.name.toUpperCase(), entity.name] as const)),
+  ).values(),
+];
+
+const UNION_UPPER_LIST: string[] = UNION_NAMES.map((name) => name.toUpperCase());
+
+const UNION_UPPER = new Set(UNION_UPPER_LIST);
+
+/**
+ * Every name the two authoritative tables classify as something other than an
+ * EXPRESS ENTITY: the cross-schema IDS table plus the pin's own TYPE / ENUM /
+ * SELECT maps. This is the set `getEntityInfoAcrossSchemas` subtracts.
+ */
+const NON_ENTITIES = new Set([
+  ...IFC_DATA_TYPES.map((t) => t.name.toUpperCase()),
+  ...Object.keys(SCHEMA_REGISTRY.types).map((n) => n.toUpperCase()),
+  ...Object.keys(SCHEMA_REGISTRY.enums).map((n) => n.toUpperCase()),
+  ...Object.keys(SCHEMA_REGISTRY.selects).map((n) => n.toUpperCase()),
+]);
+
+describe('isKnownType across the bundled schema union (#2003)', () => {
+  it('accepts IFC2X3-only classes the IFC4 pin dropped', () => {
+    for (const type of IFC2X3_ONLY) {
+      // Guard the premise: if the pin ever grows these, this test stops
+      // measuring what it claims to measure.
+      expect(getEntityMetadata(type), `${type} unexpectedly in the pin`).toBeUndefined();
+      expect(isKnownType(type), type).toBe(true);
+    }
+  });
+
+  it('accepts IFC4X3-only classes the IFC4 pin never had', () => {
+    for (const type of IFC4X3_ONLY) {
+      expect(getEntityMetadata(type), `${type} unexpectedly in the pin`).toBeUndefined();
+      expect(isKnownType(type), type).toBe(true);
+    }
+  });
+
+  it('accepts every class in the pin (no IFC4 regression)', () => {
+    const rejected = PINNED.filter((type) => !isKnownType(type));
+    expect(rejected).toEqual([]);
+  });
+
+  it('resolves the whole pin from the union alone, so the pin fallback stays unreachable', () => {
+    // The assertion above cannot tell which source answered: `isKnownType`
+    // falls back to the pin, so every pinned class comes back `true` even if
+    // the union lost it. Read the tables directly, the same way
+    // `inheritance-chain-equivalence.test.ts` does, or the "no IFC4
+    // regression" claim is true by construction.
+    //
+    // The fallback is not dead weight even so: it is what keeps a pinned class
+    // accepted if a future regenerated non-entity table ever named one, which
+    // is exactly the case the subtraction above would otherwise break.
+    const unresolvable = PINNED.filter(
+      (type) => !UNION_UPPER.has(type.toUpperCase()) || NON_ENTITIES.has(type.toUpperCase()),
+    );
+    expect(unresolvable).toEqual([]);
+  });
+
+  it('still rejects typos, near-misses and vendor extensions', () => {
+    // The whole reason the guard exists. A one-character slip off a real class
+    // in each of the three schemas, plus a plausible-looking invention.
+    const typos = [
+      'IfcWal',
+      'IfcWalll',
+      'IfcRoadd',
+      'IfcRoa',
+      'IfcMov',
+      'IfcMovee',
+      'IfcSpaceProgramm',
+      'IfcAcmeVendorExtension',
+      'IfcBuildingElementWidget',
+      'Wall',
+      'IFC',
+      '',
+    ];
+    for (const type of typos) {
+      expect(isKnownType(type), type).toBe(false);
+    }
+  });
+
+  it('rejects EXPRESS defined types that ride along in the bundled entity tables', () => {
+    // The `ENTITIES_*` tables carry `IfcLengthMeasure`, `IfcBoolean` and 130
+    // other defined types as rows. They are not instantiable, the pin has
+    // always answered `false` for them, and widening the union lookup without
+    // subtracting them would flip that.
+    for (const type of ['IfcLengthMeasure', 'IfcBoolean', 'IfcCountMeasure', 'IfcTextAlignment', 'IfcPositiveLengthMeasure']) {
+      expect(NON_ENTITIES.has(type.toUpperCase()), `${type} should be a non-entity`).toBe(true);
+      expect(isKnownType(type), type).toBe(false);
+    }
+  });
+
+  it('rejects the six EXPRESS TYPEs only the pin knows about', () => {
+    // The IDS-derived `IFC_DATA_TYPES` omits these six; `SCHEMA_REGISTRY.types`
+    // carries them. Subtracting only the first table left them accepted.
+    for (const type of TYPES_ONLY_IN_THE_PIN) {
+      expect(
+        IFC_DATA_TYPES.some((t) => t.name.toUpperCase() === type.toUpperCase()),
+        `${type} should be absent from IFC_DATA_TYPES`,
+      ).toBe(false);
+      expect(Object.keys(SCHEMA_REGISTRY.types)).toContain(type);
+      expect(isKnownType(type), type).toBe(false);
+    }
+  });
+
+  it('needs both tables and only those two, measured against the union', () => {
+    // Pins the contribution of each source, so dropping one is visible and
+    // adding a third that changes nothing is visible too.
+    const idsTable = new Set(IFC_DATA_TYPES.map((t) => t.name.toUpperCase()));
+    const contributes = (names: string[]) => UNION_UPPER_LIST.filter(
+      (upper) => !idsTable.has(upper) && names.includes(upper),
+    ).length;
+    const upperKeys = (o: Record<string, unknown>) => Object.keys(o).map((n) => n.toUpperCase());
+
+    expect(UNION_UPPER_LIST.filter((upper) => idsTable.has(upper))).toHaveLength(132);
+    expect(contributes(upperKeys(SCHEMA_REGISTRY.types))).toBe(6);
+    // Folded in for consistency, not for effect — asserted so the comment in
+    // `ifc-schema.ts` saying they subtract nothing stays true.
+    expect(contributes(upperKeys(SCHEMA_REGISTRY.enums))).toBe(0);
+    expect(contributes(upperKeys(SCHEMA_REGISTRY.selects))).toBe(0);
+  });
+
+  it('answers known-ness, not instantiability: abstract classes stay accepted (#2035)', () => {
+    // Pre-existing and deliberately unchanged here. `main` accepts 123 abstract
+    // classes through the pin; the union adds 19 more. Rejecting them is a
+    // different predicate, belongs at the authoring boundary rather than in a
+    // name-registry check, and is tracked separately — this test exists so the
+    // split is a recorded decision rather than an oversight, and it fails the
+    // day someone changes it without changing the contract.
+    for (const type of ['IfcProduct', 'IfcRoot', 'IfcRelationship', 'IfcObjectDefinition']) {
+      expect(getEntityMetadata(type)?.isAbstract, type).toBe(true);
+      expect(isKnownType(type), type).toBe(true);
+    }
+    for (const type of ['IfcPositioningElement', 'IfcFacilityPart', 'IfcSegment']) {
+      expect(getEntityMetadata(type), `${type} unexpectedly in the pin`).toBeUndefined();
+      expect(isKnownType(type), type).toBe(true);
+    }
+  });
+
+  it('is case-insensitive in both directions', () => {
+    for (const type of [...IFC2X3_ONLY, ...IFC4X3_ONLY, 'IfcWall']) {
+      expect(isKnownType(type.toUpperCase()), type).toBe(true);
+      expect(isKnownType(type.toLowerCase()), type).toBe(true);
+    }
+  });
+
+  it('accepts every union class except the non-entity declarations', () => {
+    const wrong = UNION_NAMES.filter(
+      (name) => isKnownType(name) === NON_ENTITIES.has(name.toUpperCase()),
+    );
+    expect(wrong).toEqual([]);
+  });
+});
+
+describe('normalizeIfcTypeName across the bundled schema union (#2003)', () => {
+  it('canonicalizes cross-schema classes from any casing', () => {
+    for (const type of [...IFC2X3_ONLY, ...IFC4X3_ONLY]) {
+      expect(normalizeIfcTypeName(type.toUpperCase()), type).toBe(type);
+      expect(normalizeIfcTypeName(type.toLowerCase()), type).toBe(type);
+      expect(normalizeIfcTypeName(type), type).toBe(type);
+    }
+  });
+
+  it('gives the pin the same answer it gave before, for every pinned class', () => {
+    // Union-first ordering may only fill the pin's gaps. If the two tables ever
+    // disagreed on a class's canonical spelling this would catch it.
+    const drifted = PINNED.filter(
+      (type) => normalizeIfcTypeName(type.toUpperCase()) !== getEntityMetadata(type)?.name,
+    );
+    expect(drifted).toEqual([]);
+  });
+
+  it('leaves unknown names untouched', () => {
+    for (const type of ['IfcWal', 'IfcAcmeVendorExtension', 'ifcacmevendorextension']) {
+      expect(normalizeIfcTypeName(type), type).toBe(type);
+    }
+  });
+
+  it('never renames a class to its supertype through the alias table', () => {
+    // `ENTITY_NAME_ALIASES` maps IFC4.3 stratum leaves to the abstract
+    // `IfcGeotechnicalStratum` the bundled schema does carry. That is the right
+    // answer for an inheritance walk and the wrong one for a name-canonicalizer:
+    // resolving it here would hand the caller back a different class.
+    for (const type of ['IfcSolidStratum', 'IfcVoidStratum', 'IfcWaterStratum']) {
+      expect(normalizeIfcTypeName(type), type).toBe(type);
+    }
+  });
+});

--- a/packages/sdk/src/context.test.ts
+++ b/packages/sdk/src/context.test.ts
@@ -5,6 +5,18 @@
 import { describe, it, expect, vi } from 'vitest';
 import { BimContext, createBimContext } from './context.js';
 import type { BimBackend, Transport } from './types.js';
+// Imported for its side effect: `./index.js` is what registers the parser's
+// schema check as `@ifc-lite/mutations`' entity-type normalizer. The
+// `#2003` suite at the bottom of this file exercises that wiring against a
+// real `StoreEditor`, so it has to be loaded, not assumed.
+import './index.js';
+import {
+  MutablePropertyView,
+  StoreEditor,
+  type IfcAttributeValue,
+  type MutationEntityRef,
+  type MutationStoreShape,
+} from '@ifc-lite/mutations';
 
 /** Create a mock typed BimBackend */
 function createMockBackend() {
@@ -642,5 +654,87 @@ describe('SpatialNamespace', () => {
       min: [3, 3, 3],
       max: [7, 7, 7],
     });
+  });
+});
+
+/**
+ * `bim.store.addEntity` for classes outside the parser's IFC4_ADD2_TC1 codegen
+ * pin (#2003).
+ *
+ * `./index.js` registers `isKnownType` + `normalizeIfcTypeName` as the entity-type
+ * normalizer for `@ifc-lite/mutations`, and `StoreNamespace.addEntity` gates on
+ * `isKnownType` again before forwarding. Both read the same lookup, so while it
+ * answered from the IFC4 pin alone the SDK could not author an IFC2X3-only or
+ * IFC4X3-only class at all: `addEntity('IfcRoad', …)` threw "unknown IFC type".
+ *
+ * The store here is a real `StoreEditor` over a real `MutablePropertyView`, so
+ * these exercise the whole path — SDK guard, normalizer, overlay record — not a
+ * spy's return value.
+ */
+describe('StoreNamespace.addEntity across the bundled schema union (#2003)', () => {
+  function realStoreBackend() {
+    const byId = new Map<number, MutationEntityRef>();
+    for (let id = 1; id <= 5; id++) {
+      byId.set(id, { expressId: id, type: 'IFCWALL', byteOffset: 0, byteLength: 1, lineNumber: id });
+    }
+    const store: MutationStoreShape = { entityIndex: { byId } };
+    const editor = new StoreEditor(store, new MutablePropertyView(null, 'arch'));
+    const mock = createMockBackend();
+    mock.store.addEntity.mockImplementation(
+      (modelId: string, def: { type: string; attributes: unknown[] }) => {
+        const created = editor.addEntity(def.type, def.attributes as IfcAttributeValue[]);
+        return { modelId, expressId: created.expressId };
+      },
+    );
+    return { bim: createBimContext({ backend: mock.backend }), editor };
+  }
+
+  it('authors an IFC2X3-only class the IFC4 pin dropped', () => {
+    const { bim, editor } = realStoreBackend();
+
+    const ref = bim.store.addEntity('arch', {
+      type: 'IfcScheduleTimeControl',
+      attributes: [null, null, null, null, null],
+    });
+
+    expect(ref.expressId).toBe(6);
+    expect(editor.getNewEntity(ref.expressId)?.type).toBe('IfcScheduleTimeControl');
+  });
+
+  it('authors an IFC4X3-only class the IFC4 pin never had, canonicalizing the caller casing', () => {
+    const { bim, editor } = realStoreBackend();
+
+    // UPPERCASE STEP token in, canonical PascalCase on the overlay record.
+    const ref = bim.store.addEntity('arch', { type: 'IFCROAD', attributes: [] });
+
+    expect(editor.getNewEntity(ref.expressId)?.type).toBe('IfcRoad');
+  });
+
+  it('rejects a typo at the SDK boundary, which is why the guard exists', () => {
+    const { bim, editor } = realStoreBackend();
+
+    expect(() => bim.store.addEntity('arch', { type: 'IfcWal', attributes: [] }))
+      .toThrow(/unknown IFC type 'IfcWal'/);
+    // A one-character slip off each of the cross-schema classes above, so
+    // widening the guard to "starts with Ifc" would fail here too.
+    expect(() => bim.store.addEntity('arch', { type: 'IfcRoadd', attributes: [] }))
+      .toThrow(/unknown IFC type/);
+    expect(() => bim.store.addEntity('arch', { type: 'IfcScheduleTimeControll', attributes: [] }))
+      .toThrow(/unknown IFC type/);
+    // An EXPRESS defined type is not an instantiable entity either.
+    expect(() => bim.store.addEntity('arch', { type: 'IfcLengthMeasure', attributes: [] }))
+      .toThrow(/unknown IFC type/);
+    expect(editor.getNewEntities()).toHaveLength(0);
+  });
+
+  it('rejects a typo at the mutations boundary too, through the registered normalizer', () => {
+    // The editor-level guard is the one that catches a caller who reaches
+    // `StoreEditor` directly. Its regex passes `IfcWal`; only the normalizer
+    // the SDK registered rejects it.
+    const { editor } = realStoreBackend();
+
+    expect(() => editor.addEntity('IfcWal', [])).toThrow(/not in the IFC schema registry/);
+    expect(() => editor.addEntity('IfcRoad', [])).not.toThrow();
+    expect(() => editor.addEntity('IfcMove', [])).not.toThrow();
   });
 });

--- a/scripts/api-surface.json
+++ b/scripts/api-surface.json
@@ -910,6 +910,7 @@
     "EpsgKind: type",
     "IFC_BUILDING_STOREY_ELEVATION_INDEX: const",
     "IFC_BUILDING_STOREY_PLACEMENT_INDEX: const",
+    "IFC_DATA_TYPES: const",
     "IFC_ENTITY_NAMES: const",
     "IfcAttributeInfo: interface",
     "IfcAttributeValue: type",


### PR DESCRIPTION
Closes the last open surface of #2003. #2014 fixed the CLI and MCP lookups; this one was missed because it is a different function.

## The bug

`isKnownType` delegates to `isKnownEntity`, which is backed by the IFC4_ADD2_TC1 codegen pin alone. `packages/sdk/src/index.ts` registers it as the entity-type normalizer for `@ifc-lite/mutations`, returning `''` when it answers false, so the class is rejected outright:

```
IfcMove                  isKnownType=false
IfcScheduleTimeControl   isKnownType=false
IfcRoad                  isKnownType=false
IfcSignal                isKnownType=false
IfcWall                  isKnownType=true
```

So `addEntity('IfcRoad', ...)` could not author a perfectly valid IFC4X3 class. `normalizeIfcTypeName` had the same blind spot in a quieter form: it falls through to "preserve as-is", so a cross-schema class silently kept whatever casing the caller typed instead of being canonicalised.

**251 classes are newly accepted, of which 100 are `IfcObjectDefinition`** — exactly the 23 IFC2X3 and 77 IFC4X3 counted in the issue.

## The trap that changed the fix

The bundled `ENTITIES_*` tables come from buildingSMART SchemaInfo dumps, which list **EXPRESS defined types as entity rows**. 132 of the 1159 union rows are `IfcLengthMeasure`, `IfcBoolean`, `IfcCountMeasure` and friends, none of them instantiable.

A naive "union, else pin" would therefore have made `addEntity('IfcLengthMeasure', ...)` legal: a false accept traded for the false reject, which is a worse bug than the one being fixed. The lookup subtracts `IFC_DATA_TYPES`, the authoritative generated table, rather than a heuristic. **0 of the 776 pinned classes appear in that table**, so the subtraction cannot change an IFC4 answer.

Six union rows are EXPRESS TYPEs the data-types table does not list (`IfcBinary`, `IfcArcIndex`, `IfcLineIndex`, `IfcComplexNumber`, `IfcCompoundPlaneAngleMeasure`, `IfcPropertySetDefinitionSet`) and are now accepted. That was a choice: a `!parent && !attributes && !abstract` heuristic would have caught them and would one day reject a real class, which is the worse failure.

## The guard still rejects typos, in both directions

Union rows answering `false` went 383 to 132, and those 132 are exactly the defined types. Rejection is proven with one-character slips off each newly-accepted class, so "starts with Ifc" would not pass: `IfcWal`, `IfcWalll`, `IfcRoadd`, `IfcRoa`, `IfcMov`, `IfcMovee`, `IfcSpaceProgramm`, `IfcBuildingElementWidget`, `Wall`, `IFC`, `''`. The SDK suite asserts `addEntity` throws for `IfcWal`, `IfcRoadd`, `IfcScheduleTimeControll` and `IfcLengthMeasure`, and that the overlay stayed empty.

## A surviving mutation exposed one of my own unfalsifiable tests

8 mutations, 7 killed. **M6 (remove the pin fallback) survived**, and it was worth chasing: the union covers all 776 pinned classes today, so the fallback is unreachable for them, and the assertion "accepts every class in the pin" was passing *through the fallback*. That is the test-that-cannot-fail shape, in a test written in this PR.

Fixed with a table-level assertion that reads `ENTITIES_*` and `IFC_DATA_TYPES` directly and proves the union alone resolves the whole pin. M7 (injecting `IFCWALL` into `IFC_DATA_TYPES` and rebuilding) kills that new test, and is also the case where the fallback stops being dead: a future regenerated data table naming a pinned class.

M3, the requested `return true` unconditionally, is killed by 5 tests.

## Found while sweeping, not fixed here

`packages/export/src/demesh-writer.ts:284` has the same bug family through a different function (`getAllAttributesForEntity`), so `findAttrIndex(ref.type, 'Representation')` returns null and the element is skipped as `no-representation-attribute`:

```
IfcSignal    pinnedAttrs=0  RepresentationIdx(pinned)=-1  RepresentationIdx(union)=6
IfcPavement  pinnedAttrs=0  RepresentationIdx(pinned)=-1  RepresentationIdx(union)=6
IfcWall      pinnedAttrs=9  RepresentationIdx(pinned)=6   RepresentationIdx(union)=6
```

Different published package, needs its own test and changeset. Filing separately rather than widening this PR.

## The naming footgun, recorded

This is the fifth time an author has reached for the pinned function by default: #2001, #2003, #2014 (two sites), and this PR (two more). Nobody picked the wrong one deliberately; the pinned one simply has the shorter, more obvious name.

Recommendation: **put the qualifier on the pinned function, not the union one.** `getInheritanceChainForEntity` becomes `getInheritanceChainInIfc4Pin`, and the union walkers take the plain names. The default should be the safe answer, and the pinned lookup is the special case that ought to say so. It is also the only variant whose name lies by omission today.

Not done here: the names are emitted by `packages/codegen/src/typescript-generator.ts` and asserted by string match in its tests, so the rename has to move through the generator and all three regenerated bundles, and all three are re-exported from `@ifc-lite/parser`, making it an api-surface change and a **major** on a package at or past 1.0. Recorded in the export comment in `packages/parser/src/index.ts`.

---

## Update after review

**The six residuals are now rejected too.** I had checked `@ifc-lite/data` for a defined-type list and stopped there; the authoritative table was in the package already imported. `SCHEMA_REGISTRY.types` is the pin's own EXPRESS TYPE map (397 entries), sitting beside the `SCHEMA_REGISTRY.enums` that `attribute-slot-types.ts` already uses, and it covers the six **exactly**, no more and no fewer. So this became a table-versus-table answer rather than table-versus-heuristic, and the original hold no longer applied. Rejected names went 132 to **138**. `.enums` and `.selects` are folded in as well; they subtract nothing today and a test pins that, so the comment saying so stays true.

**Abstract classes are split out as #2035, deliberately and with a test.** `isKnownType` answers "is this a real IFC class", and `IfcProduct` is one; what `addEntity` actually wants is `known && !abstract`. Overloading a published known-ness guard to mean instantiability would silently change the contract for every other consumer. It is also not a one-surface problem: nothing in the repo enforces abstractness today, so fixing it in `bim.store.addEntity` alone would leave direct `StoreEditor` and MCP `entity_create` still accepting `IfcProduct`. And 123 of the 142 are pre-existing on main, so 87% of that change is unrelated to #2003.

Rather than leave that as prose, there is a test asserting abstract classes stay accepted, referencing #2035. A mutation implementing the abstract rejection **fails it**, so the split is an enforced decision and whoever picks up #2035 is told by a red test that they are changing a contract.

Measured for the follow-up: across the 776 classes both sources carry, the pin's `isAbstract` and the union's `abstract` have **0 disagreements**, so there is no reconciliation problem waiting.

Verified independently after the change: the six are rejected, `IfcRoad`/`IfcSignal`/`IfcMove`/`IfcScheduleTimeControl`/`IfcWall` still accepted, `IfcWal`/`IfcRoadd`/`IfcLengthMeasure` still rejected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cross-schema IFC entity recognition across IFC2X3, IFC4, and IFC4X3.
  * Entity creation now supports schema-specific classes and canonicalizes type names regardless of case.
  * Added the `IFC_DATA_TYPES` export for synchronous type classification.

* **Bug Fixes**
  * Invalid, unsupported, vendor-extension, and non-instantiable type names are now rejected consistently.

* **Documentation**
  * Documented the new type data export and cross-schema behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->