### PR TITLE
fix(export): resolve georeferencing through the effective index (#2048)

### DIFF
--- a/.changeset/georef-effective-index.md
+++ b/.changeset/georef-effective-index.md
@@ -1,0 +1,9 @@
+---
+"@ifc-lite/export": patch
+---
+
+STEP export: keep georeferencing edits when the session deleted the file's existing georeferencing.
+
+The exporter looked up `IfcProjectedCRS` / `IfcMapConversion` in the raw entity index, so a CRS the session had deleted still counted as "existing". The edit was queued against the deleted entity, the export skipped that entity, and the replacement georeferencing vanished from the output with no error. The lookup now goes through the effective (overlay-aware) index, so a deleted CRS or map conversion is recreated instead.
+
+The same index now backs the source-CRS context and length-unit lookups the georef path uses, so newly created georeferencing can no longer reference a deleted context or unit.

--- a/packages/export/src/step-exporter.test.ts
+++ b/packages/export/src/step-exporter.test.ts
@@ -72,6 +72,22 @@ function buildMockDataStore(
   } as unknown as IfcDataStore;
 }
 
+/** A minimal already-georeferenced model: `#40` CRS, `#41` MapConversion. */
+function buildGeoreferencedMockDataStore(): IfcDataStore {
+  return buildMockDataStore([
+    [1, 'IFCPROJECT', "#1=IFCPROJECT('g',$,'Project',$,$,$,$,(#20),#30);"],
+    [2, 'IFCSIUNIT', '#2=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);'],
+    [20, 'IFCGEOMETRICREPRESENTATIONCONTEXT', "#20=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.E-05,#21,$);"],
+    [21, 'IFCAXIS2PLACEMENT3D', '#21=IFCAXIS2PLACEMENT3D(#22,#23,#24);'],
+    [22, 'IFCCARTESIANPOINT', '#22=IFCCARTESIANPOINT((0.,0.,0.));'],
+    [23, 'IFCDIRECTION', '#23=IFCDIRECTION((0.,0.,1.));'],
+    [24, 'IFCDIRECTION', '#24=IFCDIRECTION((1.,0.,0.));'],
+    [30, 'IFCUNITASSIGNMENT', '#30=IFCUNITASSIGNMENT((#2));'],
+    [40, 'IFCPROJECTEDCRS', "#40=IFCPROJECTEDCRS('EPSG:2056',$,'CH1903+',$,$,$,#2);"],
+    [41, 'IFCMAPCONVERSION', '#41=IFCMAPCONVERSION(#20,#40,1.,2.,3.,1.,0.,1.);'],
+  ]);
+}
+
 /** Count `#N` references in the output that have no `#N=` definition. */
 function findDanglingRefs(content: string): number[] {
   const defined = new Set<number>();
@@ -287,6 +303,89 @@ describe('StepExporter', () => {
     });
 
     expect(decode(result.content)).toMatch(/IFCMAPCONVERSION\(#20,#\d+,2600000\.,1200000\.,500\.,1\.,0\.,1\.\);/);
+  });
+
+  it('recreates georeferencing the session deleted instead of editing the tombstone', () => {
+    const dataStore = buildGeoreferencedMockDataStore();
+    const mutationView = new LiveMutablePropertyView(null, 'model-georef');
+    mutationView.deleteEntity(40);
+    mutationView.deleteEntity(41);
+
+    const exporter = new StepExporter(dataStore, mutationView);
+    const result = exporter.export({
+      schema: 'IFC4',
+      applyMutations: true,
+      georefMutations: {
+        projectedCRS: { name: 'EPSG:1234', mapUnit: 'METRE' },
+        mapConversion: { eastings: 10, northings: 20, orthogonalHeight: 30, xAxisAbscissa: 1, xAxisOrdinate: 0, scale: 1 },
+      },
+    });
+
+    const content = decode(result.content);
+    // The tombstoned #40/#41 are never written, so the edit has to land on a
+    // NEW pair — otherwise the georeferencing disappears from the file.
+    expect(content).not.toContain('#40=');
+    expect(content).not.toContain('#41=');
+    expect(content).toContain("IFCPROJECTEDCRS('EPSG:1234'");
+    expect(content).toMatch(/IFCMAPCONVERSION\(#20,#\d+,10\.,20\.,30\.,1\.,0\.,1\.\);/);
+    expect(findDanglingRefs(content)).toEqual([]);
+  });
+
+  it('recreates a deleted IfcMapConversion while keeping the surviving IfcProjectedCRS', () => {
+    const dataStore = buildGeoreferencedMockDataStore();
+    const mutationView = new LiveMutablePropertyView(null, 'model-georef');
+    mutationView.deleteEntity(41);
+
+    const exporter = new StepExporter(dataStore, mutationView);
+    const result = exporter.export({
+      schema: 'IFC4',
+      applyMutations: true,
+      georefMutations: {
+        mapConversion: { eastings: 10, northings: 20, orthogonalHeight: 30, xAxisAbscissa: 1, xAxisOrdinate: 0, scale: 1 },
+      },
+    });
+
+    const content = decode(result.content);
+    expect(content).not.toContain('#41=');
+    expect(content).toMatch(/IFCMAPCONVERSION\(#20,#40,10\.,20\.,30\.,1\.,0\.,1\.\);/);
+    expect(findDanglingRefs(content)).toEqual([]);
+  });
+
+  it('never points new georeferencing at a deleted context or length unit', () => {
+    const dataStore = buildMockDataStore([
+      [1, 'IFCPROJECT', "#1=IFCPROJECT('g',$,'Project',$,$,$,$,(#20,#25),#30);"],
+      [2, 'IFCSIUNIT', '#2=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);'],
+      [20, 'IFCGEOMETRICREPRESENTATIONCONTEXT', "#20=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.E-05,#21,$);"],
+      [21, 'IFCAXIS2PLACEMENT3D', '#21=IFCAXIS2PLACEMENT3D(#22,#23,#24);'],
+      [22, 'IFCCARTESIANPOINT', '#22=IFCCARTESIANPOINT((0.,0.,0.));'],
+      [23, 'IFCDIRECTION', '#23=IFCDIRECTION((0.,0.,1.));'],
+      [24, 'IFCDIRECTION', '#24=IFCDIRECTION((1.,0.,0.));'],
+      [25, 'IFCGEOMETRICREPRESENTATIONCONTEXT', "#25=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.E-05,#21,$);"],
+      [30, 'IFCUNITASSIGNMENT', '#30=IFCUNITASSIGNMENT((#2));'],
+    ]);
+    const mutationView = new LiveMutablePropertyView(null, 'model-georef');
+    mutationView.deleteEntity(20);
+    mutationView.deleteEntity(2);
+
+    const exporter = new StepExporter(dataStore, mutationView);
+    const result = exporter.export({
+      schema: 'IFC4',
+      applyMutations: true,
+      georefMutations: {
+        projectedCRS: { name: 'EPSG:1234', mapUnit: 'METRE' },
+        mapConversion: { eastings: 10, northings: 20, orthogonalHeight: 30, xAxisAbscissa: 1, xAxisOrdinate: 0, scale: 1 },
+      },
+    });
+
+    const content = decode(result.content);
+    // SourceCRS falls through to the surviving context, and the map unit is
+    // synthesised rather than reusing the tombstoned #2.
+    expect(content).toMatch(/IFCMAPCONVERSION\(#25,#\d+,10\.,20\.,30\.,1\.,0\.,1\.\);/);
+    const crsLine = content.match(/#\d+=IFCPROJECTEDCRS\([^;]*\);/)?.[0] ?? '';
+    expect(crsLine).toContain("'EPSG:1234'");
+    expect(crsLine).not.toContain('#2)');
+    const newUnitId = Number(crsLine.match(/#(\d+)\);$/)?.[1]);
+    expect(content).toContain(`#${newUnitId}=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);`);
   });
 
   it('rejects georeferencing edits for IFC2X3 export', async () => {

--- a/packages/export/src/step-exporter.ts
+++ b/packages/export/src/step-exporter.ts
@@ -505,8 +505,16 @@ export class StepExporter {
     const newGeorefLines: string[] = [];
     if (options.applyMutations !== false && options.georefMutations) {
       const gm = options.georefMutations;
-      const existingCrsIds = this.dataStore.entityIndex.byType.get('IFCPROJECTEDCRS');
-      const existingMcIds = this.dataStore.entityIndex.byType.get('IFCMAPCONVERSION');
+      // `effective.byType`, not the raw index: a source IfcProjectedCRS the
+      // session tombstoned is still in `dataStore.entityIndex`, so the modify
+      // branch below would queue attribute edits against an id the
+      // source-iteration pass then skips — the replacement georeferencing
+      // vanishes from the file with no error. `effective.byType` drops
+      // tombstones and adds overlay-created records, which the new-entities
+      // pass applies `modifiedAttributes` to, so both branches agree on which
+      // georeferencing entities exist (#2048).
+      const existingCrsIds = effective.byType.get('IFCPROJECTEDCRS');
+      const existingMcIds = effective.byType.get('IFCMAPCONVERSION');
 
       // Modify existing IfcProjectedCRS
       if (gm.projectedCRS && existingCrsIds?.length) {
@@ -524,7 +532,7 @@ export class StepExporter {
         if (crs.mapProjection !== undefined) { attrMap.set('MapProjection', String(crs.mapProjection)); changed = true; }
         if (crs.mapZone !== undefined) { attrMap.set('MapZone', String(crs.mapZone)); changed = true; }
         if (crs.mapUnit !== undefined) {
-          const mapUnitRef = this.resolveMapUnitReference(String(crs.mapUnit), newGeorefLines);
+          const mapUnitRef = this.resolveMapUnitReference(String(crs.mapUnit), newGeorefLines, effective);
           attrMap.set('MapUnit', `#${mapUnitRef}`);
           changed = true;
         }
@@ -567,13 +575,13 @@ export class StepExporter {
         const proj = crs.mapProjection ? `'${escapeStepString(String(crs.mapProjection))}'` : '$';
         const zone = crs.mapZone ? `'${escapeStepString(String(crs.mapZone))}'` : '$';
         const mapUnitRef = crs.mapUnit
-          ? `#${this.resolveMapUnitReference(String(crs.mapUnit), newGeorefLines)}`
+          ? `#${this.resolveMapUnitReference(String(crs.mapUnit), newGeorefLines, effective)}`
           : '$';
         newGeorefLines.push(`#${crsId}=IFCPROJECTEDCRS(${name},${desc},${datum},${vDatum},${proj},${zone},${mapUnitRef});`);
         newEntityCount++;
 
         // Find IfcGeometricRepresentationContext as SourceCRS for MapConversion
-        const contextId = this.findPreferredGeometricRepresentationContextId();
+        const contextId = this.findPreferredGeometricRepresentationContextId(effective);
 
         if (contextId) {
           const mc = gm.mapConversion || {};
@@ -592,7 +600,7 @@ export class StepExporter {
         }
       } else if (gm.mapConversion && !existingMcIds?.length && existingCrsIds?.length) {
         // CRS exists but no MapConversion — create just the conversion
-        const contextId = this.findPreferredGeometricRepresentationContextId();
+        const contextId = this.findPreferredGeometricRepresentationContextId(effective);
         if (contextId) {
           const mc = gm.mapConversion;
           const mcId = this.nextExpressId++;
@@ -832,6 +840,7 @@ export class StepExporter {
         entityId,
         psets,
         willBeEmitted,
+        effective,
         typeOwnedPsetNamesByEntity.get(entityId),
         options.guidRandom
       );
@@ -1151,6 +1160,7 @@ export class StepExporter {
     entityId: number,
     psets: PropertySet[],
     willBeEmitted: (id: number) => boolean,
+    effective: EffectiveEntityIndex,
     typeOwnedPsetNames?: Set<string>,
     random?: RandomSource
   ): { lines: string[]; count: number; generatedTypeOwnedPsetIds: Map<string, number> } {
@@ -1167,7 +1177,7 @@ export class StepExporter {
         count++;
 
         const valueStr = serializePropertyValue(prop.value, prop.type);
-        const unitId = prop.unit ? this.findUnitId(prop.unit) : null;
+        const unitId = prop.unit ? this.findUnitId(prop.unit, effective) : null;
         const unitStr = unitId !== null ? ref(unitId) : null;
 
         // #ID=IFCPROPERTYSINGLEVALUE('Name',$,Value,Unit);
@@ -1458,9 +1468,9 @@ export class StepExporter {
     return serializeStepValue(value, forceReal);
   }
 
-  private resolveMapUnitReference(unitName: string, newGeorefLines: string[]): number {
+  private resolveMapUnitReference(unitName: string, newGeorefLines: string[], effective: EffectiveEntityIndex): number {
     const normalized = this.normalizeMapUnitName(unitName);
-    const existing = this.findLengthUnitReference(normalized);
+    const existing = this.findLengthUnitReference(normalized, effective);
     if (existing !== null) {
       return existing;
     }
@@ -1498,14 +1508,22 @@ export class StepExporter {
     return normalized;
   }
 
-  private findLengthUnitReference(preferredUnitName: string): number | null {
+  /**
+   * `effective` filters the candidates the same way the georef reads above do:
+   * returning a tombstoned unit id hands the caller a `#id` for a line the
+   * export never writes. Returning null instead makes `resolveMapUnitReference`
+   * synthesise a fresh unit, which is the outcome a deleted unit deserves.
+   */
+  private findLengthUnitReference(preferredUnitName: string, effective: EffectiveEntityIndex): number | null {
     if (!this.entityExtractor) return null;
 
-    const projectIds = this.dataStore.entityIndex.byType.get('IFCPROJECT') ?? [];
-    const projectRef = projectIds[0] ? this.dataStore.entityIndex.byId.get(projectIds[0]) : undefined;
+    // Only source records carry the bytes `extractEntity` reads, so an
+    // overlay-created project is skipped rather than shadowing the file's own.
+    const projectId = (effective.byType.get('IFCPROJECT') ?? []).find((id) => this.dataStore.entityIndex.byId.has(id));
+    const projectRef = projectId !== undefined ? this.dataStore.entityIndex.byId.get(projectId) : undefined;
     const project = projectRef ? this.entityExtractor.extractEntity(projectRef) : null;
     const unitAssignmentId = project?.attributes?.[8];
-    if (typeof unitAssignmentId !== 'number') return null;
+    if (typeof unitAssignmentId !== 'number' || effective.isDeleted(unitAssignmentId)) return null;
 
     const unitAssignmentRef = this.dataStore.entityIndex.byId.get(unitAssignmentId);
     const unitAssignment = unitAssignmentRef ? this.entityExtractor.extractEntity(unitAssignmentRef) : null;
@@ -1513,7 +1531,7 @@ export class StepExporter {
     if (!Array.isArray(units)) return null;
 
     for (const unitId of units) {
-      if (typeof unitId !== 'number') continue;
+      if (typeof unitId !== 'number' || effective.isDeleted(unitId)) continue;
       const unitRef = this.dataStore.entityIndex.byId.get(unitId);
       const unit = unitRef ? this.entityExtractor.extractEntity(unitRef) : null;
       if (!unit) continue;
@@ -1543,10 +1561,16 @@ export class StepExporter {
     return null;
   }
 
-  private findPreferredGeometricRepresentationContextId(): number | null {
+  /**
+   * `effective` again: the id returned here becomes the new IfcMapConversion's
+   * SourceCRS, so a tombstoned context would leave the created line pointing at
+   * a record the export skips — a dangling reference and an invalid file.
+   */
+  private findPreferredGeometricRepresentationContextId(effective: EffectiveEntityIndex): number | null {
     if (!this.entityExtractor) return null;
 
-    const contextIds = this.dataStore.entityIndex.byType.get('IFCGEOMETRICREPRESENTATIONCONTEXT') ?? [];
+    const contextIds = (effective.byType.get('IFCGEOMETRICREPRESENTATIONCONTEXT') ?? [])
+      .filter((id) => this.dataStore.entityIndex.byId.has(id));
     let first3dContext: number | null = null;
 
     for (const contextId of contextIds) {
@@ -1591,8 +1615,8 @@ export class StepExporter {
   /**
    * Find a unit entity ID by name (simplified - returns null for now)
    */
-  private findUnitId(unitName: string): number | null {
-    return this.findLengthUnitReference(this.normalizeMapUnitName(unitName));
+  private findUnitId(unitName: string, effective: EffectiveEntityIndex): number | null {
+    return this.findLengthUnitReference(this.normalizeMapUnitName(unitName), effective);
   }
 
   /**


### PR DESCRIPTION
Closes the first finding of #2048. The second is already fixed on main — see below.

## The one-sided guard

`step-exporter.ts:508-509` read `dataStore.entityIndex.byType` directly, so a deleted `IfcProjectedCRS`/`IfcMapConversion` was still found as "existing". The exporter then took the **modify** branch against a tombstoned record, which is never emitted — georeferencing silently vanished with no error.

RED, before the fix:

```
× recreates georeferencing the session deleted instead of editing the tombstone
  expected '...' to contain "IFCPROJECTEDCRS('EPSG:1234'"
  DATA;
  #1=IFCPROJECT(...); #2=IFCSIUNIT(...); #20=IFCGEOMETRICREPRESENTATIONCONTEXT(...);
  ENDSEC;
```

Now reads `effective.byType` from the existing `getEffectiveEntityIndex()` seam rather than a second deletion predicate — a differently-shaped guard here is how these drift apart again. `effective.byType` also *adds* overlay-created records, and the new-entities pass already applies `modifiedAttributes` (`:954`), so the modify branch stays correct for those too.

## The louder bug the fix exposed

Making the create branch reachable for deleted-CRS sessions surfaced a second raw-index read **in the same twenty lines**. `findPreferredGeometricRepresentationContextId()` (`:1557`) and `findLengthUnitReference()` (`:1512-1525`) also read the raw index, and the create branch uses their return values as `#id` references. Probe on unfixed code:

```
#31=IFCPROJECTEDCRS('EPSG:1234',$,$,$,$,$,#2);
#32=IFCMAPCONVERSION(#20,#31,10.,20.,30.,1.,0.,1.);
DANGLING: [ 2, 20 ]     // both deleted
```

That is an **invalid file**, and it reproduces on main independently of this change — a file with no CRS at all takes the create branch too. Fixed here because my change makes it newly reachable, with `effective` threaded through `resolveMapUnitReference` / `findLengthUnitReference` / `findUnitId` / `generatePropertySetEntities` so no half-guarded helper is left behind.

## Finding 2: already fixed, untouched

The IFCX-ops-for-a-tombstoned-entity half is closed on main by #2050 — `change-set-to-ops.ts:167-168`. No action taken.

## Evidence

| guard neutralised | replacements | result |
|---|---|---|
| `effective.byType` → raw, both georef lines | 2 | 2 failed / 335 passed — both new tests |
| context lookup → raw `byType` | 1 | 1 failed / 30 passed |
| `\|\| effective.isDeleted(unitId)` removed | 1 | 1 failed / 30 passed |

337 passed / 29 skipped, typecheck 34/34.

## Same-shape sweep — reported, not fixed

- `packages/parser/src/georef-extractor.ts:101` reads `entitiesByType.get('IfcProjectedCRS')` from the parsed store. Same shape, but the parser layer has no overlay threaded, so a deleted CRS still yields georeferencing to the viewer. Needs an effective index plumbed in — a design call rather than a guard.
- `apps/viewer/src/components/mcp/playground-dispatcher.ts:662` counts `IFCMAPCONVERSION` off the raw store.
- Broader and distinct from this shape: surviving source lines are never rewritten when they reference a deleted entity — `#30=IFCUNITASSIGNMENT((#2))` keeps `#2` after `deleteEntity(2)`.

Benign on inspection: `:1084` (`IFCOWNERHISTORY`, filtered by `willBeEmitted`), `:1677` (only ever *adds* skips), `:1797` (already cleared in the issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved georeferenced STEP exports by preventing references to deleted coordinate systems, map conversions, contexts, units, and related entities.
  * Recreates missing georeferencing records with valid identifiers when needed.
  * Ensures exported files contain no dangling entity references.
  * Preserves valid surviving georeferencing entities and synthesizes replacement units when necessary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->