### PR TITLE
ci(docker): build the server image on PRs that touch its Dockerfile

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -25,14 +25,19 @@ on:
   # shapely ship cp-tagged wheels), invisible because no PR ever built a
   # Dockerfile.
   #
-  # Deliberately narrower than the push paths: source changes are already
-  # covered by test.yml's "Validate Server Binary" jobs plus the post-merge
-  # build here, and ~1/3 of commits touch rust/**, so triggering a cold
-  # cargo-chef build on every such PR would buy runner hours for a lane whose
-  # only unique signal is "does this Dockerfile still build".
+  # Deliberately much narrower than the push paths. Over the last 6 months the
+  # push paths matched 447 commits and the Dockerfile alone matched ~6, so
+  # scoping to the Dockerfile is the difference between a Depot build on most
+  # PRs and roughly one a month. Source changes are already covered by
+  # test.yml's "Validate Server Binary" jobs plus the post-merge build here;
+  # the only unique signal this lane adds is "does the image still build".
+  #
+  # This workflow's own path is NOT listed: it would fire a full ~9 min image
+  # build on every dependabot actions-SHA bump (10 of the 31 commits that
+  # touched either file) for no build-relevant change. Use workflow_dispatch
+  # to exercise an edit to this file.
   pull_request:
     paths:
-      - '.github/workflows/docker.yml'
       - 'apps/server/Dockerfile'
   workflow_dispatch:
 
@@ -146,7 +151,12 @@ jobs:
           # fail and take the build down with it, on exactly the PRs this lane
           # exists to catch. PRs read the cache and never write it; main keeps
           # it warm.
-          cache-to: ${{ github.event_name == 'pull_request' && '' || format('type=registry,ref={0}:buildcache,mode=max,image-manifest=true,oci-mediatypes=true', env.CACHE_IMAGE) }}
+          #
+          # The condition is written "not pull_request && <value> || ''" and
+          # not the other way round on purpose: Actions has no ternary, and in
+          # `a && b || c` an empty-string b is FALSY, so putting '' in the b
+          # slot silently falls through to c and the cache export runs anyway.
+          cache-to: ${{ github.event_name != 'pull_request' && format('type=registry,ref={0}:buildcache,mode=max,image-manifest=true,oci-mediatypes=true', env.CACHE_IMAGE) || '' }}
           # Build arm64 only for actual releases (distribution images). On the
           # frequent push-to-main builds (~1/3 of commits touch rust/** and
           # trigger this workflow) we build amd64 only — the arm64 leg runs

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,6 +18,22 @@ on:
       - 'Cargo.toml'
       - 'apps/server/**'
       - 'rust/**'
+  # Build the image BEFORE merge when the Dockerfile itself changes. The push
+  # lane above only reports once a change has already landed on main, which is
+  # how #2008 reached review fully green — a python 3.12 -> 3.14 base bump
+  # whose requirements.lock could not resolve on the new interpreter (numpy /
+  # shapely ship cp-tagged wheels), invisible because no PR ever built a
+  # Dockerfile.
+  #
+  # Deliberately narrower than the push paths: source changes are already
+  # covered by test.yml's "Validate Server Binary" jobs plus the post-merge
+  # build here, and ~1/3 of commits touch rust/**, so triggering a cold
+  # cargo-chef build on every such PR would buy runner hours for a lane whose
+  # only unique signal is "does this Dockerfile still build".
+  pull_request:
+    paths:
+      - '.github/workflows/docker.yml'
+      - 'apps/server/Dockerfile'
   workflow_dispatch:
 
 concurrency:
@@ -86,6 +102,10 @@ jobs:
             type=raw,value=latest,event=tag
             # sha for push-to-main builds
             type=sha,prefix=,event=branch
+            # pr-123 for the build-only PR lane. Never pushed (see `push:`
+            # below); it just keeps the tag list non-empty so buildx has
+            # something to name the image.
+            type=ref,event=pr
 
       # The registry cache exporter requires a fully lowercase repository name
       # (OCI spec), but ${{ github.repository_owner }} preserves case
@@ -120,7 +140,13 @@ jobs:
           # *raise* compute minutes. image-manifest+oci-mediatypes make the
           # cache blob a GHCR-compatible OCI manifest (required for the registry
           # backend to push to ghcr.io).
-          cache-to: type=registry,ref=${{ env.CACHE_IMAGE }}:buildcache,mode=max,image-manifest=true,oci-mediatypes=true
+          #
+          # Empty on pull_request: a PR from a fork — and every Dependabot PR —
+          # runs with a read-only GITHUB_TOKEN, so exporting the cache would
+          # fail and take the build down with it, on exactly the PRs this lane
+          # exists to catch. PRs read the cache and never write it; main keeps
+          # it warm.
+          cache-to: ${{ github.event_name == 'pull_request' && '' || format('type=registry,ref={0}:buildcache,mode=max,image-manifest=true,oci-mediatypes=true', env.CACHE_IMAGE) }}
           # Build arm64 only for actual releases (distribution images). On the
           # frequent push-to-main builds (~1/3 of commits touch rust/** and
           # trigger this workflow) we build amd64 only — the arm64 leg runs


### PR DESCRIPTION
Closes the gap behind #2008 and #2009: `docker.yml` had no `pull_request` trigger, so **no PR in this repo ever built a Dockerfile**. Both bumps reached review fully green while nothing exercised what they changed - #2008 would have failed at `pip install` (numpy 2.0.2 has no cp313/cp314 wheel, shapely 2.0.7 no cp314, and the slim image has no compiler to fall back on).

For the record, since it came up: this trigger was never here and removed. #477 shipped the workflow with release/push/dispatch only, and the `push: ${{ github.event_name != \x27pull_request\x27 }}` guard has been vestigial boilerplate since day one. What did happen is two rounds of deliberate cost-cutting on this workflow, #981 and #1477.

**Cost, measured.** Over the last 6 months the push-lane paths matched **447** commits, Dockerfile-or-workflow matched **31**, and `apps/server/Dockerfile` alone matched **~6**. So the trigger is scoped to the Dockerfile only - roughly one build a month, ~9 min on the 4-core Depot runner. This workflow s own path is deliberately excluded: 10 of those 31 commits were dependabot actions-SHA bumps that would each fire a full image build for no build-relevant change. Use `workflow_dispatch` to exercise an edit to this file.

**No push, no cache write.** The `push:` guard already existed. `cache-to` is now empty on PRs, because fork and Dependabot PRs run with a read-only `GITHUB_TOKEN` and a cache export would fail the build on exactly the PRs this exists to catch.

The first version of that guard was wrong and the first run proved it: run 30795917428 passed the full `cache-to` and wrote the cache. Actions has no ternary, and in `a && b || c` an empty-string `b` is **falsy**, so `is_pr && \x27\x27 || format(...)` fell straight through to the format branch. Fixed by putting the non-empty value in the `&&` slot.

**Verification.** The first push proved the trigger fires and the image builds on a PR (green "Build & Push Docker Image", and I confirmed no `pr-*` tag reached GHCR - the registry has 0 tags). The corrected `cache-to` is **not** exercised by a run, because narrowing the paths means this workflow-only PR no longer triggers the lane; the next Dockerfile PR is its first real run. If it is still wrong the failure is a red check on that PR, not a prod issue.

Still uncovered: `packages/collab-server/Dockerfile` and `tools/ifcopenshell_reference/Dockerfile` are built by no workflow.