### PR TITLE
fix(geometry): mask the prepass class byte before comparing it (#2065)

### DIFF
--- a/.changeset/prepass-class-code-mask.md
+++ b/.changeset/prepass-class-code-mask.md
@@ -1,0 +1,11 @@
+---
+"@ifc-lite/geometry": patch
+---
+
+Mask the prepass class byte before comparing it on the host (#2065).
+
+`rust/processing/src/shard_classes.rs` defines the per-record prepass class byte as a named code in the low bits (`PREPASS_CLASS_CODE_MASK` = `0x3F`) with flag bits composed on top (`PREPASS_CLASS_FLAG_GEOMETRY_JOB` = `0x80`, `PREPASS_CLASS_FLAG_TYPE_CANDIDATE` = `0x40`). The Rust consumer masks before matching (`gpu_meshes/prepass_discovery.rs`); the sharded-scan span-list rebuild in `geometry-parallel.ts` compared the whole byte against bare literals `4..10`.
+
+No output changes today: `classify_type_name` returns the named codes early, and the one later flag OR-in (`classify_type_name_with_content`) is gated on a spatial-container predicate that none of those keywords satisfy, so classes 4–10 never carry a flag bit as the classification rules stand. The failure mode if that ever changed was silent and total for the affected record — a flagged byte such as `0x80 | 4 = 132` is an out-of-bounds `Uint32Array` write (discarded without error) and misses the span-list map entirely, so the styled item, void, fill or aggregate would simply never appear.
+
+The span-list rebuild now lives in an exported, unit-tested `extractPrepassSpanLists()` that masks both comparisons, sizes its count table by the code mask rather than by the highest class the host consumes (so a class added on the Rust side can no longer write out of bounds), and names the codes as constants instead of restating them in a comment. A test pins those constants to the Rust source of truth.

--- a/packages/geometry/src/geometry-parallel.ts
+++ b/packages/geometry/src/geometry-parallel.ts
@@ -37,6 +37,77 @@ import { notifyIfWasmAssetUnavailable, notifyIfWorkerScriptUnavailable } from '.
 import { compileSharedWasmModule } from './wasm-shared-module.js';
 
 /**
+ * Prepass class-byte layout, mirroring the `PREPASS_CLASS_*` definitions in
+ * `rust/processing/src/shard_classes.rs` (the source of truth — these are
+ * pinned to it by `prepass-class-spans.test.ts`).
+ *
+ * The producer packs a named code in the LOW bits and composes FLAG bits on
+ * top (`PREPASS_CLASS_FLAG_GEOMETRY_JOB` 0x80, `..._FLAG_TYPE_CANDIDATE`
+ * 0x40), so a consumer must mask before comparing — the Rust consumer does
+ * (`gpu_meshes/prepass_discovery.rs`), and so does {@link extractPrepassSpanLists}.
+ */
+export const PREPASS_CLASS_CODE_MASK = 0x3f;
+/** `IFCSTYLEDITEM`. */
+export const PREPASS_CLASS_STYLED_ITEM = 4;
+/** `IFCINDEXEDCOLOURMAP`. */
+export const PREPASS_CLASS_INDEXED_COLOUR_MAP = 5;
+/** `IFCMATERIALDEFINITIONREPRESENTATION`. */
+export const PREPASS_CLASS_MATERIAL_DEF_REPR = 6;
+/** `IFCRELASSOCIATESMATERIAL`. */
+export const PREPASS_CLASS_REL_ASSOCIATES_MATERIAL = 7;
+/** `IFCRELVOIDSELEMENT`. */
+export const PREPASS_CLASS_REL_VOIDS = 8;
+/** `IFCRELFILLSELEMENT`. */
+export const PREPASS_CLASS_REL_FILLS = 9;
+/** `IFCRELAGGREGATES`. */
+export const PREPASS_CLASS_REL_AGGREGATES = 10;
+
+/** The classes the host builds span lists for (every other code is ignored). */
+const HOST_SPAN_CLASSES = [
+  PREPASS_CLASS_STYLED_ITEM,
+  PREPASS_CLASS_INDEXED_COLOUR_MAP,
+  PREPASS_CLASS_MATERIAL_DEF_REPR,
+  PREPASS_CLASS_REL_ASSOCIATES_MATERIAL,
+  PREPASS_CLASS_REL_VOIDS,
+  PREPASS_CLASS_REL_FILLS,
+  PREPASS_CLASS_REL_AGGREGATES,
+] as const;
+
+/**
+ * Build one `(id, start, length)` span list per host-consumed prepass class
+ * from the stitched shard columns, in FILE ORDER. Every comparison goes
+ * through {@link PREPASS_CLASS_CODE_MASK}, so a record that carries a flag bit
+ * alongside its named code still lands in its list instead of being dropped.
+ * Returns exact-size arrays (one entry per class in `HOST_SPAN_CLASSES`,
+ * empty when the file has none).
+ */
+export function extractPrepassSpanLists(
+  classes: Uint8Array,
+  ids: Uint32Array,
+  starts: Uint32Array,
+  lengths: Uint32Array,
+): Map<number, Uint32Array> {
+  // Sized by the code mask rather than by the highest class the host consumes:
+  // a masked code is always < 64, so a class added on the Rust side cannot
+  // write out of bounds here (typed arrays discard such writes silently).
+  const counts = new Uint32Array(PREPASS_CLASS_CODE_MASK + 1);
+  for (let i = 0; i < classes.length; i++) counts[classes[i] & PREPASS_CLASS_CODE_MASK]++;
+  const slots = new Map<number, { arr: Uint32Array; w: number }>();
+  for (const k of HOST_SPAN_CLASSES) slots.set(k, { arr: new Uint32Array(counts[k] * 3), w: 0 });
+  for (let i = 0; i < classes.length; i++) {
+    const slot = slots.get(classes[i] & PREPASS_CLASS_CODE_MASK);
+    if (!slot) continue;
+    slot.arr[slot.w] = ids[i];
+    slot.arr[slot.w + 1] = starts[i];
+    slot.arr[slot.w + 2] = lengths[i];
+    slot.w += 3;
+  }
+  const spans = new Map<number, Uint32Array>();
+  for (const [k, slot] of slots) spans.set(k, slot.arr);
+  return spans;
+}
+
+/**
  * Plan content-affinity routing for one chunk: assign each job (by index) to a
  * worker bucket so that every job sharing an affinity key lands on the SAME
  * worker — across the whole stream, since `keyToWorker` is the caller's sticky
@@ -1015,32 +1086,17 @@ export async function* processParallel(
     // stitched columns, split into one contiguous slice per worker, and
     // resolve them in parallel while everyone waits on the pre-pass scan.
     const classes = stitched.classes;
-    // Class codes (see Rust PREPASS_CLASS_*): 4 styled, 5 colour map,
-    // 6 material def repr, 7 rel-associates-material, 8 voids, 9 fills,
-    // 10 aggregates. Extract each list in FILE ORDER.
-    const counts = new Uint32Array(11);
-    for (let i = 0; i < classes.length; i++) counts[classes[i]]++;
-    const kinds = [4, 5, 6, 7, 8, 9, 10] as const;
-    const spanLists = new Map<number, { arr: Uint32Array; w: number }>();
-    for (const k of kinds) spanLists.set(k, { arr: new Uint32Array(counts[k] * 3), w: 0 });
-    for (let i = 0; i < classes.length; i++) {
-      const slot = spanLists.get(classes[i]);
-      if (!slot) continue;
-      slot.arr[slot.w] = ids[i];
-      slot.arr[slot.w + 1] = starts[i];
-      slot.arr[slot.w + 2] = lengths[i];
-      slot.w += 3;
-    }
+    const spanLists = extractPrepassSpanLists(classes, ids, starts, lengths);
     supportSpans = {
-      colourMapSpans: spanLists.get(5)!.arr,
-      materialDefSpans: spanLists.get(6)!.arr,
-      relMaterialSpans: spanLists.get(7)!.arr,
-      voidSpans: spanLists.get(8)!.arr,
-      fillsSpans: spanLists.get(9)!.arr,
-      aggregateSpans: spanLists.get(10)!.arr,
+      colourMapSpans: spanLists.get(PREPASS_CLASS_INDEXED_COLOUR_MAP)!,
+      materialDefSpans: spanLists.get(PREPASS_CLASS_MATERIAL_DEF_REPR)!,
+      relMaterialSpans: spanLists.get(PREPASS_CLASS_REL_ASSOCIATES_MATERIAL)!,
+      voidSpans: spanLists.get(PREPASS_CLASS_REL_VOIDS)!,
+      fillsSpans: spanLists.get(PREPASS_CLASS_REL_FILLS)!,
+      aggregateSpans: spanLists.get(PREPASS_CLASS_REL_AGGREGATES)!,
     };
-    const styledCount = counts[4];
-    const styledSpans = spanLists.get(4)!.arr;
+    const styledSpans = spanLists.get(PREPASS_CLASS_STYLED_ITEM)!;
+    const styledCount = styledSpans.length / 3;
     // 2 slices per worker (round-robin): the tail is set by the SLOWEST
     // worker, and macOS occasionally schedules one onto a slow core — halving
     // the slice size halves the damage a slow core can do to the tail.

--- a/packages/geometry/src/prepass-class-spans.test.ts
+++ b/packages/geometry/src/prepass-class-spans.test.ts
@@ -1,0 +1,151 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it, expect } from 'vitest';
+import { existsSync, readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import {
+  extractPrepassSpanLists,
+  PREPASS_CLASS_CODE_MASK,
+  PREPASS_CLASS_STYLED_ITEM,
+  PREPASS_CLASS_INDEXED_COLOUR_MAP,
+  PREPASS_CLASS_MATERIAL_DEF_REPR,
+  PREPASS_CLASS_REL_ASSOCIATES_MATERIAL,
+  PREPASS_CLASS_REL_VOIDS,
+  PREPASS_CLASS_REL_FILLS,
+  PREPASS_CLASS_REL_AGGREGATES,
+} from './geometry-parallel.js';
+
+/** Flag bits the producer composes ON TOP of a named code (Rust side). */
+const FLAG_GEOMETRY_JOB = 0x80;
+const FLAG_TYPE_CANDIDATE = 0x40;
+
+/** Build the four stitched columns for `n` records with the given classes. */
+function columns(classes: number[]) {
+  const n = classes.length;
+  const ids = new Uint32Array(n);
+  const starts = new Uint32Array(n);
+  const lengths = new Uint32Array(n);
+  for (let i = 0; i < n; i++) {
+    ids[i] = 100 + i;
+    starts[i] = 1000 + i * 10;
+    lengths[i] = 5 + i;
+  }
+  return { classes: new Uint8Array(classes), ids, starts, lengths };
+}
+
+/** The `(id, start, length)` triples in a span list, as plain arrays. */
+function triples(spans: Uint32Array): number[][] {
+  const out: number[][] = [];
+  for (let i = 0; i < spans.length; i += 3) out.push([spans[i], spans[i + 1], spans[i + 2]]);
+  return out;
+}
+
+describe('extractPrepassSpanLists (prepass class byte -> span lists)', () => {
+  it('keeps a record whose class carries a FLAG bit alongside the named code', () => {
+    // The producer defines the class byte as a named code in the low bits PLUS
+    // flag bits, so `0x80 | 4` is still a styled item. Comparing the raw byte
+    // drops it silently (`spanLists.get(132)` is undefined) — mask first.
+    const c = columns([FLAG_GEOMETRY_JOB | PREPASS_CLASS_STYLED_ITEM]);
+    const spans = extractPrepassSpanLists(c.classes, c.ids, c.starts, c.lengths);
+    expect(triples(spans.get(PREPASS_CLASS_STYLED_ITEM)!)).toEqual([[100, 1000, 5]]);
+  });
+
+  it('keeps flagged records for every host-consumed class, in file order', () => {
+    const kinds = [
+      PREPASS_CLASS_STYLED_ITEM,
+      PREPASS_CLASS_INDEXED_COLOUR_MAP,
+      PREPASS_CLASS_MATERIAL_DEF_REPR,
+      PREPASS_CLASS_REL_ASSOCIATES_MATERIAL,
+      PREPASS_CLASS_REL_VOIDS,
+      PREPASS_CLASS_REL_FILLS,
+      PREPASS_CLASS_REL_AGGREGATES,
+    ];
+    // Two records per class: one plain, one carrying both flag bits.
+    const c = columns(kinds.flatMap((k) => [k, FLAG_GEOMETRY_JOB | FLAG_TYPE_CANDIDATE | k]));
+    const spans = extractPrepassSpanLists(c.classes, c.ids, c.starts, c.lengths);
+    for (let k = 0; k < kinds.length; k++) {
+      const list = spans.get(kinds[k])!;
+      expect(list.length).toBe(6); // 2 records x 3 columns, exact-size
+      // File order: the plain record (index 2k) precedes the flagged one.
+      expect(triples(list).map((t) => t[0])).toEqual([100 + 2 * k, 101 + 2 * k]);
+    }
+  });
+
+  it('keeps plain unflagged records in their own list and nowhere else', () => {
+    const c = columns([PREPASS_CLASS_STYLED_ITEM, PREPASS_CLASS_REL_VOIDS]);
+    const spans = extractPrepassSpanLists(c.classes, c.ids, c.starts, c.lengths);
+    expect(triples(spans.get(PREPASS_CLASS_STYLED_ITEM)!)).toEqual([[100, 1000, 5]]);
+    expect(triples(spans.get(PREPASS_CLASS_REL_VOIDS)!)).toEqual([[101, 1010, 6]]);
+    expect(spans.get(PREPASS_CLASS_INDEXED_COLOUR_MAP)!.length).toBe(0);
+  });
+
+  it('excludes records whose MASKED code is not one the host consumes', () => {
+    // 0 none, 2 project, 3 site, 11 mapped item, 12 rel-defines-by-type,
+    // 13 material layer set — plus the same codes carrying flag bits, and a
+    // pure-flag byte. None of these may reach a host span list.
+    const excluded = [0, 2, 3, 11, 12, 13].flatMap((k) => [k, FLAG_GEOMETRY_JOB | k]);
+    const c = columns([...excluded, FLAG_GEOMETRY_JOB, FLAG_TYPE_CANDIDATE]);
+    const spans = extractPrepassSpanLists(c.classes, c.ids, c.starts, c.lengths);
+    for (const [, list] of spans) expect(list.length).toBe(0);
+
+    // Again with ONE styled record, placed last: a consumer that funnelled
+    // unrecognised codes into a list would fill the styled slots ahead of the
+    // real record (whose triple would then be silently dropped on overflow).
+    const withStyled = columns([...excluded, PREPASS_CLASS_STYLED_ITEM]);
+    const spans2 = extractPrepassSpanLists(
+      withStyled.classes,
+      withStyled.ids,
+      withStyled.starts,
+      withStyled.lengths,
+    );
+    const last = excluded.length;
+    expect(triples(spans2.get(PREPASS_CLASS_STYLED_ITEM)!)).toEqual([
+      [withStyled.ids[last], withStyled.starts[last], withStyled.lengths[last]],
+    ]);
+    for (const [k, list] of spans2) {
+      if (k !== PREPASS_CLASS_STYLED_ITEM) expect(list.length).toBe(0);
+    }
+  });
+});
+
+// The class codes above are a restatement of the Rust producer's constants;
+// pin them to that source of truth so the two cannot drift silently (the whole
+// point of the mask being applied on both sides). Skipped gracefully when this
+// package is tested outside the monorepo.
+const rustSource = fileURLToPath(
+  new URL('../../../rust/processing/src/shard_classes.rs', import.meta.url),
+);
+
+describe.skipIf(!existsSync(rustSource))('prepass class constants match the Rust source', () => {
+  // Guarded read: with skipIf active the describe body still runs at collection
+  // time, so an unguarded readFileSync would hard-fail instead of skipping.
+  const src = existsSync(rustSource) ? readFileSync(rustSource, 'utf8') : '';
+  const rustConst = (name: string): number | undefined => {
+    const m = new RegExp(`pub const ${name}: u8 = (0x[0-9a-fA-F]+|\\d+);`).exec(src);
+    return m ? Number(m[1]) : undefined;
+  };
+
+  it.each([
+    ['PREPASS_CLASS_CODE_MASK', PREPASS_CLASS_CODE_MASK],
+    ['PREPASS_CLASS_STYLED_ITEM', PREPASS_CLASS_STYLED_ITEM],
+    ['PREPASS_CLASS_INDEXED_COLOUR_MAP', PREPASS_CLASS_INDEXED_COLOUR_MAP],
+    ['PREPASS_CLASS_MATERIAL_DEF_REPR', PREPASS_CLASS_MATERIAL_DEF_REPR],
+    ['PREPASS_CLASS_REL_ASSOCIATES_MATERIAL', PREPASS_CLASS_REL_ASSOCIATES_MATERIAL],
+    ['PREPASS_CLASS_REL_VOIDS', PREPASS_CLASS_REL_VOIDS],
+    ['PREPASS_CLASS_REL_FILLS', PREPASS_CLASS_REL_FILLS],
+    ['PREPASS_CLASS_REL_AGGREGATES', PREPASS_CLASS_REL_AGGREGATES],
+  ])('%s', (name, tsValue) => {
+    expect(rustConst(name)).toBe(tsValue);
+  });
+
+  it('sizes the count table so no masked code can write out of bounds', () => {
+    // Every named Rust code must fit under the mask, which is what makes
+    // `Uint32Array(PREPASS_CLASS_CODE_MASK + 1)` safe for codes the host does
+    // not yet know about.
+    const named = [...src.matchAll(/pub const PREPASS_CLASS_(?!FLAG_|CODE_MASK)\w+: u8 = (\d+);/g)];
+    expect(named.length).toBeGreaterThan(0);
+    for (const m of named) expect(Number(m[1])).toBeLessThanOrEqual(PREPASS_CLASS_CODE_MASK);
+  });
+});

--- a/packages/geometry/src/prepass-class-spans.test.ts
+++ b/packages/geometry/src/prepass-class-spans.test.ts
@@ -144,7 +144,14 @@ describe.skipIf(!existsSync(rustSource))('prepass class constants match the Rust
     // Every named Rust code must fit under the mask, which is what makes
     // `Uint32Array(PREPASS_CLASS_CODE_MASK + 1)` safe for codes the host does
     // not yet know about.
-    const named = [...src.matchAll(/pub const PREPASS_CLASS_(?!FLAG_|CODE_MASK)\w+: u8 = (\d+);/g)];
+    // Hex-tolerant, matching `rustConst` above: a named code written `0x0b`
+    // would be SKIPPED by a decimal-only `(\d+)` rather than checked, and the
+    // length guard below would not notice because the other codes still match.
+    // A check that quietly narrows its own scope is the defect this file exists
+    // to prevent (maintainer finding on #2072).
+    const named = [
+      ...src.matchAll(/pub const PREPASS_CLASS_(?!FLAG_|CODE_MASK)\w+: u8 = (0x[0-9a-fA-F]+|\d+);/g),
+    ];
     expect(named.length).toBeGreaterThan(0);
     for (const m of named) expect(Number(m[1])).toBeLessThanOrEqual(PREPASS_CLASS_CODE_MASK);
   });


### PR DESCRIPTION
Closes #2065 — the host-side half of the class-column question you raised on #2054.

**No output changes today, and this PR claims nothing more than that.** Re-verified against `upstream/main` before writing a line: `classify_type_name` returns the named codes early (`shard_classes.rs:137-141`), so classes 4–10 never acquire a flag bit from that path, and the only later OR-in is gated on `is_representationless_spatial_container_by_name`, which requires a non-`Unknown` `IfcProduct` subtype (`schema_helpers.rs:177-188`) — none of the seven host-consumed keywords qualify. The unmasked comparison is correct **by coincidence of the current classification rules, not by construction**.

## Why close it anyway

The failure it defers is silent and total. `counts` was `Uint32Array(11)`, so a flagged byte like `0x80|4 = 132` was an out-of-bounds write that typed arrays **discard silently**, and `slots.get(132)` was `undefined` → `continue`. The entity vanished from the span list with no error. `counts` is now mask-sized, so a masked code is always in range.

## Two judgement calls, stated rather than buried

**`HOST_SPAN_CLASSES` stays explicit.** The 4–10 hard-coding is fixed in the half that matters — the count table — but the *list* the host extracts is still enumerated deliberately. The host only wants those seven, and a genuinely new Rust-side class it doesn't consume should be **ignored**, not auto-extracted. What changed is that ignoring it is a `Map` miss rather than memory corruption.

**No Rust→TS codegen.** There is no existing constant-codegen pipeline between the two sides (`scripts/generate-*` are all data generators), and standing one up for eight `u8`s is out of proportion. Instead this uses the repo's existing anti-drift idiom — the `*.parity.test.ts` pattern from `packages/parser`/`packages/encoding` that reads the Rust source directly. `prepass-class-spans.test.ts` parses `shard_classes.rs` and asserts each TS constant equals the Rust one, plus that every named Rust code fits under the mask. So drift is a failing test rather than a stale comment, which is the theme of #2053/#2054. `describe.skipIf(!existsSync(...))` keeps it green when the package is tested outside the monorepo.

## Evidence

The pre-fix logic was inline in a closure and untestable, so the honest RED is the mutation that reproduces it byte-for-byte — strip both masks from the extracted function:

```
FAIL > keeps a record whose class carries a FLAG bit alongside the named code
  - [ [ 100, 1000, 5 ] ]
  + []
FAIL > keeps flagged records for every host-consumed class, in file order
  expected 3 to be 6
```

I re-ran that myself on the pushed tree (`REPLACEMENTS=2`, both lines re-read): 2 failed / 200 passed, restored 202/202.

| mutation | result |
|---|---|
| drop both masks (= pre-fix code) | 2 failed |
| `0x3f` → `0x07` (over-masking) | 5 failed |
| `?? slots.get(STYLED_ITEM)` fallback (accept-everything) | **initially survived** — see below |

**The third one is worth your attention.** The first version of the exclusion test could not kill it, because the styled array is exact-size and the surplus writes were *themselves* silently discarded — the same typed-array behaviour this issue is about, biting the test instead of the code. Fixed by placing one styled record **last** among excluded ones, so a funnel-everything consumer fills the styled slots ahead of the real record and drops it. That mutation now fails.

Negative cases pass and deliberately do **not** depend on the mask (they stayed green under the RED mutation — they guard the opposite failure): plain `4` and `8` land in their own lists; masked codes the host doesn't consume (`0, 2, 3, 11, 12, 13`, each also with `0x80` set, plus pure-flag bytes `0x80`/`0x40`) produce empty lists everywhere.

`packages/geometry` 202 passing (was 189), typecheck 34/34, `check-test-wiring` passes. Changeset included — `@ifc-lite/geometry` is published — and it states plainly that no output changes today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved geometry prepass handling so flagged class codes are recognized correctly.
  * Prevented unrecognized or non-host-consumed records from entering span lists.
  * Preserved file order and produced accurate span ranges for supported classes.

* **Tests**
  * Added coverage for flagged and unflagged classes, filtering, ordering, and cross-language class-code consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->