### PR TITLE
docs(export): the Duplex fixture is fetched, not committed (#2053)

### DIFF
--- a/packages/export/src/type-owned-psets.ts
+++ b/packages/export/src/type-owned-psets.ts
@@ -32,8 +32,10 @@ const typeObjectByClass = new Map<string, boolean>();
  * slot 5 and do not end in `Type`. A `TYPE` suffix test called them occurrences
  * and routed their psets onto an `IfcRelDefinesByProperties` — precisely the
  * misclassification this module exists to prevent, on a class of file that is
- * still most of what is in the wild. The committed Duplex fixture has six of
- * each.
+ * still most of what is in the wild. The Duplex fixture has six of each; it is
+ * not committed, so fetch it with `pnpm fixtures` (checksummed in
+ * `tests/models/manifest.json`) and count for yourself — the
+ * `overlay-effective-model.test.ts` case that reads it skips when it is absent.
  *
  * The suffix test was also too WIDE in the other direction:
  * `IfcRelDefinesByType` ends in `TYPE` and is a relationship, so a property edit


### PR DESCRIPTION
Closes the second finding of #2053 — the one I offered to take separately on #2054.

## The claim vs the repo

`packages/export/src/type-owned-psets.ts:35` said "The **committed** Duplex fixture has six of each". All four supporting facts verified against `upstream/main`:

- `.gitignore:84-94` — `tests/models/**/*.ifc`, under "IFC test fixtures are fetched on demand via `pnpm fixtures` … They must NOT be committed to the repo"
- `tests/models/manifest.json:31-35` — `ara3d/duplex.ifc`, sha256 `b347a2c8…`, 2380763 bytes
- `packages/export/src/overlay-effective-model.test.ts:605` — `it.skipIf(!existsSync(DUPLEX))`

## The count is true, so I kept it

Rather than delete the figure, I fetched the fixture and counted. sha256 matches the manifest byte-for-byte; `grep -c '=IFCDOORSTYLE('` → 6, `grep -c '=IFCWINDOWSTYLE('` → 6. Only the word "committed" was false.

```diff
- * still most of what is in the wild. The committed Duplex fixture has six of
- * each.
+ * still most of what is in the wild. The Duplex fixture has six of each; it is
+ * not committed, so fetch it with `pnpm fixtures` (checksummed in
+ * `tests/models/manifest.json`) and count for yourself — the
+ * `overlay-effective-model.test.ts` case that reads it skips when it is absent.
```

Deleting the number, or leaving it bare, would have missed the point of #2053: a comment asserting something nothing enforces is worse than no comment, because it tells the next reader they need not check. The figure is now checkable rather than unfalsifiable.

Comment-only — filtering the diff for non-comment lines returns nothing. Export tests identical before and after (332 passed / 28 skipped; the one failing suite is `lod1-generator.test.ts`, pre-existing, unbuilt `@ifc-lite/wasm` in a fresh worktree). No changeset: no runtime, API or output change.

## Same-shape sweep — reported, not fixed

Live instances of the same shape, left alone deliberately:

- `packages/export/CHANGELOG.md:30` — identical "the committed Duplex fixture has six of each" wording
- `packages/wasm/CHANGELOG.md:49` — "The committed `AB22.ifc` infrastructure fixture" (`manifest.json:7`, also on-demand)
- `packages/wasm/CHANGELOG.md:39` — "Measured against the committed corpus … 283 of 5,577 voided hosts"

Those three are **published changelogs generated by changesets** — a historical record of what was released. Rewriting them is your call, not something to fold into a comment fix.

- `rust/geometry/src/csg/mod.rs:86` — "Six of duplex.ifc's material-layer wall slices shipped 81 NaN normal components": two figures from the same on-demand fixture with no pointer to how to reproduce them. Doesn't say "committed", but same theme. Different crate, so reporting rather than sprawling.

Checked and **refuted** — these really are tracked, comments accurate: `packages/cli/src/commands/export-usd.test.ts:7` (hello-wall), `apps/viewer/src/lib/tours/demo-kit.ts:6` (building-architecture), `rust/processing/tests/faceted_brep_point_cache.rs:15` (shared_point_faceted_brep). The remaining ~30 "committed X" hits refer to genuinely committed JSON artifacts and scorecards, not fixtures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how to obtain the Duplex fixture for testing.
  * Documented checksum verification and the behavior when the fixture is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->