### PR TITLE
fix(viewer): keep type-library and hidden-class geometry out of 2D drawings (#2058, #2060)

### DIFF
--- a/apps/viewer/src/components/viewer/Section2DPanel.tsx
+++ b/apps/viewer/src/components/viewer/Section2DPanel.tsx
@@ -73,6 +73,9 @@ export function Section2DPanel({
   const setDrawingError = useViewerStore((s) => s.setDrawing2DError);
   const displayOptions = useViewerStore((s) => s.drawing2DDisplayOptions);
   const updateDisplayOptions = useViewerStore((s) => s.updateDrawing2DDisplayOptions);
+  // Class-level Visibility toggles — the section honours them like the 3D
+  // viewport does, so a hidden IfcSpace/IfcOpeningElement is not cut (#2060).
+  const typeVisibility = useViewerStore((s) => s.typeVisibility);
   // Graphic overrides
   const graphicOverridePresets = useViewerStore((s) => s.graphicOverridePresets);
   const activePresetId = useViewerStore((s) => s.activePresetId);
@@ -278,7 +281,7 @@ export function Section2DPanel({
   // ═══════════════════════════════════════════════════════════════════════════
 
   const { generateDrawing, doRegenerate, isRegenerating } = useDrawingGeneration({
-    geometryResult, ifcDataStore, sectionPlane, displayOptions,
+    geometryResult, ifcDataStore, sectionPlane, displayOptions, typeVisibility,
     combinedHiddenIds, combinedIsolatedIds, computedIsolatedIds,
     models, panelVisible, drawing,
     setDrawing, setDrawingStatus, setDrawingProgress, setDrawingError,

--- a/apps/viewer/src/hooks/useConstructionUnderlay.ts
+++ b/apps/viewer/src/hooks/useConstructionUnderlay.ts
@@ -19,6 +19,7 @@ import { useEffect, useRef, useState } from 'react';
 import { Drawing2DGenerator, createSectionConfig } from '@ifc-lite/drawing-2d';
 import type { CoordinateInfo } from '@ifc-lite/geometry';
 import { useViewerStore } from '@/store';
+import { selectModelMeshes } from '@/lib/type-view-visibility';
 
 export interface UnderlayLine {
   a: [number, number];
@@ -37,7 +38,9 @@ export function useConstructionUnderlay(
   const genRef = useRef<Drawing2DGenerator | null>(null);
 
   useEffect(() => {
-    const meshes = geometryResult?.meshes;
+    // Building elements only — the type library never belongs in a 2D
+    // underlay any more than it belongs in a section (#2058).
+    const meshes = geometryResult?.meshes ? selectModelMeshes(geometryResult.meshes) : undefined;
     if (!enabled || floorElevation === null || !meshes || meshes.length === 0) {
       setLines([]);
       return;

--- a/apps/viewer/src/hooks/useDrawingGeneration.projection.test.tsx
+++ b/apps/viewer/src/hooks/useDrawingGeneration.projection.test.tsx
@@ -1,0 +1,439 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The CONSTRUCTION-PROJECTION half of the drawing pipeline (#2058 / #2060).
+ *
+ * The two sibling suites both run with `showConstructionProjection: false`, so
+ * everything the hook does under `projectionOn` — the profile filters and the
+ * storey-band scoping — was structurally unreachable from the test suite: the
+ * `if (projectionOn)` blocks never executed anywhere. This file turns
+ * projection ON so those lines run.
+ *
+ * Projection reaches the drawing by two routes that the mesh filters do NOT
+ * cover:
+ *
+ *  1. `projectionProfiles` — extruded-area-solid outlines pulled straight out
+ *     of the IFC source by `GeometryProcessor.extractProfiles`, never from
+ *     `geometryResult.meshes`. Filtering the mesh list therefore does nothing
+ *     to them; they need their own `isTypeVisible` pass (#2060).
+ *  2. the storey bands — `storeyFloorsFromMeshes` derives per-storey floor
+ *     levels from mesh geometry, and those levels decide how deep the
+ *     projection reaches on each side of the cut (#2058).
+ *
+ * The profile suite drives the REAL wasm extractor over a real (inline) IFC
+ * file, so the profiles under test are the ones production would get.
+ */
+
+import '@/test/setup-dom.js';
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import type { Drawing2D } from '@ifc-lite/drawing-2d';
+import type { GeometryResult, MeshData } from '@ifc-lite/geometry';
+import { IfcTypeEnum, type SpatialHierarchy, type SpatialNode } from '@ifc-lite/data';
+import type { TypeVisibilityGate } from '@/store/typeVisibilityFilter';
+import { useDrawingGeneration } from './useDrawingGeneration.js';
+
+// ─── Real wasm under happy-dom ───────────────────────────────────────────
+
+/**
+ * Let `GeometryProcessor.init()` load the engine in this environment.
+ *
+ * `@ifc-lite/geometry` reads the `.wasm` off disk only when
+ * `typeof window === 'undefined'`; `setup-dom` defines `window`, so the bridge
+ * takes the browser path and `fetch`es a `file:` URL, which happy-dom rejects.
+ * The hook catches that and degrades to zero profiles — which would make every
+ * profile assertion below pass VACUOUSLY, filter or no filter. Serving `file:`
+ * from disk makes the real extractor run; the "class is visible" test is the
+ * canary that it did.
+ */
+function serveFileUrlsFromDisk(): void {
+  const upstream = globalThis.fetch;
+  const patched = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    const href =
+      input instanceof URL ? input.href
+      : typeof input === 'string' ? input
+      : input.url;
+    if (href.startsWith('file:')) {
+      const bytes = await readFile(fileURLToPath(href));
+      return new Response(bytes, { headers: { 'content-type': 'application/wasm' } });
+    }
+    return upstream(input, init);
+  };
+  globalThis.fetch = patched;
+
+  // `WebAssembly.instantiateStreaming` is Node's and rejects happy-dom's
+  // `Response` outright ("must be an instance of Response ... Received an
+  // instance of Response"). wasm-bindgen only falls back to the buffered
+  // `instantiate` when the streaming entry point is absent, so remove it for
+  // this process; the buffered path compiles the same bytes.
+  Reflect.deleteProperty(WebAssembly, 'instantiateStreaming');
+}
+
+before(() => { serveFileUrlsFromDisk(); });
+
+// ─── Fixture helpers ─────────────────────────────────────────────────────
+
+/** Axis-aligned box in render space (Y-up), 12 triangles. The CPU cutter, the
+ *  edge extractor and `storeyFloorsFromMeshes` only read positions/indices. */
+function box(
+  expressId: number,
+  ifcType: string,
+  geometryClass: number,
+  min: [number, number, number],
+  max: [number, number, number],
+): MeshData {
+  const [x0, y0, z0] = min;
+  const [x1, y1, z1] = max;
+  const positions = new Float32Array([
+    x0, y0, z0,  x1, y0, z0,  x1, y1, z0,  x0, y1, z0,
+    x0, y0, z1,  x1, y0, z1,  x1, y1, z1,  x0, y1, z1,
+  ]);
+  const indices = new Uint32Array([
+    0, 1, 2,  0, 2, 3, // -z
+    4, 6, 5,  4, 7, 6, // +z
+    0, 4, 5,  0, 5, 1, // -y
+    3, 2, 6,  3, 6, 7, // +y
+    0, 3, 7,  0, 7, 4, // -x
+    1, 5, 6,  1, 6, 2, // +x
+  ]);
+  return {
+    expressId,
+    ifcType,
+    modelIndex: 0,
+    positions,
+    normals: new Float32Array(positions.length),
+    indices,
+    color: [0.5, 0.5, 0.5, 1],
+    geometryClass,
+  };
+}
+
+function geometry(
+  meshes: MeshData[],
+  min: [number, number, number],
+  max: [number, number, number],
+): GeometryResult {
+  return {
+    meshes,
+    totalTriangles: meshes.length * 12,
+    totalVertices: meshes.length * 8,
+    coordinateInfo: {
+      originShift: { x: 0, y: 0, z: 0 },
+      originalBounds: { min: { x: min[0], y: min[1], z: min[2] }, max: { x: max[0], y: max[1], z: max[2] } },
+      shiftedBounds:  { min: { x: min[0], y: min[1], z: min[2] }, max: { x: max[0], y: max[1], z: max[2] } },
+      hasLargeCoordinates: false,
+    },
+  };
+}
+
+const ALL_VISIBLE: TypeVisibilityGate = {
+  spaces: true, spatialZones: true, openings: true,
+  virtualElements: true, site: true, ifcAnnotations: true,
+};
+
+const SPACES_HIDDEN: TypeVisibilityGate = { ...ALL_VISIBLE, spaces: false };
+
+interface HarnessOptions {
+  geometryResult: GeometryResult;
+  typeVisibility: TypeVisibilityGate;
+  ifcDataStore: { source: Uint8Array; spatialHierarchy?: SpatialHierarchy } | null;
+}
+
+/** Drive the real hook once, with construction projection ON, and return the
+ *  drawing it publishes. */
+async function generate(options: HarnessOptions): Promise<Drawing2D | null> {
+  let drawing: Drawing2D | null = null;
+  let run: (() => Promise<void>) | null = null;
+
+  function Harness(): null {
+    const { generateDrawing } = useDrawingGeneration({
+      geometryResult: options.geometryResult,
+      ifcDataStore: options.ifcDataStore,
+      sectionPlane: { axis: 'down', position: 50, flipped: false },
+      displayOptions: {
+        showHiddenLines: false,
+        useSymbolicRepresentations: false,
+        show3DOverlay: false,
+        scale: 50,
+        // The whole point of this file: the sibling suites leave this false,
+        // which makes every `projectionOn` branch dead in the suite.
+        showConstructionProjection: true,
+      },
+      typeVisibility: options.typeVisibility,
+      combinedHiddenIds: new Set<number>(),
+      combinedIsolatedIds: null,
+      computedIsolatedIds: null,
+      models: new Map([['m0', { id: 'm0', visible: true }]]),
+      // Panel closed: the auto-generate effects stay out of the way so the
+      // drawing under test is the one this harness asks for, not a race.
+      panelVisible: false,
+      drawing: null,
+      setDrawing: (d) => { drawing = d; },
+      setDrawingStatus: () => {},
+      setDrawingProgress: () => {},
+      setDrawingError: () => {},
+    });
+    run = generateDrawing;
+    return null;
+  }
+
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  let root: Root | null = null;
+  try {
+    await act(async () => { root = createRoot(container); root.render(<Harness />); });
+    assert.ok(run, 'harness never rendered — the hook was not called');
+    await act(async () => { await run!(); });
+    return drawing;
+  } finally {
+    if (root) await act(async () => { root!.unmount(); });
+    container.remove();
+  }
+}
+
+/** Entity ids that reached the drawing as PROJECTION (not cut) geometry. */
+function projectedIds(drawing: Drawing2D | null): Set<number> {
+  return new Set(
+    (drawing?.lines ?? [])
+      .filter((l) => l.category !== 'cut')
+      .map((l) => l.entityId),
+  );
+}
+
+// ─── Suite 1: the projection-profile visibility filter (#2060) ───────────
+
+/**
+ * Two extruded-area solids, an `IfcWall` and an `IfcSpace`, both 3 m tall from
+ * z=0. `extractProfiles` returns one profile each (verified: express ids 38 and
+ * 48), so the profile projector — which never looks at `geometryResult.meshes`
+ * — is the ONLY route these reach the drawing by once the mesh filter has
+ * dropped the hidden space.
+ */
+const PROFILE_IFC = `ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''),'2;1');
+FILE_NAME('projection_profiles.ifc','2026-08-04T00:00:00',(''),(''),'ifc-lite','ifc-lite','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCCARTESIANPOINT((0.,0.,0.));
+#2=IFCAXIS2PLACEMENT3D(#1,$,$);
+#3=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+#4=IFCUNITASSIGNMENT((#3));
+#5=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.0E-5,#2,$);
+#6=IFCDIRECTION((0.,0.,1.));
+#19=IFCLOCALPLACEMENT($,#2);
+#20=IFCSITE('0SITE56789ABCDEFGHIJKL',$,'Site',$,$,#19,$,$,.ELEMENT.,$,$,$,$,$);
+#21=IFCLOCALPLACEMENT(#19,#2);
+#22=IFCBUILDING('0BLDG56789ABCDEFGHIJKL',$,'Building',$,$,#21,$,$,.ELEMENT.,$,$,$);
+#23=IFCLOCALPLACEMENT(#21,#2);
+#24=IFCBUILDINGSTOREY('0STRY56789ABCDEFGHIJKL',$,'Storey',$,$,#23,$,$,.ELEMENT.,0.);
+#25=IFCPROJECT('0PRJ456789ABCDEFGHIJKL',$,'Proj',$,$,$,$,(#5),#4);
+#30=IFCCARTESIANPOINT((4.,0.));
+#31=IFCAXIS2PLACEMENT2D(#30,$);
+#32=IFCRECTANGLEPROFILEDEF(.AREA.,'WALL',#31,8.,0.4);
+#33=IFCAXIS2PLACEMENT3D(#1,$,$);
+#34=IFCEXTRUDEDAREASOLID(#32,#33,#6,3.);
+#35=IFCSHAPEREPRESENTATION(#5,'Body','SweptSolid',(#34));
+#36=IFCPRODUCTDEFINITIONSHAPE($,$,(#35));
+#37=IFCLOCALPLACEMENT(#23,#2);
+#38=IFCWALL('0WALL56789ABCDEFGHIJKL',$,'Wall',$,$,#37,#36,$,$);
+#40=IFCCARTESIANPOINT((4.,3.));
+#41=IFCAXIS2PLACEMENT2D(#40,$);
+#42=IFCRECTANGLEPROFILEDEF(.AREA.,'SPACE',#41,2.,2.);
+#43=IFCAXIS2PLACEMENT3D(#1,$,$);
+#44=IFCEXTRUDEDAREASOLID(#42,#43,#6,3.);
+#45=IFCSHAPEREPRESENTATION(#5,'Body','SweptSolid',(#44));
+#46=IFCPRODUCTDEFINITIONSHAPE($,$,(#45));
+#47=IFCLOCALPLACEMENT(#23,#2);
+#48=IFCSPACE('0SPAC56789ABCDEFGHIJKL',$,'Space',$,$,#47,#46,$,.ELEMENT.,$,$);
+#62=IFCRELAGGREGATES('0REL156789ABCDEFGHIJKL',$,$,$,#25,(#20));
+#63=IFCRELAGGREGATES('0REL256789ABCDEFGHIJKL',$,$,$,#20,(#22));
+#64=IFCRELAGGREGATES('0REL356789ABCDEFGHIJKL',$,$,$,#22,(#24));
+#65=IFCRELCONTAINEDINSPATIALSTRUCTURE('0REL456789ABCDEFGHIJKL',$,$,$,(#38),#24);
+#66=IFCRELAGGREGATES('0REL556789ABCDEFGHIJKL',$,$,$,#24,(#48));
+ENDSEC;
+END-ISO-10303-21;
+`;
+
+/** Express ids as authored in `PROFILE_IFC`. */
+const PROFILE_WALL_ID = 38;
+const PROFILE_SPACE_ID = 48;
+
+/**
+ * Render-frame (Y-up) meshes: IFC (x,y,z) maps to (x, z, −y), so the 3 m
+ * extrusion along +Z becomes the render Y span.
+ *
+ * Deliberately WALL ONLY. Giving the space a mesh too would let it reach the
+ * drawing by the silhouette route as well, and "the space is absent" would then
+ * be satisfied by the mesh filter (#2060's other half) with the profile filter
+ * gone. With no space mesh, the profile is the space's ONLY route in — so both
+ * assertions below are about the profile filter and nothing else.
+ */
+const PROFILE_MESHES: MeshData[] = [
+  box(PROFILE_WALL_ID, 'IfcWall', 0, [0, 0, -0.2], [8, 3, 0.2]),
+];
+
+describe('useDrawingGeneration construction projection: profile visibility (#2060)', () => {
+  it('drops a hidden class from the projection profiles', async () => {
+    const drawing = await generate({
+      geometryResult: geometry(PROFILE_MESHES, [0, 0, -0.2], [8, 3, 0.2]),
+      typeVisibility: SPACES_HIDDEN,
+      ifcDataStore: { source: new TextEncoder().encode(PROFILE_IFC) },
+    });
+
+    const ids = projectedIds(drawing);
+    // Negative case: the visible wall's profile must still project, otherwise
+    // this asserts nothing about the filter — only that projection is broken.
+    assert.ok(
+      ids.has(PROFILE_WALL_ID),
+      `the visible wall must still project; got ${[...ids]}`,
+    );
+    assert.ok(
+      !ids.has(PROFILE_SPACE_ID),
+      `a hidden IfcSpace must not project through its extruded-solid profile; got ${[...ids]}`,
+    );
+  });
+
+  it('keeps the same profile when the class is visible', async () => {
+    // Pins that the assertion above is a VISIBILITY result, not an artefact of
+    // the space having no extractable profile in the first place.
+    const drawing = await generate({
+      geometryResult: geometry(PROFILE_MESHES, [0, 0, -0.2], [8, 3, 0.2]),
+      typeVisibility: ALL_VISIBLE,
+      ifcDataStore: { source: new TextEncoder().encode(PROFILE_IFC) },
+    });
+
+    const ids = projectedIds(drawing);
+    assert.ok(
+      ids.has(PROFILE_SPACE_ID),
+      `the space profile must project when Spaces are visible; got ${[...ids]}`,
+    );
+  });
+});
+
+// ─── Suite 2: storey bands are derived from the FILTERED mesh set (#2058) ─
+
+/**
+ * `storeyFloorsFromMeshes` reads the mesh list to place each storey's floor,
+ * and those floors clamp how deep the projection reaches. Feeding it the raw
+ * `geometryResult.meshes` lets a type-library template — which draws at the
+ * MappingOrigin, not where any occurrence sits — contribute a floor level, and
+ * a floor level between the cut and the storey below truncates the visible
+ * (solid) band, culling geometry that belongs on the plan.
+ *
+ * Reachability, stated precisely: `elementToStorey` is built from
+ * `IfcRelContainedInSpatialStructure` (products only), but
+ * `spatial-hierarchy-builder.ts` then walks `IfcRelAggregates` from every
+ * contained element and maps EVERY descendant to that storey with no type
+ * check — and `IfcRelAggregates.RelatedObjects` is `IfcObjectDefinition`, which
+ * admits `IfcTypeObject`. So a type product aggregated under a placed element
+ * does land in `elementToStorey`. That is an unusual file shape, not the
+ * AC20-FZK-Haus case: on a file where no type id reaches `elementToStorey` the
+ * type template contributes no floor either way and the guard is inert. This
+ * test pins the coupling — the band computation must see the same mesh set the
+ * cut does — rather than reproducing a defect observed on a real model.
+ */
+const STOREY_LOWER = 1000;
+const STOREY_UPPER = 1001;
+
+const BASEMENT_SLAB = 10;   // must project: it is inside the lower storey's band
+const CUT_WALL = 11;        // spans the cut, so the drawing has cut bounds
+const UPPER_SLAB = 20;      // the upper storey's floor level
+const TYPE_TEMPLATE = 900;  // instanced type template, drawn at the MappingOrigin
+
+const STOREY_MESHES: MeshData[] = [
+  box(BASEMENT_SLAB, 'IfcSlab',     0, [0, -2.5, 0], [4, -2.3, 4]),
+  box(CUT_WALL,      'IfcWall',     0, [0, -3.0, 0], [4,  6.0, 0.2]),
+  box(UPPER_SLAB,    'IfcSlab',     0, [0,  3.0, 0], [4,  3.2, 4]),
+  // At the mapping origin (y = 0), between the cut and the storey below.
+  box(TYPE_TEMPLATE, 'IfcWallType', 2, [0,  0.0, 0], [1,  2.0, 0.2]),
+];
+
+/** Minimal `SpatialHierarchy`: the hook reads `elementToStorey` and
+ *  `byBuilding.size` only, but the interface is fully implemented so no cast is
+ *  needed. */
+function spatialHierarchy(elementToStorey: Map<number, number>): SpatialHierarchy {
+  const project: SpatialNode = {
+    expressId: 1, type: IfcTypeEnum.IfcProject, name: 'Proj', children: [], elements: [],
+  };
+  return {
+    project,
+    byStorey: new Map([
+      [STOREY_LOWER, [BASEMENT_SLAB, CUT_WALL]],
+      [STOREY_UPPER, [UPPER_SLAB]],
+    ]),
+    byBuilding: new Map([[2, []]]),
+    bySite: new Map(),
+    bySpace: new Map(),
+    storeyElevations: new Map([[STOREY_LOWER, -3], [STOREY_UPPER, 3]]),
+    storeyHeights: new Map(),
+    elementToStorey,
+    getStoreyElements: (storeyId) => (storeyId === STOREY_LOWER ? [BASEMENT_SLAB, CUT_WALL] : [UPPER_SLAB]),
+    getStoreyByElevation: () => null,
+    getContainingSpace: () => null,
+    getPath: () => [project],
+  };
+}
+
+/** An IFC with no swept solids: profile extraction succeeds and returns
+ *  nothing, so this suite exercises the band scoping in isolation from the
+ *  profile path above. */
+const NO_PROFILE_IFC = `ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''),'2;1');
+FILE_NAME('storey_bands.ifc','2026-08-04T00:00:00',(''),(''),'ifc-lite','ifc-lite','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCCARTESIANPOINT((0.,0.,0.));
+#2=IFCAXIS2PLACEMENT3D(#1,$,$);
+#3=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+#4=IFCUNITASSIGNMENT((#3));
+#5=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.0E-5,#2,$);
+#25=IFCPROJECT('0PRJ456789ABCDEFGHIJKL',$,'Proj',$,$,$,$,(#5),#4);
+ENDSEC;
+END-ISO-10303-21;
+`;
+
+describe('useDrawingGeneration construction projection: storey bands (#2058)', () => {
+  it('excludes type-library geometry from the storey floor levels', async () => {
+    // `elementToStorey` maps the type template to the UPPER storey — reachable
+    // via the untyped `IfcRelAggregates` walk described above. Unfiltered, its
+    // mapping-origin geometry (y = 0) drags that storey's floor from 3 down to
+    // 0, so the cut at y = 1.5 lands in a phantom [0, …) band and the solid
+    // band below the cut shrinks from 4.5 m to 1.5 m — cutting the basement
+    // slab, ~3.8 m below the cut, out of the plan.
+    const drawing = await generate({
+      geometryResult: geometry(STOREY_MESHES, [0, -3, 0], [4, 6, 4]),
+      typeVisibility: ALL_VISIBLE,
+      ifcDataStore: {
+        source: new TextEncoder().encode(NO_PROFILE_IFC),
+        spatialHierarchy: spatialHierarchy(new Map([
+          [BASEMENT_SLAB, STOREY_LOWER],
+          [CUT_WALL, STOREY_LOWER],
+          [UPPER_SLAB, STOREY_UPPER],
+          [TYPE_TEMPLATE, STOREY_UPPER],
+        ])),
+      },
+    });
+
+    const ids = projectedIds(drawing);
+    assert.ok(
+      ids.has(BASEMENT_SLAB),
+      `geometry inside the cut storey must project; the phantom band from the ` +
+      `type template truncated it. got ${[...ids]}`,
+    );
+    // The template itself is never drawn — the mesh filter already removed it.
+    assert.ok(
+      !ids.has(TYPE_TEMPLATE),
+      `the type template must not be drawn at all; got ${[...ids]}`,
+    );
+  });
+});

--- a/apps/viewer/src/hooks/useDrawingGeneration.projection.test.tsx
+++ b/apps/viewer/src/hooks/useDrawingGeneration.projection.test.tsx
@@ -437,3 +437,56 @@ describe('useDrawingGeneration construction projection: storey bands (#2058)', (
     );
   });
 });
+
+// ─── Suite 3: the profile route must mirror the mesh-class gate (#2070 review) ─
+
+/**
+ * `selectModelMeshes` drops type-library geometry (geometryClass 1/2) from
+ * `meshesToProcess` by express id (#2058). Until this suite, nothing checked
+ * that `projectionProfiles` — a second, independent route into the drawing
+ * that never reads `geometryClass` at all — respected the same exclusion.
+ *
+ * `extractProfiles` only walks `IfcProduct` entities today (verified against
+ * `rust/core/src/schema_helpers.rs::has_geometry_by_name`, gated on
+ * `is_subtype_of(IfcProduct)`), so it cannot itself emit a profile keyed to an
+ * `IfcXxxType` id — that gate lives in a different crate and nothing pins it
+ * from this side. This fixture reproduces the reachable half of the same
+ * shape without depending on that Rust invariant: a REAL occurrence (`IfcWall`
+ * #38, mesh + extruded-solid profile both real) whose mesh is tagged
+ * `geometryClass: 2` — an instanced-type duplicate — alongside another placed
+ * mesh so `selectModelMeshes` has occurrence geometry to compare against and
+ * drops #38 from the cut. Before the fix, the profile route did not know
+ * about that exclusion at all and still projected the wall's 3 m extrusion.
+ */
+const PLACED_SLAB_ID = 99; // keeps `hasOccurrenceGeometry` true and the cut non-empty; no matching IFC entity, so it has no profile of its own.
+
+const CLASS_GATE_MESHES: MeshData[] = [
+  box(PROFILE_WALL_ID, 'IfcWall', 2, [0, 0, -0.2], [8, 3, 0.2]), // instanced-type duplicate — must be dropped from the cut AND the projection
+  box(PLACED_SLAB_ID, 'IfcSlab', 0, [0, 0, -0.2], [8, 3, 0.2]),
+];
+
+describe('useDrawingGeneration construction projection: profile route mirrors the mesh-class gate (#2070)', () => {
+  it('does not project a profile whose express id was dropped from the cut as type-library geometry', async () => {
+    const drawing = await generate({
+      geometryResult: geometry(CLASS_GATE_MESHES, [0, 0, -0.2], [8, 3, 0.2]),
+      typeVisibility: ALL_VISIBLE,
+      ifcDataStore: { source: new TextEncoder().encode(PROFILE_IFC) },
+    });
+
+    const ids = projectedIds(drawing);
+    assert.ok(
+      !ids.has(PROFILE_WALL_ID),
+      `a geometryClass-2 wall dropped from the cut must not reach the drawing ` +
+      `via its extruded-solid profile either; got ${[...ids]}`,
+    );
+    // Control: an express id with NO mesh at all (the space, #48, absent from
+    // CLASS_GATE_MESHES) never went through the class gate, so this filter
+    // must leave it alone — proving the fix targets ids the gate actually
+    // excluded, not profiles in general.
+    assert.ok(
+      ids.has(PROFILE_SPACE_ID),
+      `a mesh-less entity's profile must be unaffected by the class-gate ` +
+      `mirror; got ${[...ids]}`,
+    );
+  });
+});

--- a/apps/viewer/src/hooks/useDrawingGeneration.test.tsx
+++ b/apps/viewer/src/hooks/useDrawingGeneration.test.tsx
@@ -106,6 +106,16 @@ async function generate(geometryResult: GeometryResult): Promise<Drawing2D | nul
       // Panel closed: the auto-generate effects stay out of the way so the
       // drawing under test is the one this harness asks for, not a race.
       panelVisible: false,
+      // Every class visible: this suite is about the type-LIBRARY filter
+      // (#2058), so the category filter (#2060) must not remove anything here.
+      typeVisibility: {
+        spaces: true,
+        spatialZones: true,
+        openings: true,
+        virtualElements: true,
+        site: true,
+        ifcAnnotations: true,
+      },
       drawing: null,
       setDrawing: (d) => { drawing = d; },
       setDrawingStatus: () => {},

--- a/apps/viewer/src/hooks/useDrawingGeneration.test.tsx
+++ b/apps/viewer/src/hooks/useDrawingGeneration.test.tsx
@@ -1,0 +1,196 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Type-library geometry must not bleed into the standard 2D drawing (#2058).
+ *
+ * `geometryResult.meshes` carries the whole scene — placed occurrences AND the
+ * type-library copies the wasm mesh pass emits (`geometryClass` 1 = orphan
+ * type, 2 = instanced type). The 3D viewport routes that set through
+ * `isMeshVisibleInViewMode`, so class 2 never reaches the Model view. The 2D
+ * drawing generator filtered only on hiding/isolation, so every instanced type
+ * template was cut and drawn on top of the plan — AC20-FZK-Haus alone carries
+ * 32 such meshes (IfcWallType/IfcDoorType/IfcWindowType) against 285
+ * occurrence meshes.
+ *
+ * These render the real hook (no mocked generator): two boxes straddling one
+ * plan cut, one occurrence and one type template, and assert on the entity ids
+ * that come back in the generated `Drawing2D`.
+ */
+
+import '@/test/setup-dom.js';
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import type { Drawing2D } from '@ifc-lite/drawing-2d';
+import type { GeometryResult, MeshData } from '@ifc-lite/geometry';
+import { useDrawingGeneration } from './useDrawingGeneration.js';
+
+// ─── Fixture ─────────────────────────────────────────────────────────────
+
+/** Axis-aligned box in render space (Y-up), 12 triangles, flat normals
+ *  omitted (the CPU cutter and edge extractor only read positions/indices). */
+function box(
+  expressId: number,
+  ifcType: string,
+  geometryClass: number,
+  min: [number, number, number],
+  max: [number, number, number],
+): MeshData {
+  const [x0, y0, z0] = min;
+  const [x1, y1, z1] = max;
+  const positions = new Float32Array([
+    x0, y0, z0,  x1, y0, z0,  x1, y1, z0,  x0, y1, z0,
+    x0, y0, z1,  x1, y0, z1,  x1, y1, z1,  x0, y1, z1,
+  ]);
+  const indices = new Uint32Array([
+    0, 1, 2,  0, 2, 3, // -z
+    4, 6, 5,  4, 7, 6, // +z
+    0, 4, 5,  0, 5, 1, // -y
+    3, 2, 6,  3, 6, 7, // +y
+    0, 3, 7,  0, 7, 4, // -x
+    1, 5, 6,  1, 6, 2, // +x
+  ]);
+  return {
+    expressId,
+    ifcType,
+    modelIndex: 0,
+    positions,
+    normals: new Float32Array(positions.length),
+    indices,
+    color: [0.5, 0.5, 0.5, 1],
+    geometryClass,
+  };
+}
+
+const OCCURRENCE_ID = 100;
+const TYPE_ID = 200;
+
+function geometry(meshes: MeshData[], max: [number, number, number]): GeometryResult {
+  return {
+    meshes,
+    totalTriangles: meshes.length * 12,
+    totalVertices: meshes.length * 8,
+    coordinateInfo: {
+      originShift: { x: 0, y: 0, z: 0 },
+      originalBounds: { min: { x: 0, y: 0, z: 0 }, max: { x: max[0], y: max[1], z: max[2] } },
+      shiftedBounds: { min: { x: 0, y: 0, z: 0 }, max: { x: max[0], y: max[1], z: max[2] } },
+      hasLargeCoordinates: false,
+    },
+  };
+}
+
+/** Drive the real hook once and return the drawing it publishes. */
+async function generate(geometryResult: GeometryResult): Promise<Drawing2D | null> {
+  let drawing: Drawing2D | null = null;
+  let run: (() => Promise<void>) | null = null;
+
+  function Harness(): null {
+    const { generateDrawing } = useDrawingGeneration({
+      geometryResult,
+      ifcDataStore: null,
+      sectionPlane: { axis: 'down', position: 50, flipped: false },
+      displayOptions: {
+        showHiddenLines: false,
+        useSymbolicRepresentations: false,
+        show3DOverlay: false,
+        scale: 50,
+        showConstructionProjection: false,
+      },
+      combinedHiddenIds: new Set<number>(),
+      combinedIsolatedIds: null,
+      computedIsolatedIds: null,
+      models: new Map([['m0', { id: 'm0', visible: true }]]),
+      // Panel closed: the auto-generate effects stay out of the way so the
+      // drawing under test is the one this harness asks for, not a race.
+      panelVisible: false,
+      drawing: null,
+      setDrawing: (d) => { drawing = d; },
+      setDrawingStatus: () => {},
+      setDrawingProgress: () => {},
+      setDrawingError: () => {},
+    });
+    run = generateDrawing;
+    return null;
+  }
+
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  let root: Root | null = null;
+  try {
+    await act(async () => { root = createRoot(container); root.render(<Harness />); });
+    assert.ok(run, 'harness never rendered — the hook was not called');
+    await act(async () => { await run!(); });
+    return drawing;
+  } finally {
+    if (root) await act(async () => { root!.unmount(); });
+    container.remove();
+  }
+}
+
+function entityIds(drawing: Drawing2D | null): Set<number> {
+  const out = new Set<number>();
+  for (const line of drawing?.lines ?? []) out.add(line.entityId);
+  for (const poly of drawing?.cutPolygons ?? []) out.add(poly.entityId);
+  return out;
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────
+
+describe('useDrawingGeneration type-library geometry (#2058)', () => {
+  it('cuts the occurrence but not the instanced type template', async () => {
+    const drawing = await generate(
+      geometry(
+        [
+          box(OCCURRENCE_ID, 'IfcWall', 0, [0, 0, 0], [2, 3, 0.2]),
+          box(TYPE_ID, 'IfcWallType', 2, [5, 0, 0], [7, 3, 0.2]),
+        ],
+        [7, 3, 0.2],
+      ),
+    );
+
+    const ids = entityIds(drawing);
+    // Negative case: the real building must still be drawn.
+    assert.ok(
+      ids.has(OCCURRENCE_ID),
+      `occurrence geometry must still reach the 2D drawing; got ids ${[...ids]}`,
+    );
+    // The bug: the type template must not.
+    assert.ok(
+      !ids.has(TYPE_ID),
+      `instanced type geometry must not reach the 2D drawing; got ids ${[...ids]}`,
+    );
+  });
+
+  it('keeps orphan type geometry when the model has no occurrences at all', async () => {
+    // A pure type-library file (buildingSMART annex-E) has nothing else to
+    // draw — dropping class 1 unconditionally would blank the drawing, which
+    // is exactly the trap `isMeshVisibleInViewMode` already encodes for 3D.
+    const drawing = await generate(
+      geometry([box(TYPE_ID, 'IfcBoilerType', 1, [0, 0, 0], [2, 3, 0.2])], [2, 3, 0.2]),
+    );
+
+    assert.ok(
+      entityIds(drawing).has(TYPE_ID),
+      'orphan type geometry must still be drawn for a model with no occurrences',
+    );
+  });
+
+  it('drops orphan type geometry once the model has placed occurrences', async () => {
+    const drawing = await generate(
+      geometry(
+        [
+          box(OCCURRENCE_ID, 'IfcWall', 0, [0, 0, 0], [2, 3, 0.2]),
+          box(TYPE_ID, 'IfcBoilerType', 1, [5, 0, 0], [7, 3, 0.2]),
+        ],
+        [7, 3, 0.2],
+      ),
+    );
+
+    const ids = entityIds(drawing);
+    assert.ok(ids.has(OCCURRENCE_ID), 'occurrence geometry must still be drawn');
+    assert.ok(!ids.has(TYPE_ID), 'orphan type-library geometry must not be drawn alongside it');
+  });
+});

--- a/apps/viewer/src/hooks/useDrawingGeneration.ts
+++ b/apps/viewer/src/hooks/useDrawingGeneration.ts
@@ -31,6 +31,7 @@ import type { SpatialHierarchy } from '@ifc-lite/data';
 import * as IfcWasm from '@ifc-lite/wasm';
 import { customPlaneCenter } from '@/store';
 import { selectModelMeshes } from '@/lib/type-view-visibility';
+import { isTypeVisible, type TypeVisibilityGate } from '@/store/typeVisibilityFilter';
 
 // The winding-robust Rust `meshOutline2d` binding (issue #979) is gitignored →
 // CI-built, so reference it defensively: against an older wasm bundle it's
@@ -103,6 +104,12 @@ interface UseDrawingGenerationParams {
     };
   };
   displayOptions: { showHiddenLines: boolean; useSymbolicRepresentations: boolean; show3DOverlay: boolean; scale: number; showConstructionProjection: boolean };
+  /**
+   * Class-level Visibility toggles (Spaces, Openings, Site, Virtual Elements,
+   * Spatial Zones, Annotations). Global, not 3D-only — see the filter in
+   * `generateDrawing` (issue #2060).
+   */
+  typeVisibility: TypeVisibilityGate;
   combinedHiddenIds: Set<number>;
   combinedIsolatedIds: Set<number> | null;
   computedIsolatedIds?: Set<number> | null;
@@ -127,6 +134,7 @@ export function useDrawingGeneration({
   ifcDataStore,
   sectionPlane,
   displayOptions,
+  typeVisibility,
   combinedHiddenIds,
   combinedIsolatedIds,
   computedIsolatedIds,
@@ -647,6 +655,18 @@ export function useDrawingGeneration({
       // Filter meshes by visibility (respect 3D hiding/isolation)
       let meshesToProcess = modelMeshes;
 
+      // Class-level Visibility toggles (issue #2060). These are a GLOBAL
+      // filter, not a 3D-only one: `ViewportContainer` applies `isTypeVisible`
+      // to the mesh list it hands the renderer, but the drawing derives its own
+      // list from `geometryResult.meshes` and only ever filtered
+      // hiding/isolation. So a hidden IfcSpace / IfcOpeningElement was still
+      // cut — its fill and outline showed in the 2D Section view, and via the
+      // 3D section overlay (which uploads `drawing.cutPolygons` /
+      // `drawing.lines` verbatim, see `useRenderUpdates.ts`) in the 3D view
+      // too. Same shared mapping as the viewport, Cesium, basket and GLB
+      // export, so all six toggles stay in lockstep.
+      meshesToProcess = meshesToProcess.filter((mesh) => isTypeVisible(mesh.ifcType, typeVisibility));
+
       // Filter out hidden entities (using combined multi-model set)
       if (combinedHiddenIds.size > 0) {
         meshesToProcess = meshesToProcess.filter(
@@ -688,9 +708,12 @@ export function useDrawingGeneration({
       // meshes, so projection respects 3D hiding and storey isolation —
       // otherwise other storeys' profiles project through the plan and the
       // dedup keys (built from profiles) would suppress silhouettes for
-      // entities that aren't actually drawn.
+      // entities that aren't actually drawn. Class visibility rides along for
+      // the same reason (#2060): a profile is another way for a hidden
+      // IfcSpace to reach the drawing.
       let projectionProfiles = profiles;
       if (projectionOn && profiles.length > 0) {
+        projectionProfiles = projectionProfiles.filter((p) => isTypeVisible(p.ifcType, typeVisibility));
         if (combinedHiddenIds.size > 0) {
           projectionProfiles = projectionProfiles.filter((p) => !combinedHiddenIds.has(p.expressId));
         }
@@ -1035,6 +1058,7 @@ export function useDrawingGeneration({
     ifcDataStore,
     sectionPlane,
     displayOptions,
+    typeVisibility,
     combinedHiddenIds,
     combinedIsolatedIds,
     computedIsolatedIds,
@@ -1049,6 +1073,7 @@ export function useDrawingGeneration({
   const prevPanelVisibleRef = useRef(false);
   const prevOverlayEnabledRef = useRef(false);
   const prevMeshCountRef = useRef(0);
+  const prevTypeVisibilityRef = useRef(typeVisibility);
 
   // Auto-generate when panel opens (or 3D overlay is enabled) and no drawing exists
   // Also regenerate when geometry changes significantly (e.g., models hidden/shown)
@@ -1064,11 +1089,17 @@ export function useDrawingGeneration({
     const overlayJustEnabled = displayOptions.show3DOverlay && !wasOverlayEnabled;
     const isNowActive = panelVisible || displayOptions.show3DOverlay;
     const geometryChanged = currentMeshCount !== prevMeshCount;
+    // Flipping a class toggle changes the drawing's input without changing the
+    // mesh count, so `geometryChanged` never fires for it (issue #2060). The
+    // store replaces the whole `typeVisibility` object on every toggle, so an
+    // identity compare is enough.
+    const typeVisibilityChanged = prevTypeVisibilityRef.current !== typeVisibility;
 
     // Always update refs
     prevPanelVisibleRef.current = panelVisible;
     prevOverlayEnabledRef.current = displayOptions.show3DOverlay;
     prevMeshCountRef.current = currentMeshCount;
+    prevTypeVisibilityRef.current = typeVisibility;
 
     if (isNowActive) {
       if (!hasGeometry) {
@@ -1077,16 +1108,17 @@ export function useDrawingGeneration({
           setDrawing(null);
           setDrawingStatus('idle');
         }
-      } else if (panelJustOpened || overlayJustEnabled || !drawing || geometryChanged) {
+      } else if (panelJustOpened || overlayJustEnabled || !drawing || geometryChanged || typeVisibilityChanged) {
         // Generate if:
         // 1. Panel just opened, OR
         // 2. Overlay just enabled, OR
         // 3. No drawing exists, OR
-        // 4. Geometry changed significantly (models hidden/shown)
+        // 4. Geometry changed significantly (models hidden/shown), OR
+        // 5. A class-visibility toggle flipped (issue #2060)
         generateDrawing();
       }
     }
-  }, [panelVisible, displayOptions.show3DOverlay, drawing, geometryResult, generateDrawing, setDrawing, setDrawingStatus]);
+  }, [panelVisible, displayOptions.show3DOverlay, drawing, geometryResult, typeVisibility, generateDrawing, setDrawing, setDrawingStatus]);
 
   // Auto-regenerate when section plane changes
   // Strategy: INSTANT - no debounce, but prevent overlapping computations

--- a/apps/viewer/src/hooks/useDrawingGeneration.ts
+++ b/apps/viewer/src/hooks/useDrawingGeneration.ts
@@ -30,7 +30,7 @@ import { GeometryProcessor, type GeometryResult } from '@ifc-lite/geometry';
 import type { SpatialHierarchy } from '@ifc-lite/data';
 import * as IfcWasm from '@ifc-lite/wasm';
 import { customPlaneCenter } from '@/store';
-import { selectModelMeshes } from '@/lib/type-view-visibility';
+import { buildModelViewIdFilter, selectModelMeshes } from '@/lib/type-view-visibility';
 import { isTypeVisible, type TypeVisibilityGate } from '@/store/typeVisibilityFilter';
 
 // The winding-robust Rust `meshOutline2d` binding (issue #979) is gitignored →
@@ -214,6 +214,13 @@ export function useDrawingGeneration({
     // hiding/isolation, so every type template was cut and projected on top of
     // the plan — AC20-FZK-Haus alone carries 32 of them.
     const modelMeshes = selectModelMeshes(geometryResult.meshes);
+
+    // Mirror of the same gate, keyed by express id, for construction-projection
+    // profiles (issue #2070 review): they reach the drawing WITHOUT going
+    // through `modelMeshes`, so filtering the mesh list alone left them
+    // ungated. See `buildModelViewIdFilter`'s doc comment for why this matters
+    // even though today's `extractProfiles` can't produce a type-library id.
+    const isModelViewExpressId = buildModelViewIdFilter(geometryResult.meshes);
 
     // Only show full loading overlay for initial generation, not regeneration
     if (!isRegenerate) {
@@ -713,6 +720,11 @@ export function useDrawingGeneration({
       // IfcSpace to reach the drawing.
       let projectionProfiles = profiles;
       if (projectionOn && profiles.length > 0) {
+        // #2058's mesh-class gate, mirrored onto profiles (#2070 review):
+        // `modelMeshes` above already dropped type-library geometry from the
+        // cut by express id; without this, a profile sharing that same
+        // express id would still be free to project it back in.
+        projectionProfiles = projectionProfiles.filter((p) => isModelViewExpressId(p.expressId));
         projectionProfiles = projectionProfiles.filter((p) => isTypeVisible(p.ifcType, typeVisibility));
         if (combinedHiddenIds.size > 0) {
           projectionProfiles = projectionProfiles.filter((p) => !combinedHiddenIds.has(p.expressId));
@@ -1092,7 +1104,11 @@ export function useDrawingGeneration({
     // Flipping a class toggle changes the drawing's input without changing the
     // mesh count, so `geometryChanged` never fires for it (issue #2060). The
     // store replaces the whole `typeVisibility` object on every toggle, so an
-    // identity compare is enough.
+    // identity compare is enough — this hook's own tests can't prove that on
+    // their own, since they pass their own object literals; it's pinned by
+    // `visibilitySlice.test.ts`'s "replaces the typeVisibility object identity
+    // on every toggle" case, which fails if `toggleTypeVisibility` is
+    // refactored to structural sharing (#2070 review).
     const typeVisibilityChanged = prevTypeVisibilityRef.current !== typeVisibility;
 
     // Always update refs

--- a/apps/viewer/src/hooks/useDrawingGeneration.ts
+++ b/apps/viewer/src/hooks/useDrawingGeneration.ts
@@ -30,6 +30,7 @@ import { GeometryProcessor, type GeometryResult } from '@ifc-lite/geometry';
 import type { SpatialHierarchy } from '@ifc-lite/data';
 import * as IfcWasm from '@ifc-lite/wasm';
 import { customPlaneCenter } from '@/store';
+import { selectModelMeshes } from '@/lib/type-view-visibility';
 
 // The winding-robust Rust `meshOutline2d` binding (issue #979) is gitignored →
 // CI-built, so reference it defensively: against an older wasm bundle it's
@@ -196,6 +197,15 @@ export function useDrawingGeneration({
       setDrawingError('No visible geometry');
       return;
     }
+
+    // Drop type-library geometry (issue #2058). `geometryResult.meshes` holds
+    // the whole scene, including the `IfcTypeProduct` RepresentationMap copies
+    // the wasm mesh pass emits (geometryClass 1 = orphan type, 2 = instanced
+    // type). The 3D viewport routes them through the same view-mode predicate,
+    // so the Model view never shows them; the drawing filtered only on
+    // hiding/isolation, so every type template was cut and projected on top of
+    // the plan — AC20-FZK-Haus alone carries 32 of them.
+    const modelMeshes = selectModelMeshes(geometryResult.meshes);
 
     // Only show full loading overlay for initial generation, not regeneration
     if (!isRegenerate) {
@@ -558,7 +568,7 @@ export function useDrawingGeneration({
         const floors =
           cached && cached.sourceId === modelCacheKey
             ? cached.floors
-            : storeyFloorsFromMeshes(geometryResult.meshes, sh.elementToStorey);
+            : storeyFloorsFromMeshes(modelMeshes, sh.elementToStorey);
         if (!cached || cached.sourceId !== modelCacheKey) {
           storeyFloorsCacheRef.current = { floors, sourceId: modelCacheKey };
         }
@@ -635,7 +645,7 @@ export function useDrawingGeneration({
       }
 
       // Filter meshes by visibility (respect 3D hiding/isolation)
-      let meshesToProcess = geometryResult.meshes;
+      let meshesToProcess = modelMeshes;
 
       // Filter out hidden entities (using combined multi-model set)
       if (combinedHiddenIds.size > 0) {

--- a/apps/viewer/src/hooks/useDrawingGeneration.type-visibility.test.tsx
+++ b/apps/viewer/src/hooks/useDrawingGeneration.type-visibility.test.tsx
@@ -1,0 +1,277 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Class-level visibility must reach the section, not just the 3D mesh set (#2060).
+ *
+ * The Visibility toggles (Spaces, Openings, Site, Virtual Elements, Spatial
+ * Zones, Annotations) are applied by `ViewportContainer` to the mesh list it
+ * hands the renderer. The 2D drawing derives its OWN mesh list from
+ * `geometryResult.meshes` and filtered only hiding/isolation, so a hidden
+ * `IfcSpace` / `IfcOpeningElement` was still cut: its fill and outline showed
+ * in the 2D Section view, and — because the 3D section overlay uploads
+ * `drawing.cutPolygons` / `drawing.lines` verbatim (`useRenderUpdates.ts`) —
+ * in the 3D view too. On AC20-FZK-Haus a mid-height plan cut put 6 IfcSpace
+ * and 14 IfcOpeningElement entities into the drawing with both toggles at
+ * their shipped default of `false`.
+ *
+ * These render the real hook (no mocked generator): one box per class
+ * straddling a plan cut, asserted on the entity ids that come back. Cut
+ * polygons are asserted SEPARATELY from lines — the polygons are what the 3D
+ * overlay fills, the lines are what both views outline, and the two disagreed
+ * in #2058.
+ */
+
+import '@/test/setup-dom.js';
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import type { Drawing2D } from '@ifc-lite/drawing-2d';
+import type { GeometryResult, MeshData } from '@ifc-lite/geometry';
+import type { TypeVisibilityGate } from '@/store/typeVisibilityFilter';
+import { useDrawingGeneration } from './useDrawingGeneration.js';
+
+// ─── Fixture ─────────────────────────────────────────────────────────────
+
+/** Axis-aligned box in render space (Y-up), 12 triangles. The CPU cutter and
+ *  edge extractor only read positions/indices, so normals stay zeroed. */
+function box(
+  expressId: number,
+  ifcType: string,
+  x0: number,
+  x1: number,
+): MeshData {
+  const [y0, z0, y1, z1] = [0, 0, 3, 0.2];
+  const positions = new Float32Array([
+    x0, y0, z0,  x1, y0, z0,  x1, y1, z0,  x0, y1, z0,
+    x0, y0, z1,  x1, y0, z1,  x1, y1, z1,  x0, y1, z1,
+  ]);
+  const indices = new Uint32Array([
+    0, 1, 2,  0, 2, 3, // -z
+    4, 6, 5,  4, 7, 6, // +z
+    0, 4, 5,  0, 5, 1, // -y
+    3, 2, 6,  3, 6, 7, // +y
+    0, 3, 7,  0, 7, 4, // -x
+    1, 5, 6,  1, 6, 2, // +x
+  ]);
+  return {
+    expressId,
+    ifcType,
+    modelIndex: 0,
+    positions,
+    normals: new Float32Array(positions.length),
+    indices,
+    color: [0.5, 0.5, 0.5, 1],
+    geometryClass: 0,
+  };
+}
+
+/** One occurrence per gated class plus two ordinary building elements. */
+const IDS = {
+  wall: 100,
+  door: 101,
+  space: 200,
+  opening: 201,
+  site: 202,
+  virtual: 203,
+  zone: 204,
+} as const;
+
+const MESHES: MeshData[] = [
+  box(IDS.wall,    'IfcWall',             0,  2),
+  box(IDS.door,    'IfcDoor',             3,  5),
+  box(IDS.space,   'IfcSpace',            6,  8),
+  box(IDS.opening, 'IfcOpeningElement',   9, 11),
+  box(IDS.site,    'IfcSite',            12, 14),
+  box(IDS.virtual, 'IfcVirtualElement',  15, 17),
+  box(IDS.zone,    'IfcSpatialZone',     18, 20),
+];
+
+const GEOMETRY: GeometryResult = {
+  meshes: MESHES,
+  totalTriangles: MESHES.length * 12,
+  totalVertices: MESHES.length * 8,
+  coordinateInfo: {
+    originShift: { x: 0, y: 0, z: 0 },
+    originalBounds: { min: { x: 0, y: 0, z: 0 }, max: { x: 20, y: 3, z: 0.2 } },
+    shiftedBounds:  { min: { x: 0, y: 0, z: 0 }, max: { x: 20, y: 3, z: 0.2 } },
+    hasLargeCoordinates: false,
+  },
+};
+
+const ALL_VISIBLE: TypeVisibilityGate = {
+  spaces: true, spatialZones: true, openings: true,
+  virtualElements: true, site: true, ifcAnnotations: true,
+};
+
+const ALL_HIDDEN: TypeVisibilityGate = {
+  spaces: false, spatialZones: false, openings: false,
+  virtualElements: false, site: false, ifcAnnotations: false,
+};
+
+interface HarnessProps {
+  typeVisibility: TypeVisibilityGate;
+  /** Panel open → the hook's own auto-generate effect drives generation. */
+  panelVisible: boolean;
+  drawing: Drawing2D | null;
+  setDrawing: (d: Drawing2D | null) => void;
+  onRun: (run: () => Promise<void>) => void;
+}
+
+function Harness({ typeVisibility, panelVisible, drawing, setDrawing, onRun }: HarnessProps): null {
+  const { generateDrawing } = useDrawingGeneration({
+    geometryResult: GEOMETRY,
+    ifcDataStore: null,
+    sectionPlane: { axis: 'down', position: 50, flipped: false },
+    displayOptions: {
+      showHiddenLines: false,
+      useSymbolicRepresentations: false,
+      show3DOverlay: false,
+      scale: 50,
+      showConstructionProjection: false,
+    },
+    typeVisibility,
+    combinedHiddenIds: new Set<number>(),
+    combinedIsolatedIds: null,
+    computedIsolatedIds: null,
+    models: new Map([['m0', { id: 'm0', visible: true }]]),
+    panelVisible,
+    drawing,
+    setDrawing,
+    setDrawingStatus: () => {},
+    setDrawingProgress: () => {},
+    setDrawingError: () => {},
+  });
+  onRun(generateDrawing);
+  return null;
+}
+
+/** Drive the real hook once and return the drawing it publishes. */
+async function generate(typeVisibility: TypeVisibilityGate): Promise<Drawing2D | null> {
+  let drawing: Drawing2D | null = null;
+  let run: (() => Promise<void>) | null = null;
+
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  let root: Root | null = null;
+  try {
+    await act(async () => {
+      root = createRoot(container);
+      // Panel closed: the auto-generate effects stay out of the way so the
+      // drawing under test is the one this harness asks for, not a race.
+      root.render(
+        <Harness
+          typeVisibility={typeVisibility}
+          panelVisible={false}
+          drawing={null}
+          setDrawing={(d) => { drawing = d; }}
+          onRun={(r) => { run = r; }}
+        />,
+      );
+    });
+    assert.ok(run, 'harness never rendered — the hook was not called');
+    await act(async () => { await run!(); });
+    return drawing;
+  } finally {
+    if (root) await act(async () => { root!.unmount(); });
+    container.remove();
+  }
+}
+
+/** Entity ids of the 2D outlines — what both the 2D view and the 3D overlay draw. */
+function lineIds(drawing: Drawing2D | null): Set<number> {
+  return new Set((drawing?.lines ?? []).map((l) => l.entityId));
+}
+
+/** Entity ids of the cut fills — what the 3D section overlay triangulates. */
+function polygonIds(drawing: Drawing2D | null): Set<number> {
+  return new Set((drawing?.cutPolygons ?? []).map((p) => p.entityId));
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────
+
+describe('useDrawingGeneration class visibility (#2060)', () => {
+  it('drops every hidden class from the cut fills the 3D overlay renders', async () => {
+    const ids = polygonIds(await generate(ALL_HIDDEN));
+
+    // Negative case: the real building must still be cut.
+    assert.ok(ids.has(IDS.wall), `wall must still be cut; got ${[...ids]}`);
+    assert.ok(ids.has(IDS.door), `door must still be cut; got ${[...ids]}`);
+
+    for (const [name, id] of [
+      ['IfcSpace', IDS.space], ['IfcOpeningElement', IDS.opening],
+      ['IfcSite', IDS.site], ['IfcVirtualElement', IDS.virtual],
+      ['IfcSpatialZone', IDS.zone],
+    ] as const) {
+      assert.ok(!ids.has(id), `hidden ${name} must not produce a cut fill; got ${[...ids]}`);
+    }
+  });
+
+  it('drops every hidden class from the 2D outlines', async () => {
+    const ids = lineIds(await generate(ALL_HIDDEN));
+
+    assert.ok(ids.has(IDS.wall), `wall must still be outlined; got ${[...ids]}`);
+    assert.ok(ids.has(IDS.door), `door must still be outlined; got ${[...ids]}`);
+
+    for (const [name, id] of [
+      ['IfcSpace', IDS.space], ['IfcOpeningElement', IDS.opening],
+      ['IfcSite', IDS.site], ['IfcVirtualElement', IDS.virtual],
+      ['IfcSpatialZone', IDS.zone],
+    ] as const) {
+      assert.ok(!ids.has(id), `hidden ${name} must not be outlined; got ${[...ids]}`);
+    }
+  });
+
+  it('keeps those same classes in the section when their toggles are ON', async () => {
+    // This is a visibility filter, not a blanket exclusion: a user who turns
+    // Spaces on expects room fills in the plan.
+    const drawing = await generate(ALL_VISIBLE);
+    const polys = polygonIds(drawing);
+    const lines = lineIds(drawing);
+
+    for (const [name, id] of Object.entries(IDS)) {
+      assert.ok(polys.has(id), `${name} must be cut when its class is visible; got ${[...polys]}`);
+      assert.ok(lines.has(id), `${name} must be outlined when its class is visible; got ${[...lines]}`);
+    }
+  });
+
+  it('regenerates the open section when a class toggle flips', async () => {
+    // Flipping a toggle changes the drawing's input without changing the mesh
+    // count, so the hook's `geometryChanged` trigger never fires for it. Without
+    // its own trigger the fix would only take effect on the next manual
+    // Regenerate — invisible to the user who just unticked Spaces.
+    let drawing: Drawing2D | null = null;
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    let root: Root | null = null;
+    try {
+      const render = async (typeVisibility: TypeVisibilityGate) => {
+        await act(async () => {
+          root!.render(
+            <Harness
+              typeVisibility={typeVisibility}
+              panelVisible
+              drawing={drawing}
+              setDrawing={(d) => { drawing = d; }}
+              onRun={() => {}}
+            />,
+          );
+        });
+      };
+
+      await act(async () => { root = createRoot(container); });
+      await render(ALL_VISIBLE);
+      assert.ok(polygonIds(drawing).has(IDS.space), 'panel-open generation should cut the visible space');
+
+      await render(ALL_HIDDEN);
+      const polys = polygonIds(drawing);
+      assert.ok(polys.has(IDS.wall), `wall must survive the regeneration; got ${[...polys]}`);
+      assert.ok(!polys.has(IDS.space), `space must be gone after its toggle flips; got ${[...polys]}`);
+    } finally {
+      if (root) await act(async () => { root!.unmount(); });
+      container.remove();
+    }
+  });
+});

--- a/apps/viewer/src/lib/type-view-visibility.test.ts
+++ b/apps/viewer/src/lib/type-view-visibility.test.ts
@@ -5,7 +5,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
 
-import { isMeshVisibleInViewMode, meshClassIsPlaced } from './type-view-visibility.js';
+import { isMeshVisibleInViewMode, meshClassIsPlaced, selectModelMeshes } from './type-view-visibility.js';
 
 describe('meshClassIsPlaced (#1353 layer-slice follow-up)', () => {
   it('counts occurrences (0) AND material-layer slices (3) as placed geometry', () => {
@@ -63,5 +63,26 @@ describe('isMeshVisibleInViewMode (#1353)', () => {
       isMeshVisibleInViewMode(1, 'model', true),
       isMeshVisibleInViewMode(1, 'types', true),
     );
+  });
+});
+
+describe('selectModelMeshes — the mesh set a 2D drawing cuts (#2058)', () => {
+  const m = (expressId: number, geometryClass?: number) => ({ expressId, geometryClass });
+
+  it('keeps occurrences and layer slices, drops the type library', () => {
+    const kept = selectModelMeshes([m(1, 0), m(2, 2), m(3, 1), m(4, 3)]);
+    assert.deepEqual(kept.map((x) => x.expressId), [1, 4]);
+  });
+
+  it('treats an absent geometryClass as an occurrence (legacy caches)', () => {
+    const kept = selectModelMeshes([m(7), m(8, 2)]);
+    assert.deepEqual(kept.map((x) => x.expressId), [7]);
+  });
+
+  it('keeps orphan types when the file has no placed occurrence at all', () => {
+    // Pure type-library file: dropping class 1 here would blank the drawing,
+    // the same trap `isMeshVisibleInViewMode` already guards for 3D.
+    const kept = selectModelMeshes([m(1, 1), m(2, 2)]);
+    assert.deepEqual(kept.map((x) => x.expressId), [1]);
   });
 });

--- a/apps/viewer/src/lib/type-view-visibility.ts
+++ b/apps/viewer/src/lib/type-view-visibility.ts
@@ -73,3 +73,40 @@ export function selectModelMeshes<T extends { geometryClass?: number }>(meshes: 
     isMeshVisibleInViewMode(m.geometryClass ?? 0, 'model', hasOccurrenceGeometry),
   );
 }
+
+/**
+ * `selectModelMeshes`'s gate, keyed by express id instead of by mesh — for
+ * anything that reaches a 2D drawing WITHOUT going through the mesh list
+ * (construction-projection profiles, `extractProfiles` output). Filtering
+ * `meshesToProcess` alone leaves that second route ungated: if a profile ever
+ * carries the express id of type-library geometry (today `extractProfiles`
+ * only walks `IfcProduct` entities, so it doesn't — but that is a property of
+ * the Rust extractor, not of this filter, and nothing pins it), the profile
+ * would project the exact geometry the mesh filter just removed from the cut.
+ *
+ * Reuses `isMeshVisibleInViewMode` — the SAME predicate `selectModelMeshes`
+ * applies — so the two filter sites can't drift back apart; call this with
+ * `geometryResult.meshes` and it derives one id → verdict lookup for every
+ * consumer.
+ *
+ * An id with NO mesh at all (e.g. an `IfcSpace` with a body representation but
+ * no rendered mesh) never went through the class gate in the first place, so
+ * it passes through unaffected here — hiding/isolation/`isTypeVisible` are
+ * what govern it, exactly as before this function existed.
+ */
+export function buildModelViewIdFilter(
+  meshes: readonly { expressId: number; geometryClass?: number }[],
+): (expressId: number) => boolean {
+  const hasOccurrenceGeometry = meshes.some((m) => meshClassIsPlaced(m.geometryClass ?? 0));
+  const classById = new Map<number, number>();
+  for (const m of meshes) {
+    // An express id's geometryClass is consistent across its own mesh
+    // entries (e.g. material-layer slices are all class 3), so first-write
+    // is as good as any.
+    if (!classById.has(m.expressId)) classById.set(m.expressId, m.geometryClass ?? 0);
+  }
+  return (expressId: number) => {
+    const geometryClass = classById.get(expressId);
+    return geometryClass === undefined || isMeshVisibleInViewMode(geometryClass, 'model', hasOccurrenceGeometry);
+  };
+}

--- a/apps/viewer/src/lib/type-view-visibility.ts
+++ b/apps/viewer/src/lib/type-view-visibility.ts
@@ -54,3 +54,22 @@ export function isMeshVisibleInViewMode(
   // class 0 (occurrence) and class 3 (layer slice) are the real model.
   return true;
 }
+
+/**
+ * The real-model subset of a mesh list — what a 2D drawing cuts (#2058).
+ *
+ * `geometryResult.meshes` carries the whole scene, type library included, and
+ * the Model/Types switch is a 3D control: a standard 2D section, plan or
+ * sketch underlay always draws the building. So this resolves
+ * `hasOccurrenceGeometry` over the list and applies `isMeshVisibleInViewMode`
+ * pinned to `'model'` — one predicate for every consumer rather than a second,
+ * differently-shaped guard that drifts. A pure type-library file (no placed
+ * occurrence at all) still keeps its orphan class-1 geometry, exactly as the
+ * Model view does.
+ */
+export function selectModelMeshes<T extends { geometryClass?: number }>(meshes: readonly T[]): T[] {
+  const hasOccurrenceGeometry = meshes.some((m) => meshClassIsPlaced(m.geometryClass ?? 0));
+  return meshes.filter((m) =>
+    isMeshVisibleInViewMode(m.geometryClass ?? 0, 'model', hasOccurrenceGeometry),
+  );
+}

--- a/apps/viewer/src/store/slices/visibilitySlice.test.ts
+++ b/apps/viewer/src/store/slices/visibilitySlice.test.ts
@@ -280,6 +280,23 @@ describe('VisibilitySlice', () => {
       }
     });
 
+    it('replaces the typeVisibility object identity on every toggle', () => {
+      // `useDrawingGeneration` decides whether to regenerate an open section by
+      // comparing `typeVisibility` BY IDENTITY against the previous render's
+      // value (issue #2060). That is only sound because this slice spreads a
+      // fresh object per toggle. A refactor to structural sharing — mutating in
+      // place, or returning the same object when the value is unchanged —
+      // would leave the drawing stale with the hook's own tests still green,
+      // since they pass their own object literals. Fail here instead.
+      const before = state.typeVisibility;
+      state.toggleTypeVisibility('spaces');
+      assert.notStrictEqual(
+        state.typeVisibility,
+        before,
+        'toggleTypeVisibility must return a NEW typeVisibility object',
+      );
+    });
+
     it('resetTypeVisibility restores semantic defaults', () => {
       // Flip everything away from defaults first.
       state.toggleTypeVisibility('spaces');   // false -> true

--- a/apps/viewer/src/store/typeVisibilityFilter.ts
+++ b/apps/viewer/src/store/typeVisibilityFilter.ts
@@ -21,6 +21,14 @@ type TypeVisibilityKey = keyof Pick<
 >;
 
 /**
+ * The slice of `typeVisibility` these helpers read — the toggles that gate a
+ * whole IFC class. Consumers that only forward the gate (the 2D drawing hook)
+ * take this rather than the full `TypeVisibility`, which also carries controls
+ * with no class mapping (`ifcGrid`).
+ */
+export type TypeVisibilityGate = Pick<TypeVisibility, TypeVisibilityKey>;
+
+/**
  * IFC class → toggle key. When the mapped toggle is `false` the class is
  * hidden from the viewport / export.
  *
@@ -49,7 +57,7 @@ const IFC_TYPE_TO_VISIBILITY_KEY: Readonly<Record<string, TypeVisibilityKey>> = 
  */
 export function isTypeVisible(
   ifcType: string | undefined,
-  typeVisibility: Pick<TypeVisibility, TypeVisibilityKey>,
+  typeVisibility: TypeVisibilityGate,
 ): boolean {
   if (!ifcType) return true;
   const key = IFC_TYPE_TO_VISIBILITY_KEY[ifcType];
@@ -63,7 +71,7 @@ export function isTypeVisible(
  * matches the viewport.
  */
 export function buildHiddenIfcTypes(
-  typeVisibility: Pick<TypeVisibility, TypeVisibilityKey>,
+  typeVisibility: TypeVisibilityGate,
 ): Set<string> {
   const out = new Set<string>();
   for (const [ifcType, key] of Object.entries(IFC_TYPE_TO_VISIBILITY_KEY)) {


### PR DESCRIPTION
Closes #2058, and folds in the entire #2060 fix (commit `68fe1ce8`) — **class-level Visibility toggles** (Spaces, Openings, Site, Virtual Elements, Spatial Zones, Annotations) threaded through `Section2DPanel`, the `TypeVisibilityGate` type, and a regeneration trigger. Same file, same function, adjacent lines to #2058's fix; landing them separately would have been a typecheck failure, not a mergeable split (`useDrawingGeneration.test.tsx`'s harness needs the `typeVisibility` prop `68fe1ce8` adds). **Your 3D ruling stands and nothing here touches it.**

## Reproduced on the real fixture

`AC20-FZK-Haus.ifc` through the live mesh path, then fed to the real `Drawing2DGenerator` on a plan cut at y=1.561 (model spans −1.00…6.32), which is what the Section 2D panel does:

```
BEFORE: meshes=317 lines=762 polygons=235 | type-entity lines=104
        type ids drawn=[15234,17730,21177,22346,27350,31392,59692]
AFTER:  meshes=285 lines=658 polygons=197 | type-entity lines=0
```

104 of 762 cut lines and 38 of 235 cut polygons belonged to `IfcWallType`/`IfcDoorType` templates rather than to the building. **These counts come from driving the generator directly, not from looking at a rendered plan view** — no browser check has been done in either review pass, and this lands in the live 2D-plan render path. Worth one look at an actual Section 2D panel before merge.

**One correction to the report:** the bleed is **unconditional** — it does not depend on the Types toggle at all. The user simply noticed it after switching. So this was reachable in a default plan view the whole time.

## Root cause — the one-sided-guard shape

- **3D**: `ViewportContainer.tsx:829` gates every mesh through `isMeshVisibleInViewMode(...)` (`lib/type-view-visibility.ts:37`).
- **2D**: `useDrawingGeneration.ts:637-660` started from `geometryResult.meshes` and filtered only on hidden ids / isolation / storey isolation — **no `geometryClass` awareness anywhere in the file**.

Grepping `isMeshVisibleInViewMode|meshClassIsPlaced` returned exactly **one** non-test consumer. That is how the two drifted.

**A second consumer had the identical defect**, found by grepping `Drawing2DGenerator`: `useConstructionUnderlay.ts:41`, the Space Sketch plan underlay, also cut raw meshes. Fixed too.

**Category visibility (#2060) is a third mechanism**, distinct from both the hidden-id set and #2058's `geometryClass` gate: a store object of booleans resolved through `IFC_TYPE_TO_VISIBILITY_KEY`/`isTypeVisible`. The 3D mesh path applies it at `ViewportContainer.tsx:838`; the drawing path never did, so with Spaces and Openings hidden, `AC20-FZK-Haus.ifc` still put 6 `IfcSpace` and 14 `IfcOpeningElement` entities into the drawing (26+70 lines, 6+28 cut polygons) — reachable by default, since both toggles ship `false`.

`extract_profiles` (`rust/geometry/src/profile_extractor.rs:85`) gates on `has_geometry_by_name` → `is_subtype_of(IfcProduct)` (`schema_helpers.rs:102`), so today it cannot itself emit a profile keyed to an `IfcXxxType` id — verified by reading the Rust source, not assumed. **That is a property of the Rust extractor, though, not something this filter enforces from the TS side**, and a wall occurrence dropped from the cut by the class gate (`geometryClass` 1/2) still shares its express id with a real, unfiltered profile — see the #2070 review section below for why that mattered anyway.

## The fix reuses the existing predicate

`selectModelMeshes` sits beside `isMeshVisibleInViewMode` and applies it **pinned to `'model'`** — a standard 2D drawing is always the real building; Model/Types is a 3D control. Pinning rather than hard-excluding preserves the annex-E case: a pure type-library file still draws its class-1 orphans. `storeyFloorsFromMeshes` gets the filtered set too.

**On the storey-band claim — corrected per review.** The original version of this section claimed type templates "can't invent a phantom storey band." That overstates it: the guard is **inert on ordinary files**. Type-product meshes carry the *type's* own express id (`processor/mod.rs:841`), and `elementToStorey` is built from `IfcRelContainedInSpatialStructure`, whose `RelatedElements` are products — so on AC20-FZK-Haus, or any normal file, a template never reaches `elementToStorey` and contributes no storey level either way, filtered or not. The one path that *does* reach it is `spatial-hierarchy-builder.ts:300-311`, which walks `IfcRelAggregates` from every contained element and maps every descendant with no type check (`RelatedObjects` is `IfcObjectDefinition`, which admits `IfcTypeObject`) — an unusual file shape, not the fixture above. `storeyFloorsFromMeshes(modelMeshes)` is a consistency guard for that shape, pinned by a synthetic-fixture test (`useDrawingGeneration.projection.test.tsx`), not a fix for a defect observed on a real model.

## Evidence

Replacing `selectModelMeshes`' body with `return [...meshes]` fails **5 tests** across both suites — I re-ran that myself on the pushed tree (`REPLACEMENTS=1`, region re-read). Restored: 16/16.

Both negative cases asserted, because "exclude more from 2D" is the obvious wrong fix:
- **occurrence geometry still reaches the drawing** (658 lines survive on FZK-Haus) — asserted in two tests;
- **a pure type library still draws its orphans** — asserted, and it's the subtest that passed even in RED.

RED used the real hook rendered, not a mock, and the harness demonstrably renders: the passing subtest asserts geometry *is* produced while the failing one reports real cut entity ids (`got ids 100,200`).

No changeset — `@ifc-lite/viewer` is `private: true`.

## #2070 review follow-ups

**Main defect, fixed.** `projectionProfiles` (construction-projection profiles, a route into the drawing that never reads `geometryClass` at all) was filtered only on hiding/isolation/`isTypeVisible` — not on the same class gate `selectModelMeshes` applies to the cut. Added `buildModelViewIdFilter` (`lib/type-view-visibility.ts`), the same `isMeshVisibleInViewMode` predicate keyed by express id instead of by mesh, and applied it to `projectionProfiles` in `useDrawingGeneration.ts`. An id with no mesh at all (e.g. a mesh-less `IfcSpace` whose only route in is its profile) is untouched — only ids the class gate actually dropped from `meshesToProcess` are excluded from projection too.

Regression test (`useDrawingGeneration.projection.test.tsx`, "profile route mirrors the mesh-class gate"): a real `IfcWall` occurrence (real mesh, real extruded-solid profile via the wasm extractor) tagged `geometryClass: 2` reaches RED without the fix — its profile still projects (`got 38,48,99`) — and GREEN with it, while a mesh-less space's profile is asserted unaffected as a control. `showConstructionProjection: true` is required to reach the `if (projectionOn)` block at all, which — as flagged in review — both existing test files leave `false`, so this block was previously dead in the suite, not just thinly covered.

Mutation-tested both the new hook filter line and the new `buildModelViewIdFilter` predicate (`REPLACEMENTS=1` each, region re-read after edit): both drop the suite from 0 to 1 failure — the new test, specifically — confirming it is the thing catching the regression. Restored by file copy.

**Scope disclosure — fixed** (this body; title already named both issues).

**Identity-compare comment (`useDrawingGeneration.ts:~1104`) — annotated.** It was true but unpinned when first flagged. `visibilitySlice.test.ts` now has a case asserting `toggleTypeVisibility` returns a new object identity, which fails under an `Object.assign` refactor while the hook's own suite stays green (confirming the hook alone couldn't catch it). The comment now points at that test.

2578 passing (was 2569 pre-review, 2577 after the first review round), typecheck 34/34.

## Three caveats, stated rather than buried

1. **The 3D negative case is an argument-from-diff, not a new render test.** `ViewportContainer.tsx` is not in the diff and `isMeshVisibleInViewMode` is only appended to, and the existing `Types view` suite still passes — but I did not add a new viewport rendering test asserting 3D still shows type geometry.
2. **`useConstructionUnderlay` is covered only by the `selectModelMeshes` unit tests**, not end-to-end. There's no existing render test for the Space Sketch underlay and I didn't stand one up.
3. **No browser check has been done at any point in this PR.** Every line/polygon count above comes from driving `Drawing2DGenerator` directly. "Type geometry no longer bleeds in" is ultimately a visual claim on a live render path — that verification is still open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved 2D drawings by excluding IFC type-library and template geometry when placed model geometry is available.
  * Preserved orphan type geometry when no placed instances exist.
  * Ensured construction underlays, cuts, projections, and storey-floor views display the correct model geometry.
  * Applied element-type visibility settings consistently to 2D sections and 3D cut overlays, including immediate regeneration when settings change.

* **Tests**
  * Added coverage for model geometry selection, visibility toggles, template handling, orphan geometry, and rendered occurrences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
