### PR TITLE
fix(sandbox): report a timeout inside a drained job instead of a stale value

### DIFF
--- a/.changeset/sandbox-job-timeout.md
+++ b/.changeset/sandbox-job-timeout.md
@@ -1,0 +1,9 @@
+---
+"@ifc-lite/sandbox": patch
+---
+
+Report a sandbox CPU timeout that hits an `async` script body instead of returning a stale value.
+
+QuickJS surfaces an interrupted top-level body as an eval error, so a script that spins in its main body already failed with `interrupted`. But an `async` function body runs as a promise job, and `executePendingJobs()` reports no error when the CPU deadline cuts one short — so `eval()` returned the value the main body had produced before the job ran and reported success. A script whose real work happened inside `async function run()` could therefore time out and still look like it had completed.
+
+The sandbox now records whether its interrupt handler actually fired and, after draining the job queue, raises the same `ScriptError: interrupted` the main-body path already raises. Scripts whose jobs complete normally are unaffected and still return the main-body value.

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -46,6 +46,14 @@ export class Sandbox {
   private bridgeDispose: (() => void) | null = null;
   /** Mutable start time — updated by eval(), read by interrupt handler */
   private evalStartTime = 0;
+  /**
+   * Set by the interrupt handler when it actually cuts execution short.
+   * Cleared at the start of every eval(). QuickJS reports an interrupted
+   * *main body* as an eval error, but an interrupted *promise job* is
+   * swallowed by executePendingJobs(), so this flag is the only signal that
+   * the drained jobs hit the CPU deadline.
+   */
+  private interrupted = false;
   private readonly sessionId = createSandboxSessionId();
 
   constructor(
@@ -76,6 +84,7 @@ export class Sandbox {
       const timeoutMs = this.config.limits.timeoutMs ?? DEFAULT_LIMITS.timeoutMs;
       this.runtime.setInterruptHandler(() => {
         if (this.evalStartTime > 0 && Date.now() - this.evalStartTime > timeoutMs) {
+          this.interrupted = true;
           return true; // Interrupt execution
         }
         return false;
@@ -131,6 +140,7 @@ export class Sandbox {
       }
     };
 
+    this.interrupted = false;
     this.evalStartTime = Date.now();
 
     const result = this.vm.evalCode(jsCode, options?.filename ?? 'script.js');
@@ -175,6 +185,15 @@ export class Sandbox {
           this.logs,
           durationMs,
         );
+      }
+
+      // The main body finished, but a drained job may have been cut short by
+      // the CPU deadline — executePendingJobs() reports no error for that, so
+      // result.value still holds the (stale) main-body value. Reporting it as
+      // a success hands the caller a silently truncated run, so surface the
+      // same 'interrupted' ScriptError QuickJS raises for a main-body timeout.
+      if (this.interrupted) {
+        throw new ScriptError('interrupted', this.logs, durationMs);
       }
 
       let value: unknown;

--- a/packages/sandbox/src/timeout-interrupt.test.ts
+++ b/packages/sandbox/src/timeout-interrupt.test.ts
@@ -1,0 +1,91 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Regression tests for the silently-swallowed CPU timeout.
+ *
+ * QuickJS surfaces an interrupted *main body* as an eval error, so a script
+ * that spins in its top level already fails with `interrupted`. A script that
+ * spins inside an `async` body runs as a *promise job*, and
+ * `executePendingJobs()` reports no error when the interrupt handler cuts one
+ * short — so `eval()` used to return the pre-job main-body value and report
+ * success, handing the caller a silently truncated run.
+ *
+ * These tests drive the real `createSandbox` with a short `timeoutMs`.
+ *
+ * This file is kept separate so vitest gives it its own worker: an interrupt
+ * abort poisons the shared WASM module for every later test in the process.
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { BimContext } from '@ifc-lite/sdk';
+import { createSandbox, ScriptError } from './sandbox.js';
+
+/** The scripts under test never touch `bim`, so an empty context suffices. */
+const EMPTY_SDK = {} as unknown as BimContext;
+
+/** Busy-spins without allocating — the CPU deadline is the only way out. */
+const SPIN = 'let n = 0; while (true) { n += 1; }';
+
+/** Runs `script` and returns the rejection, failing if it resolves instead. */
+async function evalRejection(script: string, timeoutMs: number): Promise<unknown> {
+  const sandbox = await createSandbox(EMPTY_SDK, { limits: { timeoutMs } });
+  try {
+    const result = await sandbox.eval(script, { typescript: false });
+    throw new Error(`expected a timeout, but eval resolved with ${JSON.stringify(result.value)}`);
+  } catch (err) {
+    return err;
+  } finally {
+    sandbox.dispose();
+  }
+}
+
+describe('sandbox CPU timeout', () => {
+  it('reports a main-body timeout as an interrupted error', async () => {
+    const err = await evalRejection(`${SPIN} 'unreached'`, 200);
+
+    expect(err).toBeInstanceOf(ScriptError);
+    expect((err as ScriptError).message).toBe('interrupted');
+  }, 30_000);
+
+  it('reports a timeout inside a drained promise job the same way', async () => {
+    const err = await evalRejection(
+      `async function run() { await 0; ${SPIN} } run(); 'started'`,
+      200,
+    );
+
+    expect(err).toBeInstanceOf(ScriptError);
+    expect((err as ScriptError).message).toBe('interrupted');
+  }, 30_000);
+
+  it('still returns the main-body value when the jobs complete', async () => {
+    const sandbox = await createSandbox(EMPTY_SDK, { limits: { timeoutMs: 5_000 } });
+    try {
+      // `ran` proves the job really was drained rather than skipped — the
+      // assertion would hold even for a no-op job without it.
+      const result = await sandbox.eval(
+        "let ran = false; async function run() { await 0; ran = true; } run(); 'started'",
+        { typescript: false },
+      );
+      expect(result.value).toBe('started');
+
+      const ran = await sandbox.eval('ran', { typescript: false });
+      expect(ran.value).toBe(true);
+    } finally {
+      sandbox.dispose();
+    }
+  }, 30_000);
+
+  it('does not carry a timeout over to the next eval', async () => {
+    const sandbox = await createSandbox(EMPTY_SDK, { limits: { timeoutMs: 200 } });
+    try {
+      await expect(sandbox.eval(SPIN, { typescript: false })).rejects.toThrow(ScriptError);
+
+      const result = await sandbox.eval("'fine'", { typescript: false });
+      expect(result.value).toBe('fine');
+    } finally {
+      sandbox.dispose();
+    }
+  }, 30_000);
+});


### PR DESCRIPTION
Found while investigating #1922 and deliberately left out of #2062, which touches `dispose()` only. Independent of it.

## A timeout that reported success

QuickJS surfaces an interrupted **main body** as an eval error, but an interrupted **promise job** is swallowed by `executePendingJobs()`. So `result.value` still held the main body's value and `eval()` returned it as a success. Same spin loop, two answers:

```
main body spin   -> ScriptError: interrupted     (correct)
drained job spin -> RESOLVED with "started"      (silently truncated run)
```

The user gets a plausible answer from a run that was cut short — no error, nothing to notice. At the documented 30 s default this is reachable by any async script that overruns.

Nothing consulted the sandbox's own interrupt handler, which was the only remaining signal: it returned `true` and recorded nothing (`sandbox.ts:77-82`). The drain result is disposed without inspection at `:155-157`, and the only failure signal consulted was `result.error`, which reflects the main body alone (`:164-195`).

## The fix

The handler now records that it fired; the flag clears at the top of every `eval()`; it is checked after the drain — **after** the existing `result.error` branch, so the main-body path is byte-for-byte unchanged. It throws the same `ScriptError('interrupted')` QuickJS raises for a main-body timeout, so the two paths report identically rather than inventing a second error shape.

## Guarded against over-breadth

The obvious failure mode here is turning every async script into a timeout. `still returns the main-body value when the jobs complete` asserts `result.value === 'started'` **and** then evaluates `ran` in the same sandbox to prove the job actually executed — a no-op job would satisfy the value assertion alone. It passes both before and after the fix, which is the point. A fourth test pins the per-eval reset.

## Evidence

Each of the three parts is separately mutation-killed:

| mutant | replacements | outcome |
|---|---|---|
| drop `this.interrupted = true` from the handler | 1 | drained-job test fails |
| drop the post-drain `if (this.interrupted) throw` | 1 | drained-job test fails |
| drop the per-eval reset | 1 | `does not carry a timeout over to the next eval` fails |

I re-ran the first myself on the pushed tree (`REPLACEMENTS=1`, grep confirming the line was gone): 1 failed / 40 passed, and the negative-case test stayed green.

The test helper turns a resolve into a thrown `Error`, so a swallowed failure is not possible — the assertion fails on the *class* of what came back, not on a truthiness check.

sandbox 41 passing (was 37), extensions 598, sdk 62, typecheck 34/34.

`timeout-interrupt.test.ts` is its own file, and uses a **non-allocating** spin loop so it trips the CPU interrupt without risking the OOM abort from #1922 — that abort poisons the WASM module for the rest of the vitest worker, which is why `dispose-leak.test.ts` and `dispose-abort.test.ts` are separate too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - CPU timeouts during asynchronous sandbox jobs now report `ScriptError: interrupted` instead of returning an outdated result.
  - Normally completed jobs continue to return their expected results and execute side effects.
  - Subsequent evaluations remain unaffected after a timeout.

- **Tests**
  - Added regression coverage for main-script and asynchronous job timeouts, successful promise completion, and recovery after interruption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->