### PR TITLE
fix(sandbox): derive the esbuild CDN url from the loaded host version (#2079)

### DIFF
--- a/.changeset/sandbox-esbuild-wasm-cdn-version.md
+++ b/.changeset/sandbox-esbuild-wasm-cdn-version.md
@@ -1,0 +1,11 @@
+---
+"@ifc-lite/sandbox": patch
+---
+
+Derive the `esbuild.wasm` CDN fallback URL from the loaded `esbuild-wasm` host version instead of a hard-coded one.
+
+`transpile.ts` asked unpkg for `esbuild-wasm@0.27.3/esbuild.wasm` under a comment claiming it was "version-pinned to match installed package", while the package depended on `^0.28.1` and resolved 0.28.1. `esbuild.initialize()` rejects a host/binary version mismatch outright ("Host version does not match binary version"), so that fallback could not start: every embedder reaching it dropped to the regex transpiler instead of esbuild. A hard-coded literal and a `^` range cannot stay in step by construction, so the URL now interpolates `esbuild.version` from the module that was just imported — the same host whose version `initialize()` checks — and there is nothing left to keep in sync. The dependency range is unchanged.
+
+The CDN branch is only reached under bundlers that do not implement Vite's `?url` asset hint; the first-party viewer builds with Vite and takes the bundled-asset path, so it was never affected.
+
+Covered by `transpile-wasm-url.test.ts`, which mocks `esbuild-wasm` with a fabricated version and asserts the URL follows it, so a re-introduced literal fails CI.

--- a/packages/sandbox/src/transpile-wasm-url.test.ts
+++ b/packages/sandbox/src/transpile-wasm-url.test.ts
@@ -1,0 +1,75 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The CDN fallback URL for `esbuild.wasm` must name the same version as the
+ * `esbuild-wasm` JS host that loads it: `esbuild.initialize()` rejects a
+ * host/binary mismatch outright ("Host version does not match binary
+ * version"), so a stale version in the URL means the fallback cannot start at
+ * all and the sandbox silently degrades to the regex transpiler.
+ *
+ * The version here is faked, deliberately: the assertion is that the URL is
+ * *derived* from whatever host is loaded, not that it equals today's release.
+ * A coordinated dependency bump therefore keeps this green, while re-hardcoding
+ * a literal version turns it red.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { readFile } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+
+const { FAKE_VERSION, captured } = vi.hoisted(() => ({
+  FAKE_VERSION: '9.9.9-fake',
+  captured: { wasmURL: undefined as string | undefined, initialized: false },
+}));
+
+vi.mock('esbuild-wasm', () => {
+  // Shape mirrors the real package: named exports plus a `default` carrying
+  // the same members, which is what `transpile.ts` reaches for first.
+  const fake = {
+    version: FAKE_VERSION,
+    initialize: async (options: { wasmURL?: string }) => {
+      captured.wasmURL = options.wasmURL;
+      captured.initialized = true;
+    },
+    transform: async (code: string) => ({ code }),
+  };
+  return { ...fake, default: fake };
+});
+
+// The Vite-only `?url` asset hint is what the CDN branch is a fallback for.
+// Force that branch by making the asset unresolvable, as a non-Vite bundler
+// would.
+vi.mock('esbuild-wasm/esbuild.wasm?url', () => {
+  throw new Error('no ?url asset resolver (simulating a non-Vite bundler)');
+});
+
+describe('esbuild.wasm CDN fallback URL', () => {
+  beforeEach(() => {
+    captured.wasmURL = undefined;
+    captured.initialized = false;
+    vi.resetModules();
+  });
+
+  it('names the version of the esbuild-wasm host that will load it', async () => {
+    const { transpileTypeScript } = await import('./transpile.js');
+    await transpileTypeScript('const x: number = 1;');
+
+    expect(captured.initialized).toBe(true);
+    expect(captured.wasmURL).toBe(`https://unpkg.com/esbuild-wasm@${FAKE_VERSION}/esbuild.wasm`);
+  });
+
+  // The test above proves the URL follows the host's `version`; this one proves
+  // that `version` is a real thing the installed package exports, and that it
+  // is the version unpkg would be asked for. Without it, a dropped export would
+  // yield `esbuild-wasm@undefined` and still satisfy the mock.
+  it('reads a version from the installed esbuild-wasm that matches its manifest', async () => {
+    const actual = await vi.importActual<{ version: string }>('esbuild-wasm');
+    const manifestPath = createRequire(import.meta.url).resolve('esbuild-wasm/package.json');
+    const manifest = JSON.parse(await readFile(manifestPath, 'utf8')) as { version: string };
+
+    expect(actual.version).toMatch(/^\d+\.\d+\.\d+/);
+    expect(actual.version).toBe(manifest.version);
+  });
+});

--- a/packages/sandbox/src/transpile.ts
+++ b/packages/sandbox/src/transpile.ts
@@ -18,6 +18,8 @@
 // ============================================================================
 
 interface EsbuildLike {
+  /** Version of the JS host. `initialize()` rejects a binary that disagrees. */
+  version: string;
   initialize: (options: { wasmURL?: string; worker?: boolean }) => Promise<void>;
   transform: (code: string, options: { loader: string; target: string }) => Promise<{ code: string }>;
 }
@@ -56,8 +58,11 @@ function getEsbuild(): Promise<EsbuildLike | null> {
         const wasmMod = await import('esbuild-wasm/esbuild.wasm?url' as string);
         wasmURL = (wasmMod as { default: string }).default;
       } catch {
-        // Fallback: CDN (version-pinned to match installed package)
-        wasmURL = `https://unpkg.com/esbuild-wasm@0.27.3/esbuild.wasm`;
+        // Fallback: CDN. The version comes from the loaded host rather than a
+        // literal — `initialize()` rejects a host/binary mismatch outright
+        // ("Host version does not match binary version"), and a hard-coded
+        // version cannot stay in step with a `^` dependency range.
+        wasmURL = `https://unpkg.com/esbuild-wasm@${esbuild.version}/esbuild.wasm`;
       }
 
       await esbuild.initialize({ wasmURL, worker: false });


### PR DESCRIPTION
Closes #2079 — the broken fallback the house-rule sweep (#2080) uncovered when it made the swallowing `catch` log its cause.

## The defect, each fact verified against `upstream/main`

| claim | result |
|---|---|
| `transpile.ts:60` hard-codes `esbuild-wasm@0.27.3` | confirmed, verbatim, with the "version-pinned to match installed package" comment |
| `package.json` declares `^0.28.1` | confirmed |
| installed is 0.28.1 | confirmed — lockfile has only `esbuild-wasm@0.28.1`, and the module's `version` export is `0.28.1` |
| esbuild rejects a host/binary mismatch | confirmed **by source inspection, not execution** — `lib/main.js:918` and `lib/browser.js:939` throw `Cannot start service: Host version "0.28.1" does not match binary version …`, with the host version baked in at build time |

**Explicitly not claimed:** the CDN path has not been exercised against the network. I could not fetch the 0.27.3 wasm from unpkg in this environment, so this establishes the mismatch, not an observed end-to-end success.

## Derive rather than pin — and it costs less than the pin would

I recommended exact-pinning plus a parity test in the issue. Deriving turned out to be cleaner here, so that is what this does:

```ts
wasmURL = `https://unpkg.com/esbuild-wasm@${esbuild.version}/esbuild.wasm`;
```

`esbuild-wasm` exports `version`, and it is **exactly** the value `initialize()` compares against the binary — the source of truth rather than a proxy for it. It is already in hand: `getEsbuild()` imports the module before resolving the URL, so there is no new import and the ~10MB lazy-load code-split is untouched.

**Consequence worth calling out: the `^0.28.1` range stays as it is.** Deriving makes the pin unnecessary, so there is no dependency-policy change for you to veto — which is the main reason to prefer it over the option I originally suggested.

## Evidence

RED against unmodified `upstream/main`:

```
AssertionError: expected 'https://unpkg.com/esbuild-wasm@0.27.3…' to be 'https://unpkg.com/esbuild-wasm@9.9.9-…'
Expected: "https://unpkg.com/esbuild-wasm@9.9.9-fake/esbuild.wasm"
Received: "https://unpkg.com/esbuild-wasm@0.27.3/esbuild.wasm"
```

The test mocks `esbuild-wasm` with a fabricated version and mocks the `?url` import to throw, forcing the CDN branch. I re-ran the re-hardcoding mutation myself on the pushed tree (`REPLACEMENTS=1`, line re-read): 1 failed / 42 passed, restored 43/43.

**A second test guards the mock itself** — it asserts the *real* installed module exports a semver `version` matching its own `package.json`. Without it, a dropped `version` export would produce `esbuild-wasm@undefined` and still satisfy the mock.

**Negative case:** changing the fabricated version to a different value still passes, so the test asserts *agreement* rather than carrying a second copy of the number — which was the failure mode of the thing it replaces.

43 passing (was 41), typecheck 34/34.

## Conflict note

Textual conflict with **#2080** is likely: that PR adds a `console.warn` to the same `catch` block without touching the literal, while this one changes the literal and its comment. Resolution is to keep both — the warning and the derived URL are complementary, and the warning is what would have surfaced this years earlier.

## One process note

My first mutation attempt used `perl -i -pe 's/\Qesbuild-wasm@${esbuild.version}\E/…/'`. Perl interpolated `${esbuild.version}` to empty **inside `\Q…\E`**, so the pattern degraded to `esbuild-wasm@` and reported `replacements=8`, rewriting comments and the import specifier across the file. The STDERR count plus re-reading the region caught it immediately; restored from pristine via `git checkout --` and redid it with a `$`-free pattern asserting exactly 1.

That is the second distinct way a mutation has silently misapplied here today, and both were caught only by the count-and-re-read step rather than by the suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
