### PR TITLE
test(bcf,solar): close 23 mutation-verified coverage gaps

### DIFF
--- a/packages/bcf/src/index.test.ts
+++ b/packages/bcf/src/index.test.ts
@@ -1,0 +1,119 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it, expect } from 'vitest';
+import {
+  parseARGBColor,
+  toARGBColor,
+  createBCFProject,
+  createBCFTopic,
+  createBCFComment,
+  addTopicToProject,
+  addCommentToTopic,
+  addViewpointToTopic,
+  updateTopicStatus,
+} from './index.js';
+
+/**
+ * BCF colours are ARGB — alpha FIRST — which is the opposite of the RGBA order
+ * most web code uses. Nothing pinned the channel order, so a swapped pair (or a
+ * transposed 6-digit fallback) produced a perfectly valid-looking hex string
+ * that painted the wrong colour in the receiving tool.
+ */
+describe('ARGB colour helpers', () => {
+  describe('parseARGBColor', () => {
+    it('reads the 8-digit form as alpha, red, green, blue in that order', () => {
+      expect(parseARGBColor('80112233')).toEqual({ a: 0x80, r: 0x11, g: 0x22, b: 0x33 });
+      // Opaque red, the canonical BCF example.
+      expect(parseARGBColor('FFFF0000')).toEqual({ a: 255, r: 255, g: 0, b: 0 });
+    });
+
+    it('treats the 6-digit form as opaque RGB', () => {
+      // Distinct channel values so a transposition cannot pass by symmetry.
+      expect(parseARGBColor('112233')).toEqual({ a: 255, r: 0x11, g: 0x22, b: 0x33 });
+    });
+
+    it('tolerates a leading # in either length', () => {
+      expect(parseARGBColor('#112233')).toEqual({ a: 255, r: 0x11, g: 0x22, b: 0x33 });
+      expect(parseARGBColor('#80112233')).toEqual({ a: 0x80, r: 0x11, g: 0x22, b: 0x33 });
+    });
+  });
+
+  describe('toARGBColor', () => {
+    it('emits alpha first, uppercase, zero-padded', () => {
+      expect(toARGBColor(0x11, 0x22, 0x33, 0x44)).toBe('44112233');
+      // Alpha defaults to fully opaque.
+      expect(toARGBColor(255, 0, 0)).toBe('FFFF0000');
+      // Single-digit nibbles must be padded, not truncated.
+      expect(toARGBColor(1, 2, 3, 4)).toBe('04010203');
+    });
+
+    it('clamps and rounds out-of-range channels instead of emitting garbage hex', () => {
+      expect(toARGBColor(-5, 300, 10.6, 255)).toBe('FF00FF0B');
+    });
+
+    it('round-trips through parseARGBColor', () => {
+      for (const [r, g, b, a] of [[0, 0, 0, 0], [255, 255, 255, 255], [1, 128, 254, 7]] as const) {
+        expect(parseARGBColor(toARGBColor(r, g, b, a))).toEqual({ r, g, b, a });
+      }
+    });
+  });
+});
+
+describe('project/topic convenience helpers', () => {
+  it('defaults a new project to BCF 2.1 with a generated project id', () => {
+    const p = createBCFProject();
+    expect(p.version).toBe('2.1');
+    expect(p.projectId).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-/i);
+    expect(p.topics.size).toBe(0);
+    expect(p.name).toBeUndefined();
+
+    expect(createBCFProject({ version: '3.0', name: 'N' })).toMatchObject({ version: '3.0', name: 'N' });
+  });
+
+  it('defaults a new topic to an open Issue and keeps explicit overrides', () => {
+    const t = createBCFTopic({ title: 'T', author: 'a@example.com' });
+    expect(t.topicType).toBe('Issue');
+    expect(t.topicStatus).toBe('Open');
+    expect(t.creationAuthor).toBe('a@example.com');
+    expect(t.comments).toEqual([]);
+    expect(t.viewpoints).toEqual([]);
+
+    const custom = createBCFTopic({
+      title: 'T',
+      author: 'a@example.com',
+      topicType: 'Clash',
+      topicStatus: 'Closed',
+    });
+    expect(custom.topicType).toBe('Clash');
+    expect(custom.topicStatus).toBe('Closed');
+  });
+
+  it('keys a topic in the project map by its own GUID', () => {
+    const project = createBCFProject();
+    const topic = createBCFTopic({ title: 'T', author: 'a@example.com' });
+    addTopicToProject(project, topic);
+    expect(project.topics.get(topic.guid)).toBe(topic);
+  });
+
+  it('stamps modifiedDate when a comment, viewpoint or status change lands', () => {
+    const topic = createBCFTopic({ title: 'T', author: 'a@example.com' });
+    expect(topic.modifiedDate).toBeUndefined();
+
+    addCommentToTopic(topic, createBCFComment({ author: 'b@example.com', comment: 'hi' }));
+    expect(topic.comments).toHaveLength(1);
+    expect(topic.modifiedDate).toBeDefined();
+
+    topic.modifiedDate = undefined;
+    addViewpointToTopic(topic, { guid: 'vp-1' });
+    expect(topic.viewpoints).toHaveLength(1);
+    expect(topic.modifiedDate).toBeDefined();
+
+    topic.modifiedDate = undefined;
+    updateTopicStatus(topic, 'Closed', 'c@example.com');
+    expect(topic.topicStatus).toBe('Closed');
+    expect(topic.modifiedAuthor).toBe('c@example.com');
+    expect(topic.modifiedDate).toBeDefined();
+  });
+});

--- a/packages/bcf/src/overlay.test.ts
+++ b/packages/bcf/src/overlay.test.ts
@@ -1,0 +1,165 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it, expect } from 'vitest';
+import { computeMarkerPositions, type EntityBoundsLookup, type OverlayBBox } from './overlay.js';
+import type { BCFTopic, BCFViewpoint } from './types.js';
+
+const GUID_A = 'AAAAAAAAAAAAAAAAAAAAAA';
+const GUID_B = 'BBBBBBBBBBBBBBBBBBBBBB';
+
+function topic(overrides: Partial<BCFTopic> = {}): BCFTopic {
+  return {
+    guid: `topic-${Math.random().toString(36).slice(2)}`,
+    title: 'T',
+    creationDate: '2026-01-01T00:00:00.000Z',
+    creationAuthor: 'a@example.com',
+    comments: [],
+    viewpoints: [],
+    ...overrides,
+  };
+}
+
+/** A viewpoint whose camera sits at the BCF origin looking along +Y (BCF forward). */
+function cameraViewpoint(direction = { x: 0, y: 1, z: 0 }): BCFViewpoint {
+  return {
+    guid: 'vp-cam',
+    perspectiveCamera: {
+      cameraViewPoint: { x: 1, y: 2, z: 3 },
+      cameraDirection: direction,
+      cameraUpVector: { x: 0, y: 0, z: 1 },
+      fieldOfView: 60,
+    },
+  };
+}
+
+const noBounds: EntityBoundsLookup = () => null;
+
+describe('computeMarkerPositions', () => {
+  const bbox: OverlayBBox = { min: { x: 0, y: 0, z: 0 }, max: { x: 4, y: 10, z: 6 } };
+  const boundsFor = (guid: string): EntityBoundsLookup => (g) => (g === guid ? bbox : null);
+
+  it('floats a component marker above the bbox top and anchors the connector on it', () => {
+    // The lift is 30% of the element height with a 0.5 m floor. Without it the
+    // marker sits exactly on the bbox top and z-fights the geometry it labels.
+    const t = topic({ viewpoints: [{ guid: 'vp', components: { selection: [{ ifcGuid: GUID_A }] } }] });
+    const [marker] = computeMarkerPositions([t], boundsFor(GUID_A));
+
+    expect(marker.positionSource).toBe('component');
+    // Centre in X/Z, top + 30% of a 10 m height.
+    expect(marker.connectorAnchor).toEqual({ x: 2, y: 10, z: 3 });
+    expect(marker.position).toEqual({ x: 2, y: 13, z: 3 });
+  });
+
+  it('applies the 0.5 m minimum lift to a zero-height element', () => {
+    // A flat element (a slab face, a 2D annotation) has height 0, so the
+    // percentage lift collapses; the floor is what keeps the marker visible.
+    const flat: OverlayBBox = { min: { x: 0, y: 5, z: 0 }, max: { x: 2, y: 5, z: 2 } };
+    const t = topic({ viewpoints: [{ guid: 'vp', components: { selection: [{ ifcGuid: GUID_A }] } }] });
+    const [marker] = computeMarkerPositions([t], (g) => (g === GUID_A ? flat : null));
+
+    expect(marker.connectorAnchor!.y).toBe(5);
+    expect(marker.position.y).toBe(5.5);
+  });
+
+  it('falls back through camera-target to camera-position when no component resolves', () => {
+    // Strategy 2: BCF direction {0,1,0} is Y-up {0,0,-1}, so the target is
+    // targetDistance units along -Z from the (converted) camera position.
+    const withDirection = topic({ viewpoints: [cameraViewpoint()] });
+    const [target] = computeMarkerPositions([withDirection], noBounds, { targetDistance: 10 });
+    expect(target.positionSource).toBe('camera-target');
+    expect(target.position).toEqual({ x: 1, y: 3, z: -12 });
+    expect(target.connectorAnchor).toBeUndefined();
+
+    // Strategy 3: a degenerate (zero-length) direction has no derivable target,
+    // so the marker falls back to the camera position itself.
+    const degenerate = topic({ viewpoints: [cameraViewpoint({ x: 0, y: 0, z: 0 })] });
+    const [position] = computeMarkerPositions([degenerate], noBounds, { targetDistance: 10 });
+    expect(position.positionSource).toBe('camera-position');
+    expect(position.position).toEqual({ x: 1, y: 3, z: -2 });
+  });
+
+  it('prefers a resolvable component over the camera, and skips unresolvable ones', () => {
+    // The first selected component has no geometry loaded; the second does. The
+    // loop must keep looking rather than giving up and falling back to a camera.
+    const t = topic({
+      viewpoints: [
+        {
+          guid: 'vp',
+          components: { selection: [{ ifcGuid: GUID_B }, { ifcGuid: GUID_A }] },
+          perspectiveCamera: cameraViewpoint().perspectiveCamera,
+        },
+      ],
+    });
+    const [marker] = computeMarkerPositions([t], boundsFor(GUID_A));
+    expect(marker.positionSource).toBe('component');
+    expect(marker.position).toEqual({ x: 2, y: 13, z: 3 });
+  });
+
+  it('uses isolation exceptions as component anchors only when defaultVisibility is false', () => {
+    const isolation = topic({
+      viewpoints: [{
+        guid: 'vp',
+        components: { visibility: { defaultVisibility: false, exceptions: [{ ifcGuid: GUID_A }] } },
+        perspectiveCamera: cameraViewpoint().perspectiveCamera,
+      }],
+    });
+    expect(computeMarkerPositions([isolation], boundsFor(GUID_A))[0].positionSource).toBe('component');
+
+    // The same exceptions with defaultVisibility=true are a HIDE list — anchoring
+    // the marker to a hidden element would point at nothing.
+    const hiding = topic({
+      viewpoints: [{
+        guid: 'vp',
+        components: { visibility: { defaultVisibility: true, exceptions: [{ ifcGuid: GUID_A }] } },
+        perspectiveCamera: cameraViewpoint().perspectiveCamera,
+      }],
+    });
+    expect(computeMarkerPositions([hiding], boundsFor(GUID_A))[0].positionSource).toBe('camera-target');
+  });
+
+  it('keeps matching statuses and drops non-matching ones, case-insensitively', () => {
+    // Both directions of the filter: an inverted comparison would pass a test
+    // that only ever checked one of them.
+    const open = topic({ topicStatus: 'Open', viewpoints: [cameraViewpoint()] });
+    const closed = topic({ topicStatus: 'Closed', viewpoints: [cameraViewpoint()] });
+
+    const kept = computeMarkerPositions([open, closed], noBounds, { statusFilter: ['open'] });
+    expect(kept.map((m) => m.topicGuid)).toEqual([open.guid]);
+
+    const inverse = computeMarkerPositions([open, closed], noBounds, { statusFilter: ['CLOSED'] });
+    expect(inverse.map((m) => m.topicGuid)).toEqual([closed.guid]);
+
+    // An empty filter is "no filter", not "match nothing".
+    expect(computeMarkerPositions([open, closed], noBounds, { statusFilter: [] })).toHaveLength(2);
+  });
+
+  it('numbers markers from 1 when the topic carries no index', () => {
+    // Marker labels are user-facing; a 0-based fallback would show "0" on the
+    // first pin. An explicit topic index still wins.
+    const a = topic({ viewpoints: [cameraViewpoint()] });
+    const b = topic({ viewpoints: [cameraViewpoint()] });
+    const c = topic({ index: 42, viewpoints: [cameraViewpoint()] });
+
+    expect(computeMarkerPositions([a, b, c], noBounds).map((m) => m.index)).toEqual([1, 2, 42]);
+  });
+
+  it('skips topics with no derivable position and defaults the display fields', () => {
+    const positionless = topic({ viewpoints: [{ guid: 'vp-empty' }] });
+    const noViewpoints = topic();
+    const ok = topic({ viewpoints: [cameraViewpoint()], comments: [
+      { guid: 'c1', date: '2026-01-01T00:00:00.000Z', author: 'a@example.com', comment: 'x' },
+    ] });
+
+    const markers = computeMarkerPositions([positionless, noViewpoints, ok], noBounds);
+    expect(markers.map((m) => m.topicGuid)).toEqual([ok.guid]);
+    expect(markers[0]).toMatchObject({
+      status: 'Open',
+      priority: 'Normal',
+      topicType: 'Issue',
+      commentCount: 1,
+      hasViewpoint: true,
+    });
+  });
+});

--- a/packages/bcf/src/viewpoint.test.ts
+++ b/packages/bcf/src/viewpoint.test.ts
@@ -5,8 +5,16 @@
 import { describe, it, expect } from 'vitest';
 import {
   cameraToPerspective,
+  cameraToOrthogonal,
   perspectiveToCamera,
+  orthogonalToCamera,
+  sectionPlaneToClippingPlane,
+  clippingPlaneToSectionPlane,
+  createViewpoint,
+  extractViewpointState,
   type ViewerCameraState,
+  type ViewerBounds,
+  type ViewerSectionPlane,
 } from './viewpoint.js';
 
 /**
@@ -147,6 +155,136 @@ describe('BCF Viewpoint Coordinate Conversion', () => {
 
       // FOV should match
       expect(roundtripped.fov).toBeCloseTo(originalViewer.fov, 3);
+    });
+  });
+
+  describe('orthogonal camera (Z-up <-> Y-up)', () => {
+    // Only the perspective pair had fixtures; the orthogonal pair — including the
+    // view-to-world scale a receiving viewer uses to size the ortho frustum —
+    // was entirely unpinned.
+    it('carries viewToWorldScale through the round-trip unchanged', () => {
+      const viewer: ViewerCameraState = {
+        position: { x: 0, y: 100, z: 0 },
+        target: { x: 0, y: 0, z: 0 },
+        up: { x: 0, y: 0, z: -1 },
+        fov: Math.PI / 4,
+        isOrthographic: true,
+        orthoScale: 42.5,
+      };
+
+      const bcf = cameraToOrthogonal(viewer, viewer.orthoScale!);
+      expect(bcf.viewToWorldScale).toBe(42.5);
+      // Viewer {0,100,0} -> BCF {0,0,100}; looking straight down is BCF -Z.
+      expect(bcf.cameraViewPoint).toEqual({ x: 0, y: -0, z: 100 });
+      expect(bcf.cameraDirection.z).toBeCloseTo(-1, 6);
+
+      const back = orthogonalToCamera(bcf, 100);
+      expect(back.isOrthographic).toBe(true);
+      expect(back.orthoScale).toBe(42.5);
+      expect(back.position.x).toBeCloseTo(0, 6);
+      expect(back.position.y).toBeCloseTo(100, 6);
+      expect(back.target.y).toBeCloseTo(0, 6);
+    });
+  });
+
+  describe('section plane <-> clipping plane', () => {
+    const bounds: ViewerBounds = { min: { x: 0, y: 0, z: 0 }, max: { x: 10, y: 20, z: 30 } };
+
+    // The `enabled` guard is the only thing standing between a disabled section
+    // plane and a clipping plane written into the BCF: inverting it silently
+    // exports a cut model as un-cut and vice versa.
+    it('returns a plane when enabled and null when disabled', () => {
+      const enabled: ViewerSectionPlane = { axis: 'down', position: 50, enabled: true, flipped: false };
+      const plane = sectionPlaneToClippingPlane(enabled, bounds);
+      expect(plane).not.toBeNull();
+      // Viewer location {5,10,15} -> BCF {5,-15,10}; viewer dir {0,-1,0} -> BCF z=-1.
+      expect(plane!.location.x).toBeCloseTo(5, 6);
+      expect(plane!.location.y).toBeCloseTo(-15, 6);
+      expect(plane!.location.z).toBeCloseTo(10, 6);
+      expect(plane!.direction.z).toBeCloseTo(-1, 6);
+
+      expect(sectionPlaneToClippingPlane({ ...enabled, enabled: false }, bounds)).toBeNull();
+    });
+
+    // `flipped` is a two-valued signal; a fixture that only ever exercised the
+    // un-flipped case would leave the comparison free to point either way.
+    it('recovers axis, position and BOTH flip directions', () => {
+      for (const axis of ['down', 'front', 'side'] as const) {
+        for (const flipped of [false, true]) {
+          const source: ViewerSectionPlane = { axis, position: 25, enabled: true, flipped };
+          const plane = sectionPlaneToClippingPlane(source, bounds)!;
+          const back = clippingPlaneToSectionPlane(plane, bounds);
+
+          expect(back.axis).toBe(axis);
+          expect(back.position).toBeCloseTo(25, 6);
+          expect(back.flipped).toBe(flipped);
+          expect(back.enabled).toBe(true);
+        }
+      }
+    });
+
+    it('falls back to the midpoint when the axis has zero extent', () => {
+      const flat: ViewerBounds = { min: { x: 0, y: 5, z: 0 }, max: { x: 10, y: 5, z: 30 } };
+      const plane = sectionPlaneToClippingPlane(
+        { axis: 'down', position: 80, enabled: true, flipped: false },
+        flat,
+      )!;
+      expect(clippingPlaneToSectionPlane(plane, flat).position).toBe(50);
+    });
+  });
+
+  describe('createViewpoint / extractViewpointState', () => {
+    const camera: ViewerCameraState = {
+      position: { x: 0, y: 10, z: 10 },
+      target: { x: 0, y: 0, z: 0 },
+      up: { x: 0, y: 1, z: 0 },
+      fov: Math.PI / 3,
+    };
+
+    // visibleGuids means "isolate these" (defaultVisibility=false) and hiddenGuids
+    // means "hide these" (defaultVisibility=true). Getting the flag wrong inverts
+    // what the receiving viewer shows, with no error anywhere.
+    it('encodes isolation as defaultVisibility=false and hiding as true', () => {
+      const isolate = createViewpoint({ camera, visibleGuids: ['KEEPVISIBLE00000000001'] });
+      expect(isolate.components?.visibility?.defaultVisibility).toBe(false);
+      expect(isolate.components?.visibility?.exceptions).toEqual([{ ifcGuid: 'KEEPVISIBLE00000000001' }]);
+
+      const hide = createViewpoint({ camera, hiddenGuids: ['HIDEME0000000000000001'] });
+      expect(hide.components?.visibility?.defaultVisibility).toBe(true);
+      expect(hide.components?.visibility?.exceptions).toEqual([{ ifcGuid: 'HIDEME0000000000000001' }]);
+    });
+
+    it('round-trips isolation and hiding back into the right bucket', () => {
+      const isolate = extractViewpointState(createViewpoint({ camera, visibleGuids: ['A000000000000000000001'] }));
+      expect(isolate.visibleGuids).toEqual(['A000000000000000000001']);
+      expect(isolate.hiddenGuids).toEqual([]);
+
+      const hide = extractViewpointState(createViewpoint({ camera, hiddenGuids: ['B000000000000000000001'] }));
+      expect(hide.hiddenGuids).toEqual(['B000000000000000000001']);
+      expect(hide.visibleGuids).toEqual([]);
+    });
+
+    it('omits components entirely when nothing is selected, hidden or coloured', () => {
+      const bare = createViewpoint({ camera });
+      expect(bare.components).toBeUndefined();
+      expect(bare.perspectiveCamera).toBeDefined();
+      expect(bare.orthogonalCamera).toBeUndefined();
+
+      const state = extractViewpointState(bare);
+      expect(state.selectedGuids).toEqual([]);
+      expect(state.coloredGuids).toEqual([]);
+      expect(state.sectionPlane).toBeUndefined();
+    });
+
+    it('uses the orthogonal camera only when the state is orthographic AND scaled', () => {
+      const ortho = createViewpoint({ camera: { ...camera, isOrthographic: true, orthoScale: 7 } });
+      expect(ortho.orthogonalCamera?.viewToWorldScale).toBe(7);
+      expect(ortho.perspectiveCamera).toBeUndefined();
+
+      // isOrthographic with no scale has no usable frustum size -> perspective.
+      const noScale = createViewpoint({ camera: { ...camera, isOrthographic: true } });
+      expect(noScale.perspectiveCamera).toBeDefined();
+      expect(noScale.orthogonalCamera).toBeUndefined();
     });
   });
 

--- a/packages/bcf/src/writer.test.ts
+++ b/packages/bcf/src/writer.test.ts
@@ -643,6 +643,224 @@ describe('BCF Writer', () => {
     }
   });
 
+  // --------------------------------------------------------------------------
+  // Fields that a BCF consumer reads but that no fixture pinned. Each of these
+  // survived a mutation of the writer: the file stayed readable, so nothing on
+  // our side errored — the receiving tool just got the wrong answer.
+  // --------------------------------------------------------------------------
+
+  /** Wrap a single topic in a minimal project and return its markup.bcf text. */
+  async function markupFor(topic: BCFTopic, version: '2.1' | '3.0' = '2.1'): Promise<string> {
+    const project: BCFProject = { version, topics: new Map([[topic.guid, topic]]) };
+    const zip = await JSZip.loadAsync(await blobToArrayBuffer(await writeBCF(project)));
+    const content = await zip.file(`${topic.guid}/markup.bcf`)?.async('string');
+    expect(content).toBeDefined();
+    return content!;
+  }
+
+  function baseTopic(overrides: Partial<BCFTopic> = {}): BCFTopic {
+    return {
+      guid: generateUuid(),
+      title: 'T',
+      creationDate: '2026-01-01T00:00:00.000Z',
+      creationAuthor: 'creator@example.com',
+      viewpoints: [],
+      comments: [],
+      ...overrides,
+    };
+  }
+
+  it('defaults DefaultVisibility to true when a viewpoint has components but no visibility', async () => {
+    // Visibility is REQUIRED inside Components, so the writer synthesises one.
+    // Emitting false instead of true would tell the receiving tool to hide the
+    // entire model and show only the selection.
+    const vp: BCFViewpoint = {
+      guid: generateUuid(),
+      components: { selection: [{ ifcGuid: '0abc123def456789012345' }] },
+    };
+    const topic = baseTopic({ viewpoints: [vp] });
+    const project: BCFProject = { version: '2.1', topics: new Map([[topic.guid, topic]]) };
+    const zip = await JSZip.loadAsync(await blobToArrayBuffer(await writeBCF(project)));
+    const content = await zip.file(`${topic.guid}/Viewpoint_${vp.guid}.bcfv`)?.async('string');
+
+    expect(content).toContain('DefaultVisibility="true"');
+    expect(content).not.toContain('DefaultVisibility="false"');
+  });
+
+  it('writes DefaultVisibility="false" when isolation is explicitly requested', async () => {
+    // The other half of the two-valued signal: an explicit false must survive the
+    // `?? true` default rather than being coerced back to true.
+    const vp: BCFViewpoint = {
+      guid: generateUuid(),
+      components: {
+        visibility: { defaultVisibility: false, exceptions: [{ ifcGuid: '1abc123def456789012345' }] },
+      },
+    };
+    const topic = baseTopic({ viewpoints: [vp] });
+    const project: BCFProject = { version: '2.1', topics: new Map([[topic.guid, topic]]) };
+    const zip = await JSZip.loadAsync(await blobToArrayBuffer(await writeBCF(project)));
+    const content = await zip.file(`${topic.guid}/Viewpoint_${vp.guid}.bcfv`)?.async('string');
+
+    expect(content).toContain('DefaultVisibility="false"');
+  });
+
+  it('round-trips both visibility modes so isolation is not inverted on read', async () => {
+    // Reader side: DefaultVisibility is parsed as `!== 'false'`. Inverting that
+    // comparison silently turns an isolation viewpoint into a hide-list and vice
+    // versa — the viewer then shows exactly the elements it should have hidden.
+    const isolate: BCFViewpoint = {
+      guid: generateUuid(),
+      components: { visibility: { defaultVisibility: false, exceptions: [{ ifcGuid: 'ISOLATED0000000000000a' }] } },
+    };
+    const hide: BCFViewpoint = {
+      guid: generateUuid(),
+      components: { visibility: { defaultVisibility: true, exceptions: [{ ifcGuid: 'HIDDEN00000000000000ab' }] } },
+    };
+    const topic = baseTopic({ viewpoints: [isolate, hide] });
+    const project: BCFProject = { version: '2.1', topics: new Map([[topic.guid, topic]]) };
+
+    const readProject = await readBCF(await (await writeBCF(project)).arrayBuffer());
+    const readVps = readProject.topics.get(topic.guid)!.viewpoints;
+    const readIsolate = readVps.find((v) => v.guid === isolate.guid)!;
+    const readHide = readVps.find((v) => v.guid === hide.guid)!;
+
+    expect(readIsolate.components?.visibility?.defaultVisibility).toBe(false);
+    expect(readIsolate.components?.visibility?.exceptions?.[0].ifcGuid).toBe('ISOLATED0000000000000a');
+    expect(readHide.components?.visibility?.defaultVisibility).toBe(true);
+    expect(readHide.components?.visibility?.exceptions?.[0].ifcGuid).toBe('HIDDEN00000000000000ab');
+  });
+
+  it('names a JPEG snapshot .jpg and a PNG snapshot .png, consistently in markup and archive', async () => {
+    // The extension is derived from the snapshot data-URL prefix. Hard-coding
+    // 'png' still produces a readable archive, but the entry then advertises PNG
+    // while carrying JPEG bytes — a consumer that trusts the extension misdecodes.
+    const jpegVp: BCFViewpoint = {
+      guid: generateUuid(),
+      // 'AAAA' is valid base64, so the data-URL branch writes real bytes.
+      snapshot: 'data:image/jpeg;base64,AAAA',
+    };
+    const pngVp: BCFViewpoint = { guid: generateUuid(), snapshot: 'data:image/png;base64,AAAA' };
+    const topic = baseTopic({ viewpoints: [jpegVp, pngVp] });
+    const project: BCFProject = { version: '2.1', topics: new Map([[topic.guid, topic]]) };
+    const zip = await JSZip.loadAsync(await blobToArrayBuffer(await writeBCF(project)));
+    const markup = await zip.file(`${topic.guid}/markup.bcf`)?.async('string');
+
+    expect(markup).toContain(`<Snapshot>Snapshot_${jpegVp.guid}.jpg</Snapshot>`);
+    expect(markup).toContain(`<Snapshot>Snapshot_${pngVp.guid}.png</Snapshot>`);
+    // The referenced entries must actually exist under those names.
+    expect(zip.file(`${topic.guid}/Snapshot_${jpegVp.guid}.jpg`)).not.toBeNull();
+    expect(zip.file(`${topic.guid}/Snapshot_${pngVp.guid}.png`)).not.toBeNull();
+  });
+
+  it('falls back to CreationAuthor for ModifiedAuthor, which the schema requires alongside ModifiedDate', async () => {
+    // ModifiedAuthor is mandatory once ModifiedDate is present. Writing an empty
+    // element instead of the fallback yields schema-invalid markup that a
+    // validating consumer rejects outright.
+    const noAuthor = await markupFor(baseTopic({ modifiedDate: '2026-02-02T00:00:00.000Z' }));
+    expect(noAuthor).toContain('<ModifiedAuthor>creator@example.com</ModifiedAuthor>');
+
+    // An explicit modifiedAuthor must win over the fallback.
+    const withAuthor = await markupFor(
+      baseTopic({ modifiedDate: '2026-02-02T00:00:00.000Z', modifiedAuthor: 'editor@example.com' }),
+    );
+    expect(withAuthor).toContain('<ModifiedAuthor>editor@example.com</ModifiedAuthor>');
+    expect(withAuthor).not.toContain('creator@example.com</ModifiedAuthor>');
+  });
+
+  it('omits a BimSnippet that is missing the schema-required ReferenceSchema', async () => {
+    // ReferenceSchema is required inside BimSnippet; emitting the snippet without
+    // it would produce markup that fails XSD validation.
+    const incomplete = await markupFor(
+      baseTopic({ bimSnippet: { snippetType: 'IFC', isExternal: true, reference: 'a.ifc' } }),
+    );
+    expect(incomplete).not.toContain('<BimSnippet');
+
+    // A complete snippet is still emitted — the guard must not drop everything.
+    const complete = await markupFor(
+      baseTopic({
+        bimSnippet: {
+          snippetType: 'IFC',
+          isExternal: true,
+          reference: 'a.ifc',
+          referenceSchema: 'https://example.com/schema.xsd',
+        },
+      }),
+    );
+    expect(complete).toContain('<BimSnippet SnippetType="IFC"');
+    expect(complete).toContain('<ReferenceSchema>https://example.com/schema.xsd</ReferenceSchema>');
+  });
+
+  it('writes ViewSetupHints with the spec attribute names, only for the hints that are set', async () => {
+    const vp: BCFViewpoint = {
+      guid: generateUuid(),
+      components: {
+        visibility: {
+          defaultVisibility: true,
+          viewSetupHints: { spacesVisible: true, spaceBoundariesVisible: false },
+        },
+      },
+    };
+    const topic = baseTopic({ viewpoints: [vp] });
+    const project: BCFProject = { version: '2.1', topics: new Map([[topic.guid, topic]]) };
+    const zip = await JSZip.loadAsync(await blobToArrayBuffer(await writeBCF(project)));
+    const content = await zip.file(`${topic.guid}/Viewpoint_${vp.guid}.bcfv`)?.async('string');
+
+    // Exact spec spellings — a typo'd attribute is silently ignored by consumers.
+    expect(content).toContain('SpacesVisible="true"');
+    expect(content).toContain('SpaceBoundariesVisible="false"');
+    // An unset hint must be omitted, not emitted as "undefined".
+    expect(content).not.toContain('OpeningsVisible');
+    // ViewSetupHints belongs at Components level, before Selection/Visibility.
+    expect(content!.indexOf('<ViewSetupHints')).toBeLessThan(content!.indexOf('<Visibility'));
+  });
+
+  it('round-trips Coloring with the spec Color attribute name', async () => {
+    // The coloring write path had no fixture at all; renaming the `Color`
+    // attribute produced an archive that reads back with no coloring at all.
+    const vp: BCFViewpoint = {
+      guid: generateUuid(),
+      components: {
+        visibility: { defaultVisibility: true },
+        coloring: [{ color: 'FFFF0000', components: [{ ifcGuid: 'REDELEMENT00000000000a' }] }],
+      },
+    };
+    const topic = baseTopic({ viewpoints: [vp] });
+    const project: BCFProject = { version: '2.1', topics: new Map([[topic.guid, topic]]) };
+    const blob = await writeBCF(project);
+    const zip = await JSZip.loadAsync(await blobToArrayBuffer(blob));
+    const content = await zip.file(`${topic.guid}/Viewpoint_${vp.guid}.bcfv`)?.async('string');
+    expect(content).toContain('<Color Color="FFFF0000">');
+
+    const readVp = (await readBCF(await blob.arrayBuffer())).topics.get(topic.guid)!.viewpoints[0];
+    expect(readVp.components?.coloring).toEqual([
+      { color: 'FFFF0000', components: [{ ifcGuid: 'REDELEMENT00000000000a', authoringToolId: undefined, originatingSystem: undefined }] },
+    ]);
+  });
+
+  it('round-trips a JPG bitmap format rather than collapsing every bitmap to PNG', async () => {
+    // The reader normalises Format to JPG|PNG. Collapsing to PNG unconditionally
+    // stayed green because the only bitmap fixture was already a PNG.
+    const vp: BCFViewpoint = {
+      guid: generateUuid(),
+      bitmaps: [
+        {
+          format: 'JPG',
+          reference: 'b.jpg',
+          location: { x: 0, y: 0, z: 0 },
+          normal: { x: 0, y: 0, z: 1 },
+          up: { x: 0, y: 1, z: 0 },
+          height: 1,
+        },
+      ],
+    };
+    const topic = baseTopic({ viewpoints: [vp] });
+    const project: BCFProject = { version: '2.1', topics: new Map([[topic.guid, topic]]) };
+
+    const readVp = (await readBCF(await (await writeBCF(project)).arrayBuffer()))
+      .topics.get(topic.guid)!.viewpoints[0];
+    expect(readVp.bitmaps?.[0].format).toBe('JPG');
+  });
+
   it('folder disambiguation is deterministic across writes of the same project', async () => {
     const makeTopic = (guid: string): BCFTopic => ({
       guid,

--- a/packages/solar/src/solar-position.test.ts
+++ b/packages/solar/src/solar-position.test.ts
@@ -125,4 +125,74 @@ describe('sunTimes', () => {
     const spSummer = sunTimes(new Date('2024-12-21T12:00:00Z'), -90, 0);
     expect(spSummer.alwaysUp).toBe(true);
   });
+
+  // Every other sunTimes test sits on the prime meridian, so the `- 4 * longitude`
+  // term in solarNoonMinutes was free: flipping its sign left the suite green while
+  // shifting sunrise/sunset by 8 minutes per degree of longitude (over an hour for
+  // a central-European site).
+  it('shifts solar noon 4 minutes earlier per degree of EAST longitude', () => {
+    const instant = new Date('2024-06-20T12:00:00Z');
+    const atMeridian = sunTimes(instant, 47, 0);
+    const east15 = sunTimes(instant, 47, 15);
+    const west15 = sunTimes(instant, 47, -15);
+
+    // 15° east == one hour of longitude: the sun crosses the meridian an hour
+    // EARLIER in UTC, and an hour later 15° west. Sign and magnitude both pinned.
+    const hour = 3_600_000;
+    expect(east15.solarNoon.getTime()).toBe(atMeridian.solarNoon.getTime() - hour);
+    expect(west15.solarNoon.getTime()).toBe(atMeridian.solarNoon.getTime() + hour);
+
+    // Sunrise/sunset ride the same shift (the hour angle is longitude-independent).
+    expect(east15.sunrise!.getTime()).toBe(atMeridian.sunrise!.getTime() - hour);
+    expect(east15.sunset!.getTime()).toBe(atMeridian.sunset!.getTime() - hour);
+  });
+
+  // The 90°50′ sunrise zenith bakes in atmospheric refraction + the solar semi-
+  // diameter. Dropping it to a geometric 90° kept every existing test green
+  // (they all use `toBeCloseTo(12, 0)`), yet moves sunrise ~3 minutes.
+  it('applies the 90°50′ refraction correction, so the equinox day exceeds 12 h', () => {
+    // At the equator on the equinox the geometric day is 12 h exactly; refraction
+    // is the ONLY thing that can lengthen it. ~12 h 07 m is the textbook value.
+    const t = sunTimes(new Date('2024-03-20T12:00:00Z'), 0, 0);
+    const hours = (t.sunset!.getTime() - t.sunrise!.getTime()) / 3_600_000;
+    expect(hours).toBeGreaterThan(12.08);
+    expect(hours).toBeCloseTo(12.111, 2);
+  });
+
+  // At an exact pole the hour-angle formula divides by cos(lat) = 0, so the
+  // always-up decision is made from the declination alone. That comparison is
+  // against MINUS the refraction allowance; using plus only differs while the
+  // declination sits inside the ±0.833° band — i.e. the days around an equinox,
+  // which no existing fixture visits.
+  it('counts the refraction band as daylight at an exact pole around the equinox', () => {
+    // 2024-03-18: declination ≈ −0.64°, geometrically below the horizon but
+    // inside the 0.833° refraction allowance → the sun still counts as up.
+    const inBand = sunTimes(new Date('2024-03-18T12:00:00Z'), 90, 0);
+    expect(inBand.alwaysUp).toBe(true);
+    expect(inBand.alwaysDown).toBe(false);
+
+    // 2024-03-10: declination ≈ −3.8°, clear of the band → polar night. Pins the
+    // other side of the comparison so the test cannot pass by always answering up.
+    const belowBand = sunTimes(new Date('2024-03-10T12:00:00Z'), 90, 0);
+    expect(belowBand.alwaysUp).toBe(false);
+    expect(belowBand.alwaysDown).toBe(true);
+  });
+});
+
+describe('sunPosition longitude handling', () => {
+  // Every other sunPosition test uses longitude 0, leaving the `+ 4 * longitude`
+  // term in the true-solar-time conversion unpinned: flipping its sign kept the
+  // whole suite green while moving the sun by 20° of azimuth per 15° of longitude.
+  it('reaches solar noon earlier in UTC the further east the site is', () => {
+    const equinox = '2024-03-20';
+    // Solar noon at 15°E is ~11:07 UTC, so at 12:00 UTC the sun is already past
+    // the meridian (azimuth > 180°); at 15°W it has not reached it yet (< 180°).
+    const east = sunPosition(new Date(`${equinox}T12:00:00Z`), 47, 15);
+    const west = sunPosition(new Date(`${equinox}T12:00:00Z`), 47, -15);
+
+    expect(east.azimuth).toBeGreaterThan(180);
+    expect(west.azimuth).toBeLessThan(180);
+    // 30° of longitude == 2 h of hour angle == 30° of hour angle either side.
+    expect(east.azimuth - west.azimuth).toBeGreaterThan(30);
+  });
 });

--- a/packages/solar/src/sun-path.test.ts
+++ b/packages/solar/src/sun-path.test.ts
@@ -55,6 +55,19 @@ describe('dayPath', () => {
     expect(all.some((s) => s.aboveHorizon)).toBe(true);
   });
 
+  // The sampling loop is `m <= 1440`, i.e. inclusive of the closing midnight, so
+  // a day yields 1440/step + 1 samples and the polyline closes on the next day's
+  // start. No test pinned the count, so `m < 1440` (dropping the closing sample)
+  // went unnoticed — a renderer drawing a closed dome arc would show a gap.
+  it('samples the whole UTC day inclusive of the closing midnight', () => {
+    const day = new Date('2024-06-20T12:00:00Z');
+    const all = dayPath(day, LAT, LON, { stepMinutes: 60, aboveHorizonOnly: false });
+
+    expect(all).toHaveLength(1440 / 60 + 1);
+    expect(all[0].time.toISOString()).toBe('2024-06-20T00:00:00.000Z');
+    expect(all[all.length - 1].time.toISOString()).toBe('2024-06-21T00:00:00.000Z');
+  });
+
   it('traces a longer summer arc than a winter arc', () => {
     const summer = dayPath(new Date('2024-06-20T12:00:00Z'), LAT, LON, { stepMinutes: 10 });
     const winter = dayPath(new Date('2024-12-21T12:00:00Z'), LAT, LON, { stepMinutes: 10 });
@@ -71,6 +84,19 @@ describe('analemmaPaths', () => {
       expect(p.hour).toBeGreaterThanOrEqual(0);
       expect(p.hour).toBeLessThan(24);
     }
+  });
+
+  // The year length comes from a Gregorian leap-year test. Nothing asserted the
+  // sample count, so hard-coding 365 stayed green while silently truncating a
+  // leap year's analemma before 31 December.
+  it('walks every calendar day, honouring Gregorian leap years', () => {
+    const lengthFor = (year: number): number =>
+      analemmaPaths(year, LAT, LON, { dayStep: 1 })[0].samples.length;
+
+    expect(lengthFor(2024)).toBe(366); // divisible by 4
+    expect(lengthFor(2023)).toBe(365); // common year
+    expect(lengthFor(2100)).toBe(365); // century, not divisible by 400
+    expect(lengthFor(2000)).toBe(366); // divisible by 400
   });
 
   it('includes a midday analemma but not a deep-night one in the UK', () => {


### PR DESCRIPTION
A mutation sweep of `packages/bcf` and `packages/solar` — neither previously swept.

**27 mutations, 4 already killed by the existing suites, 23 survivors.** Three of the four kills were deliberate CONTROLS, run first to prove the harness was operating on mutated source before any survivor was believed. Every survivor is a genuine untested gap; no equivalent mutants were needed to pad the count, and no production behaviour was found to be wrong. **Test-only — no production code is changed.**

Baseline → final: bcf 5 files / 109 tests → 7 files / 144 tests; solar 2 files / 23 tests → 2 files / 29 tests. Both suites were green before and are green after.

The two packages fail in opposite ways, which is why they were paired. BCF is an interoperability format: a wrong field produces a file another tool misreads, with no error on our side. Solar is maths, where a wrong answer arrives confident rather than loud.

## Method

Each mutation was applied by an exact-substring replacement that asserted a replacement count of exactly 1, re-read the file from disk and asserted the new text was present before the suite was run, then restored from a saved backup (never `git checkout --`). Every new test was RED-verified under its own mutation (failing alone, with collateral only on other new tests) and GREEN with the mutation reverted.

### Controls (expected to be killed, and were)

| # | File | Mutation | Killed by |
|---|---|---|---|
| C1 | `solar/sun-path.ts` | `u: Math.sin(alt)` → `-Math.sin(alt)` | `azimuthAltitudeToEnu > maps north/east/up correctly` |
| C2 | `bcf/writer.ts` | `escapeXml` `&` → `&` (no-op) | `should roundtrip XML special characters …` |
| C3 | `bcf/reader.ts` | `parseComments` `lastIndexOf` → `indexOf` | 4 interop comment tests |

## solar — 7 gaps

Every existing solar fixture sits on the prime meridian, so **both** longitude terms in the package were free variables.

| # | Mutation | Before | Test that now kills it |
|---|---|---|---|
| S6 | `sunTimes`: `720 - 4 * longitude - eot` → `720 + 4 * longitude - eot` | SURVIVED | `shifts solar noon 4 minutes earlier per degree of EAST longitude` |
| S9 | `sunPositionFromGeometry`: `+ 4 * longitude` → `- 4 * longitude` | SURVIVED | `reaches solar noon earlier in UTC the further east the site is` |
| S8 | `SUNRISE_ZENITH = 90.833` → `90.0` | SURVIVED | `applies the 90°50′ refraction correction, so the equinox day exceeds 12 h` |
| S10 | pole branch `poleAltitude >= -(SUNRISE_ZENITH - 90)` → `>= +(…)` | SURVIVED | `counts the refraction band as daylight at an exact pole around the equinox` |
| S2 | `dayPath`: `m <= 1440` → `m < 1440` | SURVIVED | `samples the whole UTC day inclusive of the closing midnight` |
| S3 | `analemmaPaths`: `isLeap(year) ? 366 : 365` → `365` | SURVIVED | `walks every calendar day, honouring Gregorian leap years` |
| S4 | `domeGraticule`: `alt < 90` → `alt <= 90` | **already killed** | `builds altitude rings and azimuth spokes at the requested spacing` |
| S7 | `sunTimes`: `- equationOfTime` → `+ equationOfTime` | **already killed** | `points due south at altitude ≈ (90 − lat) at solar noon on the equinox` |

What a user would have seen:

- **S6 / S9** — the longitude sign. Flipping it kept all 23 tests green while moving sunrise, sunset and the sun's own position by 8 minutes (2° of hour angle) per degree of longitude. For a central-European site that is over an hour: a shadow study would be computed for the wrong time of day, silently. These are now pinned as an exact one-hour shift at 15°E and 15°W, and as azimuth either side of the meridian at 12:00 UTC.
- **S8** — `90.833°` is the refraction + solar-semi-diameter allowance. Dropping it to a geometric 90° moves sunrise ~3 minutes, which every existing daylight assertion absorbed because they all used `toBeCloseTo(hours, 0)`. Pinned at the equator on the equinox, where the geometric day is exactly 12 h and refraction is the only thing that can lengthen it (~12 h 07 m).
- **S10** — at an exact pole the hour-angle formula divides by `cos(lat) = 0`, so always-up is decided from the declination against **minus** that allowance. The sign only matters while the declination is inside the ±0.833° band, i.e. the few days around an equinox. Pinned on both sides of the band so the test cannot pass by always answering "up".
- **S2 / S3** — sample counts. `dayPath` deliberately closes the arc on the next midnight (1440/step + 1 samples) and `analemmaPaths` walks a real Gregorian year; nothing asserted either, so truncating the day or hard-coding 365 was invisible. A renderer drawing a closed dome arc would show a gap; a leap-year analemma would end before 31 December.

## bcf — 16 gaps

`overlay.ts` had no test file at all, `index.ts`'s own helpers were untested, and two thirds of `viewpoint.ts` was reachable only through re-exports.

### Writer

| # | Mutation | Test that now kills it |
|---|---|---|
| B3 | `defaultVisibility ?? true` → `?? false` | `defaults DefaultVisibility to true when a viewpoint has components but no visibility` |
| B4 | `snapshotExt` → always `'png'` | `names a JPEG snapshot .jpg and a PNG snapshot .png, consistently in markup and archive` |
| B5 | `modifiedAuthor \|\| creationAuthor` → `modifiedAuthor ?? ''` | `falls back to CreationAuthor for ModifiedAuthor, …` |
| B6 | `if (topic.bimSnippet?.referenceSchema)` → `if (topic.bimSnippet)` | `omits a BimSnippet that is missing the schema-required ReferenceSchema` |
| B7 | `SpacesVisible` → `SpaceVisible` | `writes ViewSetupHints with the spec attribute names, …` |
| B8 | `<Color Color=` → `<Color Colour=` | `round-trips Coloring with the spec Color attribute name` |

`Visibility` is required inside `Components`, so the writer synthesises one — emitting `false` instead of `true` tells the receiving tool to hide the entire model and show only the selection. The snapshot extension must agree between the markup `<Snapshot>` reference and the archive entry, or a consumer that trusts the extension misdecodes JPEG bytes as PNG. `ModifiedAuthor` is mandatory once `ModifiedDate` is present, and a `BimSnippet` without `ReferenceSchema` is XSD-invalid; both mutations produced markup a validating consumer rejects outright. `ViewSetupHints` and `Coloring` had no fixtures at all.

Each writer test pins **both** directions where the field is two-valued: default-true *and* explicit-false visibility; JPEG *and* PNG; fallback author *and* explicit author; incomplete snippet omitted *and* complete snippet emitted; set hints present *and* unset hints absent.

### Reader

| # | Mutation | Test that now kills it |
|---|---|---|
| B18 | `defaultVisMatch?.[1] !== 'false'` → `=== 'false'` | `round-trips both visibility modes so isolation is not inverted on read` |
| B19 | bitmap `format.toUpperCase() === 'JPG' ? 'JPG' : 'PNG'` → `'PNG'` | `round-trips a JPG bitmap format rather than collapsing every bitmap to PNG` |

B18 is the worst of the set: inverting that comparison turns an isolation viewpoint into a hide-list and a hide-list into an isolation, so the viewer shows exactly the elements the topic asked it to hide. It survived because no fixture read visibility back at all. B19 survived because the only bitmap fixture was already a PNG.

### Viewpoint

| # | Mutation | Test that now kills it |
|---|---|---|
| B9 | `orthoScale: camera.viewToWorldScale` → `* 2` | `carries viewToWorldScale through the round-trip unchanged` |
| B10 | `if (!sectionPlane.enabled)` → `if (sectionPlane.enabled)` | `returns a plane when enabled and null when disabled` |
| B11 | `flipped = viewerDirection.y > 0` → `< 0` | `recovers axis, position and BOTH flip directions` |
| B12 | isolation `defaultVisibility: false` → `true` | `round-trips isolation and hiding back into the right bucket` |

Only the perspective camera pair had fixtures. The orthogonal pair — including `viewToWorldScale`, which sizes the receiving viewer's frustum — was entirely unpinned, as were both section-plane converters and `createViewpoint`/`extractViewpointState`. B10's inversion exports a cut model as un-cut and an un-cut model as cut. B11 is covered for all three axes in both flip directions.

### Index

| # | Mutation | Test that now kills it |
|---|---|---|
| B13 | `parseARGBColor` 6-digit red channel `substring(0,2)` → `substring(4,6)` | `treats the 6-digit form as opaque RGB` / `tolerates a leading # …` |
| B14 | `toARGBColor` → RGBA channel order | `emits alpha first, uppercase, zero-padded` / `round-trips through parseARGBColor` |

BCF colours are ARGB — **alpha first** — the opposite of the RGBA order most web code uses, and neither helper had a fixture. Both orders are now pinned with distinct per-channel values (`0x11/0x22/0x33/0x44`) so a transposition cannot pass by symmetry, plus clamping/rounding of out-of-range channels.

### Overlay

| # | Mutation | Test that now kills it |
|---|---|---|
| B15 | `lift = Math.max(height * 0.3, 0.5)` → `0` | `floats a component marker above the bbox top …` |
| B16 | `if (!statusFilter.some(...))` → `if (statusFilter.some(...))` | `keeps matching statuses and drops non-matching ones, case-insensitively` |
| B17 | `topic.index ?? i + 1` → `?? i` | `numbers markers from 1 when the topic carries no index` |

`overlay.ts` had no test file, so the whole position-derivation priority chain (component bbox → camera target → camera position), the isolation-vs-hide distinction for exception components, the marker lift and its 0.5 m floor for zero-height elements, the status filter and the 1-based numbering fallback were all free. B16 is pinned in both directions plus the empty-filter case (an empty filter means "no filter", not "match nothing"), so an inverted comparison cannot pass.

## Verification

- `pnpm typecheck` at the repo root: 34/34 tasks successful.
- The root `tsconfig.json` and both package tsconfigs exclude `**/*.test.ts`, so typecheck does **not** cover test files. The new and modified test files were typechecked separately against each package's compiler options with the test exclusion lifted — clean.
- `pnpm vitest run` in `packages/bcf`: 144/144. In `packages/solar`: 29/29.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for BCF color handling, project and topic helpers, viewpoints, overlays, visibility, snapshots, metadata, and serialization edge cases.
  * Added regression coverage for solar timing, atmospheric refraction, polar daylight, midnight sampling, leap years, and century-year calculations.
  * Improved confidence in consistent behavior across camera types, section planes, marker positioning, and date-based sun paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->