### PR TITLE
fix(processing): enforce the shard-scan parity the doc only claimed (#2053)

### DIFF
--- a/packages/wasm/pkg/ifc-lite.d.ts
+++ b/packages/wasm/pkg/ifc-lite.d.ts
@@ -558,8 +558,11 @@ export class IfcAPI {
      * Byte offsets returned are GLOBAL (relative to file start), so shards
      * concatenate without rewriting. Returns a plain object:
      *   `{ ids: Uint32Array, starts: Uint32Array, lengths: Uint32Array,
-     *      handoff: number }`
-     * where `handoff` is the global start of the first entity at/after
+     *      classes: Uint8Array, handoff: number }`
+     * where `classes` is the parallel per-record prepass class byte
+     * (`PREPASS_CLASS_*`: named code in the low bits plus the geometry-job /
+     * type-candidate flags) the host filters on to rebuild pre-pass span
+     * lists, and `handoff` is the global start of the first entity at/after
      * `range_end` (the next shard's first real entity), or `-1` at EOF.
      */
     scanEntityIndexShard(data: Uint8Array, range_start: number, range_end: number): any;

--- a/packages/wasm/pkg/ifc-lite.d.ts
+++ b/packages/wasm/pkg/ifc-lite.d.ts
@@ -547,9 +547,13 @@ export class IfcAPI {
      * range_end)` shard; the main thread stitches the returned columns into the
      * full entity index (byte-identical to the single-threaded
      * `build_entity_index`) by binary-searching each shard for the previous
-     * shard's `handoff`. Delegates to `ifc_lite_processing::scan_shard`, the
-     * exact per-chunk primitive the native `build_entity_index_parallel` fans
-     * across cores — so the sharded merge cannot drift from the serial builder.
+     * shard's `handoff`. Delegates to `ifc_lite_processing::scan_shard_classified`
+     * — a separately-maintained loop over the same `EntityScanner` primitive as
+     * `scan_shard` (the one the native `build_entity_index_parallel` fans across
+     * cores), plus a per-record class column this sharded path also needs. The
+     * two loops' records/handoff are kept in parity by a dedicated test
+     * (`rust/processing/tests/issue_2053_shard_scan_parity.rs`), not by
+     * delegation — edit one without the other and that test catches the drift.
      *
      * Byte offsets returned are GLOBAL (relative to file start), so shards
      * concatenate without rewriting. Returns a plain object:

--- a/rust/processing/tests/issue_2053_shard_scan_parity.rs
+++ b/rust/processing/tests/issue_2053_shard_scan_parity.rs
@@ -14,10 +14,15 @@
 //! This test makes the "cannot drift" property in `prepass_sharded.rs`'s doc
 //! comment a maintained invariant instead of prose: it asserts the two
 //! functions produce IDENTICAL records (id, start, end) and handoff for the
-//! same input over the same byte range, covering both a whole-file single
-//! shard and a shard boundary landing mid-entity (the handoff/stitch case,
-//! where the two loops are most likely to diverge since it exercises the
-//! `range_end` cutoff and speculative-scan restart logic in each independently).
+//! same input over the same byte range, and additionally that
+//! `scan_shard_classified`'s extra `classes` column — the output that has no
+//! counterpart in `scan_shard`, and which the browser host indexes
+//! POSITIONALLY against the records — stays aligned with those records: same
+//! length, and each byte the class of the record at that index. Both are
+//! checked over a whole-file single shard and over a shard boundary landing
+//! mid-entity (the handoff/stitch case, where the two loops are most likely to
+//! diverge since it exercises the `range_end` cutoff and speculative-scan
+//! restart logic in each independently).
 //!
 //! `ifc-lite-processing` (this crate) is covered by the required CI lane
 //! (`cargo test --workspace --exclude ifc-lite-wasm`); `ifc-lite-wasm`, which
@@ -26,7 +31,23 @@
 //! specifically so a parity regression fails CI instead of only ever being
 //! caught locally.
 
-use ifc_lite_processing::{scan_shard, scan_shard_classified};
+use ifc_lite_processing::{classify_type_name, scan_shard, scan_shard_classified};
+
+/// Parse the raw STEP keyword at a record start (`#id=KEYWORD(...`). Mirrors
+/// `issue_1910_shard_class_ci_coverage.rs`'s copy of the same helper —
+/// duplicated rather than shared because integration tests are separate
+/// crates and the original (`prepass_discovery.rs::keyword_at`) is private to
+/// the excluded wasm crate.
+fn keyword_at(content: &[u8], start: usize, end: usize) -> &str {
+    let span = &content[start..end.min(content.len())];
+    let eq = span.iter().position(|&b| b == b'=').map(|p| p + 1).unwrap_or(0);
+    let kw_end = span[eq..]
+        .iter()
+        .position(|&b| b == b'(')
+        .map(|p| eq + p)
+        .unwrap_or(span.len());
+    std::str::from_utf8(&span[eq..kw_end]).unwrap_or("").trim()
+}
 
 /// A small synthetic DATA section with enough entities, and varied enough
 /// record lengths, that a boundary swept across the whole byte range lands
@@ -48,15 +69,37 @@ fn synthetic_ifc() -> String {
         }
     }
     content.push_str("ENDSEC;\nEND-ISO-10303-21;\n");
+
+    // The class oracle below is name-only (`classify_type_name`), so it is
+    // ground truth for this fixture only while none of its keywords can take
+    // the #1910 instance-level exception that `classify_type_name_with_content`
+    // adds on top. Asserted rather than assumed: add a keyword here that IS a
+    // spatial container and the oracle would silently start disagreeing with
+    // a correct `scan_shard_classified`.
+    for keyword in ["IFCPROJECT", "IFCWALL", "IFCDOOR"] {
+        assert!(
+            !ifc_lite_core::is_representationless_spatial_container_by_name(keyword),
+            "fixture keyword {keyword} takes the #1910 instance-level exception, so \
+             classify_type_name is no longer a valid oracle for its class byte"
+        );
+    }
     content
 }
 
 /// Compare the two scans' output for identical records (same ids, starts,
 /// lengths, i.e. (id, start, end) triples in the same order) and identical
-/// handoff over `[range_start, range_end)`.
+/// handoff over `[range_start, range_end)`, and check that the classified
+/// scan's extra `classes` column is positionally aligned with those records.
+///
+/// The alignment check does NOT compare `classes` against another
+/// `scan_shard_classified` call: the host's failure mode is this one function
+/// emitting a class column shifted against its own records, and a shift like
+/// that lands identically in every range decomposition, so a self-comparison
+/// across ranges cannot see it. The oracle is instead recomputed per record
+/// from the record's own keyword, which pins each byte to a specific record.
 fn assert_shard_scans_match(content: &[u8], range_start: usize, range_end: usize, label: &str) {
     let (plain_records, plain_handoff) = scan_shard(content, range_start, range_end);
-    let (classified_records, _classes, classified_handoff) =
+    let (classified_records, classes, classified_handoff) =
         scan_shard_classified(content, range_start, range_end);
 
     assert_eq!(
@@ -69,6 +112,23 @@ fn assert_shard_scans_match(content: &[u8], range_start: usize, range_end: usize
         "scan_shard vs scan_shard_classified handoff mismatch for {label} \
          (range [{range_start}, {range_end}))"
     );
+    assert_eq!(
+        classes.len(),
+        classified_records.len(),
+        "scan_shard_classified class column length must match its record count for \
+         {label} (range [{range_start}, {range_end})) — the host indexes classes \
+         positionally against the records"
+    );
+    for (i, &(id, start, end)) in classified_records.iter().enumerate() {
+        let keyword = keyword_at(content, start, end);
+        assert_eq!(
+            classes[i],
+            classify_type_name(keyword),
+            "class byte at index {i} does not belong to the record at that index \
+             (#{id} {keyword}) for {label} (range [{range_start}, {range_end})) — \
+             the class column is misaligned with the records"
+        );
+    }
 }
 
 /// Whole file scanned as a single shard: the simplest case, and the one the

--- a/rust/processing/tests/issue_2053_shard_scan_parity.rs
+++ b/rust/processing/tests/issue_2053_shard_scan_parity.rs
@@ -1,0 +1,108 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Parity regression for #2053: `scan_shard` (native
+//! `build_entity_index_parallel`'s per-chunk primitive) and
+//! `scan_shard_classified` (the wasm sharded pre-pass's per-worker primitive,
+//! `rust/wasm-bindings/src/api/gpu_meshes/prepass_sharded.rs`'s
+//! `scanEntityIndexShard`) are two independently-maintained loops over
+//! `EntityScanner` — `scan_shard_classified` deliberately does NOT delegate to
+//! `scan_shard` (see `parallel_scan.rs`'s doc comment on `scan_shard`), so
+//! nothing stops them drifting apart if one is edited without the other.
+//!
+//! This test makes the "cannot drift" property in `prepass_sharded.rs`'s doc
+//! comment a maintained invariant instead of prose: it asserts the two
+//! functions produce IDENTICAL records (id, start, end) and handoff for the
+//! same input over the same byte range, covering both a whole-file single
+//! shard and a shard boundary landing mid-entity (the handoff/stitch case,
+//! where the two loops are most likely to diverge since it exercises the
+//! `range_end` cutoff and speculative-scan restart logic in each independently).
+//!
+//! `ifc-lite-processing` (this crate) is covered by the required CI lane
+//! (`cargo test --workspace --exclude ifc-lite-wasm`); `ifc-lite-wasm`, which
+//! actually calls `scan_shard_classified` in production, is excluded from it
+//! entirely (#2049) — this test lives here, not in `rust/wasm-bindings/`,
+//! specifically so a parity regression fails CI instead of only ever being
+//! caught locally.
+
+use ifc_lite_processing::{scan_shard, scan_shard_classified};
+
+/// A small synthetic DATA section with enough entities, and varied enough
+/// record lengths, that a boundary swept across the whole byte range lands
+/// inside a record body at some sweep position — not just on a `\n`.
+fn synthetic_ifc() -> String {
+    let mut content = String::from(
+        "ISO-10303-21;\nHEADER;\nENDSEC;\nDATA;\n#1=IFCPROJECT('0$ScRe4drECQ4DMSqUjd6d',$,'P',$,$,$,$,(#2),#3);\n",
+    );
+    for id in 2..=60u32 {
+        // Alternate short and long records so record bodies straddle many
+        // candidate boundary offsets.
+        if id % 3 == 0 {
+            let long_name = "N".repeat(80);
+            content.push_str(&format!(
+                "#{id}=IFCWALL('{long_name}{id}',$,$,$,$,$,$,$);\n"
+            ));
+        } else {
+            content.push_str(&format!("#{id}=IFCDOOR('g{id}',$,$,$,$,$,$,$);\n"));
+        }
+    }
+    content.push_str("ENDSEC;\nEND-ISO-10303-21;\n");
+    content
+}
+
+/// Compare the two scans' output for identical records (same ids, starts,
+/// lengths, i.e. (id, start, end) triples in the same order) and identical
+/// handoff over `[range_start, range_end)`.
+fn assert_shard_scans_match(content: &[u8], range_start: usize, range_end: usize, label: &str) {
+    let (plain_records, plain_handoff) = scan_shard(content, range_start, range_end);
+    let (classified_records, _classes, classified_handoff) =
+        scan_shard_classified(content, range_start, range_end);
+
+    assert_eq!(
+        plain_records, classified_records,
+        "scan_shard vs scan_shard_classified record mismatch for {label} \
+         (range [{range_start}, {range_end}))"
+    );
+    assert_eq!(
+        plain_handoff, classified_handoff,
+        "scan_shard vs scan_shard_classified handoff mismatch for {label} \
+         (range [{range_start}, {range_end}))"
+    );
+}
+
+/// Whole file scanned as a single shard: the simplest case, and the one the
+/// native `build_entity_index_parallel`'s chunk-0 and a one-shard sharded
+/// pre-pass both reduce to.
+#[test]
+fn single_shard_whole_file_matches() {
+    let content = synthetic_ifc();
+    let bytes = content.as_bytes();
+    assert_shard_scans_match(bytes, 0, bytes.len(), "single-shard-whole-file");
+}
+
+/// The handoff/stitch case: split the same file into two shards at MANY
+/// candidate boundary offsets, sweeping across the whole byte range so at
+/// least some boundaries land mid-record (inside a quoted string or between
+/// an id and its closing `)`), not just on a `\n`. For every split point,
+/// both the first shard `[0, split)` and the second shard `[split, len)` must
+/// match between the two functions — this is where a speculative-scan
+/// re-sync bug in one loop but not the other would show up.
+#[test]
+fn shard_boundary_mid_entity_handoff_matches() {
+    let content = synthetic_ifc();
+    let bytes = content.as_bytes();
+    let len = bytes.len();
+
+    let mut checked = 0usize;
+    for split in 1..len {
+        assert_shard_scans_match(bytes, 0, split, &format!("first-shard@{split}"));
+        assert_shard_scans_match(bytes, split, len, &format!("second-shard@{split}"));
+        checked += 1;
+    }
+    assert!(
+        checked > 100,
+        "sweep must exercise well over 100 boundary positions to have confidence \
+         some land mid-entity; only checked {checked}"
+    );
+}

--- a/rust/wasm-bindings/src/api/gpu_meshes/prepass_sharded.rs
+++ b/rust/wasm-bindings/src/api/gpu_meshes/prepass_sharded.rs
@@ -87,9 +87,13 @@ impl IfcAPI {
     /// range_end)` shard; the main thread stitches the returned columns into the
     /// full entity index (byte-identical to the single-threaded
     /// `build_entity_index`) by binary-searching each shard for the previous
-    /// shard's `handoff`. Delegates to `ifc_lite_processing::scan_shard`, the
-    /// exact per-chunk primitive the native `build_entity_index_parallel` fans
-    /// across cores — so the sharded merge cannot drift from the serial builder.
+    /// shard's `handoff`. Delegates to `ifc_lite_processing::scan_shard_classified`
+    /// — a separately-maintained loop over the same `EntityScanner` primitive as
+    /// `scan_shard` (the one the native `build_entity_index_parallel` fans across
+    /// cores), plus a per-record class column this sharded path also needs. The
+    /// two loops' records/handoff are kept in parity by a dedicated test
+    /// (`rust/processing/tests/issue_2053_shard_scan_parity.rs`), not by
+    /// delegation — edit one without the other and that test catches the drift.
     ///
     /// Byte offsets returned are GLOBAL (relative to file start), so shards
     /// concatenate without rewriting. Returns a plain object:

--- a/rust/wasm-bindings/src/api/gpu_meshes/prepass_sharded.rs
+++ b/rust/wasm-bindings/src/api/gpu_meshes/prepass_sharded.rs
@@ -98,8 +98,11 @@ impl IfcAPI {
     /// Byte offsets returned are GLOBAL (relative to file start), so shards
     /// concatenate without rewriting. Returns a plain object:
     ///   `{ ids: Uint32Array, starts: Uint32Array, lengths: Uint32Array,
-    ///      handoff: number }`
-    /// where `handoff` is the global start of the first entity at/after
+    ///      classes: Uint8Array, handoff: number }`
+    /// where `classes` is the parallel per-record prepass class byte
+    /// (`PREPASS_CLASS_*`: named code in the low bits plus the geometry-job /
+    /// type-candidate flags) the host filters on to rebuild pre-pass span
+    /// lists, and `handoff` is the global start of the first entity at/after
     /// `range_end` (the next shard's first real entity), or `-1` at EOF.
     #[wasm_bindgen(js_name = scanEntityIndexShard)]
     pub fn scan_entity_index_shard(


### PR DESCRIPTION
Closes the first finding of #2053.

## The claim vs the code

`prepass_sharded.rs:90` said it *"delegates to `ifc_lite_processing::scan_shard` … so the sharded merge cannot drift from the serial builder."* Line 111 calls `scan_shard_classified`. `scan_shard` has no callers outside its own module, and the two are separately maintained loops — `parallel_scan.rs:81` says so from the other side.

The sentence asserted a **safety property** grounded in a delegation that had stopped happening. `git log -p` shows an earlier version really did delegate; a perf change swapped in the classified loop and left the prose behind.

## First question: do the loops still agree?

Checked before writing anything, because a real divergence would matter far more than a stale comment. **They agree.** Both push `(id, start, entity_end)` from the same `EntityScanner` with the same `range_end` cutoff and the same `new`/`new_at` selection; the classified one additionally computes a class byte.

## Correcting the sentence alone would have left the invariant unenforced

So the parity is now a test rather than a promise. It asserts identical records **and** identical handoff, and the boundary case sweeps **all 3694 byte offsets** of the fixture as split points, checking both shards at each — guaranteeing many splits land mid-record, which is where re-sync would diverge if it ever did.

**Where it lives is deliberate.** `rust/wasm-bindings` is excluded from CI entirely (`--exclude ifc-lite-wasm`, #2049), so a parity test placed next to the caller would never run — recreating the precise trap this issue is about. It's in `rust/processing/tests/`, which the required lane covers, and both functions are exported from `ifc_lite_processing` so it reaches them cleanly.

## Evidence

Offsetting one loop's `start` by a byte on every seventh record fails **both** tests with explicit left/right diffs. Parity **2/2**, processing lib **57/57**, ratchet **4/4**, wasm lib **27/27**.

No changeset — a doc correction plus a test, with no runtime change for any `@ifc-lite/wasm` consumer.

## Worth noting

This one had a concrete cost before it was found: on #1970 I added a CI-visible regression through `scan_shard_classified` precisely because that is what the sharded path runs. Had I trusted this comment, I'd have tested `scan_shard` — a function nothing in that path calls.

The second finding in #2053 (a comment citing "the committed Duplex fixture", which is gitignored and fetched on demand) is untouched here — happy to take it separately if you want it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency between shard scanning methods, including when entity boundaries are split across shards.
  * Ensured classified scan results and handoff behavior remain aligned with standard scanning.
  * Added broader validation across complete files and split positions to help prevent regressions.

* **Documentation**
  * Clarified shard scanning behavior, delegation, and per-record classification output.
  * Documented parity expectations between standard and classified shard scans.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->