### PR TITLE
fix(export): resolve attribute slots across schemas, not the IFC4 pin (#2032)

### DIFF
--- a/.changeset/demesh-writer-ifc4x3-attr-index.md
+++ b/.changeset/demesh-writer-ifc4x3-attr-index.md
@@ -1,0 +1,11 @@
+---
+"@ifc-lite/export": patch
+---
+
+Stop silently dropping IFC4X3-only element types from de-meshed and LOD0 exports (#2032).
+
+Both `demesh-writer.ts` and `lod0-generator.ts` carried a private `findAttrIndex` that resolved positional attribute slots through the parser's IFC4-pinned registry. For a class that exists only in IFC4X3 — `IfcSignal`, `IfcPavement`, `IfcCourse` and the rest of the infrastructure additions — that registry returns nothing, so every attribute index came back null.
+
+In the de-mesh writer that meant `Representation` could not be located and the element was skipped with reason `no-representation-attribute`. In the LOD0 generator it meant `ObjectPlacement` could not be located and the element was dropped from the walk entirely, with no skip reason recorded anywhere — so an infrastructure model could lose elements from its LOD0 export with nothing in the output to say so.
+
+Both now resolve slots through the cross-schema union already used by `attribute-real-slots.ts` and `attribute-slot-types.ts`.

--- a/packages/export/src/demesh-writer.test.ts
+++ b/packages/export/src/demesh-writer.test.ts
@@ -196,6 +196,21 @@ describe('applySimplifiedGeometry', () => {
     // element #10's Representation was replaced, not skipped.
     expect(out).toMatch(/#10=IFC\w+\([^\n]*#\d+/);
     expect(danglingRefs(out)).toEqual([]);
+
+    // Write-and-reparse: `danglingRefs` only proves the text is internally
+    // consistent, not that a parser can read it back. Reparsing is what shows
+    // the element actually survives a round trip rather than merely appearing
+    // in the output. The class is not asserted here because the IFC4 target
+    // downcasts the IFC4X3-only IfcSignal on write (see above); what has to
+    // survive is #10 and its replaced representation.
+    const reparsed = await new IfcParser().parseColumnar(
+      new TextEncoder().encode(out).buffer,
+      { disableWorkerScan: true },
+    );
+    expect(reparsed.entityIndex.byId.has(10)).toBe(true);
+    const reparsedText = new TextDecoder().decode(reparsed.source);
+    expect(reparsedText).toMatch(/#10=IFC\w+\([^\n]*#\d+/);
+    expect(reparsedText).toMatch(/IFCTRIANGULATEDFACESET/);
   });
 
   it('keeps openings when stripOpenings is false', async () => {

--- a/packages/export/src/demesh-writer.test.ts
+++ b/packages/export/src/demesh-writer.test.ts
@@ -19,6 +19,34 @@ function danglingRefs(text: string): number[] {
   return [...refs].filter((id) => !defined.has(id)).sort((a, b) => a - b);
 }
 
+/**
+ * Entity types reachable from `startId` by following `#n` references.
+ *
+ * Asserting that an IFCTRIANGULATEDFACESET merely EXISTS in the output would
+ * also pass if #10 still pointed at its old representation and the new faceset
+ * were emitted as an orphan. Reachability is what actually ties the element to
+ * the geometry that replaced it.
+ */
+function typesReachableFrom(text: string, startId: number): Set<string> {
+  const lineById = new Map<number, string>();
+  for (const m of text.matchAll(/(?:^|\n)\s*#(\d+)\s*=\s*(IFC\w+)([^\n]*)/g)) {
+    lineById.set(+m[1], `${m[2]}${m[3]}`);
+  }
+  const seen = new Set<number>();
+  const types = new Set<string>();
+  const stack = [startId];
+  while (stack.length > 0) {
+    const id = stack.pop()!;
+    if (seen.has(id)) continue;
+    seen.add(id);
+    const line = lineById.get(id);
+    if (line === undefined) continue;
+    types.add(line.slice(0, line.indexOf('(')));
+    for (const r of line.matchAll(/#(\d+)/g)) stack.push(+r[1]);
+  }
+  return types;
+}
+
 const HEADER = `ISO-10303-21;
 HEADER;
 FILE_DESCRIPTION((''),'2;1');
@@ -210,7 +238,11 @@ describe('applySimplifiedGeometry', () => {
     expect(reparsed.entityIndex.byId.has(10)).toBe(true);
     const reparsedText = new TextDecoder().decode(reparsed.source);
     expect(reparsedText).toMatch(/#10=IFC\w+\([^\n]*#\d+/);
-    expect(reparsedText).toMatch(/IFCTRIANGULATEDFACESET/);
+
+    // Follow #10's reference chain rather than asserting the faceset exists
+    // somewhere: the weaker form would also pass if #10 kept its original
+    // representation and the tessellation were emitted unattached.
+    expect(typesReachableFrom(reparsedText, 10)).toContain('IFCTRIANGULATEDFACESET');
   });
 
   it('keeps openings when stripOpenings is false', async () => {

--- a/packages/export/src/demesh-writer.test.ts
+++ b/packages/export/src/demesh-writer.test.ts
@@ -85,6 +85,34 @@ const FIXTURE_SHARED = `${HEADER}
 #132=IFCDIRECTION((0.,0.,1.));
 ${FOOTER}`;
 
+// IFC4X3-only element (IfcSignal is not in the parser's IFC4-pinned
+// registry — packages/parser/src/generated/schema-registry.ts). Its
+// Representation attribute sits at positional index 6, same as IfcWall's,
+// but only the cross-schema union lookup (getAttributeNamesAcrossSchemas)
+// can find it.
+const FIXTURE_IFC4X3_SIGNAL = `ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''),'2;1');
+FILE_NAME('t.ifc','',(''),(''),'','','');
+FILE_SCHEMA(('IFC4X3'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('0proj00000000000000000',$,'P',$,$,$,$,(#7),#9);
+#5=IFCCARTESIANPOINT((0.,0.,0.));
+#6=IFCAXIS2PLACEMENT3D(#5,$,$);
+#7=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.E-05,#6,$);
+#8=IFCGEOMETRICREPRESENTATIONSUBCONTEXT('Body','Model',*,*,*,*,#7,$,.MODEL_VIEW.,$);
+#9=IFCUNITASSIGNMENT((#91));
+#91=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+#10=IFCSIGNAL('0sig10000000000000000',$,'S',$,$,$,#100,$,$);
+#100=IFCPRODUCTDEFINITIONSHAPE($,$,(#110));
+#110=IFCSHAPEREPRESENTATION(#8,'Body','SweptSolid',(#120));
+#120=IFCEXTRUDEDAREASOLID(#130,#131,#132,2.);
+#130=IFCRECTANGLEPROFILEDEF(.AREA.,$,$,1.,1.);
+#131=IFCAXIS2PLACEMENT3D(#5,$,$);
+#132=IFCDIRECTION((0.,0.,1.));
+${FOOTER}`;
+
 /** Unit tetrahedron in the element's local frame (file units). */
 const TETRA = {
   positions: [0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1],
@@ -147,6 +175,26 @@ describe('applySimplifiedGeometry', () => {
     expect(out).toMatch(/#8=IFCGEOMETRICREPRESENTATIONSUBCONTEXT/);
     expect(out).toMatch(/#5=IFCCARTESIANPOINT/);
 
+    expect(danglingRefs(out)).toEqual([]);
+  });
+
+  it('replaces the representation on an IFC4X3-only element type (attribute index resolved across schemas)', async () => {
+    const { store, view, editor } = await loadStore(FIXTURE_IFC4X3_SIGNAL);
+    const report = applySimplifiedGeometry(store, editor, [{ expressId: 10, ...TETRA }]);
+
+    // Bug #2032: findAttrIndex used the IFC4-pinned attribute table, under
+    // which IfcSignal (an IFC4X3 leaf) has zero known attributes, so the
+    // Representation slot was never found and the element was silently
+    // skipped with 'no-representation-attribute'.
+    expect(report.skipped).toEqual([]);
+    expect(report.replaced).toEqual([10]);
+
+    const out = exportText(store, view);
+    expect(out).toMatch(/IFCTRIANGULATEDFACESET/);
+    // The exporter targets IFC4 in this test and downcasts the IFC4X3-only
+    // IfcSignal on write (unrelated to this fix); what matters is that
+    // element #10's Representation was replaced, not skipped.
+    expect(out).toMatch(/#10=IFC\w+\([^\n]*#\d+/);
     expect(danglingRefs(out)).toEqual([]);
   });
 

--- a/packages/export/src/demesh-writer.ts
+++ b/packages/export/src/demesh-writer.ts
@@ -25,7 +25,7 @@
  * path).
  */
 
-import { EntityExtractor, getAllAttributesForEntity, type IfcDataStore } from '@ifc-lite/parser';
+import { EntityExtractor, getAttributeNamesAcrossSchemas, type IfcDataStore } from '@ifc-lite/parser';
 import { pruneReplacedSubgraphs } from './demesh-prune.js';
 import { stepReal } from './step-serialization.js';
 
@@ -282,9 +282,13 @@ function findBodyContextId(
 }
 
 function findAttrIndex(typeName: string, attrName: string): number | null {
-  const attrs = getAllAttributesForEntity(typeName);
-  if (!attrs || attrs.length === 0) return null;
-  const idx = attrs.findIndex((a) => a?.name === attrName);
+  // Cross-schema union, not just the parser's IFC4-pinned registry —
+  // otherwise IFC4X3-only leaves (IfcSignal, IfcPavement, IfcCourse, …)
+  // resolve zero attributes and every element of that type is silently
+  // skipped as 'no-representation-attribute' (#2032).
+  const names = getAttributeNamesAcrossSchemas(typeName);
+  if (!names || names.length === 0) return null;
+  const idx = names.indexOf(attrName);
   return idx >= 0 ? idx : null;
 }
 

--- a/packages/export/src/lod0-generator.test.ts
+++ b/packages/export/src/lod0-generator.test.ts
@@ -26,6 +26,17 @@ DATA;
 ENDSEC;
 END-ISO-10303-21;`;
 
+// #2032's sibling: `findAttrIndex` used the IFC4-pinned registry, so an
+// IFC4X3-only leaf resolved zero attributes, `ObjectPlacement` came back
+// null, and the walk's `continue` dropped the element from the export
+// entirely — silently, with no skip reason recorded anywhere.
+const IFC4X3_SIGNAL = IFC_WITH_BOUNDING_BOX
+  .replace("FILE_SCHEMA(('IFC4'))", "FILE_SCHEMA(('IFC4X3'))")
+  .replace(
+    "#40=IFCWALL('wall-guid',$,'Wall; with semicolon',$,$,#10,#30,$,.NOTDEFINED.);",
+    "#40=IFCSIGNAL('signal-guid',$,'Signal',$,$,#10,#30,$,$);",
+  );
+
 describe('generateLod0', () => {
   it('uses the shared IFC scanner and preserves quoted semicolons in element names', async () => {
     const lod0 = await generateLod0(new TextEncoder().encode(IFC_WITH_BOUNDING_BOX));
@@ -41,6 +52,16 @@ describe('generateLod0', () => {
     expect(lod0.elements[0].bbox).toEqual({
       min: [10, 20, 30],
       max: [12, 23, 34],
+    });
+  });
+  it('includes an IFC4X3-only element rather than silently dropping it (#2032 sibling)', async () => {
+    const lod0 = await generateLod0(new TextEncoder().encode(IFC4X3_SIGNAL));
+
+    expect(lod0.elements).toHaveLength(1);
+    expect(lod0.elements[0]).toMatchObject({
+      expressID: 40,
+      globalId: 'signal-guid',
+      ifcClass: 'IFCSIGNAL',
     });
   });
 });

--- a/packages/export/src/lod0-generator.ts
+++ b/packages/export/src/lod0-generator.ts
@@ -5,7 +5,7 @@
 import {
   EntityExtractor,
   extractLengthUnitScale,
-  getAllAttributesForEntity,
+  getAttributeNamesAcrossSchemas,
   scanIfcEntities,
 } from '@ifc-lite/parser';
 
@@ -47,9 +47,15 @@ function buildEntityIndex(entityRefs: EntityRef[]): Index {
 }
 
 function findAttrIndex(typeName: string, attrName: string): number | null {
-  const attrs = getAllAttributesForEntity(typeName);
-  if (!attrs || attrs.length === 0) return null;
-  const idx = attrs.findIndex((a) => a?.name === attrName);
+  // Cross-schema union, not the parser's IFC4-pinned registry. With the
+  // pinned lookup an IFC4X3-only leaf (IfcSignal, IfcPavement, IfcCourse, …)
+  // resolves zero attributes, so `ObjectPlacement` comes back null and the
+  // element is dropped from the LOD0 export entirely by the `continue` at the
+  // top of the walk — silently, with no skip reason recorded. Same defect as
+  // #2032 in demesh-writer.ts, which shared this helper verbatim.
+  const names = getAttributeNamesAcrossSchemas(typeName);
+  if (!names || names.length === 0) return null;
+  const idx = names.indexOf(attrName);
   return idx >= 0 ? idx : null;
 }
 


### PR DESCRIPTION
Closes #2032, and fixes a second instance of the same bug that the issue didn't name.

## The reported bug

`demesh-writer.ts`'s `findAttrIndex` resolved positional attribute slots through the parser's IFC4-pinned registry. For a class that exists only in IFC4X3 — `IfcSignal`, `IfcPavement`, `IfcCourse`, the infrastructure additions — that registry returns nothing, so `Representation` resolved to `null` and every element of that type was skipped with reason `no-representation-attribute`.

## The one it didn't name, and it's worse

Grepping for the shape turned up `lod0-generator.ts` carrying a **byte-identical** copy of the helper. There the null index is `ObjectPlacement`, and the walk treats that as `continue` — so the element is dropped from the LOD0 export **entirely, with no skip reason recorded anywhere**.

The de-mesh case at least leaves a trace in `report.skipped`. The LOD0 case leaves nothing: an infrastructure model can lose elements from its LOD0 output with no indication in the result that anything was omitted. Worth fixing in the same PR since it's literally the same function.

Both now use `getAttributeNamesAcrossSchemas` — the cross-schema union already used by `attribute-real-slots.ts`, `attribute-slot-types.ts` and #2033's Tag-hashing fix, so this follows an established convention rather than inventing one.

## Evidence

Each fix is pinned **separately**, so neither test stands in for the other:

| mutation | result |
|---|---|
| de-mesh writer back to the pinned lookup | its IFC4X3 test fails, and only it |
| LOD0 back to the pinned lookup | its IFC4X3 test fails, and only it |

**333 passed / 29 skipped**, up from 331 baseline — the two new tests.

## Found but deliberately not fixed

Same pinned lookup, lower severity, reported rather than swept in:

- `unit-normalize.ts:147` and `select-qualification.ts:77` — both degrade gracefully (empty plan, or left to the default serializer) rather than dropping content
- `mcp/tools/discovery.ts:242` — affects an info tool's attribute listing, not exported data

Happy to take those as a follow-up if you'd rather they were consistent, but they aren't data-integrity bugs and I'd rather not widen a fix PR on my own judgement.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed IFC4X3 infrastructure elements being omitted from de-meshed and LOD0 exports.
  * IFC4X3 signal elements now retain their expected identifiers, class information, and tessellated geometry during export.

* **Tests**
  * Added regression coverage for IFC4X3 signal exports in both de-meshed and LOD0 workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->