### PR TITLE
fix(mutations): drop component ops for a tombstoned entity (#2048)

### DIFF
--- a/.changeset/tombstone-entity-drops-components.md
+++ b/.changeset/tombstone-entity-drops-components.md
@@ -1,0 +1,9 @@
+---
+"@ifc-lite/mutations": patch
+---
+
+Drop component ops for entities whose final change-set state is `tombstone-entity` (#2048).
+
+`changeSetToOps` folds `entityOps` (last-write-wins per entity) and `components` (per componentKey) in the same pass over the mutation list, but previously emitted every accumulated component op regardless of whether the entity ended up deleted. A `CREATE_PROPERTY` mutation followed later by `DELETE_ENTITY` for the same entity produced both a `tombstone-entity` op and a `set-component` op carrying the now-meaningless property values — which `apps/viewer`'s `buildDeltaNodes` merged onto the same `IfcxNode`, publishing live property values alongside `IFCLITE_ATTR.DELETED: true`.
+
+Component ops are now filtered against each entity's final `entityOps` state after both passes complete (not during the fold, since an entity's terminal state — LWW — is only known once the whole mutation list has been consumed). An entity tombstoned and then recreated in the same change set keeps its components, since `entityOps` resolves to `add-entity` for that identity.

--- a/packages/mutations/src/change-set-to-ops.test.ts
+++ b/packages/mutations/src/change-set-to-ops.test.ts
@@ -29,7 +29,14 @@ function changeSet(mutations: Mutation[]): ChangeSet {
 }
 
 const resolver: EntityIdentityResolver = {
-  globalIdOf: (expressId) => (expressId === 42 ? '3fAx$GlobalId42' : undefined),
+  globalIdOf: (expressId) => {
+    if (expressId === 42) return '3fAx$GlobalId42';
+    if (expressId === 5) return '3fAx$GlobalId05';
+    if (expressId === 6) return '3fAx$GlobalId06';
+    if (expressId === 9) return '3fAx$GlobalId09';
+    if (expressId === 10) return '3fAx$GlobalId10';
+    return undefined;
+  },
   ifcTypeOf: (expressId) => (expressId === 7 ? 'IfcWall' : undefined),
   nameOf: (expressId) => (expressId === 7 ? 'W-07' : undefined),
   spatialParentPathOf: (expressId) => (expressId === 7 ? '/project/storey-EG' : undefined),
@@ -62,12 +69,11 @@ describe('changeSetToOps', () => {
     });
   });
 
-  it('expresses deletions: property → null member, pset → tombstone-component, entity → tombstone-entity', () => {
+  it('expresses component-level deletions when the entity itself survives: property → null member, pset → tombstone-component', () => {
     const result = changeSetToOps(
       changeSet([
         mutation('DELETE_PROPERTY', 42, { psetName: 'Pset_WallCommon', propName: 'IsExternal' }),
         mutation('DELETE_PROPERTY_SET', 42, { psetName: 'Pset_Obsolete' }),
-        mutation('DELETE_ENTITY', 42),
       ]),
       resolver
     );
@@ -82,7 +88,11 @@ describe('changeSetToOps', () => {
       entity: '3fAx$GlobalId42',
       componentKey: 'pset:Pset_Obsolete',
     });
-    expect(result.ops).toContainEqual({ op: 'tombstone-entity', entity: '3fAx$GlobalId42' });
+  });
+
+  it('an entity-level delete alone emits only tombstone-entity', () => {
+    const result = changeSetToOps(changeSet([mutation('DELETE_ENTITY', 10)]), resolver);
+    expect(result.ops).toEqual([{ op: 'tombstone-entity', entity: '3fAx$GlobalId10' }]);
   });
 
   it('derives identity for entities without GlobalId and records it for the identity_map', () => {
@@ -162,5 +172,68 @@ describe('changeSetToOps', () => {
     const result = changeSetToOps(changeSet([foreign]), resolver);
     expect(result.ops).toEqual([]);
     expect(result.skipped).toEqual([foreign]);
+  });
+
+  it('drops component ops for an entity whose final state is tombstone-entity (#2048 finding 2)', () => {
+    const result = changeSetToOps(
+      changeSet([
+        mutation('CREATE_PROPERTY', 5, { psetName: 'Pset_Foo', propName: 'Bar', newValue: 42 }),
+        mutation('DELETE_ENTITY', 5),
+      ]),
+      resolver
+    );
+    expect(result.ops).toEqual([{ op: 'tombstone-entity', entity: '3fAx$GlobalId05' }]);
+    expect(result.ops.some((op) => op.op === 'set-component')).toBe(false);
+  });
+
+  it('keeps components for an entity that is tombstoned and then recreated in the same change set', () => {
+    const result = changeSetToOps(
+      changeSet([
+        mutation('CREATE_PROPERTY', 6, { psetName: 'Pset_Foo', propName: 'Bar', newValue: 1 }),
+        mutation('DELETE_ENTITY', 6),
+        mutation('CREATE_ENTITY', 6),
+        mutation('CREATE_PROPERTY', 6, { psetName: 'Pset_Foo', propName: 'Baz', newValue: 2 }),
+      ]),
+      resolver
+    );
+    expect(result.ops).toContainEqual({ op: 'add-entity', entity: '3fAx$GlobalId06', ifcType: undefined });
+    expect(result.ops).toContainEqual({
+      op: 'set-component',
+      entity: '3fAx$GlobalId06',
+      componentKey: 'pset:Pset_Foo',
+      values: { Bar: 1, Baz: 2 },
+    });
+    expect(result.ops.some((op) => op.op === 'tombstone-entity')).toBe(false);
+  });
+
+  it('keeps components for an entity with a CREATE_ENTITY op but no delete', () => {
+    const result = changeSetToOps(
+      changeSet([
+        mutation('CREATE_ENTITY', 9),
+        mutation('CREATE_PROPERTY', 9, { psetName: 'Pset_Foo', propName: 'Bar', newValue: 1 }),
+      ]),
+      resolver
+    );
+    expect(result.ops).toContainEqual({ op: 'add-entity', entity: '3fAx$GlobalId09', ifcType: undefined });
+    expect(result.ops).toContainEqual({
+      op: 'set-component',
+      entity: '3fAx$GlobalId09',
+      componentKey: 'pset:Pset_Foo',
+      values: { Bar: 1 },
+    });
+  });
+
+  it('keeps components for an entity with no entity-op at all', () => {
+    const result = changeSetToOps(
+      changeSet([mutation('CREATE_PROPERTY', 42, { psetName: 'Pset_Foo', propName: 'Bar', newValue: 1 })]),
+      resolver
+    );
+    expect(result.ops).toContainEqual({
+      op: 'set-component',
+      entity: '3fAx$GlobalId42',
+      componentKey: 'pset:Pset_Foo',
+      values: { Bar: 1 },
+    });
+    expect(result.ops.some((op) => op.op === 'tombstone-entity')).toBe(false);
   });
 });

--- a/packages/mutations/src/change-set-to-ops.ts
+++ b/packages/mutations/src/change-set-to-ops.ts
@@ -154,7 +154,18 @@ export function changeSetToOps(
   }
 
   const ops: ChangeSetOp[] = [...entityOps.values()];
+  // Component ops fold in mutation order alongside entityOps above, but an
+  // entity's terminal state (LWW over entityOps) is only known once the
+  // whole mutation list has been consumed. Filter here, after both are
+  // complete, rather than during the fold: a DELETE_ENTITY appearing after
+  // the property mutation that produced a component would otherwise be
+  // missed by an in-flight check (the same forward-pass hazard as #2044).
+  // An entity tombstoned and later recreated (DELETE_ENTITY then
+  // CREATE_ENTITY for the same identity) resolves to 'add-entity' here,
+  // since entityOps is itself LWW keyed by entity — so its components
+  // correctly survive.
   for (const [entity, perEntity] of components) {
+    if (entityOps.get(entity)?.op === 'tombstone-entity') continue;
     for (const [componentKey, values] of perEntity) {
       if (values === null) {
         ops.push({ op: 'tombstone-component', entity, componentKey });


### PR DESCRIPTION
Closes **finding 2** of #2048. Finding 1 (the georef CRS gap in `step-exporter.ts`) is deliberately untouched — that file is in the area you have been reshaping across #2011/#2036, so it stays flagged for you.

## What was wrong

`entityOps` is last-write-wins, so `DELETE_ENTITY` after `CREATE_ENTITY` correctly collapses to `tombstone-entity`. But `components` is a **second pass** over the same mutation list, never intersected with it. An entity edited then deleted emitted both:

```
{ op: 'tombstone-entity', entity: 'GUID-5' }
{ op: 'set-component',   entity: 'GUID-5', componentKey: 'pset:Pset_Foo', values: { Bar: 42 } }
```

`publish.ts:85-131` merges both onto the same `IfcxNode` regardless of order, so a published layer carried live `bsi::ifc::prop::Bar: 42` next to `IFCLITE_ATTR.DELETED: true`.

## Where the filter runs, and why it matters

**After both passes**, against final `entityOps` state — not inside the component fold. An entity's terminal state is only known once the whole list is consumed, so filtering during the fold would miss a delete arriving *after* the property mutation. That is precisely the forward-pass hazard that produced the #2044 ordering hole, and it seemed worth not repeating it two issues later.

## Tombstone-then-recreate

Tested, and it survives correctly: `entityOps` being last-write-wins means DELETE-then-CREATE for one identity resolves to `add-entity`, the filter doesn't fire, and components from both sides are kept.

Not reachable through `StoreEditor` today — `addEntity` refuses to reuse a just-tombstoned id — but `changeSetToOps` imposes no such constraint of its own, so a future or alternate producer could emit it. Cheap to pin now.

## One test was split, not edited to fit

The pre-existing "expresses deletions" test asserted component-level deletions **and** an entity deletion on the same entity — which is the defect itself. Rather than adjust its expectation to match the new behaviour, it is now two tests: component-level deletions on a *surviving* entity, and an entity-level delete alone. Neither weakens what was covered.

Removing the filter fails exactly the new test and nothing else. Mutations **79**, viewer **2360 / 0 / 2**, typecheck 34/34.

## Left undefended on purpose

`publish.ts` still merges ops without checking for a tombstone. With this fix it never receives conflicting ops, so nothing is broken — but it isn't independently defended. I'd rather raise that than add a second guard enforcing the same invariant, since two places obscure which one is load-bearing. Say if you'd prefer belt-and-braces there.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Entity deletions now correctly remove associated component changes.
  * Components are preserved when an entity is recreated or ultimately remains active.
  * Improved handling of complex create, delete, and recreate sequences.

* **Tests**
  * Added coverage for entity tombstones, component deletions, recreations, and entities without direct entity operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->