### PR TITLE
fix(wasm): clear the two clippy violations sitting on main (#2049)

### DIFF
--- a/rust/processing/tests/module_size_allowlist.txt
+++ b/rust/processing/tests/module_size_allowlist.txt
@@ -234,7 +234,10 @@
 # +61: #1781 external image textures — textureId/textureUrl fields + getters, set_texture_ref, and the get/takeMesh/Clone field threading.
 # +17: #1891 follow-on — geometry_aabb_values field + geometryAabbValues getter (the doc carries the Y-up frame contract and the world-box rationale so a future reader does not re-derive them), the four constructor/Clone initializers, and the #[cfg(test)] include for mesh_tests.rs (the test file itself is ratchet-exempt). Net +17 and not +56, because the two Z-up→Y-up conversion helpers moved out to a new sibling frame_swap.rs (107 lines, under the house limit, no row): the box swap is now shared by the f32 local bounds and the f64 world AABB, so the min/max reversal lives in exactly one place.
 # -46: #1891 closedness added geometry_volume_values + geometry_closure_flags, and the whole per-entity fingerprint surface (the five index-parallel arrays' getters — including the Y-up swap on the way out — plus GeometryFingerprint and push_geometry_hash) moved OUT to the child module zero_copy/mesh_fingerprint.rs (new, 161 lines, under the house limit, no row) — net down despite two new arrays; budget refreshed downward.
-     724 rust/wasm-bindings/src/zero_copy/mesh.rs
+# +3: #2049 — `set_texture` was the one 8-arg fn in this crate missing the
+# `#[allow(clippy::too_many_arguments)]` its 21 peers carry. The crate's lint
+# has never run in CI (`--exclude ifc-lite-wasm`), which is how it drifted.
+     727 rust/wasm-bindings/src/zero_copy/mesh.rs
      743 rust/wasm-bindings/src/zero_copy/symbolic.rs
 # +65: #1910 follow-up — buildPrePassOnce's combined_pre_pass is a third
 # geometry-job discovery path with the same has_geometry_by_name gap as the

--- a/rust/wasm-bindings/src/api/bool2d.rs
+++ b/rust/wasm-bindings/src/api/bool2d.rs
@@ -67,7 +67,7 @@ impl Contours2D {
     /// boolean would keep rather than exposing an unsanitised soup.
     #[wasm_bindgen(constructor)]
     pub fn new(coords: &[f64], ring_lengths: &[u32]) -> Result<Contours2D, JsValue> {
-        if coords.len() % 2 != 0 {
+        if !coords.len().is_multiple_of(2) {
             return Err(js_sys::Error::new("Contours2D: coords length must be even").into());
         }
         // Checked arithmetic: on wasm32 `usize` is 32-bit, so a crafted

--- a/rust/wasm-bindings/src/zero_copy/mesh.rs
+++ b/rust/wasm-bindings/src/zero_copy/mesh.rs
@@ -296,6 +296,14 @@ impl MeshDataJs {
     /// `positions` and need no coordinate flip (they are 2D); the winding
     /// reversal in `new` swaps indices, not vertices, so per-vertex UVs stay
     /// aligned. Call after `new`.
+    // `#[wasm_bindgen]` methods are the public JS API surface: each argument
+    // here is a separate JS call parameter (the decoded texture's raw
+    // pixels/dimensions/repeat flags/id), so grouping them into a Rust
+    // struct wouldn't reduce arity on the JS side — `wasm_bindgen` would
+    // still need to unpack a JS object field-by-field, adding an indirection
+    // layer for no clarity gain. The eight are already cohesive (one
+    // decoded-texture attachment call).
+    #[allow(clippy::too_many_arguments)]
     pub fn set_texture(
         &mut self,
         uvs: Vec<f32>,

--- a/rust/wasm-bindings/src/zero_copy/mesh.rs
+++ b/rust/wasm-bindings/src/zero_copy/mesh.rs
@@ -296,13 +296,8 @@ impl MeshDataJs {
     /// `positions` and need no coordinate flip (they are 2D); the winding
     /// reversal in `new` swaps indices, not vertices, so per-vertex UVs stay
     /// aligned. Call after `new`.
-    // `#[wasm_bindgen]` methods are the public JS API surface: each argument
-    // here is a separate JS call parameter (the decoded texture's raw
-    // pixels/dimensions/repeat flags/id), so grouping them into a Rust
-    // struct wouldn't reduce arity on the JS side — `wasm_bindgen` would
-    // still need to unpack a JS object field-by-field, adding an indirection
-    // layer for no clarity gain. The eight are already cohesive (one
-    // decoded-texture attachment call).
+    // Each arg is a distinct JS call parameter; a Rust struct would not reduce
+    // arity for JS callers. Matches the 21 other sites in this crate.
     #[allow(clippy::too_many_arguments)]
     pub fn set_texture(
         &mut self,


### PR DESCRIPTION
The code half of #2049. **No workflow change** — see below.

`cargo clippy -p ifc-lite-wasm --all-targets -- -D warnings` fails on current `main` with two errors. They've been invisible because CI runs `--workspace --exclude ifc-lite-wasm`, so this crate's lint has never executed on any PR.

**`bool2d.rs:70`** takes clippy's own rewrite — `!coords.len().is_multiple_of(2)`. Byte-identical semantics for an odd-length check on a `usize`.

**`mesh.rs:299`** (`MeshDataJs::set_texture`, 8 args) takes an `#[allow]` with a stated reason rather than a wrapper struct. The method sits inside a `#[wasm_bindgen]` impl, so it **is** the public JS API — every argument is a separate JS call parameter. A Rust struct wouldn't reduce the arity JS callers see; `wasm_bindgen` would still unpack a JS object field by field. That buys an indirection layer and no clarity, and the eight fields are already one cohesive operation. Happy to switch to a struct if you'd rather, but it looked like ceremony to satisfy a lint rather than a real improvement.

## Deliberately not included

Narrowing the `--exclude` in `test.yml` is your call and stays flagged in #2049. Keeping it out of this PR means that when the gate is turned on it's a clean change, rather than one that simultaneously appears to break something.

## Verification

`cargo clippy -p ifc-lite-wasm --all-targets -- -D warnings` is now **clean** — worth stating explicitly, since the crate had never been linted and fixing two could easily have uncovered more. Nothing was hiding behind them.

`cargo test -p ifc-lite-wasm --lib` **27/27**. Those have never run in CI either.

No changeset: neither change alters runtime behaviour or the wasm API surface. Say if you'd prefer one as a paper trail regardless.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for the JavaScript-facing texture attachment API, including its parameter requirements.
  * Clarified support for texture attachment calls with multiple parameters.

* **Maintenance**
  * Improved validation readability while preserving existing behavior.
  * Updated internal size tracking to reflect the documentation additions.
  * No user-facing functionality or behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->