### PR TITLE
test(pointcloud,viewer): real-browser E2E for the laz-perf wasm loading path (#2097)

### DIFF
--- a/.changeset/laz-wasm-e2e-probe.md
+++ b/.changeset/laz-wasm-e2e-probe.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/pointcloud": minor
+---
+
+Add `probeLazPerfWasmLoad()`, an internal E2E test hook that exercises the real laz-perf wasm loader (the Vite `?url` asset fetch plus the `Module.wasmBinary` hand-off to emscripten) without needing a `.laz` fixture. No other test drove this path for real: every existing test substitutes the loader via `setLazPerfLoaderForTesting()`, so a broken `?url` resolution or a broken `wasmBinary` hand-off stayed invisible until a real browser tried to open a LAZ file (#2097). Used by `apps/viewer`'s `laz-probe.html` (E2E-only, not linked from the app UI) and asserted by `tests/e2e/laz-wasm.e2e.spec.ts` against a real production build.

--- a/apps/viewer/laz-probe.html
+++ b/apps/viewer/laz-probe.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>laz-perf wasm probe (E2E only, see #2097)</title>
+</head>
+<body>
+  <!--
+    E2E-only page, not linked from the app UI. Loaded by
+    tests/e2e/laz-wasm.e2e.spec.ts against a real `vite build` to prove the
+    laz-perf wasm asset pipeline works end to end (issue #2097).
+  -->
+  <script type="module" src="/src/e2e/laz-wasm-probe-entry.ts"></script>
+</body>
+</html>

--- a/apps/viewer/src/e2e/laz-wasm-probe-entry.ts
+++ b/apps/viewer/src/e2e/laz-wasm-probe-entry.ts
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Entry for `laz-probe.html`, an E2E-only page read by
+ * `tests/e2e/laz-wasm.e2e.spec.ts` (#2097).
+ *
+ * Every other test that touches `LazStreamingSource` substitutes the wasm
+ * loader (`setLazPerfLoaderForTesting`), so the two mechanisms that make LAZ
+ * work in a real browser — the Vite `?url` wasm-asset fetch and the
+ * `Module.wasmBinary` hand-off to emscripten — are otherwise never
+ * exercised against a real production build. This page is not linked from
+ * the app UI; it exists solely so `pnpm --filter @ifc-lite/viewer build`
+ * bundles `probeLazPerfWasmLoad()` through the real asset pipeline, and a
+ * Playwright test can read the result off `window.__LAZ_PROBE__`.
+ */
+import { probeLazPerfWasmLoad } from '@ifc-lite/pointcloud';
+
+declare global {
+  interface Window {
+    __LAZ_PROBE__?: Awaited<ReturnType<typeof probeLazPerfWasmLoad>>;
+  }
+}
+
+void probeLazPerfWasmLoad().then((result) => {
+  window.__LAZ_PROBE__ = result;
+});

--- a/apps/viewer/vite.config.ts
+++ b/apps/viewer/vite.config.ts
@@ -328,6 +328,13 @@ export default defineConfig({
       // longer ships a desktop app; downstream desktop builders supply
       // @tauri-apps in their own host layer.
       external: ['@tauri-apps/api/event'],
+      input: {
+        main: path.resolve(__dirname, 'index.html'),
+        // E2E-only, not linked from the app UI: reads the laz-perf wasm
+        // asset pipeline through the real build so
+        // tests/e2e/laz-wasm.e2e.spec.ts can assert it end to end (#2097).
+        lazProbe: path.resolve(__dirname, 'laz-probe.html'),
+      },
       output: {
         manualChunks(id) {
           if (id.includes('/packages/sandbox/')) return 'sandbox';

--- a/packages/pointcloud/src/index.ts
+++ b/packages/pointcloud/src/index.ts
@@ -43,7 +43,7 @@ export type {
   DownsampleHint,
 } from './streaming/types.js';
 export { LasStreamingSource } from './streaming/las-source.js';
-export { LazStreamingSource } from './streaming/laz-source.js';
+export { LazStreamingSource, probeLazPerfWasmLoad } from './streaming/laz-source.js';
 export { PlyStreamingSource } from './streaming/ply-source.js';
 export { PcdStreamingSource } from './streaming/pcd-source.js';
 export { E57StreamingSource } from './streaming/e57-source.js';

--- a/packages/pointcloud/src/streaming/laz-source.ts
+++ b/packages/pointcloud/src/streaming/laz-source.ts
@@ -119,6 +119,26 @@ async function fetchLazPerfWasm(): Promise<Uint8Array> {
 let loadLazPerf = memoizeAsync(importLazPerf);
 
 /**
+ * @internal E2E probe only — `tests/e2e/laz-wasm.e2e.spec.ts`. Exercises the
+ * two mechanisms #2097 found unasserted: the Vite `?url` wasm-asset fetch
+ * and the `Module.wasmBinary` hand-off to emscripten. Deliberately calls
+ * `importLazPerf()` directly rather than the memoized `loadLazPerf` (so the
+ * probe isn't affected by, and can't be swapped by, `setLazPerfLoaderForTesting`)
+ * and needs no `.laz` fixture: reaching a real `LASZip` constructor proves
+ * both mechanisms worked, independent of decoding any actual point data.
+ */
+export async function probeLazPerfWasmLoad(): Promise<
+  { ok: true; hasLASZip: boolean } | { ok: false; error: string }
+> {
+  try {
+    const mod = await importLazPerf();
+    return { ok: true, hasLASZip: typeof mod.LASZip === 'function' };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+/**
  * @internal Test seam. The real loader fetches wasm over the network and
  * instantiates an emscripten module, neither of which a unit test can
  * drive, so tests swap in a stub. Returns a restore function.

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -24,7 +24,7 @@ export default defineConfig({
   projects: [
     {
       name: 'viewer-e2e',
-      testMatch: /(viewer-smoke|usd-export)\.e2e\.spec\.ts/,
+      testMatch: /(viewer-smoke|usd-export|laz-wasm)\.e2e\.spec\.ts/,
       timeout: 240000,
       use: {
         ...devices['Desktop Chrome'],
@@ -45,7 +45,7 @@ export default defineConfig({
     },
     {
       name: 'viewer-e2e-ci',
-      testMatch: /(viewer-smoke|usd-export)\.e2e\.spec\.ts/,
+      testMatch: /(viewer-smoke|usd-export|laz-wasm)\.e2e\.spec\.ts/,
       timeout: 240000,
       use: {
         baseURL: 'http://localhost:3000',

--- a/scripts/api-surface.json
+++ b/scripts/api-surface.json
@@ -3577,6 +3577,7 @@
     "parseLasHeader: function",
     "parsePlyHeader: function",
     "probeAsciiPointsLayout: function",
+    "probeLazPerfWasmLoad: function",
     "sampleMaxRgbChannel: function",
     "streamPointCloud: function",
     "stripE57PageCrc: function"

--- a/tests/e2e/laz-wasm.e2e.spec.ts
+++ b/tests/e2e/laz-wasm.e2e.spec.ts
@@ -1,0 +1,68 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Real-browser, real-build E2E for the laz-perf wasm loading path (#2097).
+ *
+ * Nothing else exercises this end to end: `laz-source.test.ts` drives
+ * `LazStreamingSource` through `setLazPerfLoaderForTesting`, which replaces
+ * `importLazPerf` wholesale, so the two mechanisms that actually make LAZ
+ * work in a browser never run:
+ *
+ *   1. `import('laz-perf/lib/web/laz-perf.wasm?url')` — Vite's asset
+ *      pipeline resolving the wasm to a hashed, `application/wasm` URL.
+ *   2. `factory({ wasmBinary })` — handing the pre-fetched bytes to
+ *      emscripten so its own (broken-under-Vite) `locateFile` fetch is
+ *      skipped.
+ *
+ * If either breaks, every unit/vitest suite stays green (see AGENTS.md
+ * §Geometry & WASM and the issue) while every LAZ open fails in a real
+ * browser. vitest can't catch it either: `?url` resolves there too, but to
+ * the dev-server `/@fs/...` form, which `fetch` cannot consume under Node
+ * and which is not the production `/assets/...` form anyway — a green
+ * vitest test would assert the wrong pipeline (see issue #2097 comments for
+ * the measured trap).
+ *
+ * This test reads `window.__LAZ_PROBE__` off `laz-probe.html`
+ * (apps/viewer/src/e2e/laz-wasm-probe-entry.ts), a small page — not linked
+ * from the app UI — added to the real `vite build` input list solely so a
+ * production build exercises `probeLazPerfWasmLoad()`. That function calls
+ * the real `importLazPerf()` (bypassing the `setLazPerfLoaderForTesting`
+ * seam) and reports whether a real `LASZip` constructor came back.
+ *
+ * WHAT THIS DOES NOT COVER: decoding actual LAZ-compressed point data.
+ * There is no `.laz` fixture in `tests/models/manifest.json`, and one can't
+ * be synthesized in-repo: `laz-perf@0.0.7` is decode-only (`LASZip`,
+ * `ChunkDecoder`; no writer/compressor). Reaching a real `LASZip`
+ * constructor proves both wasm-loading mechanisms above already worked
+ * (emscripten only hands back a working module if instantiation
+ * succeeded), independent of decoding any actual points — but the decode
+ * step itself (`laszip.open()` on real compressed bytes) is unasserted
+ * anywhere in this repo.
+ */
+
+import { test, expect } from '@playwright/test';
+
+test.describe('laz-perf wasm loading path (real build, real browser)', () => {
+  test('the ?url wasm asset resolves and the wasmBinary hand-off succeeds', async ({ page }) => {
+    const consoleErrors: string[] = [];
+    page.on('pageerror', (err) => consoleErrors.push(String(err)));
+
+    await page.goto('/laz-probe.html');
+    const handle = await page.waitForFunction(
+      () => (window as { __LAZ_PROBE__?: unknown }).__LAZ_PROBE__,
+      undefined,
+      { timeout: 60000 },
+    );
+    const result = (await handle.jsonValue()) as
+      | { ok: true; hasLASZip: boolean }
+      | { ok: false; error: string };
+
+    expect(consoleErrors, `uncaught page errors: ${consoleErrors.join('; ')}`).toEqual([]);
+    expect(result.ok, `laz-perf wasm failed to load: ${result.ok ? '' : result.error}`).toBe(true);
+    if (result.ok) {
+      expect(result.hasLASZip).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Closes the gap #2097 describes: nothing exercised the laz-perf wasm loading path end to end, so every existing test stayed green while a broken `?url` resolution or a broken `wasmBinary` hand-off would fail every LAZ open in a real browser.

- `packages/pointcloud/src/streaming/laz-source.ts` gains `probeLazPerfWasmLoad()`, a test-only export that calls the real `importLazPerf()` directly (bypassing `setLazPerfLoaderForTesting`) and reports whether a real `LASZip` constructor came back.
- `apps/viewer/laz-probe.html` + `apps/viewer/src/e2e/laz-wasm-probe-entry.ts`: a small E2E-only page, not linked from the app UI, added to the real `vite build` input list so a production build actually bundles and runs the probe through Vite's real `?url` asset pipeline.
- `tests/e2e/laz-wasm.e2e.spec.ts`: Playwright test that loads that page against a real `vite preview` (production build, real MIME types) and asserts `probeLazPerfWasmLoad()` succeeded.

## What IS covered

Both mechanisms the issue names as unasserted:
1. `import('laz-perf/lib/web/laz-perf.wasm?url')` resolving to a real, hashed, `application/wasm`-served asset in the **production build** (not the vitest dev-server `/@fs/...` form, which is a different pipeline — see the issue thread for why vitest was ruled out).
2. `factory({ wasmBinary })` — the hand-off succeeding rather than falling back to emscripten's own broken `locateFile` fetch (the original bug this code exists to avoid).

Getting back a working `LASZip` constructor from a real emscripten instantiation proves both, independent of decoding any actual point data.

**Mutation-tested**: pointing the `?url` specifier at a nonexistent module fails the `vite build` outright. Corrupting the fetched wasm URL post-resolution (so `fetch` 404s and the wasm loader receives the SPA `index.html` fallback instead) builds clean but fails this test at runtime with `WebAssembly.instantiate(): expected magic word 00 61 73 6d, found 3c 21 44 4f` — the same failure class as the original "MIME type 'text/plain'" bug. Restored via file copy afterward.

## What is NOT covered

Decoding actual LAZ-compressed point data (`laszip.open()` on real bytes, points coming out correctly). There is no `.laz` fixture in `tests/models/manifest.json`, and one can't be synthesized in-repo: `laz-perf@0.0.7` is decode-only (`LASZip`/`ChunkDecoder`, no writer/compressor). That gap is unchanged by this PR — see the issue thread for the full investigation (vitest and the wasm-contract script were both ruled out as homes for it, and why).

## Test plan

- [x] `pnpm --filter @ifc-lite/pointcloud test` — 131 passed, 2 skipped
- [x] `pnpm --filter @ifc-lite/viewer typecheck`, `pnpm --filter @ifc-lite/viewer-embed typecheck`
- [x] `node scripts/check-api-surface.mjs` (snapshot updated, changeset added — `probeLazPerfWasmLoad` is a new minor export on `@ifc-lite/pointcloud`)
- [x] `node scripts/check-test-wiring.mjs`
- [x] Manual run of `tests/e2e/laz-wasm.e2e.spec.ts` against a real `vite build` + `vite preview`, in a real Chromium: passes on the current tree, fails with the SPA-fallback wasm-magic-word error when the `?url`→fetch wiring is deliberately broken.

I could not run this through the repo's actual `viewer-e2e-ci` Playwright project locally (it pins `channel: 'chrome'`, and this sandbox has no real Chrome installed, only Playwright's bundled Chromium — which reproduced the same pass/fail behavior). CI has real Chrome, so this should run there unmodified; flagging in case anything about the `chrome` channel specifically needs a second look.