### PR TITLE
fix(sdk,parser): reject abstract IFC classes at the authoring boundary (#2035)

### DIFF
--- a/.changeset/addentity-rejects-abstract-types.md
+++ b/.changeset/addentity-rejects-abstract-types.md
@@ -1,5 +1,5 @@
 ---
-"@ifc-lite/parser": patch
+"@ifc-lite/parser": minor
 "@ifc-lite/sdk": patch
 ---
 

--- a/.changeset/addentity-rejects-abstract-types.md
+++ b/.changeset/addentity-rejects-abstract-types.md
@@ -1,0 +1,10 @@
+---
+"@ifc-lite/parser": patch
+"@ifc-lite/sdk": patch
+---
+
+`bim.store.addEntity` and the MCP `entity_create` tool now reject abstract IFC classes (#2035).
+
+`IfcProduct`, `IfcRoot`, `IfcRelationship` and the other ~123 EXPRESS `ABSTRACT SUPERTYPE`s are real classes, so the existing `isKnownType` guard accepted them — `addEntity('IfcProduct', …)` wrote `#N=IFCPRODUCT(...)` into the overlay and out to the exported file, which is not valid IFC.
+
+`@ifc-lite/parser` now exports `isInstantiable(type)`, answering `known && !abstract` from the same cross-schema union (2X3 + 4 + 4X3) `isKnownType` already resolves against. `@ifc-lite/sdk` wires it into both the `bim.store.addEntity` guard and the shared entity-type normalizer that `@ifc-lite/mutations`' `StoreEditor.addEntity` consumes — the same choke point the MCP `entity_create` tool goes through via `ensureEditor()`. Passing an abstract type now throws instead of silently authoring an invalid STEP record.

--- a/docs/api/typescript.md
+++ b/docs/api/typescript.md
@@ -241,7 +241,16 @@ class RelationshipGraphBuilder { /* build(): RelationshipGraph */ }
 
 Each table type also has `fromColumns` / `toColumns` helpers for structured-clone transfer across workers (`entityTableFromColumns`, `propertyTableToColumns`, ...). Shared enums and types live here too: `IfcTypeEnum`, `PropertyValueType`, `QuantityType`, `RelationshipType`, `SpatialHierarchy`, `IfcStoreBase`, the generated entity-name lists (`ENTITIES_IFC2X3` / `IFC4` / `IFC4X3`), plus utilities like `safeUtf8Decode` and `createLogger`.
 
-`IFC_DATA_TYPES` sits alongside those entity lists: the raw, read-only table of EXPRESS **defined types** (`IfcLengthMeasure`, `IfcBoolean`, `IfcTextAlignment`, ...) across all three schemas. The upstream data the `ENTITIES_*` lists come from carries defined types as entity rows, so any synchronous consumer deciding "is this name a class I may instantiate?" has to subtract this table — that is what `@ifc-lite/parser`'s `isKnownType` does. Prefer the async `findDataType(version, name)` when you only need a single lookup and are not inside a synchronous guard.
+`IFC_DATA_TYPES` sits alongside those entity lists: the raw, read-only table of EXPRESS **defined types** (`IfcLengthMeasure`, `IfcBoolean`, `IfcTextAlignment`, ...) across all three schemas. The upstream data the `ENTITIES_*` lists come from carries defined types as entity rows, so any synchronous consumer deciding "is this name a real class?" has to subtract this table — that is what `@ifc-lite/parser`'s `isKnownType` does. Prefer the async `findDataType(version, name)` when you only need a single lookup and are not inside a synchronous guard.
+
+`@ifc-lite/parser` exports two type predicates, and they answer different questions:
+
+| predicate | question | `IfcWall` | `IfcProduct` | `IfcLengthMeasure` |
+| --- | --- | --- | --- | --- |
+| `isKnownType` | is this a real EXPRESS entity name? | `true` | `true` | `false` |
+| `isInstantiable` | may I author an entity of this class? | `true` | `false` | `false` |
+
+`IfcProduct` is the distinction: it is a real class, so `isKnownType` accepts it, but it is an EXPRESS `ABSTRACT SUPERTYPE` and cannot legally exist as an instance. Roughly 123 classes are abstract in this way. **Use `isInstantiable` for anything that creates entities** (`bim.store.addEntity`, the MCP `entity_create` tool); `isKnownType` is for recognising a name you have read, not for authoring. Both resolve across the union of the bundled schemas, so IFC4X3-only classes such as `IfcSignal` behave the same under either.
 
 ---
 

--- a/packages/mcp/src/overlay.test.ts
+++ b/packages/mcp/src/overlay.test.ts
@@ -240,6 +240,31 @@ describe('model_diff over queued mutations', () => {
     expect(out.contentDiff?.pendingMutationsBySide).toEqual({ base: 0, head: 2 });
   }, 30_000);
 
+  it('entity_create rejects an abstract IFC type (#2035)', async () => {
+    await session();
+    const tool = ALL_TOOLS.find((t) => t.name === 'entity_create');
+    if (!tool) throw new Error('entity_create not registered');
+
+    // `IfcProduct` is a real EXPRESS class (so a known-ness check alone
+    // accepts it) but an ABSTRACT SUPERTYPE — instantiating it would write
+    // `#N=IFCPRODUCT(...)` into the exported file, which is not valid IFC.
+    // `entity_create` calls `StoreEditor.addEntity` directly (not through
+    // the SDK's `bim.store.addEntity` wrapper), so it throws rather than
+    // returning an `isError` result — the tool-call wrapper that would
+    // catch this and shape it into a `CallToolResult` sits above the raw
+    // handler invoked here.
+    await expect(async () =>
+      tool.handler({ model_id: 'head', type: 'IfcProduct', attributes: [] }, ctx),
+    ).rejects.toThrow(/not in the IFC schema registry/);
+
+    // A concrete subtype of the same abstract class still works.
+    await call('entity_create', {
+      model_id: 'head',
+      type: 'IfcWall',
+      attributes: [`'${guid('WALD')}'`, null, "'Wall D'", null, null, '#40', null, "'tagD'", null],
+    });
+  }, 30_000);
+
   it('content-matches a created entity against the one it replaces', async () => {
     await session();
     // The re-GUID the flag exists for, performed through the mutation tools:

--- a/packages/parser/src/ifc-schema.ts
+++ b/packages/parser/src/ifc-schema.ts
@@ -168,13 +168,37 @@ export function getAttributeNamesAcrossSchemas(type: string): string[] {
  * rejected.
  *
  * Known-ness, not instantiability: abstract supertypes (`IfcProduct`,
- * `IfcRoot`) answer `true`, as they always have. Rejecting those is a separate,
- * pre-existing question tracked in #2035 — it is a different predicate and it
- * belongs at the authoring boundary, not in a name-registry check.
+ * `IfcRoot`) answer `true`, as they always have — that is a different
+ * predicate, {@link isInstantiable}, and it belongs at the authoring
+ * boundary, not in a name-registry check (#2035).
  */
 export function isKnownType(type: string): boolean {
     if (getEntityInfoAcrossSchemas(type)) return true;
     return isKnownEntity(type);
+}
+
+/**
+ * Check whether a type is a real IFC entity class that can actually be
+ * instantiated — `known && !abstract`.
+ *
+ * {@link isKnownType} answers a different question ("is this a real EXPRESS
+ * class name") and always has: `IfcProduct`, `IfcRoot` and `IfcRelationship`
+ * are real classes and abstract EXPRESS supertypes, so `isKnownType` answers
+ * `true` for them, and authoring code that only checked known-ness could
+ * write `#N=IFCPRODUCT(...)` into an exported file, which is not valid IFC
+ * (#2035).
+ *
+ * Same union-first, pin-second resolution order as {@link isKnownType}: the
+ * bundled schema union's `abstract` flag and the codegen pin's `isAbstract`
+ * flag agree on every class both know, so there is no reconciliation
+ * question, only which table happens to carry the name.
+ */
+export function isInstantiable(type: string): boolean {
+    const info = getEntityInfoAcrossSchemas(type);
+    if (info) return !info.abstract;
+    const metadata = getEntityMetadata(type);
+    if (metadata) return !metadata.isAbstract;
+    return false;
 }
 
 /**

--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -141,7 +141,7 @@ export * from './types.js';
 // (`…ForEntityInIfc4Pin`), leaving the union walker the plain name, so the easy
 // choice is the safe one. That is a rename across every consumer and does not
 // belong in a fix PR; it needs its own.
-export { getAttributeNames, getAttributeNamesAcrossSchemas, getAttributeNameAt, isKnownType, normalizeIfcTypeName, resolveEntityNameAlias, getInheritanceChain as getInheritanceChainAcrossSchemas } from './ifc-schema.js';
+export { getAttributeNames, getAttributeNamesAcrossSchemas, getAttributeNameAt, isKnownType, isInstantiable, normalizeIfcTypeName, resolveEntityNameAlias, getInheritanceChain as getInheritanceChainAcrossSchemas } from './ifc-schema.js';
 
 import type { IfcEntity, ParseResult } from './types.js';
 import { EntityIndexBuilder } from './entity-index.js';

--- a/packages/parser/test/instantiable-across-schemas.test.ts
+++ b/packages/parser/test/instantiable-across-schemas.test.ts
@@ -1,0 +1,55 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `isInstantiable` answers `known && !abstract`, the predicate an authoring
+ * boundary actually needs (#2035).
+ *
+ * `isKnownType` answers a different question — "is this a real EXPRESS class
+ * name" — and always has: it says `true` for `IfcProduct`, `IfcRoot` and
+ * `IfcRelationship`, which are real classes but EXPRESS `ABSTRACT
+ * SUPERTYPE`s. Before `isInstantiable` existed, nothing separated "real
+ * class" from "instantiable class", so `@ifc-lite/sdk`'s `addEntity` guard
+ * (which only checked `isKnownType`) would accept `addEntity('IfcProduct',
+ * …)` and write an invalid `#N=IFCPRODUCT(...)` STEP record.
+ *
+ * Resolves across the bundled schema union (2X3 + 4 + 4X3) first, falling
+ * back to the codegen pin — same order as `isKnownType` — so an
+ * IFC4X3-only concrete class (`IfcRoad`) is not mistaken for abstract just
+ * because the pin doesn't carry it.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { isInstantiable, isKnownType } from '../src/ifc-schema.js';
+
+describe('isInstantiable (#2035)', () => {
+  it('rejects abstract EXPRESS supertypes that isKnownType accepts', () => {
+    for (const type of ['IfcProduct', 'IfcRoot', 'IfcRelationship', 'IfcElement', 'IfcSpatialStructureElement']) {
+      expect(isKnownType(type), `${type} should still be known`).toBe(true);
+      expect(isInstantiable(type), `${type} should not be instantiable`).toBe(false);
+    }
+  });
+
+  it('accepts concrete leaf classes', () => {
+    for (const type of ['IfcWall', 'IfcDoor', 'IfcWindow', 'IfcBeam']) {
+      expect(isInstantiable(type)).toBe(true);
+    }
+  });
+
+  it('accepts a concrete class outside the IFC4 codegen pin (cross-schema union)', () => {
+    // IfcRoad is IFC4X3-only infrastructure and concrete.
+    expect(isKnownType('IfcRoad')).toBe(true);
+    expect(isInstantiable('IfcRoad')).toBe(true);
+  });
+
+  it('rejects an unknown name (typo) the same way isKnownType does', () => {
+    expect(isKnownType('IfcWal')).toBe(false);
+    expect(isInstantiable('IfcWal')).toBe(false);
+  });
+
+  it('rejects an EXPRESS defined type, which is not an entity at all', () => {
+    expect(isKnownType('IfcLengthMeasure')).toBe(false);
+    expect(isInstantiable('IfcLengthMeasure')).toBe(false);
+  });
+});

--- a/packages/sdk/src/context.test.ts
+++ b/packages/sdk/src/context.test.ts
@@ -738,3 +738,65 @@ describe('StoreNamespace.addEntity across the bundled schema union (#2003)', () 
     expect(() => editor.addEntity('IfcMove', [])).not.toThrow();
   });
 });
+
+/**
+ * `bim.store.addEntity` must refuse abstract EXPRESS supertypes (#2035).
+ *
+ * `IfcProduct`, `IfcRoot` and `IfcRelationship` are real classes, so
+ * `isKnownType` (the pre-existing guard) answers `true` for them — but they
+ * are EXPRESS `ABSTRACT SUPERTYPE`s and cannot be instantiated. Before this
+ * fix `addEntity('IfcProduct', …)` wrote `#N=IFCPRODUCT(...)` into the
+ * overlay, which is not valid IFC on export.
+ */
+describe('StoreNamespace.addEntity rejects abstract IFC classes (#2035)', () => {
+  function realStoreBackend() {
+    const byId = new Map<number, MutationEntityRef>();
+    for (let id = 1; id <= 5; id++) {
+      byId.set(id, { expressId: id, type: 'IFCWALL', byteOffset: 0, byteLength: 1, lineNumber: id });
+    }
+    const store: MutationStoreShape = { entityIndex: { byId } };
+    const editor = new StoreEditor(store, new MutablePropertyView(null, 'arch'));
+    const mock = createMockBackend();
+    mock.store.addEntity.mockImplementation(
+      (modelId: string, def: { type: string; attributes: unknown[] }) => {
+        const created = editor.addEntity(def.type, def.attributes as IfcAttributeValue[]);
+        return { modelId, expressId: created.expressId };
+      },
+    );
+    return { bim: createBimContext({ backend: mock.backend }), editor };
+  }
+
+  it('rejects IfcProduct at the SDK boundary', () => {
+    const { bim, editor } = realStoreBackend();
+
+    expect(() => bim.store.addEntity('arch', { type: 'IfcProduct', attributes: [] }))
+      .toThrow(/abstract IFC type/);
+    expect(editor.getNewEntities()).toHaveLength(0);
+  });
+
+  it('rejects IfcRoot and IfcRelationship, and still authors a concrete subtype', () => {
+    const { bim, editor } = realStoreBackend();
+
+    expect(() => bim.store.addEntity('arch', { type: 'IfcRoot', attributes: [] }))
+      .toThrow(/abstract IFC type/);
+    expect(() => bim.store.addEntity('arch', { type: 'IfcRelationship', attributes: [] }))
+      .toThrow(/abstract IFC type/);
+
+    // A concrete subtype of the same abstract classes still works.
+    const ref = bim.store.addEntity('arch', {
+      type: 'IfcWall',
+      attributes: [null, null, null, null, null, null, null, null],
+    });
+    expect(editor.getNewEntity(ref.expressId)?.type).toBe('IfcWall');
+  });
+
+  it('rejects an abstract class at the mutations boundary too, through the registered normalizer', () => {
+    // Mirrors the typo test above: the editor-level regex guard has no
+    // concept of abstractness, only the normalizer the SDK registers does.
+    const { editor } = realStoreBackend();
+
+    expect(() => editor.addEntity('IfcProduct', [])).toThrow(/not in the IFC schema registry/);
+    expect(() => editor.addEntity('IfcWall', [null, null, null, null, null, null, null, null]))
+      .not.toThrow();
+  });
+});

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -32,13 +32,22 @@
 // the parser's registry helpers at SDK load time we promote that to
 // a full schema-registry check — typos like `IfcWal` get rejected,
 // and callers see canonical PascalCase on `EntityRef.type`.
-import { normalizeIfcTypeName, isKnownType } from '@ifc-lite/parser';
+import { normalizeIfcTypeName, isKnownType, isInstantiable } from '@ifc-lite/parser';
 import { setEntityTypeNormalizer } from '@ifc-lite/mutations';
 setEntityTypeNormalizer((type) => {
   // Reject anything the schema registry doesn't know about. Vendor
   // extensions are intentionally not allowed via this path — scripts
   // should consume the raw-attribute API for those.
   if (!isKnownType(type)) return '';
+  // Reject abstract EXPRESS supertypes (IfcProduct, IfcRoot,
+  // IfcRelationship, ...). They are real classes, so `isKnownType` alone
+  // accepts them, but they cannot be instantiated: writing
+  // `#N=IFCPRODUCT(...)` produces a STEP record that isn't valid IFC
+  // (#2035). This is the single choke point every authoring boundary
+  // funnels through (SDK `store.addEntity`, `StoreEditor.addEntity` for
+  // direct callers, and the MCP `entity_create` tool via `ensureEditor()`),
+  // so the check belongs here rather than duplicated at each call site.
+  if (!isInstantiable(type)) return '';
   return normalizeIfcTypeName(type);
 });
 

--- a/packages/sdk/src/namespaces/store.ts
+++ b/packages/sdk/src/namespaces/store.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { isKnownType, normalizeIfcTypeName } from '@ifc-lite/parser';
+import { isInstantiable, isKnownType, normalizeIfcTypeName } from '@ifc-lite/parser';
 import type {
   AddBeamInStoreParams,
   AddColumnInStoreParams,
@@ -71,6 +71,18 @@ export class StoreNamespace {
     if (!isKnownType(def.type)) {
       throw new TypeError(
         `addEntity: unknown IFC type '${def.type}'. Pass a canonical PascalCase name (e.g. 'IfcWall').`,
+      );
+    }
+    // `isKnownType` answers "is this a real EXPRESS class" — it says yes for
+    // abstract supertypes (IfcProduct, IfcRoot, IfcRelationship, ...) too,
+    // since they are real classes, just not instantiable ones. Rejecting
+    // those here, before the backend call, gives a caller a useful error
+    // instead of a downstream STEP-emit failure or (absent this check) a
+    // silently invalid `#N=IFCPRODUCT(...)` record in the exported file
+    // (#2035).
+    if (!isInstantiable(def.type)) {
+      throw new TypeError(
+        `addEntity: '${def.type}' is an abstract IFC type and cannot be instantiated directly. Pass a concrete subtype instead.`,
       );
     }
     return this.backend.store.addEntity(modelId, {

--- a/scripts/api-surface.json
+++ b/scripts/api-surface.json
@@ -3493,6 +3493,7 @@
     "groupElementsByClassification: function",
     "isEntityRef: function",
     "isEnumValue: function",
+    "isInstantiable: function",
     "isKnownEntity: function",
     "isKnownType: function",
     "measureUnit: function",


### PR DESCRIPTION
Closes #2035.

`addEntity` guarded only with `isKnownType`, which answers *"is this a real EXPRESS name"* — and that is `true` for the **123 abstract supertypes** on the IFC4 pin. So `addEntity('IfcProduct')` succeeded and wrote an entity that cannot legally exist. Through MCP it's visible end to end: `entity_create` reported `Created IfcProduct as #85.` and left an invalid STEP record in the overlay.

## The fix

`isInstantiable` — `known && !abstract` — resolved **cross-schema-union first, pin second**, matching how `isKnownType` already resolves so IFC4X3-only classes behave identically under both predicates. Both doc comments now state which question each answers, because the next person reaching for a type guard here will otherwise reach for `isKnownType` again.

Applied at the shared `setEntityTypeNormalizer` callback — the single choke point that `StoreEditor.addEntity` and therefore MCP's `entity_create` both pass through — plus a direct pre-check in `bim.store.addEntity` for a clearer `TypeError`. Guarding only the SDK surface would have left the MCP path open, which is where the invalid record above came from.

## Over-rejection was the actual risk, so it was measured

Rejecting too much would be worse than the bug. Checked explicitly rather than inferred from a green suite:

- **still instantiable (17/17):** `IfcWall`, `IfcWallStandardCase`, `IfcDoor`, `IfcWindow`, `IfcSlab`, `IfcColumn`, `IfcBeam`, `IfcSpace`, `IfcBuildingStorey`, `IfcBuilding`, `IfcSite`, `IfcProject`, `IfcFurnitureType`, `IfcPropertySet`, and the IFC4X3-only `IfcSignal` / `IfcPavement` / `IfcCourse` that #2031 taught `addEntity` to author
- **correctly refused:** `IfcProduct`, `IfcRoot`, `IfcObject`, `IfcElement`, `IfcBuildingElement`

## Evidence

RED first — the pre-fix MCP test genuinely produced `Created IfcProduct as #85.` Neutralising the rejection afterwards fails exactly the normalizer test and nothing else.

parser **353**, sdk **62**, mcp **177**, typecheck 34/34.

Same-shape grep: both production `isKnownType` call sites (`sdk/src/index.ts:41`, `sdk/src/namespaces/store.ts:71`) now carry the `isInstantiable` check alongside — no orphaned twin left, which is the pattern that bit us on #2032.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Entity creation now rejects abstract IFC types with a clear error instead of producing invalid records.
  * Concrete IFC entities, such as `IfcWall`, continue to be created successfully.
  * Rejected entities no longer modify editor state.

* **New Features**
  * Added validation to identify whether an IFC type can be instantiated across supported schemas.
  * Added consistent abstract-type validation across SDK and entity creation tools.

* **Documentation**
  * Clarified the distinction between known IFC types and instantiable entity types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->